### PR TITLE
[WIP] Support graceful draining from /drain_close

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -735,24 +735,6 @@ Http::Code AdminImpl::handlerMemory(absl::string_view, Http::ResponseHeaderMap& 
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerDrainListeners(absl::string_view url, Http::ResponseHeaderMap&,
-                                            Buffer::Instance& response, AdminStream&) {
-  const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
-  ListenerManager::StopListenersType stop_listeners_type =
-      params.find("inboundonly") != params.end() ? ListenerManager::StopListenersType::InboundOnly
-                                                 : ListenerManager::StopListenersType::All;
-  if (params.find("graceful") != params.end()) {
-    server_.drainManager().startDrainSequence([this, stop_listeners_type]() {
-      server_.listenerManager().stopListeners(stop_listeners_type);
-    });
-  } else {
-    // If no graceful drain period is specified, close listeners immediately.
-    server_.listenerManager().stopListeners(stop_listeners_type);
-  }
-  response.add("OK\n");
-  return Http::Code::OK;
-}
-
 Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::ResponseHeaderMap& headers,
                                         Buffer::Instance& response, AdminStream&) {
   const std::time_t current_time =

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -735,6 +735,24 @@ Http::Code AdminImpl::handlerMemory(absl::string_view, Http::ResponseHeaderMap& 
   return Http::Code::OK;
 }
 
+Http::Code AdminImpl::handlerDrainListeners(absl::string_view url, Http::ResponseHeaderMap&,
+                                            Buffer::Instance& response, AdminStream&) {
+  const Http::Utility::QueryParams params = Http::Utility::parseQueryString(url);
+  ListenerManager::StopListenersType stop_listeners_type =
+      params.find("inboundonly") != params.end() ? ListenerManager::StopListenersType::InboundOnly
+                                                 : ListenerManager::StopListenersType::All;
+  if (params.find("graceful") != params.end()) {
+    server_.drainManager().startDrainSequence([this, stop_listeners_type]() {
+      server_.listenerManager().stopListeners(stop_listeners_type);
+    });
+  } else {
+    // If no graceful drain period is specified, close listeners immediately.
+    server_.listenerManager().stopListeners(stop_listeners_type);
+  }
+  response.add("OK\n");
+  return Http::Code::OK;
+}
+
 Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::ResponseHeaderMap& headers,
                                         Buffer::Instance& response, AdminStream&) {
   const std::time_t current_time =

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -567,6 +567,7 @@ envoy_cc_test_library(
         "//source/extensions/transport_sockets/tap:config",
         "//source/extensions/transport_sockets/tls:config",
         "//source/server:connection_handler_lib",
+        "//source/server:drain_manager_lib",
         "//source/server:hot_restart_nop_lib",
         "//source/server:listener_hooks_lib",
         "//source/server:process_context_lib",
@@ -591,6 +592,7 @@ envoy_cc_test_library(
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1213,6 +1213,48 @@ void HttpIntegrationTest::testAdminDrain(Http::CodecClient::Type admin_request_t
   }
 }
 
+void HttpIntegrationTest::testGracefulDrain(Http::CodecClient::Type admin_request_type) {
+  initialize();
+
+  uint32_t http_port = lookupPort("http");
+  codec_client_ = makeHttpConnection(http_port);
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "HEAD"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"}};
+  IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  waitForNextUpstreamRequest(0);
+  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+
+  // Invoke drain listeners endpoint and validate that we can still work on inflight requests.
+  BufferingStreamDecoderPtr admin_response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "POST", "/drain_listeners", "", admin_request_type, version_);
+  EXPECT_TRUE(admin_response->complete());
+  EXPECT_EQ("200", admin_response->headers().Status()->value().getStringView());
+  EXPECT_EQ("OK\n", admin_response->body());
+
+  upstream_request_->encodeData(512, true);
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+
+  // Wait for the response to be read by the codec client.
+  response->waitForEndStream();
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
+
+  // Validate that the listeners have been stopped.
+  test_server_->waitForCounterEq("listener_manager.listener_stopped", 1);
+
+  // Validate that port is closed and can be bound by other sockets.
+  EXPECT_NO_THROW(Network::TcpListenSocket(
+      Network::Utility::getAddressWithPort(*Network::Test::getCanonicalLoopbackAddress(version_),
+                                           http_port),
+      nullptr, true));
+}
+
 void HttpIntegrationTest::testMaxStreamDuration() {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto* static_resources = bootstrap.mutable_static_resources();

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -220,9 +220,12 @@ protected:
                     bool response_trailers_present);
   // Test /drain_listener from admin portal.
   void testAdminDrain(Http::CodecClient::Type admin_request_type);
+  void testGracefulDrain(Http::CodecClient::Type admin_request_type);
+
   // Test max stream duration.
   void testMaxStreamDuration();
   void testMaxStreamDurationWithRetry(bool invoke_retry_upstream_disconnect);
+
   Http::CodecClient::Type downstreamProtocol() const { return downstream_protocol_; }
   // Prefix listener stat with IP:port, including IP version dependent loopback address.
   std::string listenerStatPrefix(const std::string& stat_name);

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -458,7 +458,7 @@ void BaseIntegrationTest::createGeneratedApiTestServer(const std::string& bootst
   test_server_ = IntegrationTestServer::create(
       bootstrap_path, version_, on_server_ready_function_, on_server_init_function_, deterministic_,
       timeSystem(), *api_, defer_listener_finalization_, process_object_,
-      allow_unknown_static_fields, reject_unknown_dynamic_fields, concurrency_);
+      allow_unknown_static_fields, reject_unknown_dynamic_fields, concurrency_, drain_time_);
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0 &&
       !defer_listener_finalization_) {
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -418,6 +418,9 @@ protected:
   // The number of worker threads that the test server uses.
   uint32_t concurrency_{1};
 
+  // The duration of the drain manager graceful drain period.
+  std::chrono::seconds drain_time_{1};
+
   // Member variables for xDS testing.
   FakeUpstream* xds_upstream_{};
   FakeHttpConnectionPtr xds_connection_;

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -99,6 +99,8 @@ TEST_P(IntegrationTest, PerWorkerStatsAndBalancing) {
 // Validates that the drain actually drains the listeners.
 TEST_P(IntegrationTest, AdminDrainDrainsListeners) { testAdminDrain(downstreamProtocol()); }
 
+TEST_P(IntegrationTest, GracefulDrain) { testGracefulDrain(downstreamProtocol()); }
+
 TEST_P(IntegrationTest, RouterDirectResponse) {
   const std::string body = "Response body";
   const std::string file_path = TestEnvironment::writeStringToFileForTest("test_envoy", body);

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -168,12 +168,11 @@ void IntegrationTestServer::serverReady() {
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version,
                                           bool deterministic, ProcessObjectOptRef process_object,
                                           bool allow_unknown_static_fields,
-                                          bool reject_unknown_dynamic_fields,
-                                          uint32_t concurrency,
+                                          bool reject_unknown_dynamic_fields, uint32_t concurrency,
                                           std::chrono::seconds drain_time) {
-  OptionsImpl options(Server::createTestOptionsImpl(config_path_, "", version,
-                                                    allow_unknown_static_fields,
-                                                    reject_unknown_dynamic_fields, concurrency, drain_time));
+  OptionsImpl options(
+      Server::createTestOptionsImpl(config_path_, "", version, allow_unknown_static_fields,
+                                    reject_unknown_dynamic_fields, concurrency, drain_time));
   Thread::MutexBasicLockable lock;
 
   Runtime::RandomGeneratorPtr random_generator;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -37,7 +37,8 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
                                   Network::Address::IpVersion ip_version,
                                   bool allow_unknown_static_fields = false,
                                   bool reject_unknown_dynamic_fields = false,
-                                  uint32_t concurrency = 1);
+                                  uint32_t concurrency = 1,
+                                  std::chrono::seconds drain_time = std::chrono::seconds(1));
 
 class TestComponentFactory : public ComponentFactory {
 public:
@@ -266,7 +267,7 @@ public:
       std::function<void()> on_server_init_function, bool deterministic,
       Event::TestTimeSystem& time_system, Api::Api& api, bool defer_listener_finalization = false,
       ProcessObjectOptRef process_object = absl::nullopt, bool allow_unknown_static_fields = false,
-      bool reject_unknown_dynamic_fields = false, uint32_t concurrency = 1);
+      bool reject_unknown_dynamic_fields = false, uint32_t concurrency = 1, std::chrono::seconds drain_time = std::chrono::seconds(1));
   // Note that the derived class is responsible for tearing down the server in its
   // destructor.
   ~IntegrationTestServer() override;
@@ -289,7 +290,7 @@ public:
              std::function<void()> on_server_init_function, bool deterministic,
              bool defer_listener_finalization, ProcessObjectOptRef process_object,
              bool allow_unknown_static_fields, bool reject_unknown_dynamic_fields,
-             uint32_t concurrency);
+             uint32_t concurrency, std::chrono::seconds drain_time);
 
   void waitForCounterEq(const std::string& name, uint64_t value) override {
     TestUtility::waitForCounterEq(stat_store(), name, value, time_system_);
@@ -369,7 +370,8 @@ private:
    */
   void threadRoutine(const Network::Address::IpVersion version, bool deterministic,
                      ProcessObjectOptRef process_object, bool allow_unknown_static_fields,
-                     bool reject_unknown_dynamic_fields, uint32_t concurrency);
+                     bool reject_unknown_dynamic_fields, uint32_t concurrency,
+                     std::chrono::seconds drain_time);
 
   Event::TestTimeSystem& time_system_;
   Api::Api& api_;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/server/options.h"
 #include "envoy/server/process_context.h"
 #include "envoy/stats/stats.h"
@@ -15,6 +16,7 @@
 #include "common/common/logger.h"
 #include "common/common/thread.h"
 
+#include "server/drain_manager_impl.h"
 #include "server/listener_hooks.h"
 #include "server/options_impl.h"
 #include "server/server.h"
@@ -37,20 +39,10 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
                                   bool reject_unknown_dynamic_fields = false,
                                   uint32_t concurrency = 1);
 
-class TestDrainManager : public DrainManager {
-public:
-  // Server::DrainManager
-  bool drainClose() const override { return draining_; }
-  void startDrainSequence(std::function<void()>) override {}
-  void startParentShutdownSequence() override {}
-
-  bool draining_{};
-};
-
 class TestComponentFactory : public ComponentFactory {
 public:
-  Server::DrainManagerPtr createDrainManager(Server::Instance&) override {
-    return Server::DrainManagerPtr{new Server::TestDrainManager()};
+  Server::DrainManagerPtr createDrainManager(Server::Instance& server) override {
+    return Server::DrainManagerPtr{new Server::DrainManagerImpl(server, envoy::config::listener::v3::Listener::MODIFY_ONLY)};
   }
   Runtime::LoaderPtr createRuntime(Server::Instance& server,
                                    Server::Configuration::Initial& config) override {
@@ -281,7 +273,7 @@ public:
 
   void waitUntilListenersReady();
 
-  Server::TestDrainManager& drainManager() { return *drain_manager_; }
+  Server::DrainManagerImpl& drainManager() { return *drain_manager_; }
   void setOnWorkerListenerAddedCb(std::function<void()> on_worker_listener_added) {
     on_worker_listener_added_cb_ = std::move(on_worker_listener_added);
   }
@@ -336,8 +328,8 @@ public:
   void onWorkerListenerRemoved() override;
 
   // Server::ComponentFactory
-  Server::DrainManagerPtr createDrainManager(Server::Instance&) override {
-    drain_manager_ = new Server::TestDrainManager();
+  Server::DrainManagerPtr createDrainManager(Server::Instance& server) override {
+    drain_manager_ = new Server::DrainManagerImpl(server, envoy::config::listener::v3::Listener::MODIFY_ONLY);
     return Server::DrainManagerPtr{drain_manager_};
   }
   Runtime::LoaderPtr createRuntime(Server::Instance& server,
@@ -387,7 +379,7 @@ private:
   Thread::MutexBasicLockable listeners_mutex_;
   uint64_t pending_listeners_;
   ConditionalInitializer server_set_;
-  Server::TestDrainManager* drain_manager_{};
+  Server::DrainManagerImpl* drain_manager_{};
   std::function<void()> on_worker_listener_added_cb_;
   std::function<void()> on_worker_listener_removed_cb_;
   TcpDumpPtr tcp_dump_;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -43,7 +43,8 @@ OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::str
 class TestComponentFactory : public ComponentFactory {
 public:
   Server::DrainManagerPtr createDrainManager(Server::Instance& server) override {
-    return Server::DrainManagerPtr{new Server::DrainManagerImpl(server, envoy::config::listener::v3::Listener::MODIFY_ONLY)};
+    return Server::DrainManagerPtr{
+        new Server::DrainManagerImpl(server, envoy::config::listener::v3::Listener::MODIFY_ONLY)};
   }
   Runtime::LoaderPtr createRuntime(Server::Instance& server,
                                    Server::Configuration::Initial& config) override {
@@ -261,13 +262,15 @@ class IntegrationTestServer : public Logger::Loggable<Logger::Id::testing>,
                               public IntegrationTestServerStats,
                               public Server::ComponentFactory {
 public:
-  static IntegrationTestServerPtr create(
-      const std::string& config_path, const Network::Address::IpVersion version,
-      std::function<void(IntegrationTestServer&)> on_server_ready_function,
-      std::function<void()> on_server_init_function, bool deterministic,
-      Event::TestTimeSystem& time_system, Api::Api& api, bool defer_listener_finalization = false,
-      ProcessObjectOptRef process_object = absl::nullopt, bool allow_unknown_static_fields = false,
-      bool reject_unknown_dynamic_fields = false, uint32_t concurrency = 1, std::chrono::seconds drain_time = std::chrono::seconds(1));
+  static IntegrationTestServerPtr
+  create(const std::string& config_path, const Network::Address::IpVersion version,
+         std::function<void(IntegrationTestServer&)> on_server_ready_function,
+         std::function<void()> on_server_init_function, bool deterministic,
+         Event::TestTimeSystem& time_system, Api::Api& api,
+         bool defer_listener_finalization = false,
+         ProcessObjectOptRef process_object = absl::nullopt,
+         bool allow_unknown_static_fields = false, bool reject_unknown_dynamic_fields = false,
+         uint32_t concurrency = 1, std::chrono::seconds drain_time = std::chrono::seconds(1));
   // Note that the derived class is responsible for tearing down the server in its
   // destructor.
   ~IntegrationTestServer() override;
@@ -330,7 +333,8 @@ public:
 
   // Server::ComponentFactory
   Server::DrainManagerPtr createDrainManager(Server::Instance& server) override {
-    drain_manager_ = new Server::DrainManagerImpl(server, envoy::config::listener::v3::Listener::MODIFY_ONLY);
+    drain_manager_ =
+        new Server::DrainManagerImpl(server, envoy::config::listener::v3::Listener::MODIFY_ONLY);
     return Server::DrainManagerPtr{drain_manager_};
   }
   Runtime::LoaderPtr createRuntime(Server::Instance& server,


### PR DESCRIPTION
Previously, I proposed [Last Call mode](#10592). After syncing with Matt, we decided it would make more sense to enhance the existing /drain_close endpoint.

This change introduces a `graceful` query parameter such that admin call `/drain_close?graceful` will trigger the drain manager draining sequence, then close the listeners on completion. I added additional integration testing around this.

# Future work

## Graceful query parameter

Currently, the admin handler just checks for the presence of `graceful`. The actual graceful drain period is defined by the drain manager configuration, but in the future, we would actually want an optional override. So basically, if a user has configured drain manager to have a 10 minute timeout, 
 `/drain_close?graceful` should trigger a graceful drain period of 10 minutes, then close listeners. If within the ten minutes the user decides to shorten the grace period, they should be able to invoke '/drain_close?graceful=60`, for example, to replace the existing 10 minute drain period with a shorter 1-minute window.

These are future needs, but I'm looking to incrementally submit what we need. What sort of API documentation is needed for a new query parameter? Can I leave `graceful` as a boolean and change it to accept a number later? Better name suggestions are also welcome.

## Graceful draining functionality

Two expected behaviours of graceful drain are: 1. HTTP1 requests connections are closed on request termination, i.e. `keep-alive` is terminated; 2. HTTP2 streams receive `GOAWAY`. I expected this behaviour to automatically trigger with the code I wrote, but this did not turn out to be true. In integration tests at least, the HCM is not reading the real DrainManager for its drain decision. I hope to fix this in a followup PR, such that graceful drain period should include both of those features.

## Idle timeout

During the graceful drain period, idle connections that are in the header phase should be terminated. I'll have to separately scope out this work, as it's not a current feature. Once added, this behaviour should be present in both hot restart and the new `/drain_close?graceful` sequence.