### PR TITLE
grpc_transcoder: implement Skip function in transcoder input stream

### DIFF
--- a/source/common/buffer/zero_copy_input_stream_impl.cc
+++ b/source/common/buffer/zero_copy_input_stream_impl.cc
@@ -44,7 +44,22 @@ bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
   return false;
 }
 
-bool ZeroCopyInputStreamImpl::Skip(int) { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+bool ZeroCopyInputStreamImpl::Skip(int count) {
+  ASSERT(count >= 0);
+  if (position_ != 0) {
+    buffer_->drain(position_);
+    position_ = 0;
+  }
+
+  // Could not skip more than buffer length.
+  if (static_cast<uint64_t>(count) > buffer_->length()) {
+    return false;
+  }
+
+  buffer_->drain(count);
+  byte_count_ += count;
+  return true;
+}
 
 void ZeroCopyInputStreamImpl::BackUp(int count) {
   ASSERT(count >= 0);

--- a/source/common/buffer/zero_copy_input_stream_impl.cc
+++ b/source/common/buffer/zero_copy_input_stream_impl.cc
@@ -19,11 +19,15 @@ void ZeroCopyInputStreamImpl::move(Buffer::Instance& instance) {
   buffer_->move(instance);
 }
 
-bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
+void ZeroCopyInputStreamImpl::drainLastSlice() {
   if (position_ != 0) {
     buffer_->drain(position_);
     position_ = 0;
   }
+}
+
+bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
+  drainLastSlice();
 
   Buffer::RawSliceVector slices = buffer_->getRawSlices(1);
 
@@ -46,10 +50,7 @@ bool ZeroCopyInputStreamImpl::Next(const void** data, int* size) {
 
 bool ZeroCopyInputStreamImpl::Skip(int count) {
   ASSERT(count >= 0);
-  if (position_ != 0) {
-    buffer_->drain(position_);
-    position_ = 0;
-  }
+  drainLastSlice();
 
   // Could not skip more than buffer length.
   if (static_cast<uint64_t>(count) > buffer_->length()) {

--- a/source/common/buffer/zero_copy_input_stream_impl.h
+++ b/source/common/buffer/zero_copy_input_stream_impl.h
@@ -40,6 +40,10 @@ public:
   ProtobufTypes::Int64 ByteCount() const override { return byte_count_; }
 
 protected:
+  // The last slice is kept to support limited BackUp() calls.
+  // This function will drain it.
+  void drainLastSlice();
+
   Buffer::InstancePtr buffer_;
   uint64_t position_{0};
   bool finished_{false};

--- a/source/common/buffer/zero_copy_input_stream_impl.h
+++ b/source/common/buffer/zero_copy_input_stream_impl.h
@@ -36,7 +36,7 @@ public:
   // LimitingInputStream before passing to protobuf code to avoid a spin loop.
   bool Next(const void** data, int* size) override;
   void BackUp(int count) override;
-  bool Skip(int count) override; // Not implemented
+  bool Skip(int count) override;
   ProtobufTypes::Int64 ByteCount() const override { return byte_count_; }
 
 protected:

--- a/test/common/buffer/zero_copy_input_stream_test.cc
+++ b/test/common/buffer/zero_copy_input_stream_test.cc
@@ -118,7 +118,9 @@ public:
   int size_;
 
   // Convert data_ buffer into a string
-  std::string data_string() { return std::string(reinterpret_cast<const char*>(data_), size_); }
+  std::string dataString() const {
+    return std::string(reinterpret_cast<const char*>(data_), size_);
+  }
 };
 
 TEST_F(ZeroCopyInputStreamSkipTest, SkipFirstPartialSlice) {
@@ -131,7 +133,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipFirstPartialSlice) {
   // Read the first slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size() - skip_count, size_);
-  EXPECT_EQ(slice1_.substr(skip_count), data_string());
+  EXPECT_EQ(slice1_.substr(skip_count), dataString());
   EXPECT_EQ(slice1_.size(), stream_.ByteCount());
 }
 
@@ -144,7 +146,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipFirstFullSlice) {
   // Read the second slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice2_.size(), size_);
-  EXPECT_EQ(slice2_, data_string());
+  EXPECT_EQ(slice2_, dataString());
   EXPECT_EQ(slice1_.size() + slice2_.size(), stream_.ByteCount());
 }
 
@@ -152,7 +154,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, BackUpAndSkipToEndOfSlice) {
   // Read the first slice, backUp 10 byes, skip 10 bytes to the end of the first slice.
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, data_string());
+  EXPECT_EQ(slice1_, dataString());
 
   constexpr int backup_count = 10;
   stream_.BackUp(backup_count);
@@ -163,7 +165,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, BackUpAndSkipToEndOfSlice) {
   // Next read is the second slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice2_.size(), size_);
-  EXPECT_EQ(slice2_, data_string());
+  EXPECT_EQ(slice2_, dataString());
   EXPECT_EQ(slice1_.size() + slice2_.size(), stream_.ByteCount());
 }
 
@@ -171,7 +173,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipAcrossTwoSlices) {
   // Read the first slice, backUp 10 byes, skip 15 bytes; 5 bytes into the second slice.
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, data_string());
+  EXPECT_EQ(slice1_, dataString());
 
   constexpr int backup_count = 10; // the backup bytes to the end of first slice.
   constexpr int skip_count = 5;    // The skip bytes in the second slice
@@ -183,7 +185,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipAcrossTwoSlices) {
   // Read the remain second slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice2_.size() - skip_count, size_);
-  EXPECT_EQ(slice2_.substr(skip_count), data_string());
+  EXPECT_EQ(slice2_.substr(skip_count), dataString());
   EXPECT_EQ(slice1_.size() + slice2_.size(), stream_.ByteCount());
 }
 
@@ -191,7 +193,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipAcrossThreeSlices) {
   // Read the first slice, backUp 10 byes, skip 10 + slice2.size + 5; 5 bytes into the third slice.
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, data_string());
+  EXPECT_EQ(slice1_, dataString());
 
   constexpr int backup_count = 10; // the backup bytes to the end of first slice.
   constexpr int skip_count = 5;    // The skip bytes in the third slice
@@ -203,7 +205,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipAcrossThreeSlices) {
   // Read the remain third slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice3_.size() - skip_count, size_);
-  EXPECT_EQ(slice3_.substr(skip_count), data_string());
+  EXPECT_EQ(slice3_.substr(skip_count), dataString());
   EXPECT_EQ(slice1_.size() + slice2_.size() + slice3_.size(), stream_.ByteCount());
 }
 
@@ -222,7 +224,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, ReadFirstSkipToTheEnd) {
   // Read the first slice, backUp 10 byes, skip to the end of buffer
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, data_string());
+  EXPECT_EQ(slice1_, dataString());
 
   constexpr int backup_count = 10; // the backup bytes to the end of first slice.
   stream_.BackUp(backup_count);

--- a/test/common/buffer/zero_copy_input_stream_test.cc
+++ b/test/common/buffer/zero_copy_input_stream_test.cc
@@ -119,7 +119,7 @@ public:
 
   // Convert data_ buffer into a string
   absl::string_view dataString() const {
-    return absl::string_view(reinterpret_cast<const char*>(data_), size_);
+    return absl::string_view{reinterpret_cast<const char*>(data_), static_cast<size_t>(size_)};
   }
 };
 

--- a/test/common/buffer/zero_copy_input_stream_test.cc
+++ b/test/common/buffer/zero_copy_input_stream_test.cc
@@ -116,19 +116,22 @@ public:
 
   const void* data_;
   int size_;
+
+  // Convert data_ buffer into a string
+  std::string data_string() { return std::string(reinterpret_cast<const char*>(data_), size_); }
 };
 
 TEST_F(ZeroCopyInputStreamSkipTest, SkipFirstPartialSlice) {
   // Only skip the 10 bytes in the first slice.
-  const int SkipCount = 10;
-  EXPECT_TRUE(stream_.Skip(SkipCount));
+  constexpr int skip_count = 10;
+  EXPECT_TRUE(stream_.Skip(skip_count));
 
-  EXPECT_EQ(SkipCount, stream_.ByteCount());
+  EXPECT_EQ(skip_count, stream_.ByteCount());
 
   // Read the first slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
-  EXPECT_EQ(slice1_.size() - SkipCount, size_);
-  EXPECT_EQ(slice1_.substr(SkipCount), std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice1_.size() - skip_count, size_);
+  EXPECT_EQ(slice1_.substr(skip_count), data_string());
   EXPECT_EQ(slice1_.size(), stream_.ByteCount());
 }
 
@@ -141,7 +144,7 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipFirstFullSlice) {
   // Read the second slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice2_.size(), size_);
-  EXPECT_EQ(slice2_, std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice2_, data_string());
   EXPECT_EQ(slice1_.size() + slice2_.size(), stream_.ByteCount());
 }
 
@@ -149,18 +152,18 @@ TEST_F(ZeroCopyInputStreamSkipTest, BackUpAndSkipToEndOfSlice) {
   // Read the first slice, backUp 10 byes, skip 10 bytes to the end of the first slice.
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice1_, data_string());
 
-  const int BackupCount = 10;
-  stream_.BackUp(BackupCount);
-  EXPECT_TRUE(stream_.Skip(BackupCount));
+  constexpr int backup_count = 10;
+  stream_.BackUp(backup_count);
+  EXPECT_TRUE(stream_.Skip(backup_count));
 
   EXPECT_EQ(slice1_.size(), stream_.ByteCount());
 
   // Next read is the second slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice2_.size(), size_);
-  EXPECT_EQ(slice2_, std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice2_, data_string());
   EXPECT_EQ(slice1_.size() + slice2_.size(), stream_.ByteCount());
 }
 
@@ -168,19 +171,19 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipAcrossTwoSlices) {
   // Read the first slice, backUp 10 byes, skip 15 bytes; 5 bytes into the second slice.
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice1_, data_string());
 
-  const int BackupCount = 10; // the backup bytes to the end of first slice.
-  const int SkipCount = 5;    // The skip bytes in the second slice
-  stream_.BackUp(BackupCount);
-  EXPECT_TRUE(stream_.Skip(BackupCount + SkipCount));
+  constexpr int backup_count = 10; // the backup bytes to the end of first slice.
+  constexpr int skip_count = 5;    // The skip bytes in the second slice
+  stream_.BackUp(backup_count);
+  EXPECT_TRUE(stream_.Skip(backup_count + skip_count));
 
-  EXPECT_EQ(slice1_.size() + SkipCount, stream_.ByteCount());
+  EXPECT_EQ(slice1_.size() + skip_count, stream_.ByteCount());
 
   // Read the remain second slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
-  EXPECT_EQ(slice2_.size() - SkipCount, size_);
-  EXPECT_EQ(slice2_.substr(SkipCount), std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice2_.size() - skip_count, size_);
+  EXPECT_EQ(slice2_.substr(skip_count), data_string());
   EXPECT_EQ(slice1_.size() + slice2_.size(), stream_.ByteCount());
 }
 
@@ -188,19 +191,19 @@ TEST_F(ZeroCopyInputStreamSkipTest, SkipAcrossThreeSlices) {
   // Read the first slice, backUp 10 byes, skip 10 + slice2.size + 5; 5 bytes into the third slice.
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice1_, data_string());
 
-  const int BackupCount = 10; // the backup bytes to the end of first slice.
-  const int SkipCount = 5;    // The skip bytes in the third slice
-  stream_.BackUp(BackupCount);
-  EXPECT_TRUE(stream_.Skip(BackupCount + slice2_.size() + SkipCount));
+  constexpr int backup_count = 10; // the backup bytes to the end of first slice.
+  constexpr int skip_count = 5;    // The skip bytes in the third slice
+  stream_.BackUp(backup_count);
+  EXPECT_TRUE(stream_.Skip(backup_count + slice2_.size() + skip_count));
 
-  EXPECT_EQ(slice1_.size() + slice2_.size() + SkipCount, stream_.ByteCount());
+  EXPECT_EQ(slice1_.size() + slice2_.size() + skip_count, stream_.ByteCount());
 
   // Read the remain third slice
   EXPECT_TRUE(stream_.Next(&data_, &size_));
-  EXPECT_EQ(slice3_.size() - SkipCount, size_);
-  EXPECT_EQ(slice3_.substr(SkipCount), std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice3_.size() - skip_count, size_);
+  EXPECT_EQ(slice3_.substr(skip_count), data_string());
   EXPECT_EQ(slice1_.size() + slice2_.size() + slice3_.size(), stream_.ByteCount());
 }
 
@@ -219,12 +222,12 @@ TEST_F(ZeroCopyInputStreamSkipTest, ReadFirstSkipToTheEnd) {
   // Read the first slice, backUp 10 byes, skip to the end of buffer
   EXPECT_TRUE(stream_.Next(&data_, &size_));
   EXPECT_EQ(slice1_.size(), size_);
-  EXPECT_EQ(slice1_, std::string(reinterpret_cast<const char*>(data_), size_));
+  EXPECT_EQ(slice1_, data_string());
 
-  const int BackupCount = 10; // the backup bytes to the end of first slice.
-  stream_.BackUp(BackupCount);
+  constexpr int backup_count = 10; // the backup bytes to the end of first slice.
+  stream_.BackUp(backup_count);
 
-  EXPECT_TRUE(stream_.Skip(total_bytes_ - slice1_.size() + BackupCount));
+  EXPECT_TRUE(stream_.Skip(total_bytes_ - slice1_.size() + backup_count));
   EXPECT_EQ(total_bytes_, stream_.ByteCount());
 
   // Failed to skip one extra byte

--- a/test/common/buffer/zero_copy_input_stream_test.cc
+++ b/test/common/buffer/zero_copy_input_stream_test.cc
@@ -118,8 +118,8 @@ public:
   int size_;
 
   // Convert data_ buffer into a string
-  std::string dataString() const {
-    return std::string(reinterpret_cast<const char*>(data_), size_);
+  absl::string_view dataString() const {
+    return absl::string_view(reinterpret_cast<const char*>(data_), size_);
   }
 };
 

--- a/test/proto/bookstore.proto
+++ b/test/proto/bookstore.proto
@@ -120,6 +120,14 @@ service Bookstore {
       body: "content"
     };
   }
+  // To test grpc transcoding with an unknown field.
+  // This could happen when the grpc server is using a updated proto with a new field,
+  // but Envoy transcoding config is still using the old version.
+  rpc GetBigBook(google.protobuf.Empty) returns (OldBigBook) {
+    option (google.api.http) = {
+      get: "/bigbook"
+    };
+  }
 }
 
 // A shelf resource.
@@ -251,4 +259,18 @@ message DeepNestedBody {
     Nested nested = 1000000;
   }
   Nested nested = 1;
+}
+
+// gRPC server is using BigBook, but envoy transcoder filter is using
+// OldBigBook with missing `field1`.
+message BigBook {
+  string field1 = 1;
+  string field2 = 2;
+  string field3 = 3;
+}
+
+// The BigBook messsage with missing `field1`.
+message OldBigBook {
+  string field2 = 2;
+  string field3 = 3;
 }

--- a/test/proto/bookstore.proto
+++ b/test/proto/bookstore.proto
@@ -269,7 +269,7 @@ message BigBook {
   string field3 = 3;
 }
 
-// The BigBook messsage with missing `field1`.
+// The BigBook message with missing `field1`.
 message OldBigBook {
   string field2 = 2;
   string field3 = 3;


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

 [Skip](https://github.com/envoyproxy/envoy/blob/master/source/common/buffer/zero_copy_input_stream_impl.cc#L47) function in Buffer::ZeroCopyInputStream  is not implemented.  It is used in grpc transcoder filter.  It is needed in the following case:
* grpc_transcoder filter config needs to embed a proto descriptor file for the grpc service.  If it is outdated, e.g. gRPC server may use a newer version with added fields,  the gRPC server may write some fields that are unknown to the Envoy transcoder.  Transocding code needs to skip that field.

Note:  This only happens when the response message is big, and it has to be stored in more than one slice.   

Fix:  
* implemented the Skip() function. 
* added a integration test
* some unit-tests for the Skip function.

Risk Level: Low
Testing: integration test an unit-test
Docs Changes: None
Release Notes: None
