### PR TITLE
docs: provide a consistent definition of overprovisioning_factor

### DIFF
--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -80,7 +80,7 @@ message ClusterLoadAssignment {
 
     // Priority levels and localities are considered overprovisioned with this
     // factor (in percentage). This means that we don't consider a priority
-    // level or locality unhealthy until the percentage of healthy hosts
+    // level or locality unhealthy until the fraction of healthy hosts
     // multiplied by the overprovisioning factor drops below 100.
     // With the default value 140(1.4), Envoy doesn't consider a priority level
     // or a locality unhealthy until their percentage of healthy hosts drops

--- a/docs/root/intro/arch_overview/upstream/load_balancing/overprovisioning.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/overprovisioning.rst
@@ -5,6 +5,6 @@ Overprovisioning Factor
 Priority levels and localities are considered overprovisioned with
 :ref:`this percentage <envoy_v3_api_field_config.endpoint.v3.ClusterLoadAssignment.Policy.overprovisioning_factor>`.
 Envoy doesn't consider a priority level or locality unavailable until the
-percentage of available hosts multiplied by the overprovisioning factor drops
-below 100. The default value is 1.4, so a priority level or locality will not be
+fraction of available hosts multiplied by the overprovisioning factor drops
+below 100. The default value is 140 (in percentage, which means 140%), so a priority level or locality will not be
 considered unavailable until the percentage of available endpoints goes below 72%.

--- a/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
+++ b/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
@@ -78,7 +78,7 @@ message ClusterLoadAssignment {
 
     // Priority levels and localities are considered overprovisioned with this
     // factor (in percentage). This means that we don't consider a priority
-    // level or locality unhealthy until the percentage of healthy hosts
+    // level or locality unhealthy until the fraction of healthy hosts
     // multiplied by the overprovisioning factor drops below 100.
     // With the default value 140(1.4), Envoy doesn't consider a priority level
     // or a locality unhealthy until their percentage of healthy hosts drops


### PR DESCRIPTION
Commit Message:
Provide a consistent definition of overprovisioning_factor
Additional Description:
There is a bit of inconsistency in how default `overprovisioning_factor` is used in the docs. Used a consistent definition instead.
Risk Level: n/a
Testing: n/a
Docs Changes: yes
Release Notes: no
Fixes: #11164

Signed-off-by: Muge Chen <mugechen@google.com>