### PR TITLE
check_format: don't error if clang-format-9 is in PATH under home

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -214,7 +214,7 @@ def readFile(path):
 # environment variable. If it cannot be found, empty string is returned.
 def lookPath(executable):
   for path_dir in os.environ["PATH"].split(os.pathsep):
-    executable_path = os.path.join(path_dir, executable)
+    executable_path = os.path.expanduser(os.path.join(path_dir, executable))
     if os.path.exists(executable_path):
       return executable_path
   return ""


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

Commit Message:
Additional Description:
Risk Level: Low
Testing: Tested that this fixed my local issue (using `~/bin/clang-format-9`)