### PR TITLE
build: fix compile errors on clang-10

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -59,6 +59,7 @@ quiche_copts = select({
         # Remove these after upstream fix.
         "-Wno-unused-parameter",
         "-Wno-unused-function",
+        "-Wno-unknown-warning-option",
         "-Wno-deprecated-copy",
         # quic_inlined_frame.h uses offsetof() to optimize memory usage in frames.
         "-Wno-invalid-offsetof",

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -59,6 +59,7 @@ quiche_copts = select({
         # Remove these after upstream fix.
         "-Wno-unused-parameter",
         "-Wno-unused-function",
+        "-Wno-deprecated-copy",
         # quic_inlined_frame.h uses offsetof() to optimize memory usage in frames.
         "-Wno-invalid-offsetof",
     ],

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -19,7 +19,7 @@ pushd $$ROOT/wee8
 rm -rf out/wee8
 
 # Export compiler configuration.
-export CXXFLAGS="$${CXXFLAGS} -Wno-deprecated-copy -Wno-unknown-warning-option"
+export CXXFLAGS="$${CXXFLAGS-} -Wno-deprecated-copy -Wno-unknown-warning-option"
 if [[ ( `uname` == "Darwin" && $${CXX-} == "" ) || $${CXX-} == *"clang"* ]]; then
   export IS_CLANG=true
   export CC=$${CC:-clang}

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -19,10 +19,12 @@ pushd $$ROOT/wee8
 rm -rf out/wee8
 
 # Export compiler configuration.
+export CXXFLAGS="$${CXXFLAGS} -Wno-deprecated-copy"
 if [[ ( `uname` == "Darwin" && $${CXX-} == "" ) || $${CXX-} == *"clang"* ]]; then
   export IS_CLANG=true
   export CC=$${CC:-clang}
   export CXX=$${CXX:-clang++}
+  export CXXFLAGS="$${CXXFLAGS} -Wno-implicit-int-float-conversion -Wno-builtin-assume-aligned-alignment -Wno-final-dtor-non-final-class"
 else
   export IS_CLANG=false
   export CC=$${CC:-gcc}

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -19,7 +19,7 @@ pushd $$ROOT/wee8
 rm -rf out/wee8
 
 # Export compiler configuration.
-export CXXFLAGS="$${CXXFLAGS} -Wno-deprecated-copy"
+export CXXFLAGS="$${CXXFLAGS} -Wno-deprecated-copy -Wno-unknown-warning-option"
 if [[ ( `uname` == "Darwin" && $${CXX-} == "" ) || $${CXX-} == *"clang"* ]]; then
   export IS_CLANG=true
   export CC=$${CC:-clang}

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -47,9 +47,9 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProto) {
 
 TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
   BufferFilterFactory factory;
+  auto empty_proto = factory.createEmptyConfigProto();
   envoy::extensions::filters::http::buffer::v3::Buffer config =
-      *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(
-          factory.createEmptyConfigProto().get());
+      *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(empty_proto.get());
 
   config.mutable_max_request_bytes()->set_value(1028);
 
@@ -62,9 +62,9 @@ TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
 
 TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
   BufferFilterFactory factory;
+  auto empty_proto = factory.createEmptyConfigProto();
   envoy::extensions::filters::http::buffer::v3::Buffer config =
-      *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(
-          factory.createEmptyConfigProto().get());
+      *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(empty_proto.get());
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, "stats", context),
@@ -74,10 +74,8 @@ TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
 TEST(BufferFilterFactoryTest, BufferFilterEmptyRouteProto) {
   BufferFilterFactory factory;
   EXPECT_NO_THROW({
-    envoy::extensions::filters::http::buffer::v3::BufferPerRoute* config =
-        dynamic_cast<envoy::extensions::filters::http::buffer::v3::BufferPerRoute*>(
-            factory.createEmptyRouteConfigProto().get());
-    EXPECT_NE(nullptr, config);
+    EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::http::buffer::v3::BufferPerRoute*>(
+                           factory.createEmptyRouteConfigProto().get()));
   });
 }
 

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -36,16 +36,14 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidProto) {
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, EmptyProto) {
   RoleBasedAccessControlFilterConfigFactory factory;
-  auto* config = dynamic_cast<envoy::extensions::filters::http::rbac::v3::RBAC*>(
-      factory.createEmptyConfigProto().get());
-  EXPECT_NE(nullptr, config);
+  EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::http::rbac::v3::RBAC*>(
+                         factory.createEmptyConfigProto().get()));
 }
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, EmptyRouteProto) {
   RoleBasedAccessControlFilterConfigFactory factory;
-  auto* config = dynamic_cast<envoy::extensions::filters::http::rbac::v3::RBACPerRoute*>(
-      factory.createEmptyRouteConfigProto().get());
-  EXPECT_NE(nullptr, config);
+  EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::http::rbac::v3::RBACPerRoute*>(
+                         factory.createEmptyRouteConfigProto().get()));
 }
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, RouteSpecificConfig) {

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -68,9 +68,8 @@ TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, ValidProto) {
 
 TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, EmptyProto) {
   RoleBasedAccessControlNetworkFilterConfigFactory factory;
-  auto* config = dynamic_cast<envoy::extensions::filters::network::rbac::v3::RBAC*>(
-      factory.createEmptyConfigProto().get());
-  EXPECT_NE(nullptr, config);
+  EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::network::rbac::v3::RBAC*>(
+                         factory.createEmptyConfigProto().get()));
 }
 
 TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, InvalidPermission) {


### PR DESCRIPTION
Commit Message:
Additional Description:
- `-Wdeprecated-copy` are enabled by default w/`-Wextra` while quiche and wee8 is not compatible with that.
- Fixing dangling pointer in tests.
- Disable a couple more warnings on wee8

Risk Level: Low
Testing: local with clang-10, CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
