### PR TITLE
test: Fix missing instantiation of parameterized tests.

### DIFF
--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -89,6 +89,9 @@ protected:
   std::string random_string_;
   std::vector<const char*> argv_;
 };
+INSTANTIATE_TEST_SUITE_P(IpVersions, MainCommonTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 
 // Exercise the codepath to instantiate MainCommon and destruct it, with hot restart.
 TEST_P(MainCommonTest, ConstructDestructHotRestartEnabled) {
@@ -119,6 +122,9 @@ TEST_P(MainCommonTest, ConstructDestructHotRestartDisabledNoInit) {
 //   of 0x10000000000 (thread T0)
 
 class MainCommonDeathTest : public MainCommonTest {};
+INSTANTIATE_TEST_SUITE_P(IpVersions, MainCommonDeathTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 
 TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
 #if defined(__has_feature) && (__has_feature(thread_sanitizer) || __has_feature(address_sanitizer))
@@ -146,10 +152,6 @@ TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
       ".*panic: out of memory.*");
 #endif
 }
-
-INSTANTIATE_TEST_SUITE_P(IpVersions, MainCommonTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
 
 class AdminRequestTest : public MainCommonTest {
 protected:
@@ -242,6 +244,9 @@ protected:
   bool pause_before_run_{false};
   bool pause_after_run_{false};
 };
+INSTANTIATE_TEST_SUITE_P(IpVersions, AdminRequestTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 
 TEST_P(AdminRequestTest, AdminRequestGetStatsAndQuit) {
   startEnvoy();
@@ -404,9 +409,5 @@ TEST_P(MainCommonTest, ConstructDestructLogger) {
   spdlog::details::log_msg log_msg(logger_name, spdlog::level::level_enum::err, "error");
   Logger::Registry::getSink()->log(log_msg);
 }
-
-INSTANTIATE_TEST_SUITE_P(IpVersions, AdminRequestTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
 
 } // namespace Envoy

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -146,7 +146,9 @@ TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
         for (uint64_t size = initial;
              size >= initial; // Disallow wraparound to avoid infinite loops on failure.
              size *= 1000) {
-          new int[size];
+          int* p = new int[size];
+          // Use the pointer to prevent clang from optimizing the allocation away in opt mode.
+          ENVOY_LOG_MISC(debug, "p={}", reinterpret_cast<intptr_t>(p));
         }
       }(),
       ".*panic: out of memory.*");

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -915,7 +915,7 @@ TEST_F(HttpFilterTest, FilterEnabled) {
 // -------------------
 
 // Test that context extensions make it into the check request.
-TEST_F(HttpFilterTestParam, ContextExtensions) {
+TEST_P(HttpFilterTestParam, ContextExtensions) {
   // Place something in the context extensions on the virtualhost.
   envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute settingsvhost;
   (*settingsvhost.mutable_check_settings()->mutable_context_extensions())["key_vhost"] =
@@ -957,7 +957,7 @@ TEST_F(HttpFilterTestParam, ContextExtensions) {
 }
 
 // Test that filter can be disabled with route config.
-TEST_F(HttpFilterTestParam, DisabledOnRoute) {
+TEST_P(HttpFilterTestParam, DisabledOnRoute) {
   envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute settings;
   FilterConfigPerRoute auth_per_route(settings);
 
@@ -990,7 +990,7 @@ TEST_F(HttpFilterTestParam, DisabledOnRoute) {
 }
 
 // Test that filter can be disabled with route config.
-TEST_F(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
+TEST_P(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
   envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute settings;
   FilterConfigPerRoute auth_per_route(settings);
 
@@ -1036,7 +1036,7 @@ TEST_F(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
 }
 
 // Test that the request continues when the filter_callbacks has no route.
-TEST_F(HttpFilterTestParam, NoRoute) {
+TEST_P(HttpFilterTestParam, NoRoute) {
   EXPECT_CALL(*filter_callbacks_.route_, routeEntry()).WillOnce(Return(nullptr));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -1044,7 +1044,7 @@ TEST_F(HttpFilterTestParam, NoRoute) {
 }
 
 // Test that the request is stopped till there is an OK response back after which it continues on.
-TEST_F(HttpFilterTestParam, OkResponse) {
+TEST_P(HttpFilterTestParam, OkResponse) {
   InSequence s;
 
   prepareCheck();
@@ -1075,7 +1075,7 @@ TEST_F(HttpFilterTestParam, OkResponse) {
 
 // Test that an synchronous OK response from the authorization service, on the call stack, results
 // in request continuing on.
-TEST_F(HttpFilterTestParam, ImmediateOkResponse) {
+TEST_P(HttpFilterTestParam, ImmediateOkResponse) {
   InSequence s;
 
   prepareCheck();
@@ -1099,7 +1099,7 @@ TEST_F(HttpFilterTestParam, ImmediateOkResponse) {
 
 // Test that an synchronous denied response from the authorization service passing additional HTTP
 // attributes to the downstream.
-TEST_F(HttpFilterTestParam, ImmediateDeniedResponseWithHttpAttributes) {
+TEST_P(HttpFilterTestParam, ImmediateDeniedResponseWithHttpAttributes) {
   InSequence s;
 
   prepareCheck();
@@ -1130,7 +1130,7 @@ TEST_F(HttpFilterTestParam, ImmediateDeniedResponseWithHttpAttributes) {
 
 // Test that an synchronous ok response from the authorization service passing additional HTTP
 // attributes to the upstream.
-TEST_F(HttpFilterTestParam, ImmediateOkResponseWithHttpAttributes) {
+TEST_P(HttpFilterTestParam, ImmediateOkResponseWithHttpAttributes) {
   InSequence s;
 
   // `bar` will be appended to this header.
@@ -1170,7 +1170,7 @@ TEST_F(HttpFilterTestParam, ImmediateOkResponseWithHttpAttributes) {
 
 // Test that an synchronous denied response from the authorization service, on the call stack,
 // results in request not continuing.
-TEST_F(HttpFilterTestParam, ImmediateDeniedResponse) {
+TEST_P(HttpFilterTestParam, ImmediateDeniedResponse) {
   InSequence s;
 
   prepareCheck();
@@ -1194,7 +1194,7 @@ TEST_F(HttpFilterTestParam, ImmediateDeniedResponse) {
 }
 
 // Test that a denied response results in the connection closing with a 401 response to the client.
-TEST_F(HttpFilterTestParam, DeniedResponseWith401) {
+TEST_P(HttpFilterTestParam, DeniedResponseWith401) {
   InSequence s;
 
   prepareCheck();
@@ -1226,7 +1226,7 @@ TEST_F(HttpFilterTestParam, DeniedResponseWith401) {
 }
 
 // Test that a denied response results in the connection closing with a 403 response to the client.
-TEST_F(HttpFilterTestParam, DeniedResponseWith403) {
+TEST_P(HttpFilterTestParam, DeniedResponseWith403) {
   InSequence s;
 
   prepareCheck();
@@ -1261,7 +1261,7 @@ TEST_F(HttpFilterTestParam, DeniedResponseWith403) {
 }
 
 // Verify that authz response memory is not used after free.
-TEST_F(HttpFilterTestParam, DestroyResponseBeforeSendLocalReply) {
+TEST_P(HttpFilterTestParam, DestroyResponseBeforeSendLocalReply) {
   InSequence s;
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1315,7 +1315,7 @@ TEST_F(HttpFilterTestParam, DestroyResponseBeforeSendLocalReply) {
 // Verify that authz denied response headers overrides the existing encoding headers,
 // and that it adds repeated header names using the standard method of comma concatenation of values
 // for predefined inline headers while repeating other headers
-TEST_F(HttpFilterTestParam, OverrideEncodingHeaders) {
+TEST_P(HttpFilterTestParam, OverrideEncodingHeaders) {
   InSequence s;
 
   Filters::Common::ExtAuthz::Response response{};
@@ -1385,7 +1385,7 @@ TEST_F(HttpFilterTestParam, OverrideEncodingHeaders) {
 
 // Test that when a connection awaiting a authorization response is canceled then the
 // authorization call is closed.
-TEST_F(HttpFilterTestParam, ResetDuringCall) {
+TEST_P(HttpFilterTestParam, ResetDuringCall) {
   InSequence s;
 
   prepareCheck();
@@ -1403,7 +1403,7 @@ TEST_F(HttpFilterTestParam, ResetDuringCall) {
 // Regression test for https://github.com/envoyproxy/envoy/pull/8436.
 // Test that ext_authz filter is not in noop mode when cluster is not specified per route
 // (this could be the case when route is configured with redirect or direct response action).
-TEST_F(HttpFilterTestParam, NoCluster) {
+TEST_P(HttpFilterTestParam, NoCluster) {
 
   ON_CALL(filter_callbacks_, clusterInfo()).WillByDefault(Return(nullptr));
 

--- a/test/extensions/filters/http/grpc_web/BUILD
+++ b/test/extensions/filters/http/grpc_web/BUILD
@@ -42,6 +42,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",
+        "//source/extensions/filters/http/grpc_web:config",
         "//source/extensions/filters/http/grpc_web:grpc_web_filter_lib",
         "//test/integration:http_integration_lib",
         "//test/mocks/upstream:upstream_mocks",

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_integration_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_integration_test.cc
@@ -20,6 +20,9 @@ public:
     config_helper_.addFilter("name: envoy.filters.http.grpc_web");
   }
 };
+INSTANTIATE_TEST_SUITE_P(IpVersions, GrpcWebFilterIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
 
 TEST_P(GrpcWebFilterIntegrationTest, GRPCWebTrailersNotDuplicated) {
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());


### PR DESCRIPTION
Commit Message: test: Fix missing instantiation of parameterized tests.
Additional Description: gtest silently skips parameterized that have no INSTANTIATE_TEST_SUITE_P associated with them as described at https://github.com/google/googletest/pull/2683 .  Thanks @yurykats for pointing me at these failing tests.  Also, filed #11246 for redis tests that are not running for this same reason.
Risk Level: n/a
Testing: test-only changes
Docs Changes: n/a
Release Notes: n/a