### PR TITLE
network: move remaining socket syscalls to socket

### DIFF
--- a/include/envoy/network/socket.h
+++ b/include/envoy/network/socket.h
@@ -79,6 +79,11 @@ public:
   virtual Address::SocketType socketType() const PURE;
 
   /**
+   * @return the type (IP or pipe) of addresses used by the socket (subset of socket domain)
+   */
+  virtual Address::Type addressType() const PURE;
+
+  /**
    * Close the underlying socket.
    */
   virtual void close() PURE;
@@ -112,6 +117,23 @@ public:
    *   is successful, errno_ shouldn't be used.
    */
   virtual Api::SysCallIntResult connect(const Address::InstanceConstSharedPtr address) PURE;
+
+  /**
+   * Propagates option to underlying socket (@see man 2 setsockopt)
+   */
+  virtual Api::SysCallIntResult setSocketOption(int level, int optname, const void* optval,
+                                                socklen_t optlen) PURE;
+
+  /**
+   * Retrieves option from underlying socket (@see man 2 getsockopt)
+   */
+  virtual Api::SysCallIntResult getSocketOption(int level, int optname, void* optval,
+                                                socklen_t* optlen) PURE;
+
+  /**
+   * Toggle socket blocking state
+   */
+  virtual Api::SysCallIntResult setBlocking(bool blocking) PURE;
 
   /**
    * Visitor class for setting socket options.

--- a/include/envoy/network/socket.h
+++ b/include/envoy/network/socket.h
@@ -133,7 +133,7 @@ public:
   /**
    * Toggle socket blocking state
    */
-  virtual Api::SysCallIntResult setBlocking(bool blocking) PURE;
+  virtual Api::SysCallIntResult setBlockingForTest(bool blocking) PURE;
 
   /**
    * Visitor class for setting socket options.

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -8,7 +8,6 @@
 
 #include "envoy/config/core/v3/base.pb.h"
 
-#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/fmt.h"
@@ -17,6 +16,7 @@
 #include "common/grpc/common.h"
 #include "common/grpc/status.h"
 #include "common/http/utility.h"
+#include "common/network/socket_impl.h"
 #include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/utility.h"
 #include "common/stream_info/utility.h"
@@ -78,8 +78,7 @@ const std::string AccessLogFormatUtils::getHostname() {
   const size_t len = 255;
 #endif
   char name[len];
-  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
-  const Api::SysCallIntResult result = os_sys_calls.gethostname(name, len);
+  const Api::SysCallIntResult result = Network::SocketInterface::getHostName(name, len);
 
   std::string hostname = "-";
   if (result.rc_ == 0) {

--- a/source/common/access_log/access_log_formatter.cc
+++ b/source/common/access_log/access_log_formatter.cc
@@ -8,6 +8,7 @@
 
 #include "envoy/config/core/v3/base.pb.h"
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/common/empty_string.h"
 #include "common/common/fmt.h"
@@ -16,7 +17,6 @@
 #include "common/grpc/common.h"
 #include "common/grpc/status.h"
 #include "common/http/utility.h"
-#include "common/network/socket_impl.h"
 #include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/utility.h"
 #include "common/stream_info/utility.h"
@@ -78,7 +78,8 @@ const std::string AccessLogFormatUtils::getHostname() {
   const size_t len = 255;
 #endif
   char name[len];
-  const Api::SysCallIntResult result = Network::SocketInterface::getHostName(name, len);
+  Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
+  const Api::SysCallIntResult result = os_sys_calls.gethostname(name, len);
 
   std::string hostname = "-";
   if (result.rc_ == 0) {

--- a/source/common/network/address_impl.cc
+++ b/source/common/network/address_impl.cc
@@ -11,7 +11,6 @@
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
-#include "common/network/io_socket_handle_impl.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -134,10 +134,6 @@ Address::InstanceConstSharedPtr SocketInterface::peerAddressFromFd(os_fd_t fd) {
   return Address::addressFromSockAddr(ss, ss_len);
 }
 
-Api::SysCallIntResult SocketInterface::getHostName(char* name, size_t length) {
-  return Api::OsSysCallsSingleton::get().gethostname(name, length);
-}
-
 SocketImpl::SocketImpl(Address::SocketType type, Address::Type addr_type,
                        Address::IpVersion version)
     : io_handle_(SocketInterface::socket(type, addr_type, version)), sock_type_(type),
@@ -225,7 +221,7 @@ Api::SysCallIntResult SocketImpl::getSocketOption(int level, int optname, void* 
                                                     optlen);
 }
 
-Api::SysCallIntResult SocketImpl::setBlocking(bool blocking) {
+Api::SysCallIntResult SocketImpl::setBlockingForTest(bool blocking) {
   return Api::OsSysCallsSingleton::get().setsocketblocking(io_handle_->fd(), blocking);
 }
 

--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -149,6 +149,11 @@ SocketImpl::SocketImpl(IoHandlePtr&& io_handle,
 
   // Should not happen but some tests inject -1 fds
   if (SOCKET_INVALID(io_handle_->fd())) {
+    if (local_address != nullptr) {
+      addr_type_ = local_address->type();
+    } else {
+      addr_type_ = Address::Type::Ip;
+    }
     return;
   }
 

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -48,11 +48,6 @@ Address::InstanceConstSharedPtr addressFromFd(os_fd_t fd);
  */
 Address::InstanceConstSharedPtr peerAddressFromFd(os_fd_t fd);
 
-/**
- * Retrieve host name (@see man 2 gethostname)
- */
-Api::SysCallIntResult getHostName(char* name, size_t length);
-
 } // namespace SocketInterface
 
 class SocketImpl : public virtual Socket {
@@ -95,7 +90,7 @@ public:
                                         socklen_t optlen) override;
   Api::SysCallIntResult getSocketOption(int level, int optname, void* optval,
                                         socklen_t* optlen) override;
-  Api::SysCallIntResult setBlocking(bool blocking) override;
+  Api::SysCallIntResult setBlockingForTest(bool blocking) override;
 
   const OptionsSharedPtr& options() const override { return options_; }
   Address::SocketType socketType() const override { return sock_type_; }

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -48,6 +48,11 @@ Address::InstanceConstSharedPtr addressFromFd(os_fd_t fd);
  */
 Address::InstanceConstSharedPtr peerAddressFromFd(os_fd_t fd);
 
+/**
+ * Retrieve host name (@see man 2 gethostname)
+ */
+Api::SysCallIntResult getHostName(char* name, size_t length);
+
 } // namespace SocketInterface
 
 class SocketImpl : public virtual Socket {
@@ -86,18 +91,24 @@ public:
   Api::SysCallIntResult bind(Network::Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult listen(int backlog) override;
   Api::SysCallIntResult connect(const Address::InstanceConstSharedPtr addr) override;
+  Api::SysCallIntResult setSocketOption(int level, int optname, const void* optval,
+                                        socklen_t optlen) override;
+  Api::SysCallIntResult getSocketOption(int level, int optname, void* optval,
+                                        socklen_t* optlen) override;
+  Api::SysCallIntResult setBlocking(bool blocking) override;
 
   const OptionsSharedPtr& options() const override { return options_; }
   Address::SocketType socketType() const override { return sock_type_; }
+  Address::Type addressType() const override { return addr_type_; }
 
 protected:
-  SocketImpl(IoHandlePtr&& io_handle, const Address::InstanceConstSharedPtr& local_address)
-      : io_handle_(std::move(io_handle)), local_address_(local_address) {}
+  SocketImpl(IoHandlePtr&& io_handle, const Address::InstanceConstSharedPtr& local_address);
 
   const IoHandlePtr io_handle_;
   Address::InstanceConstSharedPtr local_address_;
   OptionsSharedPtr options_;
   Address::SocketType sock_type_;
+  Address::Type addr_type_;
 };
 
 } // namespace Network

--- a/source/common/network/socket_option_impl.cc
+++ b/source/common/network/socket_option_impl.cc
@@ -53,9 +53,7 @@ Api::SysCallIntResult SocketOptionImpl::setSocketOption(Socket& socket,
     return {-1, ENOTSUP};
   }
 
-  auto& os_syscalls = Api::OsSysCallsSingleton::get();
-  return os_syscalls.setsockopt(socket.ioHandle().fd(), optname.level(), optname.option(), value,
-                                size);
+  return socket.setSocketOption(optname.level(), optname.option(), value, size);
 }
 
 } // namespace Network

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -374,7 +374,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(Socket& sock) {
 #else
   // TODO(zuercher): determine if connection redirection is possible under macOS (c.f. pfctl and
   // divert), and whether it's possible to find the learn destination address.
-  UNREFERENCED_PARAMETER(fd);
+  UNREFERENCED_PARAMETER(sock);
   return nullptr;
 #endif
 }

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -343,15 +343,15 @@ Address::InstanceConstSharedPtr Utility::getAddressWithPort(const Address::Insta
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
-Address::InstanceConstSharedPtr Utility::getOriginalDst(os_fd_t fd) {
+Address::InstanceConstSharedPtr Utility::getOriginalDst(Socket& sock) {
 #ifdef SOL_IP
   sockaddr_storage orig_addr;
   socklen_t addr_len = sizeof(sockaddr_storage);
   int socket_domain;
   socklen_t domain_len = sizeof(socket_domain);
-  auto& os_syscalls = Api::OsSysCallsSingleton::get();
+  // TODO(fcoras): improve once we store ip version in socket
   const Api::SysCallIntResult result =
-      os_syscalls.getsockopt(fd, SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
+      sock.getSocketOption(SOL_SOCKET, SO_DOMAIN, &socket_domain, &domain_len);
   int status = result.rc_;
 
   if (status != 0) {
@@ -359,9 +359,9 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(os_fd_t fd) {
   }
 
   if (socket_domain == AF_INET) {
-    status = os_syscalls.getsockopt(fd, SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len).rc_;
+    status = sock.getSocketOption(SOL_IP, SO_ORIGINAL_DST, &orig_addr, &addr_len).rc_;
   } else if (socket_domain == AF_INET6) {
-    status = os_syscalls.getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len).rc_;
+    status = sock.getSocketOption(SOL_IPV6, IP6T_SO_ORIGINAL_DST, &orig_addr, &addr_len).rc_;
   } else {
     return nullptr;
   }
@@ -370,16 +370,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(os_fd_t fd) {
     return nullptr;
   }
 
-  switch (orig_addr.ss_family) {
-  case AF_INET:
-    return Address::InstanceConstSharedPtr{
-        new Address::Ipv4Instance(reinterpret_cast<sockaddr_in*>(&orig_addr))};
-  case AF_INET6:
-    return Address::InstanceConstSharedPtr{
-        new Address::Ipv6Instance(reinterpret_cast<sockaddr_in6&>(orig_addr))};
-  default:
-    return nullptr;
-  }
+  return Address::addressFromSockAddr(orig_addr, 0, true /* default for v6 constructor */);
 #else
   // TODO(zuercher): determine if connection redirection is possible under macOS (c.f. pfctl and
   // divert), and whether it's possible to find the learn destination address.

--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -231,13 +231,13 @@ public:
                                                             uint32_t port);
 
   /**
-   * Retrieve the original destination address from an accepted fd.
+   * Retrieve the original destination address from an accepted socket.
    * The address (IP and port) may be not local and the port may differ from
    * the listener port if the packets were redirected using iptables
-   * @param fd is the descriptor returned by accept()
+   * @param sock is accepted socket
    * @return the original destination or nullptr if not available.
    */
-  static Address::InstanceConstSharedPtr getOriginalDst(os_fd_t fd);
+  static Address::InstanceConstSharedPtr getOriginalDst(Socket& sock);
 
   /**
    * Parses a string containing a comma-separated list of port numbers and/or

--- a/source/extensions/filters/listener/original_dst/original_dst.cc
+++ b/source/extensions/filters/listener/original_dst/original_dst.cc
@@ -10,18 +10,16 @@ namespace Extensions {
 namespace ListenerFilters {
 namespace OriginalDst {
 
-Network::Address::InstanceConstSharedPtr OriginalDstFilter::getOriginalDst(os_fd_t fd) {
-  return Network::Utility::getOriginalDst(fd);
+Network::Address::InstanceConstSharedPtr OriginalDstFilter::getOriginalDst(Network::Socket& sock) {
+  return Network::Utility::getOriginalDst(sock);
 }
 
 Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbacks& cb) {
   ENVOY_LOG(debug, "original_dst: New connection accepted");
   Network::ConnectionSocket& socket = cb.socket();
-  const Network::Address::Instance& local_address = *socket.localAddress();
 
-  if (local_address.type() == Network::Address::Type::Ip) {
-    Network::Address::InstanceConstSharedPtr original_local_address =
-        getOriginalDst(socket.ioHandle().fd());
+  if (socket.addressType() == Network::Address::Type::Ip) {
+    Network::Address::InstanceConstSharedPtr original_local_address = getOriginalDst(socket);
 
     // A listener that has the use_original_dst flag set to true can still receive
     // connections that are NOT redirected using iptables. If a connection was not redirected,

--- a/source/extensions/filters/listener/original_dst/original_dst.h
+++ b/source/extensions/filters/listener/original_dst/original_dst.h
@@ -14,7 +14,7 @@ namespace OriginalDst {
  */
 class OriginalDstFilter : public Network::ListenerFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  virtual Network::Address::InstanceConstSharedPtr getOriginalDst(os_fd_t fd);
+  virtual Network::Address::InstanceConstSharedPtr getOriginalDst(Network::Socket& sock);
 
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -51,17 +51,12 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
   // Create a socket on which we'll listen for connections from clients.
   SocketImpl sock(SocketType::Stream, addr_port);
   ASSERT_GE(sock.ioHandle().fd(), 0) << addr_port->asString();
-  auto& os_sys_calls = Api::OsSysCallsSingleton::get();
 
   // Check that IPv6 sockets accept IPv6 connections only.
   if (addr_port->ip()->version() == IpVersion::v6) {
     int socket_v6only = 0;
     socklen_t size_int = sizeof(socket_v6only);
-    ASSERT_GE(
-        os_sys_calls
-            .getsockopt(sock.ioHandle().fd(), IPPROTO_IPV6, IPV6_V6ONLY, &socket_v6only, &size_int)
-            .rc_,
-        0);
+    ASSERT_GE(sock.getSocketOption(IPPROTO_IPV6, IPV6_V6ONLY, &socket_v6only, &size_int).rc_, 0);
     EXPECT_EQ(v6only, socket_v6only != 0);
   }
 
@@ -74,7 +69,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
   // require another thread.
   ASSERT_EQ(sock.listen(128).rc_, 0);
 
-  auto client_connect = [&os_sys_calls](Address::InstanceConstSharedPtr addr_port) {
+  auto client_connect = [](Address::InstanceConstSharedPtr addr_port) {
     // Create a client socket and connect to the server.
     SocketImpl client_sock(SocketType::Stream, addr_port);
 
@@ -84,7 +79,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
     // operation of ::connect(), so connect returns with errno==EWOULDBLOCK before the tcp
     // handshake can complete. For testing convenience, re-enable blocking on the socket
     // so that connect will wait for the handshake to complete.
-    ASSERT_EQ(os_sys_calls.setsocketblocking(client_sock.ioHandle().fd(), true).rc_, 0);
+    ASSERT_EQ(client_sock.setBlocking(true).rc_, 0);
 
     // Connect to the server.
     const Api::SysCallIntResult result = client_sock.connect(addr_port);

--- a/test/common/network/address_impl_test.cc
+++ b/test/common/network/address_impl_test.cc
@@ -79,7 +79,7 @@ void testSocketBindAndConnect(Network::Address::IpVersion ip_version, bool v6onl
     // operation of ::connect(), so connect returns with errno==EWOULDBLOCK before the tcp
     // handshake can complete. For testing convenience, re-enable blocking on the socket
     // so that connect will wait for the handshake to complete.
-    ASSERT_EQ(client_sock.setBlocking(true).rc_, 0);
+    ASSERT_EQ(client_sock.setBlockingForTest(true).rc_, 0);
 
     // Connect to the server.
     const Api::SysCallIntResult result = client_sock.connect(addr_port);

--- a/test/common/network/socket_option_factory_test.cc
+++ b/test/common/network/socket_option_factory_test.cc
@@ -59,13 +59,13 @@ TEST_F(SocketOptionFactoryTest, TestBuildSocketMarkOptions) {
 
   const int type = expected_option.level();
   const int option = expected_option.option();
-  EXPECT_CALL(os_sys_calls_mock_, setsockopt_(_, _, _, _, sizeof(int)))
-      .WillOnce(Invoke([type, option](os_fd_t, int input_type, int input_option, const void* optval,
-                                      socklen_t) -> int {
+  EXPECT_CALL(socket_mock_, setSocketOption(_, _, _, sizeof(int)))
+      .WillOnce(Invoke([type, option](int input_type, int input_option, const void* optval,
+                                      socklen_t) -> Api::SysCallIntResult {
         EXPECT_EQ(100, *static_cast<const int*>(optval));
         EXPECT_EQ(type, input_type);
         EXPECT_EQ(option, input_option);
-        return 0;
+        return {0, 0};
       }));
 
   EXPECT_TRUE(Network::Socket::applyOptions(options, socket_mock_,
@@ -83,14 +83,14 @@ TEST_F(SocketOptionFactoryTest, TestBuildIpv4TransparentOptions) {
 
   const int type = expected_option.level();
   const int option = expected_option.option();
-  EXPECT_CALL(os_sys_calls_mock_, setsockopt_(_, _, _, _, sizeof(int)))
+  EXPECT_CALL(socket_mock_, setSocketOption(_, _, _, sizeof(int)))
       .Times(2)
-      .WillRepeatedly(Invoke([type, option](os_fd_t, int input_type, int input_option,
-                                            const void* optval, socklen_t) -> int {
+      .WillRepeatedly(Invoke([type, option](int input_type, int input_option, const void* optval,
+                                            socklen_t) -> Api::SysCallIntResult {
         EXPECT_EQ(type, input_type);
         EXPECT_EQ(option, input_option);
         EXPECT_EQ(1, *static_cast<const int*>(optval));
-        return 0;
+        return {0, 0};
       }));
 
   EXPECT_TRUE(Network::Socket::applyOptions(options, socket_mock_,
@@ -110,14 +110,14 @@ TEST_F(SocketOptionFactoryTest, TestBuildIpv6TransparentOptions) {
 
   const int type = expected_option.level();
   const int option = expected_option.option();
-  EXPECT_CALL(os_sys_calls_mock_, setsockopt_(_, _, _, _, sizeof(int)))
+  EXPECT_CALL(socket_mock_, setSocketOption(_, _, _, sizeof(int)))
       .Times(2)
-      .WillRepeatedly(Invoke([type, option](os_fd_t, int input_type, int input_option,
-                                            const void* optval, socklen_t) -> int {
+      .WillRepeatedly(Invoke([type, option](int input_type, int input_option, const void* optval,
+                                            socklen_t) -> Api::SysCallIntResult {
         EXPECT_EQ(type, input_type);
         EXPECT_EQ(option, input_option);
         EXPECT_EQ(1, *static_cast<const int*>(optval));
-        return 0;
+        return {0, 0};
       }));
 
   EXPECT_TRUE(Network::Socket::applyOptions(options, socket_mock_,

--- a/test/common/network/socket_option_impl_test.cc
+++ b/test/common/network/socket_option_impl_test.cc
@@ -32,10 +32,10 @@ TEST_F(SocketOptionImplTest, HasName) {
   // If we fail to set an option, verify that the log message
   // contains the option name so the operator can debug.
   SocketOptionImpl socket_option{envoy::config::core::v3::SocketOption::STATE_PREBIND, optname, 1};
-  EXPECT_CALL(os_sys_calls_, setsockopt_(_, _, _, _, _))
-      .WillOnce(Invoke([](os_fd_t, int, int, const void* optval, socklen_t) -> int {
+  EXPECT_CALL(socket_, setSocketOption(_, _, _, _))
+      .WillOnce(Invoke([](int, int, const void* optval, socklen_t) -> Api::SysCallIntResult {
         EXPECT_EQ(1, *static_cast<const int*>(optval));
-        return -1;
+        return {-1, 0};
       }));
 
   EXPECT_LOG_CONTAINS(
@@ -46,10 +46,10 @@ TEST_F(SocketOptionImplTest, HasName) {
 TEST_F(SocketOptionImplTest, SetOptionSuccessTrue) {
   SocketOptionImpl socket_option{envoy::config::core::v3::SocketOption::STATE_PREBIND,
                                  ENVOY_MAKE_SOCKET_OPTION_NAME(5, 10), 1};
-  EXPECT_CALL(os_sys_calls_, setsockopt_(_, 5, 10, _, sizeof(int)))
-      .WillOnce(Invoke([](os_fd_t, int, int, const void* optval, socklen_t) -> int {
+  EXPECT_CALL(socket_, setSocketOption(5, 10, _, sizeof(int)))
+      .WillOnce(Invoke([](int, int, const void* optval, socklen_t) -> Api::SysCallIntResult {
         EXPECT_EQ(1, *static_cast<const int*>(optval));
-        return 0;
+        return {0, 0};
       }));
   EXPECT_TRUE(
       socket_option.setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));

--- a/test/common/network/socket_option_test.h
+++ b/test/common/network/socket_option_test.h
@@ -75,12 +75,13 @@ public:
       const std::set<envoy::config::core::v3::SocketOption::SocketState>& when) {
     for (auto state : when) {
       if (option_name.hasValue()) {
-        EXPECT_CALL(os_sys_calls_,
-                    setsockopt_(_, option_name.level(), option_name.option(), _, sizeof(int)))
-            .WillOnce(Invoke([option_val](os_fd_t, int, int, const void* optval, socklen_t) -> int {
-              EXPECT_EQ(option_val, *static_cast<const int*>(optval));
-              return 0;
-            }));
+        EXPECT_CALL(socket_,
+                    setSocketOption(option_name.level(), option_name.option(), _, sizeof(int)))
+            .WillOnce(Invoke(
+                [option_val](int, int, const void* optval, socklen_t) -> Api::SysCallIntResult {
+                  EXPECT_EQ(option_val, *static_cast<const int*>(optval));
+                  return {0, 0};
+                }));
         EXPECT_TRUE(socket_option.setOption(socket_, state));
       } else {
         EXPECT_FALSE(socket_option.setOption(socket_, state));

--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -123,10 +123,9 @@ TEST_P(UdpListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
 #ifdef SO_RXQ_OVFL
   // Verify that overflow detection is enabled.
   int get_overflow = 0;
-  auto& os_syscalls = Api::OsSysCallsSingleton::get();
   socklen_t int_size = static_cast<socklen_t>(sizeof(get_overflow));
-  const Api::SysCallIntResult result = os_syscalls.getsockopt(
-      server_socket_->ioHandle().fd(), SOL_SOCKET, SO_RXQ_OVFL, &get_overflow, &int_size);
+  const Api::SysCallIntResult result =
+      server_socket_->getSocketOption(SOL_SOCKET, SO_RXQ_OVFL, &get_overflow, &int_size);
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(1, get_overflow);
 #endif

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -169,7 +169,10 @@ TEST_P(NetworkUtilityGetLocalAddress, GetLocalAddress) {
   EXPECT_NE(nullptr, Utility::getLocalAddress(GetParam()));
 }
 
-TEST(NetworkUtility, GetOriginalDst) { EXPECT_EQ(nullptr, Utility::getOriginalDst(-1)); }
+TEST(NetworkUtility, GetOriginalDst) {
+  testing::NiceMock<Network::MockConnectionSocket> socket;
+  EXPECT_EQ(nullptr, Utility::getOriginalDst(socket));
+}
 
 TEST(NetworkUtility, LocalConnection) {
   Network::Address::InstanceConstSharedPtr local_addr;

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -52,7 +52,7 @@ TEST(UdpOverUdsStatsdSinkTest, InitWithPipeAddress) {
 
   // Start the server.
   Network::SocketImpl sock(Network::Address::SocketType::Datagram, uds_address);
-  RELEASE_ASSERT(sock.setBlocking(false).rc_ != -1, "");
+  RELEASE_ASSERT(sock.setBlockingForTest(false).rc_ != -1, "");
   sock.bind(uds_address);
 
   // Do the flush which should have somewhere to write now.

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -51,13 +51,8 @@ TEST(UdpOverUdsStatsdSinkTest, InitWithPipeAddress) {
   sink.flush(snapshot);
 
   // Start the server.
-  // TODO(mattklein123): Right now all sockets are non-blocking. Move this non-blocking
-  // modification back to the abstraction layer so it will work for multiple platforms. Additionally
-  // this uses low level networking calls because our abstractions in this area only work for IP
-  // sockets. Revisit this also.
   Network::SocketImpl sock(Network::Address::SocketType::Datagram, uds_address);
-  RELEASE_ASSERT(
-      Api::OsSysCallsSingleton::get().setsocketblocking(sock.ioHandle().fd(), false).rc_ != -1, "");
+  RELEASE_ASSERT(sock.setBlocking(false).rc_ != -1, "");
   sock.bind(uds_address);
 
   // Do the flush which should have somewhere to write now.

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -220,6 +220,7 @@ public:
   MOCK_METHOD(IoHandle&, ioHandle, ());
   MOCK_METHOD(const IoHandle&, ioHandle, (), (const));
   MOCK_METHOD(Address::SocketType, socketType, (), (const));
+  MOCK_METHOD(Address::Type, addressType, (), (const));
   MOCK_METHOD(void, close, ());
   MOCK_METHOD(bool, isOpen, (), (const));
   MOCK_METHOD(void, addOption_, (const Socket::OptionConstSharedPtr& option));
@@ -232,6 +233,9 @@ public:
   MOCK_METHOD(Api::SysCallIntResult, bind, (const Address::InstanceConstSharedPtr));
   MOCK_METHOD(Api::SysCallIntResult, connect, (const Address::InstanceConstSharedPtr));
   MOCK_METHOD(Api::SysCallIntResult, listen, (int));
+  MOCK_METHOD(Api::SysCallIntResult, setSocketOption, (int, int, const void*, socklen_t));
+  MOCK_METHOD(Api::SysCallIntResult, getSocketOption, (int, int, void*, socklen_t*));
+  MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool));
 
   IoHandlePtr io_handle_;
   Address::InstanceConstSharedPtr local_address_;
@@ -278,6 +282,7 @@ public:
   MOCK_METHOD(IoHandle&, ioHandle, ());
   MOCK_METHOD(const IoHandle&, ioHandle, (), (const));
   MOCK_METHOD(Address::SocketType, socketType, (), (const));
+  MOCK_METHOD(Address::Type, addressType, (), (const));
   MOCK_METHOD(void, close, ());
   MOCK_METHOD(bool, isOpen, (), (const));
   MOCK_METHOD(IoHandlePtr, socket, (Address::SocketType, Address::Type, Address::IpVersion),
@@ -287,6 +292,9 @@ public:
   MOCK_METHOD(Api::SysCallIntResult, bind, (const Address::InstanceConstSharedPtr));
   MOCK_METHOD(Api::SysCallIntResult, connect, (const Address::InstanceConstSharedPtr));
   MOCK_METHOD(Api::SysCallIntResult, listen, (int));
+  MOCK_METHOD(Api::SysCallIntResult, setSocketOption, (int, int, const void*, socklen_t));
+  MOCK_METHOD(Api::SysCallIntResult, getSocketOption, (int, int, void*, socklen_t*));
+  MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool));
 
   IoHandlePtr io_handle_;
   Address::InstanceConstSharedPtr local_address_;

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -235,7 +235,7 @@ public:
   MOCK_METHOD(Api::SysCallIntResult, listen, (int));
   MOCK_METHOD(Api::SysCallIntResult, setSocketOption, (int, int, const void*, socklen_t));
   MOCK_METHOD(Api::SysCallIntResult, getSocketOption, (int, int, void*, socklen_t*));
-  MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool));
+  MOCK_METHOD(Api::SysCallIntResult, setBlockingForTest, (bool));
 
   IoHandlePtr io_handle_;
   Address::InstanceConstSharedPtr local_address_;
@@ -294,7 +294,7 @@ public:
   MOCK_METHOD(Api::SysCallIntResult, listen, (int));
   MOCK_METHOD(Api::SysCallIntResult, setSocketOption, (int, int, const void*, socklen_t));
   MOCK_METHOD(Api::SysCallIntResult, getSocketOption, (int, int, void*, socklen_t*));
-  MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool));
+  MOCK_METHOD(Api::SysCallIntResult, setBlockingForTest, (bool));
 
   IoHandlePtr io_handle_;
   Address::InstanceConstSharedPtr local_address_;

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -92,6 +92,7 @@ public:
   Network::Address::SocketType socketType() const override {
     return Network::Address::SocketType::Stream;
   }
+  Network::Address::Type addressType() const override { return local_address_->type(); }
   void setLocalAddress(const Network::Address::InstanceConstSharedPtr&) override {}
   void restoreLocalAddress(const Network::Address::InstanceConstSharedPtr&) override {}
   void setRemoteAddress(const Network::Address::InstanceConstSharedPtr&) override {}
@@ -107,6 +108,11 @@ public:
   Api::SysCallIntResult connect(const Network::Address::InstanceConstSharedPtr) override {
     return {0, 0};
   }
+  Api::SysCallIntResult setSocketOption(int, int, const void*, socklen_t) override {
+    return {0, 0};
+  }
+  Api::SysCallIntResult getSocketOption(int, int, void*, socklen_t*) override { return {0, 0}; }
+  Api::SysCallIntResult setBlocking(bool) override { return {0, 0}; }
 
 private:
   Network::IoHandlePtr io_handle_;

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -112,7 +112,7 @@ public:
     return {0, 0};
   }
   Api::SysCallIntResult getSocketOption(int, int, void*, socklen_t*) override { return {0, 0}; }
-  Api::SysCallIntResult setBlocking(bool) override { return {0, 0}; }
+  Api::SysCallIntResult setBlockingForTest(bool) override { return {0, 0}; }
 
 private:
   Network::IoHandlePtr io_handle_;

--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -55,21 +55,18 @@ udp_listener_config:
 #endif
                            /* expected_creation_params */ {true, false});
 
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ IPPROTO_IP,
+  expectSetsockopt(/* expected_sockopt_level */ IPPROTO_IP,
                    /* expected_sockopt_name */ ENVOY_IP_PKTINFO,
                    /* expected_value */ 1,
                    /* expected_num_calls */ 1);
 #ifdef SO_RXQ_OVFL
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ SOL_SOCKET,
+  expectSetsockopt(/* expected_sockopt_level */ SOL_SOCKET,
                    /* expected_sockopt_name */ SO_RXQ_OVFL,
                    /* expected_value */ 1,
                    /* expected_num_calls */ 1);
 #endif
 
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ SOL_SOCKET,
+  expectSetsockopt(/* expected_sockopt_level */ SOL_SOCKET,
                    /* expected_sockopt_name */ SO_REUSEPORT,
                    /* expected_value */ 1,
                    /* expected_num_calls */ 1);

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -77,8 +77,8 @@ public:
                         ListenSocketCreationParams expected_creation_params = {true, true}) {
     if (expected_option.hasValue()) {
       expectCreateListenSocket(expected_state, expected_num_options, expected_creation_params);
-      expectSetsockopt(os_sys_calls_, expected_option.level(), expected_option.option(),
-                       expected_value, expected_num_options);
+      expectSetsockopt(expected_option.level(), expected_option.option(), expected_value,
+                       expected_num_options);
       manager_->addOrUpdateListener(listener, "", true);
       EXPECT_EQ(1U, manager_->listeners().size());
     } else {
@@ -336,8 +336,14 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, UdpAddress) {
   EXPECT_CALL(server_.random_, uuid());
   EXPECT_CALL(*worker_, addListener(_, _, _));
   EXPECT_CALL(listener_factory_,
-              createListenSocket(_, Network::Address::SocketType::Datagram, _, {{true, false}}));
-  EXPECT_CALL(os_sys_calls_, setsockopt_(_, _, _, _, _)).Times(testing::AtLeast(1));
+              createListenSocket(_, Network::Address::SocketType::Datagram, _, {{true, false}}))
+      .WillOnce(
+          Invoke([this](const Network::Address::InstanceConstSharedPtr&,
+                        Network::Address::SocketType, const Network::Socket::OptionsSharedPtr&,
+                        const ListenSocketCreationParams&) -> Network::SocketSharedPtr {
+            return listener_factory_.socket_;
+          }));
+  EXPECT_CALL(*listener_factory_.socket_, setSocketOption(_, _, _, _)).Times(testing::AtLeast(1));
   EXPECT_CALL(os_sys_calls_, close(_)).WillRepeatedly(Return(Api::SysCallIntResult{0, errno}));
   manager_->addOrUpdateListener(listener_proto, "", true);
   EXPECT_EQ(1u, manager_->listeners().size());
@@ -3481,7 +3487,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstFilter) {
 }
 
 class OriginalDstTestFilter : public Extensions::ListenerFilters::OriginalDst::OriginalDstFilter {
-  Network::Address::InstanceConstSharedPtr getOriginalDst(os_fd_t) override {
+  Network::Address::InstanceConstSharedPtr getOriginalDst(Network::Socket&) override {
     return Network::Address::InstanceConstSharedPtr{
         new Network::Address::Ipv4Instance("127.0.0.2", 2345)};
   }
@@ -3555,7 +3561,7 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, OriginalDstTestFilter) {
 
 class OriginalDstTestFilterIPv6
     : public Extensions::ListenerFilters::OriginalDst::OriginalDstFilter {
-  Network::Address::InstanceConstSharedPtr getOriginalDst(os_fd_t) override {
+  Network::Address::InstanceConstSharedPtr getOriginalDst(Network::Socket&) override {
     return Network::Address::InstanceConstSharedPtr{
         new Network::Address::Ipv6Instance("1::2", 2345)};
   }
@@ -3728,14 +3734,12 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, ReusePortListenerDisabled) {
 #endif
                            /* expected_creation_params */ {true, false});
 
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ IPPROTO_IP,
+  expectSetsockopt(/* expected_sockopt_level */ IPPROTO_IP,
                    /* expected_sockopt_name */ ENVOY_IP_PKTINFO,
                    /* expected_value */ 1,
                    /* expected_num_calls */ 1);
 #ifdef SO_RXQ_OVFL
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ SOL_SOCKET,
+  expectSetsockopt(/* expected_sockopt_level */ SOL_SOCKET,
                    /* expected_sockopt_name */ SO_RXQ_OVFL,
                    /* expected_value */ 1,
                    /* expected_num_calls */ 1);
@@ -3764,14 +3768,14 @@ TEST_F(ListenerManagerImplWithRealFiltersTest, LiteralSockoptListenerEnabled) {
 
   expectCreateListenSocket(envoy::config::core::v3::SocketOption::STATE_PREBIND,
                            /* expected_num_options */ 3);
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ 1,
-                   /* expected_sockopt_name */ 2,
-                   /* expected_value */ 3);
-  expectSetsockopt(os_sys_calls_,
-                   /* expected_sockopt_level */ 4,
-                   /* expected_sockopt_name */ 5,
-                   /* expected_value */ 6);
+  expectSetsockopt(
+      /* expected_sockopt_level */ 1,
+      /* expected_sockopt_name */ 2,
+      /* expected_value */ 3);
+  expectSetsockopt(
+      /* expected_sockopt_level */ 4,
+      /* expected_sockopt_name */ 5,
+      /* expected_value */ 6);
   manager_->addOrUpdateListener(listener, "", true);
   EXPECT_EQ(1U, manager_->listeners().size());
 }

--- a/test/server/listener_manager_impl_test.h
+++ b/test/server/listener_manager_impl_test.h
@@ -212,18 +212,18 @@ protected:
   }
 
   /**
-   * Validate that setsockopt() is called the expected number of times with the expected options.
+   * Validate that setSocketOption() is called the expected number of times with the expected
+   * options.
    */
-  void expectSetsockopt(NiceMock<Api::MockOsSysCalls>& os_sys_calls, int expected_sockopt_level,
-                        int expected_sockopt_name, int expected_value,
+  void expectSetsockopt(int expected_sockopt_level, int expected_sockopt_name, int expected_value,
                         uint32_t expected_num_calls = 1) {
-    EXPECT_CALL(os_sys_calls,
-                setsockopt_(_, expected_sockopt_level, expected_sockopt_name, _, sizeof(int)))
+    EXPECT_CALL(*listener_factory_.socket_,
+                setSocketOption(expected_sockopt_level, expected_sockopt_name, _, sizeof(int)))
         .Times(expected_num_calls)
-        .WillRepeatedly(
-            Invoke([expected_value](os_fd_t, int, int, const void* optval, socklen_t) -> int {
+        .WillRepeatedly(Invoke(
+            [expected_value](int, int, const void* optval, socklen_t) -> Api::SysCallIntResult {
               EXPECT_EQ(expected_value, *static_cast<const int*>(optval));
-              return 0;
+              return {0, 0};
             }));
   }
 

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -230,7 +230,7 @@ Api::IoCallUint64Result readFromSocket(IoHandle& handle, const Address::Instance
 UdpSyncPeer::UdpSyncPeer(Network::Address::IpVersion version)
     : socket_(
           std::make_unique<UdpListenSocket>(getCanonicalLoopbackAddress(version), nullptr, true)) {
-  RELEASE_ASSERT(socket_->setBlocking(true).rc_ != -1, "");
+  RELEASE_ASSERT(socket_->setBlockingForTest(true).rc_ != -1, "");
 }
 
 void UdpSyncPeer::write(const std::string& buffer, const Network::Address::Instance& peer) {

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -230,9 +230,7 @@ Api::IoCallUint64Result readFromSocket(IoHandle& handle, const Address::Instance
 UdpSyncPeer::UdpSyncPeer(Network::Address::IpVersion version)
     : socket_(
           std::make_unique<UdpListenSocket>(getCanonicalLoopbackAddress(version), nullptr, true)) {
-  RELEASE_ASSERT(
-      Api::OsSysCallsSingleton::get().setsocketblocking(socket_->ioHandle().fd(), true).rc_ != -1,
-      "");
+  RELEASE_ASSERT(socket_->setBlocking(true).rc_ != -1, "");
 }
 
 void UdpSyncPeer::write(const std::string& buffer, const Network::Address::Instance& peer) {

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -801,6 +801,7 @@ openssl
 opentracing
 optimizations
 optname
+optval
 ostream
 outlier
 outliers
@@ -987,6 +988,7 @@ snapshotted
 sockaddr
 socketpair
 sockfd
+socklen
 sockopt
 sockopts
 somestring


### PR DESCRIPTION
- add functions to set/get socket options directly on socket.
- add function to update socket blocking flag

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Medium
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
