### PR TITLE
Fixed OSS-issue-22664

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -172,7 +172,7 @@ message Http2ProtocolOptions {
 
     // The 16 bit parameter identifier.
     google.protobuf.UInt32Value identifier = 1 [
-      (validate.rules).uint32 = {lte: 65536 gte: 1},
+      (validate.rules).uint32 = {lte: 65535 gte: 0},
       (validate.rules).message = {required: true}
     ];
 

--- a/api/envoy/config/core/v4alpha/protocol.proto
+++ b/api/envoy/config/core/v4alpha/protocol.proto
@@ -172,7 +172,7 @@ message Http2ProtocolOptions {
 
     // The 16 bit parameter identifier.
     google.protobuf.UInt32Value identifier = 1 [
-      (validate.rules).uint32 = {lte: 65536 gte: 1},
+      (validate.rules).uint32 = {lte: 65535 gte: 0},
       (validate.rules).message = {required: true}
     ];
 

--- a/generated_api_shadow/envoy/config/core/v3/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v3/protocol.proto
@@ -172,7 +172,7 @@ message Http2ProtocolOptions {
 
     // The 16 bit parameter identifier.
     google.protobuf.UInt32Value identifier = 1 [
-      (validate.rules).uint32 = {lte: 65536 gte: 1},
+      (validate.rules).uint32 = {lte: 65535 gte: 0},
       (validate.rules).message = {required: true}
     ];
 

--- a/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
@@ -172,7 +172,7 @@ message Http2ProtocolOptions {
 
     // The 16 bit parameter identifier.
     google.protobuf.UInt32Value identifier = 1 [
-      (validate.rules).uint32 = {lte: 65536 gte: 1},
+      (validate.rules).uint32 = {lte: 65535 gte: 0},
       (validate.rules).message = {required: true}
     ];
 

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5186283155750912
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-config_fuzz_test-5186283155750912
@@ -1,0 +1,70 @@
+static_resources {
+  clusters {
+    name: "www.google.com"
+    connect_timeout {
+      nanos: 61
+    }
+    http2_protocol_options {
+      initial_stream_window_size {
+        value: 917504
+      }
+      initial_connection_window_size {
+        value: 1952382976
+      }
+      allow_connect: true
+      max_outbound_control_frames {
+        value: 1952382976
+      }
+      stream_error_on_invalid_http_messaging: true
+      custom_settings_parameters {
+        identifier {
+          value: 65536
+        }
+        value {
+          value: 7536640
+        }
+      }
+      custom_settings_parameters {
+        identifier {
+          value: 65536
+        }
+        value {
+          value: 7536640
+        }
+      }
+    }
+    alt_stat_name: ";"
+    load_assignment {
+      cluster_name: "domains"
+      policy {
+        hidden_envoy_deprecated_disable_overprovisioning: true
+      }
+    }
+    lrs_server {
+      path: ":"
+    }
+  }
+}
+dynamic_resources {
+}
+stats_sinks {
+  hidden_envoy_deprecated_config {
+    fields {
+      key: "fffffffffffffffffffffffffff"
+      value {
+      }
+    }
+  }
+}
+stats_sinks {
+}
+stats_sinks {
+  typed_config {
+    type_url: "type.googleapis.com/envoy.api.v2.route.Route"
+    value: "J\004\022\002\010\001J\005\n\003\022\0019J\004\022\002\010\001b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000b\000"
+  }
+}
+admin {
+}
+enable_dispatcher_stats: true
+header_prefix: "*"


### PR DESCRIPTION
Commit Message:
Additional Description:
The bug in 
https://oss-fuzz.com/testcase-detail/5186283155750912 (or https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22664) 
shows ASSERT(it.identifier().value() <= std::numeric_limits<uint16_t>::max());

Notice that identifier is defined in api/envoy/config/core/v3/protocol.proto as:

google.protobuf.UInt32Value identifier = 1 
[ (validate.rules).uint32 = {lte: 65536 gte: 1}, (validate.rules).message = {required: true} ];

The value should range from 0 to 65535 instead of from 1 to 65536.

Because 65536 is greater than uint16::max, it triggers the assert to terminate the program.

The fix is to set it to {lte:65535 gte:0}, instead of {lte: 65536 gte: 1}

Risk Level: low
Testing:
Passed tests with existing corpus and this test case.


[Optional Fixes #Issue] OSS-22664

backup report:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22664

/cc @asraa 
/cc @samkerner