### PR TITLE
test: give hotrestart_test more time to run

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -313,6 +313,7 @@ def envoy_sh_test(
             data = srcs + data + cc_binary,
             tags = tags,
             deps = ["//test/test_common:environment_lib"] + cc_binary,
+            **kargs
         )
 
     else:

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -230,6 +230,7 @@ exports_files(["test_utility.sh"])
 
 envoy_sh_test(
     name = "hotrestart_test",
+    size = "enormous",
     srcs = envoy_select_hot_restart([
         "hotrestart_test.sh",
     ]),


### PR DESCRIPTION
Commit Message:
Recent changes to the hot restart test (to use dynamic base id)
make it a bit slower and it's hitting the test timeout. Give
it more time and fix the bug where we didn't pass additional
args to envoy_cc_test.

Risk Level: low
Testing: fixes tests
Doc Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
