### PR TITLE
docs: fix name typo for `envoy.retry_priorities.previous_priorities`

### DIFF
--- a/docs/root/intro/arch_overview/http/http_connection_management.rst
+++ b/docs/root/intro/arch_overview/http/http_connection_management.rst
@@ -73,7 +73,7 @@ can be used to modify this behavior, and they fall into two categories:
 
   Envoy supports the following built-in priority predicates
 
-  * *envoy.retry_priority.previous_priorities*: This will keep track of previously attempted priorities,
+  * *envoy.retry_priorities.previous_priorities*: This will keep track of previously attempted priorities,
     and adjust the priority load such that other priorities will be targeted in subsequent retry attempts.
 
 Host selection will continue until either the configured predicates accept the host or a configurable
@@ -117,7 +117,7 @@ To reject a host based on its metadata, ``envoy.retry_host_predicates.omit_host_
 This will reject any host with matching (key, value) in its metadata.
 
 To configure retries to attempt other priorities during retries, the built-in
-``envoy.retry_priority.previous_priorities`` can be used.
+``envoy.retry_priorities.previous_priorities`` can be used.
 
 .. code-block:: yaml
 


### PR DESCRIPTION


Commit Message: 
docs: fix name typo for `envoy.retry_priorities.previous_priorities`

Signed-off-by: Greg Greenway <ggreenway@apple.com>

Risk Level: None
Testing: None
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
