### PR TITLE
Lower heap and disk space used by compiling kafka tests

### DIFF
--- a/test/extensions/filters/network/kafka/BUILD
+++ b/test/extensions/filters/network/kafka/BUILD
@@ -100,7 +100,6 @@ envoy_extension_cc_test(
         ":buffer_based_test_lib",
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:kafka_request_parser_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -111,7 +110,6 @@ envoy_extension_cc_test(
     deps = [
         ":buffer_based_test_lib",
         "//source/extensions/filters/network/kafka:kafka_request_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -123,7 +121,6 @@ envoy_extension_cc_test(
         ":buffer_based_test_lib",
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:kafka_request_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -135,7 +132,6 @@ envoy_extension_cc_test(
         ":buffer_based_test_lib",
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:kafka_request_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -146,7 +142,6 @@ envoy_extension_cc_test(
     deps = [
         ":buffer_based_test_lib",
         "//source/extensions/filters/network/kafka:kafka_request_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -180,7 +175,6 @@ envoy_extension_cc_test(
         ":buffer_based_test_lib",
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:kafka_response_parser_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -191,7 +185,6 @@ envoy_extension_cc_test(
     deps = [
         ":buffer_based_test_lib",
         "//source/extensions/filters/network/kafka:kafka_response_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -203,7 +196,6 @@ envoy_extension_cc_test(
         ":buffer_based_test_lib",
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:kafka_response_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -215,7 +207,6 @@ envoy_extension_cc_test(
         ":buffer_based_test_lib",
         ":serialization_utilities_lib",
         "//source/extensions/filters/network/kafka:kafka_response_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 
@@ -226,7 +217,6 @@ envoy_extension_cc_test(
     deps = [
         ":buffer_based_test_lib",
         "//source/extensions/filters/network/kafka:kafka_response_codec_lib",
-        "//test/mocks/server:server_mocks",
     ],
 )
 

--- a/test/extensions/filters/network/kafka/broker/BUILD
+++ b/test/extensions/filters/network/kafka/broker/BUILD
@@ -27,7 +27,8 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.network.kafka_broker",
     deps = [
         "//source/extensions/filters/network/kafka:kafka_broker_filter_lib",
-        "//test/mocks/server:server_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/stats:stats_mocks",
     ],
 )
 

--- a/test/extensions/filters/network/kafka/broker/filter_unit_test.cc
+++ b/test/extensions/filters/network/kafka/broker/filter_unit_test.cc
@@ -1,7 +1,7 @@
 #include "extensions/filters/network/kafka/broker/filter.h"
 #include "extensions/filters/network/kafka/external/requests.h"
 
-#include "test/mocks/server/mocks.h"
+#include "test/mocks/network/mocks.h"
 #include "test/mocks/stats/mocks.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_request_parser_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gmock/gmock.h"
 

--- a/test/extensions/filters/network/kafka/kafka_response_parser_test.cc
+++ b/test/extensions/filters/network/kafka/kafka_response_parser_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gmock/gmock.h"
 

--- a/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/request_codec_request_test_cc.j2
@@ -14,7 +14,6 @@
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gtest/gtest.h"
 

--- a/test/extensions/filters/network/kafka/protocol/requests_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/requests_test_cc.j2
@@ -7,7 +7,6 @@
 #include "extensions/filters/network/kafka/request_codec.h"
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/response_codec_response_test_cc.j2
@@ -14,7 +14,6 @@
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gtest/gtest.h"
 

--- a/test/extensions/filters/network/kafka/protocol/responses_test_cc.j2
+++ b/test/extensions/filters/network/kafka/protocol/responses_test_cc.j2
@@ -7,7 +7,6 @@
 #include "extensions/filters/network/kafka/response_codec.h"
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/network/kafka/request_codec_integration_test.cc
+++ b/test/extensions/filters/network/kafka/request_codec_integration_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gtest/gtest.h"
 

--- a/test/extensions/filters/network/kafka/request_codec_unit_test.cc
+++ b/test/extensions/filters/network/kafka/request_codec_unit_test.cc
@@ -1,7 +1,6 @@
 #include "extensions/filters/network/kafka/request_codec.h"
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/network/kafka/response_codec_integration_test.cc
+++ b/test/extensions/filters/network/kafka/response_codec_integration_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gtest/gtest.h"
 

--- a/test/extensions/filters/network/kafka/response_codec_unit_test.cc
+++ b/test/extensions/filters/network/kafka/response_codec_unit_test.cc
@@ -1,7 +1,6 @@
 #include "extensions/filters/network/kafka/response_codec.h"
 
 #include "test/extensions/filters/network/kafka/buffer_based_test.h"
-#include "test/mocks/server/mocks.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
Commit Message: 
This patch either removes mocks.h related headers altogether from tests
which never required this very heavyweight dependency, or simplifies the
most heavyweight server/mocks.h and elects only more specific mocks. It
especially useful for reducing resource consumption on Windows with
`cl.exe` though compilation on Linux with `clang` is sped up and leaner
as well.

Additional Description:
Original/Revised Peak Working Set Memory for `cl.exe` (kb) used compiling (before/after simplifying mocks.h inclusions) on Windows
 3619976  283508 //test/extensions/filters/network/kafka:request_codec_integration_test
 3621112  177212 //test/extensions/filters/network/kafka:response_codec_integration_test
 3631680  308996 //test/extensions/filters/network/kafka:kafka_response_parser_test
 3637000  309368 //test/extensions/filters/network/kafka:kafka_request_parser_test
 3734736   93464 //test/extensions/filters/network/kafka:request_codec_unit_test
 3735984  342468 //test/extensions/filters/network/kafka:response_codec_unit_test
 4295272 2323440 //test/extensions/filters/network/kafka/broker:filter_unit_test
 4339972  932984 //test/extensions/filters/network/kafka:requests_test
 4366380  945936 //test/extensions/filters/network/kafka:request_codec_request_test
 4410788 1020112 //test/extensions/filters/network/kafka:responses_test
 4437292 1033328 //test/extensions/filters/network/kafka:response_codec_response_test

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A