### PR TITLE
Support fuzzing encoder callbacks in UberFilterFuzzer

### DIFF
--- a/test/extensions/filters/http/common/fuzz/BUILD
+++ b/test/extensions/filters/http/common/fuzz/BUILD
@@ -33,6 +33,7 @@ envoy_cc_test_library(
     deps = [
         ":filter_fuzz_proto_cc_proto",
         "//source/common/config:utility_lib",
+        "//source/common/http:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http:well_known_names",
         "//test/fuzz:utility_lib",

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_stats
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_stats
@@ -1,0 +1,47 @@
+config {
+  name: "envoy.filters.http.grpc_stats"
+  typed_config: {}
+}
+data {
+  headers {
+    headers {
+      key: ":method"
+      value: "POST"
+    }
+    headers {
+      key: ":path"
+      value: "/bookstore.Bookstore/CreateShelfWithPackageServiceAndMethod"
+    }
+    headers {
+      key: "content-type"
+      value: "application/grpc"
+    }
+  }
+}
+upstream_data {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+    headers {
+      key: "content-type"
+      value: "application/grpc"
+    }
+  }
+  proto_body {
+    message {
+      [type.googleapis.com/bookstore.Book] {
+        id: 16
+        title: "Hardy Boys"
+      }
+    }
+    chunk_size: 4
+  }
+  trailers {
+    headers {
+      key: "grpc-status"
+      value: "0"
+    }
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_transcoding_decode_encode
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_transcoding_decode_encode
@@ -27,6 +27,10 @@ upstream_data {
       key: ":status"
       value: "200"
     }
+    headers {
+      key: "content-type"
+      value: "application/grpc"
+    }
   }
   proto_body {
     message {
@@ -35,6 +39,12 @@ upstream_data {
         title: "Hardy Boys"
       }
     }
-    chunk_size: 3
+    chunk_size: 100
+  }
+  trailers {
+    headers {
+      key: "grpc-status"
+      value: "0"
+    }
   }
 }

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_transcoding_decode_encode
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_transcoding_decode_encode
@@ -1,0 +1,40 @@
+config {
+  name: "envoy.filters.http.grpc_json_transcoder"
+  typed_config: {}
+}
+data {
+  headers {
+    headers {
+      key: "content-type"
+      value: "application/json"
+    }
+    headers {
+      key: ":method"
+      value: "POST"
+    }
+    headers {
+      key: ":path"
+      value: "/bookstore.Bookstore/CreateShelfWithPackageServiceAndMethod"
+    }
+  }
+  http_body {
+    data: "{\"theme\": \"Children\"}"
+  }
+}
+upstream_data {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+  proto_body {
+    message {
+      [type.googleapis.com/bookstore.Book] {
+        id: 16
+        title: "Hardy Boys"
+      }
+    }
+    chunk_size: 3
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_transcoding_proto_data
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/grpc_transcoding_proto_data
@@ -6,16 +6,16 @@ config {
 data {
   headers {
     headers {
-      key: "content-type"
-      value: "application/json"
-    }
-    headers {
       key: ":method"
       value: "POST"
     }
     headers {
       key: ":path"
       value: "/bookstore.Bookstore/CreateShelf"
+    }
+    headers {
+      key: "content-type"
+      value: "application/grpc"
     }
   }
   proto_body {
@@ -28,5 +28,11 @@ data {
       }
     }
     chunk_size: 3
+  }
+  trailers {
+    headers {
+      key: "grpc-status"
+      value: "0"
+    }
   }
 }

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz.proto
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz.proto
@@ -8,5 +8,9 @@ import "envoy/extensions/filters/network/http_connection_manager/v3/http_connect
 message FilterFuzzTestCase {
   envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter config = 1;
 
+  // Downstream data (named for backwards compatibility).
   test.fuzz.HttpData data = 2;
+
+  // Upstream data.
+  test.fuzz.HttpData upstream_data = 3;
 }

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -50,7 +50,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& i
     TestUtility::validate(input);
     // Fuzz filter.
     static UberFilterFuzzer fuzzer;
-    fuzzer.fuzz(input.config(), input.data());
+    fuzzer.fuzz(input.config(), input.data(), input.upstream_data());
   } catch (const ProtoValidationException& e) {
     ENVOY_LOG_MISC(debug, "ProtoValidationException: {}", e.what());
   }

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -166,10 +166,10 @@ void UberFilterFuzzer::fuzz(
 
   // Data path should not throw exceptions.
   if (decoder_filter_ != nullptr) {
-    ASSERT_NO_THROW(runData(decoder_filter_.get(), downstream_data));
+    runData(decoder_filter_.get(), downstream_data);
   }
   if (encoder_filter_ != nullptr) {
-    ASSERT_NO_THROW(runData(encoder_filter_.get(), upstream_data));
+    runData(encoder_filter_.get(), upstream_data);
   }
 
   reset();

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -11,10 +11,13 @@ class UberFilterFuzzer {
 public:
   UberFilterFuzzer();
 
-  // This creates the filter config and runs the decode methods.
+  // This creates the filter config and runs the fuzzed data against the filter.
   void fuzz(const envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter&
                 proto_config,
-            const test::fuzz::HttpData& data);
+            const test::fuzz::HttpData& downstream_data, const test::fuzz::HttpData& upstream_data);
+
+  // This executes the filter decoders/encoders with the fuzzed data.
+  template <class FilterType> void runData(FilterType* filter, const test::fuzz::HttpData& data);
 
   // For fuzzing proto data, guide the mutator to useful 'Any' types.
   static void guideAnyProtoType(test::fuzz::HttpData* mutable_data, uint choice);
@@ -26,22 +29,47 @@ protected:
   void cleanFuzzedConfig(absl::string_view filter_name, Protobuf::Message* message);
 
   // Parses http or proto body into chunks.
-  std::vector<std::string> parseHttpData(const test::fuzz::HttpData& data);
+  static std::vector<std::string> parseHttpData(const test::fuzz::HttpData& data);
 
-  // This executes the decode methods to be fuzzed.
-  void decode(Http::StreamDecoderFilter* filter, const test::fuzz::HttpData& data);
+  // Templated functions to validate and send headers/data/trailers for decoders/encoders.
+  // General functions are deleted, but templated specializations for encoders/decoders are defined
+  // in the cc file.
+  template <class FilterType>
+  Http::FilterHeadersStatus sendHeaders(FilterType* filter, const test::fuzz::HttpData& data,
+                                        bool end_stream) = delete;
+
+  template <class FilterType>
+  Http::FilterDataStatus sendData(FilterType* filter, Buffer::Instance& buffer,
+                                  bool end_stream) = delete;
+
+  template <class FilterType>
+  void sendTrailers(FilterType* filter, const test::fuzz::HttpData& data) = delete;
 
   void reset();
 
 private:
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback_;
   std::shared_ptr<Network::MockDnsResolver> resolver_{std::make_shared<Network::MockDnsResolver>()};
-  std::shared_ptr<Http::StreamDecoderFilter> filter_;
   Http::FilterFactoryCb cb_;
   NiceMock<Envoy::Network::MockConnection> connection_;
   Network::Address::InstanceConstSharedPtr addr_;
+
+  // Mocked callbacks.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
+
+  // Filter constructed from the config.
+  Http::StreamDecoderFilterSharedPtr decoder_filter_;
+  Http::StreamEncoderFilterSharedPtr encoder_filter_;
+
+  // Headers/trailers need to be saved for the lifetime of the the filter,
+  // so save them as member variables.
+  // TODO(nareddyt): Use for access logging in a followup PR.
+  Http::TestRequestHeaderMapImpl request_headers_;
+  Http::TestResponseHeaderMapImpl response_headers_;
+  Http::TestRequestTrailerMapImpl request_trailers_;
+  Http::TestResponseTrailerMapImpl response_trailers_;
 };
 
 } // namespace HttpFilters

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -83,10 +83,16 @@ void UberFilterFuzzer::perFilterSetup() {
   addr_ = std::make_shared<Network::Address::Ipv4Instance>("1.2.3.4", 1111);
   ON_CALL(connection_, remoteAddress()).WillByDefault(testing::ReturnRef(addr_));
   ON_CALL(connection_, localAddress()).WillByDefault(testing::ReturnRef(addr_));
-  ON_CALL(callbacks_, connection()).WillByDefault(testing::Return(&connection_));
-  ON_CALL(callbacks_, activeSpan())
+
+  ON_CALL(decoder_callbacks_, connection()).WillByDefault(testing::Return(&connection_));
+  ON_CALL(decoder_callbacks_, activeSpan())
       .WillByDefault(testing::ReturnRef(Tracing::NullSpan::instance()));
-  callbacks_.stream_info_.protocol_ = Envoy::Http::Protocol::Http2;
+  decoder_callbacks_.stream_info_.protocol_ = Envoy::Http::Protocol::Http2;
+
+  ON_CALL(encoder_callbacks_, connection()).WillByDefault(testing::Return(&connection_));
+  ON_CALL(encoder_callbacks_, activeSpan())
+      .WillByDefault(testing::ReturnRef(Tracing::NullSpan::instance()));
+  encoder_callbacks_.stream_info_.protocol_ = Envoy::Http::Protocol::Http2;
 
   // Prepare expectations for dynamic forward proxy.
   ON_CALL(factory_context_.dispatcher_, createDnsResolver(_, _))

--- a/test/fuzz/common.proto
+++ b/test/fuzz/common.proto
@@ -18,7 +18,7 @@ message Headers {
 
 message HttpBody {
   // The bytes that will be used as the request body.
-  repeated string data = 1 [(validate.rules).repeated .min_items = 1];
+  repeated string data = 1 [(validate.rules).repeated.min_items = 1];
 }
 
 // HttpBody cannot efficiently create serialized protos.
@@ -28,7 +28,10 @@ message ProtoBody {
   google.protobuf.Any message = 1 [(validate.rules).any.required = true];
 
   // The size (in bytes) of each buffer when forming the requests.
-  uint64 chunk_size = 2 [(validate.rules).uint64.gt = 0];
+  uint64 chunk_size = 2 [(validate.rules).uint64 = {
+    gt : 0,
+    lt: 20
+  }];
 }
 
 message HttpData {

--- a/test/fuzz/common.proto
+++ b/test/fuzz/common.proto
@@ -18,7 +18,7 @@ message Headers {
 
 message HttpBody {
   // The bytes that will be used as the request body.
-  repeated string data = 1 [(validate.rules).repeated.min_items = 1];
+  repeated string data = 1 [(validate.rules).repeated .min_items = 1];
 }
 
 // HttpBody cannot efficiently create serialized protos.
@@ -28,10 +28,7 @@ message ProtoBody {
   google.protobuf.Any message = 1 [(validate.rules).any.required = true];
 
   // The size (in bytes) of each buffer when forming the requests.
-  uint64 chunk_size = 2 [(validate.rules).uint64 = {
-    gt : 0,
-    lt: 20
-  }];
+  uint64 chunk_size = 2 [(validate.rules).uint64 = {gt: 0, lt: 20}];
 }
 
 message HttpData {

--- a/test/fuzz/common.proto
+++ b/test/fuzz/common.proto
@@ -28,7 +28,7 @@ message ProtoBody {
   google.protobuf.Any message = 1 [(validate.rules).any.required = true];
 
   // The size (in bytes) of each buffer when forming the requests.
-  uint64 chunk_size = 2 [(validate.rules).uint64 = {gt: 0, lt: 20}];
+  uint64 chunk_size = 2 [(validate.rules).uint64 = {gt: 0, lt: 8192}];
 }
 
 message HttpData {

--- a/test/fuzz/fuzz_runner.cc
+++ b/test/fuzz/fuzz_runner.cc
@@ -52,7 +52,9 @@ void Runner::setupEnvironment(int argc, char** argv, spdlog::level::level_enum d
   // For fuzzing, this prevents logging when parsing text-format protos fails,
   // deprecated fields are used, etc.
   // https://github.com/protocolbuffers/protobuf/blob/204f99488ce1ef74565239cf3963111ae4c774b7/src/google/protobuf/stubs/logging.h#L223
-  ABSL_ATTRIBUTE_UNUSED static auto* log_silencer = new Protobuf::LogSilencer();
+  if (log_level_ > spdlog::level::debug) {
+    ABSL_ATTRIBUTE_UNUSED static auto* log_silencer = new Protobuf::LogSilencer();
+  }
 }
 
 } // namespace Fuzz


### PR DESCRIPTION
*Commit Message*: Support fuzzing encoder callbacks in UberFilterFuzzer

*Additional Description*:

Minimized code duplication by making use of templating and template specialization. The 6 cases for sending headers/data/trailers in decoders/encoders each have their own function. By making use of templating, we can enforce compile time checks and keep the fuzzing runtime fast. The one downside is the amount of overhead in declaring the functions, but this seems like the cleanest solution to me. 

Alternatives considered:
- If/else statements: This became messy quickly, as we also have different validation logic for request/response headers. And we need to pass extra data around to keep track of whether we were fuzzing decoders or encoders.
- Lambdas: Similar to this approach with potentially less code for defining the function. But this does not enforce compile time checking, requires passing more data around, and potentially requires dynamic casts (which are expensive, not good for fuzzing).

Unfortunately, I was not able to make these functions static (as discussed with @asraa) due to lifetime issues. The request/response headers must be kept alive for the duration of the filter (as `decodeData` may use headers from `decodeHeaders`). Best option was to make use of member variables to preserve it. This is OK, ESPv2 can workaround this (see the follow-ups below).

A few other minor changes:
- Add a small max limit to the number of chunks the proto data is broken into. Sometimes the fuzzer would fail in `absl::ByLength`, which I _assume_ is due to a large chunk size.

*Risk Level*: None

*Testing*:
- Added new entry to in-repo corpus that executes decoders and encoders.
- Ran against in-repo corpus and manually inspected the debug logs.
- Ran `with_libfuzzer` and ensured crashes did not occur in UberFilterFuzzer

*Follow-up PRs*:
- Support fuzzing access logs in a similar fashion. This should be fairly straightforward and requires no new templates.
- Split the UberFilterFuzzer into two classes: One for constructing the filter using the factory, and one for actually fuzzing the filter. In ESPv2, we have fuzz tests per filter that already set all the callbacks needed. So we can ignore all the mocks in the UberFilterFuzzer factory, and just directly use the UberFilterFuzzer filter fuzzer.

*Signed-off-by*: Teju Nareddy <nareddyt@google.com>