### PR TITLE
Fix curl expected features test for Windows

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -101,6 +101,9 @@ envoy_cmake_external(
         "CMAKE_USE_GSSAPI": "off",
         "HTTP_ONLY": "on",
         "CMAKE_INSTALL_LIBDIR": "lib",
+        # Explicitly enable Unix sockets and disable crypto for Windows
+        "USE_UNIX_SOCKETS": "on",
+        "CURL_DISABLE_CRYPTO_AUTH": "on",
         # C-Ares.
         "ENABLE_ARES": "on",
         "CARES_LIBRARY": "$EXT_BUILD_DEPS/ares",

--- a/test/dependencies/BUILD
+++ b/test/dependencies/BUILD
@@ -14,5 +14,4 @@ envoy_cc_test(
     external_deps = [
         "curl",
     ],
-    tags = ["fails_on_windows"],
 )

--- a/test/dependencies/curl_test.cc
+++ b/test/dependencies/curl_test.cc
@@ -9,28 +9,32 @@ TEST(CurlTest, BuiltWithExpectedFeatures) {
   // https://curl.haxx.se/libcurl/c/curl_version_info.html.
   curl_version_info_data* info = curl_version_info(CURLVERSION_NOW);
 
-  EXPECT_NE(0, info->features & CURL_VERSION_ASYNCHDNS);
-  EXPECT_NE(0, info->ares_num);
-  EXPECT_NE(0, info->features & CURL_VERSION_HTTP2);
-  EXPECT_NE(0, info->features & CURL_VERSION_LIBZ);
+  // In sequence as declared in curl.h. Overlook any toggle of the
+  // developer or os elections for DEBUG, CURL DEBUG and LARGE FILE
   EXPECT_NE(0, info->features & CURL_VERSION_IPV6);
-
-#ifndef WIN32
-  EXPECT_NE(0, info->features & CURL_VERSION_UNIX_SOCKETS);
-#else
-  EXPECT_EQ(0, info->features & CURL_VERSION_UNIX_SOCKETS);
-#endif
-
-  EXPECT_EQ(0, info->features & CURL_VERSION_BROTLI);
-  EXPECT_EQ(0, info->features & CURL_VERSION_GSSAPI);
-  EXPECT_EQ(0, info->features & CURL_VERSION_GSSNEGOTIATE);
   EXPECT_EQ(0, info->features & CURL_VERSION_KERBEROS4);
-  EXPECT_EQ(0, info->features & CURL_VERSION_KERBEROS5);
-  EXPECT_EQ(0, info->features & CURL_VERSION_NTLM);
-  EXPECT_EQ(0, info->features & CURL_VERSION_NTLM_WB);
-  EXPECT_EQ(0, info->features & CURL_VERSION_SPNEGO);
   EXPECT_EQ(0, info->features & CURL_VERSION_SSL);
+  EXPECT_NE(0, info->features & CURL_VERSION_LIBZ);
+  EXPECT_EQ(0, info->features & CURL_VERSION_NTLM);
+  EXPECT_EQ(0, info->features & CURL_VERSION_GSSNEGOTIATE);
+  EXPECT_NE(0, info->features & CURL_VERSION_ASYNCHDNS);
+  EXPECT_EQ(0, info->features & CURL_VERSION_SPNEGO);
+  EXPECT_EQ(0, info->features & CURL_VERSION_IDN);
   EXPECT_EQ(0, info->features & CURL_VERSION_SSPI);
+  EXPECT_EQ(0, info->features & CURL_VERSION_CONV);
+  EXPECT_EQ(0, info->features & CURL_VERSION_TLSAUTH_SRP);
+  EXPECT_EQ(0, info->features & CURL_VERSION_NTLM_WB);
+  EXPECT_NE(0, info->features & CURL_VERSION_HTTP2);
+  EXPECT_EQ(0, info->features & CURL_VERSION_GSSAPI);
+  EXPECT_EQ(0, info->features & CURL_VERSION_KERBEROS5);
+  EXPECT_NE(0, info->features & CURL_VERSION_UNIX_SOCKETS);
+  EXPECT_EQ(0, info->features & CURL_VERSION_PSL);
+  EXPECT_EQ(0, info->features & CURL_VERSION_HTTPS_PROXY);
+  EXPECT_EQ(0, info->features & CURL_VERSION_MULTI_SSL);
+  EXPECT_EQ(0, info->features & CURL_VERSION_BROTLI);
+  EXPECT_EQ(0, info->features & CURL_VERSION_ALTSVC);
+  EXPECT_EQ(0, info->features & CURL_VERSION_HTTP3);
+  EXPECT_NE(0, info->ares_num);
 }
 
 } // namespace Dependencies


### PR DESCRIPTION
Commit Message: Fix curl expected features test for Windows

Additional Description:
This patch disables various built-in Windows API's, and adds unix
domain sockets support for windows, explicitly (this mirrors the new
behavior of envoy itself, with the same prerequisites.)

Also be more strict about the expected features and reorder the tests to
match the declarations in curl.h

Co-authored-by: William A Rowe Jr <wrowe@pivotal.io>
Co-authored-by: Sunjay Bhatia <sbhatia@pivotal.io>
Signed-off-by: William A Rowe Jr <wrowe@pivotal.io>
Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>

Risk Level: low
Testing: clang on linux and msvc cl on windows
Docs Changes: n/a
Release Notes: n/a
