### PR TITLE
test: fixing a teardown ordering bug

### DIFF
--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -32,11 +32,6 @@ public:
     enable_half_close_ = true;
   }
 
-  ~TcpGrpcAccessLogIntegrationTest() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void createUpstreams() override {
     BaseIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(

--- a/test/extensions/clusters/aggregate/cluster_integration_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_integration_test.cc
@@ -119,9 +119,7 @@ public:
     use_lds_ = false;
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   void initialize() override {
     use_lds_ = false;

--- a/test/extensions/clusters/aggregate/cluster_integration_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_integration_test.cc
@@ -121,8 +121,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void initialize() override {

--- a/test/extensions/clusters/redis/redis_cluster_integration_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_integration_test.cc
@@ -143,11 +143,6 @@ public:
       : BaseIntegrationTest(GetParam(), config), num_upstreams_(num_upstreams),
         version_(GetParam()) {}
 
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void initialize() override {
     setUpstreamCount(num_upstreams_);
     setDeterministic();

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -71,11 +71,6 @@ public:
   }
 
   void SetUp() override { BaseIntegrationTest::initialize(); }
-
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 
 class AwsMetadataIntegrationTestSuccess : public AwsMetadataIntegrationTestBase {

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
@@ -27,9 +27,7 @@ public:
     setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
   }
 
-  void TearDown() override {
-    fake_upstream_connection_.reset();
-  }
+  void TearDown() override { fake_upstream_connection_.reset(); }
 
   void setupLambdaFilter(bool passthrough) {
     const std::string filter =

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_integration_test.cc
@@ -28,9 +28,7 @@ public:
   }
 
   void TearDown() override {
-    test_server_.reset();
     fake_upstream_connection_.reset();
-    fake_upstreams_.clear();
   }
 
   void setupLambdaFilter(bool passthrough) {

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -52,9 +52,7 @@ typed_config:
     HttpIntegrationTest::initialize();
   }
 
-  void TearDown() override {
-    fake_upstream_connection_.reset();
-  }
+  void TearDown() override { fake_upstream_connection_.reset(); }
 
 protected:
   FakeHttpConnection::Type upstream_protocol_;

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -53,9 +53,7 @@ typed_config:
   }
 
   void TearDown() override {
-    test_server_.reset();
     fake_upstream_connection_.reset();
-    fake_upstreams_.clear();
   }
 
 protected:

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -28,9 +28,7 @@ class GrpcJsonTranscoderIntegrationTest
 public:
   GrpcJsonTranscoderIntegrationTest()
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
-  /**
-   * Global initializer for all integration tests.
-   */
+
   void SetUp() override {
     setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
     const std::string filter =
@@ -43,15 +41,6 @@ public:
             )EOF";
     config_helper_.addFilter(
         fmt::format(filter, TestEnvironment::runfilesPath("test/proto/bookstore.descriptor")));
-  }
-
-  /**
-   * Global destructor for all integration tests.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstream_connection_.reset();
-    fake_upstreams_.clear();
   }
 
 protected:

--- a/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
+++ b/test/extensions/filters/network/direct_response/direct_response_integration_test.cc
@@ -21,20 +21,9 @@ public:
       )EOF");
   }
 
-  /**
-   * Initializer for an individual test.
-   */
   void SetUp() override {
     useListenerAccessLog("%RESPONSE_CODE_DETAILS%");
     BaseIntegrationTest::initialize();
-  }
-
-  /**
-   *  Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 };
 

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_integration_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_integration_test.cc
@@ -10,11 +10,6 @@ public:
   LocalRateLimitIntegrationTest()
       : BaseIntegrationTest(GetParam(), ConfigHelper::tcpProxyConfig()) {}
 
-  ~LocalRateLimitIntegrationTest() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void setup(const std::string& filter_yaml) {
     config_helper_.addNetworkFilter(filter_yaml);
     BaseIntegrationTest::initialize();

--- a/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
@@ -35,14 +35,7 @@ class MySQLIntegrationTest : public testing::TestWithParam<Network::Address::IpV
 public:
   MySQLIntegrationTest() : BaseIntegrationTest(GetParam(), mysqlConfig()){};
 
-  // Initializer for an individual integration test.
   void SetUp() override { BaseIntegrationTest::initialize(); }
-
-  // Destructor for an individual integration test.
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, MySQLIntegrationTest,

--- a/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
@@ -28,11 +28,6 @@ public:
   PostgresIntegrationTest() : BaseIntegrationTest(GetParam(), postgresConfig()){};
 
   void SetUp() override { BaseIntegrationTest::initialize(); }
-
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 INSTANTIATE_TEST_SUITE_P(IpVersions, PostgresIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -60,11 +60,6 @@ public:
 
     BaseIntegrationTest::initialize();
   }
-
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, RoleBasedAccessControlNetworkFilterIntegrationTest,

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -294,11 +294,6 @@ public:
       : BaseIntegrationTest(GetParam(), config), num_upstreams_(num_upstreams),
         version_(GetParam()) {}
 
-  ~RedisProxyIntegrationTest() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   // This method encodes a fake upstream's IP address and TCP port in the
   // same format as one would expect from a Redis server in
   // an ask/moved redirection error.

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -122,11 +122,6 @@ public:
     BaseThriftIntegrationTest::initialize();
   }
 
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
 protected:
   // Multiplexed requests are handled by the service name route match,
   // while oneway's are handled by the "poke" method. All other requests

--- a/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/translation_integration_test.cc
@@ -82,11 +82,6 @@ public:
     BaseThriftIntegrationTest::initialize();
   }
 
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   Buffer::OwnedImpl downstream_request_bytes_;
   Buffer::OwnedImpl downstream_response_bytes_;
   Buffer::OwnedImpl upstream_request_bytes_;

--- a/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
@@ -75,11 +75,6 @@ public:
     BaseIntegrationTest::initialize();
   }
 
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void requestResponseWithListenerAddress(const Network::Address::Instance& listener_address,
                                           const std::string& data_to_send,
                                           Network::UdpRecvData& response_datagram) {

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
@@ -46,14 +46,6 @@ public:
     BaseIntegrationTest::initialize();
   }
 
-  /**
-   *  Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void requestResponseWithListenerAddress(const Network::Address::Instance& listener_address) {
     // Send datagram to be proxied.
     Network::Test::UdpSyncPeer client(version_);

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -32,8 +32,6 @@ AdsIntegrationTest::AdsIntegrationTest()
 
 void AdsIntegrationTest::TearDown() {
   cleanUpXdsConnection();
-  test_server_.reset();
-  fake_upstreams_.clear();
 }
 
 envoy::config::cluster::v3::Cluster AdsIntegrationTest::buildCluster(const std::string& name) {

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -30,9 +30,7 @@ AdsIntegrationTest::AdsIntegrationTest()
   sotw_or_delta_ = sotwOrDelta();
 }
 
-void AdsIntegrationTest::TearDown() {
-  cleanUpXdsConnection();
-}
+void AdsIntegrationTest::TearDown() { cleanUpXdsConnection(); }
 
 envoy::config::cluster::v3::Cluster AdsIntegrationTest::buildCluster(const std::string& name) {
   return TestUtility::parseYaml<envoy::config::cluster::v3::Cluster>(fmt::format(R"EOF(

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -601,9 +601,7 @@ public:
     sotw_or_delta_ = sotwOrDelta();
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -643,9 +641,7 @@ public:
     sotw_or_delta_ = sotwOrDelta();
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -806,9 +802,7 @@ public:
     sotw_or_delta_ = sotwOrDelta();
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   void initialize() override {
     config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {

--- a/test/integration/ads_integration_test.cc
+++ b/test/integration/ads_integration_test.cc
@@ -603,8 +603,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void initialize() override {
@@ -647,8 +645,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void initialize() override {
@@ -812,8 +808,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void initialize() override {

--- a/test/integration/api_version_integration_test.cc
+++ b/test/integration/api_version_integration_test.cc
@@ -218,8 +218,6 @@ public:
     if (xds_stream_ != nullptr) {
       cleanUpXdsConnection();
     }
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   std::string endpoint_;

--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -42,8 +42,6 @@ public:
   void TearDown() override {
     if (!test_skipped_) {
       cleanUpXdsConnection();
-      test_server_.reset();
-      fake_upstreams_.clear();
     }
   }
 

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -28,18 +28,7 @@ public:
       )EOF");
   }
 
-  /**
-   * Initializer for an individual test.
-   */
   void SetUp() override { BaseIntegrationTest::initialize(); }
-
-  /**
-   *  Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, EchoIntegrationTest,

--- a/test/integration/filter_manager_integration_test.cc
+++ b/test/integration/filter_manager_integration_test.cc
@@ -410,11 +410,6 @@ public:
 
   void SetUp() override { addAuxiliaryFilter(config_helper_); }
 
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
 protected:
   // Returns configuration for a given auxiliary filter
   std::string filterConfig(const std::string& auxiliary_filter_name) override {

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -196,9 +196,6 @@ public:
       RELEASE_ASSERT(result, result.message());
       eds_connection_.reset();
     }
-    cleanupUpstreamAndDownstream();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void addHeader(Protobuf::RepeatedPtrField<envoy::config::core::v3::HeaderValueOption>* field,

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -253,9 +253,7 @@ void HttpIntegrationTest::useAccessLog(absl::string_view format) {
   ASSERT_TRUE(config_helper_.setAccessLog(access_log_name_, format));
 }
 
-HttpIntegrationTest::~HttpIntegrationTest() {
-  cleanupUpstreamAndDownstream();
-}
+HttpIntegrationTest::~HttpIntegrationTest() { cleanupUpstreamAndDownstream(); }
 
 void HttpIntegrationTest::setDownstreamProtocol(Http::CodecClient::Type downstream_protocol) {
   downstream_protocol_ = downstream_protocol;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -255,8 +255,6 @@ void HttpIntegrationTest::useAccessLog(absl::string_view format) {
 
 HttpIntegrationTest::~HttpIntegrationTest() {
   cleanupUpstreamAndDownstream();
-  test_server_.reset();
-  fake_upstreams_.clear();
 }
 
 void HttpIntegrationTest::setDownstreamProtocol(Http::CodecClient::Type downstream_protocol) {

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -284,8 +284,8 @@ BaseIntegrationTest::BaseIntegrationTest(Network::Address::IpVersion version,
 
 BaseIntegrationTest::~BaseIntegrationTest() {
   // Tear down the fake upstream before the test server.
-  // When the HTTP cocecs do runtime checks, it is important to finish all
-  // runtime access before the server, and the runtime singlton, go away.
+  // When the HTTP codecs do runtime checks, it is important to finish all
+  // runtime access before the server, and the runtime singleton, go away.
   fake_upstreams_.clear();
   test_server_.reset();
 }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -282,6 +282,14 @@ BaseIntegrationTest::BaseIntegrationTest(Network::Address::IpVersion version,
           },
           version, config) {}
 
+BaseIntegrationTest::~BaseIntegrationTest() {
+  // Tear down the fake upstream before the test server.
+  // When the HTTP cocecs do runtime checks, it is important to finish all
+  // runtime access before the server, and the runtime singlton, go away.
+  fake_upstreams_.clear();
+  test_server_.reset();
+}
+
 Network::ClientConnectionPtr BaseIntegrationTest::makeClientConnection(uint32_t port) {
   return makeClientConnectionWithOptions(port, nullptr);
 }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -162,7 +162,7 @@ public:
                       Network::Address::IpVersion version,
                       const std::string& config = ConfigHelper::httpProxyConfig());
 
-  virtual ~BaseIntegrationTest() = default;
+  virtual ~BaseIntegrationTest();
 
   // TODO(jmarantz): Remove this once
   // https://github.com/envoyproxy/envoy-filter-example/pull/69 is reverted.

--- a/test/integration/integration_admin_test.h
+++ b/test/integration/integration_admin_test.h
@@ -36,14 +36,6 @@ public:
   }
 
   /**
-   *  Destructor for an individual test.
-   */
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
-  /**
    * Validates that the passed in string conforms to output of stats in JSON format.
    */
   void validateStatsJson(const std::string& stats_json, const uint64_t expected_hist_count) {

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -844,8 +844,6 @@ TEST_P(IntegrationTest, TestHead) {
   EXPECT_THAT(response->headers(), HeaderValueOf(Headers::get().ContentLength, "12"));
   EXPECT_EQ(response->headers().TransferEncoding(), nullptr);
   EXPECT_EQ(0, response->body().size());
-
-  cleanupUpstreamAndDownstream();
 }
 
 // The Envoy HTTP/1.1 codec ASSERTs that T-E headers are cleared in
@@ -1302,7 +1300,6 @@ TEST_P(IntegrationTest, TestUpgradeHeaderInResponse) {
   response->waitForEndStream();
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("Hello World", response->body());
-  cleanupUpstreamAndDownstream();
 }
 
 TEST_P(IntegrationTest, ConnectWithNoBody) {

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -32,9 +32,7 @@ protected:
   ListenerIntegrationTest()
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion(), realTime()) {}
 
-  ~ListenerIntegrationTest() override {
-    resetConnections();
-  }
+  ~ListenerIntegrationTest() override { resetConnections(); }
 
   void initialize() override {
     // We want to use the GRPC based LDS.

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -34,7 +34,6 @@ protected:
 
   ~ListenerIntegrationTest() override {
     resetConnections();
-    cleanupUpstreamAndDownstream();
   }
 
   void initialize() override {
@@ -258,7 +257,6 @@ TEST_P(ListenerIntegrationTest, BasicSuccess) {
   verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
-  cleanupUpstreamAndDownstream();
 }
 
 } // namespace

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -75,9 +75,7 @@ public:
     sotw_or_delta_ = sotwOrDelta();
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   void initialize() override {
     // The tests infra expects the xDS server to be the second fake upstream, so

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -77,8 +77,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void initialize() override {
@@ -228,7 +226,6 @@ TEST_P(RtdsIntegrationTest, RtdsAfterAsyncPrimaryClusterInitialization) {
   EXPECT_EQ(initial_load_success_ + 1, test_server_->counter("runtime.load_success")->value());
   EXPECT_EQ(initial_keys_ + 1, test_server_->gauge("runtime.num_keys")->value());
   EXPECT_EQ(3, test_server_->gauge("runtime.num_layers")->value());
-  cleanupUpstreamAndDownstream();
 }
 
 } // namespace

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -32,9 +32,7 @@ protected:
   ScopedRdsIntegrationTest()
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion(), realTime()) {}
 
-  ~ScopedRdsIntegrationTest() override {
-    resetConnections();
-  }
+  ~ScopedRdsIntegrationTest() override { resetConnections(); }
 
   void initialize() override {
     // Setup two upstream hosts, one for each cluster.

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -34,7 +34,6 @@ protected:
 
   ~ScopedRdsIntegrationTest() override {
     resetConnections();
-    cleanupUpstreamAndDownstream();
   }
 
   void initialize() override {

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -183,10 +183,7 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-
     client_ssl_ctx_.reset();
-    cleanupUpstreamAndDownstream();
-    codec_client_.reset();
   }
 
   Network::ClientConnectionPtr makeSslClientConnection() {
@@ -346,9 +343,6 @@ public:
     client_ssl_ctx_.reset();
     cleanupUpstreamAndDownstream();
     codec_client_.reset();
-
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   void enableCombinedValidationContext(bool enable) { use_combined_validation_context_ = enable; }

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -104,9 +104,7 @@ public:
     HttpIntegrationTest::initialize();
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   void createSdsStream() {
     createXdsConnection();

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -106,8 +106,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    cleanupUpstreamAndDownstream();
-    codec_client_.reset();
   }
 
   void createSdsStream() {

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -25,11 +25,6 @@ class StatsIntegrationTest : public testing::TestWithParam<Network::Address::IpV
 public:
   StatsIntegrationTest() : BaseIntegrationTest(GetParam()) {}
 
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void initialize() override { BaseIntegrationTest::initialize(); }
 };
 

--- a/test/integration/tcp_conn_pool_integration_test.cc
+++ b/test/integration/tcp_conn_pool_integration_test.cc
@@ -124,12 +124,6 @@ public:
   // Initializer for individual tests.
   void SetUp() override { BaseIntegrationTest::initialize(); }
 
-  // Destructor for individual tests.
-  void TearDown() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
 private:
   TestFilterConfigFactory config_factory_;
   Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> filter_resolver_;

--- a/test/integration/tcp_proxy_integration_test.h
+++ b/test/integration/tcp_proxy_integration_test.h
@@ -17,11 +17,6 @@ public:
     enable_half_close_ = true;
   }
 
-  ~TcpProxyIntegrationTest() override {
-    test_server_.reset();
-    fake_upstreams_.clear();
-  }
-
   void initialize() override;
 };
 

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -244,6 +244,8 @@ TEST_P(ProxyingConnectIntegrationTest, ProxyConnect) {
   // Also test upstream to downstream data.
   upstream_request_->encodeData(12, false);
   response_->waitForBodyData(12);
+
+  cleanupUpstreamAndDownstream();
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectTerminationIntegrationTest,

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -244,8 +244,6 @@ TEST_P(ProxyingConnectIntegrationTest, ProxyConnect) {
   // Also test upstream to downstream data.
   upstream_request_->encodeData(12, false);
   response_->waitForBodyData(12);
-
-  cleanupUpstreamAndDownstream();
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectTerminationIntegrationTest,

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -140,9 +140,7 @@ public:
     use_lds_ = false;
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   // Overridden to insert this stuff into the initialize() at the very beginning of
   // HttpIntegrationTest::testRouterRequestAndResponseWithBody().
@@ -240,9 +238,7 @@ public:
     use_lds_ = false;
   }
 
-  void TearDown() override {
-    cleanUpXdsConnection();
-  }
+  void TearDown() override { cleanUpXdsConnection(); }
 
   std::string virtualHostYaml(const std::string& name, const std::string& domain) {
     return fmt::format(VhostTemplate, name, domain);

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -142,8 +142,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   // Overridden to insert this stuff into the initialize() at the very beginning of
@@ -244,8 +242,6 @@ public:
 
   void TearDown() override {
     cleanUpXdsConnection();
-    test_server_.reset();
-    fake_upstreams_.clear();
   }
 
   std::string virtualHostYaml(const std::string& name, const std::string& domain) {


### PR DESCRIPTION
As (now) commented, when codecs access runtime, it creates a destruction order invariant that the fake upstreams are torn down before the server (and its runtime).  Fixing this in the base integration test and cleaning up test sub-classes.

Risk Level: n/a (test only)
Testing: http2 test passes cleanly with 200 runs (where before it flaked out)
Docs Changes: n/a
Release Notes: n/a
Fixes #11538
