### PR TITLE
doc: clarify --concurrency 0

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -69,7 +69,8 @@ following are the command line options that Envoy supports.
 .. option:: --concurrency <integer>
 
   *(optional)* The number of :ref:`worker threads <arch_overview_threading>` to run. If not
-  specified defaults to the number of hardware threads on the machine.
+  specified defaults to the number of hardware threads on the machine. Specifically, the actual 
+  number of worker thread is 1 when you set the value 0.
 
 .. option:: -l <string>, --log-level <string>
 

--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -69,8 +69,8 @@ following are the command line options that Envoy supports.
 .. option:: --concurrency <integer>
 
   *(optional)* The number of :ref:`worker threads <arch_overview_threading>` to run. If not
-  specified defaults to the number of hardware threads on the machine. Specifically, the actual 
-  number of worker thread is 1 when you set the value 0.
+  specified defaults to the number of hardware threads on the machine. If set to zero, Envoy will 
+  still run one worker thread.
 
 .. option:: -l <string>, --log-level <string>
 


### PR DESCRIPTION
Commit Message:
Clarify doc that concurrency 0 and 1 are equivalent.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
