### PR TITLE
test: output value of ip env varialbe to set + minor signature changes

### DIFF
--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -244,10 +244,11 @@ std::vector<Network::Address::IpVersion> TestEnvironment::getIpVersionsForTest()
       parameters.push_back(version);
       if (!Network::Test::supportsIpVersion(version)) {
         const auto version_string = Network::Test::addressVersionAsString(version);
-        ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::testing), warn,
-                            "Testing with IP{} addresses may not be supported on this machine. If "
-                            "testing fails, set the environment variable ENVOY_IP_TEST_VERSIONS to 'v{}only'.",
-                            version_string, version_string);
+        ENVOY_LOG_TO_LOGGER(
+            Logger::Registry::getLog(Logger::Id::testing), warn,
+            "Testing with IP{} addresses may not be supported on this machine. If "
+            "testing fails, set the environment variable ENVOY_IP_TEST_VERSIONS to 'v{}only'.",
+            version_string, version_string);
       }
     }
   }

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -243,10 +243,11 @@ std::vector<Network::Address::IpVersion> TestEnvironment::getIpVersionsForTest()
     if (TestEnvironment::shouldRunTestForIpVersion(version)) {
       parameters.push_back(version);
       if (!Network::Test::supportsIpVersion(version)) {
+        const auto version_string = Network::Test::addressVersionAsString(version);
         ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::testing), warn,
                             "Testing with IP{} addresses may not be supported on this machine. If "
-                            "testing fails, set the environment variable ENVOY_IP_TEST_VERSIONS.",
-                            Network::Test::addressVersionAsString(version));
+                            "testing fails, set the environment variable ENVOY_IP_TEST_VERSIONS to 'v{}only'.",
+                            version_string, version_string);
       }
     }
   }

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -68,35 +68,35 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(const std::string& addr_port
   return instance;
 }
 
-const std::string getLoopbackAddressUrlString(const Address::IpVersion version) {
+std::string getLoopbackAddressUrlString(const Address::IpVersion version) {
   if (version == Address::IpVersion::v6) {
     return std::string("[::1]");
   }
   return std::string("127.0.0.1");
 }
 
-const std::string getLoopbackAddressString(const Address::IpVersion version) {
+std::string getLoopbackAddressString(const Address::IpVersion version) {
   if (version == Address::IpVersion::v6) {
     return std::string("::1");
   }
   return std::string("127.0.0.1");
 }
 
-const std::string getAnyAddressUrlString(const Address::IpVersion version) {
+std::string getAnyAddressUrlString(const Address::IpVersion version) {
   if (version == Address::IpVersion::v6) {
     return std::string("[::]");
   }
   return std::string("0.0.0.0");
 }
 
-const std::string getAnyAddressString(const Address::IpVersion version) {
+std::string getAnyAddressString(const Address::IpVersion version) {
   if (version == Address::IpVersion::v6) {
     return std::string("::");
   }
   return std::string("0.0.0.0");
 }
 
-const std::string addressVersionAsString(const Address::IpVersion version) {
+std::string addressVersionAsString(const Address::IpVersion version) {
   if (version == Address::IpVersion::v4) {
     return std::string("v4");
   }

--- a/test/test_common/network_utility.h
+++ b/test/test_common/network_utility.h
@@ -42,7 +42,7 @@ Address::InstanceConstSharedPtr findOrCheckFreePort(const std::string& addr_port
  * @param version IP address version of loopback address.
  * @return std::string URL ready loopback address as a string.
  */
-const std::string getLoopbackAddressUrlString(const Address::IpVersion version);
+std::string getLoopbackAddressUrlString(const Address::IpVersion version);
 
 /**
  * Get a IP loopback address as a string. There are no square brackets around IPv6 addresses, this
@@ -50,28 +50,28 @@ const std::string getLoopbackAddressUrlString(const Address::IpVersion version);
  * @param version IP address version of loopback address.
  * @return std::string loopback address as a string.
  */
-const std::string getLoopbackAddressString(const Address::IpVersion version);
+std::string getLoopbackAddressString(const Address::IpVersion version);
 
 /**
  * Get a URL ready IP any address as a string.
  * @param version IP address version of any address.
  * @return std::string URL ready any address as a string.
  */
-const std::string getAnyAddressUrlString(const Address::IpVersion version);
+std::string getAnyAddressUrlString(const Address::IpVersion version);
 
 /**
  * Get an IP any address as a string.
  * @param version IP address version of any address.
  * @return std::string any address as a string.
  */
-const std::string getAnyAddressString(const Address::IpVersion version);
+std::string getAnyAddressString(const Address::IpVersion version);
 
 /**
  * Return a string version of enum IpVersion version.
  * @param version IP address version.
  * @return std::string string version of IpVersion.
  */
-const std::string addressVersionAsString(const Address::IpVersion version);
+std::string addressVersionAsString(const Address::IpVersion version);
 
 /**
  * Returns a loopback address for the specified IP version (127.0.0.1 for IPv4 and ::1 for IPv6).


### PR DESCRIPTION
Commit Message: Makes it so that we explicitly mention what to set the `ENVOY_IP_TEST_VERSIONS` env variable to when running in an environment that
doesn't support all IP versions. Also removes the const qualifier from a value return type,
which is not necessary.
Additional Description:
Risk Level: Low, test only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a