### PR TITLE
http: initialize HeaderMap from iterator

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -231,18 +231,6 @@ uint64_t HeaderMapImpl::appendToHeader(HeaderString& header, absl::string_view d
   return data.size() + byte_size;
 }
 
-void HeaderMapImpl::initFromInitList(
-    HeaderMap& new_header_map,
-    const std::initializer_list<std::pair<LowerCaseString, std::string>>& values) {
-  for (auto& value : values) {
-    HeaderString key_string;
-    key_string.setCopy(value.first.get().c_str(), value.first.get().size());
-    HeaderString value_string;
-    value_string.setCopy(value.second.c_str(), value.second.size());
-    new_header_map.addViaMove(std::move(key_string), std::move(value_string));
-  }
-}
-
 void HeaderMapImpl::updateSize(uint64_t from_size, uint64_t to_size) {
   ASSERT(cached_byte_size_ >= from_size);
   cached_byte_size_ -= from_size;

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -63,6 +63,15 @@ public:
   static void
   initFromInitList(HeaderMap& new_header_map,
                    const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
+  template <class It> static void initFromInitList(HeaderMap& new_header_map, It begin, It end) {
+    for (auto it = begin; it != end; ++it) {
+      HeaderString key_string;
+      key_string.setCopy(it->first.get().c_str(), it->first.get().size());
+      HeaderString value_string;
+      value_string.setCopy(it->second.c_str(), it->second.size());
+      new_header_map.addViaMove(std::move(key_string), std::move(value_string));
+    }
+  }
 
   // Performs a manual byte size count for test verification.
   void verifyByteSizeInternalForTest() const;
@@ -329,6 +338,12 @@ std::unique_ptr<T>
 createHeaderMap(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values) {
   auto new_header_map = std::make_unique<T>();
   HeaderMapImpl::initFromInitList(*new_header_map, values);
+  return new_header_map;
+}
+
+template <class T, class It> std::unique_ptr<T> createHeaderMap(It begin, It end) {
+  auto new_header_map = std::make_unique<T>();
+  HeaderMapImpl::initFromInitList(*new_header_map, begin, end);
   return new_header_map;
 }
 

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 #include "envoy/http/header_map.h"
 
@@ -60,11 +61,12 @@ public:
   // The following "constructors" call virtual functions during construction and must use the
   // static factory pattern.
   static void copyFrom(HeaderMap& lhs, const HeaderMap& rhs);
-  static void
-  initFromInitList(HeaderMap& new_header_map,
-                   const std::initializer_list<std::pair<LowerCaseString, std::string>>& values);
+  // The value_type of iterator must be pair, and the first value of them must be LowerCaseString.
+  // If not, it won't be compiled successfully.
   template <class It> static void initFromInitList(HeaderMap& new_header_map, It begin, It end) {
     for (auto it = begin; it != end; ++it) {
+      static_assert(std::is_same<decltype(it->first), LowerCaseString>::value,
+                    "iterator must be pair and the first value of them must be LowerCaseString");
       HeaderString key_string;
       key_string.setCopy(it->first.get().c_str(), it->first.get().size());
       HeaderString value_string;
@@ -337,7 +339,7 @@ template <class T>
 std::unique_ptr<T>
 createHeaderMap(const std::initializer_list<std::pair<LowerCaseString, std::string>>& values) {
   auto new_header_map = std::make_unique<T>();
-  HeaderMapImpl::initFromInitList(*new_header_map, values);
+  HeaderMapImpl::initFromInitList(*new_header_map, values.begin(), values.end());
   return new_header_map;
 }
 

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -923,6 +923,15 @@ TEST(HeaderMapImplTest, Get) {
   }
 }
 
+TEST(HeaderMapImplTest, CreateHeaderMapFromIterator) {
+  std::vector<std::pair<LowerCaseString, std::string>> iter_headers{
+      {LowerCaseString(Headers::get().Path), "/"}, {LowerCaseString("hello"), "world"}};
+  auto headers = createHeaderMap<TestHeaderMapImpl>(iter_headers.cbegin(), iter_headers.cend());
+  EXPECT_EQ("/", headers->get(LowerCaseString(":path"))->value().getStringView());
+  EXPECT_EQ("world", headers->get(LowerCaseString("hello"))->value().getStringView());
+  EXPECT_EQ(nullptr, headers->get(LowerCaseString("foo")));
+}
+
 TEST(HeaderMapImplTest, TestHeaderList) {
   std::array<Http::LowerCaseString, 2> keys{Headers::get().Path, LowerCaseString("hello")};
   std::array<std::string, 2> values{"/", "world"};


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: This PR allows to initialize header map from iterator in addition to the initializer list.
Additional Description: This functionality is needed in wasm extensibility. Now we can extract HeaderMap only to use a function which returns only `std::vector<std::pair<absl::string_view, absl::string_view>>`. When we construct the optimized header map from the raw one, we needed to allow iterator to use `createHeaderMap`. 

Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
