### PR TITLE
test: Remove unused dependency on the dynamo filter from the server_test

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -350,7 +350,6 @@ envoy_cc_test(
         "//source/common/common:version_lib",
         "//source/extensions/access_loggers/file:config",
         "//source/extensions/filters/http/buffer:config",
-        "//source/extensions/filters/http/dynamo:config",
         "//source/extensions/filters/http/grpc_http1_bridge:config",
         "//source/extensions/filters/http/health_check:config",
         "//source/extensions/filters/http/ratelimit:config",


### PR DESCRIPTION
Commit Message:
Remove unused dependency on the dynamo filter from the test/server:server_test

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
