### PR TITLE
Adding explicit config for tracing on http conn manager.

### DIFF
--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -10,6 +10,8 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing:
+            verbose: true          
           generate_request_id: true
           codec_type: auto
           stat_prefix: ingress_http

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -10,6 +10,8 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing:
+            verbose: true          
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -38,6 +40,8 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing:
+            verbose: true          
           codec_type: auto
           stat_prefix: egress_http
           route_config:

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -10,6 +10,8 @@ static_resources:
       - name: envoy.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          tracing:
+            verbose: true          
           codec_type: auto
           stat_prefix: ingress_http
           route_config:


### PR DESCRIPTION
Signed-off-by: Andre Vegas <andrevegas@gmail.com>

Commit Message: Adding explicit config for tracing on http conn manager
Additional Description: without this config the sandbox examples didn't work out of the box. (v.13.1. - It might apply for 1.14 but not for 1.15 as there are changes on the config structure for tracing/zipkin)
Risk Level: Low
Testing: Run manual test with the zipkin examples.
Docs Changes: n/a
Release Notes: n/a

Cheers,
