### PR TITLE
Subject: updating cel-cpp version used

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -425,10 +425,10 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     com_google_cel_cpp = dict(
-        sha256 = "326ec397b55e39f48bd5380ccded1af5b04653ee96e769cd4d694f9a3bacef50",
-        strip_prefix = "cel-cpp-80e1cca533190d537a780ad007e8db64164c582e",
-        # 2020-02-26
-        urls = ["https://github.com/google/cel-cpp/archive/80e1cca533190d537a780ad007e8db64164c582e.tar.gz"],
+        sha256 = "1b283f93619b130504880d2f400bd449de9ab6be94ef26ecd2bb96921f48dd6c",
+        strip_prefix = "cel-cpp-50196761917300bbd47b59bd162e84817b67b7ab",
+        # 2020-06-08
+        urls = ["https://github.com/google/cel-cpp/archive/50196761917300bbd47b59bd162e84817b67b7ab.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -62,7 +62,7 @@ ExpressionPtr createExpression(Builder& builder, const google::api::expr::v1alph
     throw CelException(
         absl::StrCat("failed to create an expression: ", cel_expression_status.status().message()));
   }
-  return std::move(cel_expression_status.ValueOrDie());
+  return std::move(cel_expression_status.value());
 }
 
 absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena* arena,
@@ -76,7 +76,7 @@ absl::optional<CelValue> evaluate(const Expression& expr, Protobuf::Arena* arena
     return {};
   }
 
-  return eval_status.ValueOrDie();
+  return eval_status.value();
 }
 
 bool matches(const Expression& expr, const StreamInfo::StreamInfo& info,


### PR DESCRIPTION
This is a prerequisite for porting envoy to c++17 as c++17
forbids the initialization of absl::string_view() with nullptr.
The most recent patch of cel-cpp master fixes an instance of this
issue.

Signed-off-by: Yifan Yang <needyyang@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level: Should be minimum as it just changes the version of an external dependency repo and all existing tests have been passed.
Testing: No new test should be needed.
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
