### PR TITLE
tracers: report envoy version in datadog tracer

### DIFF
--- a/source/extensions/tracers/datadog/BUILD
+++ b/source/extensions/tracers/datadog/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
     ],
     external_deps = ["dd_opentracing_cpp"],
     deps = [
+        "//source/common/common:version_lib",
         "//source/common/config:utility_lib",
         "//source/common/http:async_client_utility_lib",
         "//source/common/tracing:http_tracer_lib",

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -5,6 +5,7 @@
 #include "common/common/enum_to_int.h"
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
+#include "common/common/version.h"
 #include "common/config/utility.h"
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"
@@ -34,6 +35,7 @@ Driver::Driver(const envoy::config::trace::v3::DatadogConfig& datadog_config,
   cluster_ = datadog_config.collector_cluster();
 
   // Default tracer options.
+  tracer_options_.version = absl::StrCat("envoy ", Envoy::VersionInfo::version());
   tracer_options_.operation_name_override = "envoy.proxy";
   tracer_options_.service = "envoy";
   tracer_options_.inject = std::set<datadog::opentracing::PropagationStyle>{


### PR DESCRIPTION
Commit Message:
tracers: report envoy version in datadog tracer

Additional Description:
Reports the version of envoy when using the datadog tracer.
Useful in many ways, eg: monitoring canary deployments and upgrades, diagnostic between versions etc.
I did consider composing a value using `buildVersion()` and `revision()` for a better-looking value, but decided that `version()` is more precise.

Risk Level: Low
Testing: E2E verification
Docs Changes: N/A
Release Notes: N/A
