### PR TITLE
Fixed test build failures under gcc 9

### DIFF
--- a/test/common/stats/stat_merger_fuzz_test.cc
+++ b/test/common/stats/stat_merger_fuzz_test.cc
@@ -31,7 +31,7 @@ void testDynamicEncoding(absl::string_view data, SymbolTable& symbol_table) {
     // TODO(#10008): We should remove the "1 +" below, so we can get empty
     // segments, which trigger some inconsistent handling as described in that
     // bug.
-    uint32_t num_bytes = 1 + data[index] & 0x7;
+    uint32_t num_bytes = (1 + data[index]) & 0x7;
     num_bytes = std::min(static_cast<uint32_t>(data.size() - 1),
                          num_bytes); // restrict number up to the size of data
 

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -13,9 +13,9 @@ namespace Extensions {
 namespace HttpFilters {
 
 DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& input) {
-  static PostProcessorRegistration reg = {[](test::extensions::filters::http::FilterFuzzTestCase*
-                                                 input,
-                                             unsigned int seed) {
+  static PostProcessorRegistration reg __attribute__((
+      unused)) = {[](test::extensions::filters::http::FilterFuzzTestCase* input,
+                     unsigned int seed) {
     // This ensures that the mutated configs all have valid filter names and type_urls. The list of
     // names and type_urls is pulled from the NamedHttpFilterConfigFactory. All Envoy extensions are
     // built with this test (see BUILD file).

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -13,30 +13,30 @@ namespace Extensions {
 namespace HttpFilters {
 
 DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& input) {
-  static PostProcessorRegistration reg __attribute__((
-      unused)) = {[](test::extensions::filters::http::FilterFuzzTestCase* input,
-                     unsigned int seed) {
-    // This ensures that the mutated configs all have valid filter names and type_urls. The list of
-    // names and type_urls is pulled from the NamedHttpFilterConfigFactory. All Envoy extensions are
-    // built with this test (see BUILD file).
-    // This post-processor mutation is applied only when libprotobuf-mutator calls mutate on an
-    // input, and *not* during fuzz target execution. Replaying a corpus through the fuzzer will not
-    // be affected by the post-processor mutation.
-    static const std::vector<absl::string_view> filter_names = Registry::FactoryRegistry<
-        Server::Configuration::NamedHttpFilterConfigFactory>::registeredNames();
-    static const auto factories =
-        Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::factories();
-    // Choose a valid filter name.
-    if (std::find(filter_names.begin(), filter_names.end(), input->config().name()) ==
-        std::end(filter_names)) {
-      absl::string_view filter_name = filter_names[seed % filter_names.size()];
-      input->mutable_config()->set_name(std::string(filter_name));
-    }
-    // Set the corresponding type_url for Any.
-    auto& factory = factories.at(input->config().name());
-    input->mutable_config()->mutable_typed_config()->set_type_url(absl::StrCat(
-        "type.googleapis.com/", factory->createEmptyConfigProto()->GetDescriptor()->full_name()));
-  }};
+  ABSL_ATTRIBUTE_UNUSED static PostProcessorRegistration reg = {
+      [](test::extensions::filters::http::FilterFuzzTestCase* input, unsigned int seed) {
+        // This ensures that the mutated configs all have valid filter names and type_urls. The list
+        // of names and type_urls is pulled from the NamedHttpFilterConfigFactory. All Envoy
+        // extensions are built with this test (see BUILD file). This post-processor mutation is
+        // applied only when libprotobuf-mutator calls mutate on an input, and *not* during fuzz
+        // target execution. Replaying a corpus through the fuzzer will not be affected by the
+        // post-processor mutation.
+        static const std::vector<absl::string_view> filter_names = Registry::FactoryRegistry<
+            Server::Configuration::NamedHttpFilterConfigFactory>::registeredNames();
+        static const auto factories = Registry::FactoryRegistry<
+            Server::Configuration::NamedHttpFilterConfigFactory>::factories();
+        // Choose a valid filter name.
+        if (std::find(filter_names.begin(), filter_names.end(), input->config().name()) ==
+            std::end(filter_names)) {
+          absl::string_view filter_name = filter_names[seed % filter_names.size()];
+          input->mutable_config()->set_name(std::string(filter_name));
+        }
+        // Set the corresponding type_url for Any.
+        auto& factory = factories.at(input->config().name());
+        input->mutable_config()->mutable_typed_config()->set_type_url(
+            absl::StrCat("type.googleapis.com/",
+                         factory->createEmptyConfigProto()->GetDescriptor()->full_name()));
+      }};
 
   try {
     // Catch invalid header characters.

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -166,6 +166,8 @@ const char YamlSingleDstPortBottom[] = R"EOF(
 
 class FilterChainBenchmarkFixture : public benchmark::Fixture {
 public:
+  using benchmark::Fixture::SetUp;
+
   void SetUp(::benchmark::State& state) override {
     int64_t input_size = state.range(0);
     std::vector<std::string> port_chains;


### PR DESCRIPTION
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Fixed test build failures under gcc 9
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
