### PR TITLE
set instance-protection on non-managed agents

### DIFF
--- a/.azure-pipelines/bazel.yml
+++ b/.azure-pipelines/bazel.yml
@@ -17,6 +17,11 @@ parameters:
     default: true
 
 steps:
+  - bash: |
+      /usr/local/bin/set-instance-protection.sh on
+    displayName: "Set Instance Protection on Agent to prevent scale in"
+    condition:  eq(false, ${{ parameters.managedAgent }})
+
   - task: Cache@2
     inputs:
       key: '"${{ parameters.ciTarget }}" | ./WORKSPACE | **/*.bzl'
@@ -78,3 +83,8 @@ steps:
       chmod -R u+w $(Build.StagingDirectory)
     displayName: "Self hosted agent clean up"
     condition: eq(false, ${{ parameters.managedAgent }})
+
+  - bash: |
+      /usr/local/bin/set-instance-protection.sh off
+    displayName: "Set Instance Protection on Agent to prevent scale in"
+    condition:  eq(false, ${{ parameters.managedAgent }})


### PR DESCRIPTION
Commit Message:

set instance-protection on non-managed agents

Additional Description:

Prevent automatic scaling in of non-managed agents that are currently working jobs.

Risk Level: Minimum
Testing: 

Validated setting instance protection script works manually:

```
azure-pipelines@i-0ddaddbed4d4ec867:~$ /usr/local/bin/set-instance-protection.sh on
Fetched Cached Credentials, Expire At: [2020-05-28T02:20:57Z]
azure-pipelines@i-0ddaddbed4d4ec867:~$ /usr/local/bin/set-instance-protection.sh off
Fetched Cached Credentials, Expire At: [2020-05-28T02:20:57Z]
azure-pipelines@i-0ddaddbed4d4ec867:~$ /usr/local/bin/set-instance-protection.sh on
Fetched Cached Credentials, Expire At: [2020-05-28T02:20:57Z]
```

Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Cynthia <cynthia@coan.dev>
