### PR TITLE
fuzz: Make `reset` public in UberFilterFuzzer

### DIFF
--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -22,6 +22,9 @@ public:
   // For fuzzing proto data, guide the mutator to useful 'Any' types.
   static void guideAnyProtoType(test::fuzz::HttpData* mutable_data, uint choice);
 
+  // Resets cached data (request headers, etc.). Should be called for each fuzz iteration.
+  void reset();
+
 protected:
   // Set-up filter specific mock expectations in constructor.
   void perFilterSetup();
@@ -44,8 +47,6 @@ protected:
 
   template <class FilterType>
   void sendTrailers(FilterType* filter, const test::fuzz::HttpData& data) = delete;
-
-  void reset();
 
 private:
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;


### PR DESCRIPTION
Commit Message: fuzz: Make `reset` public in UberFilterFuzzer

Additional Description: ESPv2 needs to call reset after each iteration because `UberFilterFuzzer` is statically initialized. I realize this is not the best solution, but let's add it as a temporary workaround to prevent unreproducible fuzz test failures in OSS Fuzz. I will follow up with a PR to split this into two classes, so single-target filter level fuzzers can just use a subset of the `UberFilterFuzzer` that is needed.

Risk Level: None

Testing: Build passes

Signed-off-by: Teju Nareddy <nareddyt@google.com>