### PR TITLE
zipkin: add key name to prevent bad replacements

### DIFF
--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -137,7 +137,8 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
       // us 1.58432429547687e+15. Instead we store it as the string of 1584324295476870 (when it is
       // serialized: "1584324295476870"), and replace it post MessageToJsonString serialization with
       // integer (1584324295476870 without `"`), see: JsonV2Serializer::serialize.
-      (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(annotation.timestamp(), replacements);
+      (*fields)[SPAN_TIMESTAMP] =
+          Util::uint64Value(annotation.timestamp(), "timestamp", replacements);
       (*fields)[SPAN_LOCAL_ENDPOINT] =
           ValueUtil::structValue(toProtoEndpoint(annotation.endpoint()));
     }
@@ -157,7 +158,8 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
     if (zipkin_span.isSetDuration()) {
       // Since SPAN_DURATION has the same data type with SPAN_TIMESTAMP, we use Util::uint64Value to
       // store it.
-      (*fields)[SPAN_DURATION] = Util::uint64Value(zipkin_span.duration(), replacements);
+      (*fields)[SPAN_DURATION] =
+          Util::uint64Value(zipkin_span.duration(), "duration", replacements);
     }
 
     const auto& binary_annotations = zipkin_span.binaryAnnotations();

--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -138,7 +138,7 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
       // serialized: "1584324295476870"), and replace it post MessageToJsonString serialization with
       // integer (1584324295476870 without `"`), see: JsonV2Serializer::serialize.
       (*fields)[SPAN_TIMESTAMP] =
-          Util::uint64Value(annotation.timestamp(), "timestamp", replacements);
+          Util::uint64Value(annotation.timestamp(), SPAN_TIMESTAMP, replacements);
       (*fields)[SPAN_LOCAL_ENDPOINT] =
           ValueUtil::structValue(toProtoEndpoint(annotation.endpoint()));
     }
@@ -159,7 +159,7 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
       // Since SPAN_DURATION has the same data type with SPAN_TIMESTAMP, we use Util::uint64Value to
       // store it.
       (*fields)[SPAN_DURATION] =
-          Util::uint64Value(zipkin_span.duration(), "duration", replacements);
+          Util::uint64Value(zipkin_span.duration(), SPAN_DURATION, replacements);
     }
 
     const auto& binary_annotations = zipkin_span.binaryAnnotations();

--- a/source/extensions/tracers/zipkin/util.cc
+++ b/source/extensions/tracers/zipkin/util.cc
@@ -23,7 +23,8 @@ uint64_t Util::generateRandom64(TimeSource& time_source) {
   return rand_64();
 }
 
-ProtobufWkt::Value Util::uint64Value(uint64_t value, std::string name, Replacements& replacements) {
+ProtobufWkt::Value Util::uint64Value(uint64_t value, absl::string_view name,
+                                     Replacements& replacements) {
   const std::string string_value = std::to_string(value);
   replacements.push_back({absl::StrCat("\"", name, "\":\"", string_value, "\""),
                           absl::StrCat("\"", name, "\":", string_value)});

--- a/source/extensions/tracers/zipkin/util.cc
+++ b/source/extensions/tracers/zipkin/util.cc
@@ -23,9 +23,10 @@ uint64_t Util::generateRandom64(TimeSource& time_source) {
   return rand_64();
 }
 
-ProtobufWkt::Value Util::uint64Value(uint64_t value, Replacements& replacements) {
+ProtobufWkt::Value Util::uint64Value(uint64_t value, std::string name, Replacements& replacements) {
   const std::string string_value = std::to_string(value);
-  replacements.push_back({absl::StrCat("\"", string_value, "\""), string_value});
+  replacements.push_back({absl::StrCat("\"", name, "\":\"", string_value, "\""),
+                          absl::StrCat("\"", name, "\":", string_value)});
   return ValueUtil::stringValue(string_value);
 }
 

--- a/source/extensions/tracers/zipkin/util.h
+++ b/source/extensions/tracers/zipkin/util.h
@@ -57,7 +57,7 @@ public:
    * @param replacements a container to hold the required replacements when serializing this value.
    * @return ProtobufWkt::Value wrapped uint64_t as a string.
    */
-  static ProtobufWkt::Value uint64Value(uint64_t value, std::string name,
+  static ProtobufWkt::Value uint64Value(uint64_t value, absl::string_view name,
                                         Replacements& replacements);
 };
 

--- a/source/extensions/tracers/zipkin/util.h
+++ b/source/extensions/tracers/zipkin/util.h
@@ -49,13 +49,16 @@ public:
 
   /**
    * Returns a wrapped uint64_t value as a string. In addition to that, it also pushes back a
-   * replacement to the given replacements vector.
+   * replacement to the given replacements vector. The replacement includes the supplied name
+   * as a key, for identification in a JSON stream.
    *
    * @param value unt64_t number that will be represented in string.
+   * @param name std::string that is the key for the value being replaced.
    * @param replacements a container to hold the required replacements when serializing this value.
    * @return ProtobufWkt::Value wrapped uint64_t as a string.
    */
-  static ProtobufWkt::Value uint64Value(uint64_t value, Replacements& replacements);
+  static ProtobufWkt::Value uint64Value(uint64_t value, std::string name,
+                                        Replacements& replacements);
 };
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/zipkin_core_types.cc
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.cc
@@ -69,7 +69,7 @@ void Annotation::changeEndpointServiceName(const std::string& service_name) {
 const ProtobufWkt::Struct Annotation::toStruct(Util::Replacements& replacements) const {
   ProtobufWkt::Struct annotation;
   auto* fields = annotation.mutable_fields();
-  (*fields)[ANNOTATION_TIMESTAMP] = Util::uint64Value(timestamp_, "timestamp", replacements);
+  (*fields)[ANNOTATION_TIMESTAMP] = Util::uint64Value(timestamp_, SPAN_TIMESTAMP, replacements);
   (*fields)[ANNOTATION_VALUE] = ValueUtil::stringValue(value_);
   if (endpoint_.has_value()) {
     (*fields)[ANNOTATION_ENDPOINT] =
@@ -159,13 +159,13 @@ const ProtobufWkt::Struct Span::toStruct(Util::Replacements& replacements) const
     // Usually we store number to a ProtobufWkt::Struct object via ValueUtil::numberValue.
     // However, due to the possibility of rendering that to a number with scientific notation, we
     // chose to store it as a string and keeping track the corresponding replacement.
-    (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(timestamp_.value(), "timestamp", replacements);
+    (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(timestamp_.value(), SPAN_TIMESTAMP, replacements);
   }
 
   if (duration_.has_value()) {
     // Since SPAN_DURATION has the same data type with SPAN_TIMESTAMP, we use Util::uint64Value to
     // store it.
-    (*fields)[SPAN_DURATION] = Util::uint64Value(duration_.value(), "duration", replacements);
+    (*fields)[SPAN_DURATION] = Util::uint64Value(duration_.value(), SPAN_DURATION, replacements);
   }
 
   if (!annotations_.empty()) {

--- a/source/extensions/tracers/zipkin/zipkin_core_types.cc
+++ b/source/extensions/tracers/zipkin/zipkin_core_types.cc
@@ -69,7 +69,7 @@ void Annotation::changeEndpointServiceName(const std::string& service_name) {
 const ProtobufWkt::Struct Annotation::toStruct(Util::Replacements& replacements) const {
   ProtobufWkt::Struct annotation;
   auto* fields = annotation.mutable_fields();
-  (*fields)[ANNOTATION_TIMESTAMP] = Util::uint64Value(timestamp_, replacements);
+  (*fields)[ANNOTATION_TIMESTAMP] = Util::uint64Value(timestamp_, "timestamp", replacements);
   (*fields)[ANNOTATION_VALUE] = ValueUtil::stringValue(value_);
   if (endpoint_.has_value()) {
     (*fields)[ANNOTATION_ENDPOINT] =
@@ -159,13 +159,13 @@ const ProtobufWkt::Struct Span::toStruct(Util::Replacements& replacements) const
     // Usually we store number to a ProtobufWkt::Struct object via ValueUtil::numberValue.
     // However, due to the possibility of rendering that to a number with scientific notation, we
     // chose to store it as a string and keeping track the corresponding replacement.
-    (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(timestamp_.value(), replacements);
+    (*fields)[SPAN_TIMESTAMP] = Util::uint64Value(timestamp_.value(), "timestamp", replacements);
   }
 
   if (duration_.has_value()) {
     // Since SPAN_DURATION has the same data type with SPAN_TIMESTAMP, we use Util::uint64Value to
     // store it.
-    (*fields)[SPAN_DURATION] = Util::uint64Value(duration_.value(), replacements);
+    (*fields)[SPAN_DURATION] = Util::uint64Value(duration_.value(), "duration", replacements);
   }
 
   if (!annotations_.empty()) {


### PR DESCRIPTION
Commit Message: zipkin: add key name to prevent bad replacements

Additional Description: This PR attempts to fix issues that arise with the current scheme for replacements in the Zipkin serialization that was added in #10400. In particular, this PR is trying to prevent issues that occur when size tags have the same value as the span durations. This was originally reported in https://github.com/istio/istio/issues/24177.

Risk Level: Low
Testing: Unit (with and without changes to validate)
Docs Changes: N/A
Release Notes: N/A

Reviewers: I'm not entirely comfortable with this change, as it feels like adding a hack on top of another hack, but _something_ is needed and this seemed to be the most straightforward way to correct. Hopefully, the original TODO for a better fix will cover this case as well. Please let me know if you would like to pursue a different or clearer path.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>
