### PR TITLE
docs: host_rewrite -> host_rewrite_literal in quickstart

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -80,7 +80,7 @@ The specification of the :ref:`listeners <envoy_v3_api_file_envoy/config/listene
                   domains: ["*"]
                   routes:
                   - match: { prefix: "/" }
-                    route: { host_rewrite: www.google.com, cluster: service_google }
+                    route: { host_rewrite_literal: www.google.com, cluster: service_google }
               http_filters:
               - name: envoy.filters.http.router
 


### PR DESCRIPTION
Commit Message:
Quick docs fix to match v3 protos in https://github.com/envoyproxy/envoy/blob/11c9223aac10834b7d5d2e399b0b4b59e0a3b3a1/api/envoy/config/route/v3/route_components.proto#L861

Risk Level: low
Testing: look ma no tests
Docs Changes: `docs/root/start/start.rst`
