### PR TITLE
Windows: Fix address_imp_test

### DIFF
--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -101,7 +101,7 @@ SysCallIntResult OsSysCallsImpl::bind(os_fd_t sockfd, const sockaddr* addr, sock
 
 SysCallIntResult OsSysCallsImpl::chmod(const std::string& path, mode_t mode) {
   //
-  // Windows only supports _S_IWRITE and _S_IREAD bits, other bits might will be ignored.
+  // Windows only supports _S_IWRITE and _S_IREAD bits, other bits will be ignored.
   // Also all files are always readable; it is not possible to give write-only permission.
   // For more granular security we need to rely on access-control-list (ACL) on Windows.
   //

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -100,6 +100,11 @@ SysCallIntResult OsSysCallsImpl::bind(os_fd_t sockfd, const sockaddr* addr, sock
 }
 
 SysCallIntResult OsSysCallsImpl::chmod(const std::string& path, mode_t mode) {
+  //
+  // Windows only supports _S_IWRITE and _S_IREAD bits, other bits might will be ignored.
+  // Also all files are always readable; it is not possible to give write-only permission.
+  // For more granular security we need to rely on access-control-list (ACL) on Windows.
+  //
   const int rc = ::_chmod(path.c_str(), mode);
   return {rc, rc != -1 ? 0 : errno};
 }

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -360,7 +360,7 @@ IoHandlePtr Ipv6Instance::socket(SocketType type) const {
 PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len, mode_t mode)
     : InstanceBase(Type::Pipe) {
   if (address->sun_path[0] == '\0') {
-#if !defined(__linux__)
+#if defined(__APPLE__)
     throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
 #endif
     RELEASE_ASSERT(static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1,
@@ -396,7 +396,7 @@ PipeInstance::PipeInstance(const std::string& pipe_path, mode_t mode) : Instance
     // characters of pipe_path to sun_path, including null bytes in the name. The pathname must also
     // be null terminated. The friendly name is the address path with embedded nulls replaced with
     // '@' for consistency with the first character.
-#if !defined(__linux__)
+#if defined(__APPLE__)
     throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
 #endif
     if (mode != 0) {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -361,7 +361,7 @@ PipeInstance::PipeInstance(const sockaddr_un* address, socklen_t ss_len, mode_t 
     : InstanceBase(Type::Pipe) {
   if (address->sun_path[0] == '\0') {
 #if defined(__APPLE__)
-    throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
+    throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux/windows.");
 #endif
     RELEASE_ASSERT(static_cast<unsigned int>(ss_len) >= offsetof(struct sockaddr_un, sun_path) + 1,
                    "");
@@ -397,7 +397,7 @@ PipeInstance::PipeInstance(const std::string& pipe_path, mode_t mode) : Instance
     // be null terminated. The friendly name is the address path with embedded nulls replaced with
     // '@' for consistency with the first character.
 #if defined(__APPLE__)
-    throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux.");
+    throw EnvoyException("Abstract AF_UNIX sockets are only supported on linux/windows.");
 #endif
     if (mode != 0) {
       throw EnvoyException("Cannot set mode for Abstract AF_UNIX sockets");

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -33,7 +33,6 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "address_impl_test",
     srcs = ["address_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -323,7 +323,7 @@ TEST(PipeInstanceTest, Basic) {
 
 TEST(PipeInstanceTest, BasicPermission) {
   std::string path = TestEnvironment::unixDomainSocketPath("foo.sock");
-  
+
   const mode_t mode = 0666;
   PipeInstance address(path, mode);
 


### PR DESCRIPTION
Commit Message:
 Enable Abstract sockets  for Windows and fix test permissions

Additional Description:

With this change we aim to add full support for the address_imp_test on Windows. To achieve this we made the following changes:

1. In `BasicPermission` we set the mode to be `666`. This allows us to verify in linux that we set the permissions of the socket correctly. This is the equivalent to `_S_IREAD | _S_IWRITE` in Windows. In case that we need more granular permission model, we would need to use ACL in Windows.
2. Since Windows AF_UNIX sockets support abstract sockets [source](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/) I enabled all the abstract tests in Windows.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
