### PR TITLE
Release image: Push vX.Y-latest when a release is cut

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -50,6 +50,13 @@ for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
         docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
         docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
     fi
+
+    # Push vX.Y-latest to tag the latest image in a release line
+    if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
+      RELEASE_LINE=$(echo "$IMAGE_NAME" | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')
+      docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
+      docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
+    fi
 done
 
 

--- a/docs/root/install/building.rst
+++ b/docs/root/install/building.rst
@@ -43,8 +43,7 @@ be found in the following repositories:
 
 .. note::
 
-  In the above repositories, we do **not** tag a *latest* image. As we now do security/stable
-  releases, *latest* has no good meaning and users should pin to a specific tag.
+  In the above repositories, we tag a *vX.Y-latest* image for each security/stable release line.
 
 On every master commit we additionally create a set of development Docker images. These images can
 be found in the following repositories:


### PR DESCRIPTION
Commit Message:
Release image: Push vX.Y-latest when a release is cut

Enables users of tagged releases to stay on the latest release of a
major/minor combination

Additional Description: N/A
Risk Level: Low
Testing: N/A
Docs Changes: Update docs to mention the latest tag for security/stable release branches.
Release Notes: N/A
Fixes https://github.com/envoyproxy/envoy/issues/11091
