### PR TITLE
fix: custom tags are now being applied to mirrored traces

### DIFF
--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -265,7 +265,7 @@ void AsyncRequestImpl::initialize() {
 }
 
 void AsyncRequestImpl::onComplete() {
-  Tracing::HttpTracerUtility::finalizeUpstreamSpan(*child_span_, &response_->headers(),
+  Tracing::HttpTracerUtility::finalizeDownstreamSpan(*child_span_, &request_->headers(), &response_->headers(),
                                                    response_->trailers(), streamInfo(),
                                                    Tracing::EgressConfig::get());
 
@@ -298,8 +298,8 @@ void AsyncRequestImpl::onReset() {
   }
 
   // Finalize the span based on whether we received a response or not
-  Tracing::HttpTracerUtility::finalizeUpstreamSpan(
-      *child_span_, remoteClosed() ? &response_->headers() : nullptr,
+  Tracing::HttpTracerUtility::finalizeDownstreamSpan(
+      *child_span_, &request_->headers(), remoteClosed() ? &response_->headers() : nullptr,
       remoteClosed() ? response_->trailers() : nullptr, streamInfo(), Tracing::EgressConfig::get());
 
   if (!cancelled_) {

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -265,9 +265,9 @@ void AsyncRequestImpl::initialize() {
 }
 
 void AsyncRequestImpl::onComplete() {
-  Tracing::HttpTracerUtility::finalizeDownstreamSpan(*child_span_, &request_->headers(), &response_->headers(),
-                                                   response_->trailers(), streamInfo(),
-                                                   Tracing::EgressConfig::get());
+  Tracing::HttpTracerUtility::finalizeDownstreamSpan(*child_span_, &request_->headers(),
+                                                     &response_->headers(), response_->trailers(),
+                                                     streamInfo(), Tracing::EgressConfig::get());
 
   callbacks_.onSuccess(*this, std::move(response_));
 }

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -222,6 +222,15 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
 
   setCommonTags(span, response_headers, response_trailers, stream_info, tracing_config);
 
+  CustomTagContext ctx{request_headers, stream_info};
+
+  const CustomTagMap* custom_tag_map = tracing_config.customTags();
+  if (custom_tag_map) {
+    for (const auto& it : *custom_tag_map) {
+      it.second->apply(span, ctx);
+     }
+  }
+
   span.finishSpan();
 }
 

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -222,15 +222,6 @@ void HttpTracerUtility::finalizeUpstreamSpan(Span& span,
 
   setCommonTags(span, response_headers, response_trailers, stream_info, tracing_config);
 
-  CustomTagContext ctx{request_headers, stream_info};
-
-  const CustomTagMap* custom_tag_map = tracing_config.customTags();
-  if (custom_tag_map) {
-    for (const auto& it : *custom_tag_map) {
-      it.second->apply(span, ctx);
-     }
-  }
-
   span.finishSpan();
 }
 


### PR DESCRIPTION
Signed-off-by: John Dorman <dorman@overlooked.us>

Commit Message: fix: correct tags not being applied to mirrored traces
Additional Description:
Risk Level: low
Testing: Unit tests
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/11033
[Optional Deprecated:]
