### PR TITLE
quiche: destroy file event before close socket during connection migration.

### DIFF
--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
@@ -95,6 +95,7 @@ void EnvoyQuicClientConnection::setUpConnectionSocket() {
 void EnvoyQuicClientConnection::switchConnectionSocket(
     Network::ConnectionSocketPtr&& connection_socket) {
   auto writer = std::make_unique<EnvoyQuicPacketWriter>(*connection_socket);
+  file_event_.reset();
   setConnectionSocket(std::move(connection_socket));
   setUpConnectionSocket();
   SetQuicPacketWriter(writer.release(), true);

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
@@ -96,6 +96,7 @@ void EnvoyQuicClientConnection::switchConnectionSocket(
     Network::ConnectionSocketPtr&& connection_socket) {
   auto writer = std::make_unique<EnvoyQuicPacketWriter>(*connection_socket);
   file_event_.reset();
+  // The old socket is closed in this call.
   setConnectionSocket(std::move(connection_socket));
   setUpConnectionSocket();
   SetQuicPacketWriter(writer.release(), true);

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_connection.cc
@@ -95,6 +95,8 @@ void EnvoyQuicClientConnection::setUpConnectionSocket() {
 void EnvoyQuicClientConnection::switchConnectionSocket(
     Network::ConnectionSocketPtr&& connection_socket) {
   auto writer = std::make_unique<EnvoyQuicPacketWriter>(*connection_socket);
+  // Destroy the old file_event before closing the old socket. Otherwise the socket might be picked
+  // up by another socket() call while file_event is still operating on it.
   file_event_.reset();
   // The old socket is closed in this call.
   setConnectionSocket(std::move(connection_socket));


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

The old socket should be closed after corresponding  file_event is destroyed. Otherwise the socket might be picked up by other socket() call while file_event is still operating on it. It causes TSAN failure in QuicHttpIntegrationTest.ConnectionMigration: https://dev.azure.com/cncf/envoy/_build/results?buildId=41584&view=logs&j=5eb754ee-449a-545e-2b62-07fe525d7cbc&t=1110550d-5f5f-55a9-69fd-d02adf65e59a&l=4016
 
Risk Level: low
Testing: tested QuicHttpIntegrationTest.ConnectionMigration under tsan
