### PR TITLE
test: use specific header map types in all tests

### DIFF
--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -104,20 +104,20 @@ TEST(GrpcContextTest, GetGrpcTimeout) {
 }
 
 TEST(GrpcCommonTest, GrpcStatusDetailsBin) {
-  Http::TestHeaderMapImpl empty_trailers;
+  Http::TestResponseTrailerMapImpl empty_trailers;
   EXPECT_FALSE(Common::getGrpcStatusDetailsBin(empty_trailers));
 
-  Http::TestHeaderMapImpl invalid_value{{"grpc-status-details-bin", "invalid"}};
+  Http::TestResponseTrailerMapImpl invalid_value{{"grpc-status-details-bin", "invalid"}};
   EXPECT_FALSE(Common::getGrpcStatusDetailsBin(invalid_value));
 
-  Http::TestHeaderMapImpl unpadded_value{
+  Http::TestResponseTrailerMapImpl unpadded_value{
       {"grpc-status-details-bin", "CAUSElJlc291cmNlIG5vdCBmb3VuZA"}};
   auto status = Common::getGrpcStatusDetailsBin(unpadded_value);
   ASSERT_TRUE(status);
   EXPECT_EQ(Status::WellKnownGrpcStatus::NotFound, status->code());
   EXPECT_EQ("Resource not found", status->message());
 
-  Http::TestHeaderMapImpl padded_value{
+  Http::TestResponseTrailerMapImpl padded_value{
       {"grpc-status-details-bin", "CAUSElJlc291cmNlIG5vdCBmb3VuZA=="}};
   status = Common::getGrpcStatusDetailsBin(padded_value);
   ASSERT_TRUE(status);

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -65,7 +65,7 @@ TEST(GrpcContextTest, ChargeStats) {
 TEST(GrpcContextTest, ResolveServiceAndMethod) {
   std::string service;
   std::string method;
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   headers.setPath("/service_name/method_name?a=b");
   const Http::HeaderEntry* path = headers.Path();
   Stats::TestSymbolTable symbol_table;

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -76,7 +76,8 @@ TEST_P(GrpcClientIntegrationTest, HttpNon200Status) {
   initialize();
   for (const auto http_response_status : {400, 401, 403, 404, 429, 431}) {
     auto stream = createStream(empty_metadata_);
-    const Http::TestHeaderMapImpl reply_headers{{":status", std::to_string(http_response_status)}};
+    const Http::TestResponseHeaderMapImpl reply_headers{
+        {":status", std::to_string(http_response_status)}};
     stream->expectInitialMetadata(empty_metadata_);
     stream->expectTrailingMetadata(empty_metadata_);
     // Technically this should be
@@ -93,7 +94,7 @@ TEST_P(GrpcClientIntegrationTest, HttpNon200Status) {
 TEST_P(GrpcClientIntegrationTest, GrpcStatusFallback) {
   initialize();
   auto stream = createStream(empty_metadata_);
-  const Http::TestHeaderMapImpl reply_headers{
+  const Http::TestResponseHeaderMapImpl reply_headers{
       {":status", "404"},
       {"grpc-status", std::to_string(enumToInt(Status::WellKnownGrpcStatus::PermissionDenied))},
       {"grpc-message", "error message"}};
@@ -189,7 +190,7 @@ TEST_P(GrpcClientIntegrationTest, OutOfRangeGrpcStatus) {
   EXPECT_CALL(*stream, onReceiveTrailingMetadata_(_)).WillExitIfNeeded();
   dispatcher_helper_.setStreamEventPending();
   stream->expectGrpcStatus(Status::WellKnownGrpcStatus::InvalidCode);
-  const Http::TestHeaderMapImpl reply_trailers{{"grpc-status", std::to_string(0x1337)}};
+  const Http::TestResponseTrailerMapImpl reply_trailers{{"grpc-status", std::to_string(0x1337)}};
   stream->fake_stream_->encodeTrailers(reply_trailers);
   dispatcher_helper_.runDispatcher();
 }
@@ -203,7 +204,7 @@ TEST_P(GrpcClientIntegrationTest, MissingGrpcStatus) {
   EXPECT_CALL(*stream, onReceiveTrailingMetadata_(_)).WillExitIfNeeded();
   dispatcher_helper_.setStreamEventPending();
   stream->expectGrpcStatus(Status::WellKnownGrpcStatus::Unknown);
-  const Http::TestHeaderMapImpl reply_trailers{{"some", "other header"}};
+  const Http::TestResponseTrailerMapImpl reply_trailers{{"some", "other header"}};
   stream->fake_stream_->encodeTrailers(reply_trailers);
   dispatcher_helper_.runDispatcher();
 }
@@ -304,7 +305,7 @@ TEST_P(GrpcClientIntegrationTest, StreamTrailersOnly) {
 TEST_P(GrpcClientIntegrationTest, RequestTrailersOnly) {
   initialize();
   auto request = createRequest(empty_metadata_);
-  const Http::TestHeaderMapImpl reply_headers{{":status", "200"}, {"grpc-status", "0"}};
+  const Http::TestResponseTrailerMapImpl reply_headers{{":status", "200"}, {"grpc-status", "0"}};
   EXPECT_CALL(*request->child_span_, setTag(Eq(Tracing::Tags::get().GrpcStatusCode), Eq("0")));
   EXPECT_CALL(*request->child_span_,
               setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
@@ -412,7 +413,7 @@ public:
   void expectExtraHeaders(FakeStream& fake_stream) override {
     AssertionResult result = fake_stream.waitForHeadersComplete();
     RELEASE_ASSERT(result, result.message());
-    Http::TestHeaderMapImpl stream_headers(fake_stream.headers());
+    Http::TestRequestHeaderMapImpl stream_headers(fake_stream.headers());
     if (!access_token_value_.empty()) {
       if (access_token_value_2_.empty()) {
         EXPECT_EQ("Bearer " + access_token_value_, stream_headers.get_("authorization"));

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -112,7 +112,7 @@ public:
   void expectInitialMetadata(const TestMetadata& metadata) {
     EXPECT_CALL(*this, onReceiveInitialMetadata_(_))
         .WillOnce(Invoke([this, &metadata](const Http::HeaderMap& received_headers) {
-          Http::TestHeaderMapImpl stream_headers(received_headers);
+          Http::TestResponseHeaderMapImpl stream_headers(received_headers);
           for (const auto& value : metadata) {
             EXPECT_EQ(value.second, stream_headers.get_(value.first));
           }
@@ -124,7 +124,7 @@ public:
   void expectTrailingMetadata(const TestMetadata& metadata) {
     EXPECT_CALL(*this, onReceiveTrailingMetadata_(_))
         .WillOnce(Invoke([this, &metadata](const Http::HeaderMap& received_headers) {
-          Http::TestHeaderMapImpl stream_headers(received_headers);
+          Http::TestResponseTrailerMapImpl stream_headers(received_headers);
           for (auto& value : metadata) {
             EXPECT_EQ(value.second, stream_headers.get_(value.first));
           }
@@ -139,7 +139,7 @@ public:
       reply_headers->addReference(value.first, value.second);
     }
     expectInitialMetadata(metadata);
-    fake_stream_->encodeHeaders(Http::TestHeaderMapImpl(*reply_headers), false);
+    fake_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl(*reply_headers), false);
   }
 
   void sendReply() {
@@ -164,7 +164,8 @@ public:
 
   void sendServerTrailers(Status::GrpcStatus grpc_status, const std::string& grpc_message,
                           const TestMetadata& metadata, bool trailers_only = false) {
-    Http::TestHeaderMapImpl reply_trailers{{"grpc-status", std::to_string(enumToInt(grpc_status))}};
+    Http::TestResponseTrailerMapImpl reply_trailers{
+        {"grpc-status", std::to_string(enumToInt(grpc_status))}};
     if (!grpc_message.empty()) {
       reply_trailers.addCopy("grpc-message", grpc_message);
     }
@@ -330,7 +331,7 @@ public:
   void expectInitialHeaders(FakeStream& fake_stream, const TestMetadata& initial_metadata) {
     AssertionResult result = fake_stream.waitForHeadersComplete();
     RELEASE_ASSERT(result, result.message());
-    stream_headers_ = std::make_unique<Http::TestHeaderMapImpl>(fake_stream.headers());
+    stream_headers_ = std::make_unique<Http::TestRequestHeaderMapImpl>(fake_stream.headers());
     EXPECT_EQ("POST", stream_headers_->get_(":method"));
     EXPECT_EQ("/helloworld.Greeter/SayHello", stream_headers_->get_(":path"));
     EXPECT_EQ("application/grpc", stream_headers_->get_("content-type"));
@@ -434,7 +435,7 @@ public:
   Stats::ScopeSharedPtr stats_scope_{stats_store_};
   Grpc::StatNames google_grpc_stat_names_{stats_store_->symbolTable()};
   TestMetadata service_wide_initial_metadata_;
-  std::unique_ptr<Http::TestHeaderMapImpl> stream_headers_;
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> stream_headers_;
   std::vector<std::pair<std::string, std::string>> channel_args_;
 #ifdef ENVOY_GOOGLE_GRPC
   std::unique_ptr<GoogleAsyncClientThreadLocal> google_tls_;

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -149,7 +149,7 @@ TEST_F(AsyncClientImplTest, Basic) {
         return nullptr;
       }));
 
-  TestHeaderMapImpl copy(message_->headers());
+  TestRequestHeaderMapImpl copy(message_->headers());
   copy.addCopy("x-envoy-internal", "true");
   copy.addCopy("x-forwarded-for", "127.0.0.1");
   copy.addCopy(":scheme", "http");
@@ -187,7 +187,7 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
         return nullptr;
       }));
 
-  TestHeaderMapImpl copy(message_->headers());
+  TestRequestHeaderMapImpl copy(message_->headers());
   copy.addCopy("x-envoy-internal", "true");
   copy.addCopy("x-forwarded-for", "127.0.0.1");
   copy.addCopy(":scheme", "http");
@@ -231,7 +231,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
         return nullptr;
       }));
 
-  TestHeaderMapImpl copy(message_->headers());
+  TestRequestHeaderMapImpl copy(message_->headers());
   copy.addCopy("x-envoy-internal", "true");
   copy.addCopy("x-forwarded-for", "127.0.0.1");
   copy.addCopy(":scheme", "http");
@@ -284,7 +284,7 @@ TEST_F(AsyncClientImplTest, BasicHashPolicy) {
             return &cm_.conn_pool_;
           }));
 
-  TestHeaderMapImpl copy(message_->headers());
+  TestRequestHeaderMapImpl copy(message_->headers());
   copy.addCopy("x-envoy-internal", "true");
   copy.addCopy("x-forwarded-for", "127.0.0.1");
   copy.addCopy(":scheme", "http");
@@ -1103,7 +1103,7 @@ TEST_F(AsyncClientImplTest, StreamTimeout) {
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40), _));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
 
-  TestHeaderMapImpl expected_timeout{
+  TestRequestHeaderMapImpl expected_timeout{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), false));
   EXPECT_CALL(stream_callbacks_, onData(_, true));
@@ -1138,7 +1138,7 @@ TEST_F(AsyncClientImplTest, StreamTimeoutHeadReply) {
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(40), _));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
 
-  TestHeaderMapImpl expected_timeout{
+  TestRequestHeaderMapImpl expected_timeout{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(stream_callbacks_, onHeaders_(HeaderMapEqualRef(&expected_timeout), true));
   EXPECT_CALL(stream_callbacks_, onComplete());

--- a/test/common/http/date_provider_impl_test.cc
+++ b/test/common/http/date_provider_impl_test.cc
@@ -22,7 +22,7 @@ TEST(DateProviderImplTest, All) {
   EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(500), _));
 
   TlsCachingDateProviderImpl provider(dispatcher, tls);
-  ResponseHeaderMapImpl headers;
+  TestResponseHeaderMapImpl headers;
   provider.setDateHeader(headers);
   EXPECT_NE(nullptr, headers.Date());
 

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -30,7 +30,7 @@ public:
     }
     return *headers_.Host();
   }
-  RequestHeaderMapImpl headers_;
+  TestRequestHeaderMapImpl headers_;
 };
 
 // Port's part from host header get removed
@@ -188,7 +188,8 @@ invert_match: true
 }
 
 TEST(HeaderDataConstructorTest, GetAllOfHeader) {
-  TestHeaderMapImpl headers{{"foo", "val1"}, {"bar", "bar2"}, {"foo", "eep, bar"}, {"foo", ""}};
+  TestRequestHeaderMapImpl headers{
+      {"foo", "val1"}, {"bar", "bar2"}, {"foo", "eep, bar"}, {"foo", ""}};
 
   std::vector<absl::string_view> foo_out;
   Http::HeaderUtility::getAllOfHeader(headers, "foo", foo_out);
@@ -208,7 +209,7 @@ TEST(HeaderDataConstructorTest, GetAllOfHeader) {
 }
 
 TEST(MatchHeadersTest, MayMatchOneOrMoreRequestHeader) {
-  TestHeaderMapImpl headers{{"some-header", "a"}, {"other-header", "b"}};
+  TestRequestHeaderMapImpl headers{{"some-header", "a"}, {"other-header", "b"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -227,13 +228,13 @@ regex_match: (a|b)
 }
 
 TEST(MatchHeadersTest, MustMatchAllHeaderData) {
-  TestHeaderMapImpl matching_headers_1{{"match-header-A", "1"}, {"match-header-B", "2"}};
-  TestHeaderMapImpl matching_headers_2{
+  TestRequestHeaderMapImpl matching_headers_1{{"match-header-A", "1"}, {"match-header-B", "2"}};
+  TestRequestHeaderMapImpl matching_headers_2{
       {"match-header-A", "3"}, {"match-header-B", "4"}, {"match-header-C", "5"}};
-  TestHeaderMapImpl unmatching_headers_1{{"match-header-A", "6"}};
-  TestHeaderMapImpl unmatching_headers_2{{"match-header-B", "7"}};
-  TestHeaderMapImpl unmatching_headers_3{{"match-header-A", "8"}, {"match-header-C", "9"}};
-  TestHeaderMapImpl unmatching_headers_4{{"match-header-C", "10"}, {"match-header-D", "11"}};
+  TestRequestHeaderMapImpl unmatching_headers_1{{"match-header-A", "6"}};
+  TestRequestHeaderMapImpl unmatching_headers_2{{"match-header-B", "7"}};
+  TestRequestHeaderMapImpl unmatching_headers_3{{"match-header-A", "8"}, {"match-header-C", "9"}};
+  TestRequestHeaderMapImpl unmatching_headers_4{{"match-header-C", "10"}, {"match-header-D", "11"}};
 
   const std::string yamlA = R"EOF(
 name: match-header-A
@@ -257,8 +258,8 @@ name: match-header-B
 }
 
 TEST(MatchHeadersTest, HeaderPresence) {
-  TestHeaderMapImpl matching_headers{{"match-header", "value"}};
-  TestHeaderMapImpl unmatching_headers{{"other-header", "value"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "value"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"other-header", "value"}};
   const std::string yaml = R"EOF(
 name: match-header
   )EOF";
@@ -271,9 +272,9 @@ name: match-header
 }
 
 TEST(MatchHeadersTest, HeaderExactMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "match-value"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "other-value"},
-                                       {"other-header", "match-value"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "match-value"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "other-value"},
+                                              {"other-header", "match-value"}};
   const std::string yaml = R"EOF(
 name: match-header
 exact_match: match-value
@@ -287,9 +288,9 @@ exact_match: match-value
 }
 
 TEST(MatchHeadersTest, HeaderExactMatchInverse) {
-  TestHeaderMapImpl matching_headers{{"match-header", "other-value"},
-                                     {"other-header", "match-value"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "match-value"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "other-value"},
+                                            {"other-header", "match-value"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "match-value"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -305,8 +306,9 @@ invert_match: true
 }
 
 TEST(MatchHeadersTest, HeaderRegexMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "123"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "1234"}, {"match-header", "123.456"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "1234"},
+                                              {"match-header", "123.456"}};
   const std::string yaml = R"EOF(
 name: match-header
 regex_match: \d{3}
@@ -320,8 +322,9 @@ regex_match: \d{3}
 }
 
 TEST(MatchHeadersTest, HeaderSafeRegexMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "123"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "1234"}, {"match-header", "123.456"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "1234"},
+                                              {"match-header", "123.456"}};
   const std::string yaml = R"EOF(
 name: match-header
 safe_regex_match:
@@ -337,8 +340,8 @@ safe_regex_match:
 }
 
 TEST(MatchHeadersTest, HeaderRegexInverseMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "1234"}, {"match-header", "123.456"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "1234"}, {"match-header", "123.456"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -354,11 +357,11 @@ invert_match: true
 }
 
 TEST(MatchHeadersTest, HeaderRangeMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "-1"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "0"},
-                                       {"match-header", "somestring"},
-                                       {"match-header", "10.9"},
-                                       {"match-header", "-1somestring"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "-1"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "0"},
+                                              {"match-header", "somestring"},
+                                              {"match-header", "10.9"},
+                                              {"match-header", "-1somestring"}};
   const std::string yaml = R"EOF(
 name: match-header
 range_match:
@@ -374,11 +377,11 @@ range_match:
 }
 
 TEST(MatchHeadersTest, HeaderRangeInverseMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "0"},
-                                     {"match-header", "somestring"},
-                                     {"match-header", "10.9"},
-                                     {"match-header", "-1somestring"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "-1"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "0"},
+                                            {"match-header", "somestring"},
+                                            {"match-header", "10.9"},
+                                            {"match-header", "-1somestring"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "-1"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -396,9 +399,9 @@ invert_match: true
 }
 
 TEST(MatchHeadersTest, HeaderPresentMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "123"}};
-  TestHeaderMapImpl unmatching_headers{{"nonmatch-header", "1234"},
-                                       {"other-nonmatch-header", "123.456"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"nonmatch-header", "1234"},
+                                              {"other-nonmatch-header", "123.456"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -413,9 +416,9 @@ present_match: true
 }
 
 TEST(MatchHeadersTest, HeaderPresentInverseMatch) {
-  TestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
-  TestHeaderMapImpl matching_headers{{"nonmatch-header", "1234"},
-                                     {"other-nonmatch-header", "123.456"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl matching_headers{{"nonmatch-header", "1234"},
+                                            {"other-nonmatch-header", "123.456"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -431,8 +434,8 @@ invert_match: true
 }
 
 TEST(MatchHeadersTest, HeaderPrefixMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "value123"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "123value"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "value123"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123value"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -447,8 +450,8 @@ prefix_match: value
 }
 
 TEST(MatchHeadersTest, HeaderPrefixInverseMatch) {
-  TestHeaderMapImpl unmatching_headers{{"match-header", "value123"}};
-  TestHeaderMapImpl matching_headers{{"match-header", "123value"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "value123"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "123value"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -464,8 +467,8 @@ invert_match: true
 }
 
 TEST(MatchHeadersTest, HeaderSuffixMatch) {
-  TestHeaderMapImpl matching_headers{{"match-header", "123value"}};
-  TestHeaderMapImpl unmatching_headers{{"match-header", "value123"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "123value"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "value123"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -480,8 +483,8 @@ suffix_match: value
 }
 
 TEST(MatchHeadersTest, HeaderSuffixInverseMatch) {
-  TestHeaderMapImpl unmatching_headers{{"match-header", "123value"}};
-  TestHeaderMapImpl matching_headers{{"match-header", "value123"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123value"}};
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "value123"}};
 
   const std::string yaml = R"EOF(
 name: match-header
@@ -539,14 +542,14 @@ TEST(HeaderIsValidTest, IsConnectResponse) {
 }
 
 TEST(HeaderAddTest, HeaderAdd) {
-  TestHeaderMapImpl headers{{"myheader1", "123value"}};
-  TestHeaderMapImpl headers_to_add{{"myheader2", "456value"}};
+  TestRequestHeaderMapImpl headers{{"myheader1", "123value"}};
+  TestRequestHeaderMapImpl headers_to_add{{"myheader2", "456value"}};
 
   HeaderUtility::addHeaders(headers, headers_to_add);
 
   headers_to_add.iterate(
       [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
-        TestHeaderMapImpl* headers = static_cast<TestHeaderMapImpl*>(context);
+        TestRequestHeaderMapImpl* headers = static_cast<TestRequestHeaderMapImpl*>(context);
         Http::LowerCaseString lower_key{std::string(entry.key().getStringView())};
         EXPECT_EQ(entry.value().getStringView(), headers->get(lower_key)->value().getStringView());
         return Http::HeaderMap::Iterate::Continue;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -79,7 +79,7 @@ public:
   Http::ServerConnectionPtr codec_;
 
   void expectHeadersTest(Protocol p, bool allow_absolute_url, Buffer::OwnedImpl& buffer,
-                         TestHeaderMapImpl& expected_headers);
+                         TestRequestHeaderMapImpl& expected_headers);
   void expect400(Protocol p, bool allow_absolute_url, Buffer::OwnedImpl& buffer,
                  absl::string_view details = "");
   void testRequestHeadersExceedLimit(std::string header_string, absl::string_view details = "");
@@ -90,14 +90,16 @@ public:
 
   // Send the request, and validate the received request headers.
   // Then send a response just to clean up.
-  void sendAndValidateRequestAndSendResponse(absl::string_view raw_request,
-                                             const TestHeaderMapImpl& expected_request_headers) {
+  void
+  sendAndValidateRequestAndSendResponse(absl::string_view raw_request,
+                                        const TestRequestHeaderMapImpl& expected_request_headers) {
     Buffer::OwnedImpl buffer(raw_request);
     sendAndValidateRequestAndSendResponse(buffer, expected_request_headers);
   }
 
-  void sendAndValidateRequestAndSendResponse(Buffer::Instance& buffer,
-                                             const TestHeaderMapImpl& expected_request_headers) {
+  void
+  sendAndValidateRequestAndSendResponse(Buffer::Instance& buffer,
+                                        const TestRequestHeaderMapImpl& expected_request_headers) {
     NiceMock<MockRequestDecoder> decoder;
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))
@@ -153,7 +155,7 @@ void Http1ServerConnectionImplTest::expect400(Protocol p, bool allow_absolute_ur
 
 void Http1ServerConnectionImplTest::expectHeadersTest(Protocol p, bool allow_absolute_url,
                                                       Buffer::OwnedImpl& buffer,
-                                                      TestHeaderMapImpl& expected_headers) {
+                                                      TestRequestHeaderMapImpl& expected_headers) {
   InSequence sequence;
 
   // Make a new 'codec' with the right settings
@@ -302,7 +304,7 @@ TEST_F(Http1ServerConnectionImplTest, EmptyHeader) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {"Test", ""},
       {"Hello", "World"},
       {":path", "/"},
@@ -355,7 +357,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBody) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "POST"},
       {"transfer-encoding", "chunked"},
@@ -386,7 +388,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBodySplitOverTwoDispatches) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "POST"},
       {"transfer-encoding", "chunked"},
@@ -424,7 +426,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBodyFragmentedBuffer) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "POST"},
       {"transfer-encoding", "chunked"},
@@ -453,7 +455,7 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBodyCase) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "POST"},
       {"transfer-encoding", "Chunked"},
@@ -480,7 +482,7 @@ TEST_F(Http1ServerConnectionImplTest, InvalidChunkHeader) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "POST"},
       {"transfer-encoding", "chunked"},
@@ -516,7 +518,8 @@ TEST_F(Http1ServerConnectionImplTest, IdentityAndChunkedBody) {
 TEST_F(Http1ServerConnectionImplTest, HostWithLWS) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{{":authority", "host"}, {":path", "/"}, {":method", "GET"}};
+  TestRequestHeaderMapImpl expected_headers{
+      {":authority", "host"}, {":path", "/"}, {":method", "GET"}};
 
   // Regression test spaces before and after the host header value.
   sendAndValidateRequestAndSendResponse("GET / HTTP/1.1\r\nHost: host \r\n\r\n", expected_headers);
@@ -541,10 +544,10 @@ TEST_F(Http1ServerConnectionImplTest, InnerLWSIsPreserved) {
   // reads, but the important part is that the header value is split such that the pieces have
   // leading and trailing whitespace characters.
   const std::string header_value_with_inner_lws = "v" + std::string(32 * 1024, ' ') + "v";
-  TestHeaderMapImpl expected_headers{{":authority", "host"},
-                                     {":path", "/"},
-                                     {":method", "GET"},
-                                     {"header_field", header_value_with_inner_lws}};
+  TestRequestHeaderMapImpl expected_headers{{":authority", "host"},
+                                            {":path", "/"},
+                                            {":method", "GET"},
+                                            {"header_field", header_value_with_inner_lws}};
 
   {
     // Regression test spaces in the middle are preserved
@@ -574,7 +577,7 @@ TEST_F(Http1ServerConnectionImplTest, Http10) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
+  TestRequestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
@@ -587,7 +590,7 @@ TEST_F(Http1ServerConnectionImplTest, Http10) {
 TEST_F(Http1ServerConnectionImplTest, Http10AbsoluteNoOp) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
+  TestRequestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET / HTTP/1.0\r\n\r\n");
   expectHeadersTest(Protocol::Http10, true, buffer, expected_headers);
 }
@@ -595,7 +598,7 @@ TEST_F(Http1ServerConnectionImplTest, Http10AbsoluteNoOp) {
 TEST_F(Http1ServerConnectionImplTest, Http10Absolute) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com"}, {":path", "/foobar"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com/foobar HTTP/1.0\r\n\r\n");
   expectHeadersTest(Protocol::Http10, true, buffer, expected_headers);
@@ -630,7 +633,7 @@ TEST_F(Http1ServerConnectionImplTest, Http10MultipleResponses) {
 
   // Now send an HTTP/1.1 request and make sure the protocol is tracked correctly.
   {
-    TestHeaderMapImpl expected_headers{
+    TestRequestHeaderMapImpl expected_headers{
         {":authority", "www.somewhere.com"}, {":path", "/foobar"}, {":method", "GET"}};
     Buffer::OwnedImpl buffer("GET /foobar HTTP/1.1\r\nHost: www.somewhere.com\r\n\r\n");
 
@@ -650,7 +653,7 @@ TEST_F(Http1ServerConnectionImplTest, Http10MultipleResponses) {
 TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePath1) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com"}, {":path", "/"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com/ HTTP/1.1\r\nHost: bah\r\n\r\n");
   expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
@@ -659,7 +662,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePath1) {
 TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePath2) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com"}, {":path", "/foo/bar"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com/foo/bar HTTP/1.1\r\nHost: bah\r\n\r\n");
   expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
@@ -668,7 +671,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePath2) {
 TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePathWithPort) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com:4532"}, {":path", "/foo/bar"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer(
       "GET http://www.somewhere.com:4532/foo/bar HTTP/1.1\r\nHost: bah\r\n\r\n");
@@ -678,7 +681,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePathWithPort) {
 TEST_F(Http1ServerConnectionImplTest, Http11AbsoluteEnabledNoOp) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "bah"}, {":path", "/foo/bar"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET /foo/bar HTTP/1.1\r\nHost: bah\r\n\r\n");
   expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
@@ -723,7 +726,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
 TEST_F(Http1ServerConnectionImplTest, Http11AbsolutePathNoSlash) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com"}, {":path", "/"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com HTTP/1.1\r\nHost: bah\r\n\r\n");
   expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
@@ -754,7 +757,7 @@ TEST_F(Http1ServerConnectionImplTest, SketchyConnectionHeader) {
 TEST_F(Http1ServerConnectionImplTest, Http11RelativeOnly) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "bah"}, {":path", "http://www.somewhere.com/"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com/ HTTP/1.1\r\nHost: bah\r\n\r\n");
   expectHeadersTest(Protocol::Http11, false, buffer, expected_headers);
@@ -763,7 +766,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11RelativeOnly) {
 TEST_F(Http1ServerConnectionImplTest, Http11Options) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com"}, {":path", "*"}, {":method", "OPTIONS"}};
   Buffer::OwnedImpl buffer("OPTIONS * HTTP/1.1\r\nHost: www.somewhere.com\r\n\r\n");
   expectHeadersTest(Protocol::Http11, true, buffer, expected_headers);
@@ -777,7 +780,7 @@ TEST_F(Http1ServerConnectionImplTest, SimpleGet) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
+  TestRequestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
@@ -929,7 +932,8 @@ TEST_F(Http1ServerConnectionImplTest, HostHeaderTranslation) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{{":authority", "hello"}, {":path", "/"}, {":method", "GET"}};
+  TestRequestHeaderMapImpl expected_headers{
+      {":authority", "hello"}, {":path", "/"}, {":method", "GET"}};
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\nHOST: hello\r\n\r\n");
@@ -993,7 +997,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreAllowed) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "h.com"},
       {":path", "/"},
       {":method", "GET"},
@@ -1017,7 +1021,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreAreDropped) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "h.com"},
       {":path", "/"},
       {":method", "GET"},
@@ -1168,7 +1172,8 @@ TEST_F(Http1ServerConnectionImplTest, PostWithContentLength) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{{"content-length", "5"}, {":path", "/"}, {":method", "POST"}};
+  TestRequestHeaderMapImpl expected_headers{
+      {"content-length", "5"}, {":path", "/"}, {":method", "POST"}};
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
 
   Buffer::OwnedImpl expected_data1("12345");
@@ -1193,7 +1198,8 @@ TEST_F(Http1ServerConnectionImplTest, PostWithContentLengthFragmentedBuffer) {
   MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{{"content-length", "5"}, {":path", "/"}, {":method", "POST"}};
+  TestRequestHeaderMapImpl expected_headers{
+      {"content-length", "5"}, {":path", "/"}, {":method", "POST"}};
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
 
   Buffer::OwnedImpl expected_data1("12345");
@@ -1543,7 +1549,7 @@ TEST_F(Http1ServerConnectionImplTest, RequestWithTrailersKept) { expectTrailersT
 TEST_F(Http1ServerConnectionImplTest, IgnoreUpgradeH2c) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "www.somewhere.com"}, {":path", "/"}, {":method", "GET"}};
   Buffer::OwnedImpl buffer(
       "GET http://www.somewhere.com/ HTTP/1.1\r\nConnection: "
@@ -1554,10 +1560,10 @@ TEST_F(Http1ServerConnectionImplTest, IgnoreUpgradeH2c) {
 TEST_F(Http1ServerConnectionImplTest, IgnoreUpgradeH2cClose) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{{":authority", "www.somewhere.com"},
-                                     {":path", "/"},
-                                     {":method", "GET"},
-                                     {"connection", "Close"}};
+  TestRequestHeaderMapImpl expected_headers{{":authority", "www.somewhere.com"},
+                                            {":path", "/"},
+                                            {":method", "GET"},
+                                            {"connection", "Close"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com/ HTTP/1.1\r\nConnection: "
                            "Upgrade, Close, HTTP2-Settings\r\nUpgrade: h2c\r\nHTTP2-Settings: "
                            "token64\r\nHost: bah\r\n\r\n");
@@ -1567,10 +1573,10 @@ TEST_F(Http1ServerConnectionImplTest, IgnoreUpgradeH2cClose) {
 TEST_F(Http1ServerConnectionImplTest, IgnoreUpgradeH2cCloseEtc) {
   initialize();
 
-  TestHeaderMapImpl expected_headers{{":authority", "www.somewhere.com"},
-                                     {":path", "/"},
-                                     {":method", "GET"},
-                                     {"connection", "Close"}};
+  TestRequestHeaderMapImpl expected_headers{{":authority", "www.somewhere.com"},
+                                            {":path", "/"},
+                                            {":method", "GET"},
+                                            {"connection", "Close"}};
   Buffer::OwnedImpl buffer("GET http://www.somewhere.com/ HTTP/1.1\r\nConnection: "
                            "Upgrade, Close, HTTP2-Settings, Etc\r\nUpgrade: h2c\r\nHTTP2-Settings: "
                            "token64\r\nHost: bah\r\n\r\n");
@@ -1660,7 +1666,7 @@ TEST_F(Http1ServerConnectionImplTest, ConnectRequestNoContentLength) {
   NiceMock<MockRequestDecoder> decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
-  TestHeaderMapImpl expected_headers{
+  TestRequestHeaderMapImpl expected_headers{
       {":authority", "host:80"},
       {":method", "CONNECT"},
   };

--- a/test/common/http/http2/frame_replay_test.cc
+++ b/test/common/http/http2/frame_replay_test.cc
@@ -97,7 +97,7 @@ TEST_F(ResponseFrameCommentTest, SimpleExampleHuffman) {
 
   EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
   EXPECT_TRUE(codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection).ok());
-  TestHeaderMapImpl expected_headers;
+  TestResponseHeaderMapImpl expected_headers;
   expected_headers.addCopy(":status", "200");
   expected_headers.addCopy("compression", "test");
   EXPECT_CALL(codec.response_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
@@ -177,7 +177,7 @@ TEST_F(ResponseFrameCommentTest, SimpleExamplePlain) {
 
   EXPECT_TRUE(codec.write(WellKnownFrames::defaultSettingsFrame(), connection).ok());
   EXPECT_TRUE(codec.write(WellKnownFrames::initialWindowUpdateFrame(), connection).ok());
-  TestHeaderMapImpl expected_headers;
+  TestResponseHeaderMapImpl expected_headers;
   expected_headers.addCopy(":status", "200");
   expected_headers.addCopy("compression", "test");
   EXPECT_CALL(codec.response_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), true));

--- a/test/common/http/path_utility_test.cc
+++ b/test/common/http/path_utility_test.cc
@@ -1,8 +1,9 @@
 #include <utility>
 #include <vector>
 
-#include "common/http/header_map_impl.h"
 #include "common/http/path_utility.h"
+
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -22,7 +23,7 @@ public:
     headers_.setHost(host_value);
     return *headers_.Host();
   }
-  RequestHeaderMapImpl headers_;
+  TestRequestHeaderMapImpl headers_;
 };
 
 // Already normalized path don't change.

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -398,7 +398,7 @@ TEST(HttpUtility, getLastAddressFromXFF) {
 }
 
 TEST(HttpUtility, TestParseCookie) {
-  TestHeaderMapImpl headers{
+  TestRequestHeaderMapImpl headers{
       {"someheader", "10.0.0.1"},
       {"cookie", "somekey=somevalue; someotherkey=someothervalue"},
       {"cookie", "abc=def; token=abc123; Expires=Wed, 09 Jun 2021 10:18:14 GMT"},
@@ -410,10 +410,10 @@ TEST(HttpUtility, TestParseCookie) {
 }
 
 TEST(HttpUtility, TestParseCookieBadValues) {
-  TestHeaderMapImpl headers{{"cookie", "token1=abc123; = "},
-                            {"cookie", "token2=abc123;   "},
-                            {"cookie", "; token3=abc123;"},
-                            {"cookie", "=; token4=\"abc123\""}};
+  TestRequestHeaderMapImpl headers{{"cookie", "token1=abc123; = "},
+                                   {"cookie", "token2=abc123;   "},
+                                   {"cookie", "; token3=abc123;"},
+                                   {"cookie", "=; token4=\"abc123\""}};
 
   EXPECT_EQ(Utility::parseCookieValue(headers, "token1"), "abc123");
   EXPECT_EQ(Utility::parseCookieValue(headers, "token2"), "abc123");
@@ -422,7 +422,7 @@ TEST(HttpUtility, TestParseCookieBadValues) {
 }
 
 TEST(HttpUtility, TestParseCookieWithQuotes) {
-  TestHeaderMapImpl headers{
+  TestRequestHeaderMapImpl headers{
       {"someheader", "10.0.0.1"},
       {"cookie", "dquote=\"; quoteddquote=\"\"\""},
       {"cookie", "leadingdquote=\"foobar;"},
@@ -827,7 +827,7 @@ TEST(HttpUtility, TestTeHeaderGzipTrailersSanitized) {
   // Expect that the set of headers is valid and can be sanitized
   EXPECT_TRUE(Utility::sanitizeConnectionHeader(request_headers));
 
-  Http::TestHeaderMapImpl sanitized_headers = {
+  Http::TestRequestHeaderMapImpl sanitized_headers = {
       {":method", "GET"},
       {":path", "/"},
       {":scheme", "http"},
@@ -855,7 +855,7 @@ TEST(HttpUtility, TestNominatedConnectionHeader) {
   };
   EXPECT_TRUE(Utility::sanitizeConnectionHeader(request_headers));
 
-  TestHeaderMapImpl sanitized_headers = {
+  TestRequestHeaderMapImpl sanitized_headers = {
       {":method", "GET"},
       {":path", "/"},
       {":scheme", "http"},
@@ -883,7 +883,7 @@ TEST(HttpUtility, TestNominatedConnectionHeader2) {
   };
   EXPECT_TRUE(Utility::sanitizeConnectionHeader(request_headers));
 
-  Http::TestHeaderMapImpl sanitized_headers = {
+  Http::TestRequestHeaderMapImpl sanitized_headers = {
       {":method", "GET"},
       {":path", "/"},
       {":scheme", "http"},
@@ -910,7 +910,7 @@ TEST(HttpUtility, TestNominatedPseudoHeader) {
   };
 
   // Headers remain unchanged since there are nominated pseudo headers
-  Http::TestHeaderMapImpl sanitized_headers(request_headers);
+  Http::TestRequestHeaderMapImpl sanitized_headers(request_headers);
 
   EXPECT_FALSE(Utility::sanitizeConnectionHeader(request_headers));
   EXPECT_EQ(sanitized_headers, request_headers);
@@ -932,7 +932,7 @@ TEST(HttpUtility, TestSanitizeEmptyTokensFromHeaders) {
   };
   EXPECT_TRUE(Utility::sanitizeConnectionHeader(request_headers));
 
-  Http::TestHeaderMapImpl sanitized_headers = {
+  Http::TestRequestHeaderMapImpl sanitized_headers = {
       {":method", "GET"},
       {":path", "/"},
       {":scheme", "http"},
@@ -959,7 +959,7 @@ TEST(HttpUtility, TestTooManyNominatedHeaders) {
   };
 
   // Headers remain unchanged because there are too many nominated headers
-  Http::TestHeaderMapImpl sanitized_headers(request_headers);
+  Http::TestRequestHeaderMapImpl sanitized_headers(request_headers);
 
   EXPECT_FALSE(Utility::sanitizeConnectionHeader(request_headers));
   EXPECT_EQ(sanitized_headers, request_headers);
@@ -977,7 +977,7 @@ TEST(HttpUtility, TestRejectNominatedXForwardedFor) {
   };
 
   // Headers remain unchanged due to nominated X-Forwarded* header
-  Http::TestHeaderMapImpl sanitized_headers(request_headers);
+  Http::TestRequestHeaderMapImpl sanitized_headers(request_headers);
 
   EXPECT_FALSE(Utility::sanitizeConnectionHeader(request_headers));
   EXPECT_EQ(sanitized_headers, request_headers);
@@ -995,7 +995,7 @@ TEST(HttpUtility, TestRejectNominatedXForwardedHost) {
   };
 
   // Headers remain unchanged due to nominated X-Forwarded* header
-  Http::TestHeaderMapImpl sanitized_headers(request_headers);
+  Http::TestRequestHeaderMapImpl sanitized_headers(request_headers);
 
   EXPECT_FALSE(Utility::sanitizeConnectionHeader(request_headers));
   EXPECT_EQ(sanitized_headers, request_headers);
@@ -1015,7 +1015,7 @@ TEST(HttpUtility, TestRejectNominatedXForwardedProto) {
   // Headers are not sanitized due to nominated X-Forwarded* header
   EXPECT_FALSE(Utility::sanitizeConnectionHeader(request_headers));
 
-  Http::TestHeaderMapImpl sanitized_headers = {
+  Http::TestRequestHeaderMapImpl sanitized_headers = {
       {":method", "GET"},
       {":path", "/"},
       {":scheme", "http"},
@@ -1039,7 +1039,7 @@ TEST(HttpUtility, TestRejectTrailersSubString) {
   };
   EXPECT_TRUE(Utility::sanitizeConnectionHeader(request_headers));
 
-  Http::TestHeaderMapImpl sanitized_headers = {
+  Http::TestRequestHeaderMapImpl sanitized_headers = {
       {":method", "GET"},
       {":path", "/"},
       {":scheme", "http"},
@@ -1077,7 +1077,7 @@ TEST(HttpUtility, TestRejectTeHeaderTooLong) {
   };
 
   // Headers remain unchanged because the TE value is too long
-  Http::TestHeaderMapImpl sanitized_headers(request_headers);
+  Http::TestRequestHeaderMapImpl sanitized_headers(request_headers);
 
   EXPECT_FALSE(Utility::sanitizeConnectionHeader(request_headers));
   EXPECT_EQ(sanitized_headers, request_headers);

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4016,7 +4016,7 @@ virtual_hosts:
  * @brief  Generate headers for testing
  * @param ssl set true to insert "x-forwarded-proto: https", else "x-forwarded-proto: http"
  * @param internal nullopt for no such "x-envoy-internal" header, or explicit "true/false"
- * @return Http::TestHeaderMapImpl
+ * @return Http::TestRequestHeaderMapImpl
  */
 static Http::TestRequestHeaderMapImpl genRedirectHeaders(const std::string& host,
                                                          const std::string& path, bool ssl,
@@ -4700,7 +4700,7 @@ virtual_hosts:
     Http::TestResponseHeaderMapImpl response_headers;
     StreamInfo::MockStreamInfo stream_info;
     route_entry->finalizeResponseHeaders(response_headers, stream_info);
-    EXPECT_EQ(response_headers, Http::TestHeaderMapImpl{});
+    EXPECT_EQ(response_headers, Http::TestResponseHeaderMapImpl{});
   }
 
   // Weighted Cluster with no runtime, total weight = 10000
@@ -6799,10 +6799,10 @@ virtual_hosts:
   const auto& retry_policy = config.route(headers, 0)->routeEntry()->retryPolicy();
   ASSERT_EQ(2, retry_policy.retriableHeaders().size());
 
-  Http::TestHeaderMapImpl expected_0{{":status", "500"}};
-  Http::TestHeaderMapImpl unexpected_0{{":status", "200"}};
-  Http::TestHeaderMapImpl expected_1{{"x-upstream-pushback", "bar"}};
-  Http::TestHeaderMapImpl unexpected_1{{"x-test", "foo"}};
+  Http::TestResponseHeaderMapImpl expected_0{{":status", "500"}};
+  Http::TestResponseHeaderMapImpl unexpected_0{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl expected_1{{"x-upstream-pushback", "bar"}};
+  Http::TestResponseHeaderMapImpl unexpected_1{{"x-test", "foo"}};
 
   EXPECT_TRUE(retry_policy.retriableHeaders()[0]->matchesHeaders(expected_0));
   EXPECT_FALSE(retry_policy.retriableHeaders()[0]->matchesHeaders(unexpected_0));

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -848,7 +848,7 @@ TEST(HeaderParserTest, TestParseInternal) {
       new NiceMock<Envoy::Upstream::MockHostDescription>());
   ON_CALL(stream_info, upstreamHost()).WillByDefault(Return(host));
 
-  Http::RequestHeaderMapImpl request_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::LowerCaseString(std::string("x-request-id")), 123);
   ON_CALL(stream_info, getRequestHeaders()).WillByDefault(Return(&request_headers));
 
@@ -898,7 +898,7 @@ TEST(HeaderParserTest, TestParseInternal) {
 
     HeaderParserPtr req_header_parser = HeaderParser::configure(to_add);
 
-    Http::TestHeaderMapImpl header_map{{":method", "POST"}};
+    Http::TestRequestHeaderMapImpl header_map{{":method", "POST"}};
     req_header_parser->evaluateHeaders(header_map, stream_info);
 
     std::string descriptor = fmt::format("for test case input: {}", test_case.input_);
@@ -932,7 +932,7 @@ request_headers_to_add:
 
   HeaderParserPtr req_header_parser =
       HeaderParser::configure(parseRouteFromV2Yaml(ymal).request_headers_to_add());
-  Http::TestHeaderMapImpl header_map{{":method", "POST"}};
+  Http::TestRequestHeaderMapImpl header_map{{":method", "POST"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   req_header_parser->evaluateHeaders(header_map, stream_info);
   EXPECT_TRUE(header_map.has("x-client-ip"));
@@ -954,7 +954,7 @@ request_headers_to_add:
 
   HeaderParserPtr req_header_parser =
       HeaderParser::configure(parseRouteFromV2Yaml(ymal).request_headers_to_add());
-  Http::TestHeaderMapImpl header_map{{":method", "POST"}};
+  Http::TestRequestHeaderMapImpl header_map{{":method", "POST"}};
   std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> host(
       new NiceMock<Envoy::Upstream::MockHostDescription>());
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
@@ -980,7 +980,7 @@ request_headers_to_add:
 
   HeaderParserPtr req_header_parser =
       HeaderParser::configure(parseRouteFromV2Yaml(ymal).request_headers_to_add());
-  Http::TestHeaderMapImpl header_map{{":method", "POST"}};
+  Http::TestRequestHeaderMapImpl header_map{{":method", "POST"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   req_header_parser->evaluateHeaders(header_map, stream_info);
   EXPECT_TRUE(header_map.has("static-header"));
@@ -1026,7 +1026,8 @@ request_headers_to_remove: ["x-nope"]
   const auto route = parseRouteFromV2Yaml(yaml);
   HeaderParserPtr req_header_parser =
       HeaderParser::configure(route.request_headers_to_add(), route.request_headers_to_remove());
-  Http::TestHeaderMapImpl header_map{{":method", "POST"}, {"x-safe", "safe"}, {"x-nope", "nope"}};
+  Http::TestRequestHeaderMapImpl header_map{
+      {":method", "POST"}, {"x-safe", "safe"}, {"x-nope", "nope"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   absl::optional<Envoy::Http::Protocol> protocol = Envoy::Http::Protocol::Http11;
   ON_CALL(stream_info, protocol()).WillByDefault(ReturnPointee(&protocol));
@@ -1124,7 +1125,7 @@ request_headers_to_add:
 
   HeaderParserPtr req_header_parser =
       Router::HeaderParser::configure(route.request_headers_to_add());
-  Http::TestHeaderMapImpl header_map{
+  Http::TestRequestHeaderMapImpl header_map{
       {":method", "POST"}, {"static-header", "old-value"}, {"x-client-ip", "0.0.0.0"}};
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
@@ -1213,7 +1214,8 @@ response_headers_to_remove: ["x-nope"]
   const auto route = parseRouteFromV2Yaml(yaml);
   HeaderParserPtr resp_header_parser =
       HeaderParser::configure(route.response_headers_to_add(), route.response_headers_to_remove());
-  Http::TestHeaderMapImpl header_map{{":method", "POST"}, {"x-safe", "safe"}, {"x-nope", "nope"}};
+  Http::TestRequestHeaderMapImpl header_map{
+      {":method", "POST"}, {"x-safe", "safe"}, {"x-nope", "nope"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
 
   // Initialize start_time as 2018-04-03T23:06:09.123Z in microseconds.
@@ -1263,7 +1265,7 @@ request_headers_to_remove: ["x-foo-header"]
   const auto route = parseRouteFromV2Yaml(yaml);
   HeaderParserPtr req_header_parser =
       HeaderParser::configure(route.request_headers_to_add(), route.request_headers_to_remove());
-  Http::TestHeaderMapImpl header_map{{"x-foo-header", "foo"}};
+  Http::TestRequestHeaderMapImpl header_map{{"x-foo-header", "foo"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
 
   req_header_parser->evaluateHeaders(header_map, stream_info);
@@ -1285,7 +1287,7 @@ response_headers_to_remove: ["x-foo-header"]
   const auto route = parseRouteFromV2Yaml(yaml);
   HeaderParserPtr resp_header_parser =
       HeaderParser::configure(route.response_headers_to_add(), route.response_headers_to_remove());
-  Http::TestHeaderMapImpl header_map{{"x-foo-header", "foo"}};
+  Http::TestResponseHeaderMapImpl header_map{{"x-foo-header", "foo"}};
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
 
   resp_header_parser->evaluateHeaders(header_map, stream_info);

--- a/test/common/router/header_parser_fuzz_test.cc
+++ b/test/common/router/header_parser_fuzz_test.cc
@@ -14,7 +14,7 @@ DEFINE_PROTO_FUZZER(const test::common::router::TestCase& input) {
     TestUtility::validate(input);
     Router::HeaderParserPtr parser =
         Router::HeaderParser::configure(input.headers_to_add(), input.headers_to_remove());
-    Http::HeaderMapImpl header_map;
+    Http::TestRequestHeaderMapImpl header_map;
     TestStreamInfo test_stream_info = fromStreamInfo(input.stream_info());
     parser->evaluateHeaders(header_map, test_stream_info);
     ENVOY_LOG_MISC(trace, "Success");

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -158,7 +158,7 @@ TEST_F(RdsImplTest, Basic) {
   setup();
 
   // Make sure the initial empty route table works.
-  EXPECT_EQ(nullptr, route(Http::TestHeaderMapImpl{{":authority", "foo"}}));
+  EXPECT_EQ(nullptr, route(Http::TestRequestHeaderMapImpl{{":authority", "foo"}}));
 
   // Initial request.
   const std::string response1_json = R"EOF(
@@ -178,11 +178,11 @@ TEST_F(RdsImplTest, Basic) {
 
   EXPECT_CALL(init_watcher_, ready());
   rds_callbacks_->onConfigUpdate(response1.resources(), response1.version_info());
-  EXPECT_EQ(nullptr, route(Http::TestHeaderMapImpl{{":authority", "foo"}}));
+  EXPECT_EQ(nullptr, route(Http::TestRequestHeaderMapImpl{{":authority", "foo"}}));
 
   // 2nd request with same response. Based on hash should not reload config.
   rds_callbacks_->onConfigUpdate(response1.resources(), response1.version_info());
-  EXPECT_EQ(nullptr, route(Http::TestHeaderMapImpl{{":authority", "foo"}}));
+  EXPECT_EQ(nullptr, route(Http::TestRequestHeaderMapImpl{{":authority", "foo"}}));
 
   // Load the config and verified shared count.
   ConfigConstSharedPtr config = rds_->config();
@@ -224,7 +224,7 @@ TEST_F(RdsImplTest, Basic) {
   // Make sure we don't lookup/verify clusters.
   EXPECT_CALL(server_factory_context_.cluster_manager_, get(Eq("bar"))).Times(0);
   rds_callbacks_->onConfigUpdate(response2.resources(), response2.version_info());
-  EXPECT_EQ("foo", route(Http::TestHeaderMapImpl{{":authority", "foo"}, {":path", "/foo"}})
+  EXPECT_EQ("foo", route(Http::TestRequestHeaderMapImpl{{":authority", "foo"}, {":path", "/foo"}})
                        ->routeEntry()
                        ->clusterName());
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -86,7 +86,7 @@ public:
   NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   ProtobufMessage::NullValidationVisitorImpl any_validation_visitor_;
   std::unique_ptr<ConfigImpl> config_;
-  Http::TestHeaderMapImpl header_;
+  Http::TestRequestHeaderMapImpl header_;
   const RouteEntry* route_;
   Network::Address::Ipv4Instance default_remote_address_{"10.0.0.1"};
 };
@@ -271,7 +271,7 @@ public:
   }
 
   std::unique_ptr<RateLimitPolicyEntryImpl> rate_limit_entry_;
-  Http::TestHeaderMapImpl header_;
+  Http::TestRequestHeaderMapImpl header_;
   NiceMock<MockRouteEntry> route_;
   std::vector<Envoy::RateLimit::Descriptor> descriptors_;
   Network::Address::Ipv4Instance default_remote_address_{"10.0.0.1"};
@@ -358,7 +358,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
                                          default_remote_address_);
@@ -382,7 +382,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
                                          default_remote_address_);
@@ -406,7 +406,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-test", "test_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-test", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
                                          default_remote_address_);
@@ -422,7 +422,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
                                          default_remote_address_);
@@ -455,7 +455,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
@@ -473,7 +473,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
   EXPECT_TRUE(descriptors_.empty());
@@ -491,7 +491,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
@@ -510,7 +510,7 @@ actions:
   )EOF";
 
   setupTest(yaml);
-  Http::TestHeaderMapImpl header{{"x-header-name", "test_value"}};
+  Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
   EXPECT_TRUE(descriptors_.empty());

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1437,8 +1437,8 @@ TEST_F(RouterTestSuppressEnvoyHeaders, EnvoyUpstreamServiceTime) {
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "200"}});
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_, putHttpResponseCode(200));
-  Http::TestHeaderMapImpl downstream_response_headers{{":status", "200"},
-                                                      {"x-envoy-upstream-service-time", "0"}};
+  Http::TestResponseHeaderMapImpl downstream_response_headers{
+      {":status", "200"}, {"x-envoy-upstream-service-time", "0"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(_, true))
       .WillOnce(Invoke([](Http::HeaderMap& headers, bool) {
         EXPECT_EQ(nullptr, headers.get(Http::Headers::get().EnvoyUpstreamServiceTime));

--- a/test/common/router/scoped_config_impl_test.cc
+++ b/test/common/router/scoped_config_impl_test.cc
@@ -15,7 +15,7 @@ namespace Envoy {
 namespace Router {
 namespace {
 
-using ::Envoy::Http::TestHeaderMapImpl;
+using ::Envoy::Http::TestRequestHeaderMapImpl;
 using ::testing::NiceMock;
 
 class FooFragment : public ScopeKeyFragmentBase {
@@ -116,30 +116,30 @@ TEST(HeaderValueExtractorImplTest, HeaderExtractionByIndex) {
 
   TestUtility::loadFromYaml(yaml_plain, config);
   HeaderValueExtractorImpl extractor(std::move(config));
-  std::unique_ptr<ScopeKeyFragmentBase> fragment =
-      extractor.computeFragment(TestHeaderMapImpl{{"foo_header", "part-0,part-1:value_bluh"}});
+  std::unique_ptr<ScopeKeyFragmentBase> fragment = extractor.computeFragment(
+      TestRequestHeaderMapImpl{{"foo_header", "part-0,part-1:value_bluh"}});
 
   EXPECT_NE(fragment, nullptr);
   EXPECT_EQ(*fragment, StringKeyFragment{"part-1:value_bluh"});
 
   // No such header.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{{"bar_header", "part-0"}});
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{{"bar_header", "part-0"}});
   EXPECT_EQ(fragment, nullptr);
 
   // Empty header value.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", ""},
   });
   EXPECT_EQ(fragment, nullptr);
 
   // Index out of bound.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "part-0"},
   });
   EXPECT_EQ(fragment, nullptr);
 
   // Element is empty.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "part-0,,,bluh"},
   });
   EXPECT_NE(fragment, nullptr);
@@ -159,47 +159,48 @@ TEST(HeaderValueExtractorImplTest, HeaderExtractionByKey) {
 
   TestUtility::loadFromYaml(yaml_plain, config);
   HeaderValueExtractorImpl extractor(std::move(config));
-  std::unique_ptr<ScopeKeyFragmentBase> fragment = extractor.computeFragment(TestHeaderMapImpl{
-      {"foo_header", "part-0;bar=>bluh;foo=>foo_value"},
-  });
+  std::unique_ptr<ScopeKeyFragmentBase> fragment =
+      extractor.computeFragment(TestRequestHeaderMapImpl{
+          {"foo_header", "part-0;bar=>bluh;foo=>foo_value"},
+      });
 
   EXPECT_NE(fragment, nullptr);
   EXPECT_EQ(*fragment, StringKeyFragment{"bluh"});
 
   // No such header.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"bluh", "part-0;"},
   });
   EXPECT_EQ(fragment, nullptr);
 
   // Empty header value.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", ""},
   });
   EXPECT_EQ(fragment, nullptr);
 
   // No such key.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "part-0"},
   });
   EXPECT_EQ(fragment, nullptr);
 
   // Empty value.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "bluh;;bar=>;foo=>last_value"},
   });
   EXPECT_NE(fragment, nullptr);
   EXPECT_EQ(*fragment, StringKeyFragment{""});
 
   // Duplicate values, the first value returned.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "bluh;;bar=>value1;bar=>value2;bluh;;bar=>last_value"},
   });
   EXPECT_NE(fragment, nullptr);
   EXPECT_EQ(*fragment, StringKeyFragment{"value1"});
 
   // No separator in the element, value is set to empty string.
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "bluh;;bar;bar=>value2;bluh;;bar=>last_value"},
   });
   EXPECT_NE(fragment, nullptr);
@@ -219,13 +220,14 @@ TEST(HeaderValueExtractorImplTest, ElementSeparatorEmpty) {
 
   TestUtility::loadFromYaml(yaml_plain, config);
   HeaderValueExtractorImpl extractor(std::move(config));
-  std::unique_ptr<ScopeKeyFragmentBase> fragment = extractor.computeFragment(TestHeaderMapImpl{
-      {"foo_header", "bar=b;c=d;e=f"},
-  });
+  std::unique_ptr<ScopeKeyFragmentBase> fragment =
+      extractor.computeFragment(TestRequestHeaderMapImpl{
+          {"foo_header", "bar=b;c=d;e=f"},
+      });
   EXPECT_NE(fragment, nullptr);
   EXPECT_EQ(*fragment, StringKeyFragment{"b;c=d;e=f"});
 
-  fragment = extractor.computeFragment(TestHeaderMapImpl{
+  fragment = extractor.computeFragment(TestRequestHeaderMapImpl{
       {"foo_header", "a=b;bar=d;e=f"},
   });
   EXPECT_EQ(fragment, nullptr);
@@ -297,7 +299,7 @@ TEST(ScopeKeyBuilderImplTest, Parse) {
   TestUtility::loadFromYaml(yaml_plain, config);
   ScopeKeyBuilderImpl key_builder(std::move(config));
 
-  std::unique_ptr<ScopeKey> key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  std::unique_ptr<ScopeKey> key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", "a=b,bar=bar_value,e=f"},
       {"bar_header", "a=b;bar=bar_value;index2"},
   });
@@ -305,7 +307,7 @@ TEST(ScopeKeyBuilderImplTest, Parse) {
   EXPECT_EQ(*key, makeKey({"bar_value", "index2"}));
 
   // Empty string fragment is fine.
-  key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", "a=b,bar,e=f"},
       {"bar_header", "a=b;bar=bar_value;"},
   });
@@ -313,35 +315,35 @@ TEST(ScopeKeyBuilderImplTest, Parse) {
   EXPECT_EQ(*key, makeKey({"", ""}));
 
   // Key not found.
-  key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", "a=b,meh,e=f"},
       {"bar_header", "a=b;bar=bar_value;"},
   });
   EXPECT_EQ(key, nullptr);
 
   // Index out of bound.
-  key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", "a=b,bar=bar_value,e=f"},
       {"bar_header", "a=b;bar=bar_value"},
   });
   EXPECT_EQ(key, nullptr);
 
   // Header missing.
-  key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", "a=b,bar=bar_value,e=f"},
       {"foobar_header", "a=b;bar=bar_value;index2"},
   });
   EXPECT_EQ(key, nullptr);
 
   // Header value empty.
-  key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", ""},
       {"bar_header", "a=b;bar=bar_value;index2"},
   });
   EXPECT_EQ(key, nullptr);
 
   // Case sensitive.
-  key = key_builder.computeScopeKey(TestHeaderMapImpl{
+  key = key_builder.computeScopeKey(TestRequestHeaderMapImpl{
       {"foo_header", "a=b,Bar=bar_value,e=f"},
       {"bar_header", "a=b;bar=bar_value;index2"},
   });
@@ -447,21 +449,21 @@ TEST_F(ScopedConfigImplTest, PickRoute) {
   scoped_config_impl_->addOrUpdateRoutingScope(scope_info_b_);
 
   // Key (foo, bar) maps to scope_info_a_.
-  ConfigConstSharedPtr route_config = scoped_config_impl_->getRouteConfig(TestHeaderMapImpl{
+  ConfigConstSharedPtr route_config = scoped_config_impl_->getRouteConfig(TestRequestHeaderMapImpl{
       {"foo_header", ",,key=value,bar=foo,"},
       {"bar_header", ";val1;bar;val3"},
   });
   EXPECT_EQ(route_config, scope_info_a_->routeConfig());
 
   // Key (bar, baz) maps to scope_info_b_.
-  route_config = scoped_config_impl_->getRouteConfig(TestHeaderMapImpl{
+  route_config = scoped_config_impl_->getRouteConfig(TestRequestHeaderMapImpl{
       {"foo_header", ",,key=value,bar=bar,"},
       {"bar_header", ";val1;baz;val3"},
   });
   EXPECT_EQ(route_config, scope_info_b_->routeConfig());
 
   // No such key (bar, NOT_BAZ).
-  route_config = scoped_config_impl_->getRouteConfig(TestHeaderMapImpl{
+  route_config = scoped_config_impl_->getRouteConfig(TestRequestHeaderMapImpl{
       {"foo_header", ",key=value,bar=bar,"},
       {"bar_header", ";val1;NOT_BAZ;val3"},
   });
@@ -472,7 +474,7 @@ TEST_F(ScopedConfigImplTest, PickRoute) {
 TEST_F(ScopedConfigImplTest, Update) {
   scoped_config_impl_ = std::make_unique<ScopedConfigImpl>(std::move(key_builder_config_));
 
-  TestHeaderMapImpl headers{
+  TestRequestHeaderMapImpl headers{
       {"foo_header", ",,key=value,bar=foo,"},
       {"bar_header", ";val1;bar;val3"},
   };
@@ -482,8 +484,8 @@ TEST_F(ScopedConfigImplTest, Update) {
   // Add scope_key (bar, baz).
   scoped_config_impl_->addOrUpdateRoutingScope(scope_info_b_);
   EXPECT_EQ(scoped_config_impl_->getRouteConfig(headers), nullptr);
-  EXPECT_EQ(scoped_config_impl_->getRouteConfig(
-                TestHeaderMapImpl{{"foo_header", ",,key=v,bar=bar,"}, {"bar_header", ";val1;baz"}}),
+  EXPECT_EQ(scoped_config_impl_->getRouteConfig(TestRequestHeaderMapImpl{
+                {"foo_header", ",,key=v,bar=bar,"}, {"bar_header", ";val1;baz"}}),
             scope_info_b_->routeConfig());
 
   // Add scope_key (foo, bar).
@@ -496,8 +498,8 @@ TEST_F(ScopedConfigImplTest, Update) {
   EXPECT_EQ(scoped_config_impl_->getRouteConfig(headers), nullptr);
 
   // foo_scope now is keyed by (xyz, xyz).
-  EXPECT_EQ(scoped_config_impl_->getRouteConfig(
-                TestHeaderMapImpl{{"foo_header", ",bar=xyz,foo=bar"}, {"bar_header", ";;xyz"}}),
+  EXPECT_EQ(scoped_config_impl_->getRouteConfig(TestRequestHeaderMapImpl{
+                {"foo_header", ",bar=xyz,foo=bar"}, {"bar_header", ";;xyz"}}),
             scope_info_a_v2_->routeConfig());
 
   // Remove scope "foo_scope".

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -42,7 +42,7 @@ namespace Envoy {
 namespace Router {
 namespace {
 
-using ::Envoy::Http::TestHeaderMapImpl;
+using ::Envoy::Http::TestRequestHeaderMapImpl;
 
 envoy::config::route::v3::ScopedRouteConfiguration
 parseScopedRouteConfigurationFromYaml(const std::string& yaml) {
@@ -306,24 +306,24 @@ key:
   EXPECT_NE(getScopedRdsProvider()->config<ScopedConfigImpl>(), nullptr);
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
                 ->name(),
             "");
   // RDS updates foo_routes.
   pushRdsConfig({"foo_routes"}, "111");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
                 ->name(),
             "foo_routes");
 
@@ -337,11 +337,11 @@ key:
                 .value());
   // now scope key "x-bar-key" points to nowhere.
   EXPECT_THAT(getScopedRdsProvider()->config<ScopedConfigImpl>()->getRouteConfig(
-                  TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}}),
+                  TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}}),
               IsNull());
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
 }
@@ -382,24 +382,24 @@ key:
   EXPECT_NE(getScopedRdsProvider()->config<ScopedConfigImpl>(), nullptr);
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
                 ->name(),
             "");
   // RDS updates foo_routes.
   pushRdsConfig({"foo_routes"}, "111");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
                 ->name(),
             "foo_routes");
 
@@ -415,11 +415,11 @@ key:
                 .value());
   // now scope key "x-bar-key" points to nowhere.
   EXPECT_THAT(getScopedRdsProvider()->config<ScopedConfigImpl>()->getRouteConfig(
-                  TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}}),
+                  TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}}),
               IsNull());
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
 }
@@ -458,7 +458,7 @@ key:
   EXPECT_NE(getScopedRdsProvider(), nullptr);
   EXPECT_NE(getScopedRdsProvider()->config<ScopedConfigImpl>(), nullptr);
   EXPECT_THAT(getScopedRdsProvider()->config<ScopedConfigImpl>()->getRouteConfig(
-                  TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}}),
+                  TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}}),
               IsNull());
   EXPECT_EQ(server_factory_context_.scope_.counter("foo.rds.foo_routes.config_reload").value(),
             0UL);
@@ -504,7 +504,7 @@ key:
             server_factory_context_.scope_.counter("foo.rds.foo_routes.config_reload").value());
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
 }
@@ -540,7 +540,7 @@ key:
   // No RDS "foo_routes" config push happened yet, Router::NullConfig is returned.
   EXPECT_THAT(getScopedRdsProvider()
                   ->config<ScopedConfigImpl>()
-                  ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                  ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                   ->name(),
               "");
   init_watcher_.expectReady().Times(1);
@@ -552,7 +552,7 @@ key:
             1UL);
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
 
@@ -580,7 +580,7 @@ key:
   // The same scope-key now points to the same route table.
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
 
@@ -606,7 +606,7 @@ key:
   EXPECT_EQ(getScopedRouteMap().count("foo_scope3"), 1);
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
                 ->name(),
             "bar_routes");
 
@@ -623,12 +623,12 @@ key:
   EXPECT_EQ(getScopedRouteMap().count("foo_scope4"), 1);
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}})
                 ->name(),
             "foo_routes");
   EXPECT_EQ(getScopedRdsProvider()
                 ->config<ScopedConfigImpl>()
-                ->getRouteConfig(TestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
+                ->getRouteConfig(TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}})
                 ->name(),
             "foo_routes");
 }

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -232,7 +232,7 @@ TEST_F(StreamInfoImplTest, RequestHeadersTest) {
   StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem());
   EXPECT_FALSE(stream_info.getRequestHeaders());
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   stream_info.setRequestHeaders(headers);
   EXPECT_EQ(&headers, stream_info.getRequestHeaders());
 }
@@ -243,8 +243,8 @@ TEST_F(StreamInfoImplTest, DefaultRequestIDExtensionTest) {
 
   auto rid_extension = stream_info.getRequestIDExtension();
 
-  Http::RequestHeaderMapImpl request_headers;
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
   rid_extension->set(request_headers, false);
   rid_extension->set(request_headers, true);
   rid_extension->setInResponse(response_headers, request_headers);

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -167,7 +167,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttp) {
 // Verify that check request object has only a portion of the request data.
 TEST_F(CheckRequestUtilsTest, BasicHttpWithPartialBody) {
   const uint64_t size = 4049;
-  Http::RequestHeaderMapImpl headers_;
+  Http::TestRequestHeaderMapImpl headers_;
   envoy::service::auth::v3::CheckRequest request_;
 
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
@@ -185,7 +185,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithPartialBody) {
 
 // Verify that check request object has all the request data.
 TEST_F(CheckRequestUtilsTest, BasicHttpWithFullBody) {
-  Http::RequestHeaderMapImpl headers_;
+  Http::TestRequestHeaderMapImpl headers_;
   envoy::service::auth::v3::CheckRequest request_;
 
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -84,7 +84,7 @@ TEST_P(ExtAuthzGrpcClientTest, AuthorizationOk) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   client_->onCreateInitialMetadata(headers);
 
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
@@ -108,7 +108,7 @@ TEST_P(ExtAuthzGrpcClientTest, AuthorizationOkWithAllAtributes) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   client_->onCreateInitialMetadata(headers);
 
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
@@ -131,7 +131,7 @@ TEST_P(ExtAuthzGrpcClientTest, AuthorizationDenied) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   client_->onCreateInitialMetadata(headers);
   EXPECT_EQ(nullptr, headers.RequestId());
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_unauthorized")));
@@ -155,7 +155,7 @@ TEST_P(ExtAuthzGrpcClientTest, AuthorizationDeniedGrpcUnknownStatus) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   client_->onCreateInitialMetadata(headers);
   EXPECT_EQ(nullptr, headers.RequestId());
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_unauthorized")));
@@ -182,7 +182,7 @@ TEST_P(ExtAuthzGrpcClientTest, AuthorizationDeniedWithAllAttributes) {
   expectCallSend(request);
   client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   client_->onCreateInitialMetadata(headers);
   EXPECT_EQ(nullptr, headers.RequestId());
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_unauthorized")));

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -357,7 +357,7 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOkWithAddedAuthzHeadersFromStreamInf
   const HeaderValuePair expected_header{"x-authz-header1", "123"};
   EXPECT_CALL(async_client_, send_(ContainsPairAsHeader(expected_header), _, _));
 
-  Http::RequestHeaderMapImpl request_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
   request_headers.addCopy(Http::LowerCaseString(std::string("x-request-id")),
                           expected_header.second);
 

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -64,7 +64,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
 
   {
     envoy::service::ratelimit::v3::RateLimitRequest request;
-    Http::RequestHeaderMapImpl headers;
+    Http::TestRequestHeaderMapImpl headers;
     GrpcClientImpl::createRequest(request, "foo", {{{{"foo", "bar"}}}});
     EXPECT_CALL(*async_client_, sendRaw(_, _, Grpc::ProtoBufferEq(request), Ref(client_), _, _))
         .WillOnce(
@@ -91,7 +91,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
 
   {
     envoy::service::ratelimit::v3::RateLimitRequest request;
-    Http::RequestHeaderMapImpl headers;
+    Http::TestRequestHeaderMapImpl headers;
     GrpcClientImpl::createRequest(request, "foo", {{{{"foo", "bar"}, {"bar", "baz"}}}});
     EXPECT_CALL(*async_client_, sendRaw(_, _, Grpc::ProtoBufferEq(request), _, _, _))
         .WillOnce(Return(&async_request_));

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -24,10 +24,11 @@ namespace Common {
 namespace RBAC {
 namespace {
 
-void checkEngine(const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expected,
-                 const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
-                 const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::RequestHeaderMapImpl(),
-                 const StreamInfo::StreamInfo& info = NiceMock<StreamInfo::MockStreamInfo>()) {
+void checkEngine(
+    const RBAC::RoleBasedAccessControlEngineImpl& engine, bool expected,
+    const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
+    const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl(),
+    const StreamInfo::StreamInfo& info = NiceMock<StreamInfo::MockStreamInfo>()) {
   EXPECT_EQ(expected, engine.allowed(connection, headers, info, nullptr));
 }
 
@@ -137,7 +138,7 @@ TEST(RoleBasedAccessControlEngineImpl, AllowedWhitelist) {
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
@@ -160,7 +161,7 @@ TEST(RoleBasedAccessControlEngineImpl, DeniedBlacklist) {
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
@@ -280,7 +281,7 @@ TEST(RoleBasedAccessControlEngineImpl, HeaderCondition) {
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   Envoy::Http::LowerCaseString key("foo");
   std::string value = "bar";
   headers.setReference(key, value);
@@ -321,7 +322,7 @@ TEST(RoleBasedAccessControlEngineImpl, MetadataCondition) {
   (*rbac.mutable_policies())["foo"] = policy;
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
 
   auto label = MessageUtil::keyValueStruct("label", "prod");
@@ -349,7 +350,7 @@ TEST(RoleBasedAccessControlEngineImpl, ConjunctiveCondition) {
   RBAC::RoleBasedAccessControlEngineImpl engine(rbac);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -29,7 +29,7 @@ namespace {
 void checkMatcher(
     const RBAC::Matcher& matcher, bool expected,
     const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
-    const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::RequestHeaderMapImpl(),
+    const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl(),
     const StreamInfo::StreamInfo& info = NiceMock<StreamInfo::MockStreamInfo>()) {
   EXPECT_EQ(expected, matcher.matches(connection, headers, info));
 }
@@ -47,7 +47,7 @@ TEST(AndMatcher, Permission_Set) {
   perm->set_destination_port(123);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
@@ -74,7 +74,7 @@ TEST(AndMatcher, Principal_Set) {
   cidr->mutable_prefix_len()->set_value(24);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
@@ -94,7 +94,7 @@ TEST(OrMatcher, Permission_Set) {
   perm->set_destination_port(123);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
@@ -116,7 +116,7 @@ TEST(OrMatcher, Principal_Set) {
   cidr->mutable_prefix_len()->set_value(24);
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.4.6", 456, false);
@@ -151,7 +151,7 @@ TEST(HeaderMatcher, HeaderMatcher) {
   config.set_name("foo");
   config.set_exact_match("bar");
 
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   Envoy::Http::LowerCaseString key("foo");
   std::string value = "bar";
   headers.setReference(key, value);
@@ -169,7 +169,7 @@ TEST(HeaderMatcher, HeaderMatcher) {
 
 TEST(IPMatcher, IPMatcher) {
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr connectionRemote =
       Envoy::Network::Utility::parseInternetAddress("12.13.14.15", 789, false);
@@ -232,7 +232,7 @@ TEST(IPMatcher, IPMatcher) {
 
 TEST(PortMatcher, PortMatcher) {
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
@@ -336,7 +336,7 @@ TEST(AuthenticatedMatcher, NoSSL) {
 
 TEST(MetadataMatcher, MetadataMatcher) {
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl header;
+  Envoy::Http::TestRequestHeaderMapImpl header;
   NiceMock<StreamInfo::MockStreamInfo> info;
 
   auto label = MessageUtil::keyValueStruct("label", "prod");
@@ -368,7 +368,7 @@ TEST(PolicyMatcher, PolicyMatcher) {
   RBAC::PolicyMatcher matcher(policy, builder.get());
 
   Envoy::Network::MockConnection conn;
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   NiceMock<StreamInfo::MockStreamInfo> info;
   auto ssl = std::make_shared<Ssl::MockConnectionInfo>();
   Envoy::Network::Address::InstanceConstSharedPtr addr =
@@ -431,7 +431,7 @@ TEST(RequestedServerNameMatcher, EmptyRequestedServerName) {
 }
 
 TEST(PathMatcher, NoPathInHeader) {
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   envoy::type::matcher::v3::PathMatcher matcher;
   matcher.mutable_path()->mutable_safe_regex()->mutable_google_re2();
   matcher.mutable_path()->mutable_safe_regex()->set_regex(".*");
@@ -443,7 +443,7 @@ TEST(PathMatcher, NoPathInHeader) {
 }
 
 TEST(PathMatcher, ValidPathInHeader) {
-  Envoy::Http::RequestHeaderMapImpl headers;
+  Envoy::Http::TestRequestHeaderMapImpl headers;
   envoy::type::matcher::v3::PathMatcher matcher;
   matcher.mutable_path()->set_exact("/exact");
 

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -25,8 +25,8 @@ public:
     codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   }
 
-  void doRequestAndCompression(Http::TestHeaderMapImpl&& request_headers,
-                               Http::TestHeaderMapImpl&& response_headers) {
+  void doRequestAndCompression(Http::TestRequestHeaderMapImpl&& request_headers,
+                               Http::TestResponseHeaderMapImpl&& response_headers) {
     uint64_t content_length;
     ASSERT_TRUE(absl::SimpleAtoi(response_headers.get_("content-length"), &content_length));
     const Buffer::OwnedImpl expected_response{std::string(content_length, 'a')};
@@ -48,8 +48,8 @@ public:
     EXPECT_TRUE(TestUtility::buffersEqual(expected_response, decompressed_response));
   }
 
-  void doRequestAndNoCompression(Http::TestHeaderMapImpl&& request_headers,
-                                 Http::TestHeaderMapImpl&& response_headers) {
+  void doRequestAndNoCompression(Http::TestRequestHeaderMapImpl&& request_headers,
+                                 Http::TestResponseHeaderMapImpl&& response_headers) {
     uint64_t content_length;
     ASSERT_TRUE(absl::SimpleAtoi(response_headers.get_("content-length"), &content_length));
     auto response =

--- a/test/extensions/filters/http/cors/cors_filter_integration_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_integration_test.cc
@@ -130,7 +130,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestVHostConfigSuccess
                                     "CorsPolicy.hidden_envoy_deprecated_enabled",
                                     "true");
   testPreflight(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "OPTIONS"},
           {":path", "/cors-vhost-config/test"},
           {":scheme", "http"},
@@ -138,7 +138,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestVHostConfigSuccess
           {"access-control-request-method", "GET"},
           {"origin", "test-origin"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"access-control-allow-origin", "test-origin"},
           {"access-control-allow-methods", "GET,POST"},
           {"access-control-allow-headers", "content-type,x-grpc-web"},
@@ -150,7 +150,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestVHostConfigSuccess
 
 TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestRouteConfigSuccess)) {
   testPreflight(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "OPTIONS"},
           {":path", "/cors-route-config/test"},
           {":scheme", "http"},
@@ -158,7 +158,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestRouteConfigSuccess
           {"access-control-request-method", "GET"},
           {"origin", "test-origin-1"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"access-control-allow-origin", "test-origin-1"},
           {"access-control-allow-methods", "POST"},
           {"access-control-allow-headers", "content-type"},
@@ -174,7 +174,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestRouteConfigBadOrig
                                     "CorsPolicy.hidden_envoy_deprecated_enabled",
                                     "true");
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "OPTIONS"},
           {":path", "/cors-route-config/test"},
           {":scheme", "http"},
@@ -182,7 +182,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestRouteConfigBadOrig
           {"access-control-request-method", "GET"},
           {"origin", "test-origin"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -191,7 +191,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestRouteConfigBadOrig
 
 TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestCorsDisabled)) {
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "OPTIONS"},
           {":path", "/no-cors/test"},
           {":scheme", "http"},
@@ -199,7 +199,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestCorsDisabled)) {
           {"access-control-request-method", "GET"},
           {"origin", "test-origin"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -225,7 +225,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestLegacyCorsDisabled
             ->set_value(false);
       });
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "OPTIONS"},
           {":path", "/legacy-no-cors/test"},
           {":scheme", "http"},
@@ -233,7 +233,7 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestLegacyCorsDisabled
           {"access-control-request-method", "GET"},
           {"origin", "test-origin"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -242,14 +242,14 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestLegacyCorsDisabled
 
 TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestEncodeHeaders)) {
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/cors-vhost-config/test"},
           {":scheme", "http"},
           {":authority", "test-host"},
           {"origin", "test-origin"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"access-control-allow-origin", "test-origin"},
           {"server", "envoy"},
           {"content-length", "0"},
@@ -259,14 +259,14 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestEncodeHeaders)) {
 
 TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestEncodeHeadersCredentialsAllowed)) {
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/cors-credentials-allowed/test"},
           {":scheme", "http"},
           {":authority", "test-host"},
           {"origin", "test-origin"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"access-control-allow-origin", "test-origin"},
           {"access-control-allow-credentials", "true"},
           {"server", "envoy"},
@@ -277,14 +277,14 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestEncodeHeadersCrede
 
 TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestAllowedOriginRegex)) {
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/cors-allow-origin-regex/test"},
           {":scheme", "http"},
           {":authority", "test-host"},
           {"origin", "www.envoyproxy.io"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"access-control-allow-origin", "www.envoyproxy.io"},
           {"access-control-allow-credentials", "true"},
           {"server", "envoy"},
@@ -295,14 +295,14 @@ TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestAllowedOriginRegex
 
 TEST_P(CorsFilterIntegrationTest, DEPRECATED_FEATURE_TEST(TestExposeHeaders)) {
   testNormalRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/cors-expose-headers/test"},
           {":scheme", "http"},
           {":authority", "test-host"},
           {"origin", "test-origin-1"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"access-control-allow-origin", "test-origin-1"},
           {"access-control-expose-headers", "custom-header-1,custom-header-2"},
           {"server", "envoy"},

--- a/test/extensions/filters/http/dynamo/dynamo_request_parser_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_request_parser_test.cc
@@ -20,25 +20,26 @@ namespace {
 TEST(DynamoRequestParser, parseOperation) {
   // Well formed x-amz-target header, in a format, Version.Operation
   {
-    Http::TestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X.Operation"}};
+    Http::TestRequestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X.Operation"}};
     EXPECT_EQ("Operation", RequestParser::parseOperation(headers));
   }
 
   // Not well formed x-amz-target header.
   {
-    Http::TestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X,Operation"}};
+    Http::TestRequestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "X,Operation"}};
     EXPECT_EQ("", RequestParser::parseOperation(headers));
   }
 
   // Too many entries in the Version.Operation.
   {
-    Http::TestHeaderMapImpl headers{{"X", "X"}, {"x-amz-target", "NOT_VALID.NOT_VALID.NOT_VALID"}};
+    Http::TestRequestHeaderMapImpl headers{{"X", "X"},
+                                           {"x-amz-target", "NOT_VALID.NOT_VALID.NOT_VALID"}};
     EXPECT_EQ("", RequestParser::parseOperation(headers));
   }
 
   // Required header is not present in the headers
   {
-    Http::TestHeaderMapImpl headers{{"Z", "Z"}};
+    Http::TestRequestHeaderMapImpl headers{{"Z", "Z"}};
     EXPECT_EQ("", RequestParser::parseOperation(headers));
   }
 }

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1355,7 +1355,7 @@ TEST_P(HttpFilterTestParam, DestroyResponseBeforeSendLocalReply) {
   EXPECT_CALL(filter_callbacks_, encodeData(_, true))
       .WillOnce(Invoke([&](Buffer::Instance& data, bool) {
         response_ptr.reset();
-        Http::TestHeaderMapImpl test_headers{*saved_headers};
+        Http::TestRequestHeaderMapImpl test_headers{*saved_headers};
         EXPECT_EQ(test_headers.get_("foo"), "bar");
         EXPECT_EQ(test_headers.get_("bar"), "foo");
         EXPECT_EQ(data.toString(), "foo");
@@ -1420,7 +1420,7 @@ TEST_P(HttpFilterTestParam, OverrideEncodingHeaders) {
   EXPECT_CALL(filter_callbacks_, encodeData(_, true))
       .WillOnce(Invoke([&](Buffer::Instance& data, bool) {
         response_ptr.reset();
-        Http::TestHeaderMapImpl test_headers{*saved_headers};
+        Http::TestRequestHeaderMapImpl test_headers{*saved_headers};
         EXPECT_EQ(test_headers.get_("foo"), "bar");
         EXPECT_EQ(test_headers.get_("bar"), "foo");
         EXPECT_EQ(test_headers.get_("foobar"), "DO_NOT_OVERRIDE");

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -328,7 +328,7 @@ TEST_P(FaultIntegrationTestHttp2, ResponseRateLimitTrailersBodyFlushed) {
   decoder->waitForBodyData(127);
 
   // Send trailers and wait for end stream.
-  Http::TestHeaderMapImpl trailers{{"hello", "world"}};
+  Http::TestResponseTrailerMapImpl trailers{{"hello", "world"}};
   upstream_request_->encodeTrailers(trailers);
   decoder->waitForEndStream();
   EXPECT_NE(nullptr, decoder->trailers());
@@ -348,7 +348,7 @@ TEST_P(FaultIntegrationTestHttp2, ResponseRateLimitTrailersBodyNotFlushed) {
   upstream_request_->encodeHeaders(default_response_headers_, false);
   Buffer::OwnedImpl data(std::string(128, 'a'));
   upstream_request_->encodeData(data, false);
-  Http::TestHeaderMapImpl trailers{{"hello", "world"}};
+  Http::TestResponseTrailerMapImpl trailers{{"hello", "world"}};
   upstream_request_->encodeTrailers(trailers);
 
   // Wait for a tick worth of data.

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -342,9 +342,10 @@ TEST_F(GrpcJsonTranscoderFilterTest, NoTranscoding) {
                                                  {":method", "POST"},
                                                  {":path", "/grpc.service/UnknownGrpcMethod"}};
 
-  Http::TestHeaderMapImpl expected_request_headers{{"content-type", "application/grpc"},
-                                                   {":method", "POST"},
-                                                   {":path", "/grpc.service/UnknownGrpcMethod"}};
+  Http::TestRequestHeaderMapImpl expected_request_headers{
+      {"content-type", "application/grpc"},
+      {":method", "POST"},
+      {":path", "/grpc.service/UnknownGrpcMethod"}};
 
   EXPECT_CALL(decoder_callbacks_, clearRouteCache()).Times(0);
 
@@ -363,8 +364,8 @@ TEST_F(GrpcJsonTranscoderFilterTest, NoTranscoding) {
   Http::TestResponseHeaderMapImpl response_headers{{"content-type", "application/grpc"},
                                                    {":status", "200"}};
 
-  Http::TestHeaderMapImpl expected_response_headers{{"content-type", "application/grpc"},
-                                                    {":status", "200"}};
+  Http::TestResponseHeaderMapImpl expected_response_headers{{"content-type", "application/grpc"},
+                                                            {":status", "200"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ(expected_response_headers, response_headers);
@@ -374,7 +375,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, NoTranscoding) {
   EXPECT_EQ(2, response_data.length());
 
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
-  Http::TestHeaderMapImpl expected_response_trailers{{"grpc-status", "0"}};
+  Http::TestResponseTrailerMapImpl expected_response_trailers{{"grpc-status", "0"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
   EXPECT_EQ(expected_response_trailers, response_trailers);
 }

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -25,8 +25,8 @@ public:
     codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   }
 
-  void doRequestAndCompression(Http::TestHeaderMapImpl&& request_headers,
-                               Http::TestHeaderMapImpl&& response_headers) {
+  void doRequestAndCompression(Http::TestRequestHeaderMapImpl&& request_headers,
+                               Http::TestResponseHeaderMapImpl&& response_headers) {
     uint64_t content_length;
     ASSERT_TRUE(absl::SimpleAtoi(response_headers.get_("content-length"), &content_length));
     const Buffer::OwnedImpl expected_response{std::string(content_length, 'a')};
@@ -50,8 +50,8 @@ public:
     EXPECT_TRUE(TestUtility::buffersEqual(expected_response, decompressed_response));
   }
 
-  void doRequestAndNoCompression(Http::TestHeaderMapImpl&& request_headers,
-                                 Http::TestHeaderMapImpl&& response_headers) {
+  void doRequestAndNoCompression(Http::TestRequestHeaderMapImpl&& request_headers,
+                                 Http::TestResponseHeaderMapImpl&& response_headers) {
     uint64_t content_length;
     ASSERT_TRUE(absl::SimpleAtoi(response_headers.get_("content-length"), &content_length));
     auto response =

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -181,7 +181,7 @@ response_rules:
   initializeFilter(response_config_yaml);
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-authenticated", "1"}};
   std::map<std::string, std::string> expected = {{"auth", "1"}};
-  Http::TestHeaderMapImpl empty_headers;
+  Http::TestResponseHeaderMapImpl empty_headers;
 
   EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(req_info_,
@@ -213,7 +213,7 @@ response_rules:
   initializeFilter(response_config_yaml);
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-authenticated", "1"}};
   std::map<std::string, int> expected = {{"auth", 1}};
-  Http::TestHeaderMapImpl empty_headers;
+  Http::TestResponseHeaderMapImpl empty_headers;
 
   EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(req_info_,
@@ -238,7 +238,7 @@ response_rules:
   const auto encoded = Base64::encode(data.c_str(), data.size());
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-authenticated", encoded}};
   std::map<std::string, std::string> expected = {{"auth", data}};
-  Http::TestHeaderMapImpl empty_headers;
+  Http::TestResponseHeaderMapImpl empty_headers;
 
   EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(req_info_,
@@ -416,7 +416,7 @@ response_rules:
   initializeFilter(response_config_yaml);
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-something", "thing"}};
   std::map<std::string, std::string> expected = {{"something", "else"}};
-  Http::TestHeaderMapImpl empty_headers;
+  Http::TestResponseHeaderMapImpl empty_headers;
 
   EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(req_info_,

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -3,7 +3,6 @@
 #include "envoy/extensions/filters/http/ip_tagging/v3/ip_tagging.pb.h"
 
 #include "common/buffer/buffer_impl.h"
-#include "common/http/header_map_impl.h"
 #include "common/network/address_impl.h"
 #include "common/network/utility.h"
 
@@ -81,7 +80,7 @@ TEST_F(IpTaggingFilterTest, InternalRequest) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
   // Check external requests don't get a tag.
-  request_headers = {};
+  request_headers = Http::TestRequestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_FALSE(request_headers.has(Http::Headers::get().EnvoyIpTags));
 }
@@ -147,7 +146,7 @@ ip_tags:
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ("internal_request", request_headers.get_(Http::Headers::get().EnvoyIpTags));
 
-  request_headers = {};
+  request_headers = Http::TestRequestHeaderMapImpl{};
   remote_address = Network::Utility::parseInternetAddress("1.2.3.4");
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
@@ -283,7 +282,7 @@ TEST_F(IpTaggingFilterTest, ClearRouteCache) {
 
   // no tags, no call
   EXPECT_CALL(filter_callbacks_, clearRouteCache()).Times(0);
-  request_headers = {};
+  request_headers = Http::TestRequestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_FALSE(request_headers.has(Http::Headers::get().EnvoyIpTags));
 }

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -771,12 +771,12 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"set-cookie", "flavor=chocolate; Path=/"},
-                                               {"set-cookie", "variant=chewy; Path=/"},
-                                               {"content-length", "11"}}),
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                                      {":method", "POST"},
+                                                      {":authority", "foo"},
+                                                      {"set-cookie", "flavor=chocolate; Path=/"},
+                                                      {"set-cookie", "variant=chewy; Path=/"},
+                                                      {"content-length", "11"}}),
                       message->headers());
             callbacks = &cb;
             return &request;
@@ -834,12 +834,12 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"set-cookie", "flavor=chocolate; Path=/"},
-                                               {"set-cookie", "variant=chewy; Path=/"},
-                                               {"content-length", "11"}}),
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                                      {":method", "POST"},
+                                                      {":authority", "foo"},
+                                                      {"set-cookie", "flavor=chocolate; Path=/"},
+                                                      {"set-cookie", "variant=chewy; Path=/"},
+                                                      {"content-length", "11"}}),
                       message->headers());
             callbacks = &cb;
             return &request;
@@ -893,12 +893,12 @@ TEST_F(LuaHttpFilterTest, HttpCallAsynchronous) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"set-cookie", "flavor=chocolate; Path=/"},
-                                               {"set-cookie", "variant=chewy; Path=/"},
-                                               {"content-length", "11"}}),
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                                      {":method", "POST"},
+                                                      {":authority", "foo"},
+                                                      {"set-cookie", "flavor=chocolate; Path=/"},
+                                                      {"set-cookie", "variant=chewy; Path=/"},
+                                                      {"content-length", "11"}}),
                       message->headers());
             callbacks = &cb;
             return &request;
@@ -961,10 +961,10 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
-                                               {":method", "POST"},
-                                               {":authority", "foo"},
-                                               {"content-length", "11"}}),
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/"},
+                                                      {":method", "POST"},
+                                                      {":authority", "foo"},
+                                                      {"content-length", "11"}}),
                       message->headers());
             callbacks = &cb;
             return &request;
@@ -984,7 +984,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{
                           {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
             callbacks = &cb;
@@ -1040,7 +1040,7 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
             callbacks = &cb;
@@ -1098,7 +1098,7 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
       .WillOnce(
           Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
-            EXPECT_EQ((Http::TestHeaderMapImpl{
+            EXPECT_EQ((Http::TestRequestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
                       message->headers());
             callbacks = &cb;
@@ -1110,9 +1110,9 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
 
   Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-  Http::TestHeaderMapImpl expected_headers{{":status", "403"},
-                                           {"set-cookie", "flavor=chocolate; Path=/"},
-                                           {"set-cookie", "variant=chewy; Path=/"}};
+  Http::TestResponseHeaderMapImpl expected_headers{{":status", "403"},
+                                                   {"set-cookie", "flavor=chocolate; Path=/"},
+                                                   {"set-cookie", "variant=chewy; Path=/"}};
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
   callbacks->onSuccess(request, std::move(response_message));
 }
@@ -1422,7 +1422,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
 
   for (uint64_t i = 0; i < num_loops; i++) {
     Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
-    Http::TestHeaderMapImpl expected_headers{{":status", "503"}, {"content-length", "4"}};
+    Http::TestResponseHeaderMapImpl expected_headers{{":status", "503"}, {"content-length", "4"}};
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));
     EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -50,7 +50,7 @@ TEST_F(LuaHeaderMapWrapperTest, Methods) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
   EXPECT_CALL(*this, testPrint("WORLD"));
   EXPECT_CALL(*this, testPrint("'hello' 'WORLD'"));
@@ -86,7 +86,7 @@ TEST_F(LuaHeaderMapWrapperTest, ModifiableMethods) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return false; });
   start("shouldBeOk");
 
@@ -119,13 +119,13 @@ TEST_F(LuaHeaderMapWrapperTest, Replace) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers{{":path", "/"}, {"other_header", "hello"}};
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"other_header", "hello"}};
   HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
   start("callMe");
 
-  EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/new_path"},
-                                     {"other_header", "other_header_value"},
-                                     {"new_header", "new_header_value"}}),
+  EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/new_path"},
+                                            {"other_header", "other_header_value"},
+                                            {"new_header", "new_header_value"}}),
             headers);
 }
 
@@ -142,7 +142,7 @@ TEST_F(LuaHeaderMapWrapperTest, ModifyDuringIteration) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers{{"foo", "bar"}};
+  Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}};
   HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
   EXPECT_THROW_WITH_MESSAGE(start("callMe"), Filters::Common::Lua::LuaException,
                             "[string \"...\"]:4: header map cannot be modified while iterating");
@@ -167,7 +167,7 @@ TEST_F(LuaHeaderMapWrapperTest, ModifyAfterIteration) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers{{"foo", "bar"}};
+  Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}};
   HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
   EXPECT_CALL(*this, testPrint("'foo' 'bar'"));
   EXPECT_CALL(*this, testPrint("'foo' 'bar'"));
@@ -188,7 +188,7 @@ TEST_F(LuaHeaderMapWrapperTest, DontFinishIteration) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
+  Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
   HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
   EXPECT_THROW_WITH_MESSAGE(
       start("callMe"), Filters::Common::Lua::LuaException,
@@ -208,7 +208,7 @@ TEST_F(LuaHeaderMapWrapperTest, IteratorAcrossYield) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
+  Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
   Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> wrapper(
       HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; }), true);
   yield_callback_ = [] {};

--- a/test/extensions/filters/http/on_demand/on_demand_filter_test.cc
+++ b/test/extensions/filters/http/on_demand/on_demand_filter_test.cc
@@ -31,7 +31,7 @@ public:
 
 // tests decodeHeaders() when no cached route is available and vhds is configured
 TEST_F(OnDemandFilterTest, TestDecodeHeaders) {
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   std::shared_ptr<Router::MockConfig> route_config_ptr{new NiceMock<Router::MockConfig>()};
   EXPECT_CALL(decoder_callbacks_, route()).WillOnce(Return(nullptr));
   EXPECT_CALL(decoder_callbacks_, routeConfig()).Times(2).WillRepeatedly(Return(route_config_ptr));
@@ -42,13 +42,13 @@ TEST_F(OnDemandFilterTest, TestDecodeHeaders) {
 
 // tests decodeHeaders() when no cached route is available
 TEST_F(OnDemandFilterTest, TestDecodeHeadersWhenRouteAvailable) {
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
 }
 
 // tests decodeHeaders() when no route configuration is available
 TEST_F(OnDemandFilterTest, TestDecodeHeadersWhenRouteConfigIsNotAvailable) {
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   std::shared_ptr<Router::MockConfig> route_config_ptr{new NiceMock<Router::MockConfig>()};
   EXPECT_CALL(decoder_callbacks_, route()).WillOnce(Return(nullptr));
   EXPECT_CALL(decoder_callbacks_, routeConfig()).WillOnce(Return(absl::nullopt));

--- a/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
@@ -173,7 +173,7 @@ public:
     initiateClientConnection();
     waitForRatelimitRequest();
     sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OK,
-                          Http::ResponseHeaderMapImpl{}, Http::RequestHeaderMapImpl{});
+                          Http::TestResponseHeaderMapImpl{}, Http::TestRequestHeaderMapImpl{});
     waitForSuccessfulUpstreamResponse();
     cleanup();
 
@@ -249,7 +249,7 @@ TEST_P(RatelimitIntegrationTest, OverLimit) {
   initiateClientConnection();
   waitForRatelimitRequest();
   sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT,
-                        Http::ResponseHeaderMapImpl{}, Http::RequestHeaderMapImpl{});
+                        Http::TestResponseHeaderMapImpl{}, Http::TestRequestHeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
   cleanup();
 
@@ -264,7 +264,7 @@ TEST_P(RatelimitIntegrationTest, OverLimitWithHeaders) {
   Http::TestResponseHeaderMapImpl ratelimit_response_headers{
       {"x-ratelimit-limit", "1000"}, {"x-ratelimit-remaining", "0"}, {"retry-after", "33"}};
   sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT,
-                        ratelimit_response_headers, Http::RequestHeaderMapImpl{});
+                        ratelimit_response_headers, Http::TestRequestHeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
 
   ratelimit_response_headers.iterate(

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -69,7 +69,7 @@ TEST_P(AutoSniIntegrationTest, BasicAutoSniTest) {
   setup();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   const auto response_ = sendRequestAndWaitForResponse(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "localhost"}},
       0, default_response_headers_, 0);
 
@@ -87,7 +87,7 @@ TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
   setup();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   const auto response_ = sendRequestAndWaitForResponse(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "127.0.0.1"}},
       0, default_response_headers_, 0);
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -389,7 +389,7 @@ TEST_F(ThriftRateLimitFilterTest, LimitResponseWithHeaders) {
 
   EXPECT_EQ(ThriftProxy::FilterStatus::StopIteration, filter_->messageBegin(request_metadata_));
 
-  Http::HeaderMapPtr rl_headers{new Http::TestHeaderMapImpl{
+  Http::HeaderMapPtr rl_headers{new Http::TestRequestHeaderMapImpl{
       {"x-ratelimit-limit", "1000"}, {"x-ratelimit-remaining", "0"}, {"retry-after", "33"}}};
 
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);

--- a/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/header_transport_impl_test.cc
@@ -458,7 +458,7 @@ TEST(HeaderTransportTest, InfoBlock) {
   buffer.writeByte(0); // empty value
   buffer.writeByte(0); // padding
 
-  Http::HeaderMapImpl expected_headers;
+  Http::TestRequestHeaderMapImpl expected_headers;
   expected_headers.addCopy(Http::LowerCaseString("not"), "empty");
   expected_headers.addCopy(Http::LowerCaseString("key"), "value");
   expected_headers.addCopy(Http::LowerCaseString("key2"), std::string(128, 'x'));
@@ -467,8 +467,7 @@ TEST(HeaderTransportTest, InfoBlock) {
   EXPECT_TRUE(transport.decodeFrameStart(buffer, metadata));
   EXPECT_THAT(metadata, HasFrameSize(38U));
 
-  Http::HeaderMapImpl& actual_headers = dynamic_cast<Http::HeaderMapImpl&>(metadata.headers());
-  EXPECT_EQ(expected_headers, actual_headers);
+  EXPECT_EQ(expected_headers, metadata.headers());
   EXPECT_EQ(buffer.length(), 0);
 }
 

--- a/test/extensions/filters/network/thrift_proxy/twitter_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/twitter_protocol_impl_test.cc
@@ -487,7 +487,7 @@ TEST_F(TwitterProtocolTest, ParseRequestHeader) {
   EXPECT_TRUE(metadata_->flags());
   EXPECT_EQ(5, *metadata_->flags());
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(6, test_headers.size());
 
   EXPECT_EQ("thrift-client-id", test_headers.get_(":client-id"));
@@ -523,7 +523,7 @@ TEST_F(TwitterProtocolTest, ParseEmptyRequestHeader) {
   EXPECT_FALSE(metadata_->flags());
   EXPECT_TRUE(metadata_->spans().empty());
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(0, test_headers.size());
 }
 
@@ -556,7 +556,7 @@ TEST_F(TwitterProtocolTest, WriteRequestHeader) {
   EXPECT_TRUE(*metadata_->sampled());
   EXPECT_EQ(5, *metadata_->flags());
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(4, test_headers.size());
   EXPECT_EQ("thrift-client-id", test_headers.get_(":client-id"));
   EXPECT_EQ("dest", test_headers.get_(":dest"));
@@ -581,7 +581,7 @@ TEST_F(TwitterProtocolTest, WriteMostlyEmptyRequestHeader) {
   EXPECT_FALSE(metadata_->sampled());
   EXPECT_FALSE(metadata_->flags());
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(0, test_headers.size());
 }
 
@@ -696,7 +696,7 @@ TEST_F(TwitterProtocolTest, ParseResponseHeader) {
     EXPECT_FALSE(span.debug_);
   }
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(2, test_headers.size());
   EXPECT_EQ("v1", test_headers.get_("k1"));
   EXPECT_EQ("v2", test_headers.get_("k2"));
@@ -714,7 +714,7 @@ TEST_F(TwitterProtocolTest, ParseEmptyResponseHeader) {
 
   EXPECT_TRUE(metadata_->spans().empty());
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(0, test_headers.size());
 }
 
@@ -798,7 +798,7 @@ TEST_F(TwitterProtocolTest, WriteResponseHeader) {
   EXPECT_TRUE(span2.binary_annotations_.empty());
   EXPECT_FALSE(span2.debug_);
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ("value1", test_headers.get_("key1"));
   EXPECT_EQ("value2", test_headers.get_("key2"));
 }
@@ -822,7 +822,7 @@ TEST_F(TwitterProtocolTest, WriteEmptyResponseHeader) {
 
   EXPECT_TRUE(metadata_->spans().empty());
 
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ(0, test_headers.size());
 }
 
@@ -840,7 +840,7 @@ TEST_F(TwitterProtocolTest, TestUpgradedRequestMessageBegin) {
   EXPECT_EQ(101, metadata_->sequenceId());
   EXPECT_EQ(1, *metadata_->traceId());
   EXPECT_EQ(2, *metadata_->spanId());
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ("test_client", test_headers.get_(":client-id"));
 }
 
@@ -865,7 +865,7 @@ TEST_F(TwitterProtocolTest, TestUpgradedRequestMessageContinuation) {
     EXPECT_EQ(101, metadata_->sequenceId());
     EXPECT_EQ(1, *metadata_->traceId());
     EXPECT_EQ(2, *metadata_->spanId());
-    Http::TestHeaderMapImpl test_headers(metadata_->headers());
+    Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
     EXPECT_EQ("test_client", test_headers.get_(":client-id"));
   }
 }
@@ -885,7 +885,7 @@ TEST_F(TwitterProtocolTest, TestUpgradedReplyMessageBegin) {
   EXPECT_EQ(1, metadata_->spans().size());
   EXPECT_EQ(1, metadata_->spans().front().trace_id_);
   EXPECT_EQ(2, metadata_->spans().front().span_id_);
-  Http::TestHeaderMapImpl test_headers(metadata_->headers());
+  Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
   EXPECT_EQ("test-header-value", test_headers.get_("test-header"));
 }
 
@@ -912,7 +912,7 @@ TEST_F(TwitterProtocolTest, TestUpgradedReplyMessageContinuation) {
     EXPECT_EQ(1, metadata_->spans().size());
     EXPECT_EQ(1, metadata_->spans().front().trace_id_);
     EXPECT_EQ(2, metadata_->spans().front().span_id_);
-    Http::TestHeaderMapImpl test_headers(metadata_->headers());
+    Http::TestRequestHeaderMapImpl test_headers(metadata_->headers());
     EXPECT_EQ("test-header-value", test_headers.get_("test-header"));
   }
 }

--- a/test/extensions/grpc_credentials/aws_iam/aws_iam_grpc_credentials_test.cc
+++ b/test/extensions/grpc_credentials/aws_iam/aws_iam_grpc_credentials_test.cc
@@ -36,7 +36,7 @@ public:
   void expectExtraHeaders(FakeStream& fake_stream) override {
     AssertionResult result = fake_stream.waitForHeadersComplete();
     RELEASE_ASSERT(result, result.message());
-    Http::TestHeaderMapImpl stream_headers(fake_stream.headers());
+    Http::TestRequestHeaderMapImpl stream_headers(fake_stream.headers());
     const auto auth_header = stream_headers.get_("Authorization");
     const auto auth_parts = StringUtil::splitToken(auth_header, ", ", false);
     ASSERT_EQ(4, auth_parts.size());

--- a/test/extensions/grpc_credentials/file_based_metadata/file_based_metadata_grpc_credentials_test.cc
+++ b/test/extensions/grpc_credentials/file_based_metadata/file_based_metadata_grpc_credentials_test.cc
@@ -23,7 +23,7 @@ public:
   void expectExtraHeaders(FakeStream& fake_stream) override {
     AssertionResult result = fake_stream.waitForHeadersComplete();
     RELEASE_ASSERT(result, result.message());
-    Http::TestHeaderMapImpl stream_headers(fake_stream.headers());
+    Http::TestRequestHeaderMapImpl stream_headers(fake_stream.headers());
     if (!header_value_1_.empty()) {
       EXPECT_EQ(header_prefix_1_ + header_value_1_, stream_headers.get_(header_key_1_));
     }

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -506,7 +506,7 @@ TEST_F(HystrixSinkTest, HystrixEventStreamHandler) {
   // This value doesn't matter in handlerHystrixEventStream
   absl::string_view path_and_query;
 
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
 
   NiceMock<Server::MockAdminStream> admin_stream_mock;
   NiceMock<Network::MockConnection> connection_mock;
@@ -529,11 +529,8 @@ TEST_F(HystrixSinkTest, HystrixEventStreamHandler) {
   EXPECT_EQ(response_headers.ContentType()->value(), "text/event-stream");
   EXPECT_EQ(response_headers.CacheControl()->value(), "no-cache");
   EXPECT_EQ(response_headers.Connection()->value(), "close");
-  EXPECT_EQ(response_headers.AccessControlAllowOrigin()->value(), "*");
-
-  std::string access_control_allow_headers =
-      std::string(response_headers.getAccessControlAllowHeadersValue());
-  EXPECT_THAT(access_control_allow_headers, HasSubstr("Accept"));
+  EXPECT_EQ(response_headers.get_("access-control-allow-origin"), "*");
+  EXPECT_THAT(response_headers.get_("access-control-allow-headers"), HasSubstr("Accept"));
 }
 
 } // namespace

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -150,7 +150,7 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeader) {
   Tracer tracer{span_name, std::move(broker_), server_.timeSource()};
   auto span = tracer.startSpan(operation_name, server_.timeSource().systemTime(),
                                absl::nullopt /*headers*/);
-  Http::RequestHeaderMapImpl request_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
   span->injectContext(request_headers);
   auto* header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
   ASSERT_NE(header, nullptr);
@@ -163,7 +163,7 @@ TEST_F(XRayTracerTest, SpanInjectContextHasXRayHeaderNonSampled) {
   constexpr auto span_name = "my span";
   Tracer tracer{span_name, std::move(broker_), server_.timeSource()};
   auto span = tracer.createNonSampledSpan();
-  Http::RequestHeaderMapImpl request_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
   span->injectContext(request_headers);
   auto* header = request_headers.get(Http::LowerCaseString{XRayTraceHeader});
   ASSERT_NE(header, nullptr);

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -436,7 +436,7 @@ TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
   // First request (ID will be +1 since the client will also bump).
   const uint64_t first_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
   codec_client_ = makeHttpConnection(creator());
-  Http::TestHeaderMapImpl post_request_headers{
+  Http::TestRequestHeaderMapImpl post_request_headers{
       {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
       {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
   auto response =
@@ -474,7 +474,7 @@ TEST_P(SslTapIntegrationTest, TwoRequestsWithBinaryProto) {
   // Verify a second request hits a different file.
   const uint64_t second_id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
   codec_client_ = makeHttpConnection(creator());
-  Http::TestHeaderMapImpl get_request_headers{
+  Http::TestRequestHeaderMapImpl get_request_headers{
       {":method", "GET"},     {":path", "/test/long/url"}, {":scheme", "http"},
       {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
   response =

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -97,7 +97,7 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
 
     // The AutonomousUpstream responds with 200 OK and a body of 10 bytes.
     // In the http1 codec the end stream is encoded with encodeData and 0 bytes.
-    Http::TestHeaderMapImpl expected_response_headers{{":status", "200"}};
+    Http::TestResponseHeaderMapImpl expected_response_headers{{":status", "200"}};
     EXPECT_CALL(stream_encoder_, encodeHeaders(_, false));
     EXPECT_CALL(stream_encoder_, encodeData(_, false));
     EXPECT_CALL(stream_encoder_, encodeData(BufferStringEqual(""), true)).WillOnce(Notify(&done));

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -3,7 +3,8 @@
 namespace Envoy {
 namespace {
 
-void HeaderToInt(const char header_name[], int32_t& return_int, Http::TestHeaderMapImpl& headers) {
+void HeaderToInt(const char header_name[], int32_t& return_int,
+                 Http::TestResponseHeaderMapImpl& headers) {
   const std::string header_value(headers.get_(header_name));
   if (!header_value.empty()) {
     uint64_t parsed_value;
@@ -41,7 +42,7 @@ void AutonomousStream::setEndStream(bool end_stream) {
 
 // Check all the special headers and send a customized response based on them.
 void AutonomousStream::sendResponse() {
-  Http::TestHeaderMapImpl headers(*headers_);
+  Http::TestResponseHeaderMapImpl headers(*headers_);
   upstream_.setLastRequestHeaders(*headers_);
 
   int32_t request_body_length = -1;
@@ -116,9 +117,9 @@ void AutonomousUpstream::setResponseHeaders(
   response_headers_ = std::move(response_headers);
 }
 
-Http::TestHeaderMapImpl AutonomousUpstream::responseHeaders() {
+Http::TestResponseHeaderMapImpl AutonomousUpstream::responseHeaders() {
   Thread::LockGuard lock(headers_lock_);
-  Http::TestHeaderMapImpl return_headers = *response_headers_;
+  Http::TestResponseHeaderMapImpl return_headers = *response_headers_;
   return return_headers;
 }
 

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -57,7 +57,7 @@ public:
       : FakeUpstream(address, type, time_system),
         allow_incomplete_streams_(allow_incomplete_streams),
         response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
-            Http::TestHeaderMapImpl({{":status", "200"}}))) {}
+            Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}
 
   AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory, uint32_t port,
                      FakeHttpConnection::Type type, Network::Address::IpVersion version,
@@ -65,7 +65,7 @@ public:
       : FakeUpstream(std::move(transport_socket_factory), port, type, version, time_system),
         allow_incomplete_streams_(allow_incomplete_streams),
         response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
-            Http::TestHeaderMapImpl({{":status", "200"}}))) {}
+            Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}
 
   ~AutonomousUpstream() override;
   bool
@@ -78,7 +78,7 @@ public:
   void setLastRequestHeaders(const Http::HeaderMap& headers);
   std::unique_ptr<Http::TestRequestHeaderMapImpl> lastRequestHeaders();
   void setResponseHeaders(std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers);
-  Http::TestHeaderMapImpl responseHeaders();
+  Http::TestResponseHeaderMapImpl responseHeaders();
   const bool allow_incomplete_streams_{false};
 
 private:

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -217,8 +217,8 @@ void FakeStream::startGrpcStream() {
 }
 
 void FakeStream::finishGrpcStream(Grpc::Status::GrpcStatus status) {
-  encodeTrailers(
-      Http::TestHeaderMapImpl{{"grpc-status", std::to_string(static_cast<uint32_t>(status))}});
+  encodeTrailers(Http::TestResponseTrailerMapImpl{
+      {"grpc-status", std::to_string(static_cast<uint32_t>(status))}});
 }
 
 // The TestHttp1ServerConnectionImpl outlives its underlying Network::Connection

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -419,20 +419,21 @@ public:
   }
 
 protected:
-  void performRequest(Http::TestHeaderMapImpl&& request_headers,
-                      Http::TestHeaderMapImpl&& expected_request_headers,
-                      Http::TestHeaderMapImpl&& response_headers,
-                      Http::TestHeaderMapImpl&& expected_response_headers) {
+  void performRequest(Http::TestRequestHeaderMapImpl&& request_headers,
+                      Http::TestRequestHeaderMapImpl&& expected_request_headers,
+                      Http::TestResponseHeaderMapImpl&& response_headers,
+                      Http::TestResponseHeaderMapImpl&& expected_response_headers) {
     registerTestServerPorts({"http"});
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
     auto response = sendRequestAndWaitForResponse(request_headers, 0, response_headers, 0);
 
-    compareHeaders(upstream_request_->headers(), expected_request_headers);
-    compareHeaders(response->headers(), expected_response_headers);
+    compareHeaders(Http::TestRequestHeaderMapImpl(upstream_request_->headers()),
+                   expected_request_headers);
+    compareHeaders(Http::TestResponseHeaderMapImpl(response->headers()), expected_response_headers);
   }
 
-  void compareHeaders(Http::TestHeaderMapImpl&& headers,
-                      Http::TestHeaderMapImpl& expected_headers) {
+  template <class Headers, class ExpectedHeaders>
+  void compareHeaders(Headers&& headers, ExpectedHeaders& expected_headers) {
     headers.remove(Envoy::Http::LowerCaseString{"content-length"});
     headers.remove(Envoy::Http::LowerCaseString{"date"});
     if (!routerSuppressEnvoyHeaders()) {
@@ -462,26 +463,26 @@ INSTANTIATE_TEST_SUITE_P(
 TEST_P(HeaderIntegrationTest, TestRequestAndResponseHeaderPassThrough) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
           {":authority", "no-headers.com"},
           {"x-request-foo", "downstram"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "no-headers.com"},
           {"x-request-foo", "downstram"},
           {":path", "/"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-return-foo", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-return-foo", "upstream"},
           {":status", "200"},
@@ -493,7 +494,7 @@ TEST_P(HeaderIntegrationTest, TestRequestAndResponseHeaderPassThrough) {
 TEST_P(HeaderIntegrationTest, TestVirtualHostAppendHeaderManipulation) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-only"},
           {":scheme", "http"},
@@ -501,21 +502,21 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAppendHeaderManipulation) {
           {"x-vhost-request", "downstream"},
           {"x-vhost-request-remove", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-vhost-request", "downstream"},
           {"x-vhost-request", "vhost"},
           {":path", "/vhost-only"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-vhost-response", "upstream"},
           {"x-vhost-response-remove", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-vhost-response", "upstream"},
           {"x-vhost-response", "vhost"},
@@ -527,7 +528,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAppendHeaderManipulation) {
 TEST_P(HeaderIntegrationTest, TestVirtualHostReplaceHeaderManipulation) {
   initializeFilter(HeaderMode::Replace, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-only"},
           {":scheme", "http"},
@@ -535,21 +536,21 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostReplaceHeaderManipulation) {
           {"x-vhost-request", "downstream"},
           {"x-unmodified", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-unmodified", "downstream"},
           {"x-vhost-request", "vhost"},
           {":path", "/vhost-only"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-vhost-response", "upstream"},
           {"x-unmodified", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "upstream"},
           {"x-vhost-response", "vhost"},
@@ -561,7 +562,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostReplaceHeaderManipulation) {
 TEST_P(HeaderIntegrationTest, TestRouteAppendHeaderManipulation) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/route-only"},
           {":scheme", "http"},
@@ -569,21 +570,21 @@ TEST_P(HeaderIntegrationTest, TestRouteAppendHeaderManipulation) {
           {"x-route-request", "downstream"},
           {"x-route-request-remove", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "route-headers.com"},
           {"x-route-request", "downstream"},
           {"x-route-request", "route"},
           {":path", "/route-only"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-route-response", "upstream"},
           {"x-route-response-remove", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-route-response", "upstream"},
           {"x-route-response", "route"},
@@ -595,7 +596,7 @@ TEST_P(HeaderIntegrationTest, TestRouteAppendHeaderManipulation) {
 TEST_P(HeaderIntegrationTest, TestRouteReplaceHeaderManipulation) {
   initializeFilter(HeaderMode::Replace, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/route-only"},
           {":scheme", "http"},
@@ -604,14 +605,14 @@ TEST_P(HeaderIntegrationTest, TestRouteReplaceHeaderManipulation) {
           {"x-route-request-remove", "downstream"},
           {"x-unmodified", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "route-headers.com"},
           {"x-unmodified", "downstream"},
           {"x-route-request", "route"},
           {":path", "/route-only"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -619,7 +620,7 @@ TEST_P(HeaderIntegrationTest, TestRouteReplaceHeaderManipulation) {
           {"x-route-response-remove", "upstream"},
           {"x-unmodified", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "upstream"},
           {"x-route-response", "route"},
@@ -631,7 +632,7 @@ TEST_P(HeaderIntegrationTest, TestRouteReplaceHeaderManipulation) {
 TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteAppendHeaderManipulation) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-and-route"},
           {":scheme", "http"},
@@ -641,7 +642,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteAppendHeaderManipulation) {
           {"x-route-request", "downstream"},
           {"x-route-request-remove", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-vhost-request", "downstream"},
           {"x-route-request", "downstream"},
@@ -650,7 +651,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteAppendHeaderManipulation) {
           {":path", "/vhost-and-route"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -659,7 +660,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteAppendHeaderManipulation) {
           {"x-route-response", "upstream"},
           {"x-route-response-remove", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-vhost-response", "upstream"},
           {"x-route-response", "upstream"},
@@ -673,7 +674,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteAppendHeaderManipulation) {
 TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteReplaceHeaderManipulation) {
   initializeFilter(HeaderMode::Replace, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-and-route"},
           {":scheme", "http"},
@@ -682,7 +683,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteReplaceHeaderManipulation) 
           {"x-route-request", "downstream"},
           {"x-unmodified", "request"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-unmodified", "request"},
           {"x-route-request", "route"},
@@ -690,7 +691,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteReplaceHeaderManipulation) 
           {":path", "/vhost-and-route"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -698,7 +699,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteReplaceHeaderManipulation) 
           {"x-route-response", "upstream"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {"x-route-response", "route"},
@@ -712,7 +713,7 @@ TEST_P(HeaderIntegrationTest, TestVirtualHostAndRouteReplaceHeaderManipulation) 
 TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteAppendHeaderManipulation) {
   initializeFilter(HeaderMode::Append, true);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-and-route"},
           {":scheme", "http"},
@@ -724,7 +725,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteAppendHeaderMani
           {"x-route-request", "downstream"},
           {"x-route-request-remove", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-routeconfig-request", "downstream"},
           {"x-vhost-request", "downstream"},
@@ -735,7 +736,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteAppendHeaderMani
           {":path", "/vhost-and-route"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -746,7 +747,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteAppendHeaderMani
           {"x-route-response", "upstream"},
           {"x-route-response-remove", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-routeconfig-response", "upstream"},
           {"x-vhost-response", "upstream"},
@@ -763,7 +764,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteAppendHeaderMani
 TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteReplaceHeaderManipulation) {
   initializeFilter(HeaderMode::Replace, true);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-and-route"},
           {":scheme", "http"},
@@ -773,7 +774,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteReplaceHeaderMan
           {"x-route-request", "downstream"},
           {"x-unmodified", "request"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-unmodified", "request"},
           {"x-route-request", "route"},
@@ -782,7 +783,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteReplaceHeaderMan
           {":path", "/vhost-and-route"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -791,7 +792,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteReplaceHeaderMan
           {"x-route-response", "upstream"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {"x-route-response", "route"},
@@ -806,7 +807,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostAndRouteReplaceHeaderMan
 TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterAppendHeaderManipulation) {
   initializeFilter(HeaderMode::Append, true);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-route-and-weighted-clusters"},
           {":scheme", "http"},
@@ -820,7 +821,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterAppendHea
           {"x-weighted-cluster-request", "downstream"},
           {"x-weighted-cluster-request-remove", "downstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-routeconfig-request", "downstream"},
           {"x-vhost-request", "downstream"},
@@ -833,7 +834,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterAppendHea
           {":path", "/vhost-route-and-weighted-clusters"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -846,7 +847,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterAppendHea
           {"x-weighted-cluster-response", "upstream"},
           {"x-weighted-cluster-response-remove", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-routeconfig-response", "upstream"},
           {"x-vhost-response", "upstream"},
@@ -865,7 +866,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterAppendHea
 TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterReplaceHeaderManipulation) {
   initializeFilter(HeaderMode::Replace, true);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-route-and-weighted-clusters"},
           {":scheme", "http"},
@@ -876,7 +877,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterReplaceHe
           {"x-weighted-cluster-request", "downstream"},
           {"x-unmodified", "request"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-unmodified", "request"},
           {"x-weighted-cluster-request", "weighted-cluster-1"},
@@ -886,7 +887,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterReplaceHe
           {":path", "/vhost-route-and-weighted-clusters"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -896,7 +897,7 @@ TEST_P(HeaderIntegrationTest, TestRouteConfigVirtualHostRouteAndClusterReplaceHe
           {"x-weighted-cluster-response", "upstream"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {"x-weighted-cluster-response", "weighted-cluster-1"},
@@ -912,7 +913,7 @@ TEST_P(HeaderIntegrationTest, TestDynamicHeaders) {
   prepareEDS();
   initializeFilter(HeaderMode::Replace, true);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/vhost-route-and-weighted-clusters"},
           {":scheme", "http"},
@@ -923,7 +924,7 @@ TEST_P(HeaderIntegrationTest, TestDynamicHeaders) {
           {"x-weighted-cluster-request", "downstream"},
           {"x-unmodified", "request"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "vhost-headers.com"},
           {"x-unmodified", "request"},
           {"x-weighted-cluster-request", "weighted-cluster-1"},
@@ -933,7 +934,7 @@ TEST_P(HeaderIntegrationTest, TestDynamicHeaders) {
           {":path", "/vhost-route-and-weighted-clusters"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
@@ -943,7 +944,7 @@ TEST_P(HeaderIntegrationTest, TestDynamicHeaders) {
           {"x-weighted-cluster-response", "upstream"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {"x-weighted-cluster-response", "weighted-cluster-1"},
@@ -962,27 +963,27 @@ TEST_P(HeaderIntegrationTest, TestDynamicHeaders) {
 TEST_P(HeaderIntegrationTest, TestXFFParsing) {
   initializeFilter(HeaderMode::Replace, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/test"},
           {":scheme", "http"},
           {":authority", "xff-headers.com"},
           {"x-forwarded-for", "1.2.3.4, 5.6.7.8 ,9.10.11.12"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "xff-headers.com"},
           {"x-forwarded-for", "1.2.3.4, 5.6.7.8 ,9.10.11.12"},
           {"x-real-ip", "5.6.7.8"},
           {":path", "/test"},
           {":method", "GET"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {":status", "200"},
@@ -994,7 +995,7 @@ TEST_P(HeaderIntegrationTest, TestXFFParsing) {
 TEST_P(HeaderIntegrationTest, TestAppendSameHeaders) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/test"},
           {":scheme", "http"},
@@ -1002,7 +1003,7 @@ TEST_P(HeaderIntegrationTest, TestAppendSameHeaders) {
           {"authorization", "token3"},
           {"x-foo", "value3"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "append-same-headers.com"},
           {":path", "/test"},
           {":method", "GET"},
@@ -1011,13 +1012,13 @@ TEST_P(HeaderIntegrationTest, TestAppendSameHeaders) {
           {"x-foo", "value2"},
           {"x-foo", "value1"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {":status", "200"},
@@ -1031,23 +1032,23 @@ TEST_P(HeaderIntegrationTest, TestPathAndRouteWhenNormalizePathOff) {
   normalize_path_ = false;
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/private/../public"},
           {":scheme", "http"},
           {":authority", "path-sanitization.com"},
       },
-      Http::TestHeaderMapImpl{{":authority", "path-sanitization.com"},
-                              {":path", "/private/../public"},
-                              {":method", "GET"},
-                              {"x-site", "private"}},
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{{":authority", "path-sanitization.com"},
+                                     {":path", "/private/../public"},
+                                     {":method", "GET"},
+                                     {"x-site", "private"}},
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {":status", "200"},
@@ -1061,23 +1062,23 @@ TEST_P(HeaderIntegrationTest, TestPathAndRouteOnNormalizedPath) {
   normalize_path_ = true;
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/private/../public"},
           {":scheme", "http"},
           {":authority", "path-sanitization.com"},
       },
-      Http::TestHeaderMapImpl{{":authority", "path-sanitization.com"},
-                              {":path", "/public"},
-                              {":method", "GET"},
-                              {"x-site", "public"}},
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{{":authority", "path-sanitization.com"},
+                                     {":path", "/public"},
+                                     {":method", "GET"},
+                                     {"x-site", "public"}},
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-unmodified", "response"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-unmodified", "response"},
           {":status", "200"},
@@ -1088,7 +1089,7 @@ TEST_P(HeaderIntegrationTest, TestPathAndRouteOnNormalizedPath) {
 TEST_P(HeaderIntegrationTest, TestTeHeaderPassthrough) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
@@ -1097,20 +1098,20 @@ TEST_P(HeaderIntegrationTest, TestTeHeaderPassthrough) {
           {"connection", "te, close"},
           {"te", "trailers"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "no-headers.com"},
           {":path", "/"},
           {":method", "GET"},
           {"x-request-foo", "downstram"},
           {"te", "trailers"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-return-foo", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-return-foo", "upstream"},
           {":status", "200"},
@@ -1122,7 +1123,7 @@ TEST_P(HeaderIntegrationTest, TestTeHeaderPassthrough) {
 TEST_P(HeaderIntegrationTest, TestTeHeaderSanitized) {
   initializeFilter(HeaderMode::Append, false);
   performRequest(
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":method", "GET"},
           {":path", "/"},
           {":scheme", "http"},
@@ -1134,19 +1135,19 @@ TEST_P(HeaderIntegrationTest, TestTeHeaderSanitized) {
           {"sam", "bar"},
           {"will", "baz"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestRequestHeaderMapImpl{
           {":authority", "no-headers.com"},
           {":path", "/"},
           {":method", "GET"},
           {"x-request-foo", "downstram"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"content-length", "0"},
           {":status", "200"},
           {"x-return-foo", "upstream"},
       },
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {"server", "envoy"},
           {"x-return-foo", "upstream"},
           {":status", "200"},

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -88,7 +88,7 @@ void Http2UpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   // Finish the response.
-  upstream_request_->encodeTrailers(Http::TestHeaderMapImpl{{"trailer", "bar"}});
+  upstream_request_->encodeTrailers(Http::TestResponseTrailerMapImpl{{"trailer", "bar"}});
   response->waitForEndStream();
   EXPECT_TRUE(response->complete());
 }
@@ -386,7 +386,7 @@ TEST_P(Http2UpstreamIntegrationTest, TestManyResponseHeadersRejected) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl many_headers(default_response_headers_);
+  Http::TestResponseHeaderMapImpl many_headers(default_response_headers_);
   for (int i = 0; i < 100; i++) {
     many_headers.addCopy("many", std::string(1, 'a'));
   }
@@ -431,7 +431,7 @@ TEST_P(Http2UpstreamIntegrationTest, LargeResponseHeadersRejected) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl large_headers(default_response_headers_);
+  Http::TestResponseHeaderMapImpl large_headers(default_response_headers_);
   large_headers.addCopy("large", std::string(60 * 1024, 'a'));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1292,7 +1292,7 @@ void HttpIntegrationTest::testMaxStreamDurationWithRetry(bool invoke_retry_upstr
 
     EXPECT_EQ("408", response->headers().getStatusValue());
   } else {
-    Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
     upstream_request_->encodeHeaders(response_headers, true);
 
     response->waitForHeaders();

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -299,7 +299,7 @@ TEST_P(HttpTimeoutIntegrationTest, PerTryTimeoutWithoutGlobalTimeout) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   // Encode 200 response headers for the first (timed out) request.
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   upstream_request_->encodeHeaders(response_headers, true);
 
   response->waitForHeaders();

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -500,7 +500,7 @@ TEST_P(IntegrationTest, Http09WithKeepalive) {
   initialize();
   reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
       ->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(
-          Http::TestHeaderMapImpl({{":status", "200"}, {"content-length", "0"}})));
+          Http::TestResponseHeaderMapImpl({{":status", "200"}, {"content-length", "0"}})));
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET /\r\nConnection: keep-alive\r\n\r\n",
                                 &response, true);
@@ -588,7 +588,7 @@ TEST_P(IntegrationTest, Http10WithHostandKeepAliveAndContentLengthAndLws) {
   initialize();
   reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
       ->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(
-          Http::TestHeaderMapImpl({{":status", "200"}, {"content-length", "10"}})));
+          Http::TestResponseHeaderMapImpl({{":status", "200"}, {"content-length", "10"}})));
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
                                 "GET / HTTP/1.0\r\nHost: foo.com \r\nConnection:Keep-alive\r\n\r\n",
@@ -820,10 +820,10 @@ TEST_P(IntegrationTest, TestHead) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl head_request{{":method", "HEAD"},
-                                       {":path", "/test/long/url"},
-                                       {":scheme", "http"},
-                                       {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl head_request{{":method", "HEAD"},
+                                              {":path", "/test/long/url"},
+                                              {":scheme", "http"},
+                                              {":authority", "host"}};
 
   // Without an explicit content length, assume we chunk for HTTP/1.1
   auto response = sendRequestAndWaitForResponse(head_request, 0, default_response_headers_, 0);
@@ -836,7 +836,8 @@ TEST_P(IntegrationTest, TestHead) {
   EXPECT_EQ(0, response->body().size());
 
   // Preserve explicit content length.
-  Http::TestHeaderMapImpl content_length_response{{":status", "200"}, {"content-length", "12"}};
+  Http::TestResponseHeaderMapImpl content_length_response{{":status", "200"},
+                                                          {"content-length", "12"}};
   response = sendRequestAndWaitForResponse(head_request, 0, content_length_response, 0);
   ASSERT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), HttpStatusIs("200"));
@@ -1224,7 +1225,7 @@ TEST_P(IntegrationTest, TestFloodUpstreamErrors) {
 
   // Set an Upstream reply with an invalid content-length, which will be rejected by the Envoy.
   auto response_headers = std::make_unique<Http::TestResponseHeaderMapImpl>(
-      Http::TestHeaderMapImpl({{":status", "200"}, {"content-length", "invalid"}}));
+      Http::TestResponseHeaderMapImpl({{":status", "200"}, {"content-length", "invalid"}}));
   reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
       ->setResponseHeaders(std::move(response_headers));
 

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -249,10 +249,10 @@ TEST_P(ListenerIntegrationTest, BasicSuccess) {
   codec_client_ = makeHttpConnection(lookupPort(listener_name_));
   int response_size = 800;
   int request_size = 10;
-  Http::TestHeaderMapImpl response_headers{{":status", "200"},
-                                           {"server_id", "cluster_0, backend_0"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"server_id", "cluster_0, backend_0"}};
   auto response = sendRequestAndWaitForResponse(
-      Http::TestHeaderMapImpl{
+      Http::TestResponseHeaderMapImpl{
           {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {":scheme", "http"}},
       request_size, response_headers, response_size, /*cluster_0*/ 0);
   verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -214,7 +214,7 @@ TEST_P(RedirectIntegrationTest, InternalRedirectToDestinationWithBody) {
   EXPECT_EQ("authority2", upstream_request_->headers().getHostValue());
   EXPECT_EQ("via_value", upstream_request_->headers().getViaValue());
 
-  Http::TestHeaderMapImpl response_with_big_body(
+  Http::TestResponseHeaderMapImpl response_with_big_body(
       {{":status", "200"}, {"content-length", "2000000"}});
   upstream_request_->encodeHeaders(response_with_big_body, false);
   upstream_request_->encodeData(2000000, true);

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -278,7 +278,7 @@ key:
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=xyz-route"}});
   response->waitForEndStream();
-  verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
+  verifyResponse(std::move(response), "404", Http::TestResponseHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
 
   // Test "foo-route" and 'bar-route' both gets routed to cluster_0.
@@ -349,7 +349,7 @@ key:
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=foo-route"}});
   response->waitForEndStream();
-  verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
+  verifyResponse(std::move(response), "404", Http::TestResponseHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
   // Add a new scope foo_scope4.
   const std::string& scope_route4 =
@@ -366,7 +366,7 @@ key:
   response->waitForEndStream();
   // Get 404 because RDS hasn't pushed route configuration "foo_route4" yet.
   // But scope is found and the Router::NullConfigImpl is returned.
-  verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
+  verifyResponse(std::move(response), "404", Http::TestResponseHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
 
   // RDS updated foo_route4, requests with scope key "xyz-route" now hit cluster_1.
@@ -410,7 +410,7 @@ key:
                                      {":scheme", "http"},
                                      {"Addr", "x-foo-key=foo"}});
   response->waitForEndStream();
-  verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
+  verifyResponse(std::move(response), "404", Http::TestResponseHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
 
   // SRDS update fixed the problem.

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -84,7 +84,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
   Http::RequestEncoder& encoder = client.newStream(*response);
   encoder.getStream().addCallbacks(*response);
 
-  Http::RequestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   headers.setMethod(method);
   headers.setPath(url);
   headers.setHost(host);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -530,7 +530,7 @@ public:
     *os << "is a subset of headers:\n" << expected_headers_;
   }
 
-  const TestHeaderMapImpl expected_headers_;
+  const TestRequestHeaderMapImpl expected_headers_;
 };
 
 class IsSubsetOfHeadersMatcher {
@@ -549,7 +549,7 @@ public:
   }
 
 private:
-  TestHeaderMapImpl expected_headers_;
+  TestRequestHeaderMapImpl expected_headers_;
 };
 
 IsSubsetOfHeadersMatcher IsSubsetOfHeaders(const HeaderMap& expected_headers);
@@ -586,7 +586,7 @@ public:
     *os << "is a superset of headers:\n" << expected_headers_;
   }
 
-  const TestHeaderMapImpl expected_headers_;
+  const TestRequestHeaderMapImpl expected_headers_;
 };
 
 class IsSupersetOfHeadersMatcher {
@@ -605,7 +605,7 @@ public:
   }
 
 private:
-  TestHeaderMapImpl expected_headers_;
+  TestRequestHeaderMapImpl expected_headers_;
 };
 
 IsSupersetOfHeadersMatcher IsSupersetOfHeaders(const HeaderMap& expected_headers);

--- a/test/mocks/http/mocks_test.cc
+++ b/test/mocks/http/mocks_test.cc
@@ -9,7 +9,7 @@ using ::testing::Not;
 
 namespace Http {
 TEST(HeaderValueOfTest, ConstHeaderMap) {
-  const TestHeaderMapImpl header_map{{"key", "expected value"}};
+  const TestRequestHeaderMapImpl header_map{{"key", "expected value"}};
 
   // Positive checks.
   EXPECT_THAT(header_map, HeaderValueOf("key", "expected value"));
@@ -21,7 +21,7 @@ TEST(HeaderValueOfTest, ConstHeaderMap) {
 }
 
 TEST(HeaderValueOfTest, MutableHeaderMap) {
-  TestHeaderMapImpl header_map;
+  TestRequestHeaderMapImpl header_map;
 
   // Negative checks.
   EXPECT_THAT(header_map, Not(HeaderValueOf("key", "other value")));
@@ -35,7 +35,7 @@ TEST(HeaderValueOfTest, MutableHeaderMap) {
 }
 
 TEST(HeaderValueOfTest, LowerCaseString) {
-  TestHeaderMapImpl header_map;
+  TestRequestHeaderMapImpl header_map;
   LowerCaseString key("key");
   LowerCaseString other_key("other_key");
 
@@ -63,51 +63,51 @@ TEST(HttpStatusIsTest, CheckStatus) {
 }
 
 TEST(IsSubsetOfHeadersTest, ConstHeaderMap) {
-  const TestHeaderMapImpl header_map{{"first key", "1"}};
+  const TestRequestHeaderMapImpl header_map{{"first key", "1"}};
 
-  EXPECT_THAT(header_map, IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+  EXPECT_THAT(header_map, IsSubsetOfHeaders(TestRequestHeaderMapImpl{{"first key", "1"}}));
   EXPECT_THAT(header_map,
-              IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+              IsSubsetOfHeaders(TestRequestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
 
-  EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+  EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestRequestHeaderMapImpl{{"third key", "1"}})));
 }
 
 TEST(IsSubsetOfHeadersTest, MutableHeaderMap) {
-  TestHeaderMapImpl header_map;
+  TestRequestHeaderMapImpl header_map;
   header_map.addCopy("first key", "1");
 
-  EXPECT_THAT(header_map, IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+  EXPECT_THAT(header_map, IsSubsetOfHeaders(TestRequestHeaderMapImpl{{"first key", "1"}}));
   EXPECT_THAT(header_map,
-              IsSubsetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+              IsSubsetOfHeaders(TestRequestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
 
-  EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+  EXPECT_THAT(header_map, Not(IsSubsetOfHeaders(TestRequestHeaderMapImpl{{"third key", "1"}})));
 }
 
 TEST(IsSupersetOfHeadersTest, ConstHeaderMap) {
-  const TestHeaderMapImpl header_map{{"first key", "1"}, {"second key", "2"}};
+  const TestRequestHeaderMapImpl header_map{{"first key", "1"}, {"second key", "2"}};
 
-  EXPECT_THAT(header_map,
-              IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
-  EXPECT_THAT(header_map, IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+  EXPECT_THAT(header_map, IsSupersetOfHeaders(
+                              TestRequestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+  EXPECT_THAT(header_map, IsSupersetOfHeaders(TestRequestHeaderMapImpl{{"first key", "1"}}));
 
-  EXPECT_THAT(header_map, Not(IsSupersetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+  EXPECT_THAT(header_map, Not(IsSupersetOfHeaders(TestRequestHeaderMapImpl{{"third key", "1"}})));
 }
 
 TEST(IsSupersetOfHeadersTest, MutableHeaderMap) {
-  TestHeaderMapImpl header_map;
+  TestRequestHeaderMapImpl header_map;
   header_map.addCopy("first key", "1");
   header_map.addCopy("second key", "2");
 
-  EXPECT_THAT(header_map,
-              IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
-  EXPECT_THAT(header_map, IsSupersetOfHeaders(TestHeaderMapImpl{{"first key", "1"}}));
+  EXPECT_THAT(header_map, IsSupersetOfHeaders(
+                              TestRequestHeaderMapImpl{{"first key", "1"}, {"second key", "2"}}));
+  EXPECT_THAT(header_map, IsSupersetOfHeaders(TestRequestHeaderMapImpl{{"first key", "1"}}));
 
-  EXPECT_THAT(header_map, Not(IsSupersetOfHeaders(TestHeaderMapImpl{{"third key", "1"}})));
+  EXPECT_THAT(header_map, Not(IsSupersetOfHeaders(TestRequestHeaderMapImpl{{"third key", "1"}})));
 }
 } // namespace Http
 
 TEST(HeaderHasValueRefTest, MutableValueRef) {
-  Http::TestHeaderMapImpl header_map;
+  Http::TestRequestHeaderMapImpl header_map;
 
   EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "value")));
   EXPECT_THAT(header_map, Not(HeaderHasValueRef("other key", "value")));
@@ -119,7 +119,7 @@ TEST(HeaderHasValueRefTest, MutableValueRef) {
 }
 
 TEST(HeaderHasValueRefTest, ConstValueRef) {
-  const Http::TestHeaderMapImpl header_map{{"key", "expected value"}};
+  const Http::TestRequestHeaderMapImpl header_map{{"key", "expected value"}};
 
   EXPECT_THAT(header_map, Not(HeaderHasValueRef("key", "other value")));
   EXPECT_THAT(header_map, HeaderHasValueRef("key", "expected value"));
@@ -127,7 +127,7 @@ TEST(HeaderHasValueRefTest, ConstValueRef) {
 
 TEST(HeaderHasValueRefTest, LowerCaseStringArguments) {
   Http::LowerCaseString key("key"), other_key("other key");
-  Http::TestHeaderMapImpl header_map;
+  Http::TestRequestHeaderMapImpl header_map;
 
   EXPECT_THAT(header_map, Not(HeaderHasValueRef(key, "value")));
   EXPECT_THAT(header_map, Not(HeaderHasValueRef(other_key, "value")));

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -41,7 +41,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
 
 TEST_P(AdminInstanceTest, MutatesErrorWithGet) {
   Buffer::OwnedImpl data;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   const std::string path("/healthcheck/fail");
   // TODO(jmarantz): the call to getCallback should be made to fail, but as an interim we will
   // just issue a warning, so that scripts using curl GET commands to mutate state can be fixed.
@@ -74,7 +74,7 @@ TEST_P(AdminInstanceTest, CustomHandler) {
 
   // Test removable handler.
   EXPECT_NO_LOGS(EXPECT_TRUE(admin_.addHandler("/foo/bar", "hello", callback, true, false)));
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::Accepted, getCallback("/foo/bar", header_map, response));
 
@@ -122,7 +122,7 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
   const std::string planets = "jupiter>saturn>mars";
   EXPECT_TRUE(admin_.addHandler("/planets", planets, callback, true, false));
 
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, getCallback("/", header_map, response));
   const Http::HeaderString& content_type = header_map.ContentType()->value();
@@ -133,7 +133,7 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
 }
 
 TEST_P(AdminInstanceTest, HelpUsesFormForMutations) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, getCallback("/", header_map, response));
   const std::string logging_action = "<form action='logging' method='post'";
@@ -144,7 +144,7 @@ TEST_P(AdminInstanceTest, HelpUsesFormForMutations) {
 
 TEST_P(AdminInstanceTest, ConfigDump) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto entry = admin_.getConfigTracker().add("foo", [] {
     auto msg = std::make_unique<ProtobufWkt::StringValue>();
     msg->set_value("bar");
@@ -210,7 +210,7 @@ TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
   // Run it multiple times and validate that order is preserved.
   for (size_t i = 0; i < 5; i++) {
     Buffer::OwnedImpl response;
-    Http::ResponseHeaderMapImpl header_map;
+    Http::TestResponseHeaderMapImpl header_map;
     EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
     const std::string output = response.toString();
     EXPECT_EQ(expected_json, output);
@@ -222,7 +222,7 @@ TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
 // dynamic in the JSON with ?resource=dynamic_listeners.
 TEST_P(AdminInstanceTest, ConfigDumpFiltersByResource) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto listeners = admin_.getConfigTracker().add("listeners", [] {
     auto msg = std::make_unique<envoy::admin::v3::ListenersConfigDump>();
     auto dyn_listener = msg->add_dynamic_listeners();
@@ -253,7 +253,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByResource) {
 // dynamic in the JSON with ?mask=dynamic_listeners.
 TEST_P(AdminInstanceTest, ConfigDumpFiltersByMask) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto listeners = admin_.getConfigTracker().add("listeners", [] {
     auto msg = std::make_unique<envoy::admin::v3::ListenersConfigDump>();
     auto dyn_listener = msg->add_dynamic_listeners();
@@ -306,7 +306,7 @@ ProtobufTypes::MessagePtr testDumpClustersConfig() {
 // only the desired resource and the fields specified in the mask.
 TEST_P(AdminInstanceTest, ConfigDumpFiltersByResourceAndMask) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto clusters = admin_.getConfigTracker().add("clusters", testDumpClustersConfig);
   const std::string expected_json = R"EOF({
  "configs": [
@@ -335,7 +335,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByResourceAndMask) {
 // of the config dump and the fields present in the mask query parameter.
 TEST_P(AdminInstanceTest, ConfigDumpNonExistentMask) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto clusters = admin_.getConfigTracker().add("clusters", testDumpClustersConfig);
   const std::string expected_json = R"EOF({
  "configs": [
@@ -355,7 +355,7 @@ TEST_P(AdminInstanceTest, ConfigDumpNonExistentMask) {
 // resource query parameter.
 TEST_P(AdminInstanceTest, ConfigDumpNonExistentResource) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto listeners = admin_.getConfigTracker().add("listeners", [] {
     auto msg = std::make_unique<ProtobufWkt::StringValue>();
     msg->set_value("listeners_config");
@@ -368,7 +368,7 @@ TEST_P(AdminInstanceTest, ConfigDumpNonExistentResource) {
 // repeated field.
 TEST_P(AdminInstanceTest, ConfigDumpResourceNotRepeated) {
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto clusters = admin_.getConfigTracker().add("clusters", [] {
     auto msg = std::make_unique<envoy::admin::v3::ClustersConfigDump>();
     msg->set_version_info("foo");
@@ -461,7 +461,7 @@ TEST_P(AdminInstanceTest, ClustersJson) {
   ON_CALL(*host, priority()).WillByDefault(Return(6));
 
   Buffer::OwnedImpl response;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   EXPECT_EQ(Http::Code::OK, getCallback("/clusters?format=json", header_map, response));
   std::string output_json = response.toString();
   envoy::admin::v3::Clusters output_proto;

--- a/test/server/admin/logs_handler_test.cc
+++ b/test/server/admin/logs_handler_test.cc
@@ -8,7 +8,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(AdminInstanceTest, ReopenLogs) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
 

--- a/test/server/admin/profiling_handler_test.cc
+++ b/test/server/admin/profiling_handler_test.cc
@@ -12,7 +12,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
 
 TEST_P(AdminInstanceTest, AdminCpuProfiler) {
   Buffer::OwnedImpl data;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
 
   // Can only get code coverage of AdminImpl::handlerCpuProfiler stopProfiler with
   // a real profiler linked in (successful call to startProfiler).
@@ -31,7 +31,7 @@ TEST_P(AdminInstanceTest, AdminCpuProfiler) {
 
 TEST_P(AdminInstanceTest, AdminHeapProfilerOnRepeatedRequest) {
   Buffer::OwnedImpl data;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   auto repeatResultCode = Http::Code::BadRequest;
 #ifndef PROFILER_AVAILABLE
   repeatResultCode = Http::Code::NotImplemented;
@@ -46,7 +46,7 @@ TEST_P(AdminInstanceTest, AdminHeapProfilerOnRepeatedRequest) {
 
 TEST_P(AdminInstanceTest, AdminHeapProfiler) {
   Buffer::OwnedImpl data;
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
 
   // The below flow need to begin with the profiler not running
   Profiler::Heap::stopProfiler();
@@ -68,7 +68,7 @@ TEST_P(AdminInstanceTest, AdminBadProfiler) {
   Buffer::OwnedImpl data;
   AdminImpl admin_bad_profile_path(TestEnvironment::temporaryPath("some/unlikely/bad/path.prof"),
                                    server_);
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   const absl::string_view post = Http::Headers::get().MethodValues.Post;
   request_headers_.setMethod(post);
   admin_filter_.decodeHeaders(request_headers_, false);

--- a/test/server/admin/runtime_handler_test.cc
+++ b/test/server/admin/runtime_handler_test.cc
@@ -8,7 +8,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(AdminInstanceTest, Runtime) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
 
   Runtime::MockSnapshot snapshot;
@@ -75,7 +75,7 @@ TEST_P(AdminInstanceTest, Runtime) {
 }
 
 TEST_P(AdminInstanceTest, RuntimeModify) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
 
   Runtime::MockLoader loader;
@@ -101,14 +101,14 @@ TEST_P(AdminInstanceTest, RuntimeModifyParamsInBody) {
   EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
 
   const std::string body = fmt::format("{}={}", key, value);
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, runCallback("/runtime_modify", header_map, response, "POST", body));
   EXPECT_EQ("OK\n", response.toString());
 }
 
 TEST_P(AdminInstanceTest, RuntimeModifyNoArguments) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
 
   EXPECT_EQ(Http::Code::BadRequest, postCallback("/runtime_modify", header_map, response));

--- a/test/server/admin/server_info_handler_test.cc
+++ b/test/server/admin/server_info_handler_test.cc
@@ -18,7 +18,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
 
   // Setup a context that returns null cert details.
@@ -47,7 +47,7 @@ TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
 }
 
 TEST_P(AdminInstanceTest, Memory) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl response;
   EXPECT_EQ(Http::Code::OK, getCallback("/memory", header_map, response));
   const std::string output_json = response.toString();
@@ -65,7 +65,7 @@ TEST_P(AdminInstanceTest, GetReadyRequest) {
   ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
 
   {
-    Http::ResponseHeaderMapImpl response_headers;
+    Http::TestResponseHeaderMapImpl response_headers;
     std::string body;
 
     ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
@@ -75,7 +75,7 @@ TEST_P(AdminInstanceTest, GetReadyRequest) {
   }
 
   {
-    Http::ResponseHeaderMapImpl response_headers;
+    Http::TestResponseHeaderMapImpl response_headers;
     std::string body;
 
     ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Uninitialized));
@@ -85,7 +85,7 @@ TEST_P(AdminInstanceTest, GetReadyRequest) {
     EXPECT_THAT(std::string(response_headers.getContentTypeValue()), HasSubstr("text/plain"));
   }
 
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
   std::string body;
 
   ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
@@ -108,7 +108,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
   ON_CALL(server_.hot_restart_, version()).WillByDefault(Return("foo_version"));
 
   {
-    Http::ResponseHeaderMapImpl response_headers;
+    Http::TestResponseHeaderMapImpl response_headers;
     std::string body;
 
     ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
@@ -126,7 +126,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
   }
 
   {
-    Http::ResponseHeaderMapImpl response_headers;
+    Http::TestResponseHeaderMapImpl response_headers;
     std::string body;
 
     ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Uninitialized));
@@ -142,7 +142,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
     EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
   }
 
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
   std::string body;
 
   ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
@@ -159,7 +159,7 @@ TEST_P(AdminInstanceTest, GetRequest) {
 }
 
 TEST_P(AdminInstanceTest, PostRequest) {
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
   std::string body;
   EXPECT_NO_LOGS(EXPECT_EQ(Http::Code::OK,
                            admin_.request("/healthcheck/fail", "POST", response_headers, body)));

--- a/test/server/admin/stats_handler_test.cc
+++ b/test/server/admin/stats_handler_test.cc
@@ -511,7 +511,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(AdminInstanceTest, StatsInvalidRegex) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl data;
   EXPECT_LOG_CONTAINS(
       "error", "Invalid regex: ",
@@ -526,7 +526,7 @@ TEST_P(AdminInstanceTest, StatsInvalidRegex) {
 }
 
 TEST_P(AdminInstanceTest, PrometheusStatsInvalidRegex) {
-  Http::ResponseHeaderMapImpl header_map;
+  Http::TestResponseHeaderMapImpl header_map;
   Buffer::OwnedImpl data;
   EXPECT_LOG_CONTAINS(
       "error", ": *.ptest",
@@ -549,7 +549,7 @@ TEST_P(AdminInstanceTest, TracingStatsDisabled) {
 }
 
 TEST_P(AdminInstanceTest, GetRequestJson) {
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
   std::string body;
   EXPECT_EQ(Http::Code::OK, admin_.request("/stats?format=json", "GET", response_headers, body));
   EXPECT_THAT(body, HasSubstr("{\"stats\":["));
@@ -557,7 +557,7 @@ TEST_P(AdminInstanceTest, GetRequestJson) {
 }
 
 TEST_P(AdminInstanceTest, RecentLookups) {
-  Http::ResponseHeaderMapImpl response_headers;
+  Http::TestResponseHeaderMapImpl response_headers;
   std::string body;
 
   // Recent lookup tracking is disabled by default.

--- a/test/test_common/utility_test.cc
+++ b/test/test_common/utility_test.cc
@@ -7,23 +7,24 @@
 namespace Envoy {
 
 TEST(HeaderMapEqualIgnoreOrder, ActuallyEqual) {
-  Http::TestHeaderMapImpl lhs{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
-  Http::TestHeaderMapImpl rhs{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl lhs{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl rhs{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
   EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
   EXPECT_EQ(lhs, rhs);
 }
 
 TEST(HeaderMapEqualIgnoreOrder, IgnoreOrder) {
-  Http::TestHeaderMapImpl lhs{{":method", "GET"}, {":authority", "host"}, {":path", "/"}};
-  Http::TestHeaderMapImpl rhs{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl lhs{{":method", "GET"}, {":authority", "host"}, {":path", "/"}};
+  Http::TestRequestHeaderMapImpl rhs{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
   EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
   EXPECT_THAT(&lhs, HeaderMapEqualIgnoreOrder(&rhs));
   EXPECT_FALSE(lhs == rhs);
 }
 
 TEST(HeaderMapEqualIgnoreOrder, NotEqual) {
-  Http::TestHeaderMapImpl lhs{{":method", "GET"}, {":authority", "host"}, {":authority", "host"}};
-  Http::TestHeaderMapImpl rhs{{":method", "GET"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl lhs{
+      {":method", "GET"}, {":authority", "host"}, {":authority", "host"}};
+  Http::TestRequestHeaderMapImpl rhs{{":method", "GET"}, {":authority", "host"}};
   EXPECT_FALSE(TestUtility::headerMapEqualIgnoreOrder(lhs, rhs));
 }
 


### PR DESCRIPTION
In a forthcoming change we will be dropping the default map.

Risk Level: None, test only
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
