### PR TITLE
test: restoring prior behavior for http2 flood tests

### DIFF
--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1563,6 +1563,8 @@ void Http2FloodMitigationTest::floodServer(const Http2Frame& frame, const std::s
 
   EXPECT_LE(total_bytes_sent, TransmitThreshold) << "Flood mitigation is broken.";
   EXPECT_EQ(1, test_server_->counter(flood_stat)->value());
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 // Verify that the server detects the flood using specified request parameters.
@@ -1586,6 +1588,8 @@ void Http2FloodMitigationTest::floodServer(absl::string_view host, absl::string_
   if (!flood_stat.empty()) {
     EXPECT_EQ(1, test_server_->counter(flood_stat)->value());
   }
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, Http2FloodMitigationTest,
@@ -1653,6 +1657,8 @@ TEST_P(Http2FloodMitigationTest, RST_STREAM) {
   }
   EXPECT_LE(total_bytes_sent, TransmitThreshold) << "Flood mitigation is broken.";
   EXPECT_EQ(1, test_server_->counter("http2.outbound_control_flood")->value());
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 // Verify that the server stop reading downstream connection on protocol error.
@@ -1688,6 +1694,8 @@ TEST_P(Http2FloodMitigationTest, EmptyHeaders) {
   tcp_client_->waitForDisconnect();
 
   EXPECT_EQ(1, test_server_->counter("http2.inbound_empty_frames_flood")->value());
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 TEST_P(Http2FloodMitigationTest, EmptyHeadersContinuation) {
@@ -1705,6 +1713,8 @@ TEST_P(Http2FloodMitigationTest, EmptyHeadersContinuation) {
   tcp_client_->waitForDisconnect();
 
   EXPECT_EQ(1, test_server_->counter("http2.inbound_empty_frames_flood")->value());
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 TEST_P(Http2FloodMitigationTest, EmptyData) {
@@ -1723,6 +1733,8 @@ TEST_P(Http2FloodMitigationTest, EmptyData) {
   tcp_client_->waitForDisconnect();
 
   EXPECT_EQ(1, test_server_->counter("http2.inbound_empty_frames_flood")->value());
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 TEST_P(Http2FloodMitigationTest, PriorityIdleStream) {
@@ -1787,6 +1799,8 @@ TEST_P(Http2FloodMitigationTest, ZerolenHeader) {
   tcp_client_->waitForDisconnect();
 
   EXPECT_EQ(1, test_server_->counter("http2.rx_messaging_error")->value());
+  EXPECT_EQ(1,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.invalid.header.field"));
   // expect a downstream protocol error.
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));
@@ -1823,6 +1837,8 @@ TEST_P(Http2FloodMitigationTest, ZerolenHeaderAllowed) {
   tcp_client_->close();
 
   EXPECT_EQ(1, test_server_->counter("http2.rx_messaging_error")->value());
+  EXPECT_EQ(0,
+            test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.invalid.header.field"));
   // expect Downstream Protocol Error
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("DPE"));

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -70,7 +70,11 @@ public:
 class Http2FloodMitigationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                  public HttpIntegrationTest {
 public:
-  Http2FloodMitigationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {}
+  Http2FloodMitigationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {
+    config_helper_.addConfigModifier(
+        [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+               hcm) { hcm.mutable_delayed_close_timeout()->set_seconds(1); });
+  }
 
 protected:
   void startHttp2Session();


### PR DESCRIPTION
Risk Level: n/a (test only)
Testing: passes locally (but then did before)
Docs Changes: n/a
Release Notes: n/a
Fixes #11290