### PR TITLE
Windows compilation: expected_span_name is not captured by the lambda with MSVC

### DIFF
--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -111,7 +111,7 @@ TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
 
   const XRay::Span* xray_parent_span = static_cast<XRay::Span*>(parent_span.get());
   const std::string expected_parent_id = xray_parent_span->id();
-  auto on_send = [xray_parent_span, expected_parent_id](const std::string& json) {
+  auto on_send = [&](const std::string& json) {
     ASSERT_FALSE(json.empty());
     daemon::Segment s;
     MessageUtil::loadFromJson(json, s, ProtobufMessage::getNullValidationVisitor());


### PR DESCRIPTION
Commit Message: Ensure expected_span_name is captured by lamda with MSVC
Additional Description: MSVC's lambda capture rules are more strict, it seems in this case this variable has to be explicitly captured or captured with the capture default
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
