### PR TITLE
grpc/transcoding: add support for fragmented httpBody

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -162,7 +162,11 @@ private:
   bool checkIfTranscoderFailed(const std::string& details);
   bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& data);
   void maybeSendHttpBodyRequestMessage();
-  void buildResponseFromHttpBodyOutput(Http::ResponseHeaderMap& response_headers,
+  /**
+   * Builds response from HttpBody protobuf.
+   * Returns true if at least one gRPC frame has processed.
+   */
+  bool buildResponseFromHttpBodyOutput(Http::ResponseHeaderMap& response_headers,
                                        Buffer::Instance& data);
   bool maybeConvertGrpcStatus(Grpc::Status::GrpcStatus grpc_status,
                               Http::ResponseHeaderOrTrailerMap& trailers);

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -327,7 +327,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryGetHttpBody) {
       R"(<h1>Hello!</h1>)");
 }
 
-TEST_P(GrpcJsonTranscoderIntegrationTest, StreamGetHttpBody) {
+TEST_P(GrpcJsonTranscoderIntegrationTest, StreamGetHttpLargeBody) {
   HttpIntegrationTest::initialize();
 
   testTranscoding<Empty, google::api::HttpBody>(
@@ -385,6 +385,53 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, StreamGetHttpBodyMultipleFramesInData)
   response->waitForEndStream();
   EXPECT_TRUE(response->complete());
   EXPECT_EQ(response->body(), "HelloHelloHello");
+}
+
+TEST_P(GrpcJsonTranscoderIntegrationTest, StreamGetHttpBodyFragmented) {
+  HttpIntegrationTest::initialize();
+
+  // Make request to gRPC upstream
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/indexStream"},
+      {":authority", "host"},
+  });
+  waitForNextUpstreamRequest();
+
+  // Send fragmented gRPC response
+  // Headers
+  Http::TestResponseHeaderMapImpl response_headers;
+  response_headers.setStatus(200);
+  response_headers.setContentType("application/grpc");
+  upstream_request_->encodeHeaders(response_headers, false);
+  // Fragmented payload
+  google::api::HttpBody http_body;
+  http_body.set_content_type("text/plain");
+  http_body.set_data(std::string(1024, 'a'));
+  // Fragment gRPC frame into 2 buffers equally divided
+  Buffer::OwnedImpl fragment1;
+  auto fragment2 = Grpc::Common::serializeToGrpcFrame(http_body);
+  fragment1.move(*fragment2, fragment2->length() / 2);
+  upstream_request_->encodeData(fragment1, false);
+  upstream_request_->encodeData(*fragment2, false);
+  // Trailers
+  Http::TestResponseTrailerMapImpl response_trailers;
+  auto grpc_status = Status();
+  response_trailers.setGrpcStatus(static_cast<uint64_t>(grpc_status.error_code()));
+  response_trailers.setGrpcMessage(
+      absl::string_view(grpc_status.error_message().data(), grpc_status.error_message().size()));
+  upstream_request_->encodeTrailers(response_trailers);
+  EXPECT_TRUE(upstream_request_->complete());
+
+  // Wait for complete
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  // Ensure that body was actually replaced
+  EXPECT_EQ(response->body(), http_body.data());
+  // As well as content-type header
+  auto content_type = response->headers().get(Http::LowerCaseString("content-type"));
+  EXPECT_EQ("text/plain", content_type->value().getStringView());
 }
 
 TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryEchoHttpBody) {

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -327,7 +327,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, UnaryGetHttpBody) {
       R"(<h1>Hello!</h1>)");
 }
 
-TEST_P(GrpcJsonTranscoderIntegrationTest, StreamGetHttpLargeBody) {
+TEST_P(GrpcJsonTranscoderIntegrationTest, StreamGetHttpBody) {
   HttpIntegrationTest::initialize();
 
   testTranscoding<Empty, google::api::HttpBody>(

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -899,6 +899,41 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingStreamWithHttpBodyAsOutput) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
 }
 
+TEST_F(GrpcJsonTranscoderFilterTest, TranscodingStreamWithFragmentedHttpBody) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/indexStream"}};
+
+  EXPECT_CALL(decoder_callbacks_, clearRouteCache());
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ("application/grpc", request_headers.get_("content-type"));
+  EXPECT_EQ("/indexStream", request_headers.get_("x-envoy-original-path"));
+  EXPECT_EQ("/bookstore.Bookstore/GetIndexStream", request_headers.get_(":path"));
+  EXPECT_EQ("trailers", request_headers.get_("te"));
+
+  Http::TestResponseHeaderMapImpl response_headers{{"content-type", "application/grpc"},
+                                                   {":status", "200"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_.encodeHeaders(response_headers, false));
+
+  // "Send" one fragmented gRPC frame
+  google::api::HttpBody http_body;
+  http_body.set_content_type("text/html");
+  http_body.set_data("<h1>Fragmented Message!</h1>");
+  auto fragment2 = Grpc::Common::serializeToGrpcFrame(http_body);
+  Buffer::OwnedImpl fragment1;
+  fragment1.move(*fragment2, fragment2->length() / 2);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.encodeData(fragment1, false));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.encodeData(*fragment2, false));
+
+  // Ensure that content-type is correct (taken from httpBody)
+  EXPECT_EQ("text/html", response_headers.get_("content-type"));
+
+  // Fragment1 is buffered by transcoder
+  EXPECT_EQ(0, fragment1.length());
+  // Second fragment contains entire body
+  EXPECT_EQ(http_body.data(), fragment2->toString());
+}
+
 class GrpcJsonTranscoderFilterGrpcStatusTest : public GrpcJsonTranscoderFilterTest {
 public:
   GrpcJsonTranscoderFilterGrpcStatusTest(


### PR DESCRIPTION
**Additional Description**: As mentioned in #10673 when transcoding of `httpBody` in streaming mode and grpc frame gets fragmented (e.g. large enough) - http header `Content-Type` may not be set to correct value from `content-type` of `httpBody`.
**Risk Level**: low
**Testing**: new unit/integration test
**Docs Changes**: not changed bcz of this feature was introduced in the same release
**Release Notes**: not added bcz of this feature was introduced in the same release
