### PR TITLE
docs: fix typos in config sample for compressor HTTP-filter

### DIFF
--- a/docs/root/configuration/http/http_filters/compressor_filter.rst
+++ b/docs/root/configuration/http/http_filters/compressor_filter.rst
@@ -42,10 +42,10 @@ An example configuration of the filter may look like the following:
         compressor_library:
           name: text_optimized
           typed_config:
-            "@type": type.googleapis.com/envoy.extensions.filters.http.compressor.gzip.v3.Gzip
+            "@type": type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip
             memory_level: 3
             window_bits: 10
-            compression_level: best
+            compression_level: best_compression
             compression_strategy: default_strategy
 
 By *default* compression will be *skipped* when:


### PR DESCRIPTION
Commit Message: docs: fix typos in config sample for compressor HTTP-filter
Additional Description: The documentation page for the compressor HTTP-filter contains incorrect configuration sample. Update the sample to contain correct values.
Risk Level: Low
Testing: manual tests
Docs Changes: corrected a config sample
Release Notes: N/A
Fixes #11159 
