### PR TITLE
jwt_authn: fix typo in authenticator name

### DIFF
--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -105,7 +105,7 @@ std::string AuthenticatorImpl::name() const {
     return provider_.value() + (is_allow_missing_ ? "-OPTIONAL" : "");
   }
   if (is_allow_failed_) {
-    return "_IS_ALLOW_FALED_";
+    return "_IS_ALLOW_FAILED_";
   }
   if (is_allow_missing_) {
     return "_IS_ALLOW_MISSING_";


### PR DESCRIPTION
Signed-off-by: Andrew Melis <andrewmelis@gmail.com>

Commit Message: jwt_authn: fix typo in authenticator name
Additional Description:
`_IS_ALLOW_FALED_` -> `_IS_ALLOW_FAILED_`. The string is used only in the private `AuthenticatorImpl::name()` function, which is "For debug logging only" per comment.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A