### PR TITLE
docs: update upstream network filters description

### DIFF
--- a/docs/root/intro/arch_overview/upstream/upstream_filters.rst
+++ b/docs/root/intro/arch_overview/upstream/upstream_filters.rst
@@ -4,8 +4,10 @@ Upstream network filters
 ========================
 
 Upstream clusters provide an ability to inject network level (L3/L4)
-:ref:`filters <arch_overview_network_filters>`. The filters apply to the
-connection to the upstream hosts, using the same API presented by listeners for
+filters. It should be noted that network fitler needs to
+be registered in code as an upstream filter before usage. Currently
+there are no upstream filters available in envoy out of the box.
+The filters apply to the connection to the upstream hosts, using the same API presented by listeners for
 the downstream connections. The write callbacks are invoked for any chunk of
 data sent to the upstream host, and the read callbacks are invoked for data
 received from the upstream host.

--- a/docs/root/intro/arch_overview/upstream/upstream_filters.rst
+++ b/docs/root/intro/arch_overview/upstream/upstream_filters.rst
@@ -4,10 +4,10 @@ Upstream network filters
 ========================
 
 Upstream clusters provide an ability to inject network level (L3/L4)
-filters. It should be noted that network filter needs to
-be registered in code as an upstream filter before usage. Currently
-there are no upstream filters available in envoy out of the box.
+filters. It should be noted that a network filter needs to
+be registered in code as an upstream filter before usage. Currently,
+there are no upstream filters available in Envoy out of the box.
 The filters apply to the connection to the upstream hosts, using the same API presented by listeners for
-the downstream connections. The write callbacks are invoked for any chunk of
-data sent to the upstream host, and the read callbacks are invoked for data
+the downstream connections. The write-callbacks are invoked for any chunk of
+data sent to the upstream host, and the read-callbacks are invoked for data
 received from the upstream host.

--- a/docs/root/intro/arch_overview/upstream/upstream_filters.rst
+++ b/docs/root/intro/arch_overview/upstream/upstream_filters.rst
@@ -4,7 +4,7 @@ Upstream network filters
 ========================
 
 Upstream clusters provide an ability to inject network level (L3/L4)
-filters. It should be noted that network fitler needs to
+filters. It should be noted that network filter needs to
 be registered in code as an upstream filter before usage. Currently
 there are no upstream filters available in envoy out of the box.
 The filters apply to the connection to the upstream hosts, using the same API presented by listeners for


### PR DESCRIPTION
Signed-off-by: Tsimafei Bredau <timofei.bredov@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: update upstream network filters description to reflect availability of upstream filters
Additional Description: made documentation more clear on what upstream filters are currently available and removed a link to a list of network level filters, to avoid confusion
Risk Level: Low
Testing: ran a format checker with git push hook
Docs Changes: in description of upstream filters made more clear that no upstream filters are available in current version of envoy according to #11015 and #10525 
Release Notes: N/A
Fixes #11015
