### PR TITLE
Documentation/Config changes (proposed) for #6589

### DIFF
--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -483,15 +483,31 @@ message HttpConnectionManager {
   // Should paths be normalized according to RFC 3986 before any processing of
   // requests by HTTP filters or routing? This affects the upstream *:path* header
   // as well. For paths that fail this check, Envoy will respond with 400 to
-  // paths that are malformed. This defaults to false currently but will default
-  // true in the future. When not specified, this value may be overridden by the
-  // runtime variable
+  // paths that are malformed. This defaults to true.
+  // This by default affects the upstream *:path* header as well.
+  // When not specified, this value may be overridden by the runtime variable
   // :ref:`http_connection_manager.normalize_path<config_http_conn_man_runtime_normalize_path>`.
+  // The upstream path normalization can be specified independently, see
+  // :ref:`normalize_path_for_upstream <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.normalize_path_for_upstream>`.
   // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
   // for details of normalization.
   // Note that Envoy does not perform
   // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
   google.protobuf.BoolValue normalize_path = 30;
+
+  // Should paths to upstream be normalized according to RFC 3986 after any processing of
+  // requests by HTTP filters or routing? This affects the upstream *:path* header
+  // For paths that fail this check, Envoy will respond with 400 to
+  // paths that are malformed. This defaults to the value of
+  // :ref:`normalize_path
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.normalize_path>`.
+  // When not specified, this value may be overridden by the runtime variable
+  // :ref:`http_connection_manager.normalize_path_for_upstream<config_http_conn_man_runtime_normalize_path_for_upstream>`.
+  // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
+  // for details of normalization.
+  // Note that Envoy does not perform
+  // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
+  google.protobuf.BoolValue normalize_path_for_upstream = 39;
 
   // Determines if adjacent slashes in the path are merged into one before any processing of
   // requests by HTTP filters or routing. This affects the upstream *:path* header as well. Without

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -478,15 +478,32 @@ message HttpConnectionManager {
   // Should paths be normalized according to RFC 3986 before any processing of
   // requests by HTTP filters or routing? This affects the upstream *:path* header
   // as well. For paths that fail this check, Envoy will respond with 400 to
-  // paths that are malformed. This defaults to false currently but will default
-  // true in the future. When not specified, this value may be overridden by the
-  // runtime variable
+  // paths that are malformed. This defaults to true.
+  // This by default affects the upstream *:path* header as well.
+  // When not specified, this value may be overridden by the runtime variable
   // :ref:`http_connection_manager.normalize_path<config_http_conn_man_runtime_normalize_path>`.
+  // The upstream path normalization can be specified independently, see
+  // :ref:`normalize_path_for_upstream
+  // <envoy_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.normalize_path_for_upstream>`.
   // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
   // for details of normalization.
   // Note that Envoy does not perform
   // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
   google.protobuf.BoolValue normalize_path = 30;
+
+  // Should paths to upstream be normalized according to RFC 3986 after any processing of
+  // requests by HTTP filters or routing? This affects the upstream *:path* header
+  // For paths that fail this check, Envoy will respond with 400 to
+  // paths that are malformed. This defaults to the value of
+  // :ref:`normalize_path
+  // <envoy_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.normalize_path>`.
+  // When not specified, this value may be overridden by the runtime variable
+  // :ref:`http_connection_manager.normalize_path_for_upstream<config_http_conn_man_runtime_normalize_path_for_upstream>`.
+  // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
+  // for details of normalization.
+  // Note that Envoy does not perform
+  // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
+  google.protobuf.BoolValue normalize_path_for_upstream = 39;
 
   // Determines if adjacent slashes in the path are merged into one before any processing of
   // requests by HTTP filters or routing. This affects the upstream *:path* header as well. Without

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -478,15 +478,32 @@ message HttpConnectionManager {
   // Should paths be normalized according to RFC 3986 before any processing of
   // requests by HTTP filters or routing? This affects the upstream *:path* header
   // as well. For paths that fail this check, Envoy will respond with 400 to
-  // paths that are malformed. This defaults to false currently but will default
-  // true in the future. When not specified, this value may be overridden by the
-  // runtime variable
+  // paths that are malformed. This defaults to true.
+  // This by default affects the upstream *:path* header as well.
+  // When not specified, this value may be overridden by the runtime variable
   // :ref:`http_connection_manager.normalize_path<config_http_conn_man_runtime_normalize_path>`.
+  // The upstream path normalization can be specified independently, see
+  // :ref:`normalize_path_for_upstream
+  // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.normalize_path_for_upstream>`.
   // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
   // for details of normalization.
   // Note that Envoy does not perform
   // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
   google.protobuf.BoolValue normalize_path = 30;
+
+  // Should paths to upstream be normalized according to RFC 3986 after any processing of
+  // requests by HTTP filters or routing? This affects the upstream *:path* header
+  // For paths that fail this check, Envoy will respond with 400 to
+  // paths that are malformed. This defaults to the value of
+  // :ref:`normalize_path
+  // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.normalize_path>`.
+  // When not specified, this value may be overridden by the runtime variable
+  // :ref:`http_connection_manager.normalize_path_for_upstream<config_http_conn_man_runtime_normalize_path_for_upstream>`.
+  // See `Normalization and Comparison <https://tools.ietf.org/html/rfc3986#section-6>`
+  // for details of normalization.
+  // Note that Envoy does not perform
+  // `case normalization <https://tools.ietf.org/html/rfc3986#section-6.2.2.1>`
+  google.protobuf.BoolValue normalize_path_for_upstream = 39;
 
   // Determines if adjacent slashes in the path are merged into one before any processing of
   // requests by HTTP filters or routing. This affects the upstream *:path* header as well. Without

--- a/docs/root/configuration/http/http_conn_man/runtime.rst
+++ b/docs/root/configuration/http/http_conn_man/runtime.rst
@@ -8,8 +8,38 @@ The HTTP connection manager supports the following runtime settings:
 .. _config_http_conn_man_runtime_normalize_path:
 
 http_connection_manager.normalize_path
-  % of requests that will have path normalization applied if not already configured in
+  Requests will have normalization applied if not already configured in
   :ref:`normalize_path <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.normalize_path>`.
+
+  This setting can have the following values:
+
+  +--------------+---------------------------+
+  | Value        | Expectation               |
+  +==============+===========================+
+  | 0, false     | normalization not enabled |
+  +--------------+---------------------------+
+  | 100, true    | normalization enabled     |
+  +--------------+---------------------------+
+
+  This is evaluated at configuration load time and will apply to all requests for a given
+  configuration.
+
+.. _config_http_conn_man_runtime_normalize_path_for_upstream:
+
+http_connection_manager.normalize_path_for_upstream
+  Requests to upstream will have normalization applied if not already configured in
+  :ref:`normalize_path <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.normalize_path_for_upstream>`.
+
+  This setting can have the following values:
+
+  +--------------+------------------------------------+
+  | Value        | Expectation                        |
+  +==============+====================================+
+  | 0, false     | upstream normalization not enabled |
+  +--------------+------------------------------------+
+  | 100, true    | upstream normalization enabled     |
+  +--------------+------------------------------------+
+
   This is evaluated at configuration load time and will apply to all requests for a given
   configuration.
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -310,6 +310,7 @@ private:
   HEADER_FUNC(OtSpanContext)                                                                       \
   HEADER_FUNC(Origin)                                                                              \
   HEADER_FUNC(Path)                                                                                \
+  HEADER_FUNC(OriginalPathForUpstream)                                                             \
   HEADER_FUNC(Protocol)                                                                            \
   HEADER_FUNC(Referer)                                                                             \
   HEADER_FUNC(Scheme)                                                                              \

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -136,6 +136,7 @@ public:
   const LowerCaseString Origin{"origin"};
   const LowerCaseString OtSpanContext{"x-ot-span-context"};
   const LowerCaseString Path{":path"};
+  const LowerCaseString OriginalPathForUpstream{absl::StrCat(prefix(), "-original_path_for_upstream")};
   const LowerCaseString Protocol{":protocol"};
   const LowerCaseString ProxyConnection{"proxy-connection"};
   const LowerCaseString Referer{"referer"};


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Documentation and Config changes as per request https://github.com/envoyproxy/envoy/issues/6589#issuecomment-622120041 

NOTE: Incomplete, **do not merge** this PR was incorrectly attributed to v2 and v2 is frozen.

Additional Description:
These changes are not the complete fix.
Risk Level: 
Testing:
Docs Changes:
_rst_ and _proto_ files as per commit.
Release Notes:
[Issue 6589](https://github.com/envoyproxy/envoy/issues/6589) allows for optional normalization of upstream requests independent of the normalization settings received from downstream.  Upstream normalization defaults to the _normalize_path_ setting and can be overridden with the setting _normalize_path_for_upstream_. 

It is imperative that existing functionality/behaviour is preserved. As an example,  the continued support for 0/100 in the runtime configuration for the normalize_path* properties in the http listener, while introducing support for Boolean true/false case.

Fixes #Issue 6589

There are several consequences to implementing support for this new property:

- As of proto3 defaults can not be specified in the `.proto` file.  This will require some changes to the initialisation code.  Will have to be sure to check all places where class is loaded. 
- Will need to code for the runtime case (see runtime.rst)  The `runtime.rst` in `root/configuration/http_conn_man` refers to % in relation to normalize_path.  Harvey's note in issue ~config.cc~ (see next task).  Support backward compatibility.
// TODO(htuch): we should have a boolean variant of featureEnabled() here.
- `ENVOY_NORMALIZE_PATH_BY_DEFAULT` `envoy/blob/master/source/extensions/filters/network/http_connection_manager/config.cc`
test for `ENVOY_NORMALIZE_PATH_BY_DEFAULT` line 205 should this be modified with
a boolean? (Needs a boolean featureEnabled() method as per HT's comment.)  When the adding the featureEnabled(absl::string_view, bool) ensure that specify no default conversion from int to boolean.  Include support for the `ENVOY_NORMALIZE_PATH_FOR_UPSTREAM_BY_DEFAULT`.
There is already support for `getBoolean(absl::string_view, bool default_value)`
in `envoy/source/common/runtime/runtime_impl.cc`. This can be reused. NOTE:
Support of existing functionality must be maintained (ie 0/100 -> false/true).
- `add normalize_path_for_upstream_` to the constructor `HttpConnectionManagerConfig::HttpConnectionManagerConfig()` in `envoy/blob/master/source/extensions/filters/network/http_connection_manager/config.cc`
- http manager `config.h` Need to add `normalize_path_for_upstream` to `envoy/source/extensions/filters/network/http_connection_manager/config.h`
