### PR TITLE
fuzz: Enabled "upgrade" request/response in fuzz test

### DIFF
--- a/test/common/http/conn_manager_impl_corpus/upgrade_test_case
+++ b/test/common/http/conn_manager_impl_corpus/upgrade_test_case
@@ -1,0 +1,53 @@
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "http"
+      }
+      headers {
+        key: ":authority"
+        value: "host"
+      }
+      headers {
+        key: "connection"
+        value: "upgrade"
+      }
+      headers {
+        key: "upgrade"
+        value: "WebSocket"
+      }
+    }
+  }
+}
+
+
+actions {
+  stream_action {
+    stream_id: 0
+    response {
+      headers {
+        headers {
+          key: "connection"
+          value: "upgrade"
+        }
+        headers {
+          key: "upgrade"
+          value: "WebSocket"
+        }
+        headers {
+          key: ":status"
+          value: "101"
+        }
+      }
+    }
+  }
+}

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -90,11 +90,11 @@ public:
     EXPECT_CALL(*decoder_filter_, setDecoderFilterCallbacks(_));
     EXPECT_CALL(*encoder_filter_, setEncoderFilterCallbacks(_));
     EXPECT_CALL(filter_factory_, createUpgradeFilterChain("WebSocket", _, _))
-    .WillRepeatedly(Invoke([&](absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
-                                FilterChainFactoryCallbacks& callbacks) -> bool {
-      filter_factory_.createFilterChain(callbacks);
-      return true;
-    }));
+        .WillRepeatedly(Invoke([&](absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
+                                   FilterChainFactoryCallbacks& callbacks) -> bool {
+          filter_factory_.createFilterChain(callbacks);
+          return true;
+        }));
   }
 
   // Http::ConnectionManagerConfig

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -89,6 +89,12 @@ public:
         }));
     EXPECT_CALL(*decoder_filter_, setDecoderFilterCallbacks(_));
     EXPECT_CALL(*encoder_filter_, setEncoderFilterCallbacks(_));
+    EXPECT_CALL(filter_factory_, createUpgradeFilterChain("WebSocket", _, _))
+    .WillRepeatedly(Invoke([&](absl::string_view, const Http::FilterChainFactory::UpgradeMap*,
+                                FilterChainFactoryCallbacks& callbacks) -> bool {
+      filter_factory_.createFilterChain(callbacks);
+      return true;
+    }));
   }
 
   // Http::ConnectionManagerConfig


### PR DESCRIPTION
Commit Message:
Additional Description:

Enabled "upgrade" option by adding an PEXPECT_CALL() in conn_manager_impl_fuzz_test.cc.
Covered two functions: mutateRequestHeaders() and mutateResponseHeaders() with above
changes.

Signed-off-by: jianwen <jianwendong@google.com>

Risk Level: low
Testing: Covered mutateRequestHeaders() and mutateResponseHeaders() functions with above changes.

/cc @asraa 
/cc @samkerner

