### PR TITLE
test: declare hotrestart_test as enormous to hopefully avoid timeouts.

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -230,6 +230,7 @@ exports_files(["test_utility.sh"])
 
 envoy_sh_test(
     name = "hotrestart_test",
+    size = "enormous",
     srcs = envoy_select_hot_restart([
         "hotrestart_test.sh",
     ]),


### PR DESCRIPTION
Commit Message: we gave been seeing timeouts in CI on this test, which I find takes 220 seconds on my workstation. In CI it might take longer, so declare the test enormous and hopefully no timeouts.
Additional Description:
Risk Level: low
Testing: just that test (in asan mode).
Docs Changes: n/a
Release Notes: n/a

