### PR TITLE
header-to-metadata: properly lookup most specific config

### DIFF
--- a/source/extensions/filters/http/header_to_metadata/BUILD
+++ b/source/extensions/filters/http/header_to_metadata/BUILD
@@ -19,8 +19,8 @@ envoy_cc_library(
     deps = [
         "//include/envoy/server:filter_config_interface",
         "//source/common/common:base64_lib",
-        "//source/extensions/filters/http:well_known_names",
         "//source/common/http:utility_lib",
+        "//source/extensions/filters/http:well_known_names",
         "@envoy_api//envoy/extensions/filters/http/header_to_metadata/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/header_to_metadata/BUILD
+++ b/source/extensions/filters/http/header_to_metadata/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         "//include/envoy/server:filter_config_interface",
         "//source/common/common:base64_lib",
         "//source/extensions/filters/http:well_known_names",
+        "//source/common/http:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/header_to_metadata/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -129,7 +129,6 @@ private:
                    ValueEncode) const;
   const std::string& decideNamespace(const std::string& nspace) const;
   const Config* getConfig() const;
-  const Config* getRouteConfig() const;
 };
 
 } // namespace HeaderToMetadataFilter


### PR DESCRIPTION
Use Http::Utility::resolveMostSpecificPerFilterConfig() to fetch the
correct config (route entry, route or vhost level) instead of doing it
manually (and wrong).

cc: @yuval-k

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
