### PR TITLE
[http] Remove exceptions from HTTP/1 codec callbacks

### DIFF
--- a/source/common/http/http1/BUILD
+++ b/source/common/http/http1/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/buffer:watermark_buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:cleanup_lib",
         "//source/common/common:statusor_lib",
         "//source/common/common:utility_lib",
         "//source/common/http:codec_helper_lib",

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -569,8 +569,8 @@ Envoy::StatusOr<size_t> ConnectionImpl::dispatchSlice(const char* slice, size_t 
     sendProtocolError(Http1ResponseCodeDetails::get().HttpCodecError);
     // Avoid overwriting the codec_status_ set in the callbacks.
     ASSERT(codec_status_.ok());
-    codec_status_ = codecProtocolError("http/1.1 protocol error: " +
-                                       std::string(http_errno_name(HTTP_PARSER_ERRNO(&parser_))));
+    codec_status_ = codecProtocolError(
+        absl::StrCat("http/1.1 protocol error: ", http_errno_name(HTTP_PARSER_ERRNO(&parser_))));
     return codec_status_;
   }
 
@@ -849,7 +849,6 @@ bool ServerConnectionImpl::handlePath(RequestHeaderMap& headers, unsigned int me
   if (!absolute_url.initialize(active_request.request_url_.getStringView(), is_connect)) {
     sendProtocolError(Http1ResponseCodeDetails::get().InvalidUrl);
     ASSERT(codec_status_.ok());
-    ENVOY_LOG_MISC(info, "SETTING PROTOCOL ERROR");
     codec_status_ = codecProtocolError("http/1.1 protocol error: invalid url in request line");
     return false;
   }

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -226,7 +226,10 @@ protected:
 
   bool resetStreamCalled() { return reset_stream_called_; }
 
-  // The following define special return values for http_parser callbacks.
+  // The following define special return values for http_parser callbacks. See:
+  // https://github.com/nodejs/http-parser/blob/5c5b3ac62662736de9e71640a8dc16da45b32503/http_parser.h#L72
+  // These codes do not overlap with standard HTTP Status codes. They are only used for user
+  // callbacks.
   enum class HttpParserCode {
     // Callbacks other than on_headers_complete should return a non-zero int to indicate an error
     // and

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -35,19 +35,6 @@ namespace Http1 {
   COUNTER(requests_rejected_with_underscores_in_headers)                                           \
   COUNTER(response_flood)
 
-// The following define special return values for http_parser callbacks.
-enum class HttpParserCode {
-  // Callbacks other than on_headers_complete should return a non-zero int to indicate an error and
-  // halt execution.
-  Error = -1,
-  Success = 0,
-  // Returning '1' from on_headers_complete will tell http_parser that it should not expect a body.
-  NoBody = 1,
-  // Returning '2' from on_headers_complete will tell http_parser that it should not expect a body
-  // nor any further data on the connection.
-  NoBodyData = 2,
-};
-
 /**
  * Wrapper struct for the HTTP/1 codec stats. @see stats_macros.h
  */
@@ -238,6 +225,21 @@ protected:
                  HeaderKeyFormatterPtr&& header_key_formatter, bool enable_trailers);
 
   bool resetStreamCalled() { return reset_stream_called_; }
+
+  // The following define special return values for http_parser callbacks.
+  enum class HttpParserCode {
+    // Callbacks other than on_headers_complete should return a non-zero int to indicate an error
+    // and
+    // halt execution.
+    Error = -1,
+    Success = 0,
+    // Returning '1' from on_headers_complete will tell http_parser that it should not expect a
+    // body.
+    NoBody = 1,
+    // Returning '2' from on_headers_complete will tell http_parser that it should not expect a body
+    // nor any further data on the connection.
+    NoBodyData = 2,
+  };
 
   Network::Connection& connection_;
   CodecStats stats_;


### PR DESCRIPTION
Commit Message: Remove exceptions from HTTP/1 codec callbacks. Replaces with http_parser exit codes that indicate failure. `codec_status_` propagates the error.

Additional Description: 
* I know the diff is slightly messy but the principles I abided by were: Replace throw with setting codec_status_, immediately return and propagate return up to callback with an error exit code, always `ASSERT(dispatching_)` in the body of the method that throws, always `ASSERT(codec_status_.ok())` before setting the codec status.
* The remaining exception is in `encodeHeaders`, which I will need to replace with `ENVOY_BUG`
* I audited for throws in the includes for this file and did not find anything used in the `codec_impl`, but I will need to do another pass.
* This is just part 1 of my HTTP/1 PRs. Part 2 is exception to error handling for `encodeHeaders` and any other utility functions. This is just a PR to stage.

Testing: Tests pass, `codec_impl_fuzz_test` has been running for a few minutes.
Risk level: Medium, this should do nothing but is a codec behavior change.
Issues: https://github.com/envoyproxy/envoy/issues/10878

Signed-off-by: Asra Ali <asraa@google.com>
