### PR TITLE
http: replace vector/reserve with InlinedVector in codec helper

### DIFF
--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -54,7 +54,7 @@ public:
   bool local_end_stream_{};
 
 protected:
-  void addCallbacks_(StreamCallbacks& callbacks) {
+  void addCallbacksHelper(StreamCallbacks& callbacks) {
     ASSERT(!reset_callbacks_started_ && !local_end_stream_);
     callbacks_.push_back(&callbacks);
     for (uint32_t i = 0; i < high_watermark_callbacks_; ++i) {
@@ -62,12 +62,12 @@ protected:
     }
   }
 
-  void removeCallbacks_(StreamCallbacks& callbacks) {
+  void removeCallbacksHelper(StreamCallbacks& callbacks) {
     // For performance reasons we just clear the callback and do not resize the vector.
     // Reset callbacks scale with the number of filters per request and do not get added and
     // removed multiple times.
     // The vector may not be safely resized without making sure the run.*Callbacks() helper
-    // functions above still handle removeCallbacks_() calls mid-loop.
+    // functions above still handle removeCallbacksHelper() calls mid-loop.
     for (auto& callback : callbacks_) {
       if (callback == &callbacks) {
         callback = nullptr;

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <vector>
-
 #include "envoy/http/codec.h"
 
 #include "common/common/assert.h"
+
+#include "absl/container/inlined_vector.h"
 
 namespace Envoy {
 namespace Http {
@@ -54,11 +54,6 @@ public:
   bool local_end_stream_{};
 
 protected:
-  StreamCallbackHelper() {
-    // Set space for 8 callbacks (64 bytes).
-    callbacks_.reserve(8);
-  }
-
   void addCallbacks_(StreamCallbacks& callbacks) {
     ASSERT(!reset_callbacks_started_ && !local_end_stream_);
     callbacks_.push_back(&callbacks);
@@ -82,7 +77,7 @@ protected:
   }
 
 private:
-  std::vector<StreamCallbacks*> callbacks_;
+  absl::InlinedVector<StreamCallbacks*, 8> callbacks_;
   bool reset_callbacks_started_{};
   uint32_t high_watermark_callbacks_{};
 };

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -272,7 +272,7 @@ RequestDecoder& ConnectionManagerImpl::newStream(ResponseEncoder& response_encod
   new_stream->response_encoder_->getStream().addCallbacks(*new_stream);
   new_stream->buffer_limit_ = new_stream->response_encoder_->getStream().bufferLimit();
   // If the network connection is backed up, the stream should be made aware of it on creation.
-  // Both HTTP/1.x and HTTP/2 codecs handle this in StreamCallbackHelper::addCallbacks_.
+  // Both HTTP/1.x and HTTP/2 codecs handle this in StreamCallbackHelper::addCallbacksHelper.
   ASSERT(read_callbacks_->connection().aboveHighWatermark() == false ||
          new_stream->high_watermark_count_ > 0);
   new_stream->moveIntoList(std::move(new_stream), streams_);

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -61,8 +61,8 @@ public:
   void disableChunkEncoding() override { disable_chunk_encoding_ = true; }
 
   // Http::Stream
-  void addCallbacks(StreamCallbacks& callbacks) override { addCallbacks_(callbacks); }
-  void removeCallbacks(StreamCallbacks& callbacks) override { removeCallbacks_(callbacks); }
+  void addCallbacks(StreamCallbacks& callbacks) override { addCallbacksHelper(callbacks); }
+  void removeCallbacks(StreamCallbacks& callbacks) override { removeCallbacksHelper(callbacks); }
   // After this is called, for the HTTP/1 codec, the connection should be closed, i.e. no further
   // progress may be made with the codec.
   void resetStream(StreamResetReason reason) override;

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -208,8 +208,8 @@ protected:
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override { return absl::nullopt; }
 
     // Http::Stream
-    void addCallbacks(StreamCallbacks& callbacks) override { addCallbacks_(callbacks); }
-    void removeCallbacks(StreamCallbacks& callbacks) override { removeCallbacks_(callbacks); }
+    void addCallbacks(StreamCallbacks& callbacks) override { addCallbacksHelper(callbacks); }
+    void removeCallbacks(StreamCallbacks& callbacks) override { removeCallbacksHelper(callbacks); }
     void resetStream(StreamResetReason reason) override;
     void readDisable(bool disable) override;
     uint32_t bufferLimit() override { return pending_recv_data_.highWatermark(); }

--- a/source/extensions/quic_listeners/quiche/envoy_quic_stream.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_stream.h
@@ -72,9 +72,11 @@ public:
 
   void addCallbacks(Http::StreamCallbacks& callbacks) override {
     ASSERT(!local_end_stream_);
-    addCallbacks_(callbacks);
+    addCallbacksHelper(callbacks);
   }
-  void removeCallbacks(Http::StreamCallbacks& callbacks) override { removeCallbacks_(callbacks); }
+  void removeCallbacks(Http::StreamCallbacks& callbacks) override {
+    removeCallbacksHelper(callbacks);
+  }
   uint32_t bufferLimit() override { return send_buffer_simulation_.highWatermark(); }
   const Network::Address::InstanceConstSharedPtr& connectionLocalAddress() override {
     return connection()->localAddress();


### PR DESCRIPTION
Commit Message:

Replace std::vector with explicit reservation with an InlinedVector
of the same size. This should have the same behavior and avoid
a heap allocation in the common case.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
