### PR TITLE
Add missing dependency on `assert.h`

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -411,5 +411,6 @@ envoy_cc_library(
     ],
     deps = [
         "//include/envoy/http:codes_interface",
+        "//source/common/common:assert_lib",
     ],
 )

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -1,5 +1,7 @@
 #include "common/http/status.h"
 
+#include "common/common/assert.h"
+
 #include "absl/strings/str_cat.h"
 
 namespace Envoy {


### PR DESCRIPTION
Description: PR #10777 introduces `NOT_REACHED_GCOVR_EXCL_LINE` in `status.cc`, but this macro is defined in `assert.h`. Add explicit dependency.

Risk Level: Low

Testing: Build passes

Signed-off-by: Teju Nareddy <nareddyt@google.com>
