### PR TITLE
protoxform: Add enum deprecation support.

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -552,6 +552,8 @@ message RouteAction {
   // Configures :ref:`internal redirect <arch_overview_internal_redirects>` behavior.
   // [#next-major-version: remove this definition - it's defined in the InternalRedirectPolicy message.]
   enum InternalRedirectAction {
+    option deprecated = true;
+
     PASS_THROUGH_INTERNAL_REDIRECT = 0;
     HANDLE_INTERNAL_REDIRECT = 1;
   }

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -552,13 +552,6 @@ message RouteAction {
     NOT_FOUND = 1;
   }
 
-  // Configures :ref:`internal redirect <arch_overview_internal_redirects>` behavior.
-  // [#next-major-version: remove this definition - it's defined in the InternalRedirectPolicy message.]
-  enum InternalRedirectAction {
-    PASS_THROUGH_INTERNAL_REDIRECT = 0;
-    HANDLE_INTERNAL_REDIRECT = 1;
-  }
-
   // The router is capable of shadowing traffic from one cluster to another. The current
   // implementation is "fire and forget," meaning Envoy will not wait for the shadow cluster to
   // respond before returning the response from the primary cluster. All normal statistics are

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -564,6 +564,8 @@ message RouteAction {
   // Configures :ref:`internal redirect <arch_overview_internal_redirects>` behavior.
   // [#next-major-version: remove this definition - it's defined in the InternalRedirectPolicy message.]
   enum InternalRedirectAction {
+    option deprecated = true;
+
     PASS_THROUGH_INTERNAL_REDIRECT = 0;
     HANDLE_INTERNAL_REDIRECT = 1;
   }

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -555,6 +555,8 @@ message RouteAction {
   // Configures :ref:`internal redirect <arch_overview_internal_redirects>` behavior.
   // [#next-major-version: remove this definition - it's defined in the InternalRedirectPolicy message.]
   enum InternalRedirectAction {
+    option deprecated = true;
+
     PASS_THROUGH_INTERNAL_REDIRECT = 0;
     HANDLE_INTERNAL_REDIRECT = 1;
   }

--- a/tools/protoxform/migrate.py
+++ b/tools/protoxform/migrate.py
@@ -191,6 +191,8 @@ class UpgradeVisitor(visitor.Visitor):
 
   def VisitEnum(self, enum_proto, type_context):
     upgraded_proto = copy.deepcopy(enum_proto)
+    if upgraded_proto.options.deprecated and not self._envoy_internal_shadow:
+      options.AddHideOption(upgraded_proto.options)
     for v in upgraded_proto.value:
       if v.options.deprecated:
         # We need special handling for the zero field, as proto3 needs some value

--- a/tools/protoxform/protoprint.py
+++ b/tools/protoxform/protoprint.py
@@ -566,6 +566,8 @@ class ProtoFormatVisitor(visitor.Visitor):
                                             trailing_comment, methods)
 
   def VisitEnum(self, enum_proto, type_context):
+    if protoxform_options.HasHideOption(enum_proto.options):
+      return ''
     leading_comment, trailing_comment = FormatTypeContextComments(type_context)
     formatted_options = FormatOptions(enum_proto.options)
     reserved_fields = FormatReserved(enum_proto)

--- a/tools/testdata/protoxform/envoy/v2/sample.proto
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto
@@ -19,6 +19,11 @@ message Sample {
     string key = 1;
     string value = 2;
   }
+  enum DeprecateEnum {
+    option deprecated = true;
+    FIRST = 0;
+    SECOND = 1;
+  }
   repeated Entry entries = 1;
   string will_deprecated = 2 [deprecated = true];
   string will_rename_compoent = 3 [(udpa.annotations.field_migrate).rename = "renamed_component"];

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.active_or_frozen.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.active_or_frozen.gold
@@ -18,6 +18,13 @@ enum SomeEnum {
 }
 
 message Sample {
+  enum DeprecateEnum {
+    option deprecated = true;
+
+    FIRST = 0;
+    SECOND = 1;
+  }
+
   message Entry {
     string key = 1;
 

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.next_major_version_candidate.envoy_internal.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.next_major_version_candidate.envoy_internal.gold
@@ -20,6 +20,13 @@ enum SomeEnum {
 message Sample {
   option (udpa.annotations.versioning).previous_message_type = "envoy.v2.Sample";
 
+  enum DeprecateEnum {
+    option deprecated = true;
+
+    FIRST = 0;
+    SECOND = 1;
+  }
+
   message Entry {
     option (udpa.annotations.versioning).previous_message_type = "envoy.v2.Sample.Entry";
 


### PR DESCRIPTION
Signed-off-by: pengg <pengg@google.com>

Commit Message: protoxform: Add enum deprecation support
Additional Description: Support deprecating an enum stanza as a whole by "option deprecated = true;"
Risk Level: low
Testing: Added test case; manually verified the generated config removes the deprecated enum
Docs Changes: N/A
Release Notes: N/A