### PR TITLE
api: drop_overload is not yet implemented in Envoy.

### DIFF
--- a/api/envoy/api/v2/endpoint.proto
+++ b/api/envoy/api/v2/endpoint.proto
@@ -36,6 +36,7 @@ message ClusterLoadAssignment {
   // Load balancing policy settings.
   // [#next-free-field: 6]
   message Policy {
+    // [#not-implemented-hide:]
     message DropOverload {
       // Identifier for the policy specifying the drop.
       string category = 1 [(validate.rules).string = {min_bytes: 1}];
@@ -65,6 +66,7 @@ message ClusterLoadAssignment {
     //    "throttle"_drop = 60%
     //    "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
     //    actual_outgoing_load = 20% // remaining after applying all categories.
+    // [#not-implemented-hide:]
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this

--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -40,6 +40,7 @@ message ClusterLoadAssignment {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.ClusterLoadAssignment.Policy";
 
+    // [#not-implemented-hide:]
     message DropOverload {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload";
@@ -74,6 +75,7 @@ message ClusterLoadAssignment {
     //    "throttle"_drop = 60%
     //    "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
     //    actual_outgoing_load = 20% // remaining after applying all categories.
+    // [#not-implemented-hide:]
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this

--- a/generated_api_shadow/envoy/api/v2/endpoint.proto
+++ b/generated_api_shadow/envoy/api/v2/endpoint.proto
@@ -36,6 +36,7 @@ message ClusterLoadAssignment {
   // Load balancing policy settings.
   // [#next-free-field: 6]
   message Policy {
+    // [#not-implemented-hide:]
     message DropOverload {
       // Identifier for the policy specifying the drop.
       string category = 1 [(validate.rules).string = {min_bytes: 1}];
@@ -65,6 +66,7 @@ message ClusterLoadAssignment {
     //    "throttle"_drop = 60%
     //    "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
     //    actual_outgoing_load = 20% // remaining after applying all categories.
+    // [#not-implemented-hide:]
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this

--- a/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
+++ b/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
@@ -40,6 +40,7 @@ message ClusterLoadAssignment {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.ClusterLoadAssignment.Policy";
 
+    // [#not-implemented-hide:]
     message DropOverload {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.ClusterLoadAssignment.Policy.DropOverload";
@@ -72,6 +73,7 @@ message ClusterLoadAssignment {
     //    "throttle"_drop = 60%
     //    "lb"_drop = 20%  // 50% of the remaining 'actual' load, which is 40%.
     //    actual_outgoing_load = 20% // remaining after applying all categories.
+    // [#not-implemented-hide:]
     repeated DropOverload drop_overloads = 2;
 
     // Priority levels and localities are considered overprovisioned with this


### PR DESCRIPTION
This was added before we started annotating fields missing
implementations. Fixed with a [#not-implemented-hide:] annotations for
now, the plan is to move things like this to
https://github.com/envoyproxy/envoy/issues/11085 when it lands.

Signed-off-by: Harvey Tuch <htuch@google.com>