### PR TITLE
ci: disable Windows builds.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -122,23 +122,3 @@ jobs:
           testResultsFiles: "**/bazel-testlogs/**/test.xml"
           testRunTitle: "macOS"
         condition: always()
-
-  - job: Windows
-    dependsOn: ["format"]
-    timeoutInMinutes: 360
-    pool:
-      vmImage: "windows-latest"
-    steps:
-      - powershell: |
-          .\ci\windows_ci_setup.ps1
-          Write-Host "##vso[task.prependpath]$env:TOOLS_BIN_DIR"
-        displayName: "Install dependencies"
-        env:
-          TOOLS_BIN_DIR: $(Pipeline.Workspace)\bin
-
-      - bash: ci/windows_ci_steps.sh
-        displayName: "Run Windows CI"
-        env:
-          TMPDIR: $(Agent.TempDirectory)
-          BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC"
-          BAZEL_SH: "C:\\Program Files\\Git\\bin\\bash.exe"


### PR DESCRIPTION
Windows is not supported in v1.14.x releases.

Fixes #11519.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>