### PR TITLE
feat(router): keep query string by default for redirects

### DIFF
--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -1179,6 +1179,12 @@ message RedirectAction {
     // The path portion of the URL will be swapped with this value.
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
+    //
+    // When the path redirection take place, the following rules apply:
+    //  1. If path_redirect contains query string, requests will be redirected to the given
+    //     path with the specified query string regardless of the value of strip_query
+    //  2. If strip_query is set to true, request's query string will be stripped
+    //  3. If strip_query is set to false, request's query string is left intact
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -1180,7 +1180,7 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // For exmaple, let's say we have the following routes:
+    // For example, let's say we have the following routes:
     //
     // - match: { path: "/old-path-1" }
     //   redirect: { path_redirect: "/new-path-1" }

--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -1180,11 +1180,18 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // When the path redirection take place, the following rules apply:
-    //  1. If path_redirect contains query string, requests will be redirected to the given
-    //     path with the specified query string regardless of the value of strip_query
-    //  2. If strip_query is set to true, request's query string will be stripped
-    //  3. If strip_query is set to false, request's query string is left intact
+    // For exmaple, let's say we have the following routes:
+    //
+    // - match: { path: "/old-path-1" }
+    //   redirect: { path_redirect: "/new-path-1" }
+    // - match: { path: "/old-path-2" }
+    //   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+    // - match: { path: "/old-path-3" }
+    //   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+    //
+    // 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
+    // 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
+    // 3. if request uri is "/old-path-3?bar=1", users will be redirected to "/new-path-3?foo=1"
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/api/v2/route/route_components.proto
+++ b/api/envoy/api/v2/route/route_components.proto
@@ -1177,6 +1177,8 @@ message RedirectAction {
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
+    // Please note that query string in path_redirect will override the
+    // request's query string and will not be stripped.
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1211,11 +1211,18 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // When the path redirection take place, the following rules apply:
-    //  1. If path_redirect contains query string, requests will be redirected to the given
-    //     path with the specified query string regardless of the value of strip_query
-    //  2. If strip_query is set to true, request's query string will be stripped
-    //  3. If strip_query is set to false, request's query string is left intact
+    // For exmaple, let's say we have the following routes:
+    //
+    // - match: { path: "/old-path-1" }
+    //   redirect: { path_redirect: "/new-path-1" }
+    // - match: { path: "/old-path-2" }
+    //   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+    // - match: { path: "/old-path-3" }
+    //   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+    //
+    // 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
+    // 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
+    // 3. if request uri is "/old-path-3?bar=1", users will be redirected to "/new-path-3?foo=1"
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1211,7 +1211,7 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // For exmaple, let's say we have the following routes:
+    // For example, let's say we have the following routes:
     //
     // - match: { path: "/old-path-1" }
     //   redirect: { path_redirect: "/new-path-1" }

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1208,6 +1208,8 @@ message RedirectAction {
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
+    // Please note that query string in path_redirect will override the
+    // request's query string and will not be stripped.
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1210,6 +1210,12 @@ message RedirectAction {
     // The path portion of the URL will be swapped with this value.
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
+    //
+    // When the path redirection take place, the following rules apply:
+    //  1. If path_redirect contains query string, requests will be redirected to the given
+    //     path with the specified query string regardless of the value of strip_query
+    //  2. If strip_query is set to true, request's query string will be stripped
+    //  3. If strip_query is set to false, request's query string is left intact
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1189,11 +1189,18 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // When the path redirection take place, the following rules apply:
-    //  1. If path_redirect contains query string, requests will be redirected to the given
-    //     path with the specified query string regardless of the value of strip_query
-    //  2. If strip_query is set to true, request's query string will be stripped
-    //  3. If strip_query is set to false, request's query string is left intact
+    // For exmaple, let's say we have the following routes:
+    //
+    // - match: { path: "/old-path-1" }
+    //   redirect: { path_redirect: "/new-path-1" }
+    // - match: { path: "/old-path-2" }
+    //   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+    // - match: { path: "/old-path-3" }
+    //   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+    //
+    // 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
+    // 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
+    // 3. if request uri is "/old-path-3?bar=1", users will be redirected to "/new-path-3?foo=1"
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1186,6 +1186,8 @@ message RedirectAction {
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
+    // Please note that query string in path_redirect will override the
+    // request's query string and will not be stripped.
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1189,7 +1189,7 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // For exmaple, let's say we have the following routes:
+    // For example, let's say we have the following routes:
     //
     // - match: { path: "/old-path-1" }
     //   redirect: { path_redirect: "/new-path-1" }

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1188,6 +1188,12 @@ message RedirectAction {
     // The path portion of the URL will be swapped with this value.
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
+    //
+    // When the path redirection take place, the following rules apply:
+    //  1. If path_redirect contains query string, requests will be redirected to the given
+    //     path with the specified query string regardless of the value of strip_query
+    //  2. If strip_query is set to true, request's query string will be stripped
+    //  3. If strip_query is set to false, request's query string is left intact
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,6 +9,7 @@ Incompatible Behavior Changes
 * build: official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
 * client_ssl_auth: the `auth_ip_white_list` stat has been renamed to
   :ref:`auth_ip_allowlist <config_network_filters_client_ssl_auth_stats>`.
+* router: path_redirect now keeps query string by default.
 
 Minor Behavior Changes
 ----------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,7 +9,6 @@ Incompatible Behavior Changes
 * build: official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
 * client_ssl_auth: the `auth_ip_white_list` stat has been renamed to
   :ref:`auth_ip_allowlist <config_network_filters_client_ssl_auth_stats>`.
-* router: path_redirect now keeps query string by default.
 * router: path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.preserve_query_string_in_redirects` to false.
 
 Minor Behavior Changes

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -10,6 +10,7 @@ Incompatible Behavior Changes
 * client_ssl_auth: the `auth_ip_white_list` stat has been renamed to
   :ref:`auth_ip_allowlist <config_network_filters_client_ssl_auth_stats>`.
 * router: path_redirect now keeps query string by default.
+* router: path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.preserve_query_string_in_redirects` to false.
 
 Minor Behavior Changes
 ----------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,7 +9,7 @@ Incompatible Behavior Changes
 * build: official released binary is now built on Ubuntu 18.04, requires glibc >= 2.27.
 * client_ssl_auth: the `auth_ip_white_list` stat has been renamed to
   :ref:`auth_ip_allowlist <config_network_filters_client_ssl_auth_stats>`.
-* router: path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.preserve_query_string_in_redirects` to false.
+* router: path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.preserve_query_string_in_path_redirects` to false.
 
 Minor Behavior Changes
 ----------------------

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -1179,6 +1179,12 @@ message RedirectAction {
     // The path portion of the URL will be swapped with this value.
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
+    //
+    // When the path redirection take place, the following rules apply:
+    //  1. If path_redirect contains query string, requests will be redirected to the given
+    //     path with the specified query string regardless of the value of strip_query
+    //  2. If strip_query is set to true, request's query string will be stripped
+    //  3. If strip_query is set to false, request's query string is left intact
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -1180,7 +1180,7 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // For exmaple, let's say we have the following routes:
+    // For example, let's say we have the following routes:
     //
     // - match: { path: "/old-path-1" }
     //   redirect: { path_redirect: "/new-path-1" }

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -1180,11 +1180,18 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // When the path redirection take place, the following rules apply:
-    //  1. If path_redirect contains query string, requests will be redirected to the given
-    //     path with the specified query string regardless of the value of strip_query
-    //  2. If strip_query is set to true, request's query string will be stripped
-    //  3. If strip_query is set to false, request's query string is left intact
+    // For exmaple, let's say we have the following routes:
+    //
+    // - match: { path: "/old-path-1" }
+    //   redirect: { path_redirect: "/new-path-1" }
+    // - match: { path: "/old-path-2" }
+    //   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+    // - match: { path: "/old-path-3" }
+    //   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+    //
+    // 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
+    // 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
+    // 3. if request uri is "/old-path-3?bar=1", users will be redirected to "/new-path-3?foo=1"
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/api/v2/route/route_components.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route_components.proto
@@ -1177,6 +1177,8 @@ message RedirectAction {
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
+    // Please note that query string in path_redirect will override the
+    // request's query string and will not be stripped.
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1215,6 +1215,8 @@ message RedirectAction {
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
+    // Please note that query string in path_redirect will override the
+    // request's query string and will not be stripped.
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1218,7 +1218,7 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // For exmaple, let's say we have the following routes:
+    // For example, let's say we have the following routes:
     //
     // - match: { path: "/old-path-1" }
     //   redirect: { path_redirect: "/new-path-1" }

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1217,6 +1217,12 @@ message RedirectAction {
     // The path portion of the URL will be swapped with this value.
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
+    //
+    // When the path redirection take place, the following rules apply:
+    //  1. If path_redirect contains query string, requests will be redirected to the given
+    //     path with the specified query string regardless of the value of strip_query
+    //  2. If strip_query is set to true, request's query string will be stripped
+    //  3. If strip_query is set to false, request's query string is left intact
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1218,11 +1218,18 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // When the path redirection take place, the following rules apply:
-    //  1. If path_redirect contains query string, requests will be redirected to the given
-    //     path with the specified query string regardless of the value of strip_query
-    //  2. If strip_query is set to true, request's query string will be stripped
-    //  3. If strip_query is set to false, request's query string is left intact
+    // For exmaple, let's say we have the following routes:
+    //
+    // - match: { path: "/old-path-1" }
+    //   redirect: { path_redirect: "/new-path-1" }
+    // - match: { path: "/old-path-2" }
+    //   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+    // - match: { path: "/old-path-3" }
+    //   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+    //
+    // 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
+    // 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
+    // 3. if request uri is "/old-path-3?bar=1", users will be redirected to "/new-path-3?foo=1"
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1216,6 +1216,12 @@ message RedirectAction {
     // The path portion of the URL will be swapped with this value.
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
+    //
+    // When the path redirection take place, the following rules apply:
+    //  1. If path_redirect contains query string, requests will be redirected to the given
+    //     path with the specified query string regardless of the value of strip_query
+    //  2. If strip_query is set to true, request's query string will be stripped
+    //  3. If strip_query is set to false, request's query string is left intact
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1217,11 +1217,18 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // When the path redirection take place, the following rules apply:
-    //  1. If path_redirect contains query string, requests will be redirected to the given
-    //     path with the specified query string regardless of the value of strip_query
-    //  2. If strip_query is set to true, request's query string will be stripped
-    //  3. If strip_query is set to false, request's query string is left intact
+    // For exmaple, let's say we have the following routes:
+    //
+    // - match: { path: "/old-path-1" }
+    //   redirect: { path_redirect: "/new-path-1" }
+    // - match: { path: "/old-path-2" }
+    //   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+    // - match: { path: "/old-path-3" }
+    //   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+    //
+    // 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
+    // 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
+    // 3. if request uri is "/old-path-3?bar=1", users will be redirected to "/new-path-3?foo=1"
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1217,7 +1217,7 @@ message RedirectAction {
     // Please note that query string in path_redirect will override the
     // request's query string and will not be stripped.
     //
-    // For exmaple, let's say we have the following routes:
+    // For example, let's say we have the following routes:
     //
     // - match: { path: "/old-path-1" }
     //   redirect: { path_redirect: "/new-path-1" }

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1214,6 +1214,8 @@ message RedirectAction {
 
   oneof path_rewrite_specifier {
     // The path portion of the URL will be swapped with this value.
+    // Please note that query string in path_redirect will override the
+    // request's query string and will not be stripped.
     string path_redirect = 2
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -671,14 +671,14 @@ std::string RouteEntryImplBase::newPath(const Http::RequestHeaderMap& headers) c
 
   std::string final_path_value;
   if (!path_redirect_.empty()) {
-    // the path_redirect query string, if any, takes precedence over the request's query string,
+    // The path_redirect query string, if any, takes precedence over the request's query string,
     // and it will not be stripped regardless of `strip_query`.
     if (path_redirect_has_query_) {
       final_path = path_redirect_.c_str();
     } else {
-      absl::string_view current_path = headers.getPathValue();
-      size_t path_end = current_path.find('?');
-      bool current_path_has_query = path_end != absl::string_view::npos;
+      const absl::string_view current_path = headers.getPathValue();
+      const size_t path_end = current_path.find('?');
+      const bool current_path_has_query = path_end != absl::string_view::npos;
       if (current_path_has_query) {
         final_path_value = path_redirect_;
         final_path_value.append(current_path.data() + path_end, current_path.length() - path_end);
@@ -691,7 +691,7 @@ std::string RouteEntryImplBase::newPath(const Http::RequestHeaderMap& headers) c
     final_path = headers.getPathValue();
   }
   if (!path_redirect_has_query_ && strip_query_) {
-    size_t path_end = final_path.find('?');
+    const size_t path_end = final_path.find('?');
     if (path_end != absl::string_view::npos) {
       final_path = final_path.substr(0, path_end);
     }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -671,20 +671,9 @@ std::string RouteEntryImplBase::newPath(const Http::RequestHeaderMap& headers) c
 
   std::string final_path_value;
   bool path_redirect_has_query = false;
-  /*
-    if `path_redirect` is not empty:
-      if `path_redirect` contains query string:
-        set `final_path` to `path_redirect` and keep query string anyway
-      else if `strip_query`:
-        set `final_path` to `path_redirect` and strip query string
-      else:
-        set `final_path` to `path_redirect` and keep query string if exists
-    else if `strip_query`:
-      set `final_path` to `current_path` and strip query
-    else:
-      set `final_path` to `current_path`
-  */
   if (!path_redirect_.empty()) {
+    // the path_redirect query string, if any, takes precedence over the request's query string,
+    // and it will not be stripped regardless of `strip_query`.
     absl::string_view current_path = headers.getPathValue();
     path_redirect_has_query = path_redirect_.find('?') != absl::string_view::npos;
     size_t path_end = current_path.find('?');

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -759,6 +759,7 @@ private:
   const std::string port_redirect_;
   const std::string path_redirect_;
   const bool path_redirect_has_query_;
+  const bool enable_preserve_query_in_path_redirects_;
   const bool https_redirect_;
   const std::string prefix_rewrite_redirect_;
   const bool strip_query_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -758,6 +758,7 @@ private:
   const std::string host_redirect_;
   const std::string port_redirect_;
   const std::string path_redirect_;
+  const bool path_redirect_has_query_;
   const bool https_redirect_;
   const std::string prefix_rewrite_redirect_;
   const bool strip_query_;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -70,6 +70,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.fixed_connection_close",
     "envoy.reloadable_features.http_default_alpn",
     "envoy.reloadable_features.listener_in_place_filterchain_update",
+    "envoy.reloadable_features.preserve_query_string_in_redirects",
     "envoy.reloadable_features.preserve_upstream_date",
     "envoy.reloadable_features.stop_faking_paths",
     "envoy.reloadable_features.strict_1xx_and_204_response_headers",

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -70,7 +70,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.fixed_connection_close",
     "envoy.reloadable_features.http_default_alpn",
     "envoy.reloadable_features.listener_in_place_filterchain_update",
-    "envoy.reloadable_features.preserve_query_string_in_redirects",
+    "envoy.reloadable_features.preserve_query_string_in_path_redirects",
     "envoy.reloadable_features.preserve_upstream_date",
     "envoy.reloadable_features.stop_faking_paths",
     "envoy.reloadable_features.strict_1xx_and_204_response_headers",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6234,6 +6234,69 @@ virtual_hosts:
   }
 }
 
+TEST_F(RouteConfigurationV2, PathRedirectQueryNotPreserved) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.preserve_query_string_in_redirects", "false"}});
+
+  std::string RouteDynPathRedirect = R"EOF(
+name: AllRedirects
+virtual_hosts:
+  - name: redirect
+    domains: [redirect.lyft.com]
+    routes:
+      - match: { path: "/path/redirect/"}
+        redirect: { path_redirect: "/new/path-redirect/" }
+      - match: { path: "/path/redirect/strip-query/true"}
+        redirect: { path_redirect: "/new/path-redirect/", strip_query: "true" }
+      - match: { path: "/path/redirect/query"}
+        redirect: { path_redirect: "/new/path-redirect?foo=1" }
+      - match: { path: "/path/redirect/query-with-strip"}
+        redirect: { path_redirect: "/new/path-redirect?foo=2", strip_query: "true" }
+  )EOF";
+
+  TestConfigImpl config(parseRouteConfigurationFromYaml(RouteDynPathRedirect), factory_context_,
+                        true);
+  EXPECT_EQ(nullptr, config.route(genRedirectHeaders("www.foo.com", "/foo", true, true), 0));
+
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/?lang=eng&con=US", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect/?lang=eng&con=US",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers = genRedirectHeaders(
+        "redirect.lyft.com", "/path/redirect/strip-query/true?lang=eng&con=US", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect/",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/query", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=1",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/query?bar=1", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=1",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/query-with-strip", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=2",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers = genRedirectHeaders(
+        "redirect.lyft.com", "/path/redirect/query-with-strip?bar=1", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=2",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+}
+
 // Test to check Strip Query for redirect messages
 TEST_F(RouteConfigurationV2, RedirectStripQuery) {
   std::string RouteDynPathRedirect = R"EOF(

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6250,6 +6250,12 @@ virtual_hosts:
         redirect: { host_redirect: new.lyft.com }
       - match: { path: "/path/redirect/"}
         redirect: { path_redirect: "/new/path-redirect/" }
+      - match: { path: "/path/redirect/strip-query/true"}
+        redirect: { path_redirect: "/new/path-redirect/", strip_query: "true" }
+      - match: { path: "/path/redirect/query"}
+        redirect: { path_redirect: "/new/path-redirect?foo=1" }
+      - match: { path: "/path/redirect/query-with-strip"}
+        redirect: { path_redirect: "/new/path-redirect?foo=2", strip_query: "true" }
       - match: { prefix: "/all/combinations"}
         redirect: { host_redirect: "new.lyft.com", prefix_rewrite: "/new/prefix" , https_redirect: "true", strip_query: "true" }
   )EOF";
@@ -6282,8 +6288,38 @@ virtual_hosts:
   }
   {
     Http::TestRequestHeaderMapImpl headers =
-        genRedirectHeaders("redirect.lyft.com", "/path/redirect/", true, false);
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/?lang=eng&con=US", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect/?lang=eng&con=US",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers = genRedirectHeaders(
+        "redirect.lyft.com", "/path/redirect/strip-query/true?lang=eng&con=US", true, false);
     EXPECT_EQ("https://redirect.lyft.com/new/path-redirect/",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/query", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=1",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/query?bar=1", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=1",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers =
+        genRedirectHeaders("redirect.lyft.com", "/path/redirect/query-with-strip", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=2",
+              config.route(headers, 0)->directResponseEntry()->newPath(headers));
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers = genRedirectHeaders(
+        "redirect.lyft.com", "/path/redirect/query-with-strip?bar=1", true, false);
+    EXPECT_EQ("https://redirect.lyft.com/new/path-redirect?foo=2",
               config.route(headers, 0)->directResponseEntry()->newPath(headers));
   }
   {


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

Commit Message: leave query string intact by default(`strip_query: false`) when performing path redirect.

Additional Description:
I think the current behavior(stripping query by default) is not aligned with the documentation. From the documentation of [`path_redirect`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-redirectaction-path-redirect) and [`strip_query`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-redirectaction-strip-query) field, I am under the impression that query portion is not considered part of path portion. Additionally, even if we want to strip query for path redirects, we can simply set `strip_query` to true.

Risk Level:
Testing: unit test
Docs Changes:
Release Notes: query string is not stripped by default for path redirects

Fixes #11443 
