### PR TITLE
api: add bootstrap extensions

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/event_service_config.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/socket_option.proto";
 import "envoy/config/listener/v3/listener.proto";
 import "envoy/config/metrics/v3/stats.proto";
@@ -35,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 21]
+// [#next-free-field: 22]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -181,6 +182,10 @@ message Bootstrap {
   // :ref:`use_tcp_for_dns_lookups <envoy_api_field_config.cluster.v3.Cluster.use_tcp_for_dns_lookups>` are
   // specified.
   bool use_tcp_for_dns_lookups = 20;
+
+  // Specifies optional bootstrap extensions to be instantiated at startup time.
+  // Each item contains extension specific configuration.
+  repeated core.v3.TypedExtensionConfig bootstrap_extensions = 21;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v4alpha/address.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/core/v4alpha/event_service_config.proto";
+import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/config/core/v4alpha/socket_option.proto";
 import "envoy/config/listener/v4alpha/listener.proto";
 import "envoy/config/metrics/v4alpha/stats.proto";
@@ -34,7 +35,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 21]
+// [#next-free-field: 22]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v3.Bootstrap";
@@ -173,6 +174,10 @@ message Bootstrap {
   // :ref:`use_tcp_for_dns_lookups <envoy_api_field_config.cluster.v4alpha.Cluster.use_tcp_for_dns_lookups>` are
   // specified.
   bool use_tcp_for_dns_lookups = 20;
+
+  // Specifies optional bootstrap extensions to be instantiated at startup time.
+  // Each item contains extension specific configuration.
+  repeated core.v4alpha.TypedExtensionConfig bootstrap_extensions = 21;
 }
 
 // Administration interface :ref:`operations documentation

--- a/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/address.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/event_service_config.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/socket_option.proto";
 import "envoy/config/listener/v3/listener.proto";
 import "envoy/config/metrics/v3/stats.proto";
@@ -35,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 21]
+// [#next-free-field: 22]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -179,6 +180,10 @@ message Bootstrap {
   // :ref:`use_tcp_for_dns_lookups <envoy_api_field_config.cluster.v3.Cluster.use_tcp_for_dns_lookups>` are
   // specified.
   bool use_tcp_for_dns_lookups = 20;
+
+  // Specifies optional bootstrap extensions to be instantiated at startup time.
+  // Each item contains extension specific configuration.
+  repeated core.v3.TypedExtensionConfig bootstrap_extensions = 21;
 
   Runtime hidden_envoy_deprecated_runtime = 11
       [deprecated = true, (envoy.annotations.disallowed_by_default) = true];

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v4alpha/address.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/core/v4alpha/event_service_config.proto";
+import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/config/core/v4alpha/socket_option.proto";
 import "envoy/config/listener/v4alpha/listener.proto";
 import "envoy/config/metrics/v4alpha/stats.proto";
@@ -35,7 +36,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 21]
+// [#next-free-field: 22]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v3.Bootstrap";
@@ -181,6 +182,10 @@ message Bootstrap {
   // :ref:`use_tcp_for_dns_lookups <envoy_api_field_config.cluster.v4alpha.Cluster.use_tcp_for_dns_lookups>` are
   // specified.
   bool use_tcp_for_dns_lookups = 20;
+
+  // Specifies optional bootstrap extensions to be instantiated at startup time.
+  // Each item contains extension specific configuration.
+  repeated core.v4alpha.TypedExtensionConfig bootstrap_extensions = 21;
 }
 
 // Administration interface :ref:`operations documentation

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -298,6 +298,7 @@ envoy_cc_library(
     name = "bootstrap_extension_config_interface",
     hdrs = ["bootstrap_extension_config.h"],
     deps = [
+        ":filter_config_interface",
         "//include/envoy/config:typed_config_interface",
     ],
 )

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -293,3 +293,11 @@ envoy_cc_library(
         "//include/envoy/network:connection_handler_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "bootstrap_extension_config_interface",
+    hdrs = ["bootstrap_extension_config.h"],
+    deps = [
+        "//include/envoy/config:typed_config_interface",
+    ],
+)

--- a/include/envoy/server/bootstrap_extension_config.h
+++ b/include/envoy/server/bootstrap_extension_config.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/server/filter_config.h"
+
+#include "common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * Parent class for boostrap extensions.
+ */
+class BootstrapExtension {
+public:
+  virtual ~BootstrapExtension() = default;
+};
+
+using BootstrapExtensionPtr = std::unique_ptr<BootstrapExtension>;
+
+namespace Configuration {
+
+/**
+ * Implemented for each bootstrap extension and registered via Registry::registerFactory or the
+ * convenience class RegisterFactory.
+ */
+class BootstrapExtensionFactory : public Config::TypedFactory {
+public:
+  ~BootstrapExtensionFactory() override = default;
+
+  /**
+   * Create a particular bootstrap extension implementation from a config proto. If the
+   * implementation is unable to produce a factory with the provided parameters, it should throw an
+   * EnvoyException. The returned pointer should never be nullptr.
+   * @param config the custom configuration for this bootstrap extension type.
+   * @param context general filter context through which persistent resources can be accessed.
+   */
+  virtual BootstrapExtensionPtr createBootstrapExtension(const Protobuf::Message& config,
+                                                         ServerFactoryContext& context) PURE;
+
+  std::string category() const override { return "envoy.bootstrap"; }
+};
+
+} // namespace Configuration
+} // namespace Server
+} // namespace Envoy

--- a/include/envoy/server/bootstrap_extension_config.h
+++ b/include/envoy/server/bootstrap_extension_config.h
@@ -10,7 +10,7 @@ namespace Envoy {
 namespace Server {
 
 /**
- * Parent class for boostrap extensions.
+ * Parent class for bootstrap extensions.
  */
 class BootstrapExtension {
 public:

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -397,6 +397,7 @@ envoy_cc_library(
         "//include/envoy/event:signal_interface",
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:dns_interface",
+        "//include/envoy/server:bootstrap_extension_config_interface",
         "//include/envoy/server:drain_manager_interface",
         "//include/envoy/server:instance_interface",
         "//include/envoy/server:listener_manager_interface",

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -18,6 +18,7 @@
 #include "envoy/event/timer.h"
 #include "envoy/network/dns.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/bootstrap_extension_config.h"
 #include "envoy/server/options.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -481,6 +482,16 @@ void InstanceImpl::initialize(const Options& options,
   // GuardDog (deadlock detection) object and thread setup before workers are
   // started and before our own run() loop runs.
   guard_dog_ = std::make_unique<Server::GuardDogImpl>(stats_store_, config_, *api_);
+
+  for (const auto& bootstrap_extension : bootstrap_.bootstrap_extensions()) {
+    auto& factory = Config::Utility::getAndCheckFactory<Configuration::BootstrapExtensionFactory>(
+        bootstrap_extension);
+    auto config = Config::Utility::translateAnyToFactoryConfig(
+        bootstrap_extension.typed_config(), messageValidationContext().staticValidationVisitor(),
+        factory);
+    bootstrap_extensions_.push_back(
+        factory.createBootstrapExtension(*config, serverFactoryContext()));
+  }
 }
 
 void InstanceImpl::onClusterManagerPrimaryInitializationComplete() {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -10,6 +10,7 @@
 
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/event/timer.h"
+#include "envoy/server/bootstrap_extension_config.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/guarddog.h"
 #include "envoy/server/instance.h"
@@ -346,6 +347,7 @@ private:
   Upstream::ProdClusterInfoFactory info_factory_;
   Upstream::HdsDelegatePtr hds_delegate_;
   std::unique_ptr<OverloadManagerImpl> overload_manager_;
+  std::vector<BootstrapExtensionPtr> bootstrap_extensions_;
   Envoy::MutexTracer* mutex_tracer_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -15,6 +15,7 @@ envoy_cc_mock(
     deps = [
         "//include/envoy/secret:secret_manager_interface",
         "//include/envoy/server:admin_interface",
+        "//include/envoy/server:bootstrap_extension_config_interface",
         "//include/envoy/server:configuration_interface",
         "//include/envoy/server:drain_manager_interface",
         "//include/envoy/server:filter_config_interface",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -303,6 +303,9 @@ MockTracerFactoryContext::MockTracerFactoryContext() {
 }
 
 MockTracerFactoryContext::~MockTracerFactoryContext() = default;
+
+MockBootstrapExtensionFactory::MockBootstrapExtensionFactory() = default;
+MockBootstrapExtensionFactory::~MockBootstrapExtensionFactory() = default;
 } // namespace Configuration
 } // namespace Server
 } // namespace Envoy

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -13,6 +13,7 @@
 #include "envoy/config/listener/v3/listener_components.pb.h"
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/server/admin.h"
+#include "envoy/server/bootstrap_extension_config.h"
 #include "envoy/server/configuration.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/filter_config.h"
@@ -677,6 +678,17 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
 
   testing::NiceMock<Configuration::MockServerFactoryContext> server_factory_context_;
+};
+
+class MockBootstrapExtensionFactory : public BootstrapExtensionFactory {
+public:
+  MockBootstrapExtensionFactory();
+  ~MockBootstrapExtensionFactory();
+
+  MOCK_METHOD(BootstrapExtensionPtr, createBootstrapExtension,
+              (const Protobuf::Message&, Configuration::ServerFactoryContext&), (override));
+  MOCK_METHOD(ProtobufTypes::MessagePtr, createEmptyConfigProto, (), (override));
+  MOCK_METHOD(std::string, name, (), (const override));
 };
 
 } // namespace Configuration

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -683,7 +683,7 @@ public:
 class MockBootstrapExtensionFactory : public BootstrapExtensionFactory {
 public:
   MockBootstrapExtensionFactory();
-  ~MockBootstrapExtensionFactory();
+  ~MockBootstrapExtensionFactory() override;
 
   MOCK_METHOD(BootstrapExtensionPtr, createBootstrapExtension,
               (const Protobuf::Message&, Configuration::ServerFactoryContext&), (override));

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -357,6 +357,7 @@ envoy_cc_test(
         "//source/extensions/tracers/zipkin:config",
         "//source/server:process_context_lib",
         "//source/server:server_lib",
+        "//test/common/config:dummy_config_proto_cc_proto",
         "//test/common/stats:stat_test_utility_lib",
         "//test/integration:integration_lib",
         "//test/mocks/server:server_mocks",

--- a/test/server/test_data/server/bootstrap_extensions.yaml
+++ b/test/server/test_data/server/bootstrap_extensions.yaml
@@ -1,0 +1,5 @@
+bootstrap_extensions:
+  - name: envoy_test.bootstrap.foo
+    typed_config:
+      "@type": type.googleapis.com/test.common.config.DummyConfig
+      a: foo


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Commit Message:
Adds a configurable server wide extension hook point. Allow extensions to instantiate singletons / context managers with configs in bootstrap.

Additional Description:
Risk Level: Low (not used API)
Testing: unittest, mock
Docs Changes: protodoc
Release Notes: N/A as no real extension lives today.
Fixes #11219 