### PR TITLE
docs: add overview of certificate management options

### DIFF
--- a/docs/root/operations/certificates.rst
+++ b/docs/root/operations/certificates.rst
@@ -8,6 +8,8 @@ Envoy provides several mechanisms for cert management. At a high level they can 
 1. Static :ref:`CommonTlsContext <envoy_api_msg_auth.CommonTlsContext>` referenced certificates.
    These will *not* reload automatically, and requires either a restart of the proxy or
    reloading the clusters/listeners that reference them.
+   :ref:`Hot restarting <arch_overview_hot_restart>` can be used here to pick up the new
+   certificates without dropping traffic.
 2. :ref:`Secret Discovery Service <config_secret_discovery_service>` referenced certificates.
    By using SDS, certificates can either be referenced as files (reloading the certs when the
    parent directory is moved) or through an external SDS server that can push new certificates.

--- a/docs/root/operations/certificates.rst
+++ b/docs/root/operations/certificates.rst
@@ -1,0 +1,13 @@
+.. _operations_certificates:
+
+Certificate Management
+======================
+
+Envoy provides several mechanisms for cert management. At a high level they can be broken into
+
+1. Static :ref:`CommonTlsContext <envoy_api_msg_auth.CommonTlsContext>` referenced certificates.
+   These will *not* reload automatically, and requires either a restart of the proxy or
+   reloading the clusters/listeners that reference them.
+2. :ref:`Secret Discovery Service <config_secret_discovery_service>` referenced certificates.
+   By using SDS, certificates can either be referenced as files (reloading the certs when the
+   parent directory is moved) or through an external SDS server that can push new certificates.

--- a/docs/root/operations/operations.rst
+++ b/docs/root/operations/operations.rst
@@ -13,4 +13,5 @@ Operations and administration
   runtime
   fs_flags
   traffic_tapping
+  certificates
   performance


### PR DESCRIPTION
Took a stab at providing a high level doc on what options are available, let me know if I missed something.

Signed-off-by: Snow Pettersen <kpettersen@netflix.com>

Commit Message: Adds a new page to the operations section about what options are available for managing certificates.
Additional Description: n/a
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
