### PR TITLE
http: adding a new accessor

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -385,7 +385,13 @@ private:
   virtual void setReference##name(absl::string_view value) PURE;                                   \
   virtual void set##name(absl::string_view value) PURE;                                            \
   virtual void set##name(uint64_t value) PURE;                                                     \
-  virtual size_t remove##name() PURE;
+  virtual size_t remove##name() PURE;                                                              \
+  absl::string_view get##name##Value() const {                                                     \
+    if (name() != nullptr) {                                                                       \
+      return name()->value().getStringView();                                                      \
+    }                                                                                              \
+    return "";                                                                                     \
+  }
 
 /**
  * Wraps a set of HTTP headers.

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -132,7 +132,7 @@ void AsyncStreamImpl::encodeTrailers(ResponseTrailerMapPtr&& trailers) {
 }
 
 void AsyncStreamImpl::sendHeaders(RequestHeaderMap& headers, bool end_stream) {
-  if (Http::Headers::get().MethodValues.Head == headers.Method()->value().getStringView()) {
+  if (Http::Headers::get().MethodValues.Head == headers.getMethodValue()) {
     is_head_request_ = true;
   }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -781,8 +781,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
     state_.saw_connection_close_ =
         HeaderUtility::shouldCloseConnection(protocol, *request_headers_);
   }
-  if (request_headers_->Method() && Http::Headers::get().MethodValues.Head ==
-                                        request_headers_->Method()->value().getStringView()) {
+  if (Http::Headers::get().MethodValues.Head == request_headers_->getMethodValue()) {
     state_.is_head_request_ = true;
   }
 
@@ -857,8 +856,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
       // HTTP/1.0 defaults to single-use connections. Make sure the connection
       // will be closed unless Keep-Alive is present.
       state_.saw_connection_close_ = true;
-      if (request_headers_->Connection() &&
-          absl::EqualsIgnoreCase(request_headers_->Connection()->value().getStringView(),
+      if (absl::EqualsIgnoreCase(request_headers_->getConnectionValue(),
                                  Http::Headers::get().ConnectionValues.KeepAlive)) {
         state_.saw_connection_close_ = false;
       }
@@ -886,7 +884,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   // have broken the path into pieces if applicable. NOTE: Currently the HTTP/1.1 codec only does
   // this when the allow_absolute_url flag is enabled on the HCM.
   if ((!HeaderUtility::isConnect(*request_headers_) && !request_headers_->Path()) ||
-      (request_headers_->Path() && request_headers_->Path()->value().getStringView().empty())) {
+      (request_headers_->Path() && request_headers_->getPathValue().empty())) {
     sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::NotFound, "", nullptr,
                    state_.is_head_request_, absl::nullopt,
                    StreamInfo::ResponseCodeDetails::get().MissingPath);
@@ -894,7 +892,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   }
 
   // Currently we only support relative paths at the application layer.
-  if (request_headers_->Path() && request_headers_->Path()->value().getStringView()[0] != '/') {
+  if (!request_headers_->getPathValue().empty() && request_headers_->getPathValue()[0] != '/') {
     connection_manager_.stats_.named_.downstream_rq_non_relative_path_.inc();
     sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::NotFound, "", nullptr,
                    state_.is_head_request_, absl::nullopt,
@@ -914,8 +912,8 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   ConnectionManagerUtility::maybeNormalizeHost(*request_headers_, connection_manager_.config_,
                                                localPort());
 
-  if (!fixed_connection_close && protocol == Protocol::Http11 && request_headers_->Connection() &&
-      absl::EqualsIgnoreCase(request_headers_->Connection()->value().getStringView(),
+  if (!fixed_connection_close && protocol == Protocol::Http11 &&
+      absl::EqualsIgnoreCase(request_headers_->getConnectionValue(),
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
@@ -923,8 +921,7 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   // since it is supported by http-parser the underlying parser for http
   // requests.
   if (!fixed_connection_close && protocol < Protocol::Http2 && !state_.saw_connection_close_ &&
-      request_headers_->ProxyConnection() &&
-      absl::EqualsIgnoreCase(request_headers_->ProxyConnection()->value().getStringView(),
+      absl::EqualsIgnoreCase(request_headers_->getProxyConnectionValue(),
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
@@ -1492,8 +1489,7 @@ void ConnectionManagerImpl::ActiveStream::requestRouteConfigUpdate(
     Event::Dispatcher& thread_local_dispatcher,
     Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) {
   ASSERT(!request_headers_->Host()->value().empty());
-  const auto& host_header =
-      absl::AsciiStrToLower(request_headers_->Host()->value().getStringView());
+  const auto& host_header = absl::AsciiStrToLower(request_headers_->getHostValue());
   route_config_update_requester_->requestRouteConfigUpdate(host_header, thread_local_dispatcher,
                                                            std::move(route_config_updated_cb));
 }

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -182,13 +182,12 @@ bool HeaderUtility::isEnvoyInternalRequest(const RequestHeaderMap& headers) {
 
 void HeaderUtility::stripPortFromHost(RequestHeaderMap& headers, uint32_t listener_port) {
 
-  if (headers.Method() &&
-      headers.Method()->value().getStringView() == Http::Headers::get().MethodValues.Connect) {
+  if (headers.getMethodValue() == Http::Headers::get().MethodValues.Connect) {
     // According to RFC 2817 Connect method should have port part in host header.
     // In this case we won't strip it even if configured to do so.
     return;
   }
-  const auto original_host = headers.Host()->value().getStringView();
+  const absl::string_view original_host = headers.getHostValue();
   const absl::string_view::size_type port_start = original_host.rfind(':');
   if (port_start == absl::string_view::npos) {
     return;

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -635,15 +635,14 @@ int ConnectionImpl::onHeadersCompleteBase() {
     // Ignore h2c upgrade requests until we support them.
     // See https://github.com/envoyproxy/envoy/issues/7161 for details.
     if (request_or_response_headers.Upgrade() &&
-        absl::EqualsIgnoreCase(request_or_response_headers.Upgrade()->value().getStringView(),
+        absl::EqualsIgnoreCase(request_or_response_headers.getUpgradeValue(),
                                Http::Headers::get().UpgradeValues.H2c)) {
       ENVOY_CONN_LOG(trace, "removing unsupported h2c upgrade headers.", connection_);
       request_or_response_headers.removeUpgrade();
       if (request_or_response_headers.Connection()) {
         const auto& tokens_to_remove = caseUnorderdSetContainingUpgradeAndHttp2Settings();
         std::string new_value = StringUtil::removeTokens(
-            request_or_response_headers.Connection()->value().getStringView(), ",",
-            tokens_to_remove, ",");
+            request_or_response_headers.getConnectionValue(), ",", tokens_to_remove, ",");
         if (new_value.empty()) {
           request_or_response_headers.removeConnection();
         } else {
@@ -664,8 +663,7 @@ int ConnectionImpl::onHeadersCompleteBase() {
   // Per https://tools.ietf.org/html/rfc7230#section-3.3.1 Envoy should reject
   // transfer-codings it does not understand.
   if (request_or_response_headers.TransferEncoding()) {
-    const absl::string_view encoding =
-        request_or_response_headers.TransferEncoding()->value().getStringView();
+    const absl::string_view encoding = request_or_response_headers.getTransferEncodingValue();
     if (reject_unsupported_transfer_encodings_ &&
         !absl::EqualsIgnoreCase(encoding, Headers::get().TransferEncodingValues.Chunked)) {
       error_code_ = Http::Code::NotImplemented;
@@ -829,7 +827,7 @@ int ServerConnectionImpl::onHeadersComplete() {
     if (!handling_upgrade_ && connection_header_sanitization_ && headers->Connection()) {
       // If we fail to sanitize the request, return a 400 to the client
       if (!Utility::sanitizeConnectionHeader(*headers)) {
-        absl::string_view header_value = headers->Connection()->value().getStringView();
+        absl::string_view header_value = headers->getConnectionValue();
         ENVOY_CONN_LOG(debug, "Invalid nominated headers in Connection: {}", connection_,
                        header_value);
         error_code_ = Http::Code::BadRequest;

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -634,8 +634,7 @@ int ConnectionImpl::onHeadersCompleteBase() {
   if (Utility::isUpgrade(request_or_response_headers) && upgradeAllowed()) {
     // Ignore h2c upgrade requests until we support them.
     // See https://github.com/envoyproxy/envoy/issues/7161 for details.
-    if (request_or_response_headers.Upgrade() &&
-        absl::EqualsIgnoreCase(request_or_response_headers.getUpgradeValue(),
+    if (absl::EqualsIgnoreCase(request_or_response_headers.getUpgradeValue(),
                                Http::Headers::get().UpgradeValues.H2c)) {
       ENVOY_CONN_LOG(trace, "removing unsupported h2c upgrade headers.", connection_);
       request_or_response_headers.removeUpgrade();

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -92,16 +92,13 @@ void ConnPoolImpl::StreamWrapper::decodeHeaders(ResponseHeaderMapPtr&& headers, 
     // If Connection: close OR
     //    Http/1.0 and not Connection: keep-alive OR
     //    Proxy-Connection: close
-    if ((headers->Connection() &&
-         (absl::EqualsIgnoreCase(headers->Connection()->value().getStringView(),
-                                 Headers::get().ConnectionValues.Close))) ||
+    if ((absl::EqualsIgnoreCase(headers->getConnectionValue(),
+                                Headers::get().ConnectionValues.Close)) ||
         (parent_.codec_client_->protocol() == Protocol::Http10 &&
-         (!headers->Connection() ||
-          !absl::EqualsIgnoreCase(headers->Connection()->value().getStringView(),
-                                  Headers::get().ConnectionValues.KeepAlive))) ||
-        (headers->ProxyConnection() &&
-         (absl::EqualsIgnoreCase(headers->ProxyConnection()->value().getStringView(),
-                                 Headers::get().ConnectionValues.Close)))) {
+         !absl::EqualsIgnoreCase(headers->getConnectionValue(),
+                                 Headers::get().ConnectionValues.KeepAlive)) ||
+        (absl::EqualsIgnoreCase(headers->getProxyConnectionValue(),
+                                Headers::get().ConnectionValues.Close))) {
       parent_.parent_.host_->cluster().stats().upstream_cx_close_notify_.inc();
       close_connection_ = true;
     }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -157,7 +157,7 @@ void ConnectionImpl::ClientStreamImpl::encodeHeaders(const RequestHeaderMap& hea
   Http::RequestHeaderMapPtr modified_headers;
   if (Http::Utility::isUpgrade(headers)) {
     modified_headers = createHeaderMap<RequestHeaderMapImpl>(headers);
-    upgrade_type_ = std::string(headers.Upgrade()->value().getStringView());
+    upgrade_type_ = std::string(headers.getUpgradeValue());
     Http::Utility::transformUpgradeRequestFromH1toH2(*modified_headers);
     buildHeaders(final_headers, *modified_headers);
   } else if (headers.Method() && headers.Method()->value() == "CONNECT") {

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -30,7 +30,7 @@ absl::optional<std::string> canonicalizePath(absl::string_view original_path) {
 /* static */
 bool PathUtil::canonicalPath(RequestHeaderMap& headers) {
   ASSERT(headers.Path());
-  const auto original_path = headers.Path()->value().getStringView();
+  const auto original_path = headers.getPathValue();
   // canonicalPath is supposed to apply on path component in URL instead of :path header
   const auto query_pos = original_path.find('?');
   auto normalized_path_opt = canonicalizePath(
@@ -56,7 +56,7 @@ bool PathUtil::canonicalPath(RequestHeaderMap& headers) {
 
 void PathUtil::mergeSlashes(RequestHeaderMap& headers) {
   ASSERT(headers.Path());
-  const auto original_path = headers.Path()->value().getStringView();
+  const auto original_path = headers.getPathValue();
   // Only operate on path component in URL.
   const absl::string_view::size_type query_start = original_path.find('?');
   const absl::string_view path = original_path.substr(0, query_start);

--- a/source/common/http/request_id_extension_uuid_impl.cc
+++ b/source/common/http/request_id_extension_uuid_impl.cc
@@ -27,7 +27,7 @@ void UUIDRequestIDExtension::set(RequestHeaderMap& request_headers, bool force) 
 void UUIDRequestIDExtension::setInResponse(ResponseHeaderMap& response_headers,
                                            const RequestHeaderMap& request_headers) {
   if (request_headers.RequestId()) {
-    response_headers.setRequestId(request_headers.RequestId()->value().getStringView());
+    response_headers.setRequestId(request_headers.getRequestIdValue());
   }
 }
 
@@ -36,7 +36,7 @@ bool UUIDRequestIDExtension::modBy(const RequestHeaderMap& request_headers, uint
   if (request_headers.RequestId() == nullptr) {
     return false;
   }
-  const std::string uuid(request_headers.RequestId()->value().getStringView());
+  const std::string uuid(request_headers.getRequestIdValue());
   if (uuid.length() < 8) {
     return false;
   }
@@ -54,7 +54,7 @@ TraceStatus UUIDRequestIDExtension::getTraceStatus(const RequestHeaderMap& reque
   if (request_headers.RequestId() == nullptr) {
     return TraceStatus::NoTrace;
   }
-  absl::string_view uuid = request_headers.RequestId()->value().getStringView();
+  absl::string_view uuid = request_headers.getRequestIdValue();
   if (uuid.length() != Runtime::RandomGeneratorImpl::UUID_LENGTH) {
     return TraceStatus::NoTrace;
   }
@@ -75,7 +75,7 @@ void UUIDRequestIDExtension::setTraceStatus(RequestHeaderMap& request_headers, T
   if (request_headers.RequestId() == nullptr) {
     return;
   }
-  absl::string_view uuid_view = request_headers.RequestId()->value().getStringView();
+  absl::string_view uuid_view = request_headers.getRequestIdValue();
   if (uuid_view.length() != Runtime::RandomGeneratorImpl::UUID_LENGTH) {
     return;
   }

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -50,11 +50,11 @@ void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, Stats::St
   if (stats_ == nullptr && !initialized_) {
     initialized_ = true;
 
-    const HeaderEntry* user_agent = headers.UserAgent();
-    if (user_agent != nullptr) {
-      if (user_agent->value().getStringView().find("iOS") != absl::string_view::npos) {
+    absl::string_view user_agent = headers.getUserAgentValue();
+    if (!user_agent.empty()) {
+      if (user_agent.find("iOS") != absl::string_view::npos) {
         stats_ = std::make_unique<UserAgentStats>(prefix, context_.ios_, scope, context_);
-      } else if (user_agent->value().getStringView().find("android") != absl::string_view::npos) {
+      } else if (user_agent.find("android") != absl::string_view::npos) {
         stats_ = std::make_unique<UserAgentStats>(prefix, context_.android_, scope, context_);
       }
     }

--- a/source/common/http/user_agent.cc
+++ b/source/common/http/user_agent.cc
@@ -50,7 +50,7 @@ void UserAgent::initializeFromHeaders(const RequestHeaderMap& headers, Stats::St
   if (stats_ == nullptr && !initialized_) {
     initialized_ = true;
 
-    absl::string_view user_agent = headers.getUserAgentValue();
+    const absl::string_view user_agent = headers.getUserAgentValue();
     if (!user_agent.empty()) {
       if (user_agent.find("iOS") != absl::string_view::npos) {
         stats_ = std::make_unique<UserAgentStats>(prefix, context_.ios_, scope, context_);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -393,7 +393,7 @@ uint64_t Utility::getResponseStatus(const ResponseHeaderMap& headers) {
 bool Utility::isUpgrade(const RequestOrResponseHeaderMap& headers) {
   // In firefox the "Connection" request header value is "keep-alive, Upgrade",
   // we should check if it contains the "Upgrade" token.
-  return (headers.Connection() && headers.Upgrade() &&
+  return (headers.Upgrade() &&
           Envoy::StringUtil::caseFindToken(headers.getConnectionValue(), ",",
                                            Http::Headers::get().ConnectionValues.Upgrade.c_str()));
 }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -261,8 +261,7 @@ void Utility::appendVia(RequestOrResponseHeaderMap& headers, const std::string& 
 std::string Utility::createSslRedirectPath(const RequestHeaderMap& headers) {
   ASSERT(headers.Host());
   ASSERT(headers.Path());
-  return fmt::format("https://{}{}", headers.Host()->value().getStringView(),
-                     headers.Path()->value().getStringView());
+  return fmt::format("https://{}{}", headers.getHostValue(), headers.getPathValue());
 }
 
 Utility::QueryParams Utility::parseQueryString(absl::string_view url) {
@@ -385,7 +384,7 @@ std::string Utility::makeSetCookieValue(const std::string& key, const std::strin
 uint64_t Utility::getResponseStatus(const ResponseHeaderMap& headers) {
   const HeaderEntry* header = headers.Status();
   uint64_t response_code;
-  if (!header || !absl::SimpleAtoi(headers.Status()->value().getStringView(), &response_code)) {
+  if (!header || !absl::SimpleAtoi(headers.getStatusValue(), &response_code)) {
     throw CodecClientException(":status must be specified and a valid unsigned long");
   }
   return response_code;
@@ -395,20 +394,19 @@ bool Utility::isUpgrade(const RequestOrResponseHeaderMap& headers) {
   // In firefox the "Connection" request header value is "keep-alive, Upgrade",
   // we should check if it contains the "Upgrade" token.
   return (headers.Connection() && headers.Upgrade() &&
-          Envoy::StringUtil::caseFindToken(headers.Connection()->value().getStringView(), ",",
+          Envoy::StringUtil::caseFindToken(headers.getConnectionValue(), ",",
                                            Http::Headers::get().ConnectionValues.Upgrade.c_str()));
 }
 
 bool Utility::isH2UpgradeRequest(const RequestHeaderMap& headers) {
-  return headers.Method() &&
-         headers.Method()->value().getStringView() == Http::Headers::get().MethodValues.Connect &&
+  return headers.getMethodValue() == Http::Headers::get().MethodValues.Connect &&
          headers.Protocol() && !headers.Protocol()->value().empty() &&
          headers.Protocol()->value() != Headers::get().ProtocolValues.Bytestream;
 }
 
 bool Utility::isWebSocketUpgradeRequest(const RequestHeaderMap& headers) {
   return (isUpgrade(headers) &&
-          absl::EqualsIgnoreCase(headers.Upgrade()->value().getStringView(),
+          absl::EqualsIgnoreCase(headers.getUpgradeValue(),
                                  Http::Headers::get().UpgradeValues.WebSocket));
 }
 
@@ -744,15 +742,13 @@ const std::string Utility::resetReasonToString(const Http::StreamResetReason res
 void Utility::transformUpgradeRequestFromH1toH2(RequestHeaderMap& headers) {
   ASSERT(Utility::isUpgrade(headers));
 
-  const HeaderString& upgrade = headers.Upgrade()->value();
   headers.setReferenceMethod(Http::Headers::get().MethodValues.Connect);
-  headers.setProtocol(upgrade.getStringView());
+  headers.setProtocol(headers.getUpgradeValue());
   headers.removeUpgrade();
   headers.removeConnection();
   // nghttp2 rejects upgrade requests/responses with content length, so strip
   // any unnecessary content length header.
-  if (headers.ContentLength() != nullptr &&
-      headers.ContentLength()->value().getStringView() == "0") {
+  if (headers.getContentLengthValue() == "0") {
     headers.removeContentLength();
   }
 }
@@ -763,8 +759,7 @@ void Utility::transformUpgradeResponseFromH1toH2(ResponseHeaderMap& headers) {
   }
   headers.removeUpgrade();
   headers.removeConnection();
-  if (headers.ContentLength() != nullptr &&
-      headers.ContentLength()->value().getStringView() == "0") {
+  if (headers.getContentLengthValue() == "0") {
     headers.removeContentLength();
   }
 }
@@ -772,9 +767,8 @@ void Utility::transformUpgradeResponseFromH1toH2(ResponseHeaderMap& headers) {
 void Utility::transformUpgradeRequestFromH2toH1(RequestHeaderMap& headers) {
   ASSERT(Utility::isH2UpgradeRequest(headers));
 
-  const HeaderString& protocol = headers.Protocol()->value();
   headers.setReferenceMethod(Http::Headers::get().MethodValues.Get);
-  headers.setUpgrade(protocol.getStringView());
+  headers.setUpgrade(headers.getProtocolValue());
   headers.setReferenceConnection(Http::Headers::get().ConnectionValues.Upgrade);
   headers.removeProtocol();
 }

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2940,7 +2940,7 @@ TEST_F(HttpConnectionManagerImplTest, Http10Rejected) {
   EXPECT_CALL(encoder, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ("426", headers.Status()->value().getStringView());
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
       }));
 
   Buffer::OwnedImpl fake_input("1234");
@@ -2967,7 +2967,7 @@ TEST_F(HttpConnectionManagerImplTest, Http10ConnCloseLegacy) {
 
   EXPECT_CALL(encoder, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
       }));
 
   Buffer::OwnedImpl fake_input("1234");
@@ -2992,7 +2992,7 @@ TEST_F(HttpConnectionManagerImplTest, ProxyConnectLegacyClose) {
 
   EXPECT_CALL(encoder, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
       }));
 
   Buffer::OwnedImpl fake_input("1234");
@@ -3017,7 +3017,7 @@ TEST_F(HttpConnectionManagerImplTest, ConnectLegacyClose) {
 
   EXPECT_CALL(encoder, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
       }));
 
   Buffer::OwnedImpl fake_input("1234");
@@ -3097,7 +3097,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
   EXPECT_CALL(encoder, encodeHeaders(_, false))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Connection());
-        EXPECT_EQ("upgrade", headers.Connection()->value().getStringView());
+        EXPECT_EQ("upgrade", headers.getConnectionValue());
       }));
 
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
@@ -3150,6 +3150,29 @@ TEST_F(HttpConnectionManagerImplTest, ConnectAsUpgrade) {
         RequestDecoder* decoder = &conn_manager_->newStream(encoder);
         RequestHeaderMapPtr headers{
             new TestRequestHeaderMapImpl{{":authority", "host"}, {":method", "CONNECT"}}};
+        decoder->decodeHeaders(std::move(headers), false);
+        data.drain(4);
+        return Http::okStatus();
+      }));
+
+  // Kick off the incoming data. Use extra data which should cause a redispatch.
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+}
+
+TEST_F(HttpConnectionManagerImplTest, ConnectWithEmptyPath) {
+  setup(false, "envoy-custom-server", false);
+
+  NiceMock<MockResponseEncoder> encoder;
+
+  EXPECT_CALL(filter_factory_, createUpgradeFilterChain("CONNECT", _, _))
+      .WillRepeatedly(Return(true));
+
+  EXPECT_CALL(*codec_, dispatch(_))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> Http::Status {
+        RequestDecoder* decoder = &conn_manager_->newStream(encoder);
+        RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{
+            {":authority", "host"}, {":path", ""}, {":method", "CONNECT"}}};
         decoder->decodeHeaders(std::move(headers), false);
         data.drain(4);
         return Http::okStatus();
@@ -3342,7 +3365,7 @@ TEST_F(HttpConnectionManagerImplTest, DisconnectOnProxyConnectionDisconnect) {
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(nullptr, headers.Connection());
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
         EXPECT_EQ(nullptr, headers.ProxyConnection());
       }));
   EXPECT_CALL(*decoder_filters_[0], onDestroy());
@@ -5583,7 +5606,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenOverloaded) {
 
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
       }));
 
   Buffer::OwnedImpl fake_input("1234");
@@ -5706,7 +5729,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenDraining) {
 
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
       .WillOnce(Invoke([](const ResponseHeaderMap& headers, bool) -> void {
-        EXPECT_EQ("close", headers.Connection()->value().getStringView());
+        EXPECT_EQ("close", headers.getConnectionValue());
       }));
 
   Buffer::OwnedImpl fake_input;


### PR DESCRIPTION
Adding an accessor headers.getHeaderNameValue() to replace headers.HeaderName().value().getStringView() in the common case where we really just want to look at the header value.

Risk Level: medium (HTTP changes where typos => bugs)
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a
