### PR TITLE
ext_authz: support sending multiple headers with the same name to upstream

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -213,6 +213,11 @@ message AuthorizationResponse {
   // Note that coexistent headers will be overridden.
   type.matcher.v3.ListStringMatcher allowed_upstream_headers = 1;
 
+  // When this :ref:`list <envoy_api_msg_type.matcher.v3.ListStringMatcher>` is set, authorization
+  // response headers that have a correspondent match will be added to the client's response. Note
+  // that coexistent headers will be appended.
+  type.matcher.v3.ListStringMatcher allowed_upstream_headers_to_append = 3;
+
   // When this :ref:`list <envoy_api_msg_type.matcher.v3.ListStringMatcher>`. is set, authorization
   // response headers that have a correspondent match will be added to the client's response. Note
   // that when this list is *not* set, all the authorization response headers, except *Authority

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -213,6 +213,11 @@ message AuthorizationResponse {
   // Note that coexistent headers will be overridden.
   type.matcher.v4alpha.ListStringMatcher allowed_upstream_headers = 1;
 
+  // When this :ref:`list <envoy_api_msg_type.matcher.v4alpha.ListStringMatcher>` is set, authorization
+  // response headers that have a correspondent match will be added to the client's response. Note
+  // that coexistent headers will be appended.
+  type.matcher.v4alpha.ListStringMatcher allowed_upstream_headers_to_append = 3;
+
   // When this :ref:`list <envoy_api_msg_type.matcher.v4alpha.ListStringMatcher>`. is set, authorization
   // response headers that have a correspondent match will be added to the client's response. Note
   // that when this list is *not* set, all the authorization response headers, except *Authority

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -64,6 +64,7 @@ New Features
 * ext_authz filter: added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3 deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows to force deny for protected path while filter gets disabled, by setting this key to true.
 * ext_authz filter: added API version field for both :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.transport_api_version>`
   and :ref:`Network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.transport_api_version>` filters to explicitly set the version of gRPC service endpoint and message to be used.
+* ext_authz filter: added :ref:`v3 allowed_upstream_headers_to_append <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_upstream_headers_to_append>`. This allows to append multiple headers with the same key name in AuthorizationResponse, since allowed_upstream_headers only support adding and covering values while headers having same key name.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 * fault: added support for specifying grpc_status code in abort faults using

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -64,7 +64,7 @@ New Features
 * ext_authz filter: added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3 deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows to force deny for protected path while filter gets disabled, by setting this key to true.
 * ext_authz filter: added API version field for both :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.transport_api_version>`
   and :ref:`Network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.transport_api_version>` filters to explicitly set the version of gRPC service endpoint and message to be used.
-* ext_authz filter: added :ref:`v3 allowed_upstream_headers_to_append <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_upstream_headers_to_append>`. This allows to append multiple headers with the same key name in AuthorizationResponse, since allowed_upstream_headers only support adding and covering values while headers having same key name.
+* ext_authz filter: added :ref:`v3 allowed_upstream_headers_to_append <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_upstream_headers_to_append>` to allow appending multiple header entries (returned by the authorization server) with the same key to the original request headers.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 * fault: added support for specifying grpc_status code in abort faults using

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -212,6 +212,11 @@ message AuthorizationResponse {
   // Note that coexistent headers will be overridden.
   type.matcher.v3.ListStringMatcher allowed_upstream_headers = 1;
 
+  // When this :ref:`list <envoy_api_msg_type.matcher.v3.ListStringMatcher>` is set, authorization
+  // response headers that have a correspondent match will be added to the client's response. Note
+  // that coexistent headers will be appended.
+  type.matcher.v3.ListStringMatcher allowed_upstream_headers_to_append = 3;
+
   // When this :ref:`list <envoy_api_msg_type.matcher.v3.ListStringMatcher>`. is set, authorization
   // response headers that have a correspondent match will be added to the client's response. Note
   // that when this list is *not* set, all the authorization response headers, except *Authority

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -213,6 +213,11 @@ message AuthorizationResponse {
   // Note that coexistent headers will be overridden.
   type.matcher.v4alpha.ListStringMatcher allowed_upstream_headers = 1;
 
+  // When this :ref:`list <envoy_api_msg_type.matcher.v4alpha.ListStringMatcher>` is set, authorization
+  // response headers that have a correspondent match will be added to the client's response. Note
+  // that coexistent headers will be appended.
+  type.matcher.v4alpha.ListStringMatcher allowed_upstream_headers_to_append = 3;
+
   // When this :ref:`list <envoy_api_msg_type.matcher.v4alpha.ListStringMatcher>`. is set, authorization
   // response headers that have a correspondent match will be added to the client's response. Note
   // that when this list is *not* set, all the authorization response headers, except *Authority

--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -53,6 +53,8 @@ struct Response {
   Http::HeaderVector headers_to_append;
   // Optional http headers used on either denied or ok responses.
   Http::HeaderVector headers_to_add;
+  // Optional http headers used on either denied or ok responses.
+  Http::HeaderVector headers_to_add_and_append;
   // Optional http body used only on denied response.
   std::string body;
   // Optional http status used only on denied response.

--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -49,12 +49,15 @@ enum class CheckStatus {
 struct Response {
   // Call status.
   CheckStatus status;
-  // Optional http headers used on either denied or ok responses.
+  // A set of HTTP headers returned by the authorization server, that will be optionally appended
+  // to the request to the upstream server.
   Http::HeaderVector headers_to_append;
-  // Optional http headers used on either denied or ok responses.
+  // A set of HTTP headers returned by the authorization server, optionally will be optionally set
+  // (using "setCopy") to the request to the upstream server.
+  Http::HeaderVector headers_to_set;
+  // A set of HTTP headers returned by the authorization server, optionally will be optionally added
+  // (using "addCopy") to the request to the upstream server.
   Http::HeaderVector headers_to_add;
-  // Optional http headers used on either denied or ok responses.
-  Http::HeaderVector headers_to_add_and_append;
   // Optional http body used only on denied response.
   std::string body;
   // Optional http status used only on denied response.

--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -52,10 +52,10 @@ struct Response {
   // A set of HTTP headers returned by the authorization server, that will be optionally appended
   // to the request to the upstream server.
   Http::HeaderVector headers_to_append;
-  // A set of HTTP headers returned by the authorization server, optionally will be optionally set
+  // A set of HTTP headers returned by the authorization server, will be optionally set
   // (using "setCopy") to the request to the upstream server.
   Http::HeaderVector headers_to_set;
-  // A set of HTTP headers returned by the authorization server, optionally will be optionally added
+  // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the request to the upstream server.
   Http::HeaderVector headers_to_add;
   // Optional http body used only on denied response.

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -95,7 +95,7 @@ void GrpcClientImpl::toAuthzResponseHeader(
       response->headers_to_append.emplace_back(Http::LowerCaseString(header.header().key()),
                                                header.header().value());
     } else {
-      response->headers_to_add.emplace_back(Http::LowerCaseString(header.header().key()),
+      response->headers_to_set.emplace_back(Http::LowerCaseString(header.header().key()),
                                             header.header().value());
     }
   }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -33,20 +33,28 @@ const Http::HeaderMap& lengthZeroHeader() {
 const Response& errorResponse() {
   CONSTRUCT_ON_FIRST_USE(Response,
                          Response{CheckStatus::Error, Http::HeaderVector{}, Http::HeaderVector{},
-                                  EMPTY_STRING, Http::Code::Forbidden});
+                                  Http::HeaderVector{}, EMPTY_STRING, Http::Code::Forbidden});
 }
 
 // SuccessResponse used for creating either DENIED or OK authorization responses.
 struct SuccessResponse {
   SuccessResponse(const Http::HeaderMap& headers, const MatcherSharedPtr& matchers,
-                  Response&& response)
-      : headers_(headers), matchers_(matchers), response_(std::make_unique<Response>(response)) {
+                  const MatcherSharedPtr& append_matchers, Response&& response)
+      : headers_(headers), matchers_(matchers), append_matchers_(append_matchers),
+        response_(std::make_unique<Response>(response)) {
     headers_.iterate(
         [](const Http::HeaderEntry& header, void* ctx) -> Http::HeaderMap::Iterate {
           auto* context = static_cast<SuccessResponse*>(ctx);
           // UpstreamHeaderMatcher
           if (context->matchers_->matches(header.key().getStringView())) {
             context->response_->headers_to_add.emplace_back(
+                Http::LowerCaseString{std::string(header.key().getStringView())},
+                std::string(header.value().getStringView()));
+          }
+          if (context->append_matchers_->matches(header.key().getStringView())) {
+            // if there's an existing key, we're appending it, for example, if headers are
+            // 'match-key: value1' and 'match-key: value2', this will add both value1 and value2
+            context->response_->headers_to_add_and_append.emplace_back(
                 Http::LowerCaseString{std::string(header.key().getStringView())},
                 std::string(header.value().getStringView()));
           }
@@ -57,6 +65,7 @@ struct SuccessResponse {
 
   const Http::HeaderMap& headers_;
   const MatcherSharedPtr& matchers_;
+  const MatcherSharedPtr& append_matchers_;
   ResponsePtr response_;
 };
 
@@ -127,6 +136,9 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
                            enable_case_sensitive_string_matcher_)),
       upstream_header_matchers_(toUpstreamMatchers(
           config.http_service().authorization_response().allowed_upstream_headers(),
+          enable_case_sensitive_string_matcher_)),
+      upstream_header_to_append_matchers_(toUpstreamMatchers(
+          config.http_service().authorization_response().allowed_upstream_headers_to_append(),
           enable_case_sensitive_string_matcher_)),
       cluster_name_(config.http_service().server_uri().cluster()), timeout_(timeout),
       path_prefix_(path_prefix),
@@ -316,16 +328,19 @@ ResponsePtr RawHttpClientImpl::toResponse(Http::ResponseMessagePtr message) {
   // Create an Ok authorization response.
   if (status_code == enumToInt(Http::Code::OK)) {
     SuccessResponse ok{message->headers(), config_->upstreamHeaderMatchers(),
+                       config_->upstreamHeaderToAppendMatchers(),
                        Response{CheckStatus::OK, Http::HeaderVector{}, Http::HeaderVector{},
-                                EMPTY_STRING, Http::Code::OK}};
+                                Http::HeaderVector{}, EMPTY_STRING, Http::Code::OK}};
     span_->setTag(TracingConstants::get().TraceStatus, TracingConstants::get().TraceOk);
     return std::move(ok.response_);
   }
 
   // Create a Denied authorization response.
   SuccessResponse denied{message->headers(), config_->clientHeaderMatchers(),
+                         config_->upstreamHeaderToAppendMatchers(),
                          Response{CheckStatus::Denied, Http::HeaderVector{}, Http::HeaderVector{},
-                                  message->bodyAsString(), static_cast<Http::Code>(status_code)}};
+                                  Http::HeaderVector{}, message->bodyAsString(),
+                                  static_cast<Http::Code>(status_code)}};
   span_->setTag(TracingConstants::get().TraceStatus, TracingConstants::get().TraceUnauthz);
   return std::move(denied.response_);
 }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -47,14 +47,17 @@ struct SuccessResponse {
           auto* context = static_cast<SuccessResponse*>(ctx);
           // UpstreamHeaderMatcher
           if (context->matchers_->matches(header.key().getStringView())) {
-            context->response_->headers_to_add.emplace_back(
+            context->response_->headers_to_set.emplace_back(
                 Http::LowerCaseString{std::string(header.key().getStringView())},
                 std::string(header.value().getStringView()));
           }
           if (context->append_matchers_->matches(header.key().getStringView())) {
-            // if there's an existing key, we're appending it, for example, if headers are
-            // 'match-key: value1' and 'match-key: value2', this will add both value1 and value2
-            context->response_->headers_to_add_and_append.emplace_back(
+            // If there is an existing matching key in the current headers, the new entry will be
+            // appended with the same key. For example, given {"key": "value1"} headers, if there is
+            // a matching "key" from the authorization response headers {"key": "value2"}, the
+            // request to upstream server will have two entries for "key": {"key": "value1", "key":
+            // "value2"}.
+            context->response_->headers_to_add.emplace_back(
                 Http::LowerCaseString{std::string(header.key().getStringView())},
                 std::string(header.value().getStringView()));
           }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -99,6 +99,14 @@ public:
   const MatcherSharedPtr& upstreamHeaderMatchers() const { return upstream_header_matchers_; }
 
   /**
+   * Returns a list of matchers used for selecting the authorization response headers that
+   * will be appended when using the same key should be sent to the upstream server.
+   */
+  const MatcherSharedPtr& upstreamHeaderToAppendMatchers() const {
+    return upstream_header_to_append_matchers_;
+  }
+
+  /**
    * Returns the name used for tracing.
    */
   const std::string& tracingName() { return tracing_name_; }
@@ -123,6 +131,7 @@ private:
   const MatcherSharedPtr request_header_matchers_;
   const MatcherSharedPtr client_header_matchers_;
   const MatcherSharedPtr upstream_header_matchers_;
+  const MatcherSharedPtr upstream_header_to_append_matchers_;
   const Http::LowerCaseStrPairVector authorization_headers_to_add_;
   const std::string cluster_name_;
   const std::chrono::milliseconds timeout_;

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -100,7 +100,8 @@ public:
 
   /**
    * Returns a list of matchers used for selecting the authorization response headers that
-   * will be appended when using the same key should be sent to the upstream server.
+   * should be sent to the upstream server. The same header keys will be appended, instead of
+   * be replaced.
    */
   const MatcherSharedPtr& upstreamHeaderToAppendMatchers() const {
     return upstream_header_to_append_matchers_;

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -174,6 +174,10 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
       ENVOY_STREAM_LOG(trace, "'{}':'{}'", *callbacks_, header.first.get(), header.second);
       request_headers_->setCopy(header.first, header.second);
     }
+    for (const auto& header : response->headers_to_add_and_append) {
+      ENVOY_STREAM_LOG(trace, "'{}':'{}'", *callbacks_, header.first.get(), header.second);
+      request_headers_->addCopy(header.first, header.second);
+    }
     for (const auto& header : response->headers_to_append) {
       const Http::HeaderEntry* header_to_modify = request_headers_->get(header.first);
       if (header_to_modify) {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -166,15 +166,15 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
   case CheckStatus::OK: {
     ENVOY_STREAM_LOG(trace, "ext_authz filter added header(s) to the request:", *callbacks_);
     if (config_->clearRouteCache() &&
-        (!response->headers_to_add.empty() || !response->headers_to_append.empty())) {
+        (!response->headers_to_set.empty() || !response->headers_to_append.empty())) {
       ENVOY_STREAM_LOG(debug, "ext_authz is clearing route cache", *callbacks_);
       callbacks_->clearRouteCache();
     }
-    for (const auto& header : response->headers_to_add) {
+    for (const auto& header : response->headers_to_set) {
       ENVOY_STREAM_LOG(trace, "'{}':'{}'", *callbacks_, header.first.get(), header.second);
       request_headers_->setCopy(header.first, header.second);
     }
-    for (const auto& header : response->headers_to_add_and_append) {
+    for (const auto& header : response->headers_to_add) {
       ENVOY_STREAM_LOG(trace, "'{}':'{}'", *callbacks_, header.first.get(), header.second);
       request_headers_->addCopy(header.first, header.second);
     }
@@ -216,7 +216,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
 
     callbacks_->sendLocalReply(
         response->status_code, response->body,
-        [&headers = response->headers_to_add,
+        [&headers = response->headers_to_set,
          &callbacks = *callbacks_](Http::HeaderMap& response_headers) -> void {
           ENVOY_STREAM_LOG(trace,
                            "ext_authz filter added header(s) to the local response:", callbacks);

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -73,10 +73,6 @@ public:
               value: "value"
             - key: "x-authz-header2"
               value: "value"
-            - key: "append-authz-header1"
-              value: "append-value1"
-            - key: "append-authz-header1"
-              value: "append-value2"
 
           authorization_response:
             allowed_upstream_headers:
@@ -160,7 +156,7 @@ TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
   EXPECT_FALSE(config_->requestHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(baz.get()));
 
-  // // Check allowed client headers.
+  // Check allowed client headers.
   EXPECT_TRUE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Status.get()));
   EXPECT_TRUE(config_->clientHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
   EXPECT_FALSE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Path.get()));
@@ -169,13 +165,13 @@ TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
   EXPECT_FALSE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Origin.get()));
   EXPECT_TRUE(config_->clientHeaderMatchers()->matches(foo.get()));
 
-  // // Check allowed upstream headers.
+  // Check allowed upstream headers.
   EXPECT_TRUE(config_->upstreamHeaderMatchers()->matches(bar.get()));
 
-  // // Check allowed upstream headers to append.
+  // Check allowed upstream headers to append.
   EXPECT_TRUE(config_->upstreamHeaderToAppendMatchers()->matches(alice.get()));
 
-  // // Check other attributes.
+  // Check other attributes.
   EXPECT_EQ(config_->pathPrefix(), "/bar");
   EXPECT_EQ(config_->cluster(), "ext_authz");
   EXPECT_EQ(config_->tracingName(), "async ext_authz egress");
@@ -328,12 +324,8 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeaders) {
   // append property of header value option should always be false.
   const HeaderValuePair header1{"x-authz-header1", "value"};
   const HeaderValuePair header2{"x-authz-header2", "value"};
-  const HeaderValuePair header3{"append-authz-header1", "append-value1"};
-  const HeaderValuePair header4{"append-authz-header1", "append-value2"};
   EXPECT_CALL(async_client_,
-              send_(AllOf(ContainsPairAsHeader(header1), ContainsPairAsHeader(header2),
-                          ContainsPairAsHeader(header3), ContainsPairAsHeader(header4)),
-                    _, _));
+              send_(AllOf(ContainsPairAsHeader(header1), ContainsPairAsHeader(header2)), _, _));
   client_->check(request_callbacks_, request, active_span_, stream_info_);
 
   EXPECT_CALL(request_callbacks_,

--- a/test/extensions/filters/common/ext_authz/test_common.cc
+++ b/test/extensions/filters/common/ext_authz/test_common.cc
@@ -65,7 +65,7 @@ Response TestCommon::makeAuthzResponse(CheckStatus status, Http::Code status_cod
         authz_response.headers_to_append.emplace_back(Http::LowerCaseString(header.header().key()),
                                                       header.header().value());
       } else {
-        authz_response.headers_to_add.emplace_back(Http::LowerCaseString(header.header().key()),
+        authz_response.headers_to_set.emplace_back(Http::LowerCaseString(header.header().key()),
                                                    header.header().value());
       }
     }

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -87,6 +87,10 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
         patterns:
         - exact: baz
         - prefix: x-fail
+      allowed_upstream_headers_to_append:
+        patterns:
+        - exact: baz-append
+        - prefix: x-append
 
     path_prefix: /extauth
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/listener/v3/listener_components.pb.h"
 #include "envoy/extensions/filters/http/ext_authz/v3/ext_authz.pb.h"
@@ -248,6 +250,8 @@ public:
         {":scheme", "http"},
         {":authority", "host"},
         {"x-case-sensitive-header", case_sensitive_header_value_},
+        {"baz", "foo"},
+        {"bat", "foo"},
     });
   }
 
@@ -259,6 +263,11 @@ public:
     RELEASE_ASSERT(result, result.message());
     result = ext_authz_request_->waitForEndStream(*dispatcher_);
     RELEASE_ASSERT(result, result.message());
+
+    // Send back authorization response with "baz" and "bat" headers.
+    Http::TestResponseHeaderMapImpl response_headers{
+        {":status", "200"}, {"baz", "baz"}, {"bat", "bar"}};
+    ext_authz_request_->encodeHeaders(response_headers, true);
   }
 
   void cleanup() {
@@ -294,6 +303,27 @@ public:
     initiateClientConnection();
     waitForExtAuthzRequest();
 
+    AssertionResult result =
+        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_);
+    RELEASE_ASSERT(result, result.message());
+    result = upstream_request_->waitForEndStream(*dispatcher_);
+    RELEASE_ASSERT(result, result.message());
+
+    // The original client request header value of "baz" is "foo". Since we configure to "override"
+    // the value of "baz", we expect the request headers to be sent to upstream contain only one
+    // "baz" with value "baz" (set by the authorization server).
+    EXPECT_THAT(upstream_request_->headers(), Http::HeaderValueOf("baz", "baz"));
+
+    // The original client request header value of "bat" is "foo". Since we configure to "append"
+    // the value of "bat", we expect the request headers to be sent to upstream contain two "bat"s,
+    // with values: "foo" and "bar" (the "bat: bar" header is appended by the authorization server).
+    const auto& baz_values =
+        TestUtility::getAllHeadersValuesForKey(upstream_request_->headers(), "bat");
+    EXPECT_TRUE(std::is_permutation(baz_values.begin(), baz_values.end(),
+                                    (std::vector<absl::string_view>{"foo", "bar"}).begin()));
+
     response_->waitForEndStream();
     EXPECT_TRUE(response_->complete());
 
@@ -312,10 +342,22 @@ public:
       uri: "ext_authz:9000"
       cluster: "ext_authz"
       timeout: 0.25s
+
     authorization_request:
       allowed_headers:
         patterns:
         - exact: X-Case-Sensitive-Header
+
+    authorization_response:
+      allowed_upstream_headers:
+        patterns:
+        - exact: baz
+        - prefix: x-success
+
+      allowed_upstream_headers_to_append:
+        patterns:
+        - exact: bat
+
   failure_mode_allow: true
   )EOF";
 };
@@ -355,7 +397,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ExtAuthzHttpIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-// Verifies that by default HTTP service uses the case sensitive string matcher.
+// Verifies that by default HTTP service uses the case-sensitive string matcher.
 TEST_P(ExtAuthzHttpIntegrationTest, DefaultCaseSensitiveStringMatcher) {
   setupWithDisabledCaseSensitiveStringMatcher(false);
   const auto* header_entry = ext_authz_request_->headers().get(case_sensitive_header_name_);
@@ -364,7 +406,7 @@ TEST_P(ExtAuthzHttpIntegrationTest, DefaultCaseSensitiveStringMatcher) {
 
 // Verifies that by setting "false" to
 // envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher, the string
-// matcher used by HTTP service will case insensitive.
+// matcher used by HTTP service will be case-insensitive.
 TEST_P(ExtAuthzHttpIntegrationTest, DisableCaseSensitiveStringMatcher) {
   setupWithDisabledCaseSensitiveStringMatcher(true);
   const auto* header_entry = ext_authz_request_->headers().get(case_sensitive_header_name_);

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -250,8 +250,6 @@ public:
         {"x-case-sensitive-header", case_sensitive_header_value_},
         {"baz", "foo"},
         {"bat", "foo"},
-        {"x-append-bat", "append-foo"},
-        {"x-append-bat", "append-bar"},
     });
   }
 
@@ -266,7 +264,12 @@ public:
 
     // Send back authorization response with "baz" and "bat" headers.
     Http::TestResponseHeaderMapImpl response_headers{
-        {":status", "200"}, {"baz", "baz"}, {"bat", "bar"}};
+        {":status", "200"},
+        {"baz", "baz"},
+        {"bat", "bar"},
+        {"x-append-bat", "append-foo"},
+        {"x-append-bat", "append-bar"},
+    };
     ext_authz_request_->encodeHeaders(response_headers, true);
   }
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -263,6 +263,7 @@ public:
     RELEASE_ASSERT(result, result.message());
 
     // Send back authorization response with "baz" and "bat" headers.
+    // Also add multiple values "append-foo" and "append-bar" for key "x-append-bat".
     Http::TestResponseHeaderMapImpl response_headers{
         {":status", "200"},
         {"baz", "baz"},

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -252,6 +252,8 @@ public:
         {"x-case-sensitive-header", case_sensitive_header_value_},
         {"baz", "foo"},
         {"bat", "foo"},
+        {"x-append-bat", "append-foo"},
+        {"x-append-bat", "append-bar"},
     });
   }
 
@@ -324,6 +326,11 @@ public:
     EXPECT_TRUE(std::is_permutation(baz_values.begin(), baz_values.end(),
                                     (std::vector<absl::string_view>{"foo", "bar"}).begin()));
 
+    const auto& x_success_values =
+        TestUtility::getAllHeadersValuesForKey(upstream_request_->headers(), "x-append-bat");
+    EXPECT_TRUE(std::is_permutation(x_success_values.begin(), x_success_values.end(),
+                                    (std::vector<absl::string_view>{"append-foo", "append-bar"}).begin()));
+
     response_->waitForEndStream();
     EXPECT_TRUE(response_->complete());
 
@@ -357,6 +364,7 @@ public:
       allowed_upstream_headers_to_append:
         patterns:
         - exact: bat
+        - prefix: x-append
 
   failure_mode_allow: true
   )EOF";

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -1,5 +1,3 @@
-#include <algorithm>
-
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/listener/v3/listener_components.pb.h"
 #include "envoy/extensions/filters/http/ext_authz/v3/ext_authz.pb.h"

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -597,7 +597,7 @@ TEST_F(HttpFilterTest, ClearCache) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
   response.headers_to_append = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
-  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"bar"}, "foo"}};
+  response.headers_to_set = Http::HeaderVector{{Http::LowerCaseString{"bar"}, "foo"}};
   request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
   EXPECT_EQ(
       1U, filter_callbacks_.clusterInfo()->statsScope().counterFromString("ext_authz.ok").value());
@@ -677,7 +677,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAddOnly) {
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
-  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
+  response.headers_to_set = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
   request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
   EXPECT_EQ(
       1U, filter_callbacks_.clusterInfo()->statsScope().counterFromString("ext_authz.ok").value());
@@ -752,7 +752,7 @@ TEST_F(HttpFilterTest, NoClearCacheRouteConfig) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
   response.headers_to_append = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
-  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"bar"}, "foo"}};
+  response.headers_to_set = Http::HeaderVector{{Http::LowerCaseString{"bar"}, "foo"}};
   request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
   EXPECT_EQ(
       1U, filter_callbacks_.clusterInfo()->statsScope().counterFromString("ext_authz.ok").value());
@@ -775,7 +775,7 @@ TEST_F(HttpFilterTest, NoClearCacheRouteDeniedResponse) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::Denied;
   response.status_code = Http::Code::Unauthorized;
-  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
+  response.headers_to_set = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
   auto response_ptr = std::make_unique<Filters::Common::ExtAuthz::Response>(response);
 
   EXPECT_CALL(*client_, check(_, _, testing::A<Tracing::Span&>(), _))
@@ -1169,7 +1169,7 @@ TEST_P(HttpFilterTestParam, ImmediateDeniedResponseWithHttpAttributes) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::Denied;
   response.status_code = Http::Code::Unauthorized;
-  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
+  response.headers_to_set = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"}};
   response.body = std::string{"baz"};
 
   auto response_ptr = std::make_unique<Filters::Common::ExtAuthz::Response>(response);
@@ -1211,7 +1211,7 @@ TEST_P(HttpFilterTestParam, ImmediateOkResponseWithHttpAttributes) {
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
   response.headers_to_append = Http::HeaderVector{{request_header_key, "bar"}};
-  response.headers_to_add = Http::HeaderVector{{key_to_add, "foo"}, {key_to_override, "bar"}};
+  response.headers_to_set = Http::HeaderVector{{key_to_add, "foo"}, {key_to_override, "bar"}};
 
   auto response_ptr = std::make_unique<Filters::Common::ExtAuthz::Response>(response);
 
@@ -1330,7 +1330,7 @@ TEST_P(HttpFilterTestParam, DestroyResponseBeforeSendLocalReply) {
   response.status = Filters::Common::ExtAuthz::CheckStatus::Denied;
   response.status_code = Http::Code::Forbidden;
   response.body = std::string{"foo"};
-  response.headers_to_add = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"},
+  response.headers_to_set = Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"},
                                                {Http::LowerCaseString{"bar"}, "foo"}};
   Filters::Common::ExtAuthz::ResponsePtr response_ptr =
       std::make_unique<Filters::Common::ExtAuthz::Response>(response);
@@ -1384,7 +1384,7 @@ TEST_P(HttpFilterTestParam, OverrideEncodingHeaders) {
   response.status = Filters::Common::ExtAuthz::CheckStatus::Denied;
   response.status_code = Http::Code::Forbidden;
   response.body = std::string{"foo"};
-  response.headers_to_add =
+  response.headers_to_set =
       Http::HeaderVector{{Http::LowerCaseString{"foo"}, "bar"},
                          {Http::LowerCaseString{"bar"}, "foo"},
                          {Http::LowerCaseString{"set-cookie"}, "cookie1=value"},

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -668,6 +668,30 @@ public:
                                                     use_alpha, service_namespace),
                         "/", method_name);
   }
+
+  /**
+   * Return all headers value of a given key.
+   *
+   * @param headers headers map.
+   * @param key the matching header key.
+   * @return std::vector<absl::string_view> all headers values of the matching key.
+   */
+  static std::vector<absl::string_view>
+  getAllHeadersValuesForKey(const Envoy::Http::HeaderMap& headers, const std::string& key) {
+    std::vector<absl::string_view> values;
+    std::pair<std::string, std::vector<absl::string_view>*> context = std::make_pair(key, &values);
+    Envoy::Http::HeaderMap::ConstIterateCb get_headers_cb =
+        [](const Envoy::Http::HeaderEntry& header, void* context) {
+          auto* typed_context =
+              static_cast<std::pair<std::string, std::vector<absl::string_view>*>*>(context);
+          if (header.key().getStringView() == typed_context->first) {
+            typed_context->second->push_back(header.value().getStringView());
+          }
+          return Envoy::Http::HeaderMap::Iterate::Continue;
+        };
+    headers.iterate(get_headers_cb, &context);
+    return values;
+  }
 };
 
 /**

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -668,30 +668,6 @@ public:
                                                     use_alpha, service_namespace),
                         "/", method_name);
   }
-
-  /**
-   * Return all headers value of a given key.
-   *
-   * @param headers headers map.
-   * @param key the matching header key.
-   * @return std::vector<absl::string_view> all headers values of the matching key.
-   */
-  static std::vector<absl::string_view>
-  getAllHeadersValuesForKey(const Envoy::Http::HeaderMap& headers, const std::string& key) {
-    std::vector<absl::string_view> values;
-    std::pair<std::string, std::vector<absl::string_view>*> context = std::make_pair(key, &values);
-    Envoy::Http::HeaderMap::ConstIterateCb get_headers_cb =
-        [](const Envoy::Http::HeaderEntry& header, void* context) {
-          auto* typed_context =
-              static_cast<std::pair<std::string, std::vector<absl::string_view>*>*>(context);
-          if (header.key().getStringView() == typed_context->first) {
-            typed_context->second->push_back(header.value().getStringView());
-          }
-          return Envoy::Http::HeaderMap::Iterate::Continue;
-        };
-    headers.iterate(get_headers_cb, &context);
-    return values;
-  }
 };
 
 /**


### PR DESCRIPTION
Commit Message: 
This patch adds `allowed_upstream_headers_to_append` to allow sending multiple headers with the same name to upstream.

Additional Description: 
Relevant issue: https://github.com/solo-io/gloo/issues/2983.

Risk Level: Low
Testing: Unit tests.
Docs Changes: Added.
Release Notes: Added.
Fixes https://github.com/envoyproxy/envoy/issues/11156

Signed-off-by: weixiao-huang <hwx.simle@gmail.com>