### PR TITLE
test: shorten delay close time from 1s to 100ns

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -128,6 +128,8 @@ std::string ConfigHelper::httpProxyConfig() {
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test
+          delayed_close_timeout:
+            nanos: 100
           http_filters:
             name: envoy.filters.http.router
           codec_type: HTTP1

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -308,6 +308,7 @@ tap_config:
 
   admin_client_->close();
   EXPECT_EQ(3UL, test_server_->counter("http.config_test.tap.rq_tapped")->value());
+  test_server_->waitForGaugeEq("http.admin.downstream_rq_active", 0);
 }
 
 // Verify both request and response trailer matching works.

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -970,6 +970,9 @@ TEST_P(IntegrationTest, ViaAppendWith100Continue) {
 // sent by Envoy, it will wait for response acknowledgment (via FIN/RST) from the client before
 // closing the socket (with a timeout for ensuring cleanup).
 TEST_P(IntegrationTest, TestDelayedConnectionTeardownOnGracefulClose) {
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.mutable_delayed_close_timeout()->set_seconds(1); });
   // This test will trigger an early 413 Payload Too Large response due to buffer limits being
   // exceeded. The following filter is needed since the router filter will never trigger a 413.
   config_helper_.addFilter("{ name: encoder-decoder-buffer-filter, typed_config: { \"@type\": "
@@ -1213,6 +1216,9 @@ TEST_P(IntegrationTest, TestFlood) {
 }
 
 TEST_P(IntegrationTest, TestFloodUpstreamErrors) {
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.mutable_delayed_close_timeout()->set_seconds(1); });
   autonomous_upstream_ = true;
   initialize();
 


### PR DESCRIPTION
This saves us 1s wait on dozens of tests where we wait for the client connection to close.

Risk Level: n/a (test only)
Testing: tweaked delay close tests to reinstate regular timeout
Docs Changes: n/a
Release Notes: n/a
