### PR TITLE
[admin] Class holding context for admin handlers

### DIFF
--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -86,10 +86,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "handler_ctx_lib",
+    hdrs = ["handler_ctx.h"],
+    deps = [
+        "//include/envoy/server:instance_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "stats_handler_lib",
     srcs = ["stats_handler.cc"],
     hdrs = ["stats_handler.h"],
     deps = [
+        ":handler_ctx_lib",
         ":prometheus_stats_lib",
         ":utils_lib",
         "//include/envoy/http:codes_interface",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -50,7 +50,6 @@
 #include "common/router/config_impl.h"
 #include "common/upstream/host_utility.h"
 
-#include "server/http/stats_handler.h"
 #include "server/http/utils.h"
 
 #include "extensions/access_loggers/file/file_access_log_impl.h"
@@ -992,7 +991,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats("http.admin.", no_op_store_)),
       route_config_provider_(server.timeSource()),
-      scoped_route_config_provider_(server.timeSource()),
+      scoped_route_config_provider_(server.timeSource()), stats_handler_(server),
       // TODO(jsedgwick) add /runtime_reset endpoint that removes all admin-set values
       handlers_{
           {"/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false, false},
@@ -1021,25 +1020,26 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
            false, false},
           {"/quitquitquit", "exit the server", MAKE_ADMIN_HANDLER(handlerQuitQuitQuit), false,
            true},
-          {"/reset_counters", "reset all counters to zero", StatsHandler::handlerResetCounters,
-           false, true},
+          {"/reset_counters", "reset all counters to zero",
+           MAKE_ADMIN_HANDLER(stats_handler_.handlerResetCounters), false, true},
           {"/drain_listeners", "drain listeners", MAKE_ADMIN_HANDLER(handlerDrainListeners), false,
            true},
           {"/server_info", "print server version/status information",
            MAKE_ADMIN_HANDLER(handlerServerInfo), false, false},
           {"/ready", "print server state, return 200 if LIVE, otherwise return 503",
            MAKE_ADMIN_HANDLER(handlerReady), false, false},
-          {"/stats", "print server stats", StatsHandler::handlerStats, false, false},
+          {"/stats", "print server stats", MAKE_ADMIN_HANDLER(stats_handler_.handlerStats), false,
+           false},
           {"/stats/prometheus", "print server stats in prometheus format",
-           StatsHandler::handlerPrometheusStats, false, false},
+           MAKE_ADMIN_HANDLER(stats_handler_.handlerPrometheusStats), false, false},
           {"/stats/recentlookups", "Show recent stat-name lookups",
-           StatsHandler::handlerStatsRecentLookups, false, false},
+           MAKE_ADMIN_HANDLER(stats_handler_.handlerStatsRecentLookups), false, false},
           {"/stats/recentlookups/clear", "clear list of stat-name lookups and counter",
-           StatsHandler::handlerStatsRecentLookupsClear, false, true},
+           MAKE_ADMIN_HANDLER(stats_handler_.handlerStatsRecentLookupsClear), false, true},
           {"/stats/recentlookups/disable", "disable recording of reset stat-name lookup names",
-           StatsHandler::handlerStatsRecentLookupsDisable, false, true},
+           MAKE_ADMIN_HANDLER(stats_handler_.handlerStatsRecentLookupsDisable), false, true},
           {"/stats/recentlookups/enable", "enable recording of reset stat-name lookup names",
-           StatsHandler::handlerStatsRecentLookupsEnable, false, true},
+           MAKE_ADMIN_HANDLER(stats_handler_.handlerStatsRecentLookupsEnable), false, true},
           {"/listeners", "print listener info", MAKE_ADMIN_HANDLER(handlerListenerInfo), false,
            false},
           {"/runtime", "print runtime values", MAKE_ADMIN_HANDLER(handlerRuntime), false, false},
@@ -1101,12 +1101,7 @@ Http::Code AdminImpl::runCallback(absl::string_view path_and_query,
           break;
         }
       }
-      if (handler.requires_server_) {
-        code = handler.handler_with_server_(path_and_query, response_headers, response,
-                                            admin_stream, server_);
-      } else {
-        code = handler.handler_(path_and_query, response_headers, response, admin_stream);
-      }
+      code = handler.handler_(path_and_query, response_headers, response, admin_stream);
       Memory::Utils::tryShrinkHeap();
       break;
     }

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -39,6 +39,7 @@
 
 #include "server/http/admin_filter.h"
 #include "server/http/config_tracker_impl.h"
+#include "server/http/stats_handler.h"
 
 #include "extensions/filters/http/common/pass_through_filter.h"
 
@@ -179,33 +180,16 @@ public:
     };
   }
 
-  using HandlerWithServerCb = std::function<Http::Code(
-      absl::string_view path_and_query, Http::ResponseHeaderMap& response_headers,
-      Buffer::Instance& response, AdminStream& admin_stream, Server::Instance& server)>;
-
 private:
   /**
    * Individual admin handler including prefix, help text, and callback.
    */
   struct UrlHandler {
-    UrlHandler(std::string prefix, std::string help_text, HandlerCb handler, bool removable,
-               bool mutates_server_state)
-        : prefix_(prefix), help_text_(help_text), handler_(handler), removable_(removable),
-          mutates_server_state_(mutates_server_state), requires_server_(false) {}
-
-    UrlHandler(std::string prefix, std::string help_text, HandlerWithServerCb handler_with_server,
-               bool removable, bool mutates_server_state)
-        : prefix_(prefix), help_text_(help_text), handler_with_server_(handler_with_server),
-          removable_(removable), mutates_server_state_(mutates_server_state),
-          requires_server_(true) {}
-
     const std::string prefix_;
     const std::string help_text_;
     const HandlerCb handler_;
-    const HandlerWithServerCb handler_with_server_;
     const bool removable_;
     const bool mutates_server_state_;
-    const bool requires_server_;
   };
 
   /**
@@ -458,6 +442,7 @@ private:
   Http::ConnectionManagerTracingStats tracing_stats_;
   NullRouteConfigProvider route_config_provider_;
   NullScopedRouteConfigProvider scoped_route_config_provider_;
+  Server::StatsHandler stats_handler_;
   std::list<UrlHandler> handlers_;
   const uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   const uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};

--- a/source/server/http/handler_ctx.h
+++ b/source/server/http/handler_ctx.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "envoy/server/instance.h"
+
+namespace Envoy {
+namespace Server {
+
+class HandlerContextBase {
+public:
+  HandlerContextBase(Server::Instance& server) : server_(server) {}
+
+protected:
+  Server::Instance& server_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/http/stats_handler.cc
+++ b/source/server/http/stats_handler.cc
@@ -13,21 +13,21 @@ namespace Server {
 
 const uint64_t RecentLookupsCapacity = 100;
 
+StatsHandler::StatsHandler(Server::Instance& server) : HandlerContextBase(server) {}
+
 Http::Code StatsHandler::handlerResetCounters(absl::string_view, Http::ResponseHeaderMap&,
-                                              Buffer::Instance& response, AdminStream&,
-                                              Server::Instance& server) {
-  for (const Stats::CounterSharedPtr& counter : server.stats().counters()) {
+                                              Buffer::Instance& response, AdminStream&) {
+  for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     counter->reset();
   }
-  server.stats().symbolTable().clearRecentLookups();
+  server_.stats().symbolTable().clearRecentLookups();
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code StatsHandler::handlerStatsRecentLookups(absl::string_view, Http::ResponseHeaderMap&,
-                                                   Buffer::Instance& response, AdminStream&,
-                                                   Server::Instance& server) {
-  Stats::SymbolTable& symbol_table = server.stats().symbolTable();
+                                                   Buffer::Instance& response, AdminStream&) {
+  Stats::SymbolTable& symbol_table = server_.stats().symbolTable();
   std::string table;
   const uint64_t total =
       symbol_table.getRecentLookups([&table](absl::string_view name, uint64_t count) {
@@ -43,35 +43,32 @@ Http::Code StatsHandler::handlerStatsRecentLookups(absl::string_view, Http::Resp
 }
 
 Http::Code StatsHandler::handlerStatsRecentLookupsClear(absl::string_view, Http::ResponseHeaderMap&,
-                                                        Buffer::Instance& response, AdminStream&,
-                                                        Server::Instance& server) {
-  server.stats().symbolTable().clearRecentLookups();
+                                                        Buffer::Instance& response, AdminStream&) {
+  server_.stats().symbolTable().clearRecentLookups();
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code StatsHandler::handlerStatsRecentLookupsDisable(absl::string_view,
                                                           Http::ResponseHeaderMap&,
-                                                          Buffer::Instance& response, AdminStream&,
-                                                          Server::Instance& server) {
-  server.stats().symbolTable().setRecentLookupCapacity(0);
+                                                          Buffer::Instance& response,
+                                                          AdminStream&) {
+  server_.stats().symbolTable().setRecentLookupCapacity(0);
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code StatsHandler::handlerStatsRecentLookupsEnable(absl::string_view,
                                                          Http::ResponseHeaderMap&,
-                                                         Buffer::Instance& response, AdminStream&,
-                                                         Server::Instance& server) {
-  server.stats().symbolTable().setRecentLookupCapacity(RecentLookupsCapacity);
+                                                         Buffer::Instance& response, AdminStream&) {
+  server_.stats().symbolTable().setRecentLookupCapacity(RecentLookupsCapacity);
   response.add("OK\n");
   return Http::Code::OK;
 }
 
 Http::Code StatsHandler::handlerStats(absl::string_view url,
                                       Http::ResponseHeaderMap& response_headers,
-                                      Buffer::Instance& response, AdminStream& admin_stream,
-                                      Server::Instance& server) {
+                                      Buffer::Instance& response, AdminStream& admin_stream) {
   Http::Code rc = Http::Code::OK;
   const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
 
@@ -82,13 +79,13 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
   }
 
   std::map<std::string, uint64_t> all_stats;
-  for (const Stats::CounterSharedPtr& counter : server.stats().counters()) {
+  for (const Stats::CounterSharedPtr& counter : server_.stats().counters()) {
     if (shouldShowMetric(*counter, used_only, regex)) {
       all_stats.emplace(counter->name(), counter->value());
     }
   }
 
-  for (const Stats::GaugeSharedPtr& gauge : server.stats().gauges()) {
+  for (const Stats::GaugeSharedPtr& gauge : server_.stats().gauges()) {
     if (shouldShowMetric(*gauge, used_only, regex)) {
       ASSERT(gauge->importMode() != Stats::Gauge::ImportMode::Uninitialized);
       all_stats.emplace(gauge->name(), gauge->value());
@@ -96,7 +93,7 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
   }
 
   std::map<std::string, std::string> text_readouts;
-  for (const auto& text_readout : server.stats().textReadouts()) {
+  for (const auto& text_readout : server_.stats().textReadouts()) {
     if (shouldShowMetric(*text_readout, used_only, regex)) {
       text_readouts.emplace(text_readout->name(), text_readout->value());
     }
@@ -106,9 +103,9 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     if (format_value.value() == "json") {
       response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
       response.add(
-          statsAsJson(all_stats, text_readouts, server.stats().histograms(), used_only, regex));
+          statsAsJson(all_stats, text_readouts, server_.stats().histograms(), used_only, regex));
     } else if (format_value.value() == "prometheus") {
-      return handlerPrometheusStats(url, response_headers, response, admin_stream, server);
+      return handlerPrometheusStats(url, response_headers, response, admin_stream);
     } else {
       response.add("usage: /stats?format=json  or /stats?format=prometheus \n");
       response.add("\n");
@@ -126,7 +123,7 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
     // multimap here. This makes sure that duplicate histograms get output. When shared storage is
     // implemented this can be switched back to a normal map.
     std::multimap<std::string, std::string> all_histograms;
-    for (const Stats::ParentHistogramSharedPtr& histogram : server.stats().histograms()) {
+    for (const Stats::ParentHistogramSharedPtr& histogram : server_.stats().histograms()) {
       if (shouldShowMetric(*histogram, used_only, regex)) {
         all_histograms.emplace(histogram->name(), histogram->quantileSummary());
       }
@@ -140,16 +137,15 @@ Http::Code StatsHandler::handlerStats(absl::string_view url,
 
 Http::Code StatsHandler::handlerPrometheusStats(absl::string_view path_and_query,
                                                 Http::ResponseHeaderMap&,
-                                                Buffer::Instance& response, AdminStream&,
-                                                Server::Instance& server) {
+                                                Buffer::Instance& response, AdminStream&) {
   const Http::Utility::QueryParams params = Http::Utility::parseQueryString(path_and_query);
   const bool used_only = params.find("usedonly") != params.end();
   absl::optional<std::regex> regex;
   if (!Utility::filterParam(params, response, regex)) {
     return Http::Code::BadRequest;
   }
-  PrometheusStatsFormatter::statsAsPrometheus(server.stats().counters(), server.stats().gauges(),
-                                              server.stats().histograms(), response, used_only,
+  PrometheusStatsFormatter::statsAsPrometheus(server_.stats().counters(), server_.stats().gauges(),
+                                              server_.stats().histograms(), response, used_only,
                                               regex);
   return Http::Code::OK;
 }

--- a/source/server/http/stats_handler.h
+++ b/source/server/http/stats_handler.h
@@ -11,42 +11,39 @@
 
 #include "common/stats/histogram_impl.h"
 
+#include "server/http/handler_ctx.h"
+
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Server {
 
-class StatsHandler {
+class StatsHandler : public HandlerContextBase {
 
 public:
-  static Http::Code handlerResetCounters(absl::string_view path_and_query,
-                                         Http::ResponseHeaderMap& response_headers,
-                                         Buffer::Instance& response, AdminStream&,
-                                         Server::Instance& server);
-  static Http::Code handlerStatsRecentLookups(absl::string_view path_and_query,
+  StatsHandler(Server::Instance& server);
+
+  Http::Code handlerResetCounters(absl::string_view path_and_query,
+                                  Http::ResponseHeaderMap& response_headers,
+                                  Buffer::Instance& response, AdminStream&);
+  Http::Code handlerStatsRecentLookups(absl::string_view path_and_query,
+                                       Http::ResponseHeaderMap& response_headers,
+                                       Buffer::Instance& response, AdminStream&);
+  Http::Code handlerStatsRecentLookupsClear(absl::string_view path_and_query,
+                                            Http::ResponseHeaderMap& response_headers,
+                                            Buffer::Instance& response, AdminStream&);
+  Http::Code handlerStatsRecentLookupsDisable(absl::string_view path_and_query,
                                               Http::ResponseHeaderMap& response_headers,
-                                              Buffer::Instance& response, AdminStream&,
-                                              Server::Instance& server);
-  static Http::Code handlerStatsRecentLookupsClear(absl::string_view path_and_query,
-                                                   Http::ResponseHeaderMap& response_headers,
-                                                   Buffer::Instance& response, AdminStream&,
-                                                   Server::Instance& server);
-  static Http::Code handlerStatsRecentLookupsDisable(absl::string_view path_and_query,
-                                                     Http::ResponseHeaderMap& response_headers,
-                                                     Buffer::Instance& response, AdminStream&,
-                                                     Server::Instance& server);
-  static Http::Code handlerStatsRecentLookupsEnable(absl::string_view path_and_query,
-                                                    Http::ResponseHeaderMap& response_headers,
-                                                    Buffer::Instance& response, AdminStream&,
-                                                    Server::Instance& server);
-  static Http::Code handlerStats(absl::string_view path_and_query,
-                                 Http::ResponseHeaderMap& response_headers,
-                                 Buffer::Instance& response, AdminStream&,
-                                 Server::Instance& server);
-  static Http::Code handlerPrometheusStats(absl::string_view path_and_query,
-                                           Http::ResponseHeaderMap& response_headers,
-                                           Buffer::Instance& response, AdminStream&,
-                                           Server::Instance& server);
+                                              Buffer::Instance& response, AdminStream&);
+  Http::Code handlerStatsRecentLookupsEnable(absl::string_view path_and_query,
+                                             Http::ResponseHeaderMap& response_headers,
+                                             Buffer::Instance& response, AdminStream&);
+  Http::Code handlerStats(absl::string_view path_and_query,
+                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                          AdminStream&);
+  Http::Code handlerPrometheusStats(absl::string_view path_and_query,
+                                    Http::ResponseHeaderMap& response_headers,
+                                    Buffer::Instance& response, AdminStream&);
 
 private:
   template <class StatType>


### PR DESCRIPTION
Create a class that captures context info for admin handlers, and use it as a base class for `StatsHandler`. Part of refactoring for #5505.   