### PR TITLE
Fix close_connections_on_host_health_failure

### DIFF
--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -180,6 +180,13 @@ public:
   virtual void drainConnections() PURE;
 
   /**
+   * Immediately close all existing connection pool connections. This method can be used in cases
+   * where the connection pool is not being destroyed, but the caller wishes to terminate all
+   * existing connections. For example, when a health check failure occurs.
+   */
+  virtual void closeConnections() PURE;
+
+  /**
    * Create a new connection on the pool.
    * @param cb supplies the callbacks to invoke when the connection is ready or has failed. The
    *           callbacks may be invoked immediately within the context of this call if there is a

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -53,6 +53,20 @@ void ConnPoolImpl::drainConnections() {
   }
 }
 
+void ConnPoolImpl::closeConnections() {
+  while (!ready_conns_.empty()) {
+    ready_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
+  }
+
+  while (!busy_conns_.empty()) {
+    busy_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
+  }
+
+  while (!pending_conns_.empty()) {
+    pending_conns_.front()->conn_->close(Network::ConnectionCloseType::NoFlush);
+  }
+}
+
 void ConnPoolImpl::addDrainedCallback(DrainedCb cb) {
   drained_callbacks_.push_back(cb);
   checkForDrained();

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -30,6 +30,7 @@ public:
   // ConnectionPool::Instance
   void addDrainedCallback(DrainedCb cb) override;
   void drainConnections() override;
+  void closeConnections() override;
   ConnectionPool::Cancellable* newConnection(ConnectionPool::Callbacks& callbacks) override;
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1157,7 +1157,12 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::onHostHealthFailure(
     if (container != config.host_tcp_conn_pool_map_.end()) {
       for (const auto& pair : container->second.pools_) {
         const Tcp::ConnectionPool::InstancePtr& pool = pair.second;
-        pool->drainConnections();
+        if (host->cluster().features() &
+            ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE) {
+          pool->closeConnections();
+        } else {
+          pool->drainConnections();
+        }
       }
     }
   }

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -406,15 +406,19 @@ TEST_P(TcpProxyIntegrationTest, TestNoCloseOnHealthFailure) {
       cluster->mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(1);
       cluster->mutable_health_checks(0)->mutable_healthy_threshold()->set_value(1);
       cluster->mutable_health_checks(0)->mutable_tcp_health_check();
-      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text("50696E67");;
-      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text("506F6E67");
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text(
+          "50696E67");
+      ;
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text(
+          "506F6E67");
     }
   });
 
   FakeRawConnectionPtr fake_upstream_health_connection;
   on_server_init_function_ = [&](void) -> void {
     ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_health_connection));
-    ASSERT_TRUE(fake_upstream_health_connection->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
+    ASSERT_TRUE(fake_upstream_health_connection->waitForData(
+        FakeRawConnection::waitForInexactMatch("Ping")));
     ASSERT_TRUE(fake_upstream_health_connection->write("Pong"));
   };
 
@@ -433,10 +437,12 @@ TEST_P(TcpProxyIntegrationTest, TestNoCloseOnHealthFailure) {
   ASSERT_TRUE(fake_upstream_health_connection->close());
   ASSERT_TRUE(fake_upstream_health_connection->waitForDisconnect(true));
 
-  // By waiting we know the previous health check attempt completed (with a failure since we closed the connection on it)
+  // By waiting we know the previous health check attempt completed (with a failure since we closed
+  // the connection on it)
   FakeRawConnectionPtr fake_upstream_health_connection_reconnect;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_health_connection_reconnect));
-  ASSERT_TRUE(fake_upstream_health_connection_reconnect->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
+  ASSERT_TRUE(fake_upstream_health_connection_reconnect->waitForData(
+      FakeRawConnection::waitForInexactMatch("Ping")));
 
   tcp_client->write("still");
   ASSERT_TRUE(fake_upstream_connection->waitForData(15));
@@ -470,8 +476,11 @@ TEST_P(TcpProxyIntegrationTest, TestCloseOnHealthFailure) {
       cluster->mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(1);
       cluster->mutable_health_checks(0)->mutable_healthy_threshold()->set_value(1);
       cluster->mutable_health_checks(0)->mutable_tcp_health_check();
-      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text("50696E67");;
-      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text("506F6E67");
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text(
+          "50696E67");
+      ;
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text(
+          "506F6E67");
     }
   });
 

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -390,6 +390,122 @@ TEST_P(TcpProxyIntegrationTest, TestIdletimeoutWithLargeOutstandingData) {
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect(true));
 }
 
+TEST_P(TcpProxyIntegrationTest, TestNoCloseOnHealthFailure) {
+  concurrency_ = 2;
+
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* static_resources = bootstrap.mutable_static_resources();
+    for (int i = 0; i < static_resources->clusters_size(); ++i) {
+      auto* cluster = static_resources->mutable_clusters(i);
+      cluster->set_close_connections_on_host_health_failure(false);
+      cluster->mutable_common_lb_config()->mutable_healthy_panic_threshold()->set_value(0);
+      cluster->add_health_checks()->mutable_timeout()->set_seconds(20);
+      cluster->mutable_health_checks(0)->mutable_reuse_connection()->set_value(true);
+      cluster->mutable_health_checks(0)->mutable_interval()->set_seconds(1);
+      cluster->mutable_health_checks(0)->mutable_no_traffic_interval()->set_seconds(1);
+      cluster->mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(1);
+      cluster->mutable_health_checks(0)->mutable_healthy_threshold()->set_value(1);
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check();
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text("50696E67");;
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text("506F6E67");
+    }
+  });
+
+  FakeRawConnectionPtr fake_upstream_health_connection;
+  on_server_init_function_ = [&](void) -> void {
+    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_health_connection));
+    ASSERT_TRUE(fake_upstream_health_connection->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
+    ASSERT_TRUE(fake_upstream_health_connection->write("Pong"));
+  };
+
+  initialize();
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
+  tcp_client->write("hello");
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+  ASSERT_TRUE(fake_upstream_connection->write("world"));
+  tcp_client->waitForData("world");
+  tcp_client->write("hello");
+  ASSERT_TRUE(fake_upstream_connection->waitForData(10));
+
+  ASSERT_TRUE(fake_upstream_health_connection->waitForData(8));
+  ASSERT_TRUE(fake_upstream_health_connection->close());
+  ASSERT_TRUE(fake_upstream_health_connection->waitForDisconnect(true));
+
+  // By waiting we know the previous health check attempt completed (with a failure since we closed the connection on it)
+  FakeRawConnectionPtr fake_upstream_health_connection_reconnect;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_health_connection_reconnect));
+  ASSERT_TRUE(fake_upstream_health_connection_reconnect->waitForData(FakeRawConnection::waitForInexactMatch("Ping")));
+
+  tcp_client->write("still");
+  ASSERT_TRUE(fake_upstream_connection->waitForData(15));
+  ASSERT_TRUE(fake_upstream_connection->write("here"));
+  tcp_client->waitForData("here", false);
+
+  test_server_.reset();
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
+  ASSERT_TRUE(fake_upstream_connection->close());
+  ASSERT_TRUE(fake_upstream_connection->waitForDisconnect(true));
+  ASSERT_TRUE(fake_upstream_health_connection_reconnect->waitForHalfClose());
+  ASSERT_TRUE(fake_upstream_health_connection_reconnect->close());
+  ASSERT_TRUE(fake_upstream_health_connection_reconnect->waitForDisconnect(true));
+  tcp_client->waitForHalfClose();
+  tcp_client->close();
+}
+
+TEST_P(TcpProxyIntegrationTest, TestCloseOnHealthFailure) {
+  concurrency_ = 2;
+
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* static_resources = bootstrap.mutable_static_resources();
+    for (int i = 0; i < static_resources->clusters_size(); ++i) {
+      auto* cluster = static_resources->mutable_clusters(i);
+      cluster->set_close_connections_on_host_health_failure(true);
+      cluster->mutable_common_lb_config()->mutable_healthy_panic_threshold()->set_value(0);
+      cluster->add_health_checks()->mutable_timeout()->set_seconds(20);
+      cluster->mutable_health_checks(0)->mutable_reuse_connection()->set_value(true);
+      cluster->mutable_health_checks(0)->mutable_interval()->set_seconds(1);
+      cluster->mutable_health_checks(0)->mutable_no_traffic_interval()->set_seconds(1);
+      cluster->mutable_health_checks(0)->mutable_unhealthy_threshold()->set_value(1);
+      cluster->mutable_health_checks(0)->mutable_healthy_threshold()->set_value(1);
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check();
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text("50696E67");;
+      cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text("506F6E67");
+    }
+  });
+
+  FakeRawConnectionPtr fake_upstream_health_connection;
+  on_server_init_function_ = [&](void) -> void {
+    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_health_connection));
+    ASSERT_TRUE(fake_upstream_health_connection->waitForData(4));
+    ASSERT_TRUE(fake_upstream_health_connection->write("Pong"));
+  };
+
+  initialize();
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
+  tcp_client->write("hello");
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+  ASSERT_TRUE(fake_upstream_connection->write("world"));
+  tcp_client->waitForData("world");
+  tcp_client->write("hello");
+  ASSERT_TRUE(fake_upstream_connection->waitForData(10));
+
+  ASSERT_TRUE(fake_upstream_health_connection->waitForData(8));
+  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+  ASSERT_TRUE(fake_upstream_health_connection->close());
+  ASSERT_TRUE(fake_upstream_health_connection->waitForDisconnect(true));
+
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
+  tcp_client->waitForHalfClose();
+
+  ASSERT_TRUE(fake_upstream_connection->close());
+  tcp_client->close();
+  ASSERT_TRUE(fake_upstream_connection->waitForDisconnect(true));
+}
+
 class TcpProxyMetadataMatchIntegrationTest : public TcpProxyIntegrationTest {
 public:
   void initialize() override;

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -408,7 +408,6 @@ TEST_P(TcpProxyIntegrationTest, TestNoCloseOnHealthFailure) {
       cluster->mutable_health_checks(0)->mutable_tcp_health_check();
       cluster->mutable_health_checks(0)->mutable_tcp_health_check()->mutable_send()->set_text(
           "50696E67");
-      ;
       cluster->mutable_health_checks(0)->mutable_tcp_health_check()->add_receive()->set_text(
           "506F6E67");
     }

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -62,6 +62,7 @@ public:
   // Tcp::ConnectionPool::Instance
   MOCK_METHOD(void, addDrainedCallback, (DrainedCb cb));
   MOCK_METHOD(void, drainConnections, ());
+  MOCK_METHOD(void, closeConnections, ());
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
 


### PR DESCRIPTION
close_connections_on_host_health_failure was disabled by the refactoring to
make tcp_proxy use the TCP connection pool implementation.

To fix it we:
* Add a method to immediately close all active connections on a TCP conn pool.
* Invoke this method instead of drainConnections() if close_connections_on_host_health_failure is set.

Additional Notes:
The breakage was introduced in the release immediately after the flag was introduced. It has been broken for some time (since v1.8). This fix may present some risk to users who currently have the flag enabled even though it doesn't work as documented, as the observed behaviour will change.

Risk Level: Low
Testing: Manual
Docs Changes: None
