### PR TITLE
Windows: Tag failing tests

### DIFF
--- a/test/common/access_log/BUILD
+++ b/test/common/access_log/BUILD
@@ -36,6 +36,7 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "access_log_formatter_test",
     srcs = ["access_log_formatter_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/access_log:access_log_formatter_lib",
         "//source/common/common:utility_lib",
@@ -108,4 +109,5 @@ envoy_cc_benchmark_binary(
 envoy_benchmark_test(
     name = "access_log_formatter_speed_test_benchmark_test",
     benchmark_binary = "access_log_formatter_speed_test",
+    tags = ["fails_on_windows"],
 )

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "filesystem_subscription_impl_test",
     srcs = ["filesystem_subscription_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":filesystem_subscription_test_harness",
         "//test/mocks/event:event_mocks",
@@ -271,6 +272,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "subscription_impl_test",
     srcs = ["subscription_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":delta_subscription_test_harness",
         ":filesystem_subscription_test_harness",

--- a/test/common/filesystem/BUILD
+++ b/test/common/filesystem/BUILD
@@ -29,6 +29,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "watcher_impl_test",
     srcs = ["watcher_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -16,6 +16,7 @@ envoy_package()
 envoy_cc_test(
     name = "async_client_impl_test",
     srcs = ["async_client_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":common_lib",
         "//source/common/buffer:buffer_lib",
@@ -191,6 +192,7 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "conn_manager_impl_test",
     srcs = ["conn_manager_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",

--- a/test/common/http/http1/BUILD
+++ b/test/common/http/http1/BUILD
@@ -19,6 +19,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "codec_impl_test",
     srcs = ["codec_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/event:dispatcher_interface",
@@ -44,6 +45,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "conn_pool_test",
     srcs = ["conn_pool_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_lib",

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     name = "codec_impl_test",
     srcs = ["codec_impl_test.cc"],
     shard_count = 5,
+    tags = ["fails_on_windows"],
     deps = [
         ":codec_impl_test_util",
         "//source/common/event:dispatcher_lib",
@@ -50,6 +51,7 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "conn_pool_test",
     srcs = ["conn_pool_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/http/http2:conn_pool_lib",
@@ -102,6 +104,7 @@ envoy_cc_test(
         "response_header_corpus/simple_example_huffman",
         "response_header_corpus/simple_example_plain",
     ],
+    tags = ["fails_on_windows"],
     deps = [":frame_replay_lib"],
 )
 

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -33,6 +33,7 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "address_impl_test",
     srcs = ["address_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",
@@ -58,6 +59,7 @@ envoy_cc_benchmark_binary(
 envoy_benchmark_test(
     name = "address_impl_speed_test_benchmark_test",
     benchmark_binary = "address_impl_speed_test",
+    tags = ["fails_on_windows"],
 )
 
 envoy_cc_test(
@@ -100,6 +102,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "dns_impl_test",
     srcs = ["dns_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:address_interface",
@@ -164,6 +167,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "listen_socket_impl_test",
     srcs = ["listen_socket_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:listen_socket_lib",
@@ -200,6 +204,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "udp_listener_impl_test",
     srcs = ["udp_listener_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/network:address_lib",
@@ -261,6 +266,7 @@ envoy_cc_test(
     name = "socket_option_factory_test",
     srcs = ["socket_option_factory_test.cc"],
     external_deps = ["abseil_str_format"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:socket_option_factory_lib",
@@ -276,6 +282,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "addr_family_aware_socket_option_impl_test",
     srcs = ["addr_family_aware_socket_option_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":socket_option_test",
         "//source/common/network:addr_family_aware_socket_option_lib",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -15,6 +15,7 @@ envoy_package()
 
 envoy_cc_test(
     name = "config_impl_test",
+    tags = ["fails_on_windows"],
     deps = [":config_impl_test_lib"],
 )
 
@@ -252,6 +253,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "router_test",
     srcs = ["router_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:context_lib",
@@ -283,6 +285,7 @@ envoy_cc_test(
     name = "router_upstream_log_test",
     srcs = ["router_upstream_log_test.cc"],
     external_deps = ["abseil_optional"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/network:utility_lib",

--- a/test/common/secret/BUILD
+++ b/test/common/secret/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     data = [
         "//test/extensions/transport_sockets/tls/test_data:certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/secret:sds_api_lib",
         "//source/common/secret:secret_manager_impl_lib",

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -99,6 +99,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "health_checker_impl_test",
     srcs = ["health_checker_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":utility_lib",
         "//source/common/buffer:buffer_lib",
@@ -181,6 +182,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "load_stats_reporter_test",
     srcs = ["load_stats_reporter_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/stats:stats_lib",
         "//source/common/upstream:load_stats_reporter_lib",
@@ -362,6 +364,7 @@ envoy_benchmark_test(
     name = "load_balancer_benchmark_test",
     timeout = "long",
     benchmark_binary = "load_balancer_benchmark",
+    tags = ["fails_on_windows"],
 )
 
 envoy_cc_test(

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -22,6 +22,7 @@ envoy_cc_test(
         "example_configs_test_setup.sh",
         "//configs:example_configs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":config_test_lib",
         "//test/test_common:environment_lib",

--- a/test/dependencies/BUILD
+++ b/test/dependencies/BUILD
@@ -14,4 +14,5 @@ envoy_cc_test(
     external_deps = [
         "curl",
     ],
+    tags = ["fails_on_windows"],
 )

--- a/test/extensions/access_loggers/grpc/BUILD
+++ b/test/extensions/access_loggers/grpc/BUILD
@@ -77,6 +77,7 @@ envoy_extension_cc_test(
     name = "http_grpc_access_log_integration_test",
     srcs = ["http_grpc_access_log_integration_test.cc"],
     extension_name = "envoy.access_loggers.http_grpc",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:zero_copy_input_stream_lib",
         "//source/common/grpc:codec_lib",
@@ -96,6 +97,7 @@ envoy_extension_cc_test(
     name = "tcp_grpc_access_log_integration_test",
     srcs = ["tcp_grpc_access_log_integration_test.cc"],
     extension_name = "envoy.access_loggers.http_grpc",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:zero_copy_input_stream_lib",
         "//source/common/grpc:codec_lib",

--- a/test/extensions/clusters/aggregate/BUILD
+++ b/test/extensions/clusters/aggregate/BUILD
@@ -53,6 +53,7 @@ envoy_extension_cc_test(
     name = "cluster_integration_test",
     srcs = ["cluster_integration_test.cc"],
     extension_name = "envoy.clusters.aggregate",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/config:protobuf_link_hacks",
         "//source/common/protobuf:utility_lib",

--- a/test/extensions/clusters/redis/BUILD
+++ b/test/extensions/clusters/redis/BUILD
@@ -88,6 +88,7 @@ envoy_extension_cc_test(
     size = "small",
     srcs = ["redis_cluster_integration_test.cc"],
     extension_name = "envoy.clusters.redis",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/clusters/redis:redis_cluster",
         "//source/extensions/clusters/redis:redis_cluster_lb",

--- a/test/extensions/common/aws/BUILD
+++ b/test/extensions/common/aws/BUILD
@@ -76,6 +76,7 @@ envoy_cc_test(
     srcs = [
         "aws_metadata_fetcher_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:fmt_lib",
         "//source/extensions/common/aws:utility_lib",

--- a/test/extensions/common/proxy_protocol/BUILD
+++ b/test/extensions/common/proxy_protocol/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "proxy_protocol_regression_test",
     srcs = ["proxy_protocol_regression_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/extensions/filters/common/lua/BUILD
+++ b/test/extensions/filters/common/lua/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "wrappers_test",
     srcs = ["wrappers_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":lua_wrappers_lib",
         "//source/common/buffer:buffer_lib",

--- a/test/extensions/filters/http/adaptive_concurrency/BUILD
+++ b/test/extensions/filters/http/adaptive_concurrency/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
         "adaptive_concurrency_filter_integration_test.h",
     ],
     extension_name = "envoy.filters.http.adaptive_concurrency",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/adaptive_concurrency:config",
         "//source/extensions/filters/http/fault:config",

--- a/test/extensions/filters/http/aws_lambda/BUILD
+++ b/test/extensions/filters/http/aws_lambda/BUILD
@@ -27,6 +27,7 @@ envoy_extension_cc_test(
     name = "aws_lambda_filter_integration_test",
     srcs = ["aws_lambda_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.aws_lambda",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/http:header_map_lib",
         "//source/extensions/filters/http/aws_lambda:aws_lambda_filter_lib",

--- a/test/extensions/filters/http/buffer/BUILD
+++ b/test/extensions/filters/http/buffer/BUILD
@@ -36,6 +36,7 @@ envoy_extension_cc_test(
     name = "buffer_filter_integration_test",
     srcs = ["buffer_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.buffer",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/buffer:config",
         "//test/config:utility_lib",

--- a/test/extensions/filters/http/cache/BUILD
+++ b/test/extensions/filters/http/cache/BUILD
@@ -65,6 +65,7 @@ envoy_extension_cc_test(
         "cache_filter_integration_test.cc",
     ],
     extension_name = "envoy.filters.http.cache",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/cache:config",
         "//source/extensions/filters/http/cache:http_cache_lib",

--- a/test/extensions/filters/http/cors/BUILD
+++ b/test/extensions/filters/http/cors/BUILD
@@ -30,6 +30,7 @@ envoy_extension_cc_test(
     name = "cors_filter_integration_test",
     srcs = ["cors_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.cors",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",

--- a/test/extensions/filters/http/csrf/BUILD
+++ b/test/extensions/filters/http/csrf/BUILD
@@ -31,6 +31,7 @@ envoy_extension_cc_test(
     name = "csrf_filter_integration_test",
     srcs = ["csrf_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.csrf",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/csrf:config",
         "//test/config:utility_lib",

--- a/test/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -32,6 +32,7 @@ envoy_extension_cc_test(
         "//test/config/integration/certs",
     ],
     extension_name = "envoy.filters.http.dynamic_forward_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "//source/extensions/filters/http/dynamic_forward_proxy:config",

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -57,6 +57,7 @@ envoy_extension_cc_test(
     name = "ext_authz_integration_test",
     srcs = ["ext_authz_integration_test.cc"],
     extension_name = "envoy.filters.http.ext_authz",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/ext_authz:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/http/fault/BUILD
+++ b/test/extensions/filters/http/fault/BUILD
@@ -54,6 +54,7 @@ envoy_extension_cc_test(
     name = "fault_filter_integration_test",
     srcs = ["fault_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.fault",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/fault:config",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/BUILD
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/BUILD
@@ -28,6 +28,7 @@ envoy_extension_cc_test(
     name = "reverse_bridge_integration_test",
     srcs = ["reverse_bridge_integration_test.cc"],
     extension_name = "envoy.filters.http.grpc_http1_reverse_bridge",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",

--- a/test/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/test/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -61,6 +61,7 @@ envoy_extension_cc_test(
         "//test/proto:bookstore_proto_descriptor",
     ],
     extension_name = "envoy.filters.http.grpc_json_transcoder",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/grpc:codec_lib",
         "//source/common/http:header_map_lib",

--- a/test/extensions/filters/http/gzip/BUILD
+++ b/test/extensions/filters/http/gzip/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
         "gzip_filter_integration_test.cc",
     ],
     extension_name = "envoy.filters.http.gzip",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/decompressor:decompressor_lib",
         "//source/extensions/filters/http/gzip:config",

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -117,6 +117,7 @@ envoy_extension_cc_test(
     name = "filter_integration_test",
     srcs = ["filter_integration_test.cc"],
     extension_name = "envoy.filters.http.jwt_authn",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/router:string_accessor_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -15,6 +15,7 @@ envoy_extension_cc_test(
     name = "lua_filter_test",
     srcs = ["lua_filter_test.cc"],
     extension_name = "envoy.filters.http.lua",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/http/lua:lua_filter_lib",
@@ -33,6 +34,7 @@ envoy_extension_cc_test(
     name = "wrappers_test",
     srcs = ["wrappers_test.cc"],
     extension_name = "envoy.filters.http.lua",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/http/lua:wrappers_lib",
@@ -47,6 +49,7 @@ envoy_extension_cc_test(
     name = "lua_integration_test",
     srcs = ["lua_integration_test.cc"],
     extension_name = "envoy.filters.http.lua",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/lua:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/http/rbac/BUILD
+++ b/test/extensions/filters/http/rbac/BUILD
@@ -44,6 +44,7 @@ envoy_extension_cc_test(
     name = "rbac_filter_integration_test",
     srcs = ["rbac_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.rbac",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/rbac:config",
         "//test/config:utility_lib",

--- a/test/extensions/filters/http/router/BUILD
+++ b/test/extensions/filters/http/router/BUILD
@@ -30,6 +30,7 @@ envoy_extension_cc_test(
         "//test/config/integration/certs",
     ],
     extension_name = "envoy.filters.http.router",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/router:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/http/squash/BUILD
+++ b/test/extensions/filters/http/squash/BUILD
@@ -32,6 +32,7 @@ envoy_extension_cc_test(
     name = "squash_filter_integration_test",
     srcs = ["squash_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.squash",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/squash:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/http/tap/BUILD
+++ b/test/extensions/filters/http/tap/BUILD
@@ -52,6 +52,7 @@ envoy_extension_cc_test(
     name = "tap_filter_integration_test",
     srcs = ["tap_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.tap",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/tap:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/listener/http_inspector/BUILD
+++ b/test/extensions/filters/listener/http_inspector/BUILD
@@ -15,6 +15,7 @@ envoy_extension_cc_test(
     name = "http_inspector_test",
     srcs = ["http_inspector_test.cc"],
     extension_name = "envoy.filters.listener.http_inspector",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:hex_lib",
         "//source/extensions/filters/listener/http_inspector:http_inspector_lib",

--- a/test/extensions/filters/listener/original_src/BUILD
+++ b/test/extensions/filters/listener/original_src/BUILD
@@ -25,6 +25,7 @@ envoy_extension_cc_test(
     name = "original_src_config_factory_test",
     srcs = ["original_src_config_factory_test.cc"],
     extension_name = "envoy.filters.listener.original_src",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/listener/original_src:config",
         "//source/extensions/filters/listener/original_src:config_lib",

--- a/test/extensions/filters/listener/proxy_protocol/BUILD
+++ b/test/extensions/filters/listener/proxy_protocol/BUILD
@@ -15,6 +15,7 @@ envoy_extension_cc_test(
     name = "proxy_protocol_test",
     srcs = ["proxy_protocol_test.cc"],
     extension_name = "envoy.filters.listener.proxy_protocol",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/extensions/filters/network/local_ratelimit/BUILD
+++ b/test/extensions/filters/network/local_ratelimit/BUILD
@@ -28,6 +28,7 @@ envoy_extension_cc_test(
     name = "local_ratelimit_integration_test",
     srcs = ["local_ratelimit_integration_test.cc"],
     extension_name = "envoy.filters.network.local_ratelimit",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/network/local_ratelimit:config",
         "//source/extensions/filters/network/tcp_proxy:config",

--- a/test/extensions/filters/network/mysql_proxy/BUILD
+++ b/test/extensions/filters/network/mysql_proxy/BUILD
@@ -40,6 +40,7 @@ envoy_extension_cc_test(
         "mysql_filter_test.cc",
     ],
     extension_name = "envoy.filters.network.mysql_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         ":mysql_test_utils_lib",
         "//source/extensions/filters/network/mysql_proxy:config",
@@ -56,6 +57,7 @@ envoy_extension_cc_test(
         "mysql_test_config.yaml",
     ],
     extension_name = "envoy.filters.network.mysql_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         ":mysql_test_utils_lib",
         "//source/common/tcp_proxy",

--- a/test/extensions/filters/network/postgres_proxy/BUILD
+++ b/test/extensions/filters/network/postgres_proxy/BUILD
@@ -57,6 +57,7 @@ envoy_extension_cc_test(
         "postgres_test_config.yaml",
     ],
     extension_name = "envoy.filters.network.postgres_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/tcp_proxy",
         "//source/extensions/filters/network/postgres_proxy:config",

--- a/test/extensions/filters/network/rbac/BUILD
+++ b/test/extensions/filters/network/rbac/BUILD
@@ -41,6 +41,7 @@ envoy_extension_cc_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     extension_name = "envoy.filters.network.rbac",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/network/echo:config",
         "//source/extensions/filters/network/rbac:config",

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -35,6 +35,7 @@ envoy_extension_cc_test(
     name = "conn_pool_impl_test",
     srcs = ["conn_pool_impl_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         ":redis_mocks",
         "//source/common/event:dispatcher_lib",
@@ -145,6 +146,7 @@ envoy_extension_cc_test(
     name = "redis_proxy_integration_test",
     srcs = ["redis_proxy_integration_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/network/redis_proxy:config",
         "//test/integration:integration_lib",

--- a/test/extensions/filters/network/rocketmq_proxy/BUILD
+++ b/test/extensions/filters/network/rocketmq_proxy/BUILD
@@ -49,6 +49,7 @@ envoy_extension_cc_test(
     name = "router_test",
     srcs = ["router_test.cc"],
     extension_name = "envoy.filters.network.rocketmq_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         ":mocks_lib",
         ":utility_lib",

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/BUILD
@@ -32,6 +32,7 @@ envoy_extension_cc_test(
         "//test/config/integration/certs",
     ],
     extension_name = "envoy.filters.network.sni_dynamic_forward_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "//source/extensions/filters/listener/tls_inspector:config",

--- a/test/extensions/filters/network/thrift_proxy/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/BUILD
@@ -333,6 +333,7 @@ envoy_extension_cc_test(
         "//test/extensions/filters/network/thrift_proxy/driver:generate_fixture",
     ],
     extension_name = "envoy.filters.network.thrift_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         ":utility_lib",
@@ -349,6 +350,7 @@ envoy_extension_cc_test(
         "//test/extensions/filters/network/thrift_proxy/driver:generate_fixture",
     ],
     extension_name = "envoy.filters.network.thrift_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         ":utility_lib",

--- a/test/extensions/filters/udp/udp_proxy/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/BUILD
@@ -27,6 +27,7 @@ envoy_extension_cc_test(
     name = "udp_proxy_integration_test",
     srcs = ["udp_proxy_integration_test.cc"],
     extension_name = "envoy.filters.udp_listener.udp_proxy",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/udp/udp_proxy:config",
         "//test/integration:integration_lib",

--- a/test/extensions/grpc_credentials/aws_iam/BUILD
+++ b/test/extensions/grpc_credentials/aws_iam/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test(
     name = "aws_iam_grpc_credentials_test",
     srcs = envoy_select_google_grpc(["aws_iam_grpc_credentials_test.cc"]),
     data = ["//test/config/integration/certs"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/grpc_credentials:well_known_names",
         "//source/extensions/grpc_credentials/aws_iam:config",

--- a/test/extensions/grpc_credentials/file_based_metadata/BUILD
+++ b/test/extensions/grpc_credentials/file_based_metadata/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test(
     name = "file_based_metadata_grpc_credentials_test",
     srcs = ["file_based_metadata_grpc_credentials_test.cc"],
     data = ["//test/config/integration/certs"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/grpc_credentials:well_known_names",
         "//source/extensions/grpc_credentials/file_based_metadata:config",

--- a/test/extensions/resource_monitors/injected_resource/BUILD
+++ b/test/extensions/resource_monitors/injected_resource/BUILD
@@ -15,6 +15,7 @@ envoy_package()
 envoy_cc_test(
     name = "injected_resource_monitor_test",
     srcs = ["injected_resource_monitor_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/stats:isolated_store_lib",

--- a/test/extensions/stats_sinks/common/statsd/BUILD
+++ b/test/extensions/stats_sinks/common/statsd/BUILD
@@ -30,6 +30,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "udp_statsd_test",
     srcs = ["udp_statsd_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",

--- a/test/extensions/stats_sinks/hystrix/BUILD
+++ b/test/extensions/stats_sinks/hystrix/BUILD
@@ -44,6 +44,7 @@ envoy_extension_cc_test(
     name = "hystrix_integration_test",
     srcs = ["hystrix_integration_test.cc"],
     extension_name = "envoy.stat_sinks.hystrix",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/stat_sinks/hystrix:config",
         "//test/integration:http_protocol_integration_lib",

--- a/test/extensions/stats_sinks/metrics_service/BUILD
+++ b/test/extensions/stats_sinks/metrics_service/BUILD
@@ -45,6 +45,7 @@ envoy_extension_cc_test(
     name = "metrics_service_integration_test",
     srcs = ["metrics_service_integration_test.cc"],
     extension_name = "envoy.stat_sinks.metrics_service",
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:zero_copy_input_stream_lib",
         "//source/common/grpc:codec_lib",

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -76,6 +76,7 @@ envoy_extension_cc_test(
     external_deps = [
         "grpc_alts_fake_handshaker_server",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/extensions/transport_sockets/tls/integration/BUILD
+++ b/test/extensions/transport_sockets/tls/integration/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -49,6 +49,7 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "ads_integration_test",
     srcs = ["ads_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":ads_integration_lib",
         ":http_integration_lib",
@@ -69,6 +70,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "api_listener_integration_test",
     srcs = ["api_listener_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/mocks/http:stream_encoder_mock",
@@ -79,6 +81,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "api_version_integration_test",
     srcs = ["api_version_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
@@ -109,6 +112,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/config:protobuf_link_hacks",
@@ -154,6 +158,7 @@ envoy_cc_test(
     srcs = [
         "filter_manager_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":filter_manager_integration_proto_cc_proto",
         ":http_integration_lib",
@@ -173,6 +178,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "cluster_filter_integration_test",
     srcs = ["cluster_filter_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//include/envoy/network:filter_interface",
@@ -186,6 +192,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "custom_cluster_integration_test",
     srcs = ["custom_cluster_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/upstream:load_balancer_lib",
@@ -203,6 +210,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/config:protobuf_link_hacks",
@@ -251,6 +259,7 @@ envoy_cc_test(
     srcs = [
         "header_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/config:api_version_lib",
@@ -271,6 +280,7 @@ envoy_cc_test(
         "http2_integration_test.cc",
         "http2_integration_test.h",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/buffer:buffer_lib",
@@ -296,6 +306,7 @@ envoy_cc_test(
     srcs = [
         "http_subset_lb_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/common/upstream:utility_lib",
@@ -314,6 +325,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/extensions/transport_sockets/tls:context_lib",
@@ -330,6 +342,7 @@ envoy_cc_test(
     srcs = [
         "header_casing_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
@@ -343,6 +356,7 @@ envoy_cc_test(
         "http_timeout_integration_test.cc",
         "http_timeout_integration_test.h",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
@@ -358,6 +372,7 @@ envoy_cc_test(
     # As this test has many H1/H2/v4/v6 tests it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 5,
+    tags = ["fails_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
@@ -378,6 +393,7 @@ envoy_cc_test(
         "http2_upstream_integration_test.cc",
         "http2_upstream_integration_test.h",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/http:header_map_lib",
@@ -398,6 +414,7 @@ envoy_cc_test(
         "integration_admin_test.cc",
         "integration_admin_test.h",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//include/envoy/http:header_map_interface",
@@ -475,6 +492,7 @@ envoy_cc_test(
     # As this test has many pauses for idle timeouts, it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 2,
+    tags = ["fails_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//test/test_common:test_time_lib",
@@ -609,6 +627,7 @@ envoy_cc_test(
     srcs = [
         "redirect_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
@@ -665,6 +684,7 @@ envoy_cc_test(
     # The symbol table cluster memory tests take a while to run specially under tsan.
     # Shard it to avoid test timeout.
     shard_count = 2,
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//source/common/memory:stats_lib",
@@ -682,6 +702,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "load_stats_integration_test",
     srcs = ["load_stats_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/config:utility_lib",
@@ -699,6 +720,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "hds_integration_test",
     srcs = ["hds_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         ":integration_lib",
@@ -722,6 +744,7 @@ envoy_cc_test(
     name = "header_prefix_integration_test",
     srcs = ["header_prefix_integration_test.cc"],
     coverage = False,
+    tags = ["fails_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
@@ -731,6 +754,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "overload_integration_test",
     srcs = ["overload_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//source/extensions/resource_monitors/injected_resource:config",
@@ -745,6 +769,7 @@ envoy_cc_test(
         "proxy_proto_integration_test.cc",
         "proxy_proto_integration_test.h",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/buffer:buffer_lib",
@@ -759,6 +784,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "ratelimit_integration_test",
     srcs = ["ratelimit_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/buffer:zero_copy_input_stream_lib",
@@ -777,6 +803,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "rtds_integration_test",
     srcs = ["rtds_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/common/grpc:grpc_client_integration_lib",
@@ -798,6 +825,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/event:dispatcher_includes",
@@ -822,6 +850,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/config:api_version_lib",
@@ -851,6 +880,7 @@ envoy_cc_test(
     srcs = [
         "sds_generic_secret_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//include/envoy/registry",
@@ -872,6 +902,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//source/common/config:api_version_lib",
@@ -903,6 +934,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         ":http_protocol_integration_lib",
@@ -917,6 +949,7 @@ envoy_cc_test(
     srcs = [
         "tcp_conn_pool_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//include/envoy/server:filter_config_interface",
@@ -943,6 +976,7 @@ envoy_cc_test(
         "uds_integration_test.cc",
         "uds_integration_test.h",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/event:dispatcher_includes",
@@ -957,6 +991,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "version_integration_test",
     srcs = ["version_integration_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/extensions/filters/http/ip_tagging:config",
@@ -967,6 +1002,7 @@ envoy_cc_test(
     name = "dynamic_validation_integration_test",
     srcs = ["dynamic_validation_integration_test.cc"],
     data = ["//test/config/integration:server_xds_files"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/stats:stats_lib",
@@ -979,6 +1015,7 @@ envoy_cc_test(
     name = "xds_integration_test",
     srcs = ["xds_integration_test.cc"],
     data = ["//test/config/integration:server_xds_files"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         ":http_protocol_integration_lib",
@@ -998,6 +1035,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/http:header_map_lib",
@@ -1076,6 +1114,7 @@ envoy_cc_test(
     srcs = [
         "scoped_rds_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/config:api_version_lib",
@@ -1099,6 +1138,7 @@ envoy_cc_test(
     srcs = [
         "listener_lds_integration_test.cc",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/config:api_version_lib",
@@ -1125,6 +1165,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//source/common/config:api_version_lib",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -164,6 +164,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "overload_manager_impl_test",
     srcs = ["overload_manager_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/registry",
         "//source/common/stats:isolated_store_lib",
@@ -222,6 +223,7 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "listener_manager_impl_test",
     srcs = ["listener_manager_impl_test.cc"],
+    tags = ["fails_on_windows"],
     deps = [
         ":listener_manager_impl_test_lib",
         ":utility_lib",
@@ -343,6 +345,7 @@ envoy_cc_test(
         ":server_test_data",
         ":static_validation_test_data",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:version_lib",
         "//source/extensions/access_loggers/file:config",
@@ -428,4 +431,5 @@ envoy_benchmark_test(
     name = "filter_chain_benchmark_test_benchmark_test",
     timeout = "long",
     benchmark_binary = "filter_chain_benchmark_test",
+    tags = ["fails_on_windows"],
 )

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -55,6 +55,7 @@ envoy_cc_test(
         "//configs:example_configs",
         "//test/config_test:example_configs_test_setup.sh",
     ],
+    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",


### PR DESCRIPTION
Commit Message: Tag tests that fail on Windows with fails_on_windows
Additional Description:
- 139 tests tagged in total now, a few of which are flaky and don't fail every invocation
- To enable contributors are to work on fixing these failed tests and to give a view into what progress still needs to be made
- When we are able to get CI working to build/run tests on Windows, we can ignore the tagged tests and untag them as they are fixed
- It appears a large portion of the tests will be fixable with a few patches
- there are also assumptions in test setup/teardown etc. that are not compatible with Windows at the moment
- a large percentage of the failing tests are integration tests

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
