### PR TITLE
Windows fixes for //test/common/runtime/...

### DIFF
--- a/test/common/runtime/BUILD
+++ b/test/common/runtime/BUILD
@@ -29,8 +29,6 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "runtime_protos_test",
     srcs = ["runtime_protos_test.cc"],
-    # Pass for the time being, test times out on windows
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/runtime:runtime_lib",
         "//test/mocks/runtime:runtime_mocks",
@@ -44,9 +42,6 @@ envoy_cc_test(
     name = "runtime_impl_test",
     srcs = ["runtime_impl_test.cc"],
     data = glob(["test_data/**"]) + ["filesystem_setup.sh"],
-    # Inexplicable failure promoting arguments to mock, see
-    # https://envoyproxy.slack.com/archives/CNAK09BSB/p1571946165007300
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/config:runtime_utility_lib",
         "//source/common/runtime:runtime_lib",

--- a/test/common/runtime/filesystem_setup.sh
+++ b/test/common/runtime/filesystem_setup.sh
@@ -10,8 +10,6 @@ rm -rf "${TEST_TMPDIR}/${TEST_DATA}"
 mkdir -p "${TEST_TMPDIR}/${TEST_DATA}"
 cp -RfL "${TEST_DATA}"/* "${TEST_TMPDIR}/${TEST_DATA}"
 chmod -R u+rwX "${TEST_TMPDIR}/${TEST_DATA}"
-ln -sf "${TEST_TMPDIR}/${TEST_DATA}/root" "${TEST_TMPDIR}/${TEST_DATA}/current"
-ln -sf "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/subdir" "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/badlink"
 
 # Deliberate symlink of doom.
 LOOP_PATH="${TEST_TMPDIR}/${TEST_DATA}/loop"
@@ -20,8 +18,13 @@ mkdir -p "${LOOP_PATH}"
 # the ln in MSYS2 doesn't handle recursive symlinks correctly,
 # so use the cmd built in mklink instead on Windows
 if [[ -z "${WINDIR}" ]]; then
+  ln -sf "${TEST_TMPDIR}/${TEST_DATA}/root" "${TEST_TMPDIR}/${TEST_DATA}/current"
+  ln -sf "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/subdir" "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/badlink"
   ln -sf "${LOOP_PATH}" "${LOOP_PATH}"/loop
 else
+  win_test_root="$(echo $TEST_TMPDIR/$TEST_DATA | tr '/' '\\')"
+  cmd.exe /C "mklink /D ${win_test_root}\\current ${win_test_root}\\root"
+  cmd.exe /C "mklink /D ${win_test_root}\\root\\envoy\\badlink ${win_test_root}\\root\\envoy\\subdir"
   win_loop_path="$(echo $LOOP_PATH | tr '/' '\\')"
   cmd.exe /C "mklink /D ${win_loop_path}\\loop ${win_loop_path}"
 fi

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -809,10 +809,11 @@ protected:
 
 TEST_F(DiskLayerTest, IllegalPath) {
 #ifdef WIN32
-  // no illegal paths on Windows at the moment
-  return;
-#endif
+  EXPECT_THROW_WITH_MESSAGE(DiskLayer("test", R"EOF(\\.\)EOF", *api_), EnvoyException,
+                            R"EOF(Invalid path: \\.\)EOF");
+#else
   EXPECT_THROW_WITH_MESSAGE(DiskLayer("test", "/dev", *api_), EnvoyException, "Invalid path: /dev");
+#endif
 }
 
 // Validate that we catch recursion that goes too deep in the runtime filesystem


### PR DESCRIPTION
Commit Message: Windows fixes for //test/common/runtime/...

Additional Description:
- identify a known invalid path prefix to check on windows (/dev/ means nothing special)
- correctly create symlinks on windows (msys2 ln.exe isn't able to, it copies files instead)

Co-authored-by: William A Rowe Jr <wrowe@pivotal.io>
Co-authored-by: Sunjay Bhatia <sbhatia@pivotal.io>
Signed-off-by: William A Rowe Jr <wrowe@pivotal.io>
Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>


Risk Level: low
Testing: local on Windows
Docs Changes: n/a
Release Notes: n/a
