### PR TITLE
tools: strengthen v2 API package regexes in proto_build_targets_gen.py.

### DIFF
--- a/tools/type_whisperer/proto_build_targets_gen.py
+++ b/tools/type_whisperer/proto_build_targets_gen.py
@@ -15,8 +15,8 @@ V2_REGEXES = list(
     map(re.compile, [
         r'envoy[\w\.]*\.(v1alpha\d?|v1)',
         r'envoy[\w\.]*\.(v2alpha\d?|v2)',
-        r'envoy\.type\.matcher',
-        r'envoy\.type',
+        r'envoy\.type\.matcher$',
+        r'envoy\.type$',
         r'envoy\.config\.cluster\.redis',
         r'envoy\.config\.retry\.previous_priorities',
     ]))


### PR DESCRIPTION
Some weak regexes were causing v4alpha protos to end up in the v2 docs
in https://github.com/envoyproxy/envoy/pull/10971, this PR fixes.

Signed-off-by: Harvey Tuch <htuch@google.com>