### PR TITLE
Move access_log_format out of FileAccessLogger to be shared

### DIFF
--- a/api/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/api/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -43,7 +43,7 @@ message AccessLog {
   // configurations include:
   //
   // #. "envoy.access_loggers.file": :ref:`FileAccessLog
-  //    <envoy_api_msg_extensions.access_loggers.file.v3.FileAccessLog>`
+  //    <envoy_api_msg_extensions.access_loggers.file.v4alpha.FileAccessLog>`
   // #. "envoy.access_loggers.http_grpc": :ref:`HttpGrpcAccessLogConfig
   //    <envoy_api_msg_extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig>`
   // #. "envoy.access_loggers.tcp_grpc": :ref:`TcpGrpcAccessLogConfig

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "SubstitutionFormatStringProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Substitution format string]
+
+// Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
+// to generate a new string in either plain text or JSON format.
+message SubstitutionFormatString {
+  oneof format {
+    // Text access log  :ref:`format string<config_access_log_format_strings>`.
+    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    //
+    // .. code-block::
+    //
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //
+    // The following plain text will be created:
+    //
+    // .. code-block::
+    //
+    //   upstream connect error:204
+    //
+    string text_format = 1;
+
+    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
+    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
+    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
+    // documentation for a specific command operator for details.
+    //
+    // .. code-block::
+    //
+    //  typed_json_format:
+    //    status: %RESPONSE_CODE%
+    //    message: %RESP_BODY%
+    //
+    // The following JSON object would be created:
+    //
+    // .. code-block:: json
+    //
+    //  {
+    //    "status": 500,
+    //    "message": "My error message"
+    //  }
+    //
+    google.protobuf.Struct json_format = 2;
+  }
+}

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -17,25 +17,31 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // to generate a new string in either plain text or JSON format.
 message SubstitutionFormatString {
   oneof format {
-    // Text access log  :ref:`format string<config_access_log_format_strings>`.
-    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    // Specify a format with command operators to form a text string.
+    // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
     // .. code-block::
     //
-    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
     // .. code-block::
     //
-    //   upstream connect error:204
+    //   upstream connect error:204:path=/foo
     //
     string text_format = 1;
 
-    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
-    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
-    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
-    // documentation for a specific command operator for details.
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // All values are rendered as strings.
+    google.protobuf.Struct json_format = 2;
+
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // Values are rendered as strings, numbers, or boolean values as appropriate.
+    // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
+    // See the documentation for a specific command operator for details.
     //
     // .. code-block::
     //
@@ -52,6 +58,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct typed_json_format = 3;
   }
 }

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -5,6 +5,7 @@ package envoy.config.core.v3;
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "SubstitutionFormatStringProto";
@@ -17,6 +18,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // to generate a new string in either plain text or JSON format.
 message SubstitutionFormatString {
   oneof format {
+    option (validate.required) = true;
+
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
@@ -30,12 +33,12 @@ message SubstitutionFormatString {
     //
     //   upstream connect error:204:path=/foo
     //
-    string text_format = 1;
+    string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
@@ -58,6 +61,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3;
+    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
   }
 }

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -37,11 +37,6 @@ message SubstitutionFormatString {
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
-    // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
-
-    // Specify a format with command operators to form a JSON string.
-    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // Values are rendered as strings, numbers, or boolean values as appropriate.
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
@@ -61,6 +56,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
   }
 }

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -41,11 +41,6 @@ message SubstitutionFormatString {
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
-    // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
-
-    // Specify a format with command operators to form a JSON string.
-    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // Values are rendered as strings, numbers, or boolean values as appropriate.
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
@@ -65,6 +60,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
   }
 }

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+package envoy.config.core.v4alpha;
+
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
+option java_outer_classname = "SubstitutionFormatStringProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Substitution format string]
+
+// Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
+// to generate a new string in either plain text or JSON format.
+message SubstitutionFormatString {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.core.v3.SubstitutionFormatString";
+
+  oneof format {
+    // Text access log  :ref:`format string<config_access_log_format_strings>`.
+    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    //
+    // .. code-block::
+    //
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //
+    // The following plain text will be created:
+    //
+    // .. code-block::
+    //
+    //   upstream connect error:204
+    //
+    string text_format = 1;
+
+    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
+    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
+    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
+    // documentation for a specific command operator for details.
+    //
+    // .. code-block::
+    //
+    //  typed_json_format:
+    //    status: %RESPONSE_CODE%
+    //    message: %RESP_BODY%
+    //
+    // The following JSON object would be created:
+    //
+    // .. code-block:: json
+    //
+    //  {
+    //    "status": 500,
+    //    "message": "My error message"
+    //  }
+    //
+    google.protobuf.Struct json_format = 2;
+  }
+}

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -21,25 +21,31 @@ message SubstitutionFormatString {
       "envoy.config.core.v3.SubstitutionFormatString";
 
   oneof format {
-    // Text access log  :ref:`format string<config_access_log_format_strings>`.
-    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    // Specify a format with command operators to form a text string.
+    // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
     // .. code-block::
     //
-    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
     // .. code-block::
     //
-    //   upstream connect error:204
+    //   upstream connect error:204:path=/foo
     //
     string text_format = 1;
 
-    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
-    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
-    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
-    // documentation for a specific command operator for details.
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // All values are rendered as strings.
+    google.protobuf.Struct json_format = 2;
+
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // Values are rendered as strings, numbers, or boolean values as appropriate.
+    // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
+    // See the documentation for a specific command operator for details.
     //
     // .. code-block::
     //
@@ -56,6 +62,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct typed_json_format = 3;
   }
 }

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -6,6 +6,7 @@ import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
 option java_outer_classname = "SubstitutionFormatStringProto";
@@ -21,6 +22,8 @@ message SubstitutionFormatString {
       "envoy.config.core.v3.SubstitutionFormatString";
 
   oneof format {
+    option (validate.required) = true;
+
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
@@ -34,12 +37,12 @@ message SubstitutionFormatString {
     //
     //   upstream connect error:204:path=/foo
     //
-    string text_format = 1;
+    string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
@@ -62,6 +65,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3;
+    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
   }
 }

--- a/api/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/api/envoy/extensions/access_loggers/file/v3/file.proto
@@ -53,6 +53,7 @@ message FileAccessLog {
 
     // Configuration to form access log data and format.
     // If not specified, use :ref:`default format <config_access_log_default_format>`.
-    config.core.v3.SubstitutionFormatString log_format = 5;
+    config.core.v3.SubstitutionFormatString log_format = 5
+        [(validate.rules).message = {required: true}];
   }
 }

--- a/api/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/api/envoy/extensions/access_loggers/file/v3/file.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.access_loggers.file.v3;
 
+import "envoy/config/core/v3/substitution_format_string.proto";
+
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
@@ -19,6 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`
 // that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
 // AccessLog.
+// [#next-free-field: 6]
 message FileAccessLog {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v2.FileAccessLog";
@@ -30,16 +33,26 @@ message FileAccessLog {
     // Access log :ref:`format string<config_access_log_format_strings>`.
     // Envoy supports :ref:`custom access log formats <config_access_log_format>` as well as a
     // :ref:`default format <config_access_log_default_format>`.
-    string format = 2;
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    string format = 2 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. All values
     // are rendered as strings.
-    google.protobuf.Struct json_format = 3;
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    google.protobuf.Struct json_format = 3 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
     // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
     // be produced by some command operators (e.g.FILTER_STATE or DYNAMIC_METADATA). See the
     // documentation for a specific command operator for details.
-    google.protobuf.Struct typed_json_format = 4;
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    google.protobuf.Struct typed_json_format = 4 [deprecated = true];
+
+    // Configuration to form access log data and format.
+    // If not specified, use :ref:`default format <config_access_log_default_format>`.
+    config.core.v3.SubstitutionFormatString log_format = 5;
   }
 }

--- a/api/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/api/envoy/extensions/access_loggers/file/v3/file.proto
@@ -33,13 +33,13 @@ message FileAccessLog {
     // Access log :ref:`format string<config_access_log_format_strings>`.
     // Envoy supports :ref:`custom access log formats <config_access_log_format>` as well as a
     // :ref:`default format <config_access_log_default_format>`.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     string format = 2 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. All values
     // are rendered as strings.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     google.protobuf.Struct json_format = 3 [deprecated = true];
 
@@ -47,7 +47,7 @@ message FileAccessLog {
     // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
     // be produced by some command operators (e.g.FILTER_STATE or DYNAMIC_METADATA). See the
     // documentation for a specific command operator for details.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     google.protobuf.Struct typed_json_format = 4 [deprecated = true];
 

--- a/api/envoy/extensions/access_loggers/file/v4alpha/BUILD
+++ b/api/envoy/extensions/access_loggers/file/v4alpha/BUILD
@@ -6,8 +6,8 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/config/accesslog/v2:pkg",
-        "//envoy/config/core/v3:pkg",
+        "//envoy/config/core/v4alpha:pkg",
+        "//envoy/extensions/access_loggers/file/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/extensions/access_loggers/file/v4alpha/file.proto
+++ b/api/envoy/extensions/access_loggers/file/v4alpha/file.proto
@@ -36,6 +36,7 @@ message FileAccessLog {
   oneof access_log_format {
     // Configuration to form access log data and format.
     // If not specified, use :ref:`default format <config_access_log_default_format>`.
-    config.core.v4alpha.SubstitutionFormatString log_format = 5;
+    config.core.v4alpha.SubstitutionFormatString log_format = 5
+        [(validate.rules).message = {required: true}];
   }
 }

--- a/api/envoy/extensions/access_loggers/file/v4alpha/file.proto
+++ b/api/envoy/extensions/access_loggers/file/v4alpha/file.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package envoy.extensions.access_loggers.file.v4alpha;
+
+import "envoy/config/core/v4alpha/substitution_format_string.proto";
+
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.access_loggers.file.v4alpha";
+option java_outer_classname = "FileProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: File access log]
+// [#extension: envoy.access_loggers.file]
+
+// Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v4alpha.AccessLog>`
+// that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
+// AccessLog.
+// [#next-free-field: 6]
+message FileAccessLog {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.access_loggers.file.v3.FileAccessLog";
+
+  reserved 2, 3, 4;
+
+  reserved "format", "json_format", "typed_json_format";
+
+  // A path to a local file to which to write the access log entries.
+  string path = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  oneof access_log_format {
+    // Configuration to form access log data and format.
+    // If not specified, use :ref:`default format <config_access_log_default_format>`.
+    config.core.v4alpha.SubstitutionFormatString log_format = 5;
+  }
+}

--- a/docs/root/api-v3/common_messages/common_messages.rst
+++ b/docs/root/api-v3/common_messages/common_messages.rst
@@ -17,5 +17,6 @@ Common messages
   ../config/core/v3/grpc_method_list.proto
   ../config/core/v3/http_uri.proto
   ../config/core/v3/socket_option.proto
+  ../config/core/v3/substitution_format_string.proto
   ../extensions/common/ratelimit/v3/ratelimit.proto
   ../extensions/filters/common/fault/v3/fault.proto

--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -104,6 +104,8 @@ Format dictionaries have the following restrictions:
   When using the ``typed_json_format``, integer values that exceed :math:`2^{53}` will be
   represented with reduced precision as they must be converted to floating point numbers.
 
+.. _config_access_log_command_operators:
+
 Command Operators
 -----------------
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -7,12 +7,11 @@ Changes
 * access loggers: added GRPC_STATUS operator on logging format.
 * access loggers: applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature `envoy.reloadable_features.disallow_unbounded_access_logs` to false.
 * access loggers: extened specifier for FilterStateFormatter to output :ref:`unstructured log string <config_access_log_format_filter_state>`.
-* access loggers: file access logger config added :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>` and deprecated :ref:`format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.format>`, :ref:`json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.json_format>` and :ref:`typed_json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.typed_json_format>`.
+* access loggers: file access logger config added :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
 * aggregate cluster: make route :ref:`retry_priority <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_priority>` predicates work with :ref:`this cluster type <envoy_v3_api_msg_extensions.clusters.aggregate.v3.ClusterConfig>`.
 * build: official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
 * compressor: generic :ref:`compressor <config_http_filters_compressor>` filter exposed to users.
 * config: added :ref:`version_text <config_cluster_manager_cds>` stat that reflects xDS version.
-* config: added :ref:`SubstitutionFormatString <envoy_v3_api_msg_config.core.v3.SubstitutionFormatString>`.
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -7,10 +7,12 @@ Changes
 * access loggers: added GRPC_STATUS operator on logging format.
 * access loggers: applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature `envoy.reloadable_features.disallow_unbounded_access_logs` to false.
 * access loggers: extened specifier for FilterStateFormatter to output :ref:`unstructured log string <config_access_log_format_filter_state>`.
+* access loggers: file access logger config added :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>` and deprecated :ref:`format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.format>`, :ref:`json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.json_format>` and :ref:`typed_json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.typed_json_format>`.
 * aggregate cluster: make route :ref:`retry_priority <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_priority>` predicates work with :ref:`this cluster type <envoy_v3_api_msg_extensions.clusters.aggregate.v3.ClusterConfig>`.
 * build: official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
 * compressor: generic :ref:`compressor <config_http_filters_compressor>` filter exposed to users.
 * config: added :ref:`version_text <config_cluster_manager_cds>` stat that reflects xDS version.
+* config: added :ref:`SubstitutionFormatString <envoy_v3_api_msg_config.core.v3.SubstitutionFormatString>`.
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
@@ -74,3 +76,4 @@ Deprecated
   the previous behavior, set allow_cross_scheme_redirect=true and use
   :ref:`safe_cross_scheme<envoy_v3_api_msg_extensions.internal_redirect.safe_cross_scheme.v3.SafeCrossSchemeConfig>`,
   in :ref:`predicates <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`.
+* File access logger fields :ref:`format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.format>`, :ref:`json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.json_format>` and :ref:`typed_json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.typed_json_format>` are deprecated in favor of :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.

--- a/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -43,7 +43,7 @@ message AccessLog {
   // configurations include:
   //
   // #. "envoy.access_loggers.file": :ref:`FileAccessLog
-  //    <envoy_api_msg_extensions.access_loggers.file.v3.FileAccessLog>`
+  //    <envoy_api_msg_extensions.access_loggers.file.v4alpha.FileAccessLog>`
   // #. "envoy.access_loggers.http_grpc": :ref:`HttpGrpcAccessLogConfig
   //    <envoy_api_msg_extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig>`
   // #. "envoy.access_loggers.tcp_grpc": :ref:`TcpGrpcAccessLogConfig

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "SubstitutionFormatStringProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Substitution format string]
+
+// Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
+// to generate a new string in either plain text or JSON format.
+message SubstitutionFormatString {
+  oneof format {
+    // Text access log  :ref:`format string<config_access_log_format_strings>`.
+    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    //
+    // .. code-block::
+    //
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //
+    // The following plain text will be created:
+    //
+    // .. code-block::
+    //
+    //   upstream connect error:204
+    //
+    string text_format = 1;
+
+    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
+    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
+    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
+    // documentation for a specific command operator for details.
+    //
+    // .. code-block::
+    //
+    //  typed_json_format:
+    //    status: %RESPONSE_CODE%
+    //    message: %RESP_BODY%
+    //
+    // The following JSON object would be created:
+    //
+    // .. code-block:: json
+    //
+    //  {
+    //    "status": 500,
+    //    "message": "My error message"
+    //  }
+    //
+    google.protobuf.Struct json_format = 2;
+  }
+}

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -17,25 +17,31 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // to generate a new string in either plain text or JSON format.
 message SubstitutionFormatString {
   oneof format {
-    // Text access log  :ref:`format string<config_access_log_format_strings>`.
-    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    // Specify a format with command operators to form a text string.
+    // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
     // .. code-block::
     //
-    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
     // .. code-block::
     //
-    //   upstream connect error:204
+    //   upstream connect error:204:path=/foo
     //
     string text_format = 1;
 
-    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
-    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
-    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
-    // documentation for a specific command operator for details.
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // All values are rendered as strings.
+    google.protobuf.Struct json_format = 2;
+
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // Values are rendered as strings, numbers, or boolean values as appropriate.
+    // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
+    // See the documentation for a specific command operator for details.
     //
     // .. code-block::
     //
@@ -52,6 +58,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct typed_json_format = 3;
   }
 }

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -5,6 +5,7 @@ package envoy.config.core.v3;
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "SubstitutionFormatStringProto";
@@ -17,6 +18,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // to generate a new string in either plain text or JSON format.
 message SubstitutionFormatString {
   oneof format {
+    option (validate.required) = true;
+
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
@@ -30,12 +33,12 @@ message SubstitutionFormatString {
     //
     //   upstream connect error:204:path=/foo
     //
-    string text_format = 1;
+    string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
@@ -58,6 +61,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3;
+    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
   }
 }

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -37,11 +37,6 @@ message SubstitutionFormatString {
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
-    // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
-
-    // Specify a format with command operators to form a JSON string.
-    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // Values are rendered as strings, numbers, or boolean values as appropriate.
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
@@ -61,6 +56,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
   }
 }

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -41,11 +41,6 @@ message SubstitutionFormatString {
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
-    // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
-
-    // Specify a format with command operators to form a JSON string.
-    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // Values are rendered as strings, numbers, or boolean values as appropriate.
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
@@ -65,6 +60,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
   }
 }

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+package envoy.config.core.v4alpha;
+
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
+option java_outer_classname = "SubstitutionFormatStringProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Substitution format string]
+
+// Configuration to use multiple :ref:`command operators <config_access_log_command_operators>`
+// to generate a new string in either plain text or JSON format.
+message SubstitutionFormatString {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.core.v3.SubstitutionFormatString";
+
+  oneof format {
+    // Text access log  :ref:`format string<config_access_log_format_strings>`.
+    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    //
+    // .. code-block::
+    //
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //
+    // The following plain text will be created:
+    //
+    // .. code-block::
+    //
+    //   upstream connect error:204
+    //
+    string text_format = 1;
+
+    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
+    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
+    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
+    // documentation for a specific command operator for details.
+    //
+    // .. code-block::
+    //
+    //  typed_json_format:
+    //    status: %RESPONSE_CODE%
+    //    message: %RESP_BODY%
+    //
+    // The following JSON object would be created:
+    //
+    // .. code-block:: json
+    //
+    //  {
+    //    "status": 500,
+    //    "message": "My error message"
+    //  }
+    //
+    google.protobuf.Struct json_format = 2;
+  }
+}

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -21,25 +21,31 @@ message SubstitutionFormatString {
       "envoy.config.core.v3.SubstitutionFormatString";
 
   oneof format {
-    // Text access log  :ref:`format string<config_access_log_format_strings>`.
-    // This field specifies :ref:`custom access log formats <config_access_log_format>`.
+    // Specify a format with command operators to form a text string.
+    // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
     // .. code-block::
     //
-    //   text_format: %RESP_BODY%:%RESPONSE_CODE%
+    //   text_format: %RESP_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
     // .. code-block::
     //
-    //   upstream connect error:204
+    //   upstream connect error:204:path=/foo
     //
     string text_format = 1;
 
-    // JSON access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
-    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
-    // be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA). See the
-    // documentation for a specific command operator for details.
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // All values are rendered as strings.
+    google.protobuf.Struct json_format = 2;
+
+    // Specify a format with command operators to form a JSON string.
+    // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
+    // Values are rendered as strings, numbers, or boolean values as appropriate.
+    // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
+    // See the documentation for a specific command operator for details.
     //
     // .. code-block::
     //
@@ -56,6 +62,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct typed_json_format = 3;
   }
 }

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -6,6 +6,7 @@ import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
 option java_outer_classname = "SubstitutionFormatStringProto";
@@ -21,6 +22,8 @@ message SubstitutionFormatString {
       "envoy.config.core.v3.SubstitutionFormatString";
 
   oneof format {
+    option (validate.required) = true;
+
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
@@ -34,12 +37,12 @@ message SubstitutionFormatString {
     //
     //   upstream connect error:204:path=/foo
     //
-    string text_format = 1;
+    string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
     // All values are rendered as strings.
-    google.protobuf.Struct json_format = 2;
+    google.protobuf.Struct json_format = 2 [(validate.rules).message = {required: true}];
 
     // Specify a format with command operators to form a JSON string.
     // Its details is described in :ref:`format dictionary<config_access_log_format_dictionaries>`.
@@ -62,6 +65,6 @@ message SubstitutionFormatString {
     //    "message": "My error message"
     //  }
     //
-    google.protobuf.Struct typed_json_format = 3;
+    google.protobuf.Struct typed_json_format = 3 [(validate.rules).message = {required: true}];
   }
 }

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/accesslog/v2:pkg",
+        "//envoy/config/core/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
@@ -53,6 +53,7 @@ message FileAccessLog {
 
     // Configuration to form access log data and format.
     // If not specified, use :ref:`default format <config_access_log_default_format>`.
-    config.core.v3.SubstitutionFormatString log_format = 5;
+    config.core.v3.SubstitutionFormatString log_format = 5
+        [(validate.rules).message = {required: true}];
   }
 }

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.access_loggers.file.v3;
 
+import "envoy/config/core/v3/substitution_format_string.proto";
+
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
@@ -19,6 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`
 // that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
 // AccessLog.
+// [#next-free-field: 6]
 message FileAccessLog {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v2.FileAccessLog";
@@ -30,16 +33,26 @@ message FileAccessLog {
     // Access log :ref:`format string<config_access_log_format_strings>`.
     // Envoy supports :ref:`custom access log formats <config_access_log_format>` as well as a
     // :ref:`default format <config_access_log_default_format>`.
-    string format = 2;
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    string format = 2 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. All values
     // are rendered as strings.
-    google.protobuf.Struct json_format = 3;
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    google.protobuf.Struct json_format = 3 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
     // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
     // be produced by some command operators (e.g.FILTER_STATE or DYNAMIC_METADATA). See the
     // documentation for a specific command operator for details.
-    google.protobuf.Struct typed_json_format = 4;
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    google.protobuf.Struct typed_json_format = 4 [deprecated = true];
+
+    // Configuration to form access log data and format.
+    // If not specified, use :ref:`default format <config_access_log_default_format>`.
+    config.core.v3.SubstitutionFormatString log_format = 5;
   }
 }

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v3/file.proto
@@ -33,13 +33,13 @@ message FileAccessLog {
     // Access log :ref:`format string<config_access_log_format_strings>`.
     // Envoy supports :ref:`custom access log formats <config_access_log_format>` as well as a
     // :ref:`default format <config_access_log_default_format>`.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     string format = 2 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. All values
     // are rendered as strings.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     google.protobuf.Struct json_format = 3 [deprecated = true];
 
@@ -47,7 +47,7 @@ message FileAccessLog {
     // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
     // be produced by some command operators (e.g.FILTER_STATE or DYNAMIC_METADATA). See the
     // documentation for a specific command operator for details.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     google.protobuf.Struct typed_json_format = 4 [deprecated = true];
 

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/BUILD
@@ -6,8 +6,8 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/config/accesslog/v2:pkg",
-        "//envoy/config/core/v3:pkg",
+        "//envoy/config/core/v4alpha:pkg",
+        "//envoy/extensions/access_loggers/file/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/file.proto
@@ -53,6 +53,7 @@ message FileAccessLog {
 
     // Configuration to form access log data and format.
     // If not specified, use :ref:`default format <config_access_log_default_format>`.
-    config.core.v4alpha.SubstitutionFormatString log_format = 5;
+    config.core.v4alpha.SubstitutionFormatString log_format = 5
+        [(validate.rules).message = {required: true}];
   }
 }

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/file.proto
@@ -33,13 +33,13 @@ message FileAccessLog {
     // Access log :ref:`format string<config_access_log_format_strings>`.
     // Envoy supports :ref:`custom access log formats <config_access_log_format>` as well as a
     // :ref:`default format <config_access_log_default_format>`.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     string hidden_envoy_deprecated_format = 2 [deprecated = true];
 
     // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. All values
     // are rendered as strings.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     google.protobuf.Struct hidden_envoy_deprecated_json_format = 3 [deprecated = true];
 
@@ -47,7 +47,7 @@ message FileAccessLog {
     // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
     // be produced by some command operators (e.g.FILTER_STATE or DYNAMIC_METADATA). See the
     // documentation for a specific command operator for details.
-    // It is deprecated.
+    // This field is deprecated.
     // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
     google.protobuf.Struct hidden_envoy_deprecated_typed_json_format = 4 [deprecated = true];
 

--- a/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/file.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/file/v4alpha/file.proto
@@ -1,0 +1,58 @@
+syntax = "proto3";
+
+package envoy.extensions.access_loggers.file.v4alpha;
+
+import "envoy/config/core/v4alpha/substitution_format_string.proto";
+
+import "google/protobuf/struct.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.extensions.access_loggers.file.v4alpha";
+option java_outer_classname = "FileProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: File access log]
+// [#extension: envoy.access_loggers.file]
+
+// Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v4alpha.AccessLog>`
+// that writes log entries directly to a file. Configures the built-in *envoy.access_loggers.file*
+// AccessLog.
+// [#next-free-field: 6]
+message FileAccessLog {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.access_loggers.file.v3.FileAccessLog";
+
+  // A path to a local file to which to write the access log entries.
+  string path = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  oneof access_log_format {
+    // Access log :ref:`format string<config_access_log_format_strings>`.
+    // Envoy supports :ref:`custom access log formats <config_access_log_format>` as well as a
+    // :ref:`default format <config_access_log_default_format>`.
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    string hidden_envoy_deprecated_format = 2 [deprecated = true];
+
+    // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. All values
+    // are rendered as strings.
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    google.protobuf.Struct hidden_envoy_deprecated_json_format = 3 [deprecated = true];
+
+    // Access log :ref:`format dictionary<config_access_log_format_dictionaries>`. Values are
+    // rendered as strings, numbers, or boolean values as appropriate. Nested JSON objects may
+    // be produced by some command operators (e.g.FILTER_STATE or DYNAMIC_METADATA). See the
+    // documentation for a specific command operator for details.
+    // It is deprecated.
+    // Please use :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
+    google.protobuf.Struct hidden_envoy_deprecated_typed_json_format = 4 [deprecated = true];
+
+    // Configuration to form access log data and format.
+    // If not specified, use :ref:`default format <config_access_log_default_format>`.
+    config.core.v4alpha.SubstitutionFormatString log_format = 5;
+  }
+}

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -107,8 +107,8 @@ std::string FormatterImpl::format(const Http::RequestHeaderMap& request_headers,
   return log_line;
 }
 
-JsonFormatterImpl::JsonFormatterImpl(std::unordered_map<std::string, std::string>& format_mapping,
-                                     bool preserve_types)
+JsonFormatterImpl::JsonFormatterImpl(
+    const absl::flat_hash_map<std::string, std::string>& format_mapping, bool preserve_types)
     : preserve_types_(preserve_types) {
   for (const auto& pair : format_mapping) {
     json_output_format_.emplace(pair.first, AccessLogFormatParser::parse(pair.second));

--- a/source/common/access_log/access_log_formatter.h
+++ b/source/common/access_log/access_log_formatter.h
@@ -12,6 +12,7 @@
 
 #include "common/common/utility.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -101,7 +102,7 @@ private:
 
 class JsonFormatterImpl : public Formatter {
 public:
-  JsonFormatterImpl(std::unordered_map<std::string, std::string>& format_mapping,
+  JsonFormatterImpl(const absl::flat_hash_map<std::string, std::string>& format_mapping,
                     bool preserve_types);
 
   // Formatter::format

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -68,6 +68,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "substitution_format_string_lib",
+    srcs = ["substitution_format_string.cc"],
+    hdrs = ["substitution_format_string.h"],
+    deps = [
+        "//include/envoy/access_log:access_log_interface",
+        "//source/common/access_log:access_log_formatter_lib",
+        "//source/common/protobuf",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "compiler_requirements_lib",
     hdrs = ["compiler_requirements.h"],
 )

--- a/source/common/common/substitution_format_string.cc
+++ b/source/common/common/substitution_format_string.cc
@@ -1,0 +1,37 @@
+#include "common/common/substitution_format_string.h"
+
+#include "common/access_log/access_log_formatter.h"
+
+namespace Envoy {
+namespace {
+
+std::unordered_map<std::string, std::string>
+convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
+  std::unordered_map<std::string, std::string> output;
+  for (const auto& pair : json_format.fields()) {
+    if (pair.second.kind_case() != ProtobufWkt::Value::kStringValue) {
+      throw EnvoyException("Only string values are supported in the JSON access log format.");
+    }
+    output.emplace(pair.first, pair.second.string_value());
+  }
+  return output;
+}
+
+} // namespace
+
+AccessLog::FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
+    const envoy::config::core::v3::SubstitutionFormatString& config) {
+  switch (config.format_case()) {
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
+    return std::make_unique<AccessLog::FormatterImpl>(config.text_format());
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat: {
+    auto json_format_map = convertJsonFormatToMap(config.json_format());
+    return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, true);
+  }
+  default:
+    return nullptr;
+  }
+  return nullptr;
+}
+
+} // namespace Envoy

--- a/source/common/common/substitution_format_string.cc
+++ b/source/common/common/substitution_format_string.cc
@@ -33,7 +33,7 @@ AccessLog::FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
     return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, true);
   }
   default:
-    return nullptr;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
   return nullptr;
 }

--- a/source/common/common/substitution_format_string.cc
+++ b/source/common/common/substitution_format_string.cc
@@ -6,7 +6,7 @@ namespace Envoy {
 namespace {
 
 absl::flat_hash_map<std::string, std::string>
-convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
+convertJsonFormatToMap(const ProtobufWkt::Struct& json_format) {
   absl::flat_hash_map<std::string, std::string> output;
   for (const auto& pair : json_format.fields()) {
     if (pair.second.kind_case() != ProtobufWkt::Value::kStringValue) {
@@ -19,18 +19,20 @@ convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
 
 } // namespace
 
+AccessLog::FormatterPtr
+SubstitutionFormatStringUtils::createJsonFormatter(const ProtobufWkt::Struct& struct_format,
+                                                   bool preserve_types) {
+  auto json_format_map = convertJsonFormatToMap(struct_format);
+  return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, preserve_types);
+}
+
 AccessLog::FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
     const envoy::config::core::v3::SubstitutionFormatString& config) {
   switch (config.format_case()) {
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
     return std::make_unique<AccessLog::FormatterImpl>(config.text_format());
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat: {
-    auto json_format_map = convertJsonFormatToMap(config.json_format());
-    return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, false);
-  }
-  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTypedJsonFormat: {
-    auto json_format_map = convertJsonFormatToMap(config.typed_json_format());
-    return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, true);
+    return createJsonFormatter(config.json_format(), true);
   }
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/common/common/substitution_format_string.cc
+++ b/source/common/common/substitution_format_string.cc
@@ -5,9 +5,9 @@
 namespace Envoy {
 namespace {
 
-std::unordered_map<std::string, std::string>
+absl::flat_hash_map<std::string, std::string>
 convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
-  std::unordered_map<std::string, std::string> output;
+  absl::flat_hash_map<std::string, std::string> output;
   for (const auto& pair : json_format.fields()) {
     if (pair.second.kind_case() != ProtobufWkt::Value::kStringValue) {
       throw EnvoyException("Only string values are supported in the JSON access log format.");
@@ -26,6 +26,10 @@ AccessLog::FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
     return std::make_unique<AccessLog::FormatterImpl>(config.text_format());
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat: {
     auto json_format_map = convertJsonFormatToMap(config.json_format());
+    return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, false);
+  }
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTypedJsonFormat: {
+    auto json_format_map = convertJsonFormatToMap(config.typed_json_format());
     return std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, true);
   }
   default:

--- a/source/common/common/substitution_format_string.h
+++ b/source/common/common/substitution_format_string.h
@@ -19,7 +19,7 @@ public:
    * Generate a formatter object from config SubstitutionFormatString.
    */
   static AccessLog::FormatterPtr
-  fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& foramt);
+  fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config);
 };
 
 } // namespace Envoy

--- a/source/common/common/substitution_format_string.h
+++ b/source/common/common/substitution_format_string.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "envoy/access_log/access_log.h"
+#include "envoy/config/core/v3/substitution_format_string.pb.h"
+
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+
+/**
+ * Utilities for using envoy::config::core::v3::SubstitutionFormatString
+ */
+class SubstitutionFormatStringUtils {
+public:
+  /**
+   * Generate a formatter object from config SubstitutionFormatString.
+   */
+  static AccessLog::FormatterPtr
+  fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& foramt);
+};
+
+} // namespace Envoy

--- a/source/common/common/substitution_format_string.h
+++ b/source/common/common/substitution_format_string.h
@@ -20,6 +20,12 @@ public:
    */
   static AccessLog::FormatterPtr
   fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config);
+
+  /**
+   * Generate a Json formatter object from proto::Struct config
+   */
+  static AccessLog::FormatterPtr createJsonFormatter(const ProtobufWkt::Struct& struct_format,
+                                                     bool preserve_types);
 };
 
 } // namespace Envoy

--- a/source/extensions/access_loggers/file/BUILD
+++ b/source/extensions/access_loggers/file/BUILD
@@ -29,8 +29,7 @@ envoy_cc_extension(
     deps = [
         ":file_access_log_lib",
         "//include/envoy/registry",
-        "//include/envoy/server:access_log_config_interface",
-        "//source/common/access_log:access_log_formatter_lib",
+        "//source/common/common:substitution_format_string_lib",
         "//source/common/protobuf",
         "//source/extensions/access_loggers:well_known_names",
         "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -10,6 +10,7 @@
 
 #include "common/access_log/access_log_formatter.h"
 #include "common/common/logger.h"
+#include "common/common/substitution_format_string.h"
 #include "common/protobuf/protobuf.h"
 
 #include "extensions/access_loggers/file/file_access_log_impl.h"
@@ -29,30 +30,33 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       config, context.messageValidationVisitor());
   AccessLog::FormatterPtr formatter;
 
-  if (fal_config.access_log_format_case() == envoy::extensions::access_loggers::file::v3::
-                                                 FileAccessLog::AccessLogFormatCase::kFormat ||
-      fal_config.access_log_format_case() ==
-          envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
-              ACCESS_LOG_FORMAT_NOT_SET) {
-    if (fal_config.format().empty()) {
-      formatter = AccessLog::AccessLogFormatUtils::defaultAccessLogFormatter();
-    } else {
-      formatter = std::make_unique<AccessLog::FormatterImpl>(fal_config.format());
+  if (fal_config.has_log_format()) {
+    formatter = SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format());
+  }
+  // backward compatible code for deprecated access_log_format, to be removed.
+  if (fal_config.access_log_format_case() !=
+      envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+          ACCESS_LOG_FORMAT_NOT_SET) {
+    envoy::config::core::v3::SubstitutionFormatString sff_config;
+    switch (fal_config.access_log_format_case()) {
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kFormat:
+      sff_config.set_text_format(fal_config.format());
+      break;
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+        kJsonFormat:
+      *sff_config.mutable_json_format() = fal_config.json_format();
+      break;
+    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+        kTypedJsonFormat:
+      *sff_config.mutable_json_format() = fal_config.typed_json_format();
+      break;
+    default:
+      break;
     }
-  } else if (fal_config.access_log_format_case() ==
-             envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
-                 kJsonFormat) {
-    auto json_format_map = this->convertJsonFormatToMap(fal_config.json_format());
-    formatter = std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, false);
-  } else if (fal_config.access_log_format_case() ==
-             envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
-                 kTypedJsonFormat) {
-    auto json_format_map = this->convertJsonFormatToMap(fal_config.typed_json_format());
-    formatter = std::make_unique<AccessLog::JsonFormatterImpl>(json_format_map, true);
-  } else {
-    throw EnvoyException(
-        "Invalid access_log format provided. Only 'format', 'json_format', or 'typed_json_format' "
-        "are supported.");
+    formatter = SubstitutionFormatStringUtils::fromProtoConfig(sff_config);
+  }
+  if (!formatter) {
+    formatter = AccessLog::AccessLogFormatUtils::defaultAccessLogFormatter();
   }
 
   return std::make_shared<FileAccessLog>(fal_config.path(), std::move(filter), std::move(formatter),
@@ -65,18 +69,6 @@ ProtobufTypes::MessagePtr FileAccessLogFactory::createEmptyConfigProto() {
 }
 
 std::string FileAccessLogFactory::name() const { return AccessLogNames::get().File; }
-
-std::unordered_map<std::string, std::string>
-FileAccessLogFactory::convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
-  std::unordered_map<std::string, std::string> output;
-  for (const auto& pair : json_format.fields()) {
-    if (pair.second.kind_case() != ProtobufWkt::Value::kStringValue) {
-      throw EnvoyException("Only string values are supported in the JSON access log format.");
-    }
-    output.emplace(pair.first, pair.second.string_value());
-  }
-  return output;
-}
 
 /**
  * Static registration for the file access log. @see RegisterFactory.

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -32,11 +32,10 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
 
   if (fal_config.has_log_format()) {
     formatter = SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format());
-  }
-  // backward compatible code for deprecated access_log_format, to be removed.
-  if (fal_config.access_log_format_case() !=
-      envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
-          ACCESS_LOG_FORMAT_NOT_SET) {
+  } else if (fal_config.access_log_format_case() !=
+             envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
+                 ACCESS_LOG_FORMAT_NOT_SET) {
+    // Backward compatible code for deprecated access_log_format, to be removed.
     envoy::config::core::v3::SubstitutionFormatString sff_config;
     switch (fal_config.access_log_format_case()) {
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kFormat:

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -48,7 +48,7 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       break;
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
         kTypedJsonFormat:
-      *sff_config.mutable_json_format() = fal_config.typed_json_format();
+      *sff_config.mutable_typed_json_format() = fal_config.typed_json_format();
       break;
     default:
       break;

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -51,7 +51,7 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
       *sff_config.mutable_typed_json_format() = fal_config.typed_json_format();
       break;
     default:
-      break;
+      NOT_REACHED_GCOVR_EXCL_LINE;
     }
     formatter = SubstitutionFormatStringUtils::fromProtoConfig(sff_config);
   }

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -32,22 +32,19 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
 
   if (fal_config.has_log_format()) {
     formatter = SubstitutionFormatStringUtils::fromProtoConfig(fal_config.log_format());
+  } else if (fal_config.has_json_format()) {
+    formatter = SubstitutionFormatStringUtils::createJsonFormatter(fal_config.json_format(), false);
   } else if (fal_config.access_log_format_case() !=
              envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
                  ACCESS_LOG_FORMAT_NOT_SET) {
-    // Backward compatible code for deprecated access_log_format, to be removed.
     envoy::config::core::v3::SubstitutionFormatString sff_config;
     switch (fal_config.access_log_format_case()) {
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::kFormat:
       sff_config.set_text_format(fal_config.format());
       break;
     case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
-        kJsonFormat:
-      *sff_config.mutable_json_format() = fal_config.json_format();
-      break;
-    case envoy::extensions::access_loggers::file::v3::FileAccessLog::AccessLogFormatCase::
         kTypedJsonFormat:
-      *sff_config.mutable_typed_json_format() = fal_config.typed_json_format();
+      *sff_config.mutable_json_format() = fal_config.typed_json_format();
       break;
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/access_loggers/file/config.h
+++ b/source/extensions/access_loggers/file/config.h
@@ -19,9 +19,6 @@ public:
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 
   std::string name() const override;
-
-private:
-  std::unordered_map<std::string, std::string> convertJsonFormatToMap(ProtobufWkt::Struct config);
 };
 
 } // namespace File

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -35,7 +35,7 @@ std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
 
 namespace Envoy {
 
-static void BM_AccessLogFormatter(benchmark::State& state) {
+static void bM_AccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   static const char* LogFormat =
       "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
@@ -57,9 +57,9 @@ static void BM_AccessLogFormatter(benchmark::State& state) {
   }
   benchmark::DoNotOptimize(output_bytes);
 }
-BENCHMARK(BM_AccessLogFormatter);
+BENCHMARK(bM_AccessLogFormatter);
 
-static void BM_JsonAccessLogFormatter(benchmark::State& state) {
+static void bM_JsonAccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter = makeJsonFormatter(false);
 
@@ -74,9 +74,9 @@ static void BM_JsonAccessLogFormatter(benchmark::State& state) {
   }
   benchmark::DoNotOptimize(output_bytes);
 }
-BENCHMARK(BM_JsonAccessLogFormatter);
+BENCHMARK(bM_JsonAccessLogFormatter);
 
-static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
+static void bM_TypedJsonAccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter =
       makeJsonFormatter(true);
@@ -92,6 +92,6 @@ static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
   }
   benchmark::DoNotOptimize(output_bytes);
 }
-BENCHMARK(BM_TypedJsonAccessLogFormatter);
+BENCHMARK(bM_TypedJsonAccessLogFormatter);
 
 } // namespace Envoy

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -8,7 +8,7 @@
 
 namespace {
 
-std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> MakeJsonFormatter(bool typed) {
+std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> makeJsonFormatter(bool typed) {
   absl::flat_hash_map<std::string, std::string> JsonLogFormat = {
       {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
       {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
@@ -61,7 +61,7 @@ BENCHMARK(BM_AccessLogFormatter);
 
 static void BM_JsonAccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
-  std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter = MakeJsonFormatter(false);
+  std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter = makeJsonFormatter(false);
 
   size_t output_bytes = 0;
   Http::TestRequestHeaderMapImpl request_headers;
@@ -79,7 +79,7 @@ BENCHMARK(BM_JsonAccessLogFormatter);
 static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter =
-      MakeJsonFormatter(true);
+      makeJsonFormatter(true);
 
   size_t output_bytes = 0;
   Http::TestRequestHeaderMapImpl request_headers;

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -9,7 +9,7 @@
 namespace {
 
 std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> MakeJsonFormatter(bool typed) {
-  std::unordered_map<std::string, std::string> JsonLogFormat = {
+  absl::flat_hash_map<std::string, std::string> JsonLogFormat = {
       {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
       {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
       {"method", "%REQ(:METHOD)%"},

--- a/test/common/access_log/access_log_formatter_speed_test.cc
+++ b/test/common/access_log/access_log_formatter_speed_test.cc
@@ -6,6 +6,8 @@
 
 #include "benchmark/benchmark.h"
 
+namespace Envoy {
+
 namespace {
 
 std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> makeJsonFormatter(bool typed) {
@@ -33,9 +35,8 @@ std::unique_ptr<Envoy::TestStreamInfo> makeStreamInfo() {
 
 } // namespace
 
-namespace Envoy {
-
-static void bM_AccessLogFormatter(benchmark::State& state) {
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_AccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   static const char* LogFormat =
       "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% %START_TIME(%Y/%m/%dT%H:%M:%S%z %s)% "
@@ -57,9 +58,10 @@ static void bM_AccessLogFormatter(benchmark::State& state) {
   }
   benchmark::DoNotOptimize(output_bytes);
 }
-BENCHMARK(bM_AccessLogFormatter);
+BENCHMARK(BM_AccessLogFormatter);
 
-static void bM_JsonAccessLogFormatter(benchmark::State& state) {
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_JsonAccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> json_formatter = makeJsonFormatter(false);
 
@@ -74,9 +76,10 @@ static void bM_JsonAccessLogFormatter(benchmark::State& state) {
   }
   benchmark::DoNotOptimize(output_bytes);
 }
-BENCHMARK(bM_JsonAccessLogFormatter);
+BENCHMARK(BM_JsonAccessLogFormatter);
 
-static void bM_TypedJsonAccessLogFormatter(benchmark::State& state) {
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_TypedJsonAccessLogFormatter(benchmark::State& state) {
   std::unique_ptr<Envoy::TestStreamInfo> stream_info = makeStreamInfo();
   std::unique_ptr<Envoy::AccessLog::JsonFormatterImpl> typed_json_formatter =
       makeJsonFormatter(true);
@@ -92,6 +95,6 @@ static void bM_TypedJsonAccessLogFormatter(benchmark::State& state) {
   }
   benchmark::DoNotOptimize(output_bytes);
 }
-BENCHMARK(bM_TypedJsonAccessLogFormatter);
+BENCHMARK(BM_TypedJsonAccessLogFormatter);
 
 } // namespace Envoy

--- a/test/common/access_log/access_log_formatter_test.cc
+++ b/test/common/access_log/access_log_formatter_test.cc
@@ -1473,7 +1473,7 @@ TEST(AccessLogFormatterTest, JsonFormatterPlainStringTest) {
   std::unordered_map<std::string, std::string> expected_json_map = {
       {"plain_string", "plain_string_value"}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"plain_string", "plain_string_value"}};
   JsonFormatterImpl formatter(key_mapping, false);
 
@@ -1494,7 +1494,7 @@ TEST(AccessLogFormatterTest, JsonFormatterSingleOperatorTest) {
 
   std::unordered_map<std::string, std::string> expected_json_map = {{"protocol", "HTTP/1.1"}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {{"protocol", "%PROTOCOL%"}};
+  absl::flat_hash_map<std::string, std::string> key_mapping = {{"protocol", "%PROTOCOL%"}};
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(formatter.format(request_header, response_header, response_trailer, stream_info),
@@ -1513,7 +1513,7 @@ TEST(AccessLogFormatterTest, JsonFormatterNonExistentHeaderTest) {
       {"nonexistent_response_header", "-"},
       {"some_response_header", "SOME_RESPONSE_HEADER"}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"protocol", "%PROTOCOL%"},
       {"some_request_header", "%REQ(some_request_header)%"},
       {"nonexistent_response_header", "%RESP(nonexistent_response_header)%"},
@@ -1541,7 +1541,7 @@ TEST(AccessLogFormatterTest, JsonFormatterAlternateHeaderTest) {
       {"response_absent_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER"},
       {"response_present_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER"}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"request_present_header_or_request_absent_header",
        "%REQ(request_present_header?request_absent_header)%"},
       {"request_absent_header_or_request_present_header",
@@ -1575,7 +1575,7 @@ TEST(AccessLogFormatterTest, JsonFormatterDynamicMetadataTest) {
       {"test_obj", "{\"inner_key\":\"inner_value\"}"},
       {"test_obj.inner_key", "\"inner_value\""}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key", "%DYNAMIC_METADATA(com.test:test_key)%"},
       {"test_obj", "%DYNAMIC_METADATA(com.test:test_obj)%"},
       {"test_obj.inner_key", "%DYNAMIC_METADATA(com.test:test_obj:inner_key)%"}};
@@ -1597,7 +1597,7 @@ TEST(AccessLogFormatterTest, JsonFormatterTypedDynamicMetadataTest) {
   EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
   EXPECT_CALL(Const(stream_info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key", "%DYNAMIC_METADATA(com.test:test_key)%"},
       {"test_obj", "%DYNAMIC_METADATA(com.test:test_obj)%"},
       {"test_obj.inner_key", "%DYNAMIC_METADATA(com.test:test_obj:inner_key)%"}};
@@ -1632,7 +1632,7 @@ TEST(AccessLogFormatterTest, JsonFormatterFilterStateTest) {
   std::unordered_map<std::string, std::string> expected_json_map = {
       {"test_key", "\"test_value\""}, {"test_obj", "{\"inner_key\":\"inner_value\"}"}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key", "%FILTER_STATE(test_key)%"}, {"test_obj", "%FILTER_STATE(test_obj)%"}};
 
   JsonFormatterImpl formatter(key_mapping, false);
@@ -1655,7 +1655,7 @@ TEST(AccessLogFormatterTest, JsonFormatterTypedFilterStateTest) {
                                      StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key", "%FILTER_STATE(test_key)%"}, {"test_obj", "%FILTER_STATE(test_obj)%"}};
 
   JsonFormatterImpl formatter(key_mapping, true);
@@ -1688,7 +1688,7 @@ TEST(AccessLogFormatterTest, FilterStateSpeciferTest) {
       {"test_key_typed", "\"test_value By TYPED\""},
   };
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key_plain", "%FILTER_STATE(test_key:PLAIN)%"},
       {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
 
@@ -1711,7 +1711,7 @@ TEST(AccessLogFormatterTest, TypedFilterStateSpeciferTest) {
       StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key_plain", "%FILTER_STATE(test_key:PLAIN)%"},
       {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
 
@@ -1739,7 +1739,7 @@ TEST(AccessLogFormatterTest, FilterStateErrorSpeciferTest) {
       StreamInfo::FilterState::StateType::ReadOnly);
 
   // 'ABCDE' is error specifier.
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"test_key_plain", "%FILTER_STATE(test_key:ABCDE)%"},
       {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
 
@@ -1764,7 +1764,7 @@ TEST(AccessLogFormatterTest, JsonFormatterStartTimeTest) {
       {"default", "2018-03-28T23:35:58.000Z"},
       {"all_zeroes", "000000000.0.00.000"}};
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"simple_date", "%START_TIME(%Y/%m/%d)%"},
       {"test_time", "%START_TIME(%s)%"},
       {"bad_format", "%START_TIME(bad_format)%"},
@@ -1787,7 +1787,7 @@ TEST(AccessLogFormatterTest, JsonFormatterMultiTokenTest) {
     std::unordered_map<std::string, std::string> expected_json_map = {
         {"multi_token_field", "HTTP/1.1 plainstring SOME_REQUEST_HEADER SOME_RESPONSE_HEADER"}};
 
-    std::unordered_map<std::string, std::string> key_mapping = {
+    absl::flat_hash_map<std::string, std::string> key_mapping = {
         {"multi_token_field",
          "%PROTOCOL% plainstring %REQ(some_request_header)% %RESP(some_response_header)%"}};
 
@@ -1827,7 +1827,7 @@ TEST(AccessLogFormatterTest, JsonFormatterTypedTest) {
                                      StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
-  std::unordered_map<std::string, std::string> key_mapping = {
+  absl::flat_hash_map<std::string, std::string> key_mapping = {
       {"request_duration", "%REQUEST_DURATION%"},
       {"request_duration_multi", "%REQUEST_DURATION%ms"},
       {"filter_state", "%FILTER_STATE(test_obj)%"},

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -46,6 +46,7 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -38,6 +38,17 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "substitution_format_string_test",
+    srcs = ["substitution_format_string_test.cc"],
+    deps = [
+        "//source/common/common:substitution_format_string_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
 envoy_cc_fuzz_test(
     name = "base64_fuzz_test",
     srcs = ["base64_fuzz_test.cc"],

--- a/test/common/common/substitution_format_string_test.cc
+++ b/test/common/common/substitution_format_string_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/config/core/v3/substitution_format_string.pb.validate.h"
+
 #include "common/common/substitution_format_string.h"
 
 #include "test/mocks/http/mocks.h"
@@ -26,8 +28,10 @@ public:
   envoy::config::core::v3::SubstitutionFormatString config_;
 };
 
-TEST_F(SubstitutionFormatStringUtilsTest, TestFomProtoConfigEmpty) {
-  EXPECT_EQ(nullptr, SubstitutionFormatStringUtils::fromProtoConfig(config_));
+TEST_F(SubstitutionFormatStringUtilsTest, TestEmptyIsInvalid) {
+  envoy::config::core::v3::SubstitutionFormatString empty_config;
+  std::string err;
+  EXPECT_FALSE(Validate(empty_config, &err));
 }
 
 TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigText) {

--- a/test/common/common/substitution_format_string_test.cc
+++ b/test/common/common/substitution_format_string_test.cc
@@ -62,27 +62,6 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJson) {
   const std::string expected = R"EOF({
     "text": "plain text",
     "path": "/bar/foo",
-    "code": "200"
-})EOF";
-  EXPECT_TRUE(TestUtility::jsonStringEqual(out_json, expected));
-}
-
-TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigTypedJson) {
-  const std::string yaml = R"EOF(
-  typed_json_format:
-    text: "plain text"
-    path: "%REQ(:path)%"
-    code: "%RESPONSE_CODE%"
-)EOF";
-  TestUtility::loadFromYaml(yaml, config_);
-
-  auto formatter = SubstitutionFormatStringUtils::fromProtoConfig(config_);
-  const auto out_json =
-      formatter->format(request_headers_, response_headers_, response_trailers_, stream_info_);
-
-  const std::string expected = R"EOF({
-    "text": "plain text",
-    "path": "/bar/foo",
     "code": 200
 })EOF";
   EXPECT_TRUE(TestUtility::jsonStringEqual(out_json, expected));
@@ -100,19 +79,6 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestInvalidConfigs) {
 )",
       R"(
   json_format:
-    field:
-      nest_field: "value"
-)",
-      R"(
-  typed_json_format:
-    field: true
-)",
-      R"(
-  typed_json_format:
-    field: 200
-)",
-      R"(
-  typed_json_format:
     field:
       nest_field: "value"
 )",

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -802,7 +802,7 @@ TEST(ConfigTest, AccessLogConfig) {
   {
     envoy::extensions::access_loggers::file::v3::FileAccessLog file_access_log;
     file_access_log.set_path("some_path");
-    file_access_log.set_format("the format specifier");
+    file_access_log.mutable_log_format()->set_text_format("the format specifier");
     log->mutable_typed_config()->PackFrom(file_access_log);
   }
 
@@ -859,7 +859,7 @@ public:
     access_log->set_name(Extensions::AccessLoggers::AccessLogNames::get().File);
     envoy::extensions::access_loggers::file::v3::FileAccessLog file_access_log;
     file_access_log.set_path("unused");
-    file_access_log.set_format(access_log_format);
+    file_access_log.mutable_log_format()->set_text_format(access_log_format);
     access_log->mutable_typed_config()->PackFrom(file_access_log);
     return config;
   }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -766,7 +766,7 @@ bool ConfigHelper::setAccessLog(const std::string& filename, absl::string_view f
   loadHttpConnectionManager(hcm_config);
   envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
   if (!format.empty()) {
-    access_log_config.set_format(absl::StrCat(format, "\n"));
+    access_log_config.mutable_log_format()->set_text_format(absl::StrCat(format, "\n"));
   }
   access_log_config.set_path(filename);
   hcm_config.mutable_access_log(0)->mutable_typed_config()->PackFrom(access_log_config);
@@ -781,7 +781,7 @@ bool ConfigHelper::setListenerAccessLog(const std::string& filename, absl::strin
   }
   envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
   if (!format.empty()) {
-    access_log_config.set_format(std::string(format));
+    access_log_config.mutable_log_format()->set_text_format(std::string(format));
   }
   access_log_config.set_path(filename);
   bootstrap_.mutable_static_resources()

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -250,7 +250,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
     access_log->set_name("accesslog");
     envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
     access_log_config.set_path(access_log_path);
-    access_log_config.set_format(
+    access_log_config.mutable_log_format()->set_text_format(
         "upstreamlocal=%UPSTREAM_LOCAL_ADDRESS% "
         "upstreamhost=%UPSTREAM_HOST% downstream=%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT% "
         "sent=%BYTES_SENT% received=%BYTES_RECEIVED%\n");


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

access_log_format config could be used by LocalReplyConfig. 

1) Named it as SubstitutionFormatString,
2) Moved it from `envoy/extensions/access_logger/file` into `/envoy/config/core`
2) Added substitution_format_string.{cc, h} in `source/common/common`

Required by:  https://github.com/envoyproxy/envoy/pull/11007

Risk Level: None
Testing: Unit test
Docs Changes:  Noe
Release Notes: Noe
