### PR TITLE
path: Fix merge slash for paths ending with slash and present query args

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,6 +13,7 @@ Changes
   Disabled by default and can be enabled via :ref:`enable_upstream_stats <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.enable_upstream_stats>`.
 * grpc-json: added support for streaming response using
   `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
+* http: fixed a bug where in some cases slash was moved from path to query string when :ref:`merging of adjacent slashes<envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.merge_slashes>` is enabled.
 * http: fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.
   Can be reverted temporarily by setting runtime feature `envoy.reloadable_features.fix_upgrade_response` to false.
 * http: remove legacy connection pool code and their runtime features: `envoy.reloadable_features.new_http1_connection_pool_behavior` and

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -67,7 +67,7 @@ void PathUtil::mergeSlashes(RequestHeaderMap& headers) {
   const absl::string_view prefix = absl::StartsWith(path, "/") ? "/" : absl::string_view();
   const absl::string_view suffix = absl::EndsWith(path, "/") ? "/" : absl::string_view();
   headers.setPath(absl::StrCat(
-      prefix, absl::StrJoin(absl::StrSplit(path, '/', absl::SkipEmpty()), "/"), query, suffix));
+      prefix, absl::StrJoin(absl::StrSplit(path, '/', absl::SkipEmpty()), "/"), suffix, query));
 }
 
 absl::string_view PathUtil::removeQueryAndFragment(const absl::string_view path) {

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -64,10 +64,11 @@ void PathUtil::mergeSlashes(RequestHeaderMap& headers) {
   if (path.find("//") == absl::string_view::npos) {
     return;
   }
-  const absl::string_view prefix = absl::StartsWith(path, "/") ? "/" : absl::string_view();
-  const absl::string_view suffix = absl::EndsWith(path, "/") ? "/" : absl::string_view();
-  headers.setPath(absl::StrCat(
-      prefix, absl::StrJoin(absl::StrSplit(path, '/', absl::SkipEmpty()), "/"), suffix, query));
+  const absl::string_view path_prefix = absl::StartsWith(path, "/") ? "/" : absl::string_view();
+  const absl::string_view path_suffix = absl::EndsWith(path, "/") ? "/" : absl::string_view();
+  headers.setPath(absl::StrCat(path_prefix,
+                               absl::StrJoin(absl::StrSplit(path, '/', absl::SkipEmpty()), "/"),
+                               path_suffix, query));
 }
 
 absl::string_view PathUtil::removeQueryAndFragment(const absl::string_view path) {

--- a/test/common/http/path_utility_test.cc
+++ b/test/common/http/path_utility_test.cc
@@ -105,6 +105,7 @@ TEST_F(PathUtilityTest, MergeSlashes) {
   EXPECT_EQ("/a/b/c", mergeSlashes("/a////b/c"));         // quadruple / in the middle
   EXPECT_EQ("/a/b?a=///c", mergeSlashes("/a//b?a=///c")); // slashes in the query are ignored
   EXPECT_EQ("/a/b?", mergeSlashes("/a//b?"));             // empty query
+  EXPECT_EQ("/a/?b", mergeSlashes("//a/?b"));             // ends with slash + query
 }
 
 TEST_F(PathUtilityTest, RemoveQueryAndFragment) {


### PR DESCRIPTION
Commit Message: Order of path suffix and query string was wrong, so the ending slash was moved to a query. Tests did not cover this scenario so add a new one.
Additional Description: n/a
Risk Level: low (bug fix)
Testing: added unit test
Docs Changes: n/a
Release Notes: added
Fixes #10912
