### PR TITLE
build: fix cares build

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -82,6 +82,7 @@ envoy_cmake_external(
         "CARES_SHARED": "no",
         "CARES_STATIC": "on",
         "CMAKE_CXX_COMPILER_FORCED": "on",
+        "CMAKE_INSTALL_LIBDIR": "lib",
     },
     defines = ["CARES_STATICLIB"],
     lib_source = "@com_github_c_ares_c_ares//:all",


### PR DESCRIPTION
#11149 broke CentOS/RHEL build, force lib install dir to `lib` rather than `lib64` in those distro, so rules_foreign_cc can find built static libraries.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>

