### PR TITLE
Convert cluster-related v2 API test fragments to v3

### DIFF
--- a/test/common/upstream/cds_api_impl_test.cc
+++ b/test/common/upstream/cds_api_impl_test.cc
@@ -96,7 +96,7 @@ TEST_F(CdsApiImplTest, UpdateVersionOnClusterRemove) {
   const std::string response1_yaml = R"EOF(
 version_info: '0'
 resources:
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster1
   type: EDS
   eds_cluster_config:
@@ -268,13 +268,13 @@ TEST_F(CdsApiImplTest, Basic) {
   const std::string response1_yaml = R"EOF(
 version_info: '0'
 resources:
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster1
   type: EDS
   eds_cluster_config:
     eds_config:
       path: eds path
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster2
   type: EDS
   eds_cluster_config:
@@ -295,13 +295,13 @@ resources:
   const std::string response2_yaml = R"EOF(
 version_info: '1'
 resources:
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster1
   type: EDS
   eds_cluster_config:
     eds_config:
       path: eds path
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster3
   type: EDS
   eds_cluster_config:
@@ -329,13 +329,13 @@ TEST_F(CdsApiImplTest, FailureInvalidConfig) {
   const std::string response1_yaml = R"EOF(
 version_info: '0'
 resources:
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster1
   type: EDS
   eds_cluster_config:
     eds_config:
       path: eds path
-- "@type": type.googleapis.com/envoy.api.v2.Cluster
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: cluster1
   type: EDS
   eds_cluster_config:

--- a/test/common/upstream/cluster_factory_impl_test.cc
+++ b/test/common/upstream/cluster_factory_impl_test.cc
@@ -80,6 +80,7 @@ TEST_F(TestStaticClusterImplTest, CreateWithoutConfig) {
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: staticcluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -122,6 +123,7 @@ TEST_F(TestStaticClusterImplTest, CreateWithStructConfig) {
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: staticcluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -166,6 +168,7 @@ TEST_F(TestStaticClusterImplTest, CreateWithTypedConfig) {
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: staticcluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -209,6 +212,7 @@ TEST_F(TestStaticClusterImplTest, UnsupportedClusterType) {
     connect_timeout: 0.25s
     lb_policy: ROUND_ROBIN
     load_assignment:
+        cluster_name: staticcluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -245,6 +249,7 @@ TEST_F(TestStaticClusterImplTest, HostnameWithoutDNS) {
         consistent_hashing_lb_config:
           use_hostname_for_hashing: true
       load_assignment:
+        cluster_name: staticcluster
         endpoints:
           - lb_endpoints:
             - endpoint:

--- a/test/common/upstream/cluster_factory_impl_test.cc
+++ b/test/common/upstream/cluster_factory_impl_test.cc
@@ -79,10 +79,14 @@ TEST_F(TestStaticClusterImplTest, CreateWithoutConfig) {
       name: staticcluster
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
-      hosts:
-      - socket_address:
-          address: 10.0.0.1
-          port_value: 443
+      load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 10.0.0.1
+                    port_value: 443
       cluster_type:
         name: envoy.clusters.test_static
     )EOF";
@@ -117,10 +121,14 @@ TEST_F(TestStaticClusterImplTest, CreateWithStructConfig) {
       name: staticcluster
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
-      hosts:
-      - socket_address:
-          address: 10.0.0.1
-          port_value: 443
+      load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 10.0.0.1
+                    port_value: 443
       cluster_type:
           name: envoy.clusters.custom_static
           typed_config:
@@ -157,10 +165,14 @@ TEST_F(TestStaticClusterImplTest, CreateWithTypedConfig) {
       name: staticcluster
       connect_timeout: 0.25s
       lb_policy: ROUND_ROBIN
-      hosts:
-      - socket_address:
-          address: 10.0.0.1
-          port_value: 443
+      load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 10.0.0.1
+                    port_value: 443
       cluster_type:
           name: envoy.clusters.custom_static
           typed_config:
@@ -196,10 +208,14 @@ TEST_F(TestStaticClusterImplTest, UnsupportedClusterType) {
     name: staticcluster
     connect_timeout: 0.25s
     lb_policy: ROUND_ROBIN
-    hosts:
-    - socket_address:
-        address: 10.0.0.1
-        port_value: 443
+    load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 10.0.0.1
+                    port_value: 443
     cluster_type:
         name: envoy.clusters.bad_cluster_name
         typed_config:
@@ -228,10 +244,14 @@ TEST_F(TestStaticClusterImplTest, HostnameWithoutDNS) {
       common_lb_config:
         consistent_hashing_lb_config:
           use_hostname_for_hashing: true
-      hosts:
-      - socket_address:
-          address: 10.0.0.1
-          port_value: 443
+      load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 10.0.0.1
+                    port_value: 443
       cluster_type:
         name: envoy.clusters.test_static
     )EOF";

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -54,7 +54,8 @@ public:
       type: STATIC
       lb_policy: ROUND_ROBIN
       load_assignment:
-      endpoints:
+        cluster_name: cluster_1
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -65,8 +66,7 @@ public:
               address:
                 socket_address:
                   address: 127.0.0.1
-                  port_value: 11002  
-      
+                  port_value: 11002        
   )EOF";
     const std::string merge_window_enabled = R"EOF(
       common_lb_config:
@@ -200,7 +200,7 @@ TEST_F(ClusterManagerImplTest, MultipleProtocolCluster) {
   checkConfigDump(R"EOF(
 static_clusters:
   - cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: http12_cluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
@@ -339,13 +339,14 @@ static_resources:
     type: static
     lb_policy: round_robin
     load_assignment:
+      cluster_name: foo
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 11001
   )EOF";
 
   create(parseBootstrapFromV3Yaml(yaml));
@@ -432,13 +433,14 @@ TEST_F(ClusterManagerImplTest, OriginalDstLbRestriction2) {
     type: static
     lb_policy: cluster_provided
     load_assignment:
+      cluster_name: cluster_1
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 11001
   )EOF";
 
   EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
@@ -483,24 +485,26 @@ TEST_P(ClusterManagerSubsetInitializationTest, SubsetLoadBalancerInitialization)
   clusters:
   - name: cluster_1
     connect_timeout: 0.250s
+    {}
     lb_policy: "{}"
     lb_subset_config:
       fallback_policy: ANY_ENDPOINT
       subset_selectors:
         - keys: [ "x" ]
     load_assignment:
+      cluster_name: cluster_1
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 8000
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 8001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8000
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8001
   )EOF";
 
   const std::string& policy_name = envoy::config::cluster::v3::Cluster::LbPolicy_Name(GetParam());
@@ -594,6 +598,7 @@ TEST_F(ClusterManagerImplTest, SubsetLoadBalancerLocalityAware) {
         - keys: [ "x" ]
       locality_weight_aware: true
     load_assignment:
+      cluster_name: cluster_1
       endpoints:
         - lb_endpoints:
           - endpoint:
@@ -624,18 +629,19 @@ TEST_F(ClusterManagerImplTest, RingHashLoadBalancerInitialization) {
     connect_timeout: 0.250s
     type: STATIC
     load_assignment:
+      cluster_name: redis_cluster
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 8000
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 8001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8000
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8001
   )EOF";
   create(parseBootstrapFromV3Yaml(yaml));
 }
@@ -648,18 +654,19 @@ TEST_F(ClusterManagerImplTest, RingHashLoadBalancerV2Initialization) {
       connect_timeout: 0.250s
       lb_policy: RING_HASH
       load_assignment:
+        cluster_name: redis_cluster
         endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: 127.0.0.1
-                    port_value: 8000
-            - endpoint:
-                address:
-                  socket_address:
-                    address: 127.0.0.1
-                    port_value: 8001
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 8000
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 8001
       dns_lookup_family: V4_ONLY
       ring_hash_lb_config:
         minimum_ring_size: 125
@@ -759,13 +766,14 @@ TEST_F(ClusterManagerImplTest, TcpHealthChecker) {
     type: STATIC
     lb_policy: ROUND_ROBIN
     load_assignment:
+      cluster_name: cluster_1
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 11001
     health_checks:
     - timeout: 1s
       interval: 1s
@@ -796,13 +804,14 @@ TEST_F(ClusterManagerImplTest, HttpHealthChecker) {
     type: STATIC
     lb_policy: ROUND_ROBIN
     load_assignment:
+      cluster_name: cluster_1
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 11001
     health_checks:
     - timeout: 1s
       interval: 1s
@@ -857,13 +866,14 @@ TEST_F(ClusterManagerImplTest, VerifyBufferLimits) {
     lb_policy: round_robin
     per_connection_buffer_limit_bytes: 8192
     load_assignment:
+      cluster_name: cluster_1
       endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11001
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 11001
   )EOF";
 
   create(parseBootstrapFromV3Yaml(yaml));
@@ -990,12 +1000,13 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
  version_info: version3
  static_clusters:
   - cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "cds_cluster"
       type: "STATIC"
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: cds_cluster
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1006,12 +1017,13 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
       seconds: 1234567891
       nanos: 234000000
   - cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "fake_cluster"
       type: "STATIC"
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: fake_cluster
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1022,12 +1034,13 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
       seconds: 1234567891
       nanos: 234000000
   - cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "fake_cluster2"
       type: "STATIC"
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: fake_cluster2
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1040,12 +1053,13 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
  dynamic_active_clusters:
   - version_info: "version3"
     cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "cluster3"
       type: "STATIC"
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: cluster3
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1057,12 +1071,13 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
       nanos: 234000000
   - version_info: "version3"
     cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "cluster4"
       type: "STATIC"
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: cluster4
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1074,12 +1089,13 @@ TEST_F(ClusterManagerImplTest, InitializeOrder) {
       nanos: 234000000
   - version_info: "version3"
     cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "cluster5"
       type: "STATIC"
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: cluster5
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1192,12 +1208,13 @@ TEST_F(ClusterManagerImplTest, RemoveWarmingCluster) {
 dynamic_warming_clusters:
   - version_info: "version3"
     cluster:
-      "@type": type.googleapis.com/envoy.api.v3.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
       name: "fake_cluster"
       type: STATIC
       connect_timeout: 0.25s
       load_assignment:
-      endpoints:
+        cluster_name: fake_cluster
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -1239,18 +1256,19 @@ TEST_F(ClusterManagerImplTest, ModifyWarmingCluster) {
  dynamic_warming_clusters:
    - version_info: "version3"
      cluster:
-       "@type": type.googleapis.com/envoy.api.v3.Cluster
+       "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
        name: "fake_cluster"
        type: STATIC
        connect_timeout: 0.25s
        load_assignment:
-      endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11001
+         cluster_name: fake_cluster
+         endpoints:
+         - lb_endpoints:
+           - endpoint:
+               address:
+                 socket_address:
+                   address: 127.0.0.1
+                   port_value: 11001
      last_updated:
        seconds: 1234567891
        nanos: 234000000
@@ -1276,18 +1294,19 @@ TEST_F(ClusterManagerImplTest, ModifyWarmingCluster) {
  dynamic_warming_clusters:
    - version_info: "version3"
      cluster:
-       "@type": type.googleapis.com/envoy.api.v3.Cluster
+       "@type": type.googleapis.com/envoy.config.cluster.v3.cluster
        name: "fake_cluster"
        type: STATIC
        connect_timeout: 0.25s
        load_assignment:
-      endpoints:
-        - lb_endpoints:
-          - endpoint:
-              address:
-                socket_address:
-                  address: 127.0.0.1
-                  port_value: 11002
+         cluster_name: fake_cluster
+         endpoints:
+         - lb_endpoints:
+           - endpoint:
+               address:
+                 socket_address:
+                   address: 127.0.0.1
+                   port_value: 11002
      last_updated:
        seconds: 1234567891
        nanos: 234000000
@@ -1763,6 +1782,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemove) {
             address: 1.2.3.4
             port_value: 80
       load_assignment:
+        cluster_name: cluster_1
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -1906,6 +1926,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveWithTls) {
           port_value: 80
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: cluster_1
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -2234,6 +2255,7 @@ TEST_F(ClusterManagerImplTest, DynamicHostRemoveDefaultPriority) {
           port_value: 80
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: cluster_1
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -2314,6 +2336,7 @@ TEST_F(ClusterManagerImplTest, ConnPoolDestroyWithDraining) {
           port_value: 80
       lb_policy: ROUND_ROBIN
       load_assignment:
+        cluster_name: cluster_1
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -2676,6 +2699,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
   type: STATIC
   lb_policy: ROUND_ROBIN
   load_assignment:
+    cluster_name: new_cluster
     endpoints:
       - lb_endpoints:
         - endpoint:
@@ -2686,7 +2710,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
   common_lb_config:
     update_merge_window: 3s
   )EOF";
-  EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(parseClusterFromV3Yaml(yaml), "version1"));
+  EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(parseClusterFromV2Yaml(yaml), "version1"));
 
   Cluster& cluster = cluster_manager_->activeClusters().find("new_cluster")->second;
   HostVectorSharedPtr hosts(
@@ -2734,6 +2758,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
   type: STATIC
   lb_policy: ROUND_ROBIN
   load_assignment:
+    cluster_name: new_cluster
     endpoints:
       - lb_endpoints:
         - endpoint:
@@ -2754,7 +2779,7 @@ TEST_F(ClusterManagerImplTest, MergedUpdatesDestroyedOnUpdate) {
                    .gauge("cluster_manager.warming_clusters", Stats::Gauge::ImportMode::NeverImport)
                    .value());
   EXPECT_TRUE(
-      cluster_manager_->addOrUpdateCluster(parseClusterFromV3Yaml(yaml_updated), "version2"));
+      cluster_manager_->addOrUpdateCluster(parseClusterFromV2Yaml(yaml_updated), "version2"));
   EXPECT_EQ(2, factory_.stats_
                    .gauge("cluster_manager.active_clusters", Stats::Gauge::ImportMode::NeverImport)
                    .value());
@@ -2883,7 +2908,8 @@ TEST_F(ClusterManagerImplTest, AddUpstreamFilters) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
-      endpoints:
+        cluster_name: cluster_1
+        endpoints:
         - lb_endpoints:
           - endpoint:
               address:
@@ -3195,6 +3221,7 @@ TEST_F(SockoptsTest, SockoptsUnset) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3216,6 +3243,7 @@ TEST_F(SockoptsTest, FreebindClusterOnly) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3239,6 +3267,7 @@ TEST_F(SockoptsTest, FreebindClusterManagerOnly) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3263,6 +3292,7 @@ TEST_F(SockoptsTest, FreebindClusterOverride) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3289,6 +3319,7 @@ TEST_F(SockoptsTest, SockoptsClusterOnly) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3317,6 +3348,7 @@ TEST_F(SockoptsTest, SockoptsClusterManagerOnly) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3345,6 +3377,7 @@ TEST_F(SockoptsTest, SockoptsClusterOverride) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: SockoptsCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3474,6 +3507,7 @@ TEST_F(TcpKeepaliveTest, TcpKeepaliveUnset) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: TcpKeepaliveCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3495,6 +3529,7 @@ TEST_F(TcpKeepaliveTest, TcpKeepaliveCluster) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: TcpKeepaliveCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3518,6 +3553,7 @@ TEST_F(TcpKeepaliveTest, TcpKeepaliveClusterProbes) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: TcpKeepaliveCluster
         endpoints:
           - lb_endpoints:
             - endpoint:
@@ -3542,6 +3578,7 @@ TEST_F(TcpKeepaliveTest, TcpKeepaliveWithAllOptions) {
       lb_policy: ROUND_ROBIN
       type: STATIC
       load_assignment:
+        cluster_name: TcpKeepaliveCluster
         endpoints:
           - lb_endpoints:
             - endpoint:


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: changes in test files for "Convert v2 API test fragments to v3"
Additional Description: file changes in test/common/upstream/
Risk Level: 
Testing: format test and integration test
Docs Changes:
Release Notes:
[Optional Runtime guard:]
Progress toward #10843 
[Optional Deprecated:]
Note : I will push remaining files changes in next PR
