### PR TITLE
[fuzz] Prefer vector::data() to get a pointer to vector contents.

### DIFF
--- a/source/common/common/hex.h
+++ b/source/common/common/hex.h
@@ -16,7 +16,7 @@ public:
    * @return the hex encoded string representing data
    */
   static std::string encode(const std::vector<uint8_t>& data) {
-    return encode(&data[0], data.size());
+    return encode(data.data(), data.size());
   }
 
   /**

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -506,8 +506,7 @@ Api::IoCallUint64Result Utility::writeToSocket(IoHandle& handle, const Buffer::I
                                                const Address::Ip* local_ip,
                                                const Address::Instance& peer_address) {
   Buffer::RawSliceVector slices = buffer.getRawSlices();
-  return writeToSocket(handle, !slices.empty() ? &slices[0] : nullptr, slices.size(), local_ip,
-                       peer_address);
+  return writeToSocket(handle, slices.data(), slices.size(), local_ip, peer_address);
 }
 
 Api::IoCallUint64Result Utility::writeToSocket(IoHandle& handle, Buffer::RawSlice* slices,

--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -426,7 +426,7 @@ TcpHealthCheckMatcher::MatchSegments TcpHealthCheckMatcher::loadProtoBytes(
 bool TcpHealthCheckMatcher::match(const MatchSegments& expected, const Buffer::Instance& buffer) {
   uint64_t start_index = 0;
   for (const std::vector<uint8_t>& segment : expected) {
-    ssize_t search_result = buffer.search(&segment[0], segment.size(), start_index);
+    ssize_t search_result = buffer.search(segment.data(), segment.size(), start_index);
     if (search_result == -1) {
       return false;
     }
@@ -528,7 +528,7 @@ void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onInterval() {
   if (!parent_.send_bytes_.empty()) {
     Buffer::OwnedImpl data;
     for (const std::vector<uint8_t>& segment : parent_.send_bytes_) {
-      data.add(&segment[0], segment.size());
+      data.add(segment.data(), segment.size());
     }
 
     client_->write(data, false);

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -451,7 +451,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
 int ServerContextImpl::alpnSelectCallback(const unsigned char** out, unsigned char* outlen,
                                           const unsigned char* in, unsigned int inlen) {
   // Currently this uses the standard selection algorithm in priority order.
-  const uint8_t* alpn_data = &parsed_alpn_protocols_[0];
+  const uint8_t* alpn_data = parsed_alpn_protocols_.data();
   size_t alpn_data_size = parsed_alpn_protocols_.size();
 
   if (SSL_select_next_proto(const_cast<unsigned char**>(out), outlen, alpn_data, alpn_data_size, in,
@@ -821,7 +821,7 @@ ClientContextImpl::ClientContextImpl(Stats::Scope& scope,
   ASSERT(tls_contexts_.size() == 1);
   if (!parsed_alpn_protocols_.empty()) {
     for (auto& ctx : tls_contexts_) {
-      const int rc = SSL_CTX_set_alpn_protos(ctx.ssl_ctx_.get(), &parsed_alpn_protocols_[0],
+      const int rc = SSL_CTX_set_alpn_protos(ctx.ssl_ctx_.get(), parsed_alpn_protocols_.data(),
                                              parsed_alpn_protocols_.size());
       RELEASE_ASSERT(rc == 0, Utility::getLastCryptoError().value_or(""));
     }

--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5698895985508352
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5698895985508352
@@ -1,0 +1,49 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "5"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "r"
+      }
+      headers {
+        key: ":authority"
+        value: "5"
+      }
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 1
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+      }
+    }
+  }
+}

--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -33,7 +33,7 @@ const char Http2Frame::Preamble[25] = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 void Http2Frame::setHeader(absl::string_view header) {
   ASSERT(header.size() >= HeaderSize);
   data_.assign(HeaderSize, 0);
-  memcpy(&data_[0], header.data(), HeaderSize);
+  memcpy(data_.data(), header.data(), HeaderSize);
   data_.resize(HeaderSize + payloadSize());
 }
 


### PR DESCRIPTION
Commit Message: Prefer vector::data() over &v[0] as a way to get a pointer to vector contents  Use of &v[0] on an empty vector triggers undefined-behavior warnings under ASAN.
Additional Description:
Risk Level: n/a
Testing: new fuzz input
Docs Changes: n/a
Release Notes: n/a
