### PR TITLE
alts: add explicit grpc alts version for new connections open by alts extension

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -739,6 +739,16 @@ def _com_github_grpc_grpc():
         actual = "@com_github_grpc_grpc//test/core/tsi/alts/fake_handshaker:fake_handshaker_lib",
     )
 
+    native.bind(
+        name = "grpc_alts_handshaker_proto",
+        actual = "@com_github_grpc_grpc//test/core/tsi/alts/fake_handshaker:handshaker_proto",
+    )
+
+    native.bind(
+        name = "grpc_alts_transport_security_common_proto",
+        actual = "@com_github_grpc_grpc//test/core/tsi/alts/fake_handshaker:transport_security_common_proto",
+    )
+
 def _upb():
     _repository_impl(
         name = "upb",

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -26,7 +26,9 @@ using GrpcAltsCredentialsOptionsPtr =
 
 namespace {
 
-void grpc_alts_set_rpc_protocol_versions(grpc_gcp_rpc_protocol_versions* rpc_versions) {
+// There is an equivalent function grpc_alts_set_rpc_protocol_versions in newer
+// release of gRPC that should be called directly when available.
+void grpcAltsSetRpcProtocolVersions(grpc_gcp_rpc_protocol_versions* rpc_versions) {
   grpc_gcp_rpc_protocol_versions_set_max(rpc_versions, GRPC_PROTOCOL_VERSION_MAX_MAJOR,
                                          GRPC_PROTOCOL_VERSION_MAX_MINOR);
   grpc_gcp_rpc_protocol_versions_set_min(rpc_versions, GRPC_PROTOCOL_VERSION_MIN_MAJOR,
@@ -115,7 +117,7 @@ Network::TransportSocketFactoryPtr createTransportSocketFactoryHelper(
     } else {
       options = GrpcAltsCredentialsOptionsPtr(grpc_alts_credentials_server_options_create());
     }
-    grpc_alts_set_rpc_protocol_versions(&options->rpc_versions);
+    grpcAltsSetRpcProtocolVersions(&options->rpc_versions);
     const char* target_name = is_upstream ? "" : nullptr;
     tsi_handshaker* handshaker = nullptr;
     // Specifying target name as empty since TSI won't take care of validating peer identity

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -26,6 +26,13 @@ using GrpcAltsCredentialsOptionsPtr =
 
 namespace {
 
+void grpc_alts_set_rpc_protocol_versions(grpc_gcp_rpc_protocol_versions* rpc_versions) {
+  grpc_gcp_rpc_protocol_versions_set_max(rpc_versions, GRPC_PROTOCOL_VERSION_MAX_MAJOR,
+                                         GRPC_PROTOCOL_VERSION_MAX_MINOR);
+  grpc_gcp_rpc_protocol_versions_set_min(rpc_versions, GRPC_PROTOCOL_VERSION_MIN_MAJOR,
+                                         GRPC_PROTOCOL_VERSION_MIN_MINOR);
+}
+
 // Returns true if the peer's service account is found in peers, otherwise
 // returns false and fills out err with an error message.
 bool doValidate(const tsi_peer& peer, const std::unordered_set<std::string>& peers,
@@ -108,6 +115,7 @@ Network::TransportSocketFactoryPtr createTransportSocketFactoryHelper(
     } else {
       options = GrpcAltsCredentialsOptionsPtr(grpc_alts_credentials_server_options_create());
     }
+    grpc_alts_set_rpc_protocol_versions(&options->rpc_versions);
     const char* target_name = is_upstream ? "" : nullptr;
     tsi_handshaker* handshaker = nullptr;
     // Specifying target name as empty since TSI won't take care of validating peer identity

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -26,8 +26,8 @@ using GrpcAltsCredentialsOptionsPtr =
 
 namespace {
 
-// There is an equivalent function grpc_alts_set_rpc_protocol_versions in newer
-// release of gRPC that should be called directly when available.
+// TODO: gRPC v1.30.0-pre1 defines the equivalent function grpc_alts_set_rpc_protocol_versions
+// that should be called directly when available.
 void grpcAltsSetRpcProtocolVersions(grpc_gcp_rpc_protocol_versions* rpc_versions) {
   grpc_gcp_rpc_protocol_versions_set_max(rpc_versions, GRPC_PROTOCOL_VERSION_MAX_MAJOR,
                                          GRPC_PROTOCOL_VERSION_MAX_MINOR);

--- a/source/extensions/transport_sockets/alts/grpc_tsi.h
+++ b/source/extensions/transport_sockets/alts/grpc_tsi.h
@@ -11,8 +11,10 @@
 #endif
 
 #include "grpc/grpc_security.h"
+#include "src/core/lib/transport/transport.h"
 #include "src/core/tsi/alts/handshaker/alts_shared_resource.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
+#include "src/core/tsi/alts/handshaker/transport_security_common_api.h"
 #include "src/core/tsi/transport_security_grpc.h"
 #include "src/core/tsi/transport_security_interface.h"
 

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -80,7 +80,6 @@ envoy_extension_cc_test(
     ],
     tags = ["fails_on_windows"],
     deps = [
-#        ":capturing_handshaker_lib",
         "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -75,9 +75,12 @@ envoy_extension_cc_test(
     extension_name = "envoy.transport_sockets.alts",
     external_deps = [
         "grpc_alts_fake_handshaker_server",
+        "grpc_alts_handshaker_proto",
+        "grpc_alts_transport_security_common_proto",
     ],
     tags = ["fails_on_windows"],
     deps = [
+#        ":capturing_handshaker_lib",
         "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -47,12 +47,13 @@ constexpr char kClientInitFrame[] = "ClientInit";
 // responds correctly to first client request and capturing client and server
 // ALTS versions.
 class CapturingHandshakerService : public grpc::gcp::HandshakerService::Service {
- public:
+public:
   CapturingHandshakerService() {}
 
-  grpc::Status DoHandshake(
-      grpc::ServerContext*,
-      grpc::ServerReaderWriter<grpc::gcp::HandshakerResp, grpc::gcp::HandshakerReq>* stream) override {
+  grpc::Status
+  DoHandshake(grpc::ServerContext*,
+              grpc::ServerReaderWriter<grpc::gcp::HandshakerResp, grpc::gcp::HandshakerReq>* stream)
+      override {
     grpc::gcp::HandshakerReq request;
     grpc::gcp::HandshakerResp response;
     while (stream->Read(&request)) {

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -40,7 +40,7 @@ namespace TransportSockets {
 namespace Alts {
 namespace {
 
-// Fake handshaker message, copied from grpc::gcp::FakeHandshkerService implementation.
+// Fake handshaker message, copied from grpc::gcp::FakeHandshakerService implementation.
 constexpr char kClientInitFrame[] = "ClientInit";
 
 // Hollowed out implementation of HandshakerService that is disfunctional, but

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -59,13 +59,14 @@ public:
     while (stream->Read(&request)) {
       if (request.has_client_start()) {
         client_versions = request.client_start().rpc_versions();
+        // Sets response to make first request successful.
+        response.set_out_frames(kClientInitFrame);
+        response.set_bytes_consumed(0);
+        response.mutable_status()->set_code(grpc::StatusCode::OK);
       } else if (request.has_server_start()) {
         server_versions = request.server_start().rpc_versions();
+        response.mutable_status()->set_code(grpc::StatusCode::CANCELLED);
       }
-      // Sets response to make first request successful.
-      response.set_out_frames(kClientInitFrame);
-      response.set_bytes_consumed(0);
-      response.mutable_status()->set_code(grpc::StatusCode::OK);
       stream->Write(response);
       request.Clear();
     }

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -40,7 +40,7 @@ namespace TransportSockets {
 namespace Alts {
 namespace {
 
-// Fake handshake messages, copied from grpc::gcp::FakeHandshkerService implementation.
+// Fake handshaker message, copied from grpc::gcp::FakeHandshkerService implementation.
 constexpr char kClientInitFrame[] = "ClientInit";
 
 // Hollowed out implementation of HandshakerService that is disfunctional, but
@@ -59,7 +59,7 @@ public:
     while (stream->Read(&request)) {
       if (request.has_client_start()) {
         client_versions = request.client_start().rpc_versions();
-        // Sets response to make first request successfull.
+        // Sets response to make first request successful.
         response.set_out_frames(kClientInitFrame);
         response.set_bytes_consumed(0);
         response.mutable_status()->set_code(grpc::StatusCode::OK);

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -48,7 +48,7 @@ constexpr char kClientInitFrame[] = "ClientInit";
 // ALTS versions in the process.
 class CapturingHandshakerService : public grpc::gcp::HandshakerService::Service {
 public:
-  CapturingHandshakerService() {}
+  CapturingHandshakerService() = default;
 
   grpc::Status
   DoHandshake(grpc::ServerContext*,
@@ -59,13 +59,13 @@ public:
     while (stream->Read(&request)) {
       if (request.has_client_start()) {
         client_versions = request.client_start().rpc_versions();
-        // Sets response to make first request successful.
-        response.set_out_frames(kClientInitFrame);
-        response.set_bytes_consumed(0);
-        response.mutable_status()->set_code(grpc::StatusCode::OK);
       } else if (request.has_server_start()) {
         server_versions = request.server_start().rpc_versions();
       }
+      // Sets response to make first request successful.
+      response.set_out_frames(kClientInitFrame);
+      response.set_bytes_consumed(0);
+      response.mutable_status()->set_code(grpc::StatusCode::OK);
       stream->Write(response);
       request.Clear();
     }

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -5,7 +5,18 @@
 
 #include "extensions/transport_sockets/alts/config.h"
 
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+
 #include "test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h"
+#include "test/core/tsi/alts/fake_handshaker/handshaker.grpc.pb.h"
+#include "test/core/tsi/alts/fake_handshaker/handshaker.pb.h"
+#include "test/core/tsi/alts/fake_handshaker/transport_security_common.pb.h"
+
 #include "test/integration/http_integration.h"
 #include "test/integration/integration.h"
 #include "test/integration/server.h"
@@ -29,16 +40,53 @@ namespace TransportSockets {
 namespace Alts {
 namespace {
 
+// Fake handshake messages, copied from grpc::gcp::FakeHandshkerService implementation.
+constexpr char kClientInitFrame[] = "ClientInit";
+
+// Hollowed out implementation of HandshakerService that is disfunctional, but
+// responds correctly to first client request and capturing client and server
+// ALTS versions.
+class CapturingHandshakerService : public grpc::gcp::HandshakerService::Service {
+ public:
+  CapturingHandshakerService() {}
+
+  grpc::Status DoHandshake(
+      grpc::ServerContext*,
+      grpc::ServerReaderWriter<grpc::gcp::HandshakerResp, grpc::gcp::HandshakerReq>* stream) override {
+    grpc::gcp::HandshakerReq request;
+    grpc::gcp::HandshakerResp response;
+    while (stream->Read(&request)) {
+      if (request.has_client_start()) {
+        client_versions = request.client_start().rpc_versions();
+        // Sets response to make first request successfull.
+        response.set_out_frames(kClientInitFrame);
+        response.set_bytes_consumed(0);
+        response.mutable_status()->set_code(grpc::StatusCode::OK);
+      } else if (request.has_server_start()) {
+        server_versions = request.server_start().rpc_versions();
+      }
+      stream->Write(response);
+      request.Clear();
+    }
+    return grpc::Status::OK;
+  }
+
+  // Storing client and server RPC versions for later verification.
+  grpc::gcp::RpcProtocolVersions client_versions;
+  grpc::gcp::RpcProtocolVersions server_versions;
+};
+
 class AltsIntegrationTestBase : public testing::TestWithParam<Network::Address::IpVersion>,
                                 public HttpIntegrationTest {
 public:
   AltsIntegrationTestBase(const std::string& server_peer_identity,
                           const std::string& client_peer_identity, bool server_connect_handshaker,
-                          bool client_connect_handshaker)
+                          bool client_connect_handshaker, bool swap_handshaker = false)
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()),
         server_peer_identity_(server_peer_identity), client_peer_identity_(client_peer_identity),
         server_connect_handshaker_(server_connect_handshaker),
-        client_connect_handshaker_(client_connect_handshaker) {}
+        client_connect_handshaker_(client_connect_handshaker),
+        swap_handshaker_(swap_handshaker) {}
 
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -60,7 +108,14 @@ public:
 
   void SetUp() override {
     fake_handshaker_server_thread_ = api_->threadFactory().createThread([this]() {
-      std::unique_ptr<grpc::Service> service = grpc::gcp::CreateFakeHandshakerService();
+      std::unique_ptr<grpc::Service> service;
+      if (swap_handshaker_) {
+        capturing_handshaker_service_ = new CapturingHandshakerService();
+        service = std::unique_ptr<grpc::Service>{capturing_handshaker_service_};
+      } else {
+        capturing_handshaker_service_ = nullptr;
+        service = grpc::gcp::CreateFakeHandshakerService();
+      }
 
       std::string server_address = Network::Test::getLoopbackAddressUrlString(version_) + ":0";
       grpc::ServerBuilder builder;
@@ -143,6 +198,8 @@ public:
   ConditionalInitializer fake_handshaker_server_ci_;
   int fake_handshaker_server_port_{};
   Network::TransportSocketFactoryPtr client_alts_;
+  bool swap_handshaker_;
+  CapturingHandshakerService* capturing_handshaker_service_;
 };
 
 class AltsIntegrationTestValidPeer : public AltsIntegrationTestBase {
@@ -255,6 +312,38 @@ TEST_P(AltsIntegrationTestClientWrongHandshaker, ConnectToWrongHandshakerAddress
   initialize();
   codec_client_ = makeRawHttpConnection(makeAltsConnection());
   EXPECT_FALSE(codec_client_->connected());
+}
+
+class AltsIntegrationTestCapturingHandshaker : public AltsIntegrationTestBase {
+public:
+  AltsIntegrationTestCapturingHandshaker()
+      : AltsIntegrationTestBase("", "",
+                                /* server_connect_handshaker */ true,
+                                /* client_connect_handshaker */ true,
+                                /* capturing_handshaker */ true) {}
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, AltsIntegrationTestCapturingHandshaker,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+// Verifies that handshake request should include ALTS version.
+TEST_P(AltsIntegrationTestCapturingHandshaker, CheckAltsVersion) {
+  initialize();
+  codec_client_ = makeRawHttpConnection(makeAltsConnection());
+  EXPECT_FALSE(codec_client_->connected());
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.max_rpc_version().major(),
+            capturing_handshaker_service_->server_versions.max_rpc_version().major());
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.max_rpc_version().minor(),
+            capturing_handshaker_service_->server_versions.max_rpc_version().minor());
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().major(),
+            capturing_handshaker_service_->server_versions.min_rpc_version().major());
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().minor(),
+            capturing_handshaker_service_->server_versions.min_rpc_version().minor());
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.max_rpc_version().major(), 2);
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.max_rpc_version().minor(), 1);
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().major(), 2);
+  EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().minor(), 1);
 }
 
 } // namespace

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -81,12 +81,12 @@ class AltsIntegrationTestBase : public testing::TestWithParam<Network::Address::
 public:
   AltsIntegrationTestBase(const std::string& server_peer_identity,
                           const std::string& client_peer_identity, bool server_connect_handshaker,
-                          bool client_connect_handshaker, bool swap_handshaker = false)
+                          bool client_connect_handshaker, bool capturing_handshaker = false)
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()),
         server_peer_identity_(server_peer_identity), client_peer_identity_(client_peer_identity),
         server_connect_handshaker_(server_connect_handshaker),
         client_connect_handshaker_(client_connect_handshaker),
-        swap_handshaker_(swap_handshaker) {}
+        capturing_handshaker_(capturing_handshaker) {}
 
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -109,7 +109,7 @@ public:
   void SetUp() override {
     fake_handshaker_server_thread_ = api_->threadFactory().createThread([this]() {
       std::unique_ptr<grpc::Service> service;
-      if (swap_handshaker_) {
+      if (capturing_handshaker_) {
         capturing_handshaker_service_ = new CapturingHandshakerService();
         service = std::unique_ptr<grpc::Service>{capturing_handshaker_service_};
       } else {
@@ -198,7 +198,7 @@ public:
   ConditionalInitializer fake_handshaker_server_ci_;
   int fake_handshaker_server_port_{};
   Network::TransportSocketFactoryPtr client_alts_;
-  bool swap_handshaker_;
+  bool capturing_handshaker_;
   CapturingHandshakerService* capturing_handshaker_service_;
 };
 

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -340,10 +340,10 @@ TEST_P(AltsIntegrationTestCapturingHandshaker, CheckAltsVersion) {
             capturing_handshaker_service_->server_versions.min_rpc_version().major());
   EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().minor(),
             capturing_handshaker_service_->server_versions.min_rpc_version().minor());
-  EXPECT_EQ(capturing_handshaker_service_->client_versions.max_rpc_version().major(), 2);
-  EXPECT_EQ(capturing_handshaker_service_->client_versions.max_rpc_version().minor(), 1);
-  EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().major(), 2);
-  EXPECT_EQ(capturing_handshaker_service_->client_versions.min_rpc_version().minor(), 1);
+  EXPECT_NE(0, capturing_handshaker_service_->client_versions.max_rpc_version().major());
+  EXPECT_NE(0, capturing_handshaker_service_->client_versions.max_rpc_version().minor());
+  EXPECT_NE(0, capturing_handshaker_service_->client_versions.min_rpc_version().major());
+  EXPECT_NE(0, capturing_handshaker_service_->client_versions.min_rpc_version().minor());
 }
 
 } // namespace

--- a/test/extensions/transport_sockets/alts/alts_integration_test.cc
+++ b/test/extensions/transport_sockets/alts/alts_integration_test.cc
@@ -43,9 +43,9 @@ namespace {
 // Fake handshaker message, copied from grpc::gcp::FakeHandshakerService implementation.
 constexpr char kClientInitFrame[] = "ClientInit";
 
-// Hollowed out implementation of HandshakerService that is disfunctional, but
-// responds correctly to first client request and capturing client and server
-// ALTS versions.
+// Hollowed out implementation of HandshakerService that is dysfunctional, but
+// responds correctly to the first client request, capturing client and server
+// ALTS versions in the process.
 class CapturingHandshakerService : public grpc::gcp::HandshakerService::Service {
 public:
   CapturingHandshakerService() {}


### PR DESCRIPTION
Commit Message: This PR will fix incompatibility of envoy ALTS extension with grpc-go that explicitly requires match of RPC versions when establishing ALTS connection. https://github.com/grpc/grpc-go/blob/399ae780646dfdf73dac136ddef0db066199ead9/credentials/alts/alts.go#L216
Additional Description: Currently not setting rpc version in ALTS request makes it impossible to use envoy to proxy grpc-go requests.
Risk Level: Low
Testing: Manually confirmed this fixes the issue with grpc-go server.
Docs Changes: N/A
Release Notes: N/A