### PR TITLE
Buffer overflow watermark implementation - base

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -376,7 +376,8 @@ public:
    * @return a newly created InstancePtr.
    */
   virtual InstancePtr create(std::function<void()> below_low_watermark,
-                             std::function<void()> above_high_watermark) PURE;
+                             std::function<void()> above_high_watermark,
+                             std::function<void()> above_overflow_watermark) PURE;
 };
 
 using WatermarkFactoryPtr = std::unique_ptr<WatermarkFactory>;

--- a/source/common/buffer/BUILD
+++ b/source/common/buffer/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/runtime:runtime_features_lib",
     ],
 )
 

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -1,38 +1,39 @@
 #include "common/buffer/watermark_buffer.h"
 
 #include "common/common/assert.h"
+#include "common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Buffer {
 
 void WatermarkBuffer::add(const void* data, uint64_t size) {
   OwnedImpl::add(data, size);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::add(absl::string_view data) {
   OwnedImpl::add(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::add(const Instance& data) {
   OwnedImpl::add(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::prepend(absl::string_view data) {
   OwnedImpl::prepend(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::prepend(Instance& data) {
   OwnedImpl::prepend(data);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::commit(RawSlice* iovecs, uint64_t num_iovecs) {
   OwnedImpl::commit(iovecs, num_iovecs);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::drain(uint64_t size) {
@@ -42,23 +43,23 @@ void WatermarkBuffer::drain(uint64_t size) {
 
 void WatermarkBuffer::move(Instance& rhs) {
   OwnedImpl::move(rhs);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 void WatermarkBuffer::move(Instance& rhs, uint64_t length) {
   OwnedImpl::move(rhs, length);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
 }
 
 Api::IoCallUint64Result WatermarkBuffer::read(Network::IoHandle& io_handle, uint64_t max_length) {
   Api::IoCallUint64Result result = OwnedImpl::read(io_handle, max_length);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
   return result;
 }
 
 uint64_t WatermarkBuffer::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) {
   uint64_t bytes_reserved = OwnedImpl::reserve(length, iovecs, num_iovecs);
-  checkHighWatermark();
+  checkHighAndOverflowWatermarks();
   return bytes_reserved;
 }
 
@@ -70,9 +71,19 @@ Api::IoCallUint64Result WatermarkBuffer::write(Network::IoHandle& io_handle) {
 
 void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_watermark) {
   ASSERT(low_watermark < high_watermark || (high_watermark == 0 && low_watermark == 0));
+  uint32_t overflow_watermark_multiplier =
+      Runtime::getInteger("envoy.buffer.overflow_multiplier", 2);
+  if (overflow_watermark_multiplier > 0 &&
+      (static_cast<uint64_t>(overflow_watermark_multiplier) * high_watermark) >
+          std::numeric_limits<uint32_t>::max()) {
+    ENVOY_LOG_MISC(debug, "Error setting overflow threshold: envoy.buffer.overflow_multiplier * "
+                          "high_watermark is overflowing. Disabling overflow watermark.");
+    overflow_watermark_multiplier = 0;
+  }
   low_watermark_ = low_watermark;
   high_watermark_ = high_watermark;
-  checkHighWatermark();
+  overflow_watermark_ = overflow_watermark_multiplier * high_watermark;
+  checkHighAndOverflowWatermarks();
   checkLowWatermark();
 }
 
@@ -86,14 +97,23 @@ void WatermarkBuffer::checkLowWatermark() {
   below_low_watermark_();
 }
 
-void WatermarkBuffer::checkHighWatermark() {
-  if (above_high_watermark_called_ || high_watermark_ == 0 ||
-      OwnedImpl::length() <= high_watermark_) {
+void WatermarkBuffer::checkHighAndOverflowWatermarks() {
+  if (high_watermark_ == 0 || OwnedImpl::length() <= high_watermark_) {
     return;
   }
 
-  above_high_watermark_called_ = true;
-  above_high_watermark_();
+  if (!above_high_watermark_called_) {
+    above_high_watermark_called_ = true;
+    above_high_watermark_();
+  }
+
+  // Check if overflow watermark is enabled, wasn't previously triggered,
+  // and the buffer size is above the threshold
+  if (above_overflow_watermark_ && overflow_watermark_ != 0 && !above_overflow_watermark_called_ &&
+      OwnedImpl::length() > overflow_watermark_) {
+    above_overflow_watermark_called_ = true;
+    above_overflow_watermark_();
+  }
 }
 
 } // namespace Buffer

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -13,11 +13,15 @@ namespace Buffer {
 // buffer size transitions from under the low watermark to above the high watermark, the
 // above_high_watermark function is called one time. It will not be called again until the buffer
 // is drained below the low watermark, at which point the below_low_watermark function is called.
+// If the buffer size is above the overflow watermark, above_overflow_watermark is called.
+// It is only called on the first time the buffer overflows.
 class WatermarkBuffer : public OwnedImpl {
 public:
   WatermarkBuffer(std::function<void()> below_low_watermark,
-                  std::function<void()> above_high_watermark)
-      : below_low_watermark_(below_low_watermark), above_high_watermark_(above_high_watermark) {}
+                  std::function<void()> above_high_watermark,
+                  std::function<void()> above_overflow_watermark)
+      : below_low_watermark_(below_low_watermark), above_high_watermark_(above_high_watermark),
+        above_overflow_watermark_(above_overflow_watermark) {}
 
   // Override all functions from Instance which can result in changing the size
   // of the underlying buffer.
@@ -40,20 +44,24 @@ public:
   uint32_t highWatermark() const { return high_watermark_; }
 
 private:
-  void checkHighWatermark();
+  void checkHighAndOverflowWatermarks();
   void checkLowWatermark();
 
   std::function<void()> below_low_watermark_;
   std::function<void()> above_high_watermark_;
+  std::function<void()> above_overflow_watermark_;
 
   // Used for enforcing buffer limits (off by default). If these are set to non-zero by a call to
   // setWatermarks() the watermark callbacks will be called as described above.
   uint32_t high_watermark_{0};
   uint32_t low_watermark_{0};
+  uint32_t overflow_watermark_{0};
   // Tracks the latest state of watermark callbacks.
   // True between the time above_high_watermark_ has been called until above_high_watermark_ has
   // been called.
   bool above_high_watermark_called_{false};
+  // Set to true when above_overflow_watermark_ is called (and isn't cleared).
+  bool above_overflow_watermark_called_{false};
 };
 
 using WatermarkBufferPtr = std::unique_ptr<WatermarkBuffer>;
@@ -62,8 +70,10 @@ class WatermarkBufferFactory : public WatermarkFactory {
 public:
   // Buffer::WatermarkFactory
   InstancePtr create(std::function<void()> below_low_watermark,
-                     std::function<void()> above_high_watermark) override {
-    return InstancePtr{new WatermarkBuffer(below_low_watermark, above_high_watermark)};
+                     std::function<void()> above_high_watermark,
+                     std::function<void()> above_overflow_watermark) override {
+    return InstancePtr{
+        new WatermarkBuffer(below_low_watermark, above_high_watermark, above_overflow_watermark)};
   }
 };
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -2289,9 +2289,10 @@ void ConnectionManagerImpl::ActiveStreamFilterBase::clearRouteCache() {
 }
 
 Buffer::WatermarkBufferPtr ConnectionManagerImpl::ActiveStreamDecoderFilter::createBuffer() {
-  auto buffer =
-      std::make_unique<Buffer::WatermarkBuffer>([this]() -> void { this->requestDataDrained(); },
-                                                [this]() -> void { this->requestDataTooLarge(); });
+  auto buffer = std::make_unique<Buffer::WatermarkBuffer>(
+      [this]() -> void { this->requestDataDrained(); },
+      [this]() -> void { this->requestDataTooLarge(); },
+      []() -> void { /* TODO(adip): Handle overflow watermark */ });
   buffer->setWatermarks(parent_.buffer_limit_);
   return buffer;
 }
@@ -2458,8 +2459,10 @@ ConnectionManagerImpl::ActiveStreamDecoderFilter::routeConfig() {
 }
 
 Buffer::WatermarkBufferPtr ConnectionManagerImpl::ActiveStreamEncoderFilter::createBuffer() {
-  auto buffer = new Buffer::WatermarkBuffer([this]() -> void { this->responseDataDrained(); },
-                                            [this]() -> void { this->responseDataTooLarge(); });
+  auto buffer =
+      new Buffer::WatermarkBuffer([this]() -> void { this->responseDataDrained(); },
+                                  [this]() -> void { this->responseDataTooLarge(); },
+                                  []() -> void { /* TODO(adip): Handle overflow watermark */ });
   buffer->setWatermarks(parent_.buffer_limit_);
   return Buffer::WatermarkBufferPtr{buffer};
 }

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -455,7 +455,8 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& st
       reject_unsupported_transfer_encodings_(Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.reject_unsupported_transfer_encodings")),
       output_buffer_([&]() -> void { this->onBelowLowWatermark(); },
-                     [&]() -> void { this->onAboveHighWatermark(); }),
+                     [&]() -> void { this->onAboveHighWatermark(); },
+                     []() -> void { /* TODO(adip): Handle overflow watermark */ }),
       max_headers_kb_(max_headers_kb), max_headers_count_(max_headers_count) {
   output_buffer_.setWatermarks(connection.bufferLimit());
   http_parser_init(&parser_, type);

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -273,10 +273,12 @@ protected:
     uint32_t read_disable_count_{0};
     Buffer::WatermarkBuffer pending_recv_data_{
         [this]() -> void { this->pendingRecvBufferLowWatermark(); },
-        [this]() -> void { this->pendingRecvBufferHighWatermark(); }};
+        [this]() -> void { this->pendingRecvBufferHighWatermark(); },
+        []() -> void { /* TODO(adip): Handle overflow watermark */ }};
     Buffer::WatermarkBuffer pending_send_data_{
         [this]() -> void { this->pendingSendBufferLowWatermark(); },
-        [this]() -> void { this->pendingSendBufferHighWatermark(); }};
+        [this]() -> void { this->pendingSendBufferHighWatermark(); },
+        []() -> void { /* TODO(adip): Handle overflow watermark */ }};
     HeaderMapPtr pending_trailers_to_encode_;
     std::unique_ptr<MetadataDecoder> metadata_decoder_;
     std::unique_ptr<MetadataEncoder> metadata_encoder_;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -50,7 +50,8 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
       stream_info_(stream_info), filter_manager_(*this),
       write_buffer_(dispatcher.getWatermarkFactory().create(
           [this]() -> void { this->onWriteBufferLowWatermark(); },
-          [this]() -> void { this->onWriteBufferHighWatermark(); })),
+          [this]() -> void { this->onWriteBufferHighWatermark(); },
+          []() -> void { /* TODO(adip): Handle overflow watermark */ })),
       write_buffer_above_high_watermark_(false), detect_early_close_(true),
       enable_half_close_(false), read_end_stream_raised_(false), read_end_stream_(false),
       write_end_stream_(false), current_write_end_stream_(false), dispatch_buffered_data_(false) {

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -192,7 +192,8 @@ void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
     if (!buffered_request_body_) {
       buffered_request_body_ = std::make_unique<Buffer::WatermarkBuffer>(
           [this]() -> void { this->enableDataFromDownstreamForFlowControl(); },
-          [this]() -> void { this->disableDataFromDownstreamForFlowControl(); });
+          [this]() -> void { this->disableDataFromDownstreamForFlowControl(); },
+          []() -> void { /* TODO(adip): Handle overflow watermark */ });
       buffered_request_body_->setWatermarks(parent_.callbacks()->decoderBufferLimit());
     }
 

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -502,7 +502,8 @@ StreamRateLimiter::StreamRateLimiter(uint64_t max_kbps, uint64_t max_buffered_da
       // ~63ms intervals.
       token_bucket_(SecondDivisor, time_source, SecondDivisor),
       token_timer_(dispatcher.createTimer([this] { onTokenTimer(); })),
-      buffer_(resume_data_cb, pause_data_cb) {
+      buffer_(resume_data_cb, pause_data_cb,
+              []() -> void { /* TODO(adip): Handle overflow watermark */ }) {
   ASSERT(bytes_per_time_slice_ > 0);
   ASSERT(max_buffered_data > 0);
   buffer_.setWatermarks(max_buffered_data);

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -79,6 +79,7 @@ envoy_cc_test(
         "//source/common/buffer:buffer_lib",
         "//source/common/buffer:watermark_buffer_lib",
         "//source/common/network:address_lib",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -166,16 +166,16 @@ protected:
     dispatcher_ = api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{factory});
     // The first call to create a client session will get a MockBuffer.
     // Other calls for server sessions will by default get a normal OwnedImpl.
-    EXPECT_CALL(*factory, create_(_, _))
+    EXPECT_CALL(*factory, create_(_, _, _))
         .Times(AnyNumber())
-        .WillOnce(Invoke([&](std::function<void()> below_low,
-                             std::function<void()> above_high) -> Buffer::Instance* {
-          client_write_buffer_ = new MockWatermarkBuffer(below_low, above_high);
+        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                             std::function<void()> above_overflow) -> Buffer::Instance* {
+          client_write_buffer_ = new MockWatermarkBuffer(below_low, above_high, above_overflow);
           return client_write_buffer_;
         }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
   }
 
@@ -190,12 +190,12 @@ protected:
 
   ConnectionMocks createConnectionMocks(bool create_timer = true) {
     auto dispatcher = std::make_unique<NiceMock<Event::MockDispatcher>>();
-    EXPECT_CALL(dispatcher->buffer_factory_, create_(_, _))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
+    EXPECT_CALL(dispatcher->buffer_factory_, create_(_, _, _))
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
           // ConnectionImpl calls Envoy::MockBufferFactory::create(), which calls create_() and
           // wraps the returned raw pointer below with a unique_ptr.
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
     Event::MockTimer* timer = nullptr;
@@ -1287,10 +1287,10 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayConfigDisabledTest) {
 
   NiceMock<MockConnectionCallbacks> callbacks;
   NiceMock<Event::MockDispatcher> dispatcher;
-  EXPECT_CALL(dispatcher.buffer_factory_, create_(_, _))
-      .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                std::function<void()> above_high) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high);
+  EXPECT_CALL(dispatcher.buffer_factory_, create_(_, _, _))
+      .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                std::function<void()> above_overflow) -> Buffer::Instance* {
+        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
   IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>(0);
   std::unique_ptr<Network::ConnectionImpl> server_connection(new Network::ConnectionImpl(
@@ -1475,10 +1475,10 @@ private:
 class MockTransportConnectionImplTest : public testing::Test {
 public:
   MockTransportConnectionImplTest() : stream_info_(dispatcher_.timeSource()) {
-    EXPECT_CALL(dispatcher_.buffer_factory_, create_(_, _))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+    EXPECT_CALL(dispatcher_.buffer_factory_, create_(_, _, _))
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
     file_event_ = new Event::MockFileEvent;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4368,16 +4368,16 @@ protected:
     dispatcher_ = api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{factory});
 
     // By default, expect 4 buffers to be created - the client and server read and write buffers.
-    EXPECT_CALL(*factory, create_(_, _))
+    EXPECT_CALL(*factory, create_(_, _, _))
         .Times(2)
-        .WillOnce(Invoke([&](std::function<void()> below_low,
-                             std::function<void()> above_high) -> Buffer::Instance* {
-          client_write_buffer = new MockWatermarkBuffer(below_low, above_high);
+        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                             std::function<void()> above_overflow) -> Buffer::Instance* {
+          client_write_buffer = new MockWatermarkBuffer(below_low, above_high, above_overflow);
           return client_write_buffer;
         }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low,
-                                  std::function<void()> above_high) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high);
+        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                  std::function<void()> above_overflow) -> Buffer::Instance* {
+          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
     initialize();

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -154,10 +154,11 @@ IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
                                            bool enable_half_close)
     : payload_reader_(new WaitForPayloadReader(dispatcher)),
       callbacks_(new ConnectionCallbacks(*this)) {
-  EXPECT_CALL(factory, create_(_, _))
-      .WillOnce(Invoke([&](std::function<void()> below_low,
-                           std::function<void()> above_high) -> Buffer::Instance* {
-        client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(below_low, above_high);
+  EXPECT_CALL(factory, create_(_, _, _))
+      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                           std::function<void()> above_overflow) -> Buffer::Instance* {
+        client_write_buffer_ =
+            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
         return client_write_buffer_;
       }));
 
@@ -264,10 +265,10 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
   // complex test hooks to the server and/or spin waiting on stats, neither of which I think are
   // necessary right now.
   timeSystem().advanceTimeWait(std::chrono::milliseconds(10));
-  ON_CALL(*mock_buffer_factory_, create_(_, _))
-      .WillByDefault(Invoke([](std::function<void()> below_low,
-                               std::function<void()> above_high) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high);
+  ON_CALL(*mock_buffer_factory_, create_(_, _, _))
+      .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                               std::function<void()> above_overflow) -> Buffer::Instance* {
+        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
   ON_CALL(factory_context_, api()).WillByDefault(ReturnRef(*api_));
 }

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -692,11 +692,12 @@ void TcpProxySslIntegrationTest::setupConnections() {
   // Set up the mock buffer factory so the newly created SSL client will have a mock write
   // buffer. This allows us to track the bytes actually written to the socket.
 
-  EXPECT_CALL(*mock_buffer_factory_, create_(_, _))
+  EXPECT_CALL(*mock_buffer_factory_, create_(_, _, _))
       .Times(1)
-      .WillOnce(Invoke([&](std::function<void()> below_low,
-                           std::function<void()> above_high) -> Buffer::Instance* {
-        client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(below_low, above_high);
+      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
+                           std::function<void()> above_overflow) -> Buffer::Instance* {
+        client_write_buffer_ =
+            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
         ON_CALL(*client_write_buffer_, move(_))
             .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
         ON_CALL(*client_write_buffer_, drain(_))

--- a/test/mocks/buffer/mocks.cc
+++ b/test/mocks/buffer/mocks.cc
@@ -6,16 +6,18 @@ namespace Envoy {
 
 template <>
 MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(std::function<void()> below_low,
-                                                        std::function<void()> above_high)
-    : Buffer::WatermarkBuffer(below_low, above_high) {}
+                                                        std::function<void()> above_high,
+                                                        std::function<void()> above_overflow)
+    : Buffer::WatermarkBuffer(below_low, above_high, above_overflow) {}
 
 template <>
 MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase()
-    : Buffer::WatermarkBuffer([&]() -> void {}, [&]() -> void {}) {
+    : Buffer::WatermarkBuffer([&]() -> void {}, [&]() -> void {}, [&]() -> void {}) {
   ASSERT(0); // This constructor is not supported for WatermarkBuffer.
 }
 template <>
-MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()>, std::function<void()>)
+MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()>, std::function<void()>,
+                                                  std::function<void()>)
     : Buffer::OwnedImpl() {
   ASSERT(0); // This constructor is not supported for OwnedImpl.
 }

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -17,7 +17,8 @@ namespace Envoy {
 template <class BaseClass> class MockBufferBase : public BaseClass {
 public:
   MockBufferBase();
-  MockBufferBase(std::function<void()> below_low, std::function<void()> above_high);
+  MockBufferBase(std::function<void()> below_low, std::function<void()> above_high,
+                 std::function<void()> above_overflow);
 
   MOCK_METHOD(Api::IoCallUint64Result, write, (Network::IoHandle & io_handle));
   MOCK_METHOD(void, move, (Buffer::Instance & rhs));
@@ -57,12 +58,14 @@ private:
 
 template <>
 MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(std::function<void()> below_low,
-                                                        std::function<void()> above_high);
+                                                        std::function<void()> above_high,
+                                                        std::function<void()> above_overflow);
 template <> MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase();
 
 template <>
 MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()> below_low,
-                                                  std::function<void()> above_high);
+                                                  std::function<void()> above_high,
+                                                  std::function<void()> above_overflow);
 template <> MockBufferBase<Buffer::OwnedImpl>::MockBufferBase();
 
 class MockBuffer : public MockBufferBase<Buffer::OwnedImpl> {
@@ -78,8 +81,9 @@ class MockWatermarkBuffer : public MockBufferBase<Buffer::WatermarkBuffer> {
 public:
   using BaseClass = MockBufferBase<Buffer::WatermarkBuffer>;
 
-  MockWatermarkBuffer(std::function<void()> below_low, std::function<void()> above_high)
-      : BaseClass(below_low, above_high) {
+  MockWatermarkBuffer(std::function<void()> below_low, std::function<void()> above_high,
+                      std::function<void()> above_overflow)
+      : BaseClass(below_low, above_high, above_overflow) {
     ON_CALL(*this, write(testing::_))
         .WillByDefault(testing::Invoke(this, &MockWatermarkBuffer::trackWrites));
     ON_CALL(*this, move(testing::_))
@@ -92,13 +96,14 @@ public:
   MockBufferFactory();
   ~MockBufferFactory() override;
 
-  Buffer::InstancePtr create(std::function<void()> below_low,
-                             std::function<void()> above_high) override {
-    return Buffer::InstancePtr{create_(below_low, above_high)};
+  Buffer::InstancePtr create(std::function<void()> below_low, std::function<void()> above_high,
+                             std::function<void()> above_overflow) override {
+    return Buffer::InstancePtr{create_(below_low, above_high, above_overflow)};
   }
 
   MOCK_METHOD(Buffer::Instance*, create_,
-              (std::function<void()> below_low, std::function<void()> above_high));
+              (std::function<void()> below_low, std::function<void()> above_high,
+               std::function<void()> above_overflow));
 };
 
 MATCHER_P(BufferEqual, rhs, testing::PrintToString(*rhs)) {


### PR DESCRIPTION
Basic mechanism for buffer overflow watermark.

First part of #10920 - implementing the basic callback and runtime configuration setting needed for overflow watermark.

Risk Level: Low (at the moment) - does nothing
Testing: Added unit tests.
Docs Changes: 
Release Notes: Added initial buffer overflow notification. An overflow occurs when the buffer size reaches a multiple of the buffer’s high watermark value (defaults to 2). This can be overridden by setting runtime feature _envoy.buffer.overflow_multiplier_ to a different number. Setting to 0 disables the overflow notification.
Runtime guard: Setting _envoy.buffer.overflow_multiplier_ to 0 disables this.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
