### PR TITLE
fuzz: fix ossfuzz crash in router tests

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -225,6 +225,8 @@ message Route {
     // [#not-implemented-hide:]
     // If true, a filter will define the action (e.g., it could dynamically generate the
     // RouteAction).
+    // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
+    // implemented]
     FilterAction filter_action = 17;
   }
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -225,6 +225,8 @@ message Route {
     // [#not-implemented-hide:]
     // If true, a filter will define the action (e.g., it could dynamically generate the
     // RouteAction).
+    // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
+    // implemented]
     FilterAction filter_action = 17;
   }
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -224,6 +224,8 @@ message Route {
     // [#not-implemented-hide:]
     // If true, a filter will define the action (e.g., it could dynamically generate the
     // RouteAction).
+    // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
+    // implemented]
     FilterAction filter_action = 17;
   }
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -225,6 +225,8 @@ message Route {
     // [#not-implemented-hide:]
     // If true, a filter will define the action (e.g., it could dynamically generate the
     // RouteAction).
+    // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
+    // implemented]
     FilterAction filter_action = 17;
   }
 

--- a/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5748492233605120
+++ b/test/common/router/route_corpus/clusterfuzz-testcase-minimized-route_fuzz_test-5748492233605120
@@ -1,0 +1,30 @@
+config {
+  virtual_hosts {
+    name: "["
+    domains: "bat.com"
+    routes {
+      match {
+        safe_regex {
+          google_re2 {
+          }
+          regex: "."
+        }
+      }
+      filter_action {
+      }
+    }
+  }
+}
+headers {
+  headers {
+    key: ":authority"
+    value: "bat.com"
+  }
+  headers {
+    key: ":path"
+    value: "b"
+  }
+  headers {
+    key: "x-forwarded-proto"
+  }
+}

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -29,10 +29,9 @@ cleanRouteConfig(envoy::config::route::v3::RouteConfiguration route_config) {
                         envoy::config::route::v3::RouteMatch::PathSpecifierCase::
                             kHiddenEnvoyDeprecatedRegex) {
                       routes->erase(routes->begin() + i);
-                    } else if (routes-> Get(i).has_filter_action()) {
+                    } else if (routes->Get(i).has_filter_action()) {
                       routes->erase(routes->begin() + i);
-                    }
-                    else {
+                    } else {
                       ++i;
                     }
                   }

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -22,14 +22,7 @@ cleanRouteConfig(envoy::config::route::v3::RouteConfiguration route_config) {
                 [](envoy::config::route::v3::VirtualHost& virtual_host) {
                   auto routes = virtual_host.mutable_routes();
                   for (int i = 0; i < routes->size();) {
-                    // Erase routes that use a regex matcher. This is deprecated and may cause
-                    // crashes when wildcards are matched against very long headers. See
-                    // https://github.com/envoyproxy/envoy/issues/7728.
-                    if (routes->Get(i).match().path_specifier_case() ==
-                        envoy::config::route::v3::RouteMatch::PathSpecifierCase::
-                            kHiddenEnvoyDeprecatedRegex) {
-                      routes->erase(routes->begin() + i);
-                    } else if (routes->Get(i).has_filter_action()) {
+                    if (routes->Get(i).has_filter_action()) {
                       routes->erase(routes->begin() + i);
                     } else {
                       ++i;

--- a/test/common/router/route_fuzz_test.cc
+++ b/test/common/router/route_fuzz_test.cc
@@ -29,7 +29,10 @@ cleanRouteConfig(envoy::config::route::v3::RouteConfiguration route_config) {
                         envoy::config::route::v3::RouteMatch::PathSpecifierCase::
                             kHiddenEnvoyDeprecatedRegex) {
                       routes->erase(routes->begin() + i);
-                    } else {
+                    } else if (routes-> Get(i).has_filter_action()) {
+                      routes->erase(routes->begin() + i);
+                    }
+                    else {
                       ++i;
                     }
                   }


### PR DESCRIPTION
Commit Message: Fixes oss crash in router fuzz tests due to unimplemented features being tested
Additional Description:

- `FilterAction filter_action` in the `Route` message is not implemented but was being tested, causing an assert to fail in `RouteEntryImplBase::clusterEntry`

Risk Level: Low
Testing: passed regression test that originally failed on ossfuzz
Docs Changes: N/A
Release Notes: N/A
Fixes:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21430
