### PR TITLE
Revert "http: Introduce preserve_upstream_date option (#11077)"

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -507,11 +507,6 @@ message HttpConnectionManager {
   // 3. Tracing decision (sampled, forced, etc) is set in 14th byte of the UUID.
   RequestIDExtension request_id_extension = 36;
 
-  // If `preserve_upstream_date` is true, the value of the `date` header sent by the upstream
-  // host will not be overwritten by the HTTP Connection Manager. The default behaviour is
-  // to overwrite the `date` header unconditionally.
-  bool preserve_upstream_date = 38;
-
   // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v3.Listener.address>`
   // local port and request method is not CONNECT. This affects the upstream host header as well.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -507,11 +507,6 @@ message HttpConnectionManager {
   // 3. Tracing decision (sampled, forced, etc) is set in 14th byte of the UUID.
   RequestIDExtension request_id_extension = 36;
 
-  // If `preserve_upstream_date` is true, the value of the `date` header sent by the upstream
-  // host will not be overwritten by the HTTP Connection Manager. The default behaviour is
-  // to overwrite the `date` header unconditionally.
-  bool preserve_upstream_date = 38;
-
   // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
   // local port and request method is not CONNECT. This affects the upstream host header as well.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -509,11 +509,6 @@ message HttpConnectionManager {
   // 3. Tracing decision (sampled, forced, etc) is set in 14th byte of the UUID.
   RequestIDExtension request_id_extension = 36;
 
-  // If `preserve_upstream_date` is true, the value of the `date` header sent by the upstream
-  // host will not be overwritten by the HTTP Connection Manager. The default behaviour is
-  // to overwrite the `date` header unconditionally.
-  bool preserve_upstream_date = 38;
-
   // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v3.Listener.address>`
   // local port and request method is not CONNECT. This affects the upstream host header as well.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -507,11 +507,6 @@ message HttpConnectionManager {
   // 3. Tracing decision (sampled, forced, etc) is set in 14th byte of the UUID.
   RequestIDExtension request_id_extension = 36;
 
-  // If `preserve_upstream_date` is true, the value of the `date` header sent by the upstream
-  // host will not be overwritten by the HTTP Connection Manager. The default behaviour is
-  // to overwrite the `date` header unconditionally.
-  bool preserve_upstream_date = 38;
-
   // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
   // local port and request method is not CONNECT. This affects the upstream host header as well.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -435,12 +435,6 @@ public:
    */
   virtual envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const PURE;
-
-  /**
-   * @return if the HttpConnectionManager should preserve the `date` response header sent by the
-   * upstream host.
-   */
-  virtual bool shouldPreserveUpstreamDate() const PURE;
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1631,9 +1631,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilte
 void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMap& headers,
                                                                 bool end_stream) {
   // Base headers.
-  if (!connection_manager_.config_.shouldPreserveUpstreamDate() || !headers.Date()) {
-    connection_manager_.config_.dateProvider().setDateHeader(headers);
-  }
+  connection_manager_.config_.dateProvider().setDateHeader(headers);
   // Following setReference() is safe because serverName() is constant for the life of the listener.
   const auto transformation = connection_manager_.config_.serverHeaderTransformation();
   if (transformation == ConnectionManagerConfig::HttpConnectionManagerProto::OVERWRITE ||

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -218,8 +218,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       merge_slashes_(config.merge_slashes()),
       strip_matching_port_(config.strip_matching_host_port()),
       headers_with_underscores_action_(
-          config.common_http_protocol_options().headers_with_underscores_action()),
-      preserve_upstream_date_(config.preserve_upstream_date()) {
+          config.common_http_protocol_options().headers_with_underscores_action()) {
   // If idle_timeout_ was not configured in common_http_protocol_options, use value in deprecated
   // idle_timeout field.
   // TODO(asraa): Remove when idle_timeout is removed.

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -163,7 +163,6 @@ public:
     return headers_with_underscores_action_;
   }
   std::chrono::milliseconds delayedCloseTimeout() const override { return delayed_close_timeout_; }
-  bool shouldPreserveUpstreamDate() const override { return preserve_upstream_date_; }
 
 private:
   enum class CodecType { HTTP1, HTTP2, HTTP3, AUTO };
@@ -229,7 +228,6 @@ private:
   const bool strip_matching_port_;
   const envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_;
-  const bool preserve_upstream_date_;
 
   // Default idle timeout is 5 minutes if nothing is specified in the HCM config.
   static const uint64_t StreamIdleTimeoutMs = 5 * 60 * 1000;

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -169,7 +169,6 @@ public:
   headersWithUnderscoresAction() const override {
     return envoy::config::core::v3::HttpProtocolOptions::ALLOW;
   }
-  bool shouldPreserveUpstreamDate() const override { return false; }
   Http::Code request(absl::string_view path_and_query, absl::string_view method,
                      Http::ResponseHeaderMap& response_headers, std::string& body) override;
   void closeSocket();

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -161,7 +161,6 @@ public:
   headersWithUnderscoresAction() const override {
     return envoy::config::core::v3::HttpProtocolOptions::ALLOW;
   }
-  bool shouldPreserveUpstreamDate() const override { return false; }
 
   const envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
       config_;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -354,7 +354,6 @@ public:
   headersWithUnderscoresAction() const override {
     return headers_with_underscores_action_;
   }
-  bool shouldPreserveUpstreamDate() const override { return preserve_upstream_date_; }
 
   Envoy::Event::SimulatedTimeSystem test_time_;
   NiceMock<Router::MockRouteConfigProvider> route_config_provider_;
@@ -417,7 +416,6 @@ public:
   NiceMock<Network::MockClientConnection> upstream_conn_; // for websocket tests
   NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool_; // for websocket tests
   RequestIDExtensionSharedPtr request_id_extension_;
-  bool preserve_upstream_date_ = false;
 
   // TODO(mattklein123): Not all tests have been converted over to better setup. Convert the rest.
   MockResponseEncoder response_encoder_;
@@ -973,56 +971,6 @@ TEST_F(HttpConnectionManagerImplTest, RouteShouldUseNormalizedHost) {
   // Kick off the incoming data.
   Buffer::OwnedImpl fake_input("1234");
   conn_manager_->onData(fake_input, false);
-}
-
-TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateNotSet) {
-  setup(false, "");
-  setUpEncoderAndDecoder(false, false);
-  sendRequestHeadersAndData();
-  preserve_upstream_date_ = false;
-  const auto* modified_headers = sendResponseHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
-  ASSERT_TRUE(modified_headers);
-  EXPECT_TRUE(modified_headers->Date());
-}
-
-TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateSet) {
-  setup(false, "");
-  setUpEncoderAndDecoder(false, false);
-  sendRequestHeadersAndData();
-  preserve_upstream_date_ = false;
-  const std::string expected_date{"Tue, 15 Nov 1994 08:12:31 GMT"};
-  const auto* modified_headers =
-      sendResponseHeaders(ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{
-          {":status", "200"}, {"server", "foo"}, {"date", expected_date.c_str()}}});
-  ASSERT_TRUE(modified_headers);
-  ASSERT_TRUE(modified_headers->Date());
-  EXPECT_NE(expected_date, modified_headers->Date()->value().getStringView());
-}
-
-TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateEnabledDateNotSet) {
-  setup(false, "");
-  setUpEncoderAndDecoder(false, false);
-  sendRequestHeadersAndData();
-  preserve_upstream_date_ = true;
-  const auto* modified_headers = sendResponseHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
-  ASSERT_TRUE(modified_headers);
-  EXPECT_TRUE(modified_headers->Date());
-}
-
-TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateEnabledDateSet) {
-  setup(false, "");
-  setUpEncoderAndDecoder(false, false);
-  sendRequestHeadersAndData();
-  preserve_upstream_date_ = true;
-  const std::string expected_date{"Tue, 15 Nov 1994 08:12:31 GMT"};
-  const auto* modified_headers =
-      sendResponseHeaders(ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{
-          {":status", "200"}, {"server", "foo"}, {"date", expected_date.c_str()}}});
-  ASSERT_TRUE(modified_headers);
-  ASSERT_TRUE(modified_headers->Date());
-  EXPECT_EQ(expected_date, modified_headers->Date()->value().getStringView());
 }
 
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -139,7 +139,6 @@ public:
   MOCK_METHOD(bool, shouldStripMatchingPort, (), (const));
   MOCK_METHOD(envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction,
               headersWithUnderscoresAction, (), (const));
-  MOCK_METHOD(bool, shouldPreserveUpstreamDate, (), (const));
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =
       std::make_unique<DefaultInternalAddressConfig>();

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1130,39 +1130,6 @@ TEST_F(HttpConnectionManagerConfigTest, UnconfiguredRequestTimeout) {
   EXPECT_EQ(0, config.requestTimeout().count());
 }
 
-TEST_F(HttpConnectionManagerConfigTest, DisabledPreserveResponseDate) {
-  const std::string yaml_string = R"EOF(
-  stat_prefix: ingress_http
-  request_timeout: 0s
-  route_config:
-    name: local_route
-  http_filters:
-  - name: envoy.filters.http.router
-  )EOF";
-
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
-                                     scoped_routes_config_provider_manager_, http_tracer_manager_);
-  EXPECT_FALSE(config.shouldPreserveUpstreamDate());
-}
-
-TEST_F(HttpConnectionManagerConfigTest, EnabledPreserveResponseDate) {
-  const std::string yaml_string = R"EOF(
-  stat_prefix: ingress_http
-  request_timeout: 0s
-  route_config:
-    name: local_route
-  http_filters:
-  - name: envoy.filters.http.router
-  preserve_upstream_date: true
-  )EOF";
-
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
-                                     scoped_routes_config_provider_manager_, http_tracer_manager_);
-  EXPECT_TRUE(config.shouldPreserveUpstreamDate());
-}
-
 TEST_F(HttpConnectionManagerConfigTest, SingleDateProvider) {
   const std::string yaml_string = R"EOF(
 codec_type: http1


### PR DESCRIPTION
This reverts commit 10c755e9d9b8acd7cf1702a4f49dbcbdf0696198.

Per discussion in https://github.com/envoyproxy/envoy/issues/11110
