### PR TITLE
ci: save api revision in go-control-plane

### DIFF
--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -83,6 +83,13 @@ def updatedSinceSHA(repo, last_sha):
   return git(None, 'rev-list', '%s..HEAD' % last_sha, 'api/envoy').split()
 
 
+def writeRevisionInfo(repo, sha):
+  # Put a file 
+  dst = os.path.join(repo, 'envoy', 'COMMIT')
+  with open(dst, 'w') as fh:
+    fh.write(sha)
+
+
 def syncGoProtobufs(output, repo):
   # Sync generated content against repo and return true if there is a commit necessary
   dst = os.path.join(repo, 'envoy')
@@ -109,7 +116,9 @@ if __name__ == "__main__":
   cloneGoProtobufs(repo)
   last_sha = findLastSyncSHA(repo)
   changes = updatedSinceSHA(repo, last_sha)
+  new_sha = changes[0]
   if changes:
     print('Changes detected: %s' % changes)
     syncGoProtobufs(output, repo)
-    publishGoProtobufs(repo, changes[0])
+    writeRevisionInfo(repo, new_sha)
+    publishGoProtobufs(repo, new_sha)

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -84,7 +84,7 @@ def updatedSinceSHA(repo, last_sha):
 
 
 def writeRevisionInfo(repo, sha):
-  # Put a file 
+  # Put a file in the generated code root containing the latest mirrored SHA
   dst = os.path.join(repo, 'envoy', 'COMMIT')
   with open(dst, 'w') as fh:
     fh.write(sha)


### PR DESCRIPTION
Commit Message:

When committing generated code from protos into envoyproxy/go-control-plane, also save a file 'COMMIT' with the commit SHA in the root of the generated code directory.

Additional Description:

I have a use case where I want to know the commit used for go-control-plane generated code and I don't also have git history available. This will allow me to read it from a file instead of relying on git history.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>