### PR TITLE
ci: fix go api mirror script when no changes

### DIFF
--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -116,9 +116,9 @@ if __name__ == "__main__":
   cloneGoProtobufs(repo)
   last_sha = findLastSyncSHA(repo)
   changes = updatedSinceSHA(repo, last_sha)
-  new_sha = changes[0]
   if changes:
     print('Changes detected: %s' % changes)
+    new_sha = changes[0]
     syncGoProtobufs(output, repo)
     writeRevisionInfo(repo, new_sha)
     publishGoProtobufs(repo, new_sha)


### PR DESCRIPTION
Signed-off-by: Daniel Hochman <danielhochman@users.noreply.github.com>

Commit Message: fix go api mirror script when no changes
Additional Description:
CI fails when there are no API changes with:
```
Traceback (most recent call last):
  File "tools/api/generate_go_protobuf.py", line 119, in <module>
    new_sha = changes[0]
IndexError: list index out of range
```
(broke in #11220)

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
