### PR TITLE
health_check filter & readme: fix typos

### DIFF
--- a/generated_api_shadow/README.md
+++ b/generated_api_shadow/README.md
@@ -1,6 +1,6 @@
 This directory is for generated Envoy internal artifacts (via `proto_format`).
 
-Do not hand edit any file under `envoy/`. This shadow API may only be used be
-used in the Envoy source tree.
+Do not hand edit any file under `envoy/`. This shadow API may only be used in
+the Envoy source tree.
 
-The `bazel/` tree is an symlink back to the official API Bazel rules.
+The `bazel/` tree is a symlink back to the official API Bazel rules.

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -249,9 +249,9 @@ TEST_F(HealthCheckFilterPassThroughTest, Ok) {
   EXPECT_CALL(callbacks_, encodeHeaders_(_, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
 
-  Http::TestResponseHeaderMapImpl service_hc_respnose{{":status", "200"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(service_hc_respnose, true));
-  EXPECT_EQ("cluster_name", service_hc_respnose.getEnvoyUpstreamHealthCheckedClusterValue());
+  Http::TestResponseHeaderMapImpl service_hc_response{{":status", "200"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(service_hc_response, true));
+  EXPECT_EQ("cluster_name", service_hc_response.getEnvoyUpstreamHealthCheckedClusterValue());
 }
 
 TEST_F(HealthCheckFilterPassThroughTest, OkWithContinue) {
@@ -268,9 +268,9 @@ TEST_F(HealthCheckFilterPassThroughTest, OkWithContinue) {
             filter_->encode100ContinueHeaders(continue_response));
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
   EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->encodeMetadata(metadata_map));
-  Http::TestResponseHeaderMapImpl service_hc_respnose{{":status", "200"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(service_hc_respnose, true));
-  EXPECT_EQ("cluster_name", service_hc_respnose.getEnvoyUpstreamHealthCheckedClusterValue());
+  Http::TestResponseHeaderMapImpl service_hc_response{{":status", "200"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(service_hc_response, true));
+  EXPECT_EQ("cluster_name", service_hc_response.getEnvoyUpstreamHealthCheckedClusterValue());
 }
 
 TEST_F(HealthCheckFilterPassThroughTest, Failed) {


### PR DESCRIPTION
Signed-off-by: Martin Matusiak <numerodix@gmail.com>

Commit Message: health_check filter & readme: fix typos
Additional Description:
Risk Level: Low
Testing: Re-ran //test/extensions/filters/http/health_check:*
Docs Changes: N/A
Release Notes: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
