### PR TITLE
Silence all proto logs in fuzz tests

### DIFF
--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -48,9 +48,11 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
       new Logger::Context(log_level_, TestEnvironment::getOptions().logFormat(), *lock, false);
   UNREFERENCED_PARAMETER(logging_context);
 
-  // Suppress all libprotobuf logging as long as this object exists.
-  // For fuzzing, this disables all logs when parsing text-format corpus fails.
-  static auto* log_silencer = new Protobuf::LogSilencer();
+  // Suppress all libprotobuf non-fatal logging as long as this object exists.
+  // For fuzzing, this prevents logging when parsing text-format protos fails,
+  // deprecated fields are used, etc.
+  // https://github.com/protocolbuffers/protobuf/blob/204f99488ce1ef74565239cf3963111ae4c774b7/src/google/protobuf/stubs/logging.h#L223
+  ABSL_ATTRIBUTE_UNUSED static auto* log_silencer = new Protobuf::LogSilencer();
 }
 
 } // namespace Fuzz

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -47,6 +47,10 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
   static auto* logging_context =
       new Logger::Context(log_level_, TestEnvironment::getOptions().logFormat(), *lock, false);
   UNREFERENCED_PARAMETER(logging_context);
+
+  // Suppress all libprotobuf logging as long as this object exists.
+  // For fuzzing, this disables all logs when parsing text-format corpus fails.
+  static auto* log_silencer = new Protobuf::LogSilencer();
 }
 
 } // namespace Fuzz


### PR DESCRIPTION
Description: OSS Fuzz reports a large number for the `avg_unwanted_log_lines` statistic in each fuzz test. Reduce the number of logs by silencing all `libprotobuf` non-fatal logging while running fuzz tests.

This change removes logs such as:
```
[libprotobuf WARNING external/com_google_protobuf/src/google/protobuf/text_format.cc:324] Warning parsing text-format envoy.config.bootstrap.v3.Bootstrap: 10:1: text format contains deprecated field "tracing"
[libprotobuf ERROR external/com_google_protobuf/src/google/protobuf/wire_format_lite.cc:578] String field '' contains invalid UTF-8 data when parsing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes.
```

Implementation notes:
- Taken from the libprotobuf-mutator [libfuzzer example](https://github.com/google/libprotobuf-mutator/blob/ec3cf7166aa7a190d9b6e81583dcc926e2f312cf/examples/libfuzzer/libfuzzer_example.cc#L22)
- Did not see much of a difference in executions per second. I tested against ESPv2's `iam_token_info_fuzz_test`. Before = 1052; After = 1100

Testing: Verified libprotobuf logs no longer appear when running `_with_libfuzzer`.

Signed-off-by: Teju Nareddy <nareddyt@google.com>