### PR TITLE
coverage: Improve error if gcov is not found

### DIFF
--- a/bazel/coverage/collect_cc_coverage.sh
+++ b/bazel/coverage/collect_cc_coverage.sh
@@ -61,7 +61,15 @@ function init_gcov() {
   # we would need to invoke it with "llvm-cov gcov").
   # For more details see https://llvm.org/docs/CommandGuide/llvm-cov.html.
   GCOV="${COVERAGE_DIR}/gcov"
-  ln -s "${COVERAGE_GCOV_PATH}" "${GCOV}"
+  if [ ! -f "${COVERAGE_GCOV_PATH}" ]; then
+    echo "GCov does not exist at the given path: '${COVERAGE_GCOV_PATH}'"
+    exit 1
+  fi
+  # When using a tool from a toolchain COVERAGE_GCOV_PATH will be a relative
+  # path. To make it work on different working directories it's required to
+  # convert the path to an absolute one.
+  COVERAGE_GCOV_PATH_ABS="$(cd "${COVERAGE_GCOV_PATH%/*}" && pwd)/${COVERAGE_GCOV_PATH##*/}"
+  ln -s "${COVERAGE_GCOV_PATH_ABS}" "${GCOV}"
 }
 
 # Computes code coverage data using the clang generated metadata found under


### PR DESCRIPTION
## Commit Message: coverage

Improve error if gcov is not found

## Additional Description

This commit is a copy of https://github.com/bazelbuild/bazel/commit/1c77844f24ef20447cf8a63630cc48e2cbcea62e.

ESPv2 also publishes coverage reports for our custom envoy filters. We're able to get the updated `bazel coverage` working on our workstations, but it fails in CI.
- Job status: https://testgrid.k8s.io/googleoss-esp-v2-periodic#coverage

```
May 29, 2020 3:57:32 PM com.google.devtools.coverageoutputgenerator.Main getGcovInfoFiles
INFO: No gcov info file found.
May 29, 2020 3:57:32 PM com.google.devtools.coverageoutputgenerator.Main getProfdataFileOrNull
INFO: No .profdata file found.
May 29, 2020 3:57:32 PM com.google.devtools.coverageoutputgenerator.Main main
WARNING: There was no coverage found.
(15:57:32) ERROR: output '_coverage/_coverage_report.dat' was not created
(15:57:32) ERROR: not all outputs were created or valid
```

After some research, I assume this is related to the symbolic link line, as mentioned in https://github.com/bazelbuild/bazel/issues/7004. Hence why we want to merge the latest update to the script.

## Risk Level

None, just a tooling change for CI

## Testing

Presubmit coverage job

Signed-off-by: Teju Nareddy <nareddyt@google.com>