### PR TITLE
integration: Configure drain time in integration tests

### DIFF
--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -453,10 +453,10 @@ std::string getListenerDetails(Envoy::Server::Instance& server) {
 void BaseIntegrationTest::createGeneratedApiTestServer(
     const std::string& bootstrap_path, const std::vector<std::string>& port_names,
     Server::FieldValidationConfig validator_config, bool allow_lds_rejection) {
-  test_server_ = IntegrationTestServer::create(bootstrap_path, version_, on_server_ready_function_,
-                                               on_server_init_function_, deterministic_,
-                                               timeSystem(), *api_, defer_listener_finalization_,
-                                               process_object_, validator_config, concurrency_);
+  test_server_ = IntegrationTestServer::create(
+      bootstrap_path, version_, on_server_ready_function_, on_server_init_function_, deterministic_,
+      timeSystem(), *api_, defer_listener_finalization_, process_object_, validator_config,
+      concurrency_, drain_time_);
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0 &&
       !defer_listener_finalization_) {
 

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -433,6 +433,9 @@ protected:
   // The number of worker threads that the test server uses.
   uint32_t concurrency_{1};
 
+  // The duration of the drain manager graceful drain period.
+  std::chrono::seconds drain_time_{1};
+
   // Member variables for xDS testing.
   FakeUpstream* xds_upstream_{};
   FakeHttpConnectionPtr xds_connection_;

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -276,7 +276,10 @@ typed_config:
 
 // Add a health check filter and verify correct behavior when draining.
 TEST_P(ProtocolIntegrationTest, DrainClose) {
-  drain_time_ = std::chrono::seconds(10);
+  // The probability of drain close increases over time. With a high timeout,
+  // the probability will be very low, but the rapid retries prevent this from
+  // increasing total test time.
+  drain_time_ = std::chrono::seconds(100);
   config_helper_.addFilter(ConfigHelper::defaultHealthCheckFilter());
   initialize();
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -276,6 +276,7 @@ typed_config:
 
 // Add a health check filter and verify correct behavior when draining.
 TEST_P(ProtocolIntegrationTest, DrainClose) {
+  drain_time_ = std::chrono::seconds(10);
   config_helper_.addFilter(ConfigHelper::defaultHealthCheckFilter());
   initialize();
 

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -31,14 +31,15 @@ namespace Server {
 
 OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
                                   Network::Address::IpVersion ip_version,
-                                  FieldValidationConfig validation_config, uint32_t concurrency) {
+                                  FieldValidationConfig validation_config, uint32_t concurrency,
+                                  std::chrono::seconds drain_time) {
   OptionsImpl test_options("cluster_name", "node_name", "zone_name", spdlog::level::info);
 
   test_options.setConfigPath(config_path);
   test_options.setConfigYaml(config_yaml);
   test_options.setLocalAddressIpVersion(ip_version);
   test_options.setFileFlushIntervalMsec(std::chrono::milliseconds(50));
-  test_options.setDrainTime(std::chrono::seconds(1));
+  test_options.setDrainTime(drain_time);
   test_options.setParentShutdownTime(std::chrono::seconds(2));
   test_options.setAllowUnkownFields(validation_config.allow_unknown_static_fields);
   test_options.setRejectUnknownFieldsDynamic(validation_config.reject_unknown_dynamic_fields);
@@ -56,14 +57,14 @@ IntegrationTestServerPtr IntegrationTestServer::create(
     std::function<void()> on_server_init_function, bool deterministic,
     Event::TestTimeSystem& time_system, Api::Api& api, bool defer_listener_finalization,
     ProcessObjectOptRef process_object, Server::FieldValidationConfig validation_config,
-    uint32_t concurrency) {
+    uint32_t concurrency, std::chrono::seconds drain_time) {
   IntegrationTestServerPtr server{
       std::make_unique<IntegrationTestServerImpl>(time_system, api, config_path)};
   if (server_ready_function != nullptr) {
     server->setOnServerReadyCb(server_ready_function);
   }
   server->start(version, on_server_init_function, deterministic, defer_listener_finalization,
-                process_object, validation_config, concurrency);
+                process_object, validation_config, concurrency, drain_time);
   return server;
 }
 
@@ -82,12 +83,14 @@ void IntegrationTestServer::start(const Network::Address::IpVersion version,
                                   bool defer_listener_finalization,
                                   ProcessObjectOptRef process_object,
                                   Server::FieldValidationConfig validator_config,
-                                  uint32_t concurrency) {
+                                  uint32_t concurrency, std::chrono::seconds drain_time) {
   ENVOY_LOG(info, "starting integration test server");
   ASSERT(!thread_);
-  thread_ = api_.threadFactory().createThread(
-      [version, deterministic, process_object, validator_config, concurrency, this]() -> void {
-        threadRoutine(version, deterministic, process_object, validator_config, concurrency);
+  thread_ =
+      api_.threadFactory().createThread([version, deterministic, process_object, validator_config,
+                                         concurrency, drain_time, this]() -> void {
+        threadRoutine(version, deterministic, process_object, validator_config, concurrency,
+                      drain_time);
       });
 
   // If any steps need to be done prior to workers starting, do them now. E.g., xDS pre-init.
@@ -163,9 +166,9 @@ void IntegrationTestServer::serverReady() {
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version,
                                           bool deterministic, ProcessObjectOptRef process_object,
                                           Server::FieldValidationConfig validation_config,
-                                          uint32_t concurrency) {
-  OptionsImpl options(
-      Server::createTestOptionsImpl(config_path_, "", version, validation_config, concurrency));
+                                          uint32_t concurrency, std::chrono::seconds drain_time) {
+  OptionsImpl options(Server::createTestOptionsImpl(config_path_, "", version, validation_config,
+                                                    concurrency, drain_time));
   Thread::MutexBasicLockable lock;
 
   Runtime::RandomGeneratorPtr random_generator;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -42,7 +42,8 @@ struct FieldValidationConfig {
 OptionsImpl createTestOptionsImpl(const std::string& config_path, const std::string& config_yaml,
                                   Network::Address::IpVersion ip_version,
                                   FieldValidationConfig validation_config = FieldValidationConfig(),
-                                  uint32_t concurrency = 1);
+                                  uint32_t concurrency = 1,
+                                  std::chrono::seconds drain_time = std::chrono::seconds(1));
 
 class TestComponentFactory : public ComponentFactory {
 public:
@@ -274,7 +275,7 @@ public:
          bool defer_listener_finalization = false,
          ProcessObjectOptRef process_object = absl::nullopt,
          Server::FieldValidationConfig validation_config = Server::FieldValidationConfig(),
-         uint32_t concurrency = 1);
+         uint32_t concurrency = 1, std::chrono::seconds drain_time = std::chrono::seconds(1));
   // Note that the derived class is responsible for tearing down the server in its
   // destructor.
   ~IntegrationTestServer() override;
@@ -296,7 +297,8 @@ public:
   void start(const Network::Address::IpVersion version,
              std::function<void()> on_server_init_function, bool deterministic,
              bool defer_listener_finalization, ProcessObjectOptRef process_object,
-             Server::FieldValidationConfig validation_config, uint32_t concurrency);
+             Server::FieldValidationConfig validation_config, uint32_t concurrency,
+             std::chrono::seconds drain_time);
 
   void waitForCounterEq(const std::string& name, uint64_t value) override {
     TestUtility::waitForCounterEq(statStore(), name, value, time_system_);
@@ -379,7 +381,8 @@ private:
    */
   void threadRoutine(const Network::Address::IpVersion version, bool deterministic,
                      ProcessObjectOptRef process_object,
-                     Server::FieldValidationConfig validation_config, uint32_t concurrency);
+                     Server::FieldValidationConfig validation_config, uint32_t concurrency,
+                     std::chrono::seconds drain_time);
 
   Event::TestTimeSystem& time_system_;
   Api::Api& api_;


### PR DESCRIPTION
integration: Configure drain time in integration tests
* Set `drain_time_` in integration tests to pass on to the server's DrainManagerImpl
* Lengthen the drain period to 10 seconds in DrainClose integration tests, which uncovered  #11240.
* Fix the test race with retries, i.e. keep sending requests until the drainClose() call in conn manager is hit

Risk Level: Test-only change
Testing: Test-only change

Fixes #11240