### PR TITLE
hcm: avoid invoking 100-continue handling on decode filter.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -2067,7 +2067,7 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
   allowIteration();
 
   // Only resume with do100ContinueHeaders() if we've actually seen a 100-Continue.
-  if (parent_.state_.has_continue_headers_ && !continue_headers_continued_) {
+  if (has100Continueheaders()) {
     continue_headers_continued_ = true;
     do100ContinueHeaders();
     // If the response headers have not yet come in, don't continue on with

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -139,6 +139,7 @@ private:
     virtual Buffer::WatermarkBufferPtr createBuffer() PURE;
     virtual Buffer::WatermarkBufferPtr& bufferedData() PURE;
     virtual bool complete() PURE;
+    virtual bool has100Continueheaders() PURE;
     virtual void do100ContinueHeaders() PURE;
     virtual void doHeaders(bool end_stream) PURE;
     virtual void doData(bool end_stream) PURE;
@@ -237,6 +238,7 @@ private:
     Buffer::WatermarkBufferPtr createBuffer() override;
     Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_request_data_; }
     bool complete() override { return parent_.state_.remote_complete_; }
+    bool has100Continueheaders() override { return false; }
     void do100ContinueHeaders() override { NOT_REACHED_GCOVR_EXCL_LINE; }
     void doHeaders(bool end_stream) override {
       parent_.decodeHeaders(this, *parent_.request_headers_, end_stream);
@@ -349,6 +351,9 @@ private:
     Buffer::WatermarkBufferPtr createBuffer() override;
     Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_response_data_; }
     bool complete() override { return parent_.state_.local_complete_; }
+    bool has100Continueheaders() override {
+      return parent_.state_.has_continue_headers_ && !continue_headers_continued_;
+    }
     void do100ContinueHeaders() override {
       parent_.encode100ContinueHeaders(this, *parent_.continue_headers_);
     }

--- a/test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-5674283828772864
+++ b/test/common/http/conn_manager_impl_corpus/clusterfuzz-testcase-minimized-conn_manager_impl_fuzz_test-5674283828772864
@@ -1,0 +1,120 @@
+actions {
+  stream_action {
+    request {
+      trailers {
+        headers {
+          headers {
+            key: "foo"
+            value: "bar"
+          }
+        }
+        decoder_filter_callback_action {
+          add_decoded_data {
+            size: 1000000
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "foo.com"
+      }
+      headers {
+        key: "blah"
+        value: "nosniff"
+      }
+      headers {
+        key: "cookie"
+        value: "foo=bar"
+      }
+      headers {
+        key: "cookie"
+        value: "foo2=bar2"
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data {
+        size: 3000000
+        status: DATA_STOP_ITERATION_AND_BUFFER
+        decoder_filter_callback_action {
+          add_decoded_data {
+            size: 1000000
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      trailers {
+        headers {
+          key: "foo"
+          value: "bar"
+        }
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 5505024
+  }
+}
+actions {
+  stream_action {
+    response {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      continue_decoding {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 5
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+        headers {
+          key: ":status"
+          value: "200"
+        }
+      }
+    }
+  }
+}

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -596,6 +596,7 @@ envoy_cc_test(
         "//test/integration/filters:clear_route_cache_filter_lib",
         "//test/integration/filters:encoder_decoder_buffer_filter_lib",
         "//test/integration/filters:process_context_lib",
+        "//test/integration/filters:stop_iteration_and_continue",
         "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -256,6 +256,16 @@ TEST_P(IntegrationTest, EnvoyProxyingLate100ContinueWithEncoderFilter) {
   testEnvoyProxying100Continue(false, true);
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/10923.
+TEST_P(IntegrationTest, EnvoyProxying100ContinueWithDecodeDataPause) {
+  config_helper_.addFilter(R"EOF(
+  name: stop-iteration-and-continue-filter
+  typed_config:
+    "@type": type.googleapis.com/google.protobuf.Empty
+  )EOF");
+  testEnvoyProxying100Continue(true);
+}
+
 // This is a regression for https://github.com/envoyproxy/envoy/issues/2715 and validates that a
 // pending request is not sent on a connection that has been half-closed.
 TEST_P(IntegrationTest, UpstreamDisconnectWithTwoRequests) {


### PR DESCRIPTION
The 100-continue state tracking variables were checked in
commonContinue() (on both decode/encode paths), conditioning
do100ContinueHeaders(). This makes no sense on the decode path, and can
lead to crashes as per #10923 when the decode pipeline is resumed, so
refactored the logic out to just the encode path.

Risk level: Low
Testing: Unit and integration regression tests added, as well as corpus
  entry.

Fixes oss-fuzz issue
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18461

Fixes #10923

Signed-off-by: Harvey Tuch <htuch@google.com>