### PR TITLE
http: pausing when proxying CONNECT requests for security reasons

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -664,9 +664,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
 Filter::HttpOrTcpPool Filter::createConnPool(Upstream::HostDescriptionConstSharedPtr& host) {
   Filter::HttpOrTcpPool conn_pool;
-  bool should_tcp_proxy = route_entry_->connectConfig().has_value() &&
-                          downstream_headers_->Method()->value().getStringView() ==
-                              Http::Headers::get().MethodValues.Connect;
+  const bool should_tcp_proxy = route_entry_->connectConfig().has_value() &&
+                                downstream_headers_->Method()->value().getStringView() ==
+                                    Http::Headers::get().MethodValues.Connect;
 
   if (!should_tcp_proxy) {
     conn_pool = getHttpConnPool();

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -48,7 +48,7 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
       calling_encode_headers_(false), upstream_canary_(false), decode_complete_(false),
       encode_complete_(false), encode_trailers_(false), retried_(false), awaiting_headers_(true),
       outlier_detection_timeout_recorded_(false),
-      create_per_try_timeout_on_request_complete_(false),
+      create_per_try_timeout_on_request_complete_(false), paused_for_connect_(false),
       record_timeout_budget_(parent_.cluster()->timeoutBudgetStats().has_value()) {
   if (parent_.config().start_child_span_) {
     span_ = parent_.callbacks()->activeSpan().spawnChild(
@@ -127,6 +127,12 @@ void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool e
   }
   const uint64_t response_code = Http::Utility::getResponseStatus(*headers);
   stream_info_.response_code_ = static_cast<uint32_t>(response_code);
+
+  if (paused_for_connect_ && response_code == 200) {
+    encodeBodyAndTrailers();
+    paused_for_connect_ = false;
+  }
+
   parent_.onUpstreamHeaders(response_code, std::move(headers), *this, end_stream);
 }
 
@@ -177,7 +183,7 @@ void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!encode_complete_);
   encode_complete_ = end_stream;
 
-  if (!upstream_) {
+  if (!upstream_ || paused_for_connect_) {
     ENVOY_STREAM_LOG(trace, "buffering {} bytes", *parent_.callbacks(), data.length());
     if (!buffered_request_body_) {
       buffered_request_body_ = std::make_unique<Buffer::WatermarkBuffer>(
@@ -357,6 +363,7 @@ void UpstreamRequest::onPoolReady(
   parent_.callbacks()->addDownstreamWatermarkCallbacks(downstream_watermark_manager_);
 
   calling_encode_headers_ = true;
+  auto* headers = parent_.downstreamHeaders();
   if (parent_.routeEntry()->autoHostRewrite() && !host->hostname().empty()) {
     parent_.downstreamHeaders()->setHost(host->hostname());
   }
@@ -371,8 +378,24 @@ void UpstreamRequest::onPoolReady(
   // If end_stream is set in headers, and there are metadata to send, delays end_stream. The case
   // only happens when decoding headers filters return ContinueAndEndStream.
   const bool delay_headers_end_stream = end_stream && !downstream_metadata_map_vector_.empty();
+  // Make sure that when we are forwarding CONNECT payload we do not do so until
+  // the upstream has accepted the CONNECT request.
+  if (conn_pool_->protocol().has_value() && headers->Method() &&
+      headers->Method()->value().getStringView() == Http::Headers::get().MethodValues.Connect) {
+    paused_for_connect_ = true;
+  }
+
   upstream_->encodeHeaders(*parent_.downstreamHeaders(), end_stream && !delay_headers_end_stream);
   calling_encode_headers_ = false;
+
+  if (!paused_for_connect_) {
+    encodeBodyAndTrailers();
+  }
+}
+
+void UpstreamRequest::encodeBodyAndTrailers() {
+  const bool end_stream = !buffered_request_body_ && encode_complete_ && !encode_trailers_;
+  const bool delay_headers_end_stream = end_stream && !downstream_metadata_map_vector_.empty();
 
   // It is possible to get reset in the middle of an encodeHeaders() call. This happens for
   // example in the HTTP/2 codec if the frame cannot be encoded for some reason. This should never

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -141,6 +141,13 @@ public:
   }
 
 private:
+  bool shouldSendEndStream() {
+    // Only encode end stream if the full request has been received, the body
+    // has been sent, and any trailers or metadata have also been sent.
+    return encode_complete_ && !buffered_request_body_ && !encode_trailers_ &&
+           downstream_metadata_map_vector_.empty();
+  }
+
   RouterFilterInterface& parent_;
   std::unique_ptr<GenericConnPool> conn_pool_;
   bool grpc_rq_success_deferred_;

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -119,6 +119,7 @@ public:
   };
 
   void readEnable();
+  void encodeBodyAndTrailers();
 
   // Getters and setters
   Upstream::HostDescriptionConstSharedPtr& upstreamHost() { return upstream_host_; }
@@ -172,6 +173,9 @@ private:
   // Tracks whether we deferred a per try timeout because the downstream request
   // had not been completed yet.
   bool create_per_try_timeout_on_request_complete_ : 1;
+  // True if the CONNECT headers have been sent but proxying payload is paused
+  // waiting for response headers.
+  bool paused_for_connect_ : 1;
 
   // Sentinel to indicate if timeout budget tracking is configured for the cluster,
   // and if so, if the per-try histogram should record a value.

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -5667,6 +5667,71 @@ TEST_F(RouterTest, ApplicationProtocols) {
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 }
 
+// Verify that CONNECT payload is not sent upstream until :200 response headers
+// are received.
+TEST_F(RouterTest, ConnectPauseAndResume) {
+  NiceMock<Http::MockRequestEncoder> encoder;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke(
+          [&](Http::ResponseDecoder& decoder,
+              Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+            response_decoder = &decoder;
+            callbacks.onPoolReady(encoder, cm_.conn_pool_.host_, upstream_stream_info_);
+            return nullptr;
+          }));
+  expectResponseTimerCreate();
+
+  EXPECT_CALL(encoder, encodeHeaders(_, false));
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  headers.setMethod("CONNECT");
+  router_.decodeHeaders(headers, false);
+
+  // Make sure any early data does not go upstream.
+  EXPECT_CALL(encoder, encodeData(_, _)).Times(0);
+  Buffer::OwnedImpl data;
+  router_.decodeData(data, true);
+
+  // Now send the response headers, and ensure the defered payload is proxied.
+  EXPECT_CALL(encoder, encodeData(_, _));
+  Http::ResponseHeaderMapPtr response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}});
+  response_decoder->decodeHeaders(std::move(response_headers), true);
+}
+
+// Verify that CONNECT payload is not sent upstream if non-200 response headers are received.
+TEST_F(RouterTest, ConnectPauseNoResume) {
+  NiceMock<Http::MockRequestEncoder> encoder;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
+      .WillOnce(Invoke(
+          [&](Http::ResponseDecoder& decoder,
+              Http::ConnectionPool::Callbacks& callbacks) -> Http::ConnectionPool::Cancellable* {
+            response_decoder = &decoder;
+            callbacks.onPoolReady(encoder, cm_.conn_pool_.host_, upstream_stream_info_);
+            return nullptr;
+          }));
+  expectResponseTimerCreate();
+
+  EXPECT_CALL(encoder, encodeHeaders(_, false));
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  headers.setMethod("CONNECT");
+  router_.decodeHeaders(headers, false);
+
+  // Make sure any early data does not go upstream.
+  EXPECT_CALL(encoder, encodeData(_, _)).Times(0);
+  Buffer::OwnedImpl data;
+  router_.decodeData(data, true);
+
+  // Now send the response headers, and ensure the defered payload is not proxied.
+  EXPECT_CALL(encoder, encodeData(_, _)).Times(0);
+  Http::ResponseHeaderMapPtr response_headers(
+      new Http::TestResponseHeaderMapImpl{{":status", "400"}});
+  response_decoder->decodeHeaders(std::move(response_headers), true);
+}
+
 class WatermarkTest : public RouterTest {
 public:
   void sendRequest(bool header_only_request = true, bool pool_ready = true) {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -5693,7 +5693,7 @@ TEST_F(RouterTest, ConnectPauseAndResume) {
   Buffer::OwnedImpl data;
   router_.decodeData(data, true);
 
-  // Now send the response headers, and ensure the defered payload is proxied.
+  // Now send the response headers, and ensure the deferred payload is proxied.
   EXPECT_CALL(encoder, encodeData(_, _));
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "200"}});
@@ -5725,7 +5725,7 @@ TEST_F(RouterTest, ConnectPauseNoResume) {
   Buffer::OwnedImpl data;
   router_.decodeData(data, true);
 
-  // Now send the response headers, and ensure the defered payload is not proxied.
+  // Now send the response headers, and ensure the deferred payload is not proxied.
   EXPECT_CALL(encoder, encodeData(_, _)).Times(0);
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "400"}});

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -80,8 +80,6 @@ public:
   bool enable_timeout_{};
 };
 
-// TODO(alyssawilk) make sure that if data is sent with the connect it does not go upstream
-// until the 200 headers are sent before unhiding ANY config.
 TEST_P(ConnectTerminationIntegrationTest, Basic) {
   initialize();
 


### PR DESCRIPTION
Risk Level: Low (only affects CONNECT proxying, not yet used)
Testing: new unit tests, modified integration tests
Docs Changes: n/a
Release Notes: n/a
Part of #1630 #1451