### PR TITLE
ci: enable arm64 binary only build in postsubmit

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -3,6 +3,18 @@ parameters:
     displayName: "CI target"
     type: string
     default: bazel.release
+  - name: rbe
+    displayName: "Enable RBE"
+    type: string
+    default: "true"
+  - name: bazelBuildExtraOptions
+    type: string
+    # Use https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_repository_cache_hardlinks
+    # to save disk space.
+    default: "--config=remote-ci --jobs=$(RbeJobs) --curses=no --experimental_repository_cache_hardlinks"
+  - name: managedAgent
+    type: boolean
+    default: false
 
 steps:
   - task: Cache@2
@@ -13,6 +25,7 @@ steps:
 
   - bash: .azure-pipelines/cleanup.sh
     displayName: "Removing tools from agent"
+    condition: ${{ parameters.managedAgent }}
 
   - bash: |
       echo "disk space at beginning of build:"
@@ -27,15 +40,14 @@ steps:
       }' | sudo tee /etc/docker/daemon.json
       sudo service docker restart
     displayName: "Enable IPv6"
+    condition: ${{ parameters.managedAgent }}
 
   - script: ci/run_envoy_docker.sh 'ci/do_ci.sh ${{ parameters.ciTarget }}'
     workingDirectory: $(Build.SourcesDirectory)
     env:
       ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
-      ENVOY_RBE: "true"
-      # Use https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_repository_cache_hardlinks
-      # to save disk space.
-      BAZEL_BUILD_EXTRA_OPTIONS: "--config=remote-ci --jobs=$(RbeJobs) --curses=no --experimental_repository_cache_hardlinks"
+      ENVOY_RBE: "${{ parameters.rbe }}"
+      BAZEL_BUILD_EXTRA_OPTIONS: "${{ parameters.bazelBuildExtraOptions }}"
       BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
       BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -75,6 +75,6 @@ steps:
   # TODO(lizan): This is aw workaround for self hosted azure agent can't clean up bazel local cache due to 
   # permission. Remove this once it is resolved.
   - bash: |
-      rm -rf ${Build.StagingDirectory}/tmp
+      rm -rf $(Build.StagingDirectory)/tmp
     displayName: "Self hosted agent clean up"
     condition: eq(false, ${{ parameters.managedAgent }})

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -71,3 +71,10 @@ steps:
       pathtoPublish: "$(Build.StagingDirectory)/envoy"
       artifactName: ${{ parameters.ciTarget }}
     condition: always()
+
+  # TODO(lizan): This is aw workaround for self hosted azure agent can't clean up bazel local cache due to 
+  # permission. Remove this once it is resolved.
+  - bash: |
+      rm -rf ${Build.StagingDirectory}/tmp
+    displayName: "Self hosted agent clean up"
+    condition: eq(false, ${{ parameters.managedAgent }})

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -72,9 +72,9 @@ steps:
       artifactName: ${{ parameters.ciTarget }}
     condition: always()
 
-  # TODO(lizan): This is aw workaround for self hosted azure agent can't clean up bazel local cache due to 
+  # TODO(lizan): This is a workaround for self hosted azure agent can't clean up bazel local cache due to
   # permission. Remove this once it is resolved.
   - bash: |
-      rm -rf $(Build.StagingDirectory)/tmp
+      chmod -R u+w $(Build.StagingDirectory)
     displayName: "Self hosted agent clean up"
     condition: eq(false, ${{ parameters.managedAgent }})

--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -14,7 +14,7 @@ parameters:
     default: "--config=remote-ci --jobs=$(RbeJobs) --curses=no --experimental_repository_cache_hardlinks"
   - name: managedAgent
     type: boolean
-    default: false
+    default: true
 
 steps:
   - task: Cache@2

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -50,6 +50,19 @@ jobs:
         parameters:
           ciTarget: bazel.release
 
+  - job: release_arm64
+    displayName: "Linux-aarch64 release.server_only"
+    dependsOn: ["format"]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    pool: "arm-large"
+    steps:
+      - template: bazel.yml
+        parameters:
+          managedAgent: false
+          ciTarget: bazel.release.server_only
+          rbe: ""
+          bazelBuildExtraOptions: "--curses=no"
+
   - job: bazel
     displayName: "Linux-x64"
     dependsOn: ["release"]

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -51,7 +51,7 @@ jobs:
           ciTarget: bazel.release
 
   - job: release_arm64
-    displayName: "Linux-aarch64 release.server_only"
+    displayName: "Linux-arm64 release.server_only"
     dependsOn: ["format"]
     condition: ne(variables['Build.Reason'], 'PullRequest')
     pool: "arm-large"


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Commit Message:
Experimentally enable binary only arm64 build in postsubmit. #1861

Additional Description:
Risk Level: Low 
Testing: CI
Docs Changes: N/A
Release Notes: N/A (not releasing anything really)

