### PR TITLE
test: deflaking a QUIC test

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1203,10 +1203,14 @@ void HttpIntegrationTest::testAdminDrain(Http::CodecClient::Type admin_request_t
   test_server_->waitForCounterEq("listener_manager.listener_stopped", 1);
 
   // Validate that port is closed and can be bound by other sockets.
-  EXPECT_NO_THROW(Network::TcpListenSocket(
-      Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
-                                           http_port),
-      nullptr, true));
+  // This does not work for HTTP/3 because the port is not closed until the listener is completely
+  // destroyed. TODO(danzh) fix at some point.
+  if (downstreamProtocol() != Http::CodecClient::Type::HTTP3) {
+    EXPECT_NO_THROW(Network::TcpListenSocket(
+        Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
+                                             http_port),
+        nullptr, true));
+  }
 }
 
 std::string HttpIntegrationTest::listenerStatPrefix(const std::string& stat_name) {

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1204,7 +1204,7 @@ void HttpIntegrationTest::testAdminDrain(Http::CodecClient::Type admin_request_t
 
   // Validate that port is closed and can be bound by other sockets.
   // This does not work for HTTP/3 because the port is not closed until the listener is completely
-  // destroyed. TODO(danzh) fix at some point.
+  // destroyed. TODO(danzh) Match TCP behavior as much as possible.
   if (downstreamProtocol() != Http::CodecClient::Type::HTTP3) {
     EXPECT_NO_THROW(Network::TcpListenSocket(
         Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),


### PR DESCRIPTION

Additional Description:
This test was flaking out because it was trying to check availability of a "random" TCP port rather than the UDP listening port.
It still fails if we check availability of the UDP listening port as the socket doesn't get closed on draining.  Added a TODO to address this - I think it ought to close the draining listener once there's no active streams.

Risk Level: n/a (test only)
Testing: now passes cleanly
Docs Changes: n/a 
Release Notes: n/a