### PR TITLE
health check: close conn after timeout/stream rst when grpc hc has conn reuse disabled

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -711,13 +711,13 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onResetStream(Http::St
     return;
   }
 
+  ENVOY_CONN_LOG(debug, "connection/stream error health_flags={}", *client_,
+                 HostUtility::healthFlagsToString(*host_));
+
   if (!parent_.reuse_connection_) {
     // Stream reset was unexpected, so we haven't closed the connection yet.
     client_->close();
   }
-
-  ENVOY_CONN_LOG(debug, "connection/stream error health_flags={}", *client_,
-                 HostUtility::healthFlagsToString(*host_));
 
   // TODO(baranov1ch): according to all HTTP standards, we should check if reason is one of
   // Http::StreamResetReason::RemoteRefusedStreamReset (which may mean GOAWAY),

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -4494,7 +4494,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionTimeout) {
 
   expectSessionCreate();
   expectHealthcheckStart(0);
-  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
   health_checker_->start();
 
   expectHealthcheckStop(0);
@@ -4521,7 +4521,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionStreamReset) {
 
   expectSessionCreate();
   expectHealthcheckStart(0);
-  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, true));
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
   health_checker_->start();
 
   expectHealthcheckStop(0);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -4487,6 +4487,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionBetweenChecks) {
   expectHostHealthy(true);
 }
 
+// Test that we close connections when a timeout occurs and reuse_connection is false.
 TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionTimeout) {
   setupNoReuseConnectionHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -4503,6 +4504,8 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionTimeout) {
   test_sessions_[0]->timeout_timer_->invokeCallback();
   expectHostHealthy(true);
 
+  // A new client is created because we close the connection
+  // when a timeout occurs and connection reuse is disabled.
   expectClientCreate(0);
   expectHealthcheckStart(0);
   test_sessions_[0]->interval_timer_->invokeCallback();
@@ -4514,6 +4517,7 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionTimeout) {
   expectHostHealthy(true);
 }
 
+// Test that we close connections when a stream reset occurs and reuse_connection is false.
 TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionStreamReset) {
   setupNoReuseConnectionHC();
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -4530,6 +4534,8 @@ TEST_F(GrpcHealthCheckerImplTest, DontReuseConnectionStreamReset) {
   test_sessions_[0]->request_encoder_.stream_.resetStream(Http::StreamResetReason::RemoteReset);
   expectHostHealthy(true);
 
+  // A new client is created because we close the connection
+  // when a stream reset occurs and connection reuse is disabled.
   expectClientCreate(0);
   expectHealthcheckStart(0);
   test_sessions_[0]->interval_timer_->invokeCallback();


### PR DESCRIPTION
Commit Message:
Close connection after timeout/stream reset when grpc health checker has connection reuse disabled.

Additional Description:
While investigating, https://github.com/envoyproxy/envoy/pull/11324, I noticed that it seems connections aren't closed when there is a timeout or stream reset and connection reuse is disabled.

Risk Level: low/medium
Testing: added unit tests
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Joey Muia <joseph.b.muia@gmail.com>