### PR TITLE
api: introduce TypedExtensionConfig.

### DIFF
--- a/api/envoy/config/core/v3/extension.proto
+++ b/api/envoy/config/core/v3/extension.proto
@@ -26,5 +26,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
+  google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
 }

--- a/api/envoy/config/core/v3/extension.proto
+++ b/api/envoy/config/core/v3/extension.proto
@@ -26,5 +26,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2;
+  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
 }

--- a/api/envoy/config/core/v3/extension.proto
+++ b/api/envoy/config/core/v3/extension.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/any.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "ExtensionProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Extension configuration]
+
+// Message type for extension configuration.
+// [#next-major-version: revisit all existing typed_config that doesn't use this wrapper.].
+message TypedExtensionConfig {
+  // The name of an extension. This is not used to select the extension, instead
+  // it serves the role of an opaque identifier.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The typed config for the extension. The type URL will be used to identify
+  // the extension. In the case that the type URL is *udpa.type.v1.TypedStruct*,
+  // the inner type URL of *TypedStruct* will be utilized. See the
+  // :ref:`extension configuration overview
+  // <config_overview_extension_configuration>` for further details.
+  google.protobuf.Any typed_config = 2;
+}

--- a/api/envoy/config/core/v4alpha/extension.proto
+++ b/api/envoy/config/core/v4alpha/extension.proto
@@ -30,5 +30,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
+  google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
 }

--- a/api/envoy/config/core/v4alpha/extension.proto
+++ b/api/envoy/config/core/v4alpha/extension.proto
@@ -30,5 +30,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2;
+  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
 }

--- a/api/envoy/config/core/v4alpha/extension.proto
+++ b/api/envoy/config/core/v4alpha/extension.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package envoy.config.core.v4alpha;
+
+import "google/protobuf/any.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
+option java_outer_classname = "ExtensionProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Extension configuration]
+
+// Message type for extension configuration.
+// [#next-major-version: revisit all existing typed_config that doesn't use this wrapper.].
+message TypedExtensionConfig {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.core.v3.TypedExtensionConfig";
+
+  // The name of an extension. This is not used to select the extension, instead
+  // it serves the role of an opaque identifier.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The typed config for the extension. The type URL will be used to identify
+  // the extension. In the case that the type URL is *udpa.type.v1.TypedStruct*,
+  // the inner type URL of *TypedStruct* will be utilized. See the
+  // :ref:`extension configuration overview
+  // <config_overview_extension_configuration>` for further details.
+  google.protobuf.Any typed_config = 2;
+}

--- a/docs/root/api-v3/common_messages/common_messages.rst
+++ b/docs/root/api-v3/common_messages/common_messages.rst
@@ -6,6 +6,7 @@ Common messages
   :maxdepth: 2
 
   ../config/core/v3/base.proto
+  ../config/core/v3/extension.proto
   ../config/core/v3/address.proto
   ../config/core/v3/backoff.proto
   ../config/core/v3/protocol.proto

--- a/generated_api_shadow/envoy/config/core/v3/extension.proto
+++ b/generated_api_shadow/envoy/config/core/v3/extension.proto
@@ -26,5 +26,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
+  google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
 }

--- a/generated_api_shadow/envoy/config/core/v3/extension.proto
+++ b/generated_api_shadow/envoy/config/core/v3/extension.proto
@@ -26,5 +26,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2;
+  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
 }

--- a/generated_api_shadow/envoy/config/core/v3/extension.proto
+++ b/generated_api_shadow/envoy/config/core/v3/extension.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/any.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "ExtensionProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Extension configuration]
+
+// Message type for extension configuration.
+// [#next-major-version: revisit all existing typed_config that doesn't use this wrapper.].
+message TypedExtensionConfig {
+  // The name of an extension. This is not used to select the extension, instead
+  // it serves the role of an opaque identifier.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The typed config for the extension. The type URL will be used to identify
+  // the extension. In the case that the type URL is *udpa.type.v1.TypedStruct*,
+  // the inner type URL of *TypedStruct* will be utilized. See the
+  // :ref:`extension configuration overview
+  // <config_overview_extension_configuration>` for further details.
+  google.protobuf.Any typed_config = 2;
+}

--- a/generated_api_shadow/envoy/config/core/v4alpha/extension.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/extension.proto
@@ -30,5 +30,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
+  google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
 }

--- a/generated_api_shadow/envoy/config/core/v4alpha/extension.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/extension.proto
@@ -30,5 +30,5 @@ message TypedExtensionConfig {
   // the inner type URL of *TypedStruct* will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  google.protobuf.Any typed_config = 2;
+  google.protobuf.Any typed_config = 2 [(validate.rules).message = {required: true}];
 }

--- a/generated_api_shadow/envoy/config/core/v4alpha/extension.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/extension.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package envoy.config.core.v4alpha;
+
+import "google/protobuf/any.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
+option java_outer_classname = "ExtensionProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Extension configuration]
+
+// Message type for extension configuration.
+// [#next-major-version: revisit all existing typed_config that doesn't use this wrapper.].
+message TypedExtensionConfig {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.core.v3.TypedExtensionConfig";
+
+  // The name of an extension. This is not used to select the extension, instead
+  // it serves the role of an opaque identifier.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The typed config for the extension. The type URL will be used to identify
+  // the extension. In the case that the type URL is *udpa.type.v1.TypedStruct*,
+  // the inner type URL of *TypedStruct* will be utilized. See the
+  // :ref:`extension configuration overview
+  // <config_overview_extension_configuration>` for further details.
+  google.protobuf.Any typed_config = 2;
+}


### PR DESCRIPTION
A common wrapper for name/Any that should be used for all new extensions
throughout the API.

I've left a note that we need to revisit existing typed_config at the
next major version as well, since that would be a breaking change.

Signed-off-by: Harvey Tuch <htuch@google.com>