### PR TITLE
http: refactoring http and tcp upstreams

### DIFF
--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -478,7 +478,6 @@ private:
                    Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority) PURE;
 
   std::unique_ptr<GenericConnPool> createConnPool();
-  UpstreamRequestPtr createUpstreamRequest(std::unique_ptr<GenericConnPool>&& conn_pool);
 
   void maybeDoShadowing();
   bool maybeRetryReset(Http::StreamResetReason reset_reason, UpstreamRequest& upstream_request);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -477,12 +477,9 @@ private:
                    Runtime::Loader& runtime, Runtime::RandomGenerator& random,
                    Event::Dispatcher& dispatcher, Upstream::ResourcePriority priority) PURE;
 
-  using HttpOrTcpPool =
-      absl::variant<Http::ConnectionPool::Instance*, Tcp::ConnectionPool::Instance*>;
-  HttpOrTcpPool createConnPool(Upstream::HostDescriptionConstSharedPtr& host);
-  UpstreamRequestPtr createUpstreamRequest(Filter::HttpOrTcpPool conn_pool);
+  std::unique_ptr<GenericConnPool> createConnPool();
+  UpstreamRequestPtr createUpstreamRequest(std::unique_ptr<GenericConnPool>&& conn_pool);
 
-  Http::ConnectionPool::Instance* getHttpConnPool();
   void maybeDoShadowing();
   bool maybeRetryReset(Http::StreamResetReason reset_reason, UpstreamRequest& upstream_request);
   uint32_t numRequestsAwaitingHeaders();

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -522,7 +522,7 @@ void HttpConnPool::newStream(GenericConnectionPoolCallbacks* callbacks) {
   // might get deleted inline as well. Only write the returned handle out if it is not nullptr to
   // deal with this case.
   Http::ConnectionPool::Cancellable* handle =
-      conn_pool_.newStream(*callbacks->upstreamRequest(), *this);
+      conn_pool_->newStream(*callbacks->upstreamRequest(), *this);
   if (handle) {
     conn_pool_stream_handle_ = handle;
   }
@@ -547,7 +547,7 @@ bool HttpConnPool::cancelAnyPendingRequest() {
   return false;
 }
 
-absl::optional<Http::Protocol> HttpConnPool::protocol() const { return conn_pool_.protocol(); }
+absl::optional<Http::Protocol> HttpConnPool::protocol() const { return conn_pool_->protocol(); }
 
 void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
                                  absl::string_view transport_failure_reason,

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -203,8 +203,6 @@ private:
 
 class HttpConnPool : public GenericConnPool, public Http::ConnectionPool::Callbacks {
 public:
-  HttpConnPool() = default;
-
   // GenericConnPool
   bool initialize(Upstream::ClusterManager& cm, const RouteEntry& route_entry,
                   Http::Protocol protocol, Upstream::LoadBalancerContext* ctx) override {
@@ -228,15 +226,13 @@ public:
 
 private:
   // Points to the actual connection pool to create streams from.
-  Http::ConnectionPool::Instance* conn_pool_;
+  Http::ConnectionPool::Instance* conn_pool_{};
   Http::ConnectionPool::Cancellable* conn_pool_stream_handle_{};
   GenericConnectionPoolCallbacks* callbacks_{};
 };
 
 class TcpConnPool : public GenericConnPool, public Tcp::ConnectionPool::Callbacks {
 public:
-  TcpConnPool() = default;
-
   bool initialize(Upstream::ClusterManager& cm, const RouteEntry& route_entry, Http::Protocol,
                   Upstream::LoadBalancerContext* ctx) override {
     conn_pool_ = cm.tcpConnPoolForCluster(route_entry.clusterName(),

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -35,6 +35,11 @@ class GenericConnPool : public Logger::Loggable<Logger::Id::router> {
 public:
   virtual ~GenericConnPool() = default;
 
+  // Initializes the connection pool. This must be called before the connection
+  // pool is valid, and can be used.
+  virtual bool initialize(Upstream::ClusterManager& cm, const RouteEntry& route_entry,
+                          Http::Protocol protocol, Upstream::LoadBalancerContext* ctx) PURE;
+
   // Called to create a new HTTP stream or TCP connection. The implementation
   // is then responsible for calling either onPoolReady or onPoolFailure on the
   // supplied GenericConnectionPoolCallbacks.
@@ -44,6 +49,8 @@ public:
   virtual bool cancelAnyPendingRequest() PURE;
   // Optionally returns the protocol for the connection pool.
   virtual absl::optional<Http::Protocol> protocol() const PURE;
+  // Returns the host for this conn pool.
+  virtual Upstream::HostDescriptionConstSharedPtr host() const PURE;
 };
 
 // An API for the UpstreamRequest to get callbacks from either an HTTP or TCP
@@ -196,12 +203,20 @@ private:
 
 class HttpConnPool : public GenericConnPool, public Http::ConnectionPool::Callbacks {
 public:
-  HttpConnPool(Http::ConnectionPool::Instance& conn_pool) : conn_pool_(conn_pool) {}
+  HttpConnPool() = default;
 
   // GenericConnPool
+  bool initialize(Upstream::ClusterManager& cm, const RouteEntry& route_entry,
+                  Http::Protocol protocol, Upstream::LoadBalancerContext* ctx) override {
+    conn_pool_ =
+        cm.httpConnPoolForCluster(route_entry.clusterName(), route_entry.priority(), protocol, ctx);
+    return conn_pool_ != nullptr;
+  }
+
   void newStream(GenericConnectionPoolCallbacks* callbacks) override;
   bool cancelAnyPendingRequest() override;
   absl::optional<Http::Protocol> protocol() const override;
+  Upstream::HostDescriptionConstSharedPtr host() const override { return conn_pool_->host(); }
 
   // Http::ConnectionPool::Callbacks
   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
@@ -213,14 +228,21 @@ public:
 
 private:
   // Points to the actual connection pool to create streams from.
-  Http::ConnectionPool::Instance& conn_pool_;
+  Http::ConnectionPool::Instance* conn_pool_;
   Http::ConnectionPool::Cancellable* conn_pool_stream_handle_{};
   GenericConnectionPoolCallbacks* callbacks_{};
 };
 
 class TcpConnPool : public GenericConnPool, public Tcp::ConnectionPool::Callbacks {
 public:
-  TcpConnPool(Tcp::ConnectionPool::Instance* conn_pool) : conn_pool_(conn_pool) {}
+  TcpConnPool() = default;
+
+  bool initialize(Upstream::ClusterManager& cm, const RouteEntry& route_entry, Http::Protocol,
+                  Upstream::LoadBalancerContext* ctx) override {
+    conn_pool_ = cm.tcpConnPoolForCluster(route_entry.clusterName(),
+                                          Upstream::ResourcePriority::Default, ctx);
+    return conn_pool_ != nullptr;
+  }
 
   void newStream(GenericConnectionPoolCallbacks* callbacks) override {
     callbacks_ = callbacks;
@@ -236,7 +258,7 @@ public:
     return false;
   }
   absl::optional<Http::Protocol> protocol() const override { return absl::nullopt; }
-
+  Upstream::HostDescriptionConstSharedPtr host() const override { return conn_pool_->host(); }
   // Tcp::ConnectionPool::Callbacks
   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
                      Upstream::HostDescriptionConstSharedPtr host) override {

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -111,7 +111,7 @@ public:
 
 class TcpConnPoolTest : public ::testing::Test {
 public:
-  TcpConnPoolTest() : conn_pool_(), host_(std::make_shared<NiceMock<Upstream::MockHost>>()) {
+  TcpConnPoolTest() : host_(std::make_shared<NiceMock<Upstream::MockHost>>()) {
     NiceMock<MockRouteEntry> route_entry;
     NiceMock<Upstream::MockClusterManager> cm;
     EXPECT_CALL(cm, tcpConnPoolForCluster(_, _, _)).WillOnce(Return(&mock_pool_));


### PR DESCRIPTION
Moving the choice of http or tcp connection pool from the router to the generic connection pool.

This will allow pluggable connection pools to choose to do HTTP or TCP on their own, as well as getting rid of a bunch of ugly variant logic.

Risk Level: medium (router refactor, ideally no-op) 
Testing: existing test pass
Docs Changes: n/a
Release Notes: n/a
