### PR TITLE
aws_lambda filter: add last chunk when encoding data

### DIFF
--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -251,9 +251,7 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_strea
   }
 
   ENVOY_LOG(trace, "Tranforming JSON payload to HTTP response.");
-  if (!encoder_callbacks_->encodingBuffer()) {
-    encoder_callbacks_->addEncodedData(data, false);
-  }
+  encoder_callbacks_->addEncodedData(data, false);
   const Buffer::Instance& encoding_buffer = *encoder_callbacks_->encodingBuffer();
   encoder_callbacks_->modifyEncodingBuffer([this](Buffer::Instance& enc_buf) {
     Buffer::OwnedImpl body;

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -471,6 +471,19 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeStopIterationAndBuffer) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, result);
 }
 
+TEST_F(AwsLambdaFilterTest, EncodeDataAddsLastChunk) {
+  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/});
+  filter_->resolveSettings();
+  Http::TestResponseHeaderMapImpl headers;
+  headers.setStatus(200);
+  filter_->encodeHeaders(headers, false /*end_stream*/);
+
+  Buffer::OwnedImpl buf(std::string("foobar"));
+  EXPECT_CALL(encoder_callbacks_, addEncodedData(_, false));
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer).WillRepeatedly(Return(&buf));
+  filter_->encodeData(buf, true /*end_stream*/);
+}
+
 /**
  * encodeData() data in JSON mode without a 'body' key should translate the 'headers' key to HTTP
  * headers while ignoring any HTTP/2 pseudo-headers.


### PR DESCRIPTION
This is a correction of my previous misunderstanding of how filters 
encoding/decoding work with buffering.

Signed-off-by: Marco Magdy <mmagdy@gmail.com>

Additional Description:
I've failed to come up with an integration test case that would trigger this potential bug. See below for a summary of the things I've tried so far.
Risk Level: low
Testing: see above
Docs Changes: N/A
Release Notes: N/A

In the integration test, just like the `decodData` side, I've tried to chunk the data sent back from the fake upstream. However, I observed the following:
- Because I'm sending a `content-length` header in my responses, the data is buffered automatically regardless of the chunks I'm sending. In fact, not setting the `end_stream` flag in the last chunk did not have any effect (test passed).
- I removed the `content-length` header from the response (and now the `end_stream` works as expected) however, I observed that the last chunk received by the filter is not the last chunk I sent. It appears to be always empty. All the data was sent prior. In other words, what I send gets buffered somewhere before the filter receives it. That takes all the control out of the integration test to emulate how the data is sent on the wire.
- I've tried using functions like `waitForData(size_t len)` and `dispatcher.run(NonBlock)` but none of them gave me the results I need.
- Running `gdb` on an integration test was a frustrating experience that led me nowhere. Because of the async/non-blocking nature of the calls and also strange system signals raised during debugging.
