### PR TITLE
[Windows] Removes abstract mock classes Stream Encoder/Decoder

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -16,7 +16,6 @@ envoy_package()
 envoy_cc_test(
     name = "async_client_impl_test",
     srcs = ["async_client_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":common_lib",
         "//source/common/buffer:buffer_lib",
@@ -192,7 +191,6 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "conn_manager_impl_test",
     srcs = ["conn_manager_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",

--- a/test/common/http/http1/BUILD
+++ b/test/common/http/http1/BUILD
@@ -19,7 +19,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "codec_impl_test",
     srcs = ["codec_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/event:dispatcher_interface",
@@ -45,7 +44,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "conn_pool_test",
     srcs = ["conn_pool_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_lib",

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -51,7 +51,6 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "conn_pool_test",
     srcs = ["conn_pool_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/http/http2:conn_pool_lib",

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -854,7 +854,7 @@ TEST_P(Http2CodecImplFlowControlTest, TestFlowControlInPendingSendData) {
   EXPECT_EQ(initial_stream_window + 1, client_->getStream(1)->pending_send_data_.length());
 
   // Now create a second stream on the connection.
-  MockStreamDecoder response_decoder2;
+  MockResponseDecoder response_decoder2;
   RequestEncoder* request_encoder2 = &client_->newStream(response_decoder_);
   StreamEncoder* response_encoder2;
   MockStreamCallbacks server_stream_callbacks2;

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -253,7 +253,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "router_test",
     srcs = ["router_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:context_lib",

--- a/test/mocks/http/stream_decoder.cc
+++ b/test/mocks/http/stream_decoder.cc
@@ -6,9 +6,6 @@ using testing::Invoke;
 namespace Envoy {
 namespace Http {
 
-MockStreamDecoder::MockStreamDecoder() = default;
-MockStreamDecoder::~MockStreamDecoder() = default;
-
 MockRequestDecoder::MockRequestDecoder() {
   ON_CALL(*this, decodeHeaders_(_, _)).WillByDefault(Invoke([](RequestHeaderMapPtr& headers, bool) {
     // Check to see that method is not-null. Path can be null for CONNECT and authority can be null

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -6,22 +6,16 @@
 namespace Envoy {
 namespace Http {
 
-class MockStreamDecoder : public virtual StreamDecoder {
+class MockRequestDecoder : public RequestDecoder {
 public:
-  MockStreamDecoder();
-  ~MockStreamDecoder() override;
+  MockRequestDecoder();
+  ~MockRequestDecoder() override;
 
   void decodeMetadata(MetadataMapPtr&& metadata_map) override { decodeMetadata_(metadata_map); }
 
   // Http::StreamDecoder
   MOCK_METHOD(void, decodeData, (Buffer::Instance & data, bool end_stream));
   MOCK_METHOD(void, decodeMetadata_, (MetadataMapPtr & metadata_map));
-};
-
-class MockRequestDecoder : public MockStreamDecoder, public RequestDecoder {
-public:
-  MockRequestDecoder();
-  ~MockRequestDecoder() override;
 
   void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override {
     decodeHeaders_(headers, end_stream);
@@ -33,10 +27,16 @@ public:
   MOCK_METHOD(void, decodeTrailers_, (RequestTrailerMapPtr & trailers));
 };
 
-class MockResponseDecoder : public MockStreamDecoder, public ResponseDecoder {
+class MockResponseDecoder : public ResponseDecoder {
 public:
   MockResponseDecoder();
   ~MockResponseDecoder() override;
+
+  void decodeMetadata(MetadataMapPtr&& metadata_map) override { decodeMetadata_(metadata_map); }
+
+  // Http::StreamDecoder
+  MOCK_METHOD(void, decodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(void, decodeMetadata_, (MetadataMapPtr & metadata_map));
 
   void decode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override {
     decode100ContinueHeaders_(headers);

--- a/test/mocks/http/stream_encoder.cc
+++ b/test/mocks/http/stream_encoder.cc
@@ -9,13 +9,8 @@ namespace Http {
 MockHttp1StreamEncoderOptions::MockHttp1StreamEncoderOptions() = default;
 MockHttp1StreamEncoderOptions::~MockHttp1StreamEncoderOptions() = default;
 
-MockStreamEncoder::MockStreamEncoder() {
-  ON_CALL(*this, getStream()).WillByDefault(ReturnRef(stream_));
-}
-
-MockStreamEncoder::~MockStreamEncoder() = default;
-
 MockRequestEncoder::MockRequestEncoder() {
+  ON_CALL(*this, getStream()).WillByDefault(ReturnRef(stream_));
   ON_CALL(*this, encodeHeaders(_, _))
       .WillByDefault(Invoke([](const RequestHeaderMap& headers, bool) {
         // Check to see that method is not-null. Path can be null for CONNECT and authority can be
@@ -26,6 +21,7 @@ MockRequestEncoder::MockRequestEncoder() {
 MockRequestEncoder::~MockRequestEncoder() = default;
 
 MockResponseEncoder::MockResponseEncoder() {
+  ON_CALL(*this, getStream()).WillByDefault(ReturnRef(stream_));
   ON_CALL(*this, encodeHeaders(_, _))
       .WillByDefault(Invoke([](const ResponseHeaderMap& headers, bool) {
         // Check for passing request headers as response headers in a test.

--- a/test/mocks/http/stream_encoder.h
+++ b/test/mocks/http/stream_encoder.h
@@ -17,21 +17,7 @@ public:
   MOCK_METHOD(void, disableChunkEncoding, ());
 };
 
-class MockStreamEncoder : public virtual StreamEncoder {
-public:
-  MockStreamEncoder();
-  ~MockStreamEncoder() override;
-
-  // Http::StreamEncoder
-  MOCK_METHOD(void, encodeData, (Buffer::Instance & data, bool end_stream));
-  MOCK_METHOD(void, encodeMetadata, (const MetadataMapVector& metadata_map_vector));
-  MOCK_METHOD(Stream&, getStream, ());
-  MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
-
-  testing::NiceMock<MockStream> stream_;
-};
-
-class MockRequestEncoder : public MockStreamEncoder, public RequestEncoder {
+class MockRequestEncoder : public RequestEncoder {
 public:
   MockRequestEncoder();
   ~MockRequestEncoder() override;
@@ -39,9 +25,17 @@ public:
   // Http::RequestEncoder
   MOCK_METHOD(void, encodeHeaders, (const RequestHeaderMap& headers, bool end_stream));
   MOCK_METHOD(void, encodeTrailers, (const RequestTrailerMap& trailers));
+
+  // Http::StreamEncoder
+  MOCK_METHOD(void, encodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(void, encodeMetadata, (const MetadataMapVector& metadata_map_vector));
+  MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
+  MOCK_METHOD(Stream&, getStream, (), ());
+
+  testing::NiceMock<MockStream> stream_;
 };
 
-class MockResponseEncoder : public MockStreamEncoder, public ResponseEncoder {
+class MockResponseEncoder : public ResponseEncoder {
 public:
   MockResponseEncoder();
   ~MockResponseEncoder() override;
@@ -50,6 +44,14 @@ public:
   MOCK_METHOD(void, encode100ContinueHeaders, (const ResponseHeaderMap& headers));
   MOCK_METHOD(void, encodeHeaders, (const ResponseHeaderMap& headers, bool end_stream));
   MOCK_METHOD(void, encodeTrailers, (const ResponseTrailerMap& trailers));
+
+  // Http::StreamEncoder
+  MOCK_METHOD(void, encodeData, (Buffer::Instance & data, bool end_stream));
+  MOCK_METHOD(void, encodeMetadata, (const MetadataMapVector& metadata_map_vector));
+  MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
+  MOCK_METHOD(Stream&, getStream, (), ());
+
+  testing::NiceMock<MockStream> stream_;
 };
 
 } // namespace Http


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Removes abstract mock classes Stream Encoder/Decoder

Additional Description:

As part of our effort to port Envoy to Windows we run into an issue with GTests and GMock in particular that is causing issues when we test on Windows. More specifically chromium documentation:

> NiceMock<MockFoo> and StrictMock<MockFoo> only work for mock methods defined using the MOCK_METHOD macro directly in the MockFoo class. If a mock method is defined in a base class of MockFoo, the “nice” or “strict” modifier may not affect it, depending on the compiler.

The way I interpret it is that when you inherit from a Mock class you can not guarantee that the parent Mock class functions are treated as interesting calls. This leads to a GMock warning and consequently a test error. Example base mock classes are `MockStreamEncoder` and   `MockStreamDecoder`


Tests that are now passing:

- //test/common/http:conn_manager_impl_test
- //test/common/http/http1:codec_impl_test
- //test/common/http/http1:conn_pool_test
- //test/common/http/http2:conn_pool_test
- //test/common/http:async_client_impl_test
- //test/common/router:router_test

Risk Level: Low (Test only)
Testing: Tested manually on Windows and Linux
Docs Changes: N/A
Release Notes: N/A
