### PR TITLE
docs: first pass at documenting how to add extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,25 @@ and false.
 * If a PR includes a deprecation/breaking change, notification should be sent to the
   [envoy-announce](https://groups.google.com/forum/#!forum/envoy-announce) email list.
 
+# Adding new extensions
+
+For developers adding a new extension, one can largely model off of existing extensions.
+
+Extension configuration should be located in a directory structure like
+`api/envoy/extensions/area/plugin/`, for example `api/envoy/extensions/tracers/zipkin/`
+
+The code for the extension should be located under the equivalent
+`source/extensions/area/plugin`, and include an envoy_cc_extension with the
+configuration and tagged with the appropriate security posture, and an
+envoy_cc_library with the code.
+
+Other changes will likely include
+
+  * Editing source/extensions/extensions_build_config.bzl to include the new extensions
+  * Editing docs/root/api-v3/config/config.rst to add area/area
+  * Adding docs/root/api-v3/config/area/area.rst to add a table of contents for the API docs
+  * Adding source/extensions/area/well_known_names.h for registered plugins
+
 # DCO: Sign your work
 
 Envoy ships commit hooks that allow you to auto-generate the DCO signoff line if

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ and false.
 For developers adding a new extension, one can take an existing extension as the starting point.
 
 Extension configuration should be located in a directory structure like
-`api/envoy/extensions/area/plugin/`, for example `api/envoy/extensions/tracers/zipkin/`
+`api/envoy/extensions/area/plugin/`, for example `api/envoy/extensions/access_loggers/file/`
 
 The code for the extension should be located under the equivalent
 `source/extensions/area/plugin`, and include an *envoy_cc_extension* with the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,22 +217,23 @@ and false.
 
 # Adding new extensions
 
-For developers adding a new extension, one can largely model off of existing extensions.
+For developers adding a new extension, one can take an existing extension as the starting point.
 
 Extension configuration should be located in a directory structure like
 `api/envoy/extensions/area/plugin/`, for example `api/envoy/extensions/tracers/zipkin/`
 
 The code for the extension should be located under the equivalent
-`source/extensions/area/plugin`, and include an envoy_cc_extension with the
+`source/extensions/area/plugin`, and include an *envoy_cc_extension* with the
 configuration and tagged with the appropriate security posture, and an
-envoy_cc_library with the code.
+*envoy_cc_library* with the code.  More details on how to add a new extension
+API can be found [here](api/STYLE.md):
 
 Other changes will likely include
 
-  * Editing source/extensions/extensions_build_config.bzl to include the new extensions
-  * Editing docs/root/api-v3/config/config.rst to add area/area
-  * Adding docs/root/api-v3/config/area/area.rst to add a table of contents for the API docs
-  * Adding source/extensions/area/well_known_names.h for registered plugins
+  * Editing [source/extensions/extensions_build_config.bzl](source/extensions/extensions_build_config.bzl) to include the new extensions
+  * Editing [docs/root/api-v3/config/config.rst](docs/root/api-v3/config/config.rst) to add area/area
+  * Adding [docs/root/api-v3/config/area/area.rst](docs/root/api-v3/config/area/area.rst) to add a table of contents for the API docs
+  * Adding [source/extensions/area/well_known_names.h](source/extensions/area/well_known_names.h) for registered plugins
 
 # DCO: Sign your work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ Extension configuration should be located in a directory structure like
 The code for the extension should be located under the equivalent
 `source/extensions/area/plugin`, and include an *envoy_cc_extension* with the
 configuration and tagged with the appropriate security posture, and an
-*envoy_cc_library* with the code.  More details on how to add a new extension
+*envoy_cc_library* with the code. More details on how to add a new extension
 API can be found [here](api/STYLE.md):
 
 Other changes will likely include

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,8 @@ Other changes will likely include
 
   * Editing [source/extensions/extensions_build_config.bzl](source/extensions/extensions_build_config.bzl) to include the new extensions
   * Editing [docs/root/api-v3/config/config.rst](docs/root/api-v3/config/config.rst) to add area/area
-  * Adding [docs/root/api-v3/config/area/area.rst](docs/root/api-v3/config/area/area.rst) to add a table of contents for the API docs
-  * Adding [source/extensions/area/well_known_names.h](source/extensions/area/well_known_names.h) for registered plugins
+  * Adding `docs/root/api-v3/config/area/area.rst` to add a table of contents for the API docs
+  * Adding `source/extensions/area/well_known_names.h` for registered plugins
 
 # DCO: Sign your work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ The code for the extension should be located under the equivalent
 `source/extensions/area/plugin`, and include an *envoy_cc_extension* with the
 configuration and tagged with the appropriate security posture, and an
 *envoy_cc_library* with the code. More details on how to add a new extension
-API can be found [here](api/STYLE.md):
+API can be found [here](api/STYLE.md#adding-an-extension-configuration-to-the-api):
 
 Other changes will likely include
 

--- a/docs/generate_extension_db.py
+++ b/docs/generate_extension_db.py
@@ -40,7 +40,9 @@ def GetExtensionMetadata(target):
       stderr=subprocess.PIPE)
   security_posture, status, undocumented = r.stdout.decode('utf-8').strip().split(' ')
   if IsMissing(security_posture):
-    raise ExtensionDbError('Missing security posture for %s' % target)
+    raise ExtensionDbError(
+        'Missing security posture for %s.  Please make sure the target is an envoy_cc_extension and security_posture is set'
+        % target)
   return {
       'security_posture': security_posture,
       'undocumented': False if IsMissing(undocumented) else bool(undocumented),

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -188,15 +188,20 @@ def FormatExtension(extension):
   Returns:
     RST formatted extension description.
   """
-  extension_metadata = json.loads(pathlib.Path(
-      os.getenv('EXTENSION_DB_PATH')).read_text())[extension]
-  anchor = FormatAnchor('extension_' + extension)
-  status = EXTENSION_STATUS_VALUES.get(extension_metadata['status'], '')
-  security_posture = EXTENSION_SECURITY_POSTURES[extension_metadata['security_posture']]
-  return EXTENSION_TEMPLATE.substitute(anchor=anchor,
-                                       extension=extension,
-                                       status=status,
-                                       security_posture=security_posture)
+  try:
+    extension_metadata = json.loads(pathlib.Path(
+        os.getenv('EXTENSION_DB_PATH')).read_text())[extension]
+    anchor = FormatAnchor('extension_' + extension)
+    status = EXTENSION_STATUS_VALUES.get(extension_metadata['status'], '')
+    security_posture = EXTENSION_SECURITY_POSTURES[extension_metadata['security_posture']]
+    return EXTENSION_TEMPLATE.substitute(anchor=anchor,
+                                         extension=extension,
+                                         status=status,
+                                         security_posture=security_posture)
+  except KeyError as e:
+    sys.stderr.write(
+        '\n\nDid you forget to add an entry to source/extensions/extensions_build_config.bzl?\n\n')
+    exit(1)  # Raising the error buries the above message in tracebacks.
 
 
 def FormatHeaderFromFile(style, source_code_info, proto_name):


### PR DESCRIPTION
This includes enhancing the script failures to leave breadcrumbs for devs who miss the new docs.

Risk Level: n/a (tooling / docs)
Testing: manual testing removing files from #11327
Docs Changes: yes
Release Notes: no
