### PR TITLE
dependency and docs: update jwt_verify_lib to 2020-06-03

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -278,10 +278,10 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "118f955620509f1634cbd918c63234d2048dce56b1815caf348d78e3c3dc899c",
-        strip_prefix = "jwt_verify_lib-44291b2ee4c19631e5a0a0bf4f965436a9364ca7",
-        # 2020-05-21
-        urls = ["https://github.com/google/jwt_verify_lib/archive/44291b2ee4c19631e5a0a0bf4f965436a9364ca7.tar.gz"],
+        sha256 = "c6249f6caeab616d2c232258fc9423f1c4a537418dd575a4b7d3616b8e2a0cb6",
+        strip_prefix = "jwt_verify_lib-78b4ae005db2e287e321515a8385baac7c3b4207",
+        # 2020-06-03
+        urls = ["https://github.com/google/jwt_verify_lib/archive/78b4ae005db2e287e321515a8385baac7c3b4207.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -278,10 +278,10 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "c6249f6caeab616d2c232258fc9423f1c4a537418dd575a4b7d3616b8e2a0cb6",
-        strip_prefix = "jwt_verify_lib-78b4ae005db2e287e321515a8385baac7c3b4207",
+        sha256 = "d2e28897c297bd04429e43a1b485f7350acc23cbfee6365b8a3634c17840b2f6",
+        strip_prefix = "jwt_verify_lib-f44cf49d185ad0694b472da78071b4d67313fb86",
         # 2020-06-03
-        urls = ["https://github.com/google/jwt_verify_lib/archive/78b4ae005db2e287e321515a8385baac7c3b4207.tar.gz"],
+        urls = ["https://github.com/google/jwt_verify_lib/archive/f44cf49d185ad0694b472da78071b4d67313fb86.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -8,7 +8,7 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
 .. attention::
-   ES256, ES384, ES512, HS256, HS384, HS512, RS256, RS384 and RS512 are supported for the JWT alg.
+   EdDSA, ES256, ES384, ES512, HS256, HS384, HS512, RS256, RS384 and RS512 are supported for the JWT alg.
 
 Configuration
 -------------


### PR DESCRIPTION
Signed-off-by: Jason Heiss <jheiss@twosigma.com>

Commit Message: update jwt_verify_lib to 2020-06-03
Additional Description: Add EdDSA (specifically Ed25519) support
Risk Level: low
Testing: unit and manual testing
Docs Changes: Add EdDSA to the list of JWT algs supported
Release Notes: Not necessary?
