### PR TITLE
bazel: build zlib with bazel instead of cmake

### DIFF
--- a/bazel/external/zlib.BUILD
+++ b/bazel/external/zlib.BUILD
@@ -1,0 +1,49 @@
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+_ZLIB_HEADERS = [
+    "crc32.h",
+    "deflate.h",
+    "gzguts.h",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.h",
+    "inftrees.h",
+    "trees.h",
+    "zconf.h",
+    "zlib.h",
+    "zutil.h",
+]
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+        # Include the un-prefixed headers in srcs to work
+        # around the fact that zlib isn't consistent in its
+        # choice of <> or "" delimiter when including itself.
+    ],
+    hdrs = _ZLIB_HEADERS,
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }),
+    includes = ["."],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -117,8 +117,8 @@ envoy_cmake_external(
         "NGHTTP2_INCLUDE_DIR": "$EXT_BUILD_DEPS/nghttp2/include",
         # ZLIB.
         "CURL_ZLIB": "on",
-        "ZLIB_LIBRARY": "$EXT_BUILD_DEPS/zlib",
-        "ZLIB_INCLUDE_DIR": "$EXT_BUILD_DEPS/zlib/include",
+        "ZLIB_LIBRARY": "$EXT_BUILD_DEPS/lib",
+        "ZLIB_INCLUDE_DIR": "$EXT_BUILD_DEPS/include",
         "CMAKE_CXX_COMPILER_FORCED": "on",
         "CMAKE_C_FLAGS_BAZEL": "-fPIC",
     },
@@ -132,7 +132,7 @@ envoy_cmake_external(
     deps = [
         ":ares",
         ":nghttp2",
-        ":zlib",
+        "//external:zlib",
         "//external:ssl",
     ],
 )
@@ -207,15 +207,3 @@ envoy_cmake_external(
     }),
 )
 
-envoy_cmake_external(
-    name = "zlib",
-    cache_entries = {
-        "BUILD_SHARED_LIBS": "off",
-        "CMAKE_CXX_COMPILER_FORCED": "on",
-    },
-    lib_source = "@net_zlib//:all",
-    static_libraries = select({
-        "//bazel:windows_x86_64": ["zlibstatic.lib"],
-        "//conditions:default": ["libz.a"],
-    }),
-)

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -132,8 +132,8 @@ envoy_cmake_external(
     deps = [
         ":ares",
         ":nghttp2",
-        "//external:zlib",
         "//external:ssl",
+        "//external:zlib",
     ],
 )
 
@@ -206,4 +206,3 @@ envoy_cmake_external(
         "//conditions:default": ["libyaml-cpp.a"],
     }),
 )
-

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -148,3 +148,20 @@ index 5fa5543b1..484bc41a7 100644
                  executable = ctx.executable.protoc,
                  mnemonic = "ProtoCompile",
                  use_default_shell_env = True,
+# https://github.com/protocolbuffers/protobuf/pull/7443
+diff --git a/third_party/zlib.BUILD b/third_party/zlib.BUILD
+index 093dee18dc..b4bc0b0c97 100644
+--- a/third_party/zlib.BUILD
++++ b/third_party/zlib.BUILD
+@@ -46,10 +46,7 @@ cc_library(
+         "trees.c",
+         "uncompr.c",
+         "zutil.c",
+-        # Include the un-prefixed headers in srcs to work
+-        # around the fact that zlib isn't consistent in its
+-        # choice of <> or "" delimiter when including itself.
+-    ] + _ZLIB_HEADERS,
++    ],
+     hdrs = _ZLIB_PREFIXED_HEADERS,
+     copts = select({
+         "@bazel_tools//src/conditions:windows": [],

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -150,10 +150,10 @@ index 5fa5543b1..484bc41a7 100644
                  use_default_shell_env = True,
 # https://github.com/protocolbuffers/protobuf/pull/7443
 diff --git a/third_party/zlib.BUILD b/third_party/zlib.BUILD
-index 093dee18dc..b4bc0b0c97 100644
+index 093dee18d..3e7e508d5 100644
 --- a/third_party/zlib.BUILD
 +++ b/third_party/zlib.BUILD
-@@ -46,10 +46,7 @@ cc_library(
+@@ -46,10 +46,10 @@ cc_library(
          "trees.c",
          "uncompr.c",
          "zutil.c",
@@ -161,7 +161,10 @@ index 093dee18dc..b4bc0b0c97 100644
 -        # around the fact that zlib isn't consistent in its
 -        # choice of <> or "" delimiter when including itself.
 -    ] + _ZLIB_HEADERS,
-+    ],
++    ] + select({
++        "@bazel_tools//src/conditions:windows": _ZLIB_HEADERS,
++        "//conditions:default": [],
++    }),
      hdrs = _ZLIB_PREFIXED_HEADERS,
      copts = select({
          "@bazel_tools//src/conditions:windows": [],

--- a/bazel/protobuf.patch
+++ b/bazel/protobuf.patch
@@ -148,23 +148,3 @@ index 5fa5543b1..484bc41a7 100644
                  executable = ctx.executable.protoc,
                  mnemonic = "ProtoCompile",
                  use_default_shell_env = True,
-# https://github.com/protocolbuffers/protobuf/pull/7443
-diff --git a/third_party/zlib.BUILD b/third_party/zlib.BUILD
-index 093dee18d..3e7e508d5 100644
---- a/third_party/zlib.BUILD
-+++ b/third_party/zlib.BUILD
-@@ -46,10 +46,10 @@ cc_library(
-         "trees.c",
-         "uncompr.c",
-         "zutil.c",
--        # Include the un-prefixed headers in srcs to work
--        # around the fact that zlib isn't consistent in its
--        # choice of <> or "" delimiter when including itself.
--    ] + _ZLIB_HEADERS,
-+    ] + select({
-+        "@bazel_tools//src/conditions:windows": _ZLIB_HEADERS,
-+        "//conditions:default": [],
-+    }),
-     hdrs = _ZLIB_PREFIXED_HEADERS,
-     copts = select({
-         "@bazel_tools//src/conditions:windows": [],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -323,23 +323,20 @@ def _com_github_libevent_libevent():
     )
 
 def _net_zlib():
-    location = REPOSITORY_LOCATIONS["net_zlib"]
-
-    http_archive(
-        name = "net_zlib",
-        build_file_content = BUILD_ALL_CONTENT,
-        **location
+    _repository_impl(
+        "net_zlib",
+        build_file = "@com_google_protobuf//third_party:zlib.BUILD",
     )
 
     native.bind(
         name = "zlib",
-        actual = "@envoy//bazel/foreign_cc:zlib",
+        actual = "@net_zlib//:zlib",
     )
 
     # Bind for grpc.
     native.bind(
         name = "madler_zlib",
-        actual = "@envoy//bazel/foreign_cc:zlib",
+        actual = "@net_zlib//:zlib",
     )
 
 def _com_google_cel_cpp():

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -325,7 +325,7 @@ def _com_github_libevent_libevent():
 def _net_zlib():
     _repository_impl(
         "net_zlib",
-        build_file = "@com_google_protobuf//third_party:zlib.BUILD",
+        build_file = "@envoy//bazel/external:zlib.BUILD",
     )
 
     native.bind(

--- a/tools/clang_tools/support/clang_tools.bzl
+++ b/tools/clang_tools/support/clang_tools.bzl
@@ -6,7 +6,7 @@ def clang_tools_cc_binary(name, copts = [], tags = [], deps = [], **kwargs):
             "-fno-rtti",
         ],
         tags = tags + ["manual"],
-        deps = deps + ["@envoy//bazel/foreign_cc:zlib"],
+        deps = deps + ["@net_zlib//:zlib"],
         **kwargs
     )
 


### PR DESCRIPTION
`cmake_external` doesn't work well when a custom cc_toolchain is used (e.g. Emscripten). `zlib` is a dependency of protobuf so it breaks wasm build when we try to build everything in one run, i.e. envoyproxy/envoy-wasm#498. 

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
