### PR TITLE
ci: fix missing spec.owner in ownerscheck.star.

### DIFF
--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -60,6 +60,7 @@ def _get_relevant_specs(specs, changed_files):
     status_label = spec.get("github_status_label", "")
     if files:
       relevant.append(struct(files=files,
+                             owner=spec.owner,
                              path_match=path_match,
                              allow_global_approval=allow_global_approval,
                              status_label=status_label))


### PR DESCRIPTION
The **spec was dropped in #11092 when building the struct to pass around. This lost the owner info,
resulting in errors such as
https://prod.repokitteh.app/traces/ui/envoyproxy/envoy/595f3d80-9170-11ea-9312-ad19ced22be2.

Signed-off-by: Harvey Tuch <htuch@google.com>
