### PR TITLE
Mark cluster refresh manager as flaky test

### DIFF
--- a/test/extensions/common/redis/BUILD
+++ b/test/extensions/common/redis/BUILD
@@ -26,6 +26,7 @@ envoy_extension_cc_test(
     name = "cluster_refresh_manager_test",
     srcs = ["cluster_refresh_manager_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",
+    flaky = True,
     deps = [
         "//source/common/common:lock_guard_lib",
         "//source/common/common:thread_lib",

--- a/test/extensions/common/redis/cluster_refresh_manager_test.cc
+++ b/test/extensions/common/redis/cluster_refresh_manager_test.cc
@@ -25,6 +25,7 @@ namespace Extensions {
 namespace Common {
 namespace Redis {
 
+// TODO: rewrite the tests to fix the flaky test
 class ClusterRefreshManagerTest : public testing::Test {
 public:
   ClusterRefreshManagerTest()


### PR DESCRIPTION
Signed-off-by: Henry Yang <hyang@lyft.com>

Commit Message: Mark cluster refresh manager as flaky test
Additional Description: There seems to be a race condition in the test mark as flaky for now, will rewrite the test soon.
Risk Level: low
Testing: covered by existing tests
Docs Changes: n/a
Release Notes: n/a
