### PR TITLE
docs: Fixes a mismatch in metadata attribute name (used by transport_socket_matches)

### DIFF
--- a/api/envoy/api/v2/cluster.proto
+++ b/api/envoy/api/v2/cluster.proto
@@ -471,7 +471,7 @@ message Cluster {
   reserved 12, 15;
 
   // Configuration to use different transport sockets for different endpoints.
-  // The entry of *envoy.transport_socket* in the
+  // The entry of *envoy.transport_socket_match* in the
   // :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>`
   // is used to match against the transport sockets as they appear in the list. The first
   // :ref:`match <envoy_api_msg_Cluster.TransportSocketMatch>` is used.
@@ -491,14 +491,14 @@ message Cluster {
   //    transport_socket:
   //      name: envoy.transport_sockets.raw_buffer
   //
-  // Connections to the endpoints whose metadata value under *envoy.transport_socket*
+  // Connections to the endpoints whose metadata value under *envoy.transport_socket_match*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.
   //
   // If a :ref:`socket match <envoy_api_msg_Cluster.TransportSocketMatch>` with empty match
   // criteria is provided, that always match any endpoint. For example, the "defaultToPlaintext"
   // socket match in case above.
   //
-  // If an endpoint metadata's value under *envoy.transport_socket* does not match any
+  // If an endpoint metadata's value under *envoy.transport_socket_match* does not match any
   // *TransportSocketMatch*, socket configuration fallbacks to use the *tls_context* or
   // *transport_socket* specified in this cluster.
   //

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -504,7 +504,7 @@ message Cluster {
   reserved "hosts", "tls_context", "extension_protocol_options";
 
   // Configuration to use different transport sockets for different endpoints.
-  // The entry of *envoy.transport_socket* in the
+  // The entry of *envoy.transport_socket_match* in the
   // :ref:`LbEndpoint.Metadata <envoy_api_field_config.endpoint.v3.LbEndpoint.metadata>`
   // is used to match against the transport sockets as they appear in the list. The first
   // :ref:`match <envoy_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>` is used.
@@ -524,14 +524,14 @@ message Cluster {
   //    transport_socket:
   //      name: envoy.transport_sockets.raw_buffer
   //
-  // Connections to the endpoints whose metadata value under *envoy.transport_socket*
+  // Connections to the endpoints whose metadata value under *envoy.transport_socket_match*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.
   //
   // If a :ref:`socket match <envoy_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>` with empty match
   // criteria is provided, that always match any endpoint. For example, the "defaultToPlaintext"
   // socket match in case above.
   //
-  // If an endpoint metadata's value under *envoy.transport_socket* does not match any
+  // If an endpoint metadata's value under *envoy.transport_socket_match* does not match any
   // *TransportSocketMatch*, socket configuration fallbacks to use the *tls_context* or
   // *transport_socket* specified in this cluster.
   //

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -505,7 +505,7 @@ message Cluster {
   reserved "hosts", "tls_context", "extension_protocol_options";
 
   // Configuration to use different transport sockets for different endpoints.
-  // The entry of *envoy.transport_socket* in the
+  // The entry of *envoy.transport_socket_match* in the
   // :ref:`LbEndpoint.Metadata <envoy_api_field_config.endpoint.v3.LbEndpoint.metadata>`
   // is used to match against the transport sockets as they appear in the list. The first
   // :ref:`match <envoy_api_msg_config.cluster.v4alpha.Cluster.TransportSocketMatch>` is used.
@@ -525,14 +525,14 @@ message Cluster {
   //    transport_socket:
   //      name: envoy.transport_sockets.raw_buffer
   //
-  // Connections to the endpoints whose metadata value under *envoy.transport_socket*
+  // Connections to the endpoints whose metadata value under *envoy.transport_socket_match*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.
   //
   // If a :ref:`socket match <envoy_api_msg_config.cluster.v4alpha.Cluster.TransportSocketMatch>` with empty match
   // criteria is provided, that always match any endpoint. For example, the "defaultToPlaintext"
   // socket match in case above.
   //
-  // If an endpoint metadata's value under *envoy.transport_socket* does not match any
+  // If an endpoint metadata's value under *envoy.transport_socket_match* does not match any
   // *TransportSocketMatch*, socket configuration fallbacks to use the *tls_context* or
   // *transport_socket* specified in this cluster.
   //

--- a/generated_api_shadow/envoy/api/v2/cluster.proto
+++ b/generated_api_shadow/envoy/api/v2/cluster.proto
@@ -471,7 +471,7 @@ message Cluster {
   reserved 12, 15;
 
   // Configuration to use different transport sockets for different endpoints.
-  // The entry of *envoy.transport_socket* in the
+  // The entry of *envoy.transport_socket_match* in the
   // :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>`
   // is used to match against the transport sockets as they appear in the list. The first
   // :ref:`match <envoy_api_msg_Cluster.TransportSocketMatch>` is used.
@@ -491,14 +491,14 @@ message Cluster {
   //    transport_socket:
   //      name: envoy.transport_sockets.raw_buffer
   //
-  // Connections to the endpoints whose metadata value under *envoy.transport_socket*
+  // Connections to the endpoints whose metadata value under *envoy.transport_socket_match*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.
   //
   // If a :ref:`socket match <envoy_api_msg_Cluster.TransportSocketMatch>` with empty match
   // criteria is provided, that always match any endpoint. For example, the "defaultToPlaintext"
   // socket match in case above.
   //
-  // If an endpoint metadata's value under *envoy.transport_socket* does not match any
+  // If an endpoint metadata's value under *envoy.transport_socket_match* does not match any
   // *TransportSocketMatch*, socket configuration fallbacks to use the *tls_context* or
   // *transport_socket* specified in this cluster.
   //

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -502,7 +502,7 @@ message Cluster {
   reserved 12, 15;
 
   // Configuration to use different transport sockets for different endpoints.
-  // The entry of *envoy.transport_socket* in the
+  // The entry of *envoy.transport_socket_match* in the
   // :ref:`LbEndpoint.Metadata <envoy_api_field_config.endpoint.v3.LbEndpoint.metadata>`
   // is used to match against the transport sockets as they appear in the list. The first
   // :ref:`match <envoy_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>` is used.
@@ -522,14 +522,14 @@ message Cluster {
   //    transport_socket:
   //      name: envoy.transport_sockets.raw_buffer
   //
-  // Connections to the endpoints whose metadata value under *envoy.transport_socket*
+  // Connections to the endpoints whose metadata value under *envoy.transport_socket_match*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.
   //
   // If a :ref:`socket match <envoy_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>` with empty match
   // criteria is provided, that always match any endpoint. For example, the "defaultToPlaintext"
   // socket match in case above.
   //
-  // If an endpoint metadata's value under *envoy.transport_socket* does not match any
+  // If an endpoint metadata's value under *envoy.transport_socket_match* does not match any
   // *TransportSocketMatch*, socket configuration fallbacks to use the *tls_context* or
   // *transport_socket* specified in this cluster.
   //

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -505,7 +505,7 @@ message Cluster {
   reserved "hosts", "tls_context", "extension_protocol_options";
 
   // Configuration to use different transport sockets for different endpoints.
-  // The entry of *envoy.transport_socket* in the
+  // The entry of *envoy.transport_socket_match* in the
   // :ref:`LbEndpoint.Metadata <envoy_api_field_config.endpoint.v3.LbEndpoint.metadata>`
   // is used to match against the transport sockets as they appear in the list. The first
   // :ref:`match <envoy_api_msg_config.cluster.v4alpha.Cluster.TransportSocketMatch>` is used.
@@ -525,14 +525,14 @@ message Cluster {
   //    transport_socket:
   //      name: envoy.transport_sockets.raw_buffer
   //
-  // Connections to the endpoints whose metadata value under *envoy.transport_socket*
+  // Connections to the endpoints whose metadata value under *envoy.transport_socket_match*
   // having "acceptMTLS"/"true" key/value pair use the "enableMTLS" socket configuration.
   //
   // If a :ref:`socket match <envoy_api_msg_config.cluster.v4alpha.Cluster.TransportSocketMatch>` with empty match
   // criteria is provided, that always match any endpoint. For example, the "defaultToPlaintext"
   // socket match in case above.
   //
-  // If an endpoint metadata's value under *envoy.transport_socket* does not match any
+  // If an endpoint metadata's value under *envoy.transport_socket_match* does not match any
   // *TransportSocketMatch*, socket configuration fallbacks to use the *tls_context* or
   // *transport_socket* specified in this cluster.
   //


### PR DESCRIPTION
Signed-off-by: Raghavendra Balgi <rkbalgi@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Fixes a mismatch in metadata attribute name used by transport_socket_matches
Additional Description: The attribute name in metadata should be transport_socket_match rather than transport_socket
Risk Level: Low
Testing: Manual review
Docs Changes: Not applicable
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] #10660
[Optional Deprecated:]
