### PR TITLE
http1: do not add transfer-encoding: chunked to 1xx/204 responses

### DIFF
--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -95,7 +95,7 @@ public:
 
 protected:
   StreamEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter);
-  void setIsContentLengthAllowed(bool value) { is_content_length_allowed_ = value; }
+  void setIs1xxOr204(bool value) { is_1xx_or_204_ = value; }
   void encodeHeadersBase(const RequestOrResponseHeaderMap& headers, bool end_stream);
   void encodeTrailersBase(const HeaderMap& headers);
 
@@ -109,7 +109,7 @@ protected:
   bool processing_100_continue_ : 1;
   bool is_response_to_head_request_ : 1;
   bool is_response_to_connect_request_ : 1;
-  bool is_content_length_allowed_ : 1;
+  bool is_1xx_or_204_ : 1;
 
 private:
   /**

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1653,6 +1653,32 @@ TEST_F(Http1ServerConnectionImplTest, UpgradeRequestWithNoBody) {
   EXPECT_TRUE(status.ok());
 }
 
+// Test that 101 upgrade responses do not contain content-length or transfer-encoding headers.
+TEST_F(Http1ServerConnectionImplTest, UpgradeRequestResponseHeaders) {
+  initialize();
+
+  NiceMock<MockRequestDecoder> decoder;
+  Http::ResponseEncoder* response_encoder = nullptr;
+  EXPECT_CALL(callbacks_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+        response_encoder = &encoder;
+        return decoder;
+      }));
+
+  Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\nConnection: upgrade\r\nUpgrade: foo\r\n\r\n");
+  auto status = codec_->dispatch(buffer);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(0U, buffer.length());
+
+  std::string output;
+  ON_CALL(connection_, write(_, _)).WillByDefault(AddBufferToString(&output));
+
+  TestResponseHeaderMapImpl headers{{":status", "101"}};
+  response_encoder->encodeHeaders(headers, false);
+  std::cout << "output: " << output << std::endl;
+  EXPECT_EQ("HTTP/1.1 101 Switching Protocols\r\n\r\n", output);
+}
+
 TEST_F(Http1ServerConnectionImplTest, ConnectRequestNoContentLength) {
   initialize();
 

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -100,6 +100,8 @@ void WebsocketIntegrationTest::validateUpgradeResponseHeaders(
   proxied_response_headers.removeDate();
   proxied_response_headers.removeServer();
 
+  ASSERT_TRUE(proxied_response_headers.TransferEncoding() == nullptr);
+
   commonValidate(proxied_response_headers, original_response_headers);
 
   EXPECT_THAT(&proxied_response_headers, HeaderMapEqualIgnoreOrder(&original_response_headers));
@@ -420,7 +422,7 @@ TEST_P(WebsocketIntegrationTest, BidirectionalChunkedData) {
     ASSERT_TRUE(upstream_request_->headers().TransferEncoding() != nullptr);
   }
   if (downstreamProtocol() == Http::CodecClient::Type::HTTP1) {
-    ASSERT_TRUE(response_->headers().TransferEncoding() != nullptr);
+    ASSERT_TRUE(response_->headers().TransferEncoding() == nullptr);
   }
 
   // Send both a chunked request body and "websocket" payload.


### PR DESCRIPTION
Commit Message:
Follow-on to #10811. The previous change would strip the
transfer-encoding: chunked header if returned by an upstream
during upgrade, but the http/1.1 codec adds the header back.
RFC 7230, Section 3.3.1 requires that no such header appear
in a 1xx or 204 response.

Additional Description:
Unfortunately in the first attempt I failed to realize that transfer-encoding
is re-added in the HTTP/1 codec. Adds checks and a flag in that codec to
disable adding transfer-encoding: chunked to 1xx/204 responses.

Risk Level: low
Testing: updated tests
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
