### PR TITLE
ci: Fix macOS bazelisk symlink order issue

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -41,6 +41,7 @@ fi
 # to unlink/overwrite them to install bazelisk
 echo "Installing bazelbuild/tap/bazelisk"
 brew install --force bazelbuild/tap/bazelisk
+brew unlink bazelbuild/tap/bazelisk || true
 if ! brew link --overwrite bazelbuild/tap/bazelisk; then
     echo "Failed to install and link bazelbuild/tap/bazelisk"
     exit 1


### PR DESCRIPTION
In the case that the macOS image has the `bazel` formula symlinked to
`/usr/local/bin/bazel` and bazelisk symlinked to
`/usr/local/bin/bazelisk`, when you attempt to do the `brew link
--overwrite` homebrew thinks bazelisk is already linked, even though the
`bazel` link is wrong. By unlinking and relinking it, we force homebrew
to actually overwrite `/usr/local/bin/bazel`.

This appears to have started causing issues with a GitHub actions update
this week.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>