### PR TITLE
Fixed a test failure due to the the oder in which destructors in Server::MockInstance were called

### DIFF
--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -432,8 +432,8 @@ public:
 
   TimeSource& timeSource() override { return time_system_; }
 
-  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   std::shared_ptr<testing::NiceMock<Network::MockDnsResolver>> dns_resolver_{
       new testing::NiceMock<Network::MockDnsResolver>()};
   testing::NiceMock<Api::MockApi> api_;


### PR DESCRIPTION
MockIsolatedStatsStore is being destroyed before ScopePrefixer, which
holds a reference to it, resulting in a "virtual method called" error, with this stack trace:

```
2020-04-29 22:14:12.802][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:104] Caught Aborted, suspect faulting address 0x3e80000000e
[2020-04-29 22:14:12.802][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:91] Backtrace (use tools/stack_decode.py to get line numbers):
[2020-04-29 22:14:12.802][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:92] Envoy version: 0/1.14.1/redacted/DEBUG/BoringSSL
[2020-04-29 22:14:12.835][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #0: Envoy::SignalAction::sigHandler() [0x36df3ca]
[2020-04-29 22:14:12.835][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #1: __restore_rt [0x7f7ae3d8fb20]
[2020-04-29 22:14:12.867][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #2: Envoy::Stats::ScopePrefixer::~ScopePrefixer() [0x341e8c6]
[2020-04-29 22:14:12.900][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #3: Envoy::Stats::ScopePrefixer::~ScopePrefixer() [0x341e90e]
[2020-04-29 22:14:12.931][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #4: std::default_delete<>::operator()() [0x4a9bc4]
[2020-04-29 22:14:12.963][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #5: std::unique_ptr<>::~unique_ptr() [0x49dd22]
[2020-04-29 22:14:12.995][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #6: Envoy::Upstream::ClusterInfoImpl::~ClusterInfoImpl() [0x1cf415a]
[2020-04-29 22:14:13.027][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #7: Envoy::Upstream::ClusterInfoImpl::~ClusterInfoImpl() [0x1cf41a2]
[2020-04-29 22:14:13.058][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #8: std::default_delete<>::operator()() [0xaecade]
[2020-04-29 22:14:13.091][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #9: std::_Sp_counted_deleter<>::_M_dispose() [0xaf014a]
[2020-04-29 22:14:13.122][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #10: std::_Sp_counted_base<>::_M_release() [0x457b8e]
[2020-04-29 22:14:13.154][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #11: std::__shared_count<>::~__shared_count() [0x452b7d]
[2020-04-29 22:14:13.185][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #12: std::__shared_ptr<>::~__shared_ptr() [0x4e8922]
[2020-04-29 22:14:13.218][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #13: std::shared_ptr<>::~shared_ptr() [0x4e893e]
[2020-04-29 22:14:13.250][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #14: Envoy::Router::Filter::~Filter() [0x2edfde3]
[2020-04-29 22:14:13.282][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #15: Envoy::Router::ProdFilter::~ProdFilter() [0x2ede7d6]
[2020-04-29 22:14:13.314][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #16: Envoy::Http::AsyncStreamImpl::~AsyncStreamImpl() [0x2ed93cd]
[2020-04-29 22:14:13.346][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #17: Envoy::Http::AsyncStreamImpl::~AsyncStreamImpl() [0x2ed946a]
[2020-04-29 22:14:13.377][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #18: std::default_delete<>::operator()() [0x6bed9e]
[2020-04-29 22:14:13.409][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #19: std::unique_ptr<>::~unique_ptr() [0x6bb9ee]
[2020-04-29 22:14:13.441][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #20: __gnu_cxx::new_allocator<>::destroy<>() [0xdc9ca6]
[2020-04-29 22:14:13.472][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #21: std::allocator_traits<>::destroy<>() [0xdc8764]
[2020-04-29 22:14:13.504][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #22: std::__cxx11::_List_base<>::_M_clear() [0xdc63f4]
[2020-04-29 22:14:13.536][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #23: std::__cxx11::_List_base<>::~_List_base() [0xdc24f6]
[2020-04-29 22:14:13.567][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #24: std::__cxx11::list<>::~list() [0xdc0b22]
[2020-04-29 22:14:13.599][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #25: Envoy::Event::MockDispatcher::~MockDispatcher() [0xdbd72a]
[2020-04-29 22:14:13.630][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #26: testing::NiceMock<>::~NiceMock() [0x87918a]
[2020-04-29 22:14:13.662][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #27: Envoy::ThreadLocal::MockInstance::~MockInstance() [0xa22052]
[2020-04-29 22:14:13.693][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #28: testing::NiceMock<>::~NiceMock() [0x878d76]
[2020-04-29 22:14:13.724][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #29: Envoy::Server::MockInstance::~MockInstance() [0x84dd00]
[2020-04-29 22:14:13.756][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #30: testing::NiceMock<>::~NiceMock() [0x4a5298]
[2020-04-29 22:14:13.788][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #31: Envoy::ConfigTest::ConfigTest::~ConfigTest() [0x49d986]
[2020-04-29 22:14:13.819][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #32: Envoy::ConfigTest::run() [0x494adf]
[2020-04-29 22:14:13.850][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #33: Envoy::ExampleConfigsTest_All_Test::TestBody() [0x44e3e8]
[2020-04-29 22:14:13.881][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #34: testing::internal::HandleSehExceptionsInMethodIfSupported<>() [0x40a68fb]
[2020-04-29 22:14:13.912][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #35: testing::internal::HandleExceptionsInMethodIfSupported<>() [0x40a1feb]
[2020-04-29 22:14:13.943][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #36: testing::Test::Run() [0x408c0da]
[2020-04-29 22:14:13.975][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #37: testing::TestInfo::Run() [0x408ca25]
[2020-04-29 22:14:14.006][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #38: testing::TestSuite::Run() [0x408d0e9]
[2020-04-29 22:14:14.037][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #39: testing::internal::UnitTestImpl::RunAllTests() [0x4098c79]
[2020-04-29 22:14:14.068][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #40: testing::internal::HandleSehExceptionsInMethodIfSupported<>() [0x40a7a22]
[2020-04-29 22:14:14.099][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #41: testing::internal::HandleExceptionsInMethodIfSupported<>() [0x40a2ed7]
[2020-04-29 22:14:14.130][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #42: testing::UnitTest::Run() [0x4097609]
[2020-04-29 22:14:14.161][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #43: RUN_ALL_TESTS() [0x32e12b3]
[2020-04-29 22:14:14.192][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #44: Envoy::TestRunner::RunTests() [0x32e0f56]
[2020-04-29 22:14:14.225][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #45: main [0x32df251]
[2020-04-29 22:14:14.226][14][critical][backtrace] [bazel-out/k8-dbg/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #46: __libc_start_main [0x7f7ae3bd91a3]
external/bazel_tools/tools/test/test-setup.sh: line 310:    14 Aborted                 (core dumped) "${TEST_PATH}" "$@" 2>&1
```

Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Fixed a test failure due to the the oder in which destructors were called.
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes: