### PR TITLE
docs: add section re runtime flags usage for risky changes to operations

### DIFF
--- a/docs/root/operations/runtime.rst
+++ b/docs/root/operations/runtime.rst
@@ -9,7 +9,7 @@ configured. They are documented in the relevant sections of the :ref:`configurat
 
 Runtime flags are also used as a mechanism to disable new behavior or risky changes not otherwise
 guarded by configuration. Such changes will tend to introduce a runtime guard that can be used to
-disable the new behavior/code path. These name of these runtime guards will be included in the
+disable the new behavior/code path. The names of these runtime guards will be included in the
 release notes alongside an explanation of the change that warrented the runtime guard.
 
 Due to this usage of runtime guards, some deployments might find it useful to set up

--- a/docs/root/operations/runtime.rst
+++ b/docs/root/operations/runtime.rst
@@ -7,7 +7,7 @@ Runtime
 without restarting Envoy. The runtime settings that are available depend on how the server is
 configured. They are documented in the relevant sections of the :ref:`configuration guide <config>`.
 
-Runtime flags are also used as a mechanism to disable new behavior or risky changes not otherwise
+Runtime guards are also used as a mechanism to disable new behavior or risky changes not otherwise
 guarded by configuration. Such changes will tend to introduce a runtime guard that can be used to
 disable the new behavior/code path. The names of these runtime guards will be included in the
 release notes alongside an explanation of the change that warrented the runtime guard.

--- a/docs/root/operations/runtime.rst
+++ b/docs/root/operations/runtime.rst
@@ -6,3 +6,9 @@ Runtime
 :ref:`Runtime configuration <config_runtime>` can be used to modify various server settings
 without restarting Envoy. The runtime settings that are available depend on how the server is
 configured. They are documented in the relevant sections of the :ref:`configuration guide <config>`.
+
+Runtime flags are also used as a mechanism to disable new behavior or risky changes: such changes
+will tend to introduce a runtime flag that can be used to disable the new behavior/code path. As such
+some deployments might find it useful to set up dynamic runtime configuration as a safety measure to
+be able to quickly disable this new/risky behavior without having to revert to an older version of
+Envoy or redeploy it with a new set of static runtime flags.

--- a/docs/root/operations/runtime.rst
+++ b/docs/root/operations/runtime.rst
@@ -7,8 +7,12 @@ Runtime
 without restarting Envoy. The runtime settings that are available depend on how the server is
 configured. They are documented in the relevant sections of the :ref:`configuration guide <config>`.
 
-Runtime flags are also used as a mechanism to disable new behavior or risky changes: such changes
-will tend to introduce a runtime flag that can be used to disable the new behavior/code path. As such
-some deployments might find it useful to set up dynamic runtime configuration as a safety measure to
-be able to quickly disable this new/risky behavior without having to revert to an older version of
-Envoy or redeploy it with a new set of static runtime flags.
+Runtime flags are also used as a mechanism to disable new behavior or risky changes not otherwise
+guarded by configuration. Such changes will tend to introduce a runtime guard that can be used to
+disable the new behavior/code path. These name of these runtime guards will be included in the
+release notes alongside an explanation of the change that warrented the runtime guard.
+
+Due to this usage of runtime guards, some deployments might find it useful to set up
+dynamic runtime configuration as a safety measure to be able to quickly disable the new behavior
+without having to revert to an older version of Envoy or redeploy it with a new set of static
+runtime flags.


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <kpettersen@netflix.com>

Commit Message: 
Adds a section to the runtime operations page that elaborates on the use of runtime flags
to gate new/risky changes. This also points out that it can be helpful for certain deployments
to invest in dynamic runtime setup (RTDS/file swaps) in order to be able to quickly disable the
new features.
Additional Description:
Risk Level: Low
Testing: n/a
Docs Changes: It's all docs!
Release Notes: n/a

FYI @mattklein123 @alyssawilk 