### PR TITLE
bazel: add option for disabling debug info

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -108,6 +108,11 @@ config_setting(
 )
 
 config_setting(
+    name = "no_debug_info",
+    values = {"define": "no_debug_info=1"},
+)
+
+config_setting(
     name = "asan_build",
     values = {"define": "ENVOY_CONFIG_ASAN=1"},
 )

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -215,6 +215,11 @@ By default Clang drops some debug symbols that are required for pretty printing 
 More information can be found [here](https://bugs.llvm.org/show_bug.cgi?id=24202). The easy solution
 is to set ```--copt=-fno-limit-debug-info``` on the CLI or in your .bazelrc file.
 
+## Removing debug info
+
+If you don't want your debug or release binaries to contain debug info
+to reduce binary size, pass `--define=no_debug_info=1` when building.
+
 # Testing Envoy with Bazel
 
 All the Envoy tests can be built and run with:

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -219,6 +219,11 @@ is to set ```--copt=-fno-limit-debug-info``` on the CLI or in your .bazelrc file
 
 If you don't want your debug or release binaries to contain debug info
 to reduce binary size, pass `--define=no_debug_info=1` when building.
+This is primarily useful when building envoy as a static library. When
+building a linked envoy binary you can build the implicit `.stripped`
+target from [`cc_binary`](https://docs.bazel.build/versions/master/be/c-cpp.html#cc_binary)
+or pass [`--strip=always`](https://docs.bazel.build/versions/master/command-line-reference.html#flag--strip)
+instead.
 
 # Testing Envoy with Bazel
 

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -52,6 +52,9 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
                "//conditions:default": [],
            }) + select({
+               repository + "//bazel:no_debug_info": ["-g0"],
+               "//conditions:default": [],
+           }) + select({
                repository + "//bazel:disable_tcmalloc": ["-DABSL_MALLOC_HOOK_MMAP_DISABLE"],
                "//conditions:default": ["-DTCMALLOC"],
            }) + select({


### PR DESCRIPTION
When building [envoy-mobile](https://github.com/lyft/envoy-mobile) we
don't particularly care about having significant debug info, but we want
to build with `--compilation_mode=opt`. Previously because opt builds
with `-ggdb3` by default, the produced multi-arch archive would be too
large to work with rules_apple's framework zipping.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>