### PR TITLE
switch StatNameVec from std;:vector to absl::InlinedVector, for a modest speed-up.

### DIFF
--- a/include/envoy/stats/BUILD
+++ b/include/envoy/stats/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "tag_extractor.h",
         "tag_producer.h",
     ],
+    external_deps = ["abseil_inlined_vector"],
     deps = [
         ":refcount_ptr_interface",
         ":symbol_table_interface",
@@ -50,6 +51,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "symbol_table_interface",
     hdrs = ["symbol_table.h"],
+    external_deps = ["abseil_inlined_vector"],
     deps = [
         "//source/common/common:hash_lib",
     ],

--- a/include/envoy/stats/symbol_table.h
+++ b/include/envoy/stats/symbol_table.h
@@ -7,6 +7,7 @@
 
 #include "envoy/common/pure.h"
 
+#include "absl/container/inlined_vector.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -20,7 +21,7 @@ namespace Stats {
  * declaration for StatName is in source/common/stats/symbol_table_impl.h
  */
 class StatName;
-using StatNameVec = std::vector<StatName>;
+using StatNameVec = absl::InlinedVector<StatName, 8>;
 
 class StatNameList;
 class StatNameSet;

--- a/source/common/stats/fake_symbol_table_impl.h
+++ b/source/common/stats/fake_symbol_table_impl.h
@@ -95,7 +95,7 @@ public:
   void incRefCount(const StatName&) override {}
   StoragePtr encode(absl::string_view name) override { return encodeHelper(name); }
   StoragePtr makeDynamicStorage(absl::string_view name) override { return encodeHelper(name); }
-  SymbolTable::StoragePtr join(const std::vector<StatName>& names) const override {
+  SymbolTable::StoragePtr join(const StatNameVec& names) const override {
     std::vector<absl::string_view> strings;
     for (StatName name : names) {
       if (!name.empty()) {

--- a/source/common/stats/stat_merger.cc
+++ b/source/common/stats/stat_merger.cc
@@ -20,7 +20,7 @@ StatName StatMerger::DynamicContext::makeDynamicStatName(const std::string& name
 
   // Name has embedded dynamic segments; we'll need to join together the
   // static/dynamic StatName segments.
-  std::vector<StatName> segments;
+  StatNameVec segments;
   uint32_t segment_index = 0;
   std::vector<absl::string_view> dynamic_segments;
 

--- a/source/common/stats/tag_utility.cc
+++ b/source/common/stats/tag_utility.cc
@@ -37,7 +37,7 @@ TagStatNameJoiner::TagStatNameJoiner(StatName stat_name,
 SymbolTable::StoragePtr TagStatNameJoiner::joinNameAndTags(StatName name,
                                                            const StatNameTagVector& tags,
                                                            SymbolTable& symbol_table) {
-  std::vector<StatName> stat_names;
+  StatNameVec stat_names;
   stat_names.reserve(1 + 2 * tags.size());
   stat_names.emplace_back(name);
 

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -57,7 +57,7 @@ void ThreadLocalStoreImpl::setStatsMatcher(StatsMatcherPtr&& stats_matcher) {
 
 template <class StatMapClass, class StatListClass>
 void ThreadLocalStoreImpl::removeRejectedStats(StatMapClass& map, StatListClass& list) {
-  std::vector<StatName> remove_list;
+  StatNameVec remove_list;
   for (auto& stat : map) {
     if (rejects(stat.first)) {
       remove_list.push_back(stat.first);

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -165,7 +165,11 @@ envoy_cc_fuzz_test(
 
 envoy_cc_test_binary(
     name = "symbol_table_speed_test",
-    srcs = ["symbol_table_speed_test.cc"],
+    srcs = [
+        "make_elements_helper.cc",
+        "make_elements_helper.h",
+        "symbol_table_speed_test.cc",
+    ],
     external_deps = [
         "abseil_strings",
         "benchmark",
@@ -173,7 +177,9 @@ envoy_cc_test_binary(
     deps = [
         ":stat_test_utility_lib",
         "//source/common/memory:stats_lib",
+        "//source/common/stats:isolated_store_lib",
         "//source/common/stats:symbol_table_lib",
+        "//source/common/stats:utility_lib",
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",

--- a/test/common/stats/make_elements_helper.cc
+++ b/test/common/stats/make_elements_helper.cc
@@ -1,0 +1,15 @@
+#include "common/stats/utility.h"
+
+namespace Envoy {
+namespace Stats {
+
+ElementVec makeElements(Element a, Element b, Element c, Element d, Element e) {
+  return ElementVec{a, b, c, d, e};
+}
+
+StatNameVec makeStatNames(StatName a, StatName b, StatName c, StatName d, StatName e) {
+  return StatNameVec{a, b, c, d, e};
+}
+
+} // namespace Stats
+} // namespace Envoy

--- a/test/common/stats/make_elements_helper.h
+++ b/test/common/stats/make_elements_helper.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common/stats/utility.h"
+
+namespace Envoy {
+namespace Stats {
+
+// These two trivial functions are broken out into a separate compilation unit
+// to make sure the optimizer cannot hoist vector-creation out of the loop. They
+// simply create vectors based on their 5 inputs.
+ElementVec makeElements(Element a, Element b, Element c, Element d, Element e);
+StatNameVec makeStatNames(StatName a, StatName b, StatName c, StatName d, StatName e);
+
+} // namespace Stats
+} // namespace Envoy

--- a/test/common/stats/stat_merger_fuzz_test.cc
+++ b/test/common/stats/stat_merger_fuzz_test.cc
@@ -15,7 +15,7 @@ namespace Fuzz {
 void testDynamicEncoding(absl::string_view data, SymbolTable& symbol_table) {
   StatNameDynamicPool dynamic_pool(symbol_table);
   StatNamePool symbolic_pool(symbol_table);
-  std::vector<StatName> stat_names;
+  StatNameVec stat_names;
 
   // This local string is write-only; it's used to help when debugging
   // a crash. If a crash is found, you can print the unit_test_encoding

--- a/test/common/stats/stat_merger_test.cc
+++ b/test/common/stats/stat_merger_test.cc
@@ -34,7 +34,7 @@ public:
 
     // Encode the input name into a joined StatName, using "D:" to indicate
     // a dynamic component.
-    std::vector<StatName> components;
+    StatNameVec components;
     StatNamePool symbolic_pool(symbol_table);
     StatNameDynamicPool dynamic_pool(symbol_table);
 
@@ -233,7 +233,7 @@ public:
   uint32_t dynamicEncodeDecodeTest(absl::string_view input_descriptor) {
     // Encode the input name into a joined StatName, using "D:" to indicate
     // a dynamic component.
-    std::vector<StatName> components;
+    StatNameVec components;
     StatNamePool symbolic_pool(*symbol_table_);
     StatNameDynamicPool dynamic_pool(*symbol_table_);
 

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -5,8 +5,11 @@
 
 #include "common/common/logger.h"
 #include "common/common/thread.h"
+#include "common/stats/isolated_store_impl.h"
 #include "common/stats/symbol_table_impl.h"
+#include "common/stats/utility.h"
 
+#include "test/common/stats/make_elements_helper.h"
 #include "test/test_common/utility.h"
 
 #include "absl/synchronization/blocking_counter.h"
@@ -53,6 +56,36 @@ static void BM_CreateRace(benchmark::State& state) {
   initial.free(table);
 }
 BENCHMARK(BM_CreateRace);
+
+static void BM_JoinStatNames(benchmark::State& state) {
+  Envoy::Stats::SymbolTableImpl symbol_table;
+  Envoy::Stats::IsolatedStoreImpl store(symbol_table);
+  Envoy::Stats::StatNamePool pool(symbol_table);
+  Envoy::Stats::StatName a = pool.add("a");
+  Envoy::Stats::StatName b = pool.add("b");
+  Envoy::Stats::StatName c = pool.add("c");
+  Envoy::Stats::StatName d = pool.add("d");
+  Envoy::Stats::StatName e = pool.add("e");
+  for (auto _ : state) {
+    Envoy::Stats::Utility::counterFromStatNames(store, Envoy::Stats::makeStatNames(a, b, c, d, e));
+  }
+}
+BENCHMARK(BM_JoinStatNames);
+
+static void BM_JoinElements(benchmark::State& state) {
+  Envoy::Stats::SymbolTableImpl symbol_table;
+  Envoy::Stats::IsolatedStoreImpl store(symbol_table);
+  Envoy::Stats::StatNamePool pool(symbol_table);
+  Envoy::Stats::StatName a = pool.add("a");
+  Envoy::Stats::StatName b = pool.add("b");
+  Envoy::Stats::StatName c = pool.add("c");
+  Envoy::Stats::StatName e = pool.add("e");
+  for (auto _ : state) {
+    Envoy::Stats::Utility::counterFromElements(
+        store, Envoy::Stats::makeElements(a, b, c, Envoy::Stats::DynamicName("d"), e));
+  }
+}
+BENCHMARK(BM_JoinElements);
 
 int main(int argc, char** argv) {
   Envoy::Thread::MutexBasicLockable lock;

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -15,6 +15,7 @@
 #include "absl/synchronization/blocking_counter.h"
 #include "benchmark/benchmark.h"
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_CreateRace(benchmark::State& state) {
   Envoy::Thread::ThreadFactory& thread_factory = Envoy::Thread::threadFactoryForTest();
 
@@ -57,6 +58,7 @@ static void BM_CreateRace(benchmark::State& state) {
 }
 BENCHMARK(BM_CreateRace);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_JoinStatNames(benchmark::State& state) {
   Envoy::Stats::SymbolTableImpl symbol_table;
   Envoy::Stats::IsolatedStoreImpl store(symbol_table);
@@ -72,6 +74,7 @@ static void BM_JoinStatNames(benchmark::State& state) {
 }
 BENCHMARK(BM_JoinStatNames);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_JoinElements(benchmark::State& state) {
   Envoy::Stats::SymbolTableImpl symbol_table;
   Envoy::Stats::IsolatedStoreImpl store(symbol_table);

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -137,7 +137,7 @@ public:
 
 private:
   TagVector tags_;
-  std::vector<StatName> tag_names_and_values_;
+  StatNameVec tag_names_and_values_;
   std::string tag_extracted_name_;
   StatNamePool tag_pool_;
   std::unique_ptr<StatNameManagedStorage> tag_extracted_stat_name_;


### PR DESCRIPTION
Commit Message: Switch StatNameVec from std::vector to absl::InlinedVector, which has a very modest speedup; about 10% speed improvement on symbol_table_speed_test on BM_JoinStatNames. Also benchmarks BM_JoinElements, which has even more modest gains.
Additional Description: n/a
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
