### PR TITLE
conn_pool: unifying cancellation between http and TCP

### DIFF
--- a/include/envoy/common/conn_pool.h
+++ b/include/envoy/common/conn_pool.h
@@ -1,7 +1,38 @@
 #pragma once
 
+#include "envoy/common/pure.h"
+
 namespace Envoy {
 namespace ConnectionPool {
+
+/**
+ * Controls the behavior of a canceled request.
+ */
+enum class CancelPolicy {
+  // By default, canceled requests allow a pending connection to complete and become
+  // available for a future request.
+  Default,
+  // When a request is canceled, closes a pending connection if there will still be sufficient
+  // connections to serve pending requests. CloseExcess is largely useful for callers that never
+  // re-use connections (e.g. by closing rather than releasing connections). Using CloseExcess in
+  // this situation guarantees that no idle connections will be held open by the conn pool awaiting
+  // a connection request.
+  CloseExcess,
+};
+
+/**
+ * Handle that allows a pending connection or stream request to be canceled before it is completed.
+ */
+class Cancellable {
+public:
+  virtual ~Cancellable() = default;
+
+  /**
+   * Cancel the pending connection or stream request.
+   * @param cancel_policy a CancelPolicy that controls the behavior of this cancellation.
+   */
+  virtual void cancel(CancelPolicy cancel_policy) PURE;
+};
 
 enum class PoolFailureReason {
   // A resource overflowed and policy prevented a new connection from being created.

--- a/include/envoy/http/conn_pool.h
+++ b/include/envoy/http/conn_pool.h
@@ -13,20 +13,8 @@ namespace Envoy {
 namespace Http {
 namespace ConnectionPool {
 
-/**
- * Handle that allows a pending request to be cancelled before it is bound to a connection.
- */
-class Cancellable {
-public:
-  virtual ~Cancellable() = default;
-
-  /**
-   * Cancel the pending request.
-   */
-  virtual void cancel() PURE;
-};
-
 using PoolFailureReason = ::Envoy::ConnectionPool::PoolFailureReason;
+using Cancellable = ::Envoy::ConnectionPool::Cancellable;
 
 /**
  * Pool callbacks invoked in the context of a newStream() call, either synchronously or

--- a/include/envoy/tcp/conn_pool.h
+++ b/include/envoy/tcp/conn_pool.h
@@ -13,36 +13,6 @@ namespace Envoy {
 namespace Tcp {
 namespace ConnectionPool {
 
-/**
- * Controls the behavior of a canceled connection request.
- */
-enum class CancelPolicy {
-  // By default, canceled connection requests allow a pending connection to complete and become
-  // available for a future connection request.
-  Default,
-  // When a connection request is canceled, closes a pending connection if there are more pending
-  // connections than pending connection requests. CloseExcess is useful for callers that never
-  // re-use connections (e.g. by closing rather than releasing connections). Using CloseExcess in
-  // this situation guarantees that no idle connections will be held open by the conn pool awaiting
-  // a connection request.
-  CloseExcess,
-};
-
-/**
- * Handle that allows a pending connection request to be canceled before it is completed.
- */
-class Cancellable {
-public:
-  virtual ~Cancellable() = default;
-
-  /**
-   * Cancel the pending connection request.
-   * @param cancel_policy a CancelPolicy that controls the behavior of this connection request
-   *        cancellation.
-   */
-  virtual void cancel(CancelPolicy cancel_policy) PURE;
-};
-
 /*
  * UpstreamCallbacks for connection pool upstream connection callbacks and data. Note that
  * onEvent(Connected) is never triggered since the event always occurs before a ConnectionPool
@@ -119,6 +89,8 @@ protected:
 
 using ConnectionDataPtr = std::unique_ptr<ConnectionData>;
 using PoolFailureReason = ::Envoy::ConnectionPool::PoolFailureReason;
+using Cancellable = ::Envoy::ConnectionPool::Cancellable;
+using CancelPolicy = ::Envoy::ConnectionPool::CancelPolicy;
 
 /**
  * Pool callbacks invoked in the context of a newConnection() call, either synchronously or

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -372,9 +372,9 @@ void ConnPoolImplBase::onPendingRequestCancel(PendingRequest& request,
     request.removeFromList(pending_requests_);
   }
   // There's excess capacity if
-  // pending_requests < connecting_request_capacity_ - capacity of most recent client
-  // It's calculated below with addition instead to avoid underflow issues (overflow being
-  // assumed to not be a problem across the connection pool)
+  // pending_requests < connecting_request_capacity_ - capacity of most recent client.
+  // It's calculated below with addition instead to avoid underflow issues, overflow being
+  // assumed to not be a problem across the connection pool.
   if (policy == Envoy::ConnectionPool::CancelPolicy::CloseExcess && !connecting_clients_.empty() &&
       (pending_requests_.size() + connecting_clients_.front()->effectiveConcurrentRequestLimit() <=
        connecting_request_capacity_)) {

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -371,8 +371,7 @@ void ConnPoolImplBase::onPendingRequestCancel(PendingRequest& request,
   } else {
     request.removeFromList(pending_requests_);
   }
-  if (policy == Envoy::ConnectionPool::CancelPolicy::CloseExcess &&
-      connecting_clients_.size() != 0 &&
+  if (policy == Envoy::ConnectionPool::CancelPolicy::CloseExcess && !connecting_clients_.empty() &&
       pending_requests_.size() + connecting_clients_.front()->effectiveConcurrentRequestLimit() <=
           connecting_request_capacity_) {
     connecting_clients_.front()->close();

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -15,10 +15,11 @@ ConnPoolImplBase::ConnPoolImplBase(
 ConnPoolImplBase::~ConnPoolImplBase() {
   ASSERT(ready_clients_.empty());
   ASSERT(busy_clients_.empty());
+  ASSERT(connecting_clients_.empty());
 }
 
 void ConnPoolImplBase::destructAllConnections() {
-  for (auto* list : {&ready_clients_, &busy_clients_}) {
+  for (auto* list : {&ready_clients_, &busy_clients_, &connecting_clients_}) {
     while (!list->empty()) {
       list->front()->close();
     }
@@ -43,7 +44,8 @@ void ConnPoolImplBase::tryCreateNewConnection() {
   // If we are at the connection circuit-breaker limit due to other upstreams having
   // too many open connections, and this upstream has no connections, always create one, to
   // prevent pending requests being queued to this upstream with no way to be processed.
-  if (can_create_connection || (ready_clients_.empty() && busy_clients_.empty())) {
+  if (can_create_connection ||
+      (ready_clients_.empty() && busy_clients_.empty() && connecting_clients_.empty())) {
     ENVOY_LOG(debug, "creating a new connection");
     ActiveClientPtr client = instantiateActiveClient();
     ASSERT(client->state_ == ActiveClient::State::CONNECTING);
@@ -156,7 +158,7 @@ std::list<ConnPoolImplBase::ActiveClientPtr>&
 ConnPoolImplBase::owningList(ActiveClient::State state) {
   switch (state) {
   case ActiveClient::State::CONNECTING:
-    return busy_clients_;
+    return connecting_clients_;
   case ActiveClient::State::READY:
     return ready_clients_;
   case ActiveClient::State::BUSY:
@@ -201,10 +203,8 @@ void ConnPoolImplBase::closeIdleConnections() {
   }
 
   if (pending_requests_.empty()) {
-    for (auto& client : busy_clients_) {
-      if (client->state_ == ActiveClient::State::CONNECTING) {
-        to_close.push_back(client.get());
-      }
+    for (auto& client : connecting_clients_) {
+      to_close.push_back(client.get());
     }
   }
 
@@ -227,12 +227,7 @@ void ConnPoolImplBase::drainConnections() {
   // so use a for-loop since the list is not mutated.
   ASSERT(&owningList(ActiveClient::State::DRAINING) == &busy_clients_);
   for (auto& busy_client : busy_clients_) {
-    // Moving a CONNECTING client to DRAINING would violate state assumptions, namely that DRAINING
-    // connections have active requests (otherwise they would be closed) and that clients receiving
-    // a Connected event are in state CONNECTING.
-    if (busy_client->state_ != ActiveClient::State::CONNECTING) {
-      transitionActiveClientState(*busy_client, ActiveClient::State::DRAINING);
-    }
+    transitionActiveClientState(*busy_client, ActiveClient::State::DRAINING);
   }
 }
 
@@ -243,7 +238,8 @@ void ConnPoolImplBase::checkForDrained() {
 
   closeIdleConnections();
 
-  if (pending_requests_.empty() && ready_clients_.empty() && busy_clients_.empty()) {
+  if (pending_requests_.empty() && ready_clients_.empty() && busy_clients_.empty() &&
+      connecting_clients_.empty()) {
     ENVOY_LOG(debug, "invoking drained callbacks");
     for (const DrainedCb& cb : drained_callbacks_) {
       cb();
@@ -363,7 +359,8 @@ void ConnPoolImplBase::purgePendingRequests(
   }
 }
 
-void ConnPoolImplBase::onPendingRequestCancel(PendingRequest& request) {
+void ConnPoolImplBase::onPendingRequestCancel(PendingRequest& request,
+                                              Envoy::ConnectionPool::CancelPolicy policy) {
   ENVOY_LOG(debug, "cancelling pending request");
   if (!pending_requests_to_purge_.empty()) {
     // If pending_requests_to_purge_ is not empty, it means that we are called from
@@ -373,6 +370,12 @@ void ConnPoolImplBase::onPendingRequestCancel(PendingRequest& request) {
     request.removeFromList(pending_requests_to_purge_);
   } else {
     request.removeFromList(pending_requests_);
+  }
+  if (policy == Envoy::ConnectionPool::CancelPolicy::CloseExcess &&
+      connecting_clients_.size() != 0 &&
+      pending_requests_.size() + connecting_clients_.front()->effectiveConcurrentRequestLimit() <=
+          connecting_request_capacity_) {
+    connecting_clients_.front()->close();
   }
 
   host_->cluster().stats().upstream_rq_cancelled_.inc();

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -541,7 +541,7 @@ void TcpConnPool::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data
 
 bool HttpConnPool::cancelAnyPendingRequest() {
   if (conn_pool_stream_handle_) {
-    conn_pool_stream_handle_->cancel();
+    conn_pool_stream_handle_->cancel(Tcp::ConnectionPool::CancelPolicy::Default);
     conn_pool_stream_handle_ = nullptr;
     return true;
   }

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -247,7 +247,7 @@ public:
 
   bool cancelAnyPendingRequest() override {
     if (upstream_handle_) {
-      upstream_handle_->cancel(Tcp::ConnectionPool::CancelPolicy::Default);
+      upstream_handle_->cancel(ConnectionPool::CancelPolicy::Default);
       upstream_handle_ = nullptr;
       return true;
     }

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -33,7 +33,9 @@ private:
 class HttpConnectionHandle : public ConnectionHandle {
 public:
   HttpConnectionHandle(Http::ConnectionPool::Cancellable* handle) : upstream_http_handle_(handle) {}
-  void cancel() override { upstream_http_handle_->cancel(); }
+  void cancel() override {
+    upstream_http_handle_->cancel(Tcp::ConnectionPool::CancelPolicy::Default);
+  }
 
 private:
   Http::ConnectionPool::Cancellable* upstream_http_handle_{};

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -520,8 +520,9 @@ TEST_F(Http1ConnPoolImplTest, CancelExcessBeforeBound) {
   EXPECT_NE(nullptr, handle);
 
   handle->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
-  // Unlike CancelBeforeBound there is no need to clean up the connection as the
-  // cancel closes it.
+  // Unlike CancelBeforeBound there is no need to raise a close event to destroy the connection.
+  EXPECT_CALL(conn_pool_, onClientDestroy());
+  dispatcher_.clearDeferredDeleteList();
 }
 
 /**

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -297,7 +297,7 @@ TEST_F(Http1ConnPoolImplTest, VerifyCancelInCallback) {
   EXPECT_CALL(callbacks1.pool_failure_, ready()).Times(0);
   ConnPoolCallbacks callbacks2;
   EXPECT_CALL(callbacks2.pool_failure_, ready()).WillOnce(Invoke([&]() -> void {
-    handle1->cancel();
+    handle1->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   }));
 
   NiceMock<MockResponseDecoder> outer_decoder;
@@ -362,7 +362,7 @@ TEST_F(Http1ConnPoolImplTest, MaxPendingRequests) {
 
   EXPECT_EQ(1U, cluster_->circuit_breakers_stats_.rq_pending_open_.value());
 
-  handle->cancel();
+  handle->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -497,13 +497,31 @@ TEST_F(Http1ConnPoolImplTest, CancelBeforeBound) {
   Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder, callbacks);
   EXPECT_NE(nullptr, handle);
 
-  handle->cancel();
+  handle->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   // Cause the connection to go away.
   EXPECT_CALL(conn_pool_, onClientDestroy());
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Test cancelling with CloseExcess
+ */
+TEST_F(Http1ConnPoolImplTest, CancelExcessBeforeBound) {
+  InSequence s;
+
+  // Request 1 should kick off a new connection.
+  NiceMock<MockResponseDecoder> outer_decoder;
+  ConnPoolCallbacks callbacks;
+  conn_pool_.expectClientCreate();
+  Http::ConnectionPool::Cancellable* handle = conn_pool_.newStream(outer_decoder, callbacks);
+  EXPECT_NE(nullptr, handle);
+
+  handle->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  // Unlike CancelBeforeBound there is no need to clean up the connection as the
+  // cancel closes it.
 }
 
 /**
@@ -919,7 +937,7 @@ TEST_F(Http1ConnPoolImplTest, DrainCallback) {
 
   ActiveTestRequest r1(*this, 0, ActiveTestRequest::Type::CreateConnection);
   ActiveTestRequest r2(*this, 0, ActiveTestRequest::Type::Pending);
-  r2.handle_->cancel();
+  r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_EQ(1U, cluster_->stats_.upstream_rq_total_.value());
 
   EXPECT_CALL(drained, ready());
@@ -945,7 +963,7 @@ TEST_F(Http1ConnPoolImplTest, DrainWhileConnecting) {
   EXPECT_CALL(*conn_pool_.test_clients_[0].connection_,
               close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(drained, ready());
-  handle->cancel();
+  handle->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
   dispatcher_.clearDeferredDeleteList();
@@ -1030,7 +1048,7 @@ TEST_F(Http1ConnPoolImplTest, PendingRequestIsConsideredActive) {
   EXPECT_TRUE(conn_pool_.hasActiveConnections());
 
   EXPECT_CALL(conn_pool_, onClientDestroy());
-  r1.handle_->cancel();
+  r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_EQ(0U, cluster_->stats_.upstream_rq_total_.value());
   conn_pool_.drainConnections();
   conn_pool_.test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -20,7 +20,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::AnyNumber;
 using testing::DoAll;
 using testing::InSequence;
 using testing::Invoke;

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -288,9 +288,25 @@ TEST_F(Http2ConnPoolImplTest, DrainConnectionConnecting) {
   pool_.drainConnections();
 
   // Cancel the pending request, and then the connection can be closed.
-  r.handle_->cancel();
+  r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::Default);
   EXPECT_CALL(*this, onClientDestroy());
   pool_.drainConnections();
+}
+
+/**
+ * Verify that on CloseExcess, the connection is destroyed immediately.
+ */
+TEST_F(Http2ConnPoolImplTest, CloseExcess) {
+  InSequence s;
+
+  expectClientCreate();
+  ActiveTestRequest r(*this, 0, false);
+
+  // Pending request prevents the connection from being drained
+  pool_.drainConnections();
+
+  EXPECT_CALL(*this, onClientDestroy());
+  r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
 }
 
 /**

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -20,6 +20,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::AnyNumber;
 using testing::DoAll;
 using testing::InSequence;
 using testing::Invoke;
@@ -307,6 +308,131 @@ TEST_F(Http2ConnPoolImplTest, CloseExcess) {
 
   EXPECT_CALL(*this, onClientDestroy());
   r.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+}
+
+/**
+ * Verify that on CloseExcess connections are destroyed when they can be.
+ */
+TEST_F(Http2ConnPoolImplTest, CloseExcessTwo) {
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
+  InSequence s;
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  expectClientCreate();
+  ActiveTestRequest r2(*this, 0, false);
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+}
+
+/**
+ * Verify that on CloseExcess, the connections are destroyed iff they are actually excess.
+ */
+TEST_F(Http2ConnPoolImplTest, CloseExcessMultipleRequests) {
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(3);
+  InSequence s;
+
+  // With 3 requests per connection, the first request will result in a client
+  // connection, and the next two will be queued for that connection.
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  ActiveTestRequest r2(*this, 0, false);
+  ActiveTestRequest r3(*this, 0, false);
+
+  // The fourth request will kick off a second connection, and the fifth will plan to share it.
+  expectClientCreate();
+  ActiveTestRequest r4(*this, 0, false);
+  ActiveTestRequest r5(*this, 0, false);
+
+  // The section below cancels the active requests in fairly random order, to
+  // ensure there's no association between the requests and the clients created
+  // for them.
+
+  // The first cancel will not destroy any clients, as there are still four pending
+  // requests and they can not all share the first connection.
+  {
+    EXPECT_CALL(*this, onClientDestroy()).Times(0);
+    r5.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+  // The second cancel will destroy one client, as there will be three pending requests
+  // remaining, and they only need one connection.
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+
+  // The next two calls will not destroy the final client, as there are two other
+  // pending requests waiting on it.
+  {
+    EXPECT_CALL(*this, onClientDestroy()).Times(0);
+    r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+    r4.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+  // Finally with the last request gone, the final client is destroyed.
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r3.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+}
+
+TEST_F(Http2ConnPoolImplTest, CloseExcessMixedMultiplexing) {
+  InSequence s;
+
+  // Create clients with in-order capacity:
+  // 3  2  6
+  // connection capacity is min(max requests per connection, max concurrent streams)
+  // Use maxRequestsPerConnection here since max requests is tested above.
+  EXPECT_CALL(*cluster_, maxRequestsPerConnection).WillOnce(Return(3));
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  ActiveTestRequest r2(*this, 0, false);
+  ActiveTestRequest r3(*this, 0, false);
+
+  EXPECT_CALL(*cluster_, maxRequestsPerConnection).WillOnce(Return(2));
+  expectClientCreate();
+  ActiveTestRequest r4(*this, 0, false);
+  ActiveTestRequest r5(*this, 0, false);
+
+  EXPECT_CALL(*cluster_, maxRequestsPerConnection).WillOnce(Return(3));
+  expectClientCreate();
+  ActiveTestRequest r6(*this, 0, false);
+
+  // 6 requests, capacity [3, 2, 6] - the first cancel should tear down the client with [3]
+  // since we destroy oldest first and [3, 2] can handle the remaining 5 requests.
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+
+  // 5 requests, capacity [3, 2] - no teardown
+  {
+    EXPECT_CALL(*this, onClientDestroy()).Times(0);
+    r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+  // 4 requests, capacity [3, 2] - canceling one detroys the client with [2]
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r3.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+
+  // 3 requests, capacity [3]. Tear down the last channel when all 3 are canceled.
+  {
+    EXPECT_CALL(*this, onClientDestroy()).Times(0);
+    r4.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+    r5.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
+  {
+    EXPECT_CALL(*this, onClientDestroy());
+    r6.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  }
 }
 
 /**

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -417,7 +417,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcessMixedMultiplexing) {
     EXPECT_CALL(*this, onClientDestroy()).Times(0);
     r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   }
-  // 4 requests, capacity [3, 2] - canceling one detroys the client with [2]
+  // 4 requests, capacity [3, 2] - canceling one destroys the client with [2]
   {
     EXPECT_CALL(*this, onClientDestroy());
     r3.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -388,7 +388,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcessMixedMultiplexing) {
 
   // Create clients with in-order capacity:
   // 3  2  6
-  // connection capacity is min(max requests per connection, max concurrent streams)
+  // Connection capacity is min(max requests per connection, max concurrent streams).
   // Use maxRequestsPerConnection here since max requests is tested above.
   EXPECT_CALL(*cluster_, maxRequestsPerConnection).WillOnce(Return(3));
   expectClientCreate();
@@ -401,7 +401,7 @@ TEST_F(Http2ConnPoolImplTest, CloseExcessMixedMultiplexing) {
   ActiveTestRequest r4(*this, 0, false);
   ActiveTestRequest r5(*this, 0, false);
 
-  EXPECT_CALL(*cluster_, maxRequestsPerConnection).WillOnce(Return(3));
+  EXPECT_CALL(*cluster_, maxRequestsPerConnection).WillOnce(Return(6));
   expectClientCreate();
   ActiveTestRequest r6(*this, 0, false);
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -207,7 +207,7 @@ public:
     router_.decodeHeaders(headers, true);
 
     // When the router filter gets reset we should cancel the pool request.
-    EXPECT_CALL(cancellable_, cancel());
+    EXPECT_CALL(cancellable_, cancel(_));
     router_.onDestroy();
   }
 
@@ -228,7 +228,7 @@ public:
     EXPECT_EQ(expected_count, atoi(std::string(headers.getEnvoyAttemptCountValue()).c_str()));
 
     // When the router filter gets reset we should cancel the pool request.
-    EXPECT_CALL(cancellable_, cancel());
+    EXPECT_CALL(cancellable_, cancel(_));
     router_.onDestroy();
     EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
     EXPECT_EQ(0U,
@@ -351,7 +351,7 @@ public:
   NiceMock<Upstream::MockClusterManager> cm_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Runtime::MockRandomGenerator> random_;
-  Http::ConnectionPool::MockCancellable cancellable_;
+  Envoy::ConnectionPool::MockCancellable cancellable_;
   Http::ContextImpl http_context_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
   MockShadowWriter* shadow_writer_;
@@ -409,7 +409,7 @@ TEST_F(RouterTest, UpdateServerNameFilterState) {
             stream_info.filterState()
                 ->getDataReadOnly<Network::UpstreamServerName>(Network::UpstreamServerName::key())
                 .value());
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -437,7 +437,7 @@ TEST_F(RouterTest, UpdateSubjectAltNamesFilterState) {
                         ->getDataReadOnly<Network::UpstreamSubjectAltNames>(
                             Network::UpstreamSubjectAltNames::key())
                         .value()[0]);
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -522,7 +522,7 @@ TEST_F(RouterTest, Http1Upstream) {
   EXPECT_EQ("10", headers.get_("x-envoy-expected-rq-timeout-ms"));
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -547,7 +547,7 @@ TEST_F(RouterTestSuppressEnvoyHeaders, Http1Upstream) {
   EXPECT_FALSE(headers.has("x-envoy-expected-rq-timeout-ms"));
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -568,7 +568,7 @@ TEST_F(RouterTest, Http2Upstream) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -595,7 +595,7 @@ TEST_F(RouterTest, HashPolicy) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -622,7 +622,7 @@ TEST_F(RouterTest, HashPolicyNoHash) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -818,7 +818,7 @@ TEST_F(RouterTest, MetadataMatchCriteria) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
 }
 
@@ -847,7 +847,7 @@ TEST_F(RouterTest, NoMetadataMatchCriteria) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
 }
 
@@ -860,7 +860,7 @@ TEST_F(RouterTest, CancelBeforeBoundToPool) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
@@ -4068,7 +4068,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHost) {
   response_decoder->decodeHeaders(std::move(response_headers1), true);
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
 
-  Http::ConnectionPool::MockCancellable cancellable;
+  Envoy::ConnectionPool::MockCancellable cancellable;
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](Http::ResponseDecoder& decoder,
                            Http::ConnectionPool::Callbacks&) -> Http::ConnectionPool::Cancellable* {
@@ -4078,7 +4078,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHost) {
   router_.retry_state_->callback_();
 
   // Fire timeout.
-  EXPECT_CALL(cancellable, cancel());
+  EXPECT_CALL(cancellable, cancel(_));
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
 
@@ -4124,7 +4124,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHostAltRespo
   response_decoder->decodeHeaders(std::move(response_headers1), true);
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
 
-  Http::ConnectionPool::MockCancellable cancellable;
+  Envoy::ConnectionPool::MockCancellable cancellable;
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](Http::ResponseDecoder& decoder,
                            Http::ConnectionPool::Callbacks&) -> Http::ConnectionPool::Cancellable* {
@@ -4134,7 +4134,7 @@ TEST_F(RouterTest, RetryTimeoutDuringRetryDelayWithUpstreamRequestNoHostAltRespo
   router_.retry_state_->callback_();
 
   // Fire timeout.
-  EXPECT_CALL(cancellable, cancel());
+  EXPECT_CALL(cancellable, cancel(_));
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
 
@@ -5890,7 +5890,7 @@ TEST_F(RouterTest, ApplicationProtocols) {
   router_.decodeHeaders(headers, true);
 
   // When the router filter gets reset we should cancel the pool request.
-  EXPECT_CALL(cancellable_, cancel());
+  EXPECT_CALL(cancellable_, cancel(_));
   router_.onDestroy();
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,

--- a/test/common/router/upstream_request_test.cc
+++ b/test/common/router/upstream_request_test.cc
@@ -122,7 +122,7 @@ public:
   Tcp::ConnectionPool::MockInstance mock_pool_;
   MockGenericConnectionPoolCallbacks mock_generic_callbacks_;
   std::shared_ptr<NiceMock<Upstream::MockHost>> host_;
-  NiceMock<Tcp::ConnectionPool::MockCancellable> cancellable_;
+  NiceMock<Envoy::ConnectionPool::MockCancellable> cancellable_;
 };
 
 TEST_F(TcpConnPoolTest, Basic) {

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -877,7 +877,7 @@ public:
           .WillByDefault(ReturnRef(*upstream_connections_.back()));
       upstream_hosts_.push_back(std::make_shared<NiceMock<Upstream::MockHost>>());
       conn_pool_handles_.push_back(
-          std::make_unique<NiceMock<Tcp::ConnectionPool::MockCancellable>>());
+          std::make_unique<NiceMock<Envoy::ConnectionPool::MockCancellable>>());
 
       ON_CALL(*upstream_hosts_.at(i), cluster())
           .WillByDefault(ReturnPointee(
@@ -969,7 +969,7 @@ public:
   std::vector<std::unique_ptr<NiceMock<Tcp::ConnectionPool::MockConnectionData>>>
       upstream_connection_data_{};
   std::vector<Tcp::ConnectionPool::Callbacks*> conn_pool_callbacks_;
-  std::vector<std::unique_ptr<NiceMock<Tcp::ConnectionPool::MockCancellable>>> conn_pool_handles_;
+  std::vector<std::unique_ptr<NiceMock<Envoy::ConnectionPool::MockCancellable>>> conn_pool_handles_;
   NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool_;
   Tcp::ConnectionPool::UpstreamCallbacks* upstream_callbacks_;
   StringViewSaver access_log_data_;

--- a/test/extensions/filters/network/dubbo_proxy/router_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/router_test.cc
@@ -484,7 +484,7 @@ TEST_F(DubboRouterTest, DestroyWhileConnecting) {
   initializeRouter();
   initializeMetadata(MessageType::Request);
 
-  NiceMock<Tcp::ConnectionPool::MockCancellable> conn_pool_handle;
+  NiceMock<Envoy::ConnectionPool::MockCancellable> conn_pool_handle;
   EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_, newConnection(_))
       .WillOnce(Invoke([&](Tcp::ConnectionPool::Callbacks&) -> Tcp::ConnectionPool::Cancellable* {
         return &conn_pool_handle;

--- a/test/mocks/BUILD
+++ b/test/mocks/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test_library(
     srcs = ["common.cc"],
     hdrs = ["common.h"],
     deps = [
+        "//include/envoy/common:conn_pool_interface",
         "//include/envoy/common:time_interface",
         "//include/envoy/common:token_bucket_interface",
         "//source/common/common:minimal_logger_lib",

--- a/test/mocks/common.cc
+++ b/test/mocks/common.cc
@@ -1,6 +1,11 @@
 #include "test/mocks/common.h"
 
 namespace Envoy {
+namespace ConnectionPool {
+MockCancellable::MockCancellable() = default;
+MockCancellable::~MockCancellable() = default;
+} // namespace ConnectionPool
+
 ReadyWatcher::ReadyWatcher() = default;
 ReadyWatcher::~ReadyWatcher() = default;
 

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "envoy/common/conn_pool.h"
 #include "envoy/common/scope_tracker.h"
 #include "envoy/common/time.h"
 #include "envoy/common/token_bucket.h"
@@ -94,5 +95,17 @@ class MockScopedTrackedObject : public ScopeTrackedObject {
 public:
   MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));
 };
+
+namespace ConnectionPool {
+
+class MockCancellable : public Cancellable {
+public:
+  MockCancellable();
+  ~MockCancellable() override;
+
+  // ConnectionPool::Cancellable
+  MOCK_METHOD(void, cancel, (CancelPolicy cancel_policy));
+};
+} // namespace ConnectionPool
 
 } // namespace Envoy

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -24,6 +24,7 @@ envoy_cc_mock(
     hdrs = ["conn_pool.h"],
     deps = [
         "//include/envoy/http:conn_pool_interface",
+        "//test/mocks:common_lib",
         "//test/mocks/upstream:host_mocks",
     ],
 )

--- a/test/mocks/http/conn_pool.cc
+++ b/test/mocks/http/conn_pool.cc
@@ -4,9 +4,6 @@ namespace Envoy {
 namespace Http {
 namespace ConnectionPool {
 
-MockCancellable::MockCancellable() = default;
-MockCancellable::~MockCancellable() = default;
-
 MockInstance::MockInstance()
     : host_{std::make_shared<testing::NiceMock<Upstream::MockHostDescription>>()} {
   ON_CALL(*this, host()).WillByDefault(Return(host_));

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -2,6 +2,7 @@
 
 #include "envoy/http/conn_pool.h"
 
+#include "test/mocks/common.h"
 #include "test/mocks/upstream/host.h"
 
 #include "gmock/gmock.h"
@@ -9,15 +10,6 @@
 namespace Envoy {
 namespace Http {
 namespace ConnectionPool {
-
-class MockCancellable : public Cancellable {
-public:
-  MockCancellable();
-  ~MockCancellable() override;
-
-  // Http::ConnectionPool::Cancellable
-  MOCK_METHOD(void, cancel, ());
-};
 
 class MockInstance : public Instance {
 public:

--- a/test/mocks/tcp/BUILD
+++ b/test/mocks/tcp/BUILD
@@ -15,6 +15,7 @@ envoy_cc_mock(
     deps = [
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/tcp:conn_pool_interface",
+        "//test/mocks:common_lib",
         "//test/mocks/network:network_mocks",
         "//test/mocks/upstream:host_mocks",
     ],

--- a/test/mocks/tcp/mocks.cc
+++ b/test/mocks/tcp/mocks.cc
@@ -12,9 +12,6 @@ namespace Envoy {
 namespace Tcp {
 namespace ConnectionPool {
 
-MockCancellable::MockCancellable() = default;
-MockCancellable::~MockCancellable() = default;
-
 MockUpstreamCallbacks::MockUpstreamCallbacks() = default;
 MockUpstreamCallbacks::~MockUpstreamCallbacks() = default;
 
@@ -33,7 +30,7 @@ MockInstance::MockInstance() {
 }
 MockInstance::~MockInstance() = default;
 
-MockCancellable* MockInstance::newConnectionImpl(Callbacks& cb) {
+Envoy::ConnectionPool::MockCancellable* MockInstance::newConnectionImpl(Callbacks& cb) {
   handles_.emplace_back();
   callbacks_.push_back(&cb);
   return &handles_.back();

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -15,15 +15,6 @@ namespace Envoy {
 namespace Tcp {
 namespace ConnectionPool {
 
-class MockCancellable : public Cancellable {
-public:
-  MockCancellable();
-  ~MockCancellable() override;
-
-  // Tcp::ConnectionPool::Cancellable
-  MOCK_METHOD(void, cancel, (CancelPolicy cancel_policy));
-};
-
 class MockUpstreamCallbacks : public UpstreamCallbacks {
 public:
   MockUpstreamCallbacks();
@@ -65,14 +56,14 @@ public:
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
 
-  MockCancellable* newConnectionImpl(Callbacks& cb);
+  Envoy::ConnectionPool::MockCancellable* newConnectionImpl(Callbacks& cb);
   void poolFailure(PoolFailureReason reason);
   void poolReady(Network::MockClientConnection& conn);
 
   // Invoked when connection_data_, having been assigned via poolReady is released.
   MOCK_METHOD(void, released, (Network::MockClientConnection&));
 
-  std::list<NiceMock<MockCancellable>> handles_;
+  std::list<NiceMock<Envoy::ConnectionPool::MockCancellable>> handles_;
   std::list<Callbacks*> callbacks_;
 
   std::shared_ptr<NiceMock<Upstream::MockHostDescription>> host_{


### PR DESCRIPTION
Unifying cancellation APIs and handles between the TCP and HTTP connection pool.

Risk Level: Medium (intended no-op refactor to HTTP connection pool)
Testing: new unit tests
Docs Changes: n/a
Release Notes: n/a
Part of #11528
