### PR TITLE
Non root docker

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -1,4 +1,22 @@
-FROM ubuntu:18.04
+ARG BUILD_FROM=ubuntu:18.04
+
+
+# Build stage
+FROM $BUILD_FROM as build
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install --no-install-recommends -y ca-certificates curl gcc libc-dev \
+    && echo "d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891  /tmp/su-exec.c" > /tmp/checksum \
+    && curl -o /tmp/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c \
+    && sha256sum -c /tmp/checksum \
+    && gcc -Wall /tmp/su-exec.c -o/usr/local/bin/su-exec \
+    && chown root:root /usr/local/bin/su-exec \
+    && chmod 0755 /usr/local/bin/su-exec
+
+
+# Final stage
+FROM $BUILD_FROM
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -7,6 +25,9 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /tmp/* /var/tmp/* \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local/bin/su-exec /usr/local/bin/su-exec
+RUN adduser --group --system envoy
 
 RUN mkdir -p /etc/envoy
 

--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -4,6 +4,8 @@ RUN mkdir -p /etc/envoy
 
 ADD build_release_stripped/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+RUN apk add --no-cache shadow su-exec \
+        && addgroup -S envoy && adduser --no-create-home -S envoy -G envoy
 
 EXPOSE 10000
 

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -4,6 +4,8 @@ RUN mkdir -p /etc/envoy
 
 ADD build_release/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+RUN apk add --no-cache shadow su-exec \
+        && addgroup -S envoy && adduser --no-create-home -S envoy -G envoy
 
 EXPOSE 10000
 

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -13,4 +13,14 @@ if [ "$1" = 'envoy' ]; then
 	fi
 fi
 
-exec "$@"
+if [ "$ENVOY_UID" != "0" ]; then
+    if [ -n "$ENVOY_UID" ]; then
+	usermod -u "$ENVOY_UID" envoy
+    fi
+    if [ -n "$ENVOY_GID" ]; then
+	groupmod -g "$ENVOY_GID" envoy
+    fi
+    su-exec envoy "${@}"
+else
+    exec "${@}"
+fi

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,6 +13,7 @@ Minor Behavior Changes
 *Changes that may cause incompatibilities for some users, but should not for most*
 
 * access loggers: applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature `envoy.reloadable_features.disallow_unbounded_access_logs` to false.
+* build: run as non-root inside Docker containers. Existing behaviour can be restored by setting the environment variable `ENVOY_UID` to `0`. `ENVOY_UID` and `ENVOY_GID` can be used to set the envoy user's `uid` and `gid` respectively.
 * hot restart: added the option :option:`--use-dynamic-base-id` to select an unused base ID at startup and the option :option:`--base-id-path` to write the base id to a file (for reuse with later hot restarts).
 * http: fixed several bugs with applying correct connection close behavior across the http connection manager, health checker, and connection pool. This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_connection_close` to false.
 * http: fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.


### PR DESCRIPTION
Commit Message:

Allow envoy to run as non-root user in Docker container, Fixes #11311

Additional description:
- creates a non-root user in docker recipes
- installs `su-exec` and requirements for `usermod` and `groupmod`
- updates the docker `entrypoint` to use `su-exec`

Unfortunately su-exec is not currently packaged in `debian`, so i had to compile the binary

An alternative would be to use `gosu` but its signififcantly larger

Risk Level: low/medium
The main risk is from compiling the `su-exec` binary for the `debian` build
Its not clear to me if these recipes are intended for `ci` or `production` - if the latter then introducing `su-exec` has more significant security implications
Testing: 
Docs Changes: I could not find any docs relating to running with Docker
Release Notes: n/a




