### PR TITLE
Unroot docker examples and fix stdout permissions in container

### DIFF
--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -20,6 +20,8 @@ if [ "$ENVOY_UID" != "0" ]; then
     if [ -n "$ENVOY_GID" ]; then
 	groupmod -g "$ENVOY_GID" envoy
     fi
+    # Ensure the envoy user is able to write to container logs
+    chown envoy:envoy /dev/stdout /dev/stderr
     su-exec envoy "${@}"
 else
     exec "${@}"

--- a/docs/root/start/sandboxes/cors.rst
+++ b/docs/root/start/sandboxes/cors.rst
@@ -53,9 +53,9 @@ Terminal 1
   $ docker-compose ps
 
             Name                          Command              State                            Ports
-  ----------------------------------------------------------------------------------------------------------------------------
-  frontend_front-envoy_1        /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
-  frontend_frontend-service_1   /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
+  ------------------------------------------------------------------------------------------------------------------------------
+  frontend_front-envoy_1        /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
+  frontend_frontend-service_1   /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
 
 Terminal 2
 
@@ -67,9 +67,9 @@ Terminal 2
   $ docker-compose ps
 
             Name                         Command             State                            Ports
-  --------------------------------------------------------------------------------------------------------------------------
-  backend_backend-service_1   /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
-  backend_front-envoy_1       /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8002->80/tcp, 0.0.0.0:8003->8001/tcp
+  ----------------------------------------------------------------------------------------------------------------------------
+  backend_backend-service_1   /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
+  backend_front-envoy_1       /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8002->8000/tcp, 0.0.0.0:8003->8001/tcp
 
 **Step 3: Test Envoy's CORS capabilities**
 

--- a/docs/root/start/sandboxes/csrf.rst
+++ b/docs/root/start/sandboxes/csrf.rst
@@ -55,8 +55,8 @@ Terminal 1 (samesite)
 
             Name                        Command              State                            Ports
   ----------------------------------------------------------------------------------------------------------------------
-  samesite_front-envoy_1      /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
-  samesite_service_1          /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
+  samesite_front-envoy_1      /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
+  samesite_service_1          /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
 
 Terminal 2 (crosssite)
 
@@ -69,8 +69,8 @@ Terminal 2 (crosssite)
 
             Name                       Command                State                            Ports
   ----------------------------------------------------------------------------------------------------------------------
-  crosssite_front-envoy_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 0.0.0.0:8002->80/tcp, 0.0.0.0:8003->8001/tcp
-  crosssite_service_1          /docker-entrypoint.sh /bin ... Up      10000/tcp, 80/tcp
+  crosssite_front-envoy_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 0.0.0.0:8002->8000/tcp, 0.0.0.0:8003->8001/tcp
+  crosssite_service_1          /docker-entrypoint.sh /bin ... Up      10000/tcp, 8000/tcp
 
 **Step 3: Test Envoy's CSRF capabilities**
 

--- a/docs/root/start/sandboxes/front_proxy.rst
+++ b/docs/root/start/sandboxes/front_proxy.rst
@@ -15,7 +15,7 @@ Below you can see a graphic showing the docker compose deployment:
   :width: 100%
 
 All incoming requests are routed via the front Envoy, which is acting as a reverse proxy sitting on
-the edge of the ``envoymesh`` network. Port ``80`` is mapped to  port ``8000`` by docker compose
+the edge of the ``envoymesh`` network. Port ``8000`` is exposed by docker compose
 (see :repo:`/examples/front-proxy/docker-compose.yaml`). Moreover, notice
 that all  traffic routed by the front Envoy to the service containers is actually routed to the
 service Envoys (routes setup in :repo:`/examples/front-proxy/front-envoy.yaml`). In turn the service
@@ -49,9 +49,9 @@ or ``git clone https://github.com/envoyproxy/envoy.git``::
 
             Name                         Command             State                            Ports
   --------------------------------------------------------------------------------------------------------------------------
-  front-proxy_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
-  front-proxy_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
-  front-proxy_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
+  front-proxy_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
+  front-proxy_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
+  front-proxy_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
 
 **Step 3: Test Envoy's routing capabilities**
 
@@ -174,13 +174,13 @@ can use ``docker-compose exec <container_name> /bin/bash``. For example we can
 enter the ``front-envoy`` container, and ``curl`` for services locally::
 
   $ docker-compose exec front-envoy /bin/bash
-  root@81288499f9d7:/# curl localhost:80/service/1
+  root@81288499f9d7:/# curl localhost:8000/service/1
   Hello from behind Envoy (service 1)! hostname: 85ac151715c6 resolvedhostname: 172.19.0.3
-  root@81288499f9d7:/# curl localhost:80/service/1
+  root@81288499f9d7:/# curl localhost:8000/service/1
   Hello from behind Envoy (service 1)! hostname: 20da22cfc955 resolvedhostname: 172.19.0.5
-  root@81288499f9d7:/# curl localhost:80/service/1
+  root@81288499f9d7:/# curl localhost:8000/service/1
   Hello from behind Envoy (service 1)! hostname: f26027f1ce28 resolvedhostname: 172.19.0.6
-  root@81288499f9d7:/# curl localhost:80/service/2
+  root@81288499f9d7:/# curl localhost:8000/service/2
   Hello from behind Envoy (service 2)! hostname: 92f4a3737bbc resolvedhostname: 172.19.0.2
 
 **Step 6: enter containers and curl admin**
@@ -227,7 +227,7 @@ statistics. For example inside ``frontenvoy`` we can get::
     "uptime_current_epoch": "401s",
     "uptime_all_epochs": "401s"
   }
-  
+
 .. code-block:: text
 
   root@e654c2c83277:/# curl localhost:8001/stats

--- a/docs/root/start/sandboxes/jaeger_native_tracing.rst
+++ b/docs/root/start/sandboxes/jaeger_native_tracing.rst
@@ -21,7 +21,7 @@ The three containers will be deployed inside a virtual network called ``envoymes
 only works on x86-64).
 
 All incoming requests are routed via the front Envoy, which is acting as a reverse proxy
-sitting on the edge of the ``envoymesh`` network. Port ``80`` is mapped to  port ``8000``
+sitting on the edge of the ``envoymesh`` network. Port ``8000`` is exposed
 by docker compose (see :repo:`/examples/jaeger-native-tracing/docker-compose.yaml`). Notice that
 all Envoys are configured to collect request traces (e.g., http_connection_manager/config/tracing setup in
 :repo:`/examples/jaeger-native-tracing/front-envoy-jaeger.yaml`) and setup to propagate the spans generated
@@ -59,10 +59,10 @@ To build this sandbox example, and start the example apps run the following comm
 
                 Name                              Command                State                                                      Ports
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    jaeger-native-tracing_front-envoy_1   /start-front.sh                Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    jaeger-native-tracing_front-envoy_1   /start-front.sh                Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
     jaeger-native-tracing_jaeger_1        /go/bin/all-in-one-linux - ... Up      14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, 5775/udp, 5778/tcp, 6831/udp, 6832/udp, 0.0.0.0:9411->9411/tcp
-    jaeger-native-tracing_service1_1      /start-service.sh              Up      10000/tcp, 80/tcp
-    jaeger-native-tracing_service2_1      /start-service.sh              Up      10000/tcp, 80/tcp
+    jaeger-native-tracing_service1_1      /start-service.sh              Up      10000/tcp, 8000/tcp
+    jaeger-native-tracing_service2_1      /start-service.sh              Up      10000/tcp, 8000/tcp
 
 **Step 2: Generate some load**
 

--- a/docs/root/start/sandboxes/jaeger_tracing.rst
+++ b/docs/root/start/sandboxes/jaeger_tracing.rst
@@ -10,7 +10,7 @@ service1 makes an API call to service2 before returning a response.
 The three containers will be deployed inside a virtual network called ``envoymesh``.
 
 All incoming requests are routed via the front Envoy, which is acting as a reverse proxy
-sitting on the edge of the ``envoymesh`` network. Port ``80`` is mapped to  port ``8000``
+sitting on the edge of the ``envoymesh`` network. Port ``8000`` is exposed
 by docker compose (see :repo:`/examples/jaeger-tracing/docker-compose.yaml`). Notice that
 all Envoys are configured to collect request traces (e.g., http_connection_manager/config/tracing setup in
 :repo:`/examples/jaeger-tracing/front-envoy-jaeger.yaml`) and setup to propagate the spans generated
@@ -48,10 +48,10 @@ To build this sandbox example, and start the example apps run the following comm
 
                 Name                          Command             State                                                       Ports
     ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    jaeger-tracing_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+    jaeger-tracing_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
     jaeger-tracing_jaeger_1        /go/bin/all-in-one-linux - ... Up      14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, 5775/udp, 5778/tcp, 6831/udp, 6832/udp, 0.0.0.0:9411->9411/tcp
-    jaeger-tracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
-    jaeger-tracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
+    jaeger-tracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
+    jaeger-tracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
 
 **Step 2: Generate some load**
 

--- a/docs/root/start/sandboxes/lua.rst
+++ b/docs/root/start/sandboxes/lua.rst
@@ -37,7 +37,7 @@ Terminal 1
 
       Name                     Command               State                            Ports
   --------------------------------------------------------------------------------------------------------------------
-  lua_proxy_1         /docker-entrypoint.sh /bin       Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
+  lua_proxy_1         /docker-entrypoint.sh /bin       Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
   lua_web_service_1   node ./index.js                  Up      0.0.0.0:8080->80/tcp
 
 **Step 3: Send a request to the service**

--- a/docs/root/start/sandboxes/zipkin_tracing.rst
+++ b/docs/root/start/sandboxes/zipkin_tracing.rst
@@ -10,7 +10,7 @@ service1 makes an API call to service2 before returning a response.
 The three containers will be deployed inside a virtual network called ``envoymesh``.
 
 All incoming requests are routed via the front Envoy, which is acting as a reverse proxy
-sitting on the edge of the ``envoymesh`` network. Port ``80`` is mapped to  port ``8000``
+sitting on the edge of the ``envoymesh`` network. Port ``8000`` is exposed
 by docker compose (see :repo:`/examples/zipkin-tracing/docker-compose.yaml`). Notice that
 all Envoys are configured to collect request traces (e.g., http_connection_manager/config/tracing setup in
 :repo:`/examples/zipkin-tracing/front-envoy-zipkin.yaml`) and setup to propagate the spans generated
@@ -48,9 +48,9 @@ To build this sandbox example, and start the example apps run the following comm
 
                 Name                          Command             State                            Ports
     -----------------------------------------------------------------------------------------------------------------------------
-    zipkin-tracing_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->80/tcp, 0.0.0.0:8001->8001/tcp
-    zipkin-tracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
-    zipkin-tracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 80/tcp
+    zipkin-tracing_front-envoy_1   /docker-entrypoint.sh /bin ... Up      10000/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8001->8001/tcp
+    zipkin-tracing_service1_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
+    zipkin-tracing_service2_1      /bin/sh -c /usr/local/bin/ ... Up      10000/tcp, 8000/tcp
     zipkin-tracing_zipkin_1        /busybox/sh run.sh             Up      9410/tcp, 0.0.0.0:9411->9411/tcp
 
 **Step 2: Generate some load**

--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -148,6 +148,18 @@ by using a volume.
       volumes:
         - ./envoy.yaml:/etc/envoy/envoy.yaml
 
+By default the Docker image will run as the ``envoy`` user created at build time.
+
+The ``uid`` and ``gid`` of this user can be set at runtime using the ``ENVOY_UID`` and ``ENVOY_GID``
+environment variables. This can be done, for example, on the Docker command line:
+
+  $ docker run -d --name envoy -e ENVOY_UID=777 -e ENVOY_GID=777 -p 9901:9901 -p 10000:10000 envoy:v1
+
+This can be useful if you wish to restrict or provide access to ``unix`` sockets inside the container, or
+for controlling access to an ``envoy`` socket from outside of the container.
+
+If you wish to run the container as the ``root`` user you can set ``ENVOY_UID`` to ``0``.
+
 
 Sandboxes
 ---------

--- a/examples/cors/backend/docker-compose.yaml
+++ b/examples/cors/backend/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8002:80"
+      - "8002:8000"
       - "8003:8001"
 
   backend-service:
@@ -27,7 +27,7 @@ services:
         aliases:
           - backendservice
     expose:
-      - "80"
+      - "8000"
 
 networks:
   envoymesh: {}

--- a/examples/cors/backend/front-envoy.yaml
+++ b/examples/cors/backend/front-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -85,7 +85,7 @@ static_resources:
             address:
               socket_address:
                 address: backendservice
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/cors/backend/service-envoy.yaml
+++ b/examples/cors/backend/service-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/examples/cors/frontend/docker-compose.yaml
+++ b/examples/cors/frontend/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
 
   frontend-service:
@@ -27,7 +27,7 @@ services:
         aliases:
           - frontendservice
     expose:
-      - "80"
+      - "8000"
 
 networks:
   envoymesh: {}

--- a/examples/cors/frontend/front-envoy.yaml
+++ b/examples/cors/frontend/front-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -46,7 +46,7 @@ static_resources:
             address:
               socket_address:
                 address: frontendservice
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/cors/frontend/service-envoy.yaml
+++ b/examples/cors/frontend/service-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/examples/csrf/crosssite/docker-compose.yml
+++ b/examples/csrf/crosssite/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8002:80"
+      - "8002:8000"
       - "8003:8001"
 
   service:
@@ -27,7 +27,7 @@ services:
         aliases:
           - service
     expose:
-      - "80"
+      - "8000"
 
 networks:
   envoymesh: {}

--- a/examples/csrf/crosssite/front-envoy.yaml
+++ b/examples/csrf/crosssite/front-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -44,7 +44,7 @@ static_resources:
             address:
               socket_address:
                 address: service
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/csrf/samesite/docker-compose.yml
+++ b/examples/csrf/samesite/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
 
   service:
@@ -27,7 +27,7 @@ services:
         aliases:
           - service
     expose:
-      - "80"
+      - "8000"
 
 networks:
   envoymesh: {}

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -107,7 +107,7 @@ static_resources:
             address:
               socket_address:
                 address: service
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/csrf/service-envoy.yaml
+++ b/examples/csrf/service-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/examples/fault-injection/docker-compose.yaml
+++ b/examples/fault-injection/docker-compose.yaml
@@ -13,9 +13,6 @@ services:
     ports:
       - 9211:9211
       - 9901:9901
-    # Run Envoy as root to grant access to /dev/stdout
-    environment:
-      ENVOY_UID: 0
   backend:
     image: kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
     networks:

--- a/examples/front-proxy/docker-compose.yaml
+++ b/examples/front-proxy/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
 
   service1:
@@ -29,7 +29,7 @@ services:
     environment:
       - SERVICE_NAME=1
     expose:
-      - "80"
+      - "8000"
 
   service2:
     build:
@@ -44,7 +44,7 @@ services:
     environment:
       - SERVICE_NAME=2
     expose:
-      - "80"
+      - "8000"
 
 networks:
   envoymesh: {}

--- a/examples/front-proxy/front-envoy.yaml
+++ b/examples/front-proxy/front-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -43,7 +43,7 @@ static_resources:
             address:
               socket_address:
                 address: service1
-                port_value: 80
+                port_value: 8000
   - name: service2
     connect_timeout: 0.25s
     type: strict_dns
@@ -57,7 +57,7 @@ static_resources:
             address:
               socket_address:
                 address: service2
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/front-proxy/service-envoy.yaml
+++ b/examples/front-proxy/service-envoy.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/examples/jaeger-native-tracing/docker-compose.yaml
+++ b/examples/jaeger-native-tracing/docker-compose.yaml
@@ -13,10 +13,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
     dns:
       - 8.8.8.8
@@ -38,7 +38,7 @@ services:
     environment:
       - SERVICE_NAME=1
     expose:
-      - "80"
+      - "8000"
     dns:
       - 8.8.8.8
       - 8.8.4.4
@@ -59,7 +59,7 @@ services:
     environment:
       - SERVICE_NAME=2
     expose:
-      - "80"
+      - "8000"
     dns:
       - 8.8.8.8
       - 8.8.4.4

--- a/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
@@ -64,7 +64,7 @@ static_resources:
             address:
               socket_address:
                 address: service1
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: INBOUND
     filter_chains:
     - filters:
@@ -103,7 +103,7 @@ static_resources:
             address:
               socket_address:
                 address: service2
-                port_value: 80
+                port_value: 8000
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: INBOUND
     filter_chains:
     - filters:

--- a/examples/jaeger-tracing/docker-compose.yaml
+++ b/examples/jaeger-tracing/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
 
   service1:
@@ -29,7 +29,7 @@ services:
     environment:
       - SERVICE_NAME=1
     expose:
-      - "80"
+      - "8000"
 
   service2:
     build:
@@ -44,7 +44,7 @@ services:
     environment:
       - SERVICE_NAME=2
     expose:
-      - "80"
+      - "8000"
 
   jaeger:
     image: jaegertracing/all-in-one

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
@@ -53,7 +53,7 @@ static_resources:
             address:
               socket_address:
                 address: service1
-                port_value: 80
+                port_value: 8000
   - name: jaeger
     connect_timeout: 1s
     type: strict_dns

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: INBOUND
     filter_chains:
     - filters:
@@ -101,7 +101,7 @@ static_resources:
             address:
               socket_address:
                 address: service2
-                port_value: 80
+                port_value: 8000
   - name: jaeger
     connect_timeout: 1s
     type: strict_dns

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: INBOUND
     filter_chains:
     - filters:

--- a/examples/load-reporting-service/docker-compose.yaml
+++ b/examples/load-reporting-service/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile-http-server
     volumes:
       - ./service-envoy-w-lrs.yaml:/etc/service-envoy-w-lrs.yaml
+    environment:
+      ENVOY_UID: 0
     networks:
       envoymesh:
         aliases:
@@ -17,7 +19,7 @@ services:
     ports:
       - "80-81:80"
       - "8081-8082:8081"
-      
+
   lrs_server:
     build:
       context: .
@@ -32,6 +34,6 @@ services:
       - "18000"
     ports:
       - "18000:18000"
-    
+
 networks:
   envoymesh: {}

--- a/examples/lua/docker-compose.yaml
+++ b/examples/lua/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
 
   web_service:

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -4,7 +4,7 @@ static_resources:
     address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -21,7 +21,7 @@ static_resources:
               routes:
               - match:
                   prefix: "/"
-                route: 
+                route:
                   cluster: web_service
           http_filters:
           - name: envoy.filters.http.lua
@@ -29,7 +29,7 @@ static_resources:
               "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
               inline_code: |
                 local mylibrary = require("lib.mylibrary")
-              
+
                 function envoy_on_request(request_handle)
                   request_handle:headers():add("foo", mylibrary.foobar())
                 end

--- a/examples/zipkin-tracing/docker-compose.yaml
+++ b/examples/zipkin-tracing/docker-compose.yaml
@@ -10,10 +10,10 @@ services:
     networks:
       - envoymesh
     expose:
-      - "80"
+      - "8000"
       - "8001"
     ports:
-      - "8000:80"
+      - "8000:8000"
       - "8001:8001"
 
   service1:
@@ -29,7 +29,7 @@ services:
     environment:
       - SERVICE_NAME=1
     expose:
-      - "80"
+      - "8000"
 
   service2:
     build:
@@ -44,7 +44,7 @@ services:
     environment:
       - SERVICE_NAME=2
     expose:
-      - "80"
+      - "8000"
 
   zipkin:
     image: openzipkin/zipkin

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: OUTBOUND
     filter_chains:
     - filters:
@@ -58,7 +58,7 @@ static_resources:
             address:
               socket_address:
                 address: service1
-                port_value: 80
+                port_value: 8000
   - name: zipkin
     connect_timeout: 1s
     type: strict_dns

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: INBOUND
     filter_chains:
     - filters:
@@ -99,7 +99,7 @@ static_resources:
             address:
               socket_address:
                 address: service2
-                port_value: 80
+                port_value: 8000
   - name: zipkin
     connect_timeout: 1s
     type: strict_dns

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -3,7 +3,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     traffic_direction: INBOUND
     filter_chains:
     - filters:


### PR DESCRIPTION
Commit Message: Update examples to use non-well known ports and not the root user
Additional Description:
I have updated `80` -> `8000` for any ports I could see that were exposed by an `envoy` container.

I left one example (`load-reporting-service`) using port `80` and instead added the `ENVOY_UID` env var

Some docs (eg `docs/root/start/sandboxes`) that have port `80` coded in relation to these examples, have been updated

Also adds fix for `envoy` permissions on `/dev/stdout` and `/dev/stderr`

Risk Level: Low
Testing: Manual testing
Docs Changes: 
- Sandbox examples updated to reflect port changes 
- Note added about `uid/gid` of container user

Release Notes: N/A
Fix #11506 
Fix #11551 