### PR TITLE
ext_authz: Log ext_authz gRPC messages at trace level

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -34,6 +34,7 @@ namespace Logger {
   FUNCTION(conn_handler)                                                                           \
   FUNCTION(decompression)                                                                          \
   FUNCTION(dubbo)                                                                                  \
+  FUNCTION(ext_authz)                                                                              \
   FUNCTION(rocketmq)                                                                               \
   FUNCTION(file)                                                                                   \
   FUNCTION(filter)                                                                                 \

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -41,14 +41,14 @@ void GrpcClientImpl::check(RequestCallbacks& callbacks,
   ASSERT(callbacks_ == nullptr);
   callbacks_ = &callbacks;
 
-  ENVOY_LOG(trace, "Sending CheckRequest : {}", request.DebugString());
+  ENVOY_LOG(trace, "Sending CheckRequest: {}", request.DebugString());
   request_ = async_client_->send(service_method_, request, *this, parent_span,
                                  Http::AsyncClient::RequestOptions().setTimeout(timeout_));
 }
 
 void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckResponse>&& response,
                                Tracing::Span& span) {
-  ENVOY_LOG(trace, "Received CheckResponse : {}", response->DebugString());
+  ENVOY_LOG(trace, "Received CheckResponse: {}", response->DebugString());
   ResponsePtr authz_response = std::make_unique<Response>(Response{});
   if (response->status().code() == Grpc::Status::WellKnownGrpcStatus::Ok) {
     span.setTag(TracingConstants::get().TraceStatus, TracingConstants::get().TraceOk);
@@ -75,7 +75,7 @@ void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckRe
 
 void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::string&,
                                Tracing::Span&) {
-  ENVOY_LOG(trace, "CheckRequest call failed with status : {}",
+  ENVOY_LOG(trace, "CheckRequest call failed with status: {}",
             Grpc::Utility::grpcStatusToString(status));
   ASSERT(status != Grpc::Status::WellKnownGrpcStatus::Ok);
   Response response{};

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -41,12 +41,14 @@ void GrpcClientImpl::check(RequestCallbacks& callbacks,
   ASSERT(callbacks_ == nullptr);
   callbacks_ = &callbacks;
 
+  ENVOY_LOG(trace, "Sending CheckRequest : {}", request.DebugString());
   request_ = async_client_->send(service_method_, request, *this, parent_span,
                                  Http::AsyncClient::RequestOptions().setTimeout(timeout_));
 }
 
 void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckResponse>&& response,
                                Tracing::Span& span) {
+  ENVOY_LOG(trace, "Received CheckResponse : {}", response->DebugString());
   ResponsePtr authz_response = std::make_unique<Response>(Response{});
   if (response->status().code() == Grpc::Status::WellKnownGrpcStatus::Ok) {
     span.setTag(TracingConstants::get().TraceStatus, TracingConstants::get().TraceOk);
@@ -73,6 +75,8 @@ void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckRe
 
 void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::string&,
                                Tracing::Span&) {
+  ENVOY_LOG(trace, "CheckRequest call failed with status : {}",
+            Grpc::Utility::grpcStatusToString(status));
   ASSERT(status != Grpc::Status::WellKnownGrpcStatus::Ok);
   Response response{};
   response.status = CheckStatus::Error;

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
@@ -38,7 +38,9 @@ using ExtAuthzAsyncCallbacks = Grpc::AsyncRequestCallbacks<envoy::service::auth:
  * The gRPC client does not rewrite path. NOTE: We create gRPC client for each filter stack instead
  * of a client per thread. That is ok since this is unary RPC and the cost of doing this is minimal.
  */
-class GrpcClientImpl : public Client, public ExtAuthzAsyncCallbacks {
+class GrpcClientImpl : public Client,
+                       public ExtAuthzAsyncCallbacks,
+                       public Logger::Loggable<Logger::Id::ext_authz> {
 public:
   // TODO(gsagula): remove `use_alpha` param when V2Alpha gets deprecated.
   GrpcClientImpl(Grpc::RawAsyncClientPtr&& async_client,


### PR DESCRIPTION
Commit Message: log external auth request/response proto messages
Additional Description: Logs ext auth request/response proto messages for debugging at trace level.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
