### PR TITLE
Cleanup: add const for access_log_filter::evaluate function

### DIFF
--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -67,7 +67,7 @@ public:
   virtual bool evaluate(const StreamInfo::StreamInfo& info,
                         const Http::RequestHeaderMap& request_headers,
                         const Http::ResponseHeaderMap& response_headers,
-                        const Http::ResponseTrailerMap& response_trailers) PURE;
+                        const Http::ResponseTrailerMap& response_trailers) const PURE;
 };
 
 using FilterPtr = std::unique_ptr<Filter>;

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -32,7 +32,7 @@ ComparisonFilter::ComparisonFilter(const envoy::config::accesslog::v3::Compariso
                                    Runtime::Loader& runtime)
     : config_(config), runtime_(runtime) {}
 
-bool ComparisonFilter::compareAgainstValue(uint64_t lhs) {
+bool ComparisonFilter::compareAgainstValue(uint64_t lhs) const {
   uint64_t value = config_.value().default_value();
 
   if (!config_.value().runtime_key().empty()) {
@@ -92,14 +92,15 @@ FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLog
 bool TraceableRequestFilter::evaluate(const StreamInfo::StreamInfo& info,
                                       const Http::RequestHeaderMap& request_headers,
                                       const Http::ResponseHeaderMap&,
-                                      const Http::ResponseTrailerMap&) {
+                                      const Http::ResponseTrailerMap&) const {
   Tracing::Decision decision = Tracing::HttpTracerUtility::isTracing(info, request_headers);
 
   return decision.traced && decision.reason == Tracing::Reason::ServiceForced;
 }
 
 bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                                const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
+                                const Http::ResponseHeaderMap&,
+                                const Http::ResponseTrailerMap&) const {
   if (!info.responseCode()) {
     return compareAgainstValue(0ULL);
   }
@@ -108,7 +109,8 @@ bool StatusCodeFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::
 }
 
 bool DurationFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                              const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
+                              const Http::ResponseHeaderMap&,
+                              const Http::ResponseTrailerMap&) const {
   absl::optional<std::chrono::nanoseconds> final = info.requestComplete();
   ASSERT(final);
 
@@ -124,7 +126,8 @@ RuntimeFilter::RuntimeFilter(const envoy::config::accesslog::v3::RuntimeFilter& 
 
 bool RuntimeFilter::evaluate(const StreamInfo::StreamInfo& stream_info,
                              const Http::RequestHeaderMap& request_headers,
-                             const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
+                             const Http::ResponseHeaderMap&,
+                             const Http::ResponseTrailerMap&) const {
   auto rid_extension = stream_info.getRequestIDExtension();
   uint64_t random_value;
   if (use_independent_randomness_ ||
@@ -161,7 +164,7 @@ AndFilter::AndFilter(const envoy::config::accesslog::v3::AndFilter& config,
 bool OrFilter::evaluate(const StreamInfo::StreamInfo& info,
                         const Http::RequestHeaderMap& request_headers,
                         const Http::ResponseHeaderMap& response_headers,
-                        const Http::ResponseTrailerMap& response_trailers) {
+                        const Http::ResponseTrailerMap& response_trailers) const {
   bool result = false;
   for (auto& filter : filters_) {
     result |= filter->evaluate(info, request_headers, response_headers, response_trailers);
@@ -177,7 +180,7 @@ bool OrFilter::evaluate(const StreamInfo::StreamInfo& info,
 bool AndFilter::evaluate(const StreamInfo::StreamInfo& info,
                          const Http::RequestHeaderMap& request_headers,
                          const Http::ResponseHeaderMap& response_headers,
-                         const Http::ResponseTrailerMap& response_trailers) {
+                         const Http::ResponseTrailerMap& response_trailers) const {
   bool result = true;
   for (auto& filter : filters_) {
     result &= filter->evaluate(info, request_headers, response_headers, response_trailers);
@@ -192,7 +195,7 @@ bool AndFilter::evaluate(const StreamInfo::StreamInfo& info,
 
 bool NotHealthCheckFilter::evaluate(const StreamInfo::StreamInfo& info,
                                     const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
-                                    const Http::ResponseTrailerMap&) {
+                                    const Http::ResponseTrailerMap&) const {
   return !info.healthCheck();
 }
 
@@ -201,7 +204,7 @@ HeaderFilter::HeaderFilter(const envoy::config::accesslog::v3::HeaderFilter& con
 
 bool HeaderFilter::evaluate(const StreamInfo::StreamInfo&,
                             const Http::RequestHeaderMap& request_headers,
-                            const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
+                            const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) const {
   return Http::HeaderUtility::matchHeaders(request_headers, *header_data_);
 }
 
@@ -217,7 +220,8 @@ ResponseFlagFilter::ResponseFlagFilter(
 }
 
 bool ResponseFlagFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
-                                  const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) {
+                                  const Http::ResponseHeaderMap&,
+                                  const Http::ResponseTrailerMap&) const {
   if (configured_flags_ != 0) {
     return info.intersectResponseFlags(configured_flags_);
   }
@@ -234,7 +238,7 @@ GrpcStatusFilter::GrpcStatusFilter(const envoy::config::accesslog::v3::GrpcStatu
 
 bool GrpcStatusFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
                                 const Http::ResponseHeaderMap& response_headers,
-                                const Http::ResponseTrailerMap& response_trailers) {
+                                const Http::ResponseTrailerMap& response_trailers) const {
 
   Grpc::Status::GrpcStatus status = Grpc::Status::WellKnownGrpcStatus::Unknown;
   const auto& optional_status =

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -42,7 +42,7 @@ protected:
   ComparisonFilter(const envoy::config::accesslog::v3::ComparisonFilter& config,
                    Runtime::Loader& runtime);
 
-  bool compareAgainstValue(uint64_t lhs);
+  bool compareAgainstValue(uint64_t lhs) const;
 
   envoy::config::accesslog::v3::ComparisonFilter config_;
   Runtime::Loader& runtime_;
@@ -60,7 +60,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 };
 
 /**
@@ -75,7 +75,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 };
 
 /**
@@ -104,7 +104,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 };
 
 /**
@@ -119,7 +119,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 };
 
 /**
@@ -132,7 +132,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 };
 
 /**
@@ -143,7 +143,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 };
 
 /**
@@ -157,7 +157,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 
 private:
   Runtime::Loader& runtime_;
@@ -177,7 +177,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 
 private:
   const Http::HeaderUtility::HeaderDataPtr header_data_;
@@ -193,7 +193,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 
 private:
   uint64_t configured_flags_{};
@@ -214,7 +214,7 @@ public:
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                 const Http::ResponseHeaderMap& response_headers,
-                const Http::ResponseTrailerMap& response_trailers) override;
+                const Http::ResponseTrailerMap& response_trailers) const override;
 
 private:
   GrpcStatusHashSet statuses_;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1317,7 +1317,7 @@ public:
 
   // AccessLog::Filter
   bool evaluate(const StreamInfo::StreamInfo&, const Http::RequestHeaderMap&,
-                const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) override {
+                const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&) const override {
     if (current_++ == 0) {
       return true;
     }

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1328,7 +1328,7 @@ public:
   }
 
 private:
-  uint32_t current_ = 0;
+  mutable uint32_t current_ = 0;
   uint32_t sample_rate_;
 };
 

--- a/test/mocks/access_log/mocks.h
+++ b/test/mocks/access_log/mocks.h
@@ -30,7 +30,8 @@ public:
   MOCK_METHOD(bool, evaluate,
               (const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
                const Http::ResponseHeaderMap& response_headers,
-               const Http::ResponseTrailerMap& response_trailers));
+               const Http::ResponseTrailerMap& response_trailers),
+              (const));
 };
 
 class MockAccessLogManager : public AccessLogManager {


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Add const to the function so that const object can be used to call
```
const AccessLogFilter& filter;
filter.evaluate(...) ;
```

Commit Message:
Additional Description:
Risk Level: None
Testing: None
Docs Changes: No
Release Notes: No
