### PR TITLE
stats: move histogram quantiles from static to construct on first use

### DIFF
--- a/source/common/stats/histogram_impl.cc
+++ b/source/common/stats/histogram_impl.cc
@@ -26,16 +26,14 @@ HistogramStatisticsImpl::HistogramStatisticsImpl(const histogram_t* histogram_pt
 }
 
 const std::vector<double>& HistogramStatisticsImpl::supportedQuantiles() const {
-  static const std::vector<double> supported_quantiles = {0,    0.25, 0.5,   0.75,  0.90,
-                                                          0.95, 0.99, 0.995, 0.999, 1};
-  return supported_quantiles;
+  CONSTRUCT_ON_FIRST_USE(std::vector<double>,
+                         {0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.995, 0.999, 1});
 }
 
 const std::vector<double>& HistogramStatisticsImpl::supportedBuckets() const {
-  static const std::vector<double> supported_buckets = {
-      0.5,  1,    5,     10,    25,    50,     100,    250,     500,    1000,
-      2500, 5000, 10000, 30000, 60000, 300000, 600000, 1800000, 3600000};
-  return supported_buckets;
+  CONSTRUCT_ON_FIRST_USE(std::vector<double>,
+                         {0.5, 1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000,
+                          60000, 300000, 600000, 1800000, 3600000});
 }
 
 std::string HistogramStatisticsImpl::quantileSummary() const {


### PR DESCRIPTION

Commit Message: move histogram quantiles and buckets to construct on first use idiom.
Additional Description:As discussed in https://github.com/lyft/envoy-mobile/issues/688 - moving static vectors to construct on first use.
Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
