### PR TITLE
admin: extract more handlers to separate classes 

### DIFF
--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -19,6 +19,7 @@ envoy_cc_library(
         ":logs_handler_lib",
         ":profiling_handler_lib",
         ":runtime_handler_lib",
+        ":server_cmd_handler_lib",
         ":stats_handler_lib",
         ":utils_lib",
         "//include/envoy/filesystem:filesystem_interface",
@@ -188,6 +189,22 @@ envoy_cc_library(
         "//source/common/http:codes_lib",
         "//source/common/http:header_map_lib",
         "//source/common/profiler:profiler_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "server_cmd_handler_lib",
+    srcs = ["server_cmd_handler.cc"],
+    hdrs = ["server_cmd_handler.h"],
+    deps = [
+        ":handler_ctx_lib",
+        ":utils_lib",
+        "//include/envoy/http:codes_interface",
+        "//include/envoy/server:admin_interface",
+        "//include/envoy/server:instance_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
     ],
 )
 

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         ":profiling_handler_lib",
         ":runtime_handler_lib",
         ":server_cmd_handler_lib",
+        ":server_info_handler_lib",
         ":stats_handler_lib",
         ":utils_lib",
         "//include/envoy/filesystem:filesystem_interface",
@@ -45,7 +46,6 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:mutex_tracer_lib",
         "//source/common/common:utility_lib",
-        "//source/common/common:version_includes",
         "//source/common/html:utility_lib",
         "//source/common/http:codes_lib",
         "//source/common/http:conn_manager_lib",
@@ -55,7 +55,6 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/http:request_id_extension_lib",
         "//source/common/http:utility_lib",
-        "//source/common/memory:stats_lib",
         "//source/common/memory:utils_lib",
         "//source/common/network:connection_balancer_lib",
         "//source/common/network:listen_socket_lib",
@@ -205,6 +204,25 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/http:codes_lib",
         "//source/common/http:header_map_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "server_info_handler_lib",
+    srcs = ["server_info_handler.cc"],
+    hdrs = ["server_info_handler.h"],
+    deps = [
+        ":handler_ctx_lib",
+        ":utils_lib",
+        "//include/envoy/http:codes_interface",
+        "//include/envoy/server:admin_interface",
+        "//include/envoy/server:instance_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:version_includes",
+        "//source/common/http:codes_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/memory:stats_lib",
+        "@envoy_api//envoy/admin/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -112,6 +112,7 @@ envoy_cc_library(
         "//source/common/http:codes_lib",
         "//source/common/http:header_map_lib",
         "//source/common/stats:histogram_lib",
+        "@envoy_api//envoy/admin/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -11,7 +11,6 @@
 #include "envoy/admin/v3/certs.pb.h"
 #include "envoy/admin/v3/clusters.pb.h"
 #include "envoy/admin/v3/config_dump.pb.h"
-#include "envoy/admin/v3/memory.pb.h"
 #include "envoy/admin/v3/metrics.pb.h"
 #include "envoy/admin/v3/mutex_stats.pb.h"
 #include "envoy/admin/v3/server_info.pb.h"
@@ -31,13 +30,11 @@
 #include "common/common/fmt.h"
 #include "common/common/mutex_tracer_impl.h"
 #include "common/common/utility.h"
-#include "common/common/version.h"
 #include "common/html/utility.h"
 #include "common/http/codes.h"
 #include "common/http/conn_manager_utility.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
-#include "common/memory/stats.h"
 #include "common/memory/utils.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/network/utility.h"
@@ -555,85 +552,6 @@ Http::Code AdminImpl::handlerContention(absl::string_view,
   return Http::Code::OK;
 }
 
-Http::Code AdminImpl::handlerHotRestartVersion(absl::string_view, Http::ResponseHeaderMap&,
-                                               Buffer::Instance& response, AdminStream&) {
-  response.add(server_.hotRestart().version());
-  return Http::Code::OK;
-}
-
-// TODO(ambuc): Add more tcmalloc stats, export proto details based on allocator.
-Http::Code AdminImpl::handlerMemory(absl::string_view, Http::ResponseHeaderMap& response_headers,
-                                    Buffer::Instance& response, AdminStream&) {
-  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
-  envoy::admin::v3::Memory memory;
-  memory.set_allocated(Memory::Stats::totalCurrentlyAllocated());
-  memory.set_heap_size(Memory::Stats::totalCurrentlyReserved());
-  memory.set_total_thread_cache(Memory::Stats::totalThreadCacheBytes());
-  memory.set_pageheap_unmapped(Memory::Stats::totalPageHeapUnmapped());
-  memory.set_pageheap_free(Memory::Stats::totalPageHeapFree());
-  memory.set_total_physical_bytes(Memory::Stats::totalPhysicalBytes());
-  response.add(MessageUtil::getJsonStringFromMessage(memory, true, true)); // pretty-print
-  return Http::Code::OK;
-}
-
-Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::ResponseHeaderMap& headers,
-                                        Buffer::Instance& response, AdminStream&) {
-  const std::time_t current_time =
-      std::chrono::system_clock::to_time_t(server_.timeSource().systemTime());
-  const std::time_t uptime_current_epoch = current_time - server_.startTimeCurrentEpoch();
-  const std::time_t uptime_all_epochs = current_time - server_.startTimeFirstEpoch();
-
-  ASSERT(uptime_current_epoch >= 0);
-  ASSERT(uptime_all_epochs >= 0);
-
-  envoy::admin::v3::ServerInfo server_info;
-  server_info.set_version(VersionInfo::version());
-  server_info.set_hot_restart_version(server_.hotRestart().version());
-  server_info.set_state(
-      Utility::serverState(server_.initManager().state(), server_.healthCheckFailed()));
-
-  server_info.mutable_uptime_current_epoch()->set_seconds(uptime_current_epoch);
-  server_info.mutable_uptime_all_epochs()->set_seconds(uptime_all_epochs);
-  envoy::admin::v3::CommandLineOptions* command_line_options =
-      server_info.mutable_command_line_options();
-  *command_line_options = *server_.options().toCommandLineOptions();
-  response.add(MessageUtil::getJsonStringFromMessage(server_info, true, true));
-  headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
-  return Http::Code::OK;
-}
-
-Http::Code AdminImpl::handlerReady(absl::string_view, Http::ResponseHeaderMap&,
-                                   Buffer::Instance& response, AdminStream&) {
-  const envoy::admin::v3::ServerInfo::State state =
-      Utility::serverState(server_.initManager().state(), server_.healthCheckFailed());
-
-  response.add(envoy::admin::v3::ServerInfo::State_Name(state) + "\n");
-  Http::Code code =
-      state == envoy::admin::v3::ServerInfo::LIVE ? Http::Code::OK : Http::Code::ServiceUnavailable;
-  return code;
-}
-
-Http::Code AdminImpl::handlerCerts(absl::string_view, Http::ResponseHeaderMap& response_headers,
-                                   Buffer::Instance& response, AdminStream&) {
-  // This set is used to track distinct certificates. We may have multiple listeners, upstreams, etc
-  // using the same cert.
-  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
-  envoy::admin::v3::Certificates certificates;
-  server_.sslContextManager().iterateContexts([&](const Ssl::Context& context) -> void {
-    envoy::admin::v3::Certificate& certificate = *certificates.add_certificates();
-    if (context.getCaCertInformation() != nullptr) {
-      envoy::admin::v3::CertificateDetails* ca_certificate = certificate.add_ca_cert();
-      *ca_certificate = *context.getCaCertInformation();
-    }
-    for (const auto& cert_details : context.getCertChainInformation()) {
-      envoy::admin::v3::CertificateDetails* cert_chain = certificate.add_cert_chain();
-      *cert_chain = *cert_details;
-    }
-  });
-  response.add(MessageUtil::getJsonStringFromMessage(certificates, true, true));
-  return Http::Code::OK;
-}
-
 ConfigTracker& AdminImpl::getConfigTracker() { return config_tracker_; }
 
 AdminImpl::NullRouteConfigProvider::NullRouteConfigProvider(TimeSource& time_source)
@@ -673,11 +591,12 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
       route_config_provider_(server.timeSource()),
       scoped_route_config_provider_(server.timeSource()), stats_handler_(server),
       logs_handler_(server), profiling_handler_(profile_path), runtime_handler_(server),
-      listeners_handler_(server), server_cmd_handler_(server),
+      listeners_handler_(server), server_cmd_handler_(server), server_info_handler_(server),
       // TODO(jsedgwick) add /runtime_reset endpoint that removes all admin-set values
       handlers_{
           {"/", "Admin home page", MAKE_ADMIN_HANDLER(handlerAdminHome), false, false},
-          {"/certs", "print certs on machine", MAKE_ADMIN_HANDLER(handlerCerts), false, false},
+          {"/certs", "print certs on machine",
+           MAKE_ADMIN_HANDLER(server_info_handler_.handlerCerts), false, false},
           {"/clusters", "upstream cluster status", MAKE_ADMIN_HANDLER(handlerClusters), false,
            false},
           {"/config_dump", "dump current Envoy configs (experimental)",
@@ -695,11 +614,11 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
           {"/help", "print out list of admin commands", MAKE_ADMIN_HANDLER(handlerHelp), false,
            false},
           {"/hot_restart_version", "print the hot restart compatibility version",
-           MAKE_ADMIN_HANDLER(handlerHotRestartVersion), false, false},
+           MAKE_ADMIN_HANDLER(server_info_handler_.handlerHotRestartVersion), false, false},
           {"/logging", "query/change logging levels",
            MAKE_ADMIN_HANDLER(logs_handler_.handlerLogging), false, true},
-          {"/memory", "print current allocation/heap usage", MAKE_ADMIN_HANDLER(handlerMemory),
-           false, false},
+          {"/memory", "print current allocation/heap usage",
+           MAKE_ADMIN_HANDLER(server_info_handler_.handlerMemory), false, false},
           {"/quitquitquit", "exit the server",
            MAKE_ADMIN_HANDLER(server_cmd_handler_.handlerQuitQuitQuit), false, true},
           {"/reset_counters", "reset all counters to zero",
@@ -707,9 +626,9 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
           {"/drain_listeners", "drain listeners",
            MAKE_ADMIN_HANDLER(listeners_handler_.handlerDrainListeners), false, true},
           {"/server_info", "print server version/status information",
-           MAKE_ADMIN_HANDLER(handlerServerInfo), false, false},
+           MAKE_ADMIN_HANDLER(server_info_handler_.handlerServerInfo), false, false},
           {"/ready", "print server state, return 200 if LIVE, otherwise return 503",
-           MAKE_ADMIN_HANDLER(handlerReady), false, false},
+           MAKE_ADMIN_HANDLER(server_info_handler_.handlerReady), false, false},
           {"/stats", "print server stats", MAKE_ADMIN_HANDLER(stats_handler_.handlerStats), false,
            false},
           {"/stats/prometheus", "print server stats in prometheus format",

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -282,9 +282,6 @@ private:
   Http::Code handlerConfigDump(absl::string_view path_and_query,
                                Http::ResponseHeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&) const;
-  Http::Code handlerContention(absl::string_view path_and_query,
-                               Http::ResponseHeaderMap& response_headers,
-                               Buffer::Instance& response, AdminStream&);
   Http::Code handlerHelp(absl::string_view path_and_query,
                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                          AdminStream&);

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -45,6 +45,7 @@
 #include "server/admin/profiling_handler.h"
 #include "server/admin/runtime_handler.h"
 #include "server/admin/server_cmd_handler.h"
+#include "server/admin/server_info_handler.h"
 #include "server/admin/stats_handler.h"
 
 #include "extensions/filters/http/common/pass_through_filter.h"
@@ -275,9 +276,6 @@ private:
   Http::Code handlerAdminHome(absl::string_view path_and_query,
                               Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                               AdminStream&);
-  Http::Code handlerCerts(absl::string_view path_and_query,
-                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
-                          AdminStream&);
   Http::Code handlerClusters(absl::string_view path_and_query,
                              Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                              AdminStream&);
@@ -290,19 +288,6 @@ private:
   Http::Code handlerHelp(absl::string_view path_and_query,
                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                          AdminStream&);
-  Http::Code handlerHotRestartVersion(absl::string_view path_and_query,
-                                      Http::ResponseHeaderMap& response_headers,
-                                      Buffer::Instance& response, AdminStream&);
-  Http::Code handlerMemory(absl::string_view path_and_query,
-                           Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
-                           AdminStream&);
-  Http::Code handlerMain(const std::string& path, Buffer::Instance& response, AdminStream&);
-  Http::Code handlerServerInfo(absl::string_view path_and_query,
-                               Http::ResponseHeaderMap& response_headers,
-                               Buffer::Instance& response, AdminStream&);
-  Http::Code handlerReady(absl::string_view path_and_query,
-                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
-                          AdminStream&);
 
   class AdminListenSocketFactory : public Network::ListenSocketFactory {
   public:
@@ -408,6 +393,7 @@ private:
   Server::RuntimeHandler runtime_handler_;
   Server::ListenersHandler listeners_handler_;
   Server::ServerCmdHandler server_cmd_handler_;
+  Server::ServerInfoHandler server_info_handler_;
   std::list<UrlHandler> handlers_;
   const uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   const uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -44,6 +44,7 @@
 #include "server/admin/logs_handler.h"
 #include "server/admin/profiling_handler.h"
 #include "server/admin/runtime_handler.h"
+#include "server/admin/server_cmd_handler.h"
 #include "server/admin/stats_handler.h"
 
 #include "extensions/filters/http/common/pass_through_filter.h"
@@ -286,18 +287,6 @@ private:
   Http::Code handlerContention(absl::string_view path_and_query,
                                Http::ResponseHeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&);
-  Http::Code handlerCpuProfiler(absl::string_view path_and_query,
-                                Http::ResponseHeaderMap& response_headers,
-                                Buffer::Instance& response, AdminStream&);
-  Http::Code handlerHeapProfiler(absl::string_view path_and_query,
-                                 Http::ResponseHeaderMap& response_headers,
-                                 Buffer::Instance& response, AdminStream&);
-  Http::Code handlerHealthcheckFail(absl::string_view path_and_query,
-                                    Http::ResponseHeaderMap& response_headers,
-                                    Buffer::Instance& response, AdminStream&);
-  Http::Code handlerHealthcheckOk(absl::string_view path_and_query,
-                                  Http::ResponseHeaderMap& response_headers,
-                                  Buffer::Instance& response, AdminStream&);
   Http::Code handlerHelp(absl::string_view path_and_query,
                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                          AdminStream&);
@@ -308,9 +297,6 @@ private:
                            Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                            AdminStream&);
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response, AdminStream&);
-  Http::Code handlerQuitQuitQuit(absl::string_view path_and_query,
-                                 Http::ResponseHeaderMap& response_headers,
-                                 Buffer::Instance& response, AdminStream&);
   Http::Code handlerServerInfo(absl::string_view path_and_query,
                                Http::ResponseHeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&);
@@ -421,6 +407,7 @@ private:
   Server::ProfilingHandler profiling_handler_;
   Server::RuntimeHandler runtime_handler_;
   Server::ListenersHandler listeners_handler_;
+  Server::ServerCmdHandler server_cmd_handler_;
   std::list<UrlHandler> handlers_;
   const uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
   const uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};

--- a/source/server/admin/server_cmd_handler.cc
+++ b/source/server/admin/server_cmd_handler.cc
@@ -1,0 +1,30 @@
+#include "server/admin/server_cmd_handler.h"
+
+namespace Envoy {
+namespace Server {
+
+ServerCmdHandler::ServerCmdHandler(Server::Instance& server) : HandlerContextBase(server) {}
+
+Http::Code ServerCmdHandler::handlerHealthcheckFail(absl::string_view, Http::ResponseHeaderMap&,
+                                                    Buffer::Instance& response, AdminStream&) {
+  server_.failHealthcheck(true);
+  response.add("OK\n");
+  return Http::Code::OK;
+}
+
+Http::Code ServerCmdHandler::handlerHealthcheckOk(absl::string_view, Http::ResponseHeaderMap&,
+                                                  Buffer::Instance& response, AdminStream&) {
+  server_.failHealthcheck(false);
+  response.add("OK\n");
+  return Http::Code::OK;
+}
+
+Http::Code ServerCmdHandler::handlerQuitQuitQuit(absl::string_view, Http::ResponseHeaderMap&,
+                                                 Buffer::Instance& response, AdminStream&) {
+  server_.shutdown();
+  response.add("OK\n");
+  return Http::Code::OK;
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/admin/server_cmd_handler.h
+++ b/source/server/admin/server_cmd_handler.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/http/codes.h"
+#include "envoy/http/header_map.h"
+#include "envoy/server/admin.h"
+#include "envoy/server/instance.h"
+
+#include "server/admin/handler_ctx.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Server {
+
+class ServerCmdHandler : public HandlerContextBase {
+
+public:
+  ServerCmdHandler(Server::Instance& server);
+
+  Http::Code handlerQuitQuitQuit(absl::string_view path_and_query,
+                                 Http::ResponseHeaderMap& response_headers,
+                                 Buffer::Instance& response, AdminStream&);
+
+  Http::Code handlerHealthcheckFail(absl::string_view path_and_query,
+                                    Http::ResponseHeaderMap& response_headers,
+                                    Buffer::Instance& response, AdminStream&);
+
+  Http::Code handlerHealthcheckOk(absl::string_view path_and_query,
+                                  Http::ResponseHeaderMap& response_headers,
+                                  Buffer::Instance& response, AdminStream&);
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/admin/server_info_handler.cc
+++ b/source/server/admin/server_info_handler.cc
@@ -1,0 +1,97 @@
+#include "server/admin/server_info_handler.h"
+
+#include "envoy/admin/v3/memory.pb.h"
+
+#include "common/common/version.h"
+#include "common/memory/stats.h"
+
+#include "server/admin/utils.h"
+
+namespace Envoy {
+namespace Server {
+
+ServerInfoHandler::ServerInfoHandler(Server::Instance& server) : HandlerContextBase(server) {}
+
+Http::Code ServerInfoHandler::handlerCerts(absl::string_view,
+                                           Http::ResponseHeaderMap& response_headers,
+                                           Buffer::Instance& response, AdminStream&) {
+  // This set is used to track distinct certificates. We may have multiple listeners, upstreams, etc
+  // using the same cert.
+  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
+  envoy::admin::v3::Certificates certificates;
+  server_.sslContextManager().iterateContexts([&](const Ssl::Context& context) -> void {
+    envoy::admin::v3::Certificate& certificate = *certificates.add_certificates();
+    if (context.getCaCertInformation() != nullptr) {
+      envoy::admin::v3::CertificateDetails* ca_certificate = certificate.add_ca_cert();
+      *ca_certificate = *context.getCaCertInformation();
+    }
+    for (const auto& cert_details : context.getCertChainInformation()) {
+      envoy::admin::v3::CertificateDetails* cert_chain = certificate.add_cert_chain();
+      *cert_chain = *cert_details;
+    }
+  });
+  response.add(MessageUtil::getJsonStringFromMessage(certificates, true, true));
+  return Http::Code::OK;
+}
+
+Http::Code ServerInfoHandler::handlerHotRestartVersion(absl::string_view, Http::ResponseHeaderMap&,
+                                                       Buffer::Instance& response, AdminStream&) {
+  response.add(server_.hotRestart().version());
+  return Http::Code::OK;
+}
+
+// TODO(ambuc): Add more tcmalloc stats, export proto details based on allocator.
+Http::Code ServerInfoHandler::handlerMemory(absl::string_view,
+                                            Http::ResponseHeaderMap& response_headers,
+                                            Buffer::Instance& response, AdminStream&) {
+  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
+  envoy::admin::v3::Memory memory;
+  memory.set_allocated(Memory::Stats::totalCurrentlyAllocated());
+  memory.set_heap_size(Memory::Stats::totalCurrentlyReserved());
+  memory.set_total_thread_cache(Memory::Stats::totalThreadCacheBytes());
+  memory.set_pageheap_unmapped(Memory::Stats::totalPageHeapUnmapped());
+  memory.set_pageheap_free(Memory::Stats::totalPageHeapFree());
+  memory.set_total_physical_bytes(Memory::Stats::totalPhysicalBytes());
+  response.add(MessageUtil::getJsonStringFromMessage(memory, true, true)); // pretty-print
+  return Http::Code::OK;
+}
+
+Http::Code ServerInfoHandler::handlerReady(absl::string_view, Http::ResponseHeaderMap&,
+                                           Buffer::Instance& response, AdminStream&) {
+  const envoy::admin::v3::ServerInfo::State state =
+      Utility::serverState(server_.initManager().state(), server_.healthCheckFailed());
+
+  response.add(envoy::admin::v3::ServerInfo::State_Name(state) + "\n");
+  Http::Code code =
+      state == envoy::admin::v3::ServerInfo::LIVE ? Http::Code::OK : Http::Code::ServiceUnavailable;
+  return code;
+}
+
+Http::Code ServerInfoHandler::handlerServerInfo(absl::string_view, Http::ResponseHeaderMap& headers,
+                                                Buffer::Instance& response, AdminStream&) {
+  const std::time_t current_time =
+      std::chrono::system_clock::to_time_t(server_.timeSource().systemTime());
+  const std::time_t uptime_current_epoch = current_time - server_.startTimeCurrentEpoch();
+  const std::time_t uptime_all_epochs = current_time - server_.startTimeFirstEpoch();
+
+  ASSERT(uptime_current_epoch >= 0);
+  ASSERT(uptime_all_epochs >= 0);
+
+  envoy::admin::v3::ServerInfo server_info;
+  server_info.set_version(VersionInfo::version());
+  server_info.set_hot_restart_version(server_.hotRestart().version());
+  server_info.set_state(
+      Utility::serverState(server_.initManager().state(), server_.healthCheckFailed()));
+
+  server_info.mutable_uptime_current_epoch()->set_seconds(uptime_current_epoch);
+  server_info.mutable_uptime_all_epochs()->set_seconds(uptime_all_epochs);
+  envoy::admin::v3::CommandLineOptions* command_line_options =
+      server_info.mutable_command_line_options();
+  *command_line_options = *server_.options().toCommandLineOptions();
+  response.add(MessageUtil::getJsonStringFromMessage(server_info, true, true));
+  headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
+  return Http::Code::OK;
+}
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/admin/server_info_handler.h
+++ b/source/server/admin/server_info_handler.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/http/codes.h"
+#include "envoy/http/header_map.h"
+#include "envoy/server/admin.h"
+#include "envoy/server/instance.h"
+
+#include "server/admin/handler_ctx.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Server {
+
+class ServerInfoHandler : public HandlerContextBase {
+
+public:
+  ServerInfoHandler(Server::Instance& server);
+
+  Http::Code handlerCerts(absl::string_view path_and_query,
+                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                          AdminStream&);
+
+  Http::Code handlerServerInfo(absl::string_view path_and_query,
+                               Http::ResponseHeaderMap& response_headers,
+                               Buffer::Instance& response, AdminStream&);
+
+  Http::Code handlerReady(absl::string_view path_and_query,
+                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                          AdminStream&);
+
+  Http::Code handlerHotRestartVersion(absl::string_view path_and_query,
+                                      Http::ResponseHeaderMap& response_headers,
+                                      Buffer::Instance& response, AdminStream&);
+
+  Http::Code handlerMemory(absl::string_view path_and_query,
+                           Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
+                           AdminStream&);
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/admin/stats_handler.h
+++ b/source/server/admin/stats_handler.h
@@ -44,6 +44,9 @@ public:
   Http::Code handlerPrometheusStats(absl::string_view path_and_query,
                                     Http::ResponseHeaderMap& response_headers,
                                     Buffer::Instance& response, AdminStream&);
+  Http::Code handlerContention(absl::string_view path_and_query,
+                               Http::ResponseHeaderMap& response_headers,
+                               Buffer::Instance& response, AdminStream&);
 
 private:
   template <class StatType>

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -35,7 +35,6 @@ envoy_cc_test(
         "//source/common/protobuf:utility_lib",
         "//source/common/stats:symbol_table_creator_lib",
         "//source/common/stats:thread_local_store_lib",
-        "//source/extensions/transport_sockets/tls:context_config_lib",
         "//source/server/admin:admin_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_mocks",
@@ -101,6 +100,17 @@ envoy_cc_test(
     deps = [
         ":admin_instance_lib",
         "//test/test_common:logging_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "server_info_handler_test",
+    srcs = ["server_info_handler_test.cc"],
+    deps = [
+        ":admin_instance_lib",
+        "//source/extensions/transport_sockets/tls:context_config_lib",
+        "//test/test_common:logging_lib",
+        "@envoy_api//envoy/admin/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -5,7 +5,6 @@
 
 #include "envoy/admin/v3/clusters.pb.h"
 #include "envoy/admin/v3/config_dump.pb.h"
-#include "envoy/admin/v3/memory.pb.h"
 #include "envoy/admin/v3/server_info.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
@@ -17,8 +16,6 @@
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
 
-#include "extensions/transport_sockets/tls/context_config_impl.h"
-
 #include "test/server/admin/admin_instance.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
@@ -29,11 +26,9 @@
 #include "gtest/gtest.h"
 
 using testing::AllOf;
-using testing::Ge;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::NiceMock;
-using testing::Property;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnPointee;
@@ -385,49 +380,6 @@ TEST_P(AdminInstanceTest, ConfigDumpResourceNotRepeated) {
             getCallback("/config_dump?resource=version_info", header_map, response));
 }
 
-TEST_P(AdminInstanceTest, Memory) {
-  Http::ResponseHeaderMapImpl header_map;
-  Buffer::OwnedImpl response;
-  EXPECT_EQ(Http::Code::OK, getCallback("/memory", header_map, response));
-  const std::string output_json = response.toString();
-  envoy::admin::v3::Memory output_proto;
-  TestUtility::loadFromJson(output_json, output_proto);
-  EXPECT_THAT(output_proto, AllOf(Property(&envoy::admin::v3::Memory::allocated, Ge(0)),
-                                  Property(&envoy::admin::v3::Memory::heap_size, Ge(0)),
-                                  Property(&envoy::admin::v3::Memory::pageheap_unmapped, Ge(0)),
-                                  Property(&envoy::admin::v3::Memory::pageheap_free, Ge(0)),
-                                  Property(&envoy::admin::v3::Memory::total_thread_cache, Ge(0))));
-}
-
-TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
-  Http::ResponseHeaderMapImpl header_map;
-  Buffer::OwnedImpl response;
-
-  // Setup a context that returns null cert details.
-  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
-  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext config;
-  Extensions::TransportSockets::Tls::ClientContextConfigImpl cfg(config, factory_context);
-  Stats::IsolatedStoreImpl store;
-  Envoy::Ssl::ClientContextSharedPtr client_ctx(
-      server_.sslContextManager().createSslClientContext(store, cfg));
-
-  const std::string expected_empty_json = R"EOF({
- "certificates": [
-  {
-   "ca_cert": [],
-   "cert_chain": []
-  }
- ]
-}
-)EOF";
-
-  // Validate that cert details are null and /certs handles it correctly.
-  EXPECT_EQ(nullptr, client_ctx->getCaCertInformation());
-  EXPECT_TRUE(client_ctx->getCertChainInformation().empty());
-  EXPECT_EQ(Http::Code::OK, getCallback("/certs", header_map, response));
-  EXPECT_EQ(expected_empty_json, response.toString());
-}
-
 TEST_P(AdminInstanceTest, ClustersJson) {
   Upstream::ClusterManager::ClusterInfoMap cluster_map;
   ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_map));
@@ -631,120 +583,6 @@ fake_cluster::1.2.3.4:80::success_rate::43.2
 fake_cluster::1.2.3.4:80::local_origin_success_rate::93.2
 )EOF";
   EXPECT_EQ(expected_text, response2.toString());
-}
-
-TEST_P(AdminInstanceTest, GetRequest) {
-  EXPECT_CALL(server_.options_, toCommandLineOptions()).WillRepeatedly(Invoke([] {
-    Server::CommandLineOptionsPtr command_line_options =
-        std::make_unique<envoy::admin::v3::CommandLineOptions>();
-    command_line_options->set_restart_epoch(2);
-    command_line_options->set_service_cluster("cluster");
-    return command_line_options;
-  }));
-  NiceMock<Init::MockManager> initManager;
-  ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
-  ON_CALL(server_.hot_restart_, version()).WillByDefault(Return("foo_version"));
-
-  {
-    Http::ResponseHeaderMapImpl response_headers;
-    std::string body;
-
-    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
-    EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
-    envoy::admin::v3::ServerInfo server_info_proto;
-    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-                HasSubstr("application/json"));
-
-    // We only test that it parses as the proto and that some fields are correct, since
-    // values such as timestamps + Envoy version are tricky to test for.
-    TestUtility::loadFromJson(body, server_info_proto);
-    EXPECT_EQ(server_info_proto.state(), envoy::admin::v3::ServerInfo::LIVE);
-    EXPECT_EQ(server_info_proto.hot_restart_version(), "foo_version");
-    EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
-    EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
-  }
-
-  {
-    Http::ResponseHeaderMapImpl response_headers;
-    std::string body;
-
-    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Uninitialized));
-    EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
-    envoy::admin::v3::ServerInfo server_info_proto;
-    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-                HasSubstr("application/json"));
-
-    // We only test that it parses as the proto and that some fields are correct, since
-    // values such as timestamps + Envoy version are tricky to test for.
-    TestUtility::loadFromJson(body, server_info_proto);
-    EXPECT_EQ(server_info_proto.state(), envoy::admin::v3::ServerInfo::PRE_INITIALIZING);
-    EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
-    EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
-  }
-
-  Http::ResponseHeaderMapImpl response_headers;
-  std::string body;
-
-  ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
-  EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
-  envoy::admin::v3::ServerInfo server_info_proto;
-  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-              HasSubstr("application/json"));
-
-  // We only test that it parses as the proto and that some fields are correct, since
-  // values such as timestamps + Envoy version are tricky to test for.
-  TestUtility::loadFromJson(body, server_info_proto);
-  EXPECT_EQ(server_info_proto.state(), envoy::admin::v3::ServerInfo::INITIALIZING);
-  EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
-  EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
-}
-
-TEST_P(AdminInstanceTest, GetReadyRequest) {
-  NiceMock<Init::MockManager> initManager;
-  ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
-
-  {
-    Http::ResponseHeaderMapImpl response_headers;
-    std::string body;
-
-    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
-    EXPECT_EQ(Http::Code::OK, admin_.request("/ready", "GET", response_headers, body));
-    EXPECT_EQ(body, "LIVE\n");
-    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-                HasSubstr("text/plain"));
-  }
-
-  {
-    Http::ResponseHeaderMapImpl response_headers;
-    std::string body;
-
-    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Uninitialized));
-    EXPECT_EQ(Http::Code::ServiceUnavailable,
-              admin_.request("/ready", "GET", response_headers, body));
-    EXPECT_EQ(body, "PRE_INITIALIZING\n");
-    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-                HasSubstr("text/plain"));
-  }
-
-  Http::ResponseHeaderMapImpl response_headers;
-  std::string body;
-
-  ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
-  EXPECT_EQ(Http::Code::ServiceUnavailable,
-            admin_.request("/ready", "GET", response_headers, body));
-  EXPECT_EQ(body, "INITIALIZING\n");
-  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-              HasSubstr("text/plain"));
-}
-
-TEST_P(AdminInstanceTest, PostRequest) {
-  Http::ResponseHeaderMapImpl response_headers;
-  std::string body;
-  EXPECT_NO_LOGS(EXPECT_EQ(Http::Code::OK,
-                           admin_.request("/healthcheck/fail", "POST", response_headers, body)));
-  EXPECT_EQ(body, "OK\n");
-  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
-              HasSubstr("text/plain"));
 }
 
 } // namespace Server

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -25,11 +25,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::AllOf;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::NiceMock;
-using testing::Ref;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;

--- a/test/server/admin/server_info_handler_test.cc
+++ b/test/server/admin/server_info_handler_test.cc
@@ -1,0 +1,178 @@
+#include "envoy/admin/v3/memory.pb.h"
+
+#include "extensions/transport_sockets/tls/context_config_impl.h"
+
+#include "test/server/admin/admin_instance.h"
+#include "test/test_common/logging.h"
+
+using testing::Ge;
+using testing::HasSubstr;
+using testing::Property;
+using testing::Return;
+
+namespace Envoy {
+namespace Server {
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
+  Http::ResponseHeaderMapImpl header_map;
+  Buffer::OwnedImpl response;
+
+  // Setup a context that returns null cert details.
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext config;
+  Extensions::TransportSockets::Tls::ClientContextConfigImpl cfg(config, factory_context);
+  Stats::IsolatedStoreImpl store;
+  Envoy::Ssl::ClientContextSharedPtr client_ctx(
+      server_.sslContextManager().createSslClientContext(store, cfg));
+
+  const std::string expected_empty_json = R"EOF({
+ "certificates": [
+  {
+   "ca_cert": [],
+   "cert_chain": []
+  }
+ ]
+}
+)EOF";
+
+  // Validate that cert details are null and /certs handles it correctly.
+  EXPECT_EQ(nullptr, client_ctx->getCaCertInformation());
+  EXPECT_TRUE(client_ctx->getCertChainInformation().empty());
+  EXPECT_EQ(Http::Code::OK, getCallback("/certs", header_map, response));
+  EXPECT_EQ(expected_empty_json, response.toString());
+}
+
+TEST_P(AdminInstanceTest, Memory) {
+  Http::ResponseHeaderMapImpl header_map;
+  Buffer::OwnedImpl response;
+  EXPECT_EQ(Http::Code::OK, getCallback("/memory", header_map, response));
+  const std::string output_json = response.toString();
+  envoy::admin::v3::Memory output_proto;
+  TestUtility::loadFromJson(output_json, output_proto);
+  EXPECT_THAT(output_proto, AllOf(Property(&envoy::admin::v3::Memory::allocated, Ge(0)),
+                                  Property(&envoy::admin::v3::Memory::heap_size, Ge(0)),
+                                  Property(&envoy::admin::v3::Memory::pageheap_unmapped, Ge(0)),
+                                  Property(&envoy::admin::v3::Memory::pageheap_free, Ge(0)),
+                                  Property(&envoy::admin::v3::Memory::total_thread_cache, Ge(0))));
+}
+
+TEST_P(AdminInstanceTest, GetReadyRequest) {
+  NiceMock<Init::MockManager> initManager;
+  ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
+
+  {
+    Http::ResponseHeaderMapImpl response_headers;
+    std::string body;
+
+    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
+    EXPECT_EQ(Http::Code::OK, admin_.request("/ready", "GET", response_headers, body));
+    EXPECT_EQ(body, "LIVE\n");
+    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+                HasSubstr("text/plain"));
+  }
+
+  {
+    Http::ResponseHeaderMapImpl response_headers;
+    std::string body;
+
+    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Uninitialized));
+    EXPECT_EQ(Http::Code::ServiceUnavailable,
+              admin_.request("/ready", "GET", response_headers, body));
+    EXPECT_EQ(body, "PRE_INITIALIZING\n");
+    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+                HasSubstr("text/plain"));
+  }
+
+  Http::ResponseHeaderMapImpl response_headers;
+  std::string body;
+
+  ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
+  EXPECT_EQ(Http::Code::ServiceUnavailable,
+            admin_.request("/ready", "GET", response_headers, body));
+  EXPECT_EQ(body, "INITIALIZING\n");
+  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+              HasSubstr("text/plain"));
+}
+
+TEST_P(AdminInstanceTest, GetRequest) {
+  EXPECT_CALL(server_.options_, toCommandLineOptions()).WillRepeatedly(Invoke([] {
+    Server::CommandLineOptionsPtr command_line_options =
+        std::make_unique<envoy::admin::v3::CommandLineOptions>();
+    command_line_options->set_restart_epoch(2);
+    command_line_options->set_service_cluster("cluster");
+    return command_line_options;
+  }));
+  NiceMock<Init::MockManager> initManager;
+  ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
+  ON_CALL(server_.hot_restart_, version()).WillByDefault(Return("foo_version"));
+
+  {
+    Http::ResponseHeaderMapImpl response_headers;
+    std::string body;
+
+    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
+    EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
+    envoy::admin::v3::ServerInfo server_info_proto;
+    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+                HasSubstr("application/json"));
+
+    // We only test that it parses as the proto and that some fields are correct, since
+    // values such as timestamps + Envoy version are tricky to test for.
+    TestUtility::loadFromJson(body, server_info_proto);
+    EXPECT_EQ(server_info_proto.state(), envoy::admin::v3::ServerInfo::LIVE);
+    EXPECT_EQ(server_info_proto.hot_restart_version(), "foo_version");
+    EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
+    EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
+  }
+
+  {
+    Http::ResponseHeaderMapImpl response_headers;
+    std::string body;
+
+    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Uninitialized));
+    EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
+    envoy::admin::v3::ServerInfo server_info_proto;
+    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+                HasSubstr("application/json"));
+
+    // We only test that it parses as the proto and that some fields are correct, since
+    // values such as timestamps + Envoy version are tricky to test for.
+    TestUtility::loadFromJson(body, server_info_proto);
+    EXPECT_EQ(server_info_proto.state(), envoy::admin::v3::ServerInfo::PRE_INITIALIZING);
+    EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
+    EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
+  }
+
+  Http::ResponseHeaderMapImpl response_headers;
+  std::string body;
+
+  ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
+  EXPECT_EQ(Http::Code::OK, admin_.request("/server_info", "GET", response_headers, body));
+  envoy::admin::v3::ServerInfo server_info_proto;
+  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+              HasSubstr("application/json"));
+
+  // We only test that it parses as the proto and that some fields are correct, since
+  // values such as timestamps + Envoy version are tricky to test for.
+  TestUtility::loadFromJson(body, server_info_proto);
+  EXPECT_EQ(server_info_proto.state(), envoy::admin::v3::ServerInfo::INITIALIZING);
+  EXPECT_EQ(server_info_proto.command_line_options().restart_epoch(), 2);
+  EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
+}
+
+TEST_P(AdminInstanceTest, PostRequest) {
+  Http::ResponseHeaderMapImpl response_headers;
+  std::string body;
+  EXPECT_NO_LOGS(EXPECT_EQ(Http::Code::OK,
+                           admin_.request("/healthcheck/fail", "POST", response_headers, body)));
+  EXPECT_EQ(body, "OK\n");
+  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+              HasSubstr("text/plain"));
+}
+
+} // namespace Server
+} // namespace Envoy


### PR DESCRIPTION
Description: more refactoring for #5505. In this specific PR:
- extract server command handlers to newly created `ServerCmdHandler` class
- extract server info handlers to newly created `ServerInfoHandler` class
- extract mutex stats handler to `StatsHandler` class 

Risk Level: low
Testing: pre-existing tests
Docs Changes: n/a
Release Notes: n/a
