### PR TITLE
bazelci: always exclude nocoverage tag in coverage config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -126,6 +126,7 @@ build:coverage --strategy=TestRunner=sandboxed,local
 build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
+build:coverage --test_tag_filters=-nocoverage
 build:coverage --instrumentation_filter="//source(?!/common/chromium_url|/extensions/quic_listeners/quiche/platform)[/:],//include[/:]"
 coverage:test-coverage --test_arg="--log-path /dev/null"
 coverage:test-coverage --test_arg="-l trace"


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

#11218 broked bazel ci https://buildkite.com/bazel/envoy/builds/1145