### PR TITLE
Add TextReadout to Envoy::Stats::MetricSnapshot.

### DIFF
--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -35,7 +35,11 @@ public:
    * @return a snapshot of all histograms.
    */
   virtual const std::vector<std::reference_wrapper<const ParentHistogram>>& histograms() PURE;
-  // TODO(efimki): Add support of text readouts stats.
+
+  /**
+   * @return a snapshot of all text readouts.
+   */
+  virtual const std::vector<std::reference_wrapper<const TextReadout>>& textReadouts() PURE;
 };
 
 /**

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -162,6 +162,12 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store) {
   for (const auto& histogram : snapped_histograms_) {
     histograms_.push_back(*histogram);
   }
+
+  snapped_text_readouts_ = store.textReadouts();
+  text_readouts_.reserve(snapped_text_readouts_.size());
+  for (const auto& text_readout : snapped_text_readouts_) {
+    text_readouts_.push_back(*text_readout);
+  }
 }
 
 void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -384,6 +384,9 @@ public:
   const std::vector<std::reference_wrapper<const Stats::ParentHistogram>>& histograms() override {
     return histograms_;
   }
+  const std::vector<std::reference_wrapper<const Stats::TextReadout>>& textReadouts() override {
+    return text_readouts_;
+  }
 
 private:
   std::vector<Stats::CounterSharedPtr> snapped_counters_;
@@ -392,6 +395,8 @@ private:
   std::vector<std::reference_wrapper<const Stats::Gauge>> gauges_;
   std::vector<Stats::ParentHistogramSharedPtr> snapped_histograms_;
   std::vector<std::reference_wrapper<const Stats::ParentHistogram>> histograms_;
+  std::vector<Stats::TextReadoutSharedPtr> snapped_text_readouts_;
+  std::vector<std::reference_wrapper<const Stats::TextReadout>> text_readouts_;
 };
 
 } // namespace Server

--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -102,6 +102,7 @@ public:
   Histogram& histogram(const std::string& name, Histogram::Unit unit) {
     return histogramFromString(name, unit);
   }
+  TextReadout& textReadout(const std::string& name) { return textReadoutFromString(name); }
 
   // Override the Stats::Store methods for name-based lookup of stats, to use
   // and update the string-maps in this class. Note that IsolatedStoreImpl

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -266,11 +266,12 @@ public:
   MOCK_METHOD(const std::vector<CounterSnapshot>&, counters, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const Gauge>>&, gauges, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const ParentHistogram>>&, histograms, ());
-  MOCK_METHOD(const std::vector<TextReadout>&, textReadouts, ());
+  MOCK_METHOD(const std::vector<std::reference_wrapper<const TextReadout>>&, textReadouts, ());
 
   std::vector<CounterSnapshot> counters_;
   std::vector<std::reference_wrapper<const Gauge>> gauges_;
   std::vector<std::reference_wrapper<const ParentHistogram>> histograms_;
+  std::vector<std::reference_wrapper<const TextReadout>> text_readouts_;
 };
 
 class MockSink : public Sink {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -47,6 +47,7 @@ TEST(ServerInstanceUtil, flushHelper) {
   c.inc();
   store.gauge("world", Stats::Gauge::ImportMode::Accumulate).set(5);
   store.histogram("histogram", Stats::Histogram::Unit::Unspecified);
+  store.textReadout("text").set("is important");
 
   std::list<Stats::SinkPtr> sinks;
   InstanceUtil::flushMetricsToSinks(sinks, store);
@@ -64,6 +65,10 @@ TEST(ServerInstanceUtil, flushHelper) {
     ASSERT_EQ(snapshot.gauges().size(), 1);
     EXPECT_EQ(snapshot.gauges()[0].get().name(), "world");
     EXPECT_EQ(snapshot.gauges()[0].get().value(), 5);
+
+    ASSERT_EQ(snapshot.textReadouts().size(), 1);
+    EXPECT_EQ(snapshot.textReadouts()[0].get().name(), "text");
+    EXPECT_EQ(snapshot.textReadouts()[0].get().value(), "is important");
   }));
   c.inc();
   InstanceUtil::flushMetricsToSinks(sinks, store);
@@ -77,6 +82,7 @@ TEST(ServerInstanceUtil, flushHelper) {
     EXPECT_TRUE(snapshot.counters().empty());
     EXPECT_TRUE(snapshot.gauges().empty());
     EXPECT_EQ(snapshot.histograms().size(), 1);
+    EXPECT_TRUE(snapshot.textReadouts().empty());
   }));
   InstanceUtil::flushMetricsToSinks(sinks, mock_store);
 }


### PR DESCRIPTION
Description: Add TextReadout to Envoy::Stats::MetricSnapshot.
Addresses TODO left in the initial PR.

Risk Level: low

Fixes #5790 @jmarantz

