### PR TITLE
udp: renaming ActiveUdpListener to ActiveRawUdpListener

### DIFF
--- a/source/server/active_raw_udp_listener_config.cc
+++ b/source/server/active_raw_udp_listener_config.cc
@@ -15,7 +15,7 @@ Network::ConnectionHandler::ActiveListenerPtr
 ActiveRawUdpListenerFactory::createActiveUdpListener(Network::ConnectionHandler& parent,
                                                      Event::Dispatcher& dispatcher,
                                                      Network::ListenerConfig& config) {
-  return std::make_unique<ActiveUdpListener>(parent, dispatcher, config);
+  return std::make_unique<ActiveRawUdpListener>(parent, dispatcher, config);
 }
 
 ProtobufTypes::MessagePtr ActiveRawUdpListenerConfigFactory::createEmptyConfigProto() {

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -521,14 +521,14 @@ ConnectionHandlerImpl::ActiveTcpConnection::~ActiveTcpConnection() {
   active_connections_.listener_.parent_.decNumConnections();
 }
 
-ActiveUdpListener::ActiveUdpListener(Network::ConnectionHandler& parent,
+ActiveRawUdpListener::ActiveRawUdpListener(Network::ConnectionHandler& parent,
                                      Event::Dispatcher& dispatcher, Network::ListenerConfig& config)
-    : ActiveUdpListener(
+    : ActiveRawUdpListener(
           parent,
           dispatcher.createUdpListener(config.listenSocketFactory().getListenSocket(), *this),
           config) {}
 
-ActiveUdpListener::ActiveUdpListener(Network::ConnectionHandler& parent,
+ActiveRawUdpListener::ActiveRawUdpListener(Network::ConnectionHandler& parent,
                                      Network::UdpListenerPtr&& listener,
                                      Network::ListenerConfig& config)
     : ConnectionHandlerImpl::ActiveListenerImplBase(parent, &config),
@@ -544,26 +544,26 @@ ActiveUdpListener::ActiveUdpListener(Network::ConnectionHandler& parent,
   }
 }
 
-void ActiveUdpListener::onData(Network::UdpRecvData& data) { read_filter_->onData(data); }
+void ActiveRawUdpListener::onData(Network::UdpRecvData& data) { read_filter_->onData(data); }
 
-void ActiveUdpListener::onReadReady() {}
+void ActiveRawUdpListener::onReadReady() {}
 
-void ActiveUdpListener::onWriteReady(const Network::Socket&) {
+void ActiveRawUdpListener::onWriteReady(const Network::Socket&) {
   // TODO(sumukhs): This is not used now. When write filters are implemented, this is a
   // trigger to invoke the on write ready API on the filters which is when they can write
   // data
 }
 
-void ActiveUdpListener::onReceiveError(Api::IoError::IoErrorCode error_code) {
+void ActiveRawUdpListener::onReceiveError(Api::IoError::IoErrorCode error_code) {
   read_filter_->onReceiveError(error_code);
 }
 
-void ActiveUdpListener::addReadFilter(Network::UdpListenerReadFilterPtr&& filter) {
+void ActiveRawUdpListener::addReadFilter(Network::UdpListenerReadFilterPtr&& filter) {
   ASSERT(read_filter_ == nullptr, "Cannot add a 2nd UDP read filter");
   read_filter_ = std::move(filter);
 }
 
-Network::UdpListener& ActiveUdpListener::udpListener() { return *udp_listener_; }
+Network::UdpListener& ActiveRawUdpListener::udpListener() { return *udp_listener_; }
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -522,15 +522,16 @@ ConnectionHandlerImpl::ActiveTcpConnection::~ActiveTcpConnection() {
 }
 
 ActiveRawUdpListener::ActiveRawUdpListener(Network::ConnectionHandler& parent,
-                                     Event::Dispatcher& dispatcher, Network::ListenerConfig& config)
+                                           Event::Dispatcher& dispatcher,
+                                           Network::ListenerConfig& config)
     : ActiveRawUdpListener(
           parent,
           dispatcher.createUdpListener(config.listenSocketFactory().getListenSocket(), *this),
           config) {}
 
 ActiveRawUdpListener::ActiveRawUdpListener(Network::ConnectionHandler& parent,
-                                     Network::UdpListenerPtr&& listener,
-                                     Network::ListenerConfig& config)
+                                           Network::UdpListenerPtr&& listener,
+                                           Network::ListenerConfig& config)
     : ConnectionHandlerImpl::ActiveListenerImplBase(parent, &config),
       udp_listener_(std::move(listener)), read_filter_(nullptr) {
   // Create the filter chain on creating a new udp listener

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -325,9 +325,9 @@ private:
  * Wrapper for an active udp listener owned by this handler.
  */
 class ActiveRawUdpListener : public Network::UdpListenerCallbacks,
-                          public ConnectionHandlerImpl::ActiveListenerImplBase,
-                          public Network::UdpListenerFilterManager,
-                          public Network::UdpReadFilterCallbacks {
+                             public ConnectionHandlerImpl::ActiveListenerImplBase,
+                             public Network::UdpListenerFilterManager,
+                             public Network::UdpReadFilterCallbacks {
 public:
   ActiveRawUdpListener(Network::ConnectionHandler& parent, Event::Dispatcher& dispatcher,
                        Network::ListenerConfig& config);

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -325,15 +325,15 @@ private:
  * Wrapper for an active udp listener owned by this handler.
  * TODO(danzh): rename to ActiveRawUdpListener.
  */
-class ActiveUdpListener : public Network::UdpListenerCallbacks,
+class ActiveRawUdpListener : public Network::UdpListenerCallbacks,
                           public ConnectionHandlerImpl::ActiveListenerImplBase,
                           public Network::UdpListenerFilterManager,
                           public Network::UdpReadFilterCallbacks {
 public:
-  ActiveUdpListener(Network::ConnectionHandler& parent, Event::Dispatcher& dispatcher,
-                    Network::ListenerConfig& config);
-  ActiveUdpListener(Network::ConnectionHandler& parent, Network::UdpListenerPtr&& listener,
-                    Network::ListenerConfig& config);
+  ActiveRawUdpListener(Network::ConnectionHandler& parent, Event::Dispatcher& dispatcher,
+                       Network::ListenerConfig& config);
+  ActiveRawUdpListener(Network::ConnectionHandler& parent, Network::UdpListenerPtr&& listener,
+                       Network::ListenerConfig& config);
 
   // Network::UdpListenerCallbacks
   void onData(Network::UdpRecvData& data) override;

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -323,7 +323,6 @@ private:
 
 /**
  * Wrapper for an active udp listener owned by this handler.
- * TODO(danzh): rename to ActiveRawUdpListener.
  */
 class ActiveRawUdpListener : public Network::UdpListenerCallbacks,
                           public ConnectionHandlerImpl::ActiveListenerImplBase,


### PR DESCRIPTION
Signed-off-by: Yugant <yugant@google.com>

Commit Message: Renaming the ActiveUdpListener to ActiveRawUdpListener under source/server/connection_handler_impl.h. The original name is not informative enough to distinguish with ActiveQuicListener which is also a UDP listener callback.
  
Additional Description: Submitting as a part of intern ramp up.

Risk Level:  Low

Testing:
bazel build passes successfully after the renaming.
```
> bazel build //source/exe:envoy-static 
...
INFO: Elapsed time: 5.615s, Critical Path: 4.37s
INFO: 2 processes: 2 remote.
INFO: Build completed successfully, 4 total actions
```

Ran all tests. All 631 tests passed successfully.
```
> bazel test //test/...
...
Executed 20 out of 631 tests: 631 tests pass.
INFO: Build completed successfully, 3165 total actions
```
Docs Changes: None

Release Notes: None