### PR TITLE
Reflect DiscoveryResponse.control_plane as a TextReadout stats

### DIFF
--- a/include/envoy/config/subscription.h
+++ b/include/envoy/config/subscription.h
@@ -105,7 +105,8 @@ using SubscriptionPtr = std::unique_ptr<Subscription>;
   COUNTER(update_success)                                                                          \
   GAUGE(update_time, NeverImport)                                                                  \
   GAUGE(version, NeverImport)                                                                      \
-  TEXT_READOUT(version_text)
+  TEXT_READOUT(version_text)                                                                       \
+  TEXT_READOUT(control_plane_identifier)
 
 /**
  * Struct definition for per subscription stats. @see stats_macros.h

--- a/source/common/config/filesystem_subscription_impl.cc
+++ b/source/common/config/filesystem_subscription_impl.cc
@@ -55,6 +55,7 @@ void FilesystemSubscriptionImpl::refresh() {
     stats_.update_time_.set(DateUtil::nowToMilliseconds(api_.timeSource()));
     stats_.version_.set(HashUtil::xxHash64(message.version_info()));
     stats_.version_text_.set(message.version_info());
+    stats_.control_plane_identifier_.set(message.control_plane().identifier());
     stats_.update_success_.inc();
     ENVOY_LOG(debug, "Filesystem config update accepted for {}: {}", path_, message.DebugString());
   } catch (const ProtobufMessage::UnknownProtoFieldException& e) {

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -31,7 +31,7 @@ public:
   GrpcMuxImpl(const LocalInfo::LocalInfo& local_info, Grpc::RawAsyncClientPtr async_client,
               Event::Dispatcher& dispatcher, const Protobuf::MethodDescriptor& service_method,
               envoy::config::core::v3::ApiVersion transport_api_version,
-              Runtime::RandomGenerator& random, Stats::Scope& scope,
+              Runtime::RandomGenerator& random, Stats::Scope& scope, SubscriptionStats stats,
               const RateLimitSettings& rate_limit_settings, bool skip_subsequent_node);
   ~GrpcMuxImpl() override = default;
 
@@ -134,6 +134,7 @@ private:
   // This string is a type URL.
   std::queue<std::string> request_queue_;
   const envoy::config::core::v3::ApiVersion transport_api_version_;
+  SubscriptionStats stats_;
 };
 
 class NullGrpcMuxImpl : public GrpcMux,

--- a/source/common/config/http_subscription_impl.cc
+++ b/source/common/config/http_subscription_impl.cc
@@ -90,6 +90,7 @@ void HttpSubscriptionImpl::parseResponse(const Http::ResponseMessage& response) 
     stats_.update_time_.set(DateUtil::nowToMilliseconds(dispatcher_.timeSource()));
     stats_.version_.set(HashUtil::xxHash64(request_.version_info()));
     stats_.version_text_.set(request_.version_info());
+    stats_.control_plane_identifier_.set(message.control_plane().identifier());
     stats_.update_success_.inc();
   } catch (const EnvoyException& e) {
     handleFailure(Config::ConfigUpdateFailureReason::UpdateRejected, &e);

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -69,7 +69,7 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
                                                      api_config_source, scope, true)
                   ->create(),
               dispatcher_, sotwGrpcMethod(type_url), api_config_source.transport_api_version(),
-              random_, scope, Utility::parseRateLimitSettings(api_config_source),
+              random_, scope, stats, Utility::parseRateLimitSettings(api_config_source),
               api_config_source.set_node_on_first_message_only()),
           callbacks, stats, type_url, dispatcher_, Utility::configSourceInitialFetchTimeout(config),
           /*is_aggregated*/ false);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -333,6 +333,7 @@ ClusterManagerImpl::ClusterManagerImpl(
                   : "envoy.service.discovery.v2.AggregatedDiscoveryService."
                     "StreamAggregatedResources"),
           dyn_resources.ads_config().transport_api_version(), random_, stats_,
+          Envoy::Config::Utility::generateStats(stats_),
           Envoy::Config::Utility::parseRateLimitSettings(dyn_resources.ads_config()),
           bootstrap.dynamic_resources().ads_config().set_node_on_first_message_only());
     }

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -52,7 +52,7 @@ public:
     mux_ = std::make_shared<Config::GrpcMuxImpl>(
         local_info_, std::unique_ptr<Grpc::MockAsyncClient>(async_client_), dispatcher_,
         *method_descriptor_, envoy::config::core::v3::ApiVersion::AUTO, random_, stats_store_,
-        rate_limit_settings_, true);
+        stats_, rate_limit_settings_, true);
     subscription_ = std::make_unique<GrpcSubscriptionImpl>(
         mux_, callbacks_, stats_, Config::TypeUrl::get().ClusterLoadAssignment, dispatcher_,
         init_fetch_timeout, false);


### PR DESCRIPTION
Add SubscriptionStats::control_plane_identifier field with text from DiscoveryResponse.control_plane.identifier set by the remote.

Store it in SubscriptionStats instead of ControlPlaneStats because ControlPlaneStats only seem to be available with GRPC.

Signed-off-by: Misha Efimov mef@google.com

Risk Level: Low
Testing: TBD
Docs Changes: TBD

Fixes #11000