### PR TITLE
network: add more socket apis to io handle

### DIFF
--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -12,7 +12,6 @@ envoy_cc_library(
     name = "address_interface",
     hdrs = ["address.h"],
     deps = [
-        ":io_handle_interface",
         "//include/envoy/api:os_sys_calls_interface",
     ],
 )
@@ -77,7 +76,9 @@ envoy_cc_library(
     name = "io_handle_interface",
     hdrs = ["io_handle.h"],
     deps = [
+        ":address_interface",
         "//include/envoy/api:io_error_interface",
+        "//include/envoy/api:os_sys_calls_interface",
         "//source/common/common:assert_lib",
     ],
 )

--- a/include/envoy/network/address.h
+++ b/include/envoy/network/address.h
@@ -10,7 +10,6 @@
 #include "envoy/api/os_sys_calls.h"
 #include "envoy/common/platform.h"
 #include "envoy/common/pure.h"
-#include "envoy/network/io_handle.h"
 
 #include "absl/numeric/int128.h"
 #include "absl/strings/string_view.h"

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -5,6 +5,7 @@
 #include "envoy/api/io_error.h"
 #include "envoy/common/platform.h"
 #include "envoy/common/pure.h"
+#include "envoy/network/address.h"
 
 #include "absl/container/fixed_array.h"
 
@@ -16,12 +17,6 @@ struct RawSlice;
 using RawSliceArrays = absl::FixedArray<absl::FixedArray<Buffer::RawSlice>>;
 
 namespace Network {
-namespace Address {
-class Instance;
-class Ip;
-
-using InstanceConstSharedPtr = std::shared_ptr<const Instance>;
-} // namespace Address
 
 /**
  * IoHandle: an abstract interface for all I/O operations

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -144,6 +144,58 @@ public:
    * return true if the platform supports recvmmsg() and sendmmsg().
    */
   virtual bool supportsMmsg() const PURE;
+
+  /**
+   * Bind to address. The handle should have been created with a call to socket()
+   * @param address address to bind to.
+   * @param addrlen address length
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   *   is successful, errno_ shouldn't be used.
+   */
+  virtual Api::SysCallIntResult bind(const sockaddr* address, socklen_t addrlen) PURE;
+
+  /**
+   * Listen on bound handle.
+   * @param backlog maximum number of pending connections for listener
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   *   is successful, errno_ shouldn't be used.
+   */
+  virtual Api::SysCallIntResult listen(int backlog) PURE;
+
+  /**
+   * Connect to address. The handle should have been created with a call to socket()
+   * on this object.
+   * @param address remote address to connect to.
+   * @param addrlen remote address length
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   *   is successful, errno_ shouldn't be used.
+   */
+  virtual Api::SysCallIntResult connect(const sockaddr* address, socklen_t addrlen) PURE;
+
+  /**
+   * Set option (see man 2 setsockopt)
+   */
+  virtual Api::SysCallIntResult setOption(int level, int optname, const void* optval,
+                                          socklen_t optlen) PURE;
+
+  /**
+   * Get option (see man 2 getsockopt)
+   */
+  virtual Api::SysCallIntResult getOption(int level, int optname, void* optval,
+                                          socklen_t* optlen) PURE;
+
+  /**
+   * Get local address to which handle is bound (see man 2 getsockname)
+   */
+  virtual Api::SysCallIntResult getLocalAddress(sockaddr* address, socklen_t* addrlen) PURE;
+
+  /**
+   * Toggle blocking behavior
+   * @param blocking flag to set/unset blocking state
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   * is successful, errno_ shouldn't be used.
+   */
+  virtual Api::SysCallIntResult setBlocking(bool blocking) PURE;
 };
 
 using IoHandlePtr = std::unique_ptr<IoHandle>;

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -144,6 +144,7 @@ envoy_cc_library(
     hdrs = ["hash_policy.h"],
     deps = [
         "//include/envoy/network:hash_policy_interface",
+        "//source/common/common:assert_lib",
         "//source/common/common:hash_lib",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -365,5 +365,35 @@ bool IoSocketHandleImpl::supportsMmsg() const {
   return Api::OsSysCallsSingleton::get().supportsMmsg();
 }
 
+Api::SysCallIntResult IoSocketHandleImpl::bind(const sockaddr* address, socklen_t addrlen) {
+  return Api::OsSysCallsSingleton::get().bind(fd_, address, addrlen);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::listen(int backlog) {
+  return Api::OsSysCallsSingleton::get().listen(fd_, backlog);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::connect(const sockaddr* address, socklen_t addrlen) {
+  return Api::OsSysCallsSingleton::get().connect(fd_, address, addrlen);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::setOption(int level, int optname, const void* optval,
+                                                    socklen_t optlen) {
+  return Api::OsSysCallsSingleton::get().setsockopt(fd_, level, optname, optval, optlen);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::getOption(int level, int optname, void* optval,
+                                                    socklen_t* optlen) {
+  return Api::OsSysCallsSingleton::get().getsockopt(fd_, level, optname, optval, optlen);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::getLocalAddress(sockaddr* address, socklen_t* addrlen) {
+  return Api::OsSysCallsSingleton::get().getsockname(fd_, address, addrlen);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::setBlocking(bool blocking) {
+  return Api::OsSysCallsSingleton::get().setsocketblocking(fd_, blocking);
+}
+
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -45,6 +45,15 @@ public:
 
   bool supportsMmsg() const override;
 
+  Api::SysCallIntResult bind(const sockaddr* address, socklen_t addrlen) override;
+  Api::SysCallIntResult listen(int backlog) override;
+  Api::SysCallIntResult connect(const sockaddr* address, socklen_t addrlen) override;
+  Api::SysCallIntResult setOption(int level, int optname, const void* optval,
+                                  socklen_t optlen) override;
+  Api::SysCallIntResult getOption(int level, int optname, void* optval, socklen_t* optlen) override;
+  Api::SysCallIntResult getLocalAddress(sockaddr* address, socklen_t* addrlen) override;
+  Api::SysCallIntResult setBlocking(bool blocking) override;
+
 private:
   // Converts a SysCallSizeResult to IoCallUint64Result.
   template <typename T>

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -63,6 +63,27 @@ public:
     return io_handle_.recvmmsg(slices, self_port, output);
   }
   bool supportsMmsg() const override { return io_handle_.supportsMmsg(); }
+  Api::SysCallIntResult bind(const sockaddr* address, socklen_t addrlen) override {
+    return io_handle_.bind(address, addrlen);
+  }
+  Api::SysCallIntResult listen(int backlog) override { return io_handle_.listen(backlog); }
+  Api::SysCallIntResult connect(const sockaddr* address, socklen_t addrlen) override {
+    return io_handle_.connect(address, addrlen);
+  }
+  Api::SysCallIntResult setOption(int level, int optname, const void* optval,
+                                  socklen_t optlen) override {
+    return io_handle_.setOption(level, optname, optval, optlen);
+  }
+  Api::SysCallIntResult getOption(int level, int optname, void* optval,
+                                  socklen_t* optlen) override {
+    return io_handle_.getOption(level, optname, optval, optlen);
+  }
+  Api::SysCallIntResult getLocalAddress(sockaddr* address, socklen_t* addrlen) override {
+    return io_handle_.getLocalAddress(address, addrlen);
+  }
+  Api::SysCallIntResult setBlocking(bool blocking) override {
+    return io_handle_.setBlocking(blocking);
+  }
 
 private:
   Network::IoHandle& io_handle_;

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test_library(
     srcs = ["http2_frame.cc"],
     hdrs = ["http2_frame.h"],
     deps = [
+        "//source/common/common:assert_lib",
         "//source/common/common:macros",
     ],
 )

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -29,6 +29,15 @@ public:
   MOCK_METHOD(Api::IoCallUint64Result, recvmmsg,
               (RawSliceArrays & slices, uint32_t self_port, RecvMsgOutput& output));
   MOCK_METHOD(bool, supportsMmsg, (), (const));
+  MOCK_METHOD(Api::SysCallIntResult, bind, (const sockaddr* address, socklen_t addrlen));
+  MOCK_METHOD(Api::SysCallIntResult, listen, (int backlog));
+  MOCK_METHOD(Api::SysCallIntResult, connect, (const sockaddr* address, socklen_t addrlen));
+  MOCK_METHOD(Api::SysCallIntResult, setOption,
+              (int level, int optname, const void* optval, socklen_t optlen));
+  MOCK_METHOD(Api::SysCallIntResult, getOption,
+              (int level, int optname, void* optval, socklen_t* optlen));
+  MOCK_METHOD(Api::SysCallIntResult, getLocalAddress, (sockaddr * address, socklen_t* addrlen));
+  MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool blocking));
 };
 
 } // namespace Network


### PR DESCRIPTION
Let io handle implementation interact with the underlying socket layer.

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a