### PR TITLE
 ext_authz: Allow runtime configuration to deny at disable

### DIFF
--- a/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/api/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -24,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ExtAuthz {
   // External authorization service configuration.
   oneof services {
@@ -97,6 +97,15 @@ message ExtAuthz {
   //
   // If this field is not specified, the filter will be enabled for all requests.
   api.v2.core.RuntimeFractionalPercent filter_enabled = 9;
+
+  // Specifies whether to deny the requests, when the filter is disabled.
+  // If :ref:`runtime_key <envoy_api_field_core.RuntimeFeatureFlag.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to determine whether to deny request for
+  // filter protected path at filter disabling. If filter is disabled in
+  // typed_per_filter_config for the path, requests will not be denied.
+  //
+  // If this field is not specified, all requests will be allowed when disabled.
+  api.v2.core.RuntimeFeatureFlag deny_at_disable = 11;
 
   // Specifies if the peer certificate is sent to the external service.
   //

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -96,6 +96,15 @@ message ExtAuthz {
   //
   // If this field is not specified, the filter will be enabled for all requests.
   config.core.v3.RuntimeFractionalPercent filter_enabled = 9;
+
+  // Specifies whether to deny the requests, when the filter is disabled.
+  // If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFeatureFlag.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to determine whether to deny request for
+  // filter protected path at filter disabling. If filter is disabled in
+  // typed_per_filter_config for the path, requests will not be denied.
+  //
+  // If this field is not specified, all requests will be allowed when disabled.
+  config.core.v3.RuntimeFeatureFlag deny_at_disable = 11;
 
   // Specifies if the peer certificate is sent to the external service.
   //

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.ext_authz.v3.ExtAuthz";
@@ -96,6 +96,15 @@ message ExtAuthz {
   //
   // If this field is not specified, the filter will be enabled for all requests.
   config.core.v4alpha.RuntimeFractionalPercent filter_enabled = 9;
+
+  // Specifies whether to deny the requests, when the filter is disabled.
+  // If :ref:`runtime_key <envoy_api_field_config.core.v4alpha.RuntimeFeatureFlag.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to determine whether to deny request for
+  // filter protected path at filter disabling. If filter is disabled in
+  // typed_per_filter_config for the path, requests will not be denied.
+  //
+  // If this field is not specified, all requests will be allowed when disabled.
+  config.core.v4alpha.RuntimeFeatureFlag deny_at_disable = 11;
 
   // Specifies if the peer certificate is sent to the external service.
   //

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -49,6 +49,7 @@ New Features
 * config: added :ref:`version_text <config_cluster_manager_cds>` stat that reflects xDS version.
 * decompressor: generic :ref:`decompressor <config_http_filters_decompressor>` filter exposed to users.
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
+* ext_authz filter: added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3 deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows to force deny for protected path while filter gets disabled, by setting this key to true.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
 * fault: added support for specifying grpc_status code in abort faults using

--- a/generated_api_shadow/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
+++ b/generated_api_shadow/envoy/config/filter/http/ext_authz/v2/ext_authz.proto
@@ -24,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ExtAuthz {
   // External authorization service configuration.
   oneof services {
@@ -97,6 +97,15 @@ message ExtAuthz {
   //
   // If this field is not specified, the filter will be enabled for all requests.
   api.v2.core.RuntimeFractionalPercent filter_enabled = 9;
+
+  // Specifies whether to deny the requests, when the filter is disabled.
+  // If :ref:`runtime_key <envoy_api_field_core.RuntimeFeatureFlag.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to determine whether to deny request for
+  // filter protected path at filter disabling. If filter is disabled in
+  // typed_per_filter_config for the path, requests will not be denied.
+  //
+  // If this field is not specified, all requests will be allowed when disabled.
+  api.v2.core.RuntimeFeatureFlag deny_at_disable = 11;
 
   // Specifies if the peer certificate is sent to the external service.
   //

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.ExtAuthz";
@@ -92,6 +92,15 @@ message ExtAuthz {
   //
   // If this field is not specified, the filter will be enabled for all requests.
   config.core.v3.RuntimeFractionalPercent filter_enabled = 9;
+
+  // Specifies whether to deny the requests, when the filter is disabled.
+  // If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFeatureFlag.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to determine whether to deny request for
+  // filter protected path at filter disabling. If filter is disabled in
+  // typed_per_filter_config for the path, requests will not be denied.
+  //
+  // If this field is not specified, all requests will be allowed when disabled.
+  config.core.v3.RuntimeFeatureFlag deny_at_disable = 11;
 
   // Specifies if the peer certificate is sent to the external service.
   //

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.ext_authz.v3.ExtAuthz";
@@ -96,6 +96,15 @@ message ExtAuthz {
   //
   // If this field is not specified, the filter will be enabled for all requests.
   config.core.v4alpha.RuntimeFractionalPercent filter_enabled = 9;
+
+  // Specifies whether to deny the requests, when the filter is disabled.
+  // If :ref:`runtime_key <envoy_api_field_config.core.v4alpha.RuntimeFeatureFlag.runtime_key>` is specified,
+  // Envoy will lookup the runtime key to determine whether to deny request for
+  // filter protected path at filter disabling. If filter is disabled in
+  // typed_per_filter_config for the path, requests will not be denied.
+  //
+  // If this field is not specified, all requests will be allowed when disabled.
+  config.core.v4alpha.RuntimeFeatureFlag deny_at_disable = 11;
 
   // Specifies if the peer certificate is sent to the external service.
   //

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -70,6 +70,10 @@ public:
                             ? absl::optional<Runtime::FractionalPercent>(
                                   Runtime::FractionalPercent(config.filter_enabled(), runtime_))
                             : absl::nullopt),
+        deny_at_disable_(config.has_deny_at_disable()
+                             ? absl::optional<Runtime::FeatureFlag>(
+                                   Runtime::FeatureFlag(config.deny_at_disable(), runtime_))
+                             : absl::nullopt),
         pool_(scope_.symbolTable()),
         metadata_context_namespaces_(config.metadata_context_namespaces().begin(),
                                      config.metadata_context_namespaces().end()),
@@ -92,6 +96,10 @@ public:
   Http::Code statusOnError() const { return status_on_error_; }
 
   bool filterEnabled() { return filter_enabled_.has_value() ? filter_enabled_->enabled() : true; }
+
+  bool denyAtDisable() {
+    return deny_at_disable_.has_value() ? deny_at_disable_->enabled() : false;
+  }
 
   Stats::Scope& scope() { return scope_; }
 
@@ -133,6 +141,7 @@ private:
   Http::Context& http_context_;
 
   const absl::optional<Runtime::FractionalPercent> filter_enabled_;
+  const absl::optional<Runtime::FeatureFlag> deny_at_disable_;
 
   // TODO(nezdolik): stop using pool as part of deprecating cluster scope stats.
   Stats::StatNamePool pool_;

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -29,7 +29,7 @@ public:
         new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
   }
 
-  void initializeWithDownstreamProtocol(Http::CodecClient::Type downstream_protocol) {
+  void initializeConfig() {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* ext_authz_cluster = bootstrap.mutable_static_resources()->add_clusters();
       ext_authz_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
@@ -40,14 +40,25 @@ public:
       setGrpcService(*proto_config_.mutable_grpc_service(), "ext_authz",
                      fake_upstreams_.back()->localAddress());
 
+      proto_config_.mutable_filter_enabled()->set_runtime_key("envoy.ext_authz.enable");
+      proto_config_.mutable_filter_enabled()->mutable_default_value()->set_numerator(100);
+      proto_config_.mutable_deny_at_disable()->set_runtime_key("envoy.ext_authz.deny_at_disable");
+      proto_config_.mutable_deny_at_disable()->mutable_default_value()->set_value(false);
+
       envoy::config::listener::v3::Filter ext_authz_filter;
       ext_authz_filter.set_name(Extensions::HttpFilters::HttpFilterNames::get().ExtAuthorization);
       ext_authz_filter.mutable_typed_config()->PackFrom(proto_config_);
       config_helper_.addFilter(MessageUtil::getJsonStringFromMessage(ext_authz_filter));
     });
+  }
 
-    setDownstreamProtocol(downstream_protocol);
-    HttpIntegrationTest::initialize();
+  void setDenyAtDisableRuntimeConfig(bool deny_at_disable) {
+    config_helper_.addRuntimeOverride("envoy.ext_authz.enable", "numerator: 0");
+    if (deny_at_disable) {
+      config_helper_.addRuntimeOverride("envoy.ext_authz.deny_at_disable", "true");
+    } else {
+      config_helper_.addRuntimeOverride("envoy.ext_authz.deny_at_disable", "false");
+    }
   }
 
   void initiateClientConnection(uint64_t request_body_length) {
@@ -99,7 +110,7 @@ public:
     RELEASE_ASSERT(result, result.message());
   }
 
-  void waitForSuccessfulUpstreamResponse() {
+  void waitForSuccessfulUpstreamResponse(const std::string& expected_response_code) {
     AssertionResult result =
         fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_);
     RELEASE_ASSERT(result, result.message());
@@ -116,7 +127,7 @@ public:
     EXPECT_EQ(request_body_.length(), upstream_request_->bodyLength());
 
     EXPECT_TRUE(response_->complete());
-    EXPECT_EQ("200", response_->headers().getStatusValue());
+    EXPECT_EQ(expected_response_code, response_->headers().getStatusValue());
     EXPECT_EQ(response_size_, response_->body().size());
   }
 
@@ -169,11 +180,25 @@ attributes:
 
   void expectCheckRequestWithBody(Http::CodecClient::Type downstream_protocol,
                                   uint64_t request_size) {
-    initializeWithDownstreamProtocol(downstream_protocol);
+    initializeConfig();
+    setDownstreamProtocol(downstream_protocol);
+    HttpIntegrationTest::initialize();
     initiateClientConnection(request_size);
     waitForExtAuthzRequest(expectedCheckRequest(downstream_protocol));
     sendExtAuthzResponse();
-    waitForSuccessfulUpstreamResponse();
+    waitForSuccessfulUpstreamResponse("200");
+    cleanup();
+  }
+
+  void expectFilterDisableCheck(bool deny_at_disable, const std::string& expected_status) {
+    initializeConfig();
+    setDenyAtDisableRuntimeConfig(deny_at_disable);
+    setDownstreamProtocol(Http::CodecClient::Type::HTTP2);
+    HttpIntegrationTest::initialize();
+    initiateClientConnection(4);
+    if (!deny_at_disable) {
+      waitForSuccessfulUpstreamResponse(expected_status);
+    }
     cleanup();
   }
 
@@ -318,6 +343,10 @@ TEST_P(ExtAuthzGrpcIntegrationTest, HTTP2DownstreamRequestWithBody) {
 TEST_P(ExtAuthzGrpcIntegrationTest, HTTP2DownstreamRequestWithLargeBody) {
   expectCheckRequestWithBody(Http::CodecClient::Type::HTTP2, 2048);
 }
+
+TEST_P(ExtAuthzGrpcIntegrationTest, AllowAtDisable) { expectFilterDisableCheck(false, "200"); }
+
+TEST_P(ExtAuthzGrpcIntegrationTest, DenyAtDisable) { expectFilterDisableCheck(true, "403"); }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ExtAuthzHttpIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),


### PR DESCRIPTION
Commit Message: This PR adds a runtime configuration for `envoy.filters.http.ext_authz` to deny requests when the filter is disabled.

Additional Description: It updates the frozen v2 API.
Risk Level: Low
Testing: Unit and integration tests
Docs Changes: Added
Release Notes: Added
Runtime guard: Runtime key can be specified via ExtAuthz.deny_at_disable. This runtime key will work with ExtAuthz.filter_enable key to deny all filter protected path without sending RPC to ExtAuthz auth server.

Signed-off-by: Fangpeng Liu <62083774+fpliu233@users.noreply.github.com>
