### PR TITLE
tools: added more required valgrind suppressions which are needed due to re2 interaction with protoc-gen-validate

### DIFF
--- a/tools/debugging/valgrind-suppressions.txt
+++ b/tools/debugging/valgrind-suppressions.txt
@@ -4,3 +4,27 @@
   fun:free
   ...
 }
+{
+   re2 cond-jump failure
+   Memcheck:Cond
+   fun:_ZNK3re210SparseSetTIvE8containsEi
+   ...
+}
+{
+   re2 uninit-value
+   Memcheck:Value8
+   fun:_ZNK3re210SparseSetTIvE8containsEi
+   ...
+}
+{
+   re2 cond-jump failure
+   Memcheck:Cond
+   fun:_ZNK3re211SparseArrayIiE9has_indexEi
+   ...
+}
+{
+   re2 uninit-value
+   Memcheck:Value8
+   fun:_ZNK3re211SparseArrayIiE9has_indexEi
+   ...
+}


### PR DESCRIPTION
Commit Message: I'm not sure if this is something under Envoy's control, but there's a static RE2 instance generated by protoc-gen-validate:
```
const re2::RE2 _uuidPattern("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
```
Processing this generates a lot of valgrind warnings, and this PR gets rid of them. I don't see the string `uuidPattern` in the Envoy source so I think this might be part of the proto infrastructure.

So this PR makes it so we can continue to use valgrind despite this issue.
Additional Description:
Risk Level: low
Testing: ran valgrind on a single test.
Docs Changes: n/a
Release Notes: n/a

