### PR TITLE
connection: refactoring watermark logic

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -51,12 +51,12 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
       write_buffer_(dispatcher.getWatermarkFactory().create(
           [this]() -> void { this->onWriteBufferLowWatermark(); },
           [this]() -> void { this->onWriteBufferHighWatermark(); })),
-      write_buffer_above_high_watermark_(false), detect_early_close_(true), enable_half_close_(false),
-      read_end_stream_raised_(false), read_end_stream_(false), write_end_stream_(false),
-      current_write_end_stream_(false), dispatch_buffered_data_(false) {
+      write_buffer_above_high_watermark_(false), detect_early_close_(true),
+      enable_half_close_(false), read_end_stream_raised_(false), read_end_stream_(false),
+      write_end_stream_(false), current_write_end_stream_(false), dispatch_buffered_data_(false) {
   // Treat the lack of a valid fd (which in practice only happens if we run out of FDs) as an OOM
   // condition and just crash.
-  RELEASE_ASSERT(SOCKET_VALID(ioHandle().fd()), "");
+  RELEASE_ASSERT(SOCKET_VALID(ConnectionImpl::ioHandle().fd()), "");
 
   if (!connected) {
     connecting_ = true;
@@ -71,7 +71,7 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
   // We never ask for both early close and read at the same time. If we are reading, we want to
   // consume all available data.
   file_event_ = dispatcher_.createFileEvent(
-      ioHandle().fd(), [this](uint32_t events) -> void { onFileEvent(events); }, trigger,
+      ConnectionImpl::ioHandle().fd(), [this](uint32_t events) -> void { onFileEvent(events); }, trigger,
       Event::FileReadyType::Read | Event::FileReadyType::Write);
 
   transport_socket_->setTransportSocketCallbacks(*this);

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -71,8 +71,8 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
   // We never ask for both early close and read at the same time. If we are reading, we want to
   // consume all available data.
   file_event_ = dispatcher_.createFileEvent(
-      ConnectionImpl::ioHandle().fd(), [this](uint32_t events) -> void { onFileEvent(events); }, trigger,
-      Event::FileReadyType::Read | Event::FileReadyType::Write);
+      ConnectionImpl::ioHandle().fd(), [this](uint32_t events) -> void { onFileEvent(events); },
+      trigger, Event::FileReadyType::Read | Event::FileReadyType::Write);
 
   transport_socket_->setTransportSocketCallbacks(*this);
 }

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -82,7 +82,7 @@ public:
   void setBufferLimits(uint32_t limit) override;
   uint32_t bufferLimit() const override { return read_buffer_limit_; }
   bool localAddressRestored() const override { return socket_->localAddressRestored(); }
-  bool aboveHighWatermark() const override { return above_high_watermark_; }
+  bool aboveHighWatermark() const override { return write_buffer_above_high_watermark_; }
   const ConnectionSocket::OptionsSharedPtr& socketOptions() const override {
     return socket_->options();
   }
@@ -127,8 +127,8 @@ protected:
 
   void closeSocket(ConnectionEvent close_type);
 
-  void onLowWatermark();
-  void onHighWatermark();
+  void onWriteBufferLowWatermark();
+  void onWriteBufferHighWatermark();
 
   TransportSocketPtr transport_socket_;
   ConnectionSocketPtr socket_;
@@ -174,7 +174,7 @@ private:
   uint64_t last_write_buffer_size_{};
   Buffer::Instance* current_write_buffer_{};
   uint32_t read_disable_count_{0};
-  bool above_high_watermark_ : 1;
+  bool write_buffer_above_high_watermark_ : 1;
   bool detect_early_close_ : 1;
   bool enable_half_close_ : 1;
   bool read_end_stream_raised_ : 1;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -174,7 +174,6 @@ private:
   uint64_t last_write_buffer_size_{};
   Buffer::Instance* current_write_buffer_{};
   uint32_t read_disable_count_{0};
-  bool read_enabled_ : 1;
   bool above_high_watermark_ : 1;
   bool detect_early_close_ : 1;
   bool enable_half_close_ : 1;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -188,7 +188,7 @@ protected:
     Event::FileReadyCb* file_ready_cb_;
   };
 
-  ConnectionMocks createConnectionMocks() {
+  ConnectionMocks createConnectionMocks(bool create_timer = true) {
     auto dispatcher = std::make_unique<NiceMock<Event::MockDispatcher>>();
     EXPECT_CALL(dispatcher->buffer_factory_, create_(_, _))
         .WillRepeatedly(Invoke([](std::function<void()> below_low,
@@ -198,9 +198,12 @@ protected:
           return new Buffer::WatermarkBuffer(below_low, above_high);
         }));
 
-    // This timer will be returned (transferring ownership) to the ConnectionImpl when createTimer()
-    // is called to allocate the delayed close timer.
-    Event::MockTimer* timer = new Event::MockTimer(dispatcher.get());
+    Event::MockTimer* timer = nullptr;
+    if (create_timer) {
+      // This timer will be returned (transferring ownership) to the ConnectionImpl when
+      // createTimer() is called to allocate the delayed close timer.
+      timer = new Event::MockTimer(dispatcher.get());
+    }
 
     NiceMock<Event::MockFileEvent>* file_event = new NiceMock<Event::MockFileEvent>;
     EXPECT_CALL(*dispatcher, createFileEvent_(0, _, _, _))
@@ -482,24 +485,41 @@ TEST_P(ConnectionImplTest, ConnectionStats) {
 // Ensure the new counter logic in ReadDisable avoids tripping asserts in ReadDisable guarding
 // against actual enabling twice in a row.
 TEST_P(ConnectionImplTest, ReadDisable) {
-  setUpBasicConnection();
+  ConnectionMocks mocks = createConnectionMocks(false);
+  IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>(0);
+  auto connection = std::make_unique<Network::ConnectionImpl>(
+      *mocks.dispatcher_,
+      std::make_unique<ConnectionSocketImpl>(std::move(io_handle), nullptr, nullptr),
+      std::move(mocks.transport_socket_), stream_info_, true);
 
-  client_connection_->readDisable(true);
-  client_connection_->readDisable(false);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_));
+  connection->readDisable(true);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_));
+  connection->readDisable(false);
 
-  client_connection_->readDisable(true);
-  client_connection_->readDisable(true);
-  client_connection_->readDisable(false);
-  client_connection_->readDisable(false);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_));
+  connection->readDisable(true);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_)).Times(0);
+  connection->readDisable(true);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_)).Times(0);
+  connection->readDisable(false);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_));
+  connection->readDisable(false);
 
-  client_connection_->readDisable(true);
-  client_connection_->readDisable(true);
-  client_connection_->readDisable(false);
-  client_connection_->readDisable(true);
-  client_connection_->readDisable(false);
-  client_connection_->readDisable(false);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_));
+  connection->readDisable(true);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_)).Times(0);
+  connection->readDisable(true);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_)).Times(0);
+  connection->readDisable(false);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_)).Times(0);
+  connection->readDisable(true);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_)).Times(0);
+  connection->readDisable(false);
+  EXPECT_CALL(*mocks.file_event_, setEnabled(_));
+  connection->readDisable(false);
 
-  disconnect(false);
+  connection->close(ConnectionCloseType::NoFlush);
 }
 
 // The HTTP/1 codec handles pipelined connections by relying on readDisable(false) resulting in the

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -90,7 +90,7 @@ TEST_P(ConnectionImplDeathTest, BadFd) {
       ConnectionImpl(*dispatcher,
                      std::make_unique<ConnectionSocketImpl>(std::move(io_handle), nullptr, nullptr),
                      Network::Test::createRawBufferSocket(), stream_info, false),
-      ".*assert failure: SOCKET_VALID\\(ioHandle\\(\\)\\.fd\\(\\)\\).*");
+      ".*assert failure: SOCKET_VALID\\(ConnectionImpl::ioHandle\\(\\)\\.fd\\(\\)\\).*");
 }
 
 class ConnectionImplTest : public testing::TestWithParam<Address::IpVersion> {

--- a/test/integration/filters/pause_filter.cc
+++ b/test/integration/filters/pause_filter.cc
@@ -30,7 +30,7 @@ public:
       // If this is the second stream to decode headers and we're at high watermark. force low
       // watermark state
       if (number_of_decode_calls_ref_ == 2 && connection()->aboveHighWatermark()) {
-        connection()->onLowWatermark();
+        connection()->onWriteBufferLowWatermark();
       }
     }
     return PassThroughFilter::decodeData(buf, end_stream);
@@ -43,7 +43,7 @@ public:
       // If this is the first stream to encode headers and we're not at high watermark, force high
       // watermark state.
       if (number_of_encode_calls_ref_ == 1 && !connection()->aboveHighWatermark()) {
-        connection()->onHighWatermark();
+        connection()->onWriteBufferHighWatermark();
       }
     }
     return PassThroughFilter::encodeData(buf, end_stream);

--- a/test/integration/filters/random_pause_filter.cc
+++ b/test/integration/filters/random_pause_filter.cc
@@ -25,9 +25,9 @@ public:
     // Roughly every 5th encode (5 being arbitrary) swap the watermark state.
     if (random % 5 == 0) {
       if (connection()->aboveHighWatermark()) {
-        connection()->onLowWatermark();
+        connection()->onWriteBufferLowWatermark();
       } else {
-        connection()->onHighWatermark();
+        connection()->onWriteBufferHighWatermark();
       }
     }
     return Http::PassThroughFilter::encodeData(buf, end_stream);


### PR DESCRIPTION
Commit Message: cleaning up connection watermark logic: intended as a no-op refactor.

Additional Description:
I think when the connection went from boolean to reference counted, we (probably I) should have replaced the bool with an int instead of extending the bool with an int.  IMO it's much easier to reason about this way.

Risk Level: Medium (intended as no-op, but watermarks...)
Testing: enhanced existing tests.
Docs Changes: n/a
Release Notes: n/a
