### PR TITLE
Push vX.Y-latest when a release is cut (#11405)

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -47,6 +47,13 @@ for BUILD_TYPE in "" "-alpine" "-alpine-debug"; do
         docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
         docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
     fi
+
+    # Push vX.Y-latest to tag the latest image in a release line
+    if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
+      RELEASE_LINE=$(echo "$IMAGE_NAME" | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')
+      docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
+      docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
+    fi
 done
 
 

--- a/docs/root/install/building.rst
+++ b/docs/root/install/building.rst
@@ -41,13 +41,9 @@ be found in the following repositories:
 * `envoyproxy/envoy-alpine-debug <https://hub.docker.com/r/envoyproxy/envoy-alpine-debug/tags/>`_:
   Release binary with debug symbols on top of a **glibc** alpine base.
 
-In the above repositories, the *latest* tag points to the latest official release.
-
 .. note::
 
-  The above repositories used to contain the dev images described below. They remain to avoid
-  breaking existing users. New dev images are added to the repositories described in the following
-  section.
+  In the above repositories, we tag a *vX.Y-latest* image for each security/stable release line.
 
 On every master commit we additionally create a set of development Docker images. These images can
 be found in the following repositories:


### PR DESCRIPTION
Enables users of tagged releases to stay on the latest release of a
major/minor combination

Resolves https://github.com/envoyproxy/envoy/issues/11091

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>
Signed-off-by: Piotr Sikora <piotrsikora@google.com>