### PR TITLE
 server: clear deferred deletions during shutdown

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -294,6 +294,12 @@ public:
    * have either received and applied their responses or timed out.
    */
   virtual void startRtdsSubscriptions(ReadyCallback on_done) PURE;
+
+  /**
+   * Stops any existing RTDS subscriptions. This should be called prior to invalidating the the streams
+   * managed by the cluster manager.
+   */
+  virtual void stop() PURE;
 };
 
 using LoaderPtr = std::unique_ptr<Loader>;

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -296,8 +296,8 @@ public:
   virtual void startRtdsSubscriptions(ReadyCallback on_done) PURE;
 
   /**
-   * Stops any existing RTDS subscriptions. This should be called prior to invalidating the the streams
-   * managed by the cluster manager.
+   * Stops any existing RTDS subscriptions. This should be called prior to invalidating the the
+   * streams managed by the cluster manager.
    */
   virtual void stop() PURE;
 };

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -254,7 +254,10 @@ public:
   std::shared_ptr<const Snapshot> threadsafeSnapshot() override;
   void mergeValues(const std::unordered_map<std::string, std::string>& values) override;
   void startRtdsSubscriptions(ReadyCallback on_done) override;
-
+  void stop() override {
+    subscriptions_.clear();
+  }
+  
 private:
   friend RtdsSubscription;
 

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -254,10 +254,8 @@ public:
   std::shared_ptr<const Snapshot> threadsafeSnapshot() override;
   void mergeValues(const std::unordered_map<std::string, std::string>& values) override;
   void startRtdsSubscriptions(ReadyCallback on_done) override;
-  void stop() override {
-    subscriptions_.clear();
-  }
-  
+  void stop() override { subscriptions_.clear(); }
+
 private:
   friend RtdsSubscription;
 

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -15,7 +15,7 @@ namespace Tls {
 
 ContextManagerImpl::~ContextManagerImpl() {
   removeEmptyContexts();
-  KNOWN_ISSUE_ASSERT(contexts_.empty(), "https://github.com/envoyproxy/envoy/issues/10030");
+  ASSERT(contexts_.empty());
 }
 
 void ContextManagerImpl::removeEmptyContexts() {

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -67,8 +67,8 @@ public:
                      Filesystem::Instance& file_system);
 
   ~ValidationInstance() {
-    // This ensures that we don't have any pending deletions that extend the lifetime of objects beyond the
-    // lifetime of the other fields.
+    // This ensures that we don't have any pending deletions that extend the lifetime of objects
+    // beyond the lifetime of the other fields.
     dispatcher_->clearDeferredDeleteList();
   }
 

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -66,7 +66,7 @@ public:
                      ComponentFactory& component_factory, Thread::ThreadFactory& thread_factory,
                      Filesystem::Instance& file_system);
 
-  ~ValidationInstance() {
+  ~ValidationInstance() override {
     // This ensures that we don't have any pending deletions that extend the lifetime of objects
     // beyond the lifetime of the other fields.
     dispatcher_->clearDeferredDeleteList();

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -66,6 +66,12 @@ public:
                      ComponentFactory& component_factory, Thread::ThreadFactory& thread_factory,
                      Filesystem::Instance& file_system);
 
+  ~ValidationInstance() {
+    // This ensures that we don't have any pending deletions that extend the lifetime of objects beyond the
+    // lifetime of the other fields.
+    dispatcher_->clearDeferredDeleteList();
+  }
+
   // Server::Instance
   Admin& admin() override { return admin_; }
   Api::Api& api() override { return *api_; }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -129,6 +129,10 @@ InstanceImpl::~InstanceImpl() {
   ENVOY_LOG(debug, "destroying listener manager");
   listener_manager_.reset();
   ENVOY_LOG(debug, "destroyed listener manager");
+
+  // This ensures that we don't have any pending deletions that extend the lifetime of objects beyond the
+  // lifetime of the other fields.
+  dispatcher_->clearDeferredDeleteList();
 }
 
 Upstream::ClusterManager& InstanceImpl::clusterManager() { return *config_.clusterManager(); }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -130,6 +130,10 @@ InstanceImpl::~InstanceImpl() {
   listener_manager_.reset();
   ENVOY_LOG(debug, "destroyed listener manager");
 
+  // Stop the RTDS subscriptions before we shut everything down, as clearing the deferred list will
+  // otherwise invalidate the streams used by RTDS.
+  Runtime::LoaderSingleton::get().stop();
+
   // This ensures that we don't have any pending deletions that extend the lifetime of objects
   // beyond the lifetime of the other fields.
   dispatcher_->clearDeferredDeleteList();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -130,8 +130,8 @@ InstanceImpl::~InstanceImpl() {
   listener_manager_.reset();
   ENVOY_LOG(debug, "destroyed listener manager");
 
-  // This ensures that we don't have any pending deletions that extend the lifetime of objects beyond the
-  // lifetime of the other fields.
+  // This ensures that we don't have any pending deletions that extend the lifetime of objects
+  // beyond the lifetime of the other fields.
   dispatcher_->clearDeferredDeleteList();
 }
 

--- a/test/mocks/runtime/mocks.h
+++ b/test/mocks/runtime/mocks.h
@@ -75,6 +75,7 @@ public:
   MOCK_METHOD(std::shared_ptr<const Snapshot>, threadsafeSnapshot, ());
   MOCK_METHOD(void, mergeValues, ((const std::unordered_map<std::string, std::string>&)));
   MOCK_METHOD(void, startRtdsSubscriptions, (ReadyCallback));
+  MOCK_METHOD(void, stop, ());
 
   testing::NiceMock<MockSnapshot> snapshot_;
 };


### PR DESCRIPTION
Commit Message: 
This adds a call to clear out deferred deletions during server shutdown. This ensures that we don't have any lingering deletions that retain a
handle to a ClusterInfo which prevents the SslContext from being
released from the manager.

Additional Description:
Risk Level: Low
Testing: n/a

Fixes #10030
