### PR TITLE
eds_speed_test: add GrpcMuxImpl config ingestion path to benchmark.

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -104,6 +104,9 @@ envoy_cc_benchmark_binary(
     ],
     deps = [
         ":utility_lib",
+        "//source/common/config:grpc_mux_lib",
+        "//source/common/config:grpc_subscription_lib",
+        "//source/common/config:protobuf_link_hacks",
         "//source/common/config:utility_lib",
         "//source/common/upstream:eds_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",

--- a/test/common/upstream/eds_speed_test.cc
+++ b/test/common/upstream/eds_speed_test.cc
@@ -8,6 +8,8 @@
 #include "envoy/service/discovery/v3/discovery.pb.h"
 #include "envoy/stats/scope.h"
 
+#include "common/config/grpc_mux_impl.h"
+#include "common/config/grpc_subscription_impl.h"
 #include "common/config/utility.h"
 #include "common/singleton/manager_impl.h"
 #include "common/upstream/eds.h"
@@ -30,7 +32,18 @@ namespace Upstream {
 
 class EdsSpeedTest {
 public:
-  EdsSpeedTest(benchmark::State& state) : state_(state), api_(Api::createApiForTest(stats_)) {}
+  EdsSpeedTest(benchmark::State& state, bool v2_config)
+      : state_(state), v2_config_(v2_config),
+        type_url_(v2_config_
+                      ? "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
+                      : "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"),
+        subscription_stats_(Config::Utility::generateStats(stats_)),
+        api_(Api::createApiForTest(stats_)), async_client_(new Grpc::MockAsyncClient()),
+        grpc_mux_(new Config::GrpcMuxImpl(
+            local_info_, std::unique_ptr<Grpc::MockAsyncClient>(async_client_), dispatcher_,
+            *Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+                "envoy.service.endpoint.v3.EndpointDiscoveryService.StreamEndpoints"),
+            envoy::config::core::v3::ApiVersion::AUTO, random_, stats_, {}, true)) {}
 
   void resetCluster(const std::string& yaml_config, Cluster::InitializePhase initialize_phase) {
     local_info_.node_.mutable_locality()->set_zone("us-east-1a");
@@ -45,6 +58,9 @@ public:
                                                 std::move(scope), false);
     EXPECT_EQ(initialize_phase, cluster_->initializePhase());
     eds_callbacks_ = cm_.subscription_factory_.callbacks_;
+    subscription_ = std::make_unique<Config::GrpcSubscriptionImpl>(
+        grpc_mux_, *eds_callbacks_, subscription_stats_, type_url_, dispatcher_,
+        std::chrono::milliseconds(), false);
   }
 
   void initialize() {
@@ -54,8 +70,7 @@ public:
 
   // Set up an EDS config with multiple priorities, localities, weights and make sure
   // they are loaded and reloaded as expected.
-  void priorityAndLocalityWeightedHelper(bool v2_config, bool ignore_unknown_dynamic_fields,
-                                         int num_hosts) {
+  void priorityAndLocalityWeightedHelper(bool ignore_unknown_dynamic_fields, size_t num_hosts) {
     state_.PauseTiming();
     envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
     cluster_load_assignment.set_cluster_name("fare");
@@ -83,7 +98,7 @@ public:
     endpoints->mutable_load_balancing_weight()->set_value(1);
 
     uint32_t port = 1000;
-    for (int i = 0; i < num_hosts; ++i) {
+    for (size_t i = 0; i < num_hosts; ++i) {
       auto* socket_address = endpoints->add_lb_endpoints()
                                  ->mutable_endpoint()
                                  ->mutable_address()
@@ -96,23 +111,31 @@ public:
     validation_visitor_.setSkipValidation(ignore_unknown_dynamic_fields);
 
     initialize();
-    Protobuf::RepeatedPtrField<ProtobufWkt::Any> resources;
-    auto* resource = resources.Add();
+    auto response = std::make_unique<envoy::service::discovery::v3::DiscoveryResponse>();
+    response->set_type_url(type_url_);
+    auto* resource = response->mutable_resources()->Add();
     resource->PackFrom(cluster_load_assignment);
-    if (v2_config) {
+    if (v2_config_) {
       RELEASE_ASSERT(resource->type_url() ==
                          "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
                      "");
       resource->set_type_url("type.googleapis.com/envoy.api.v2.ClusterLoadAssignment");
     }
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _)).WillOnce(testing::Return(&async_stream_));
+    subscription_->start({"fare"});
     state_.ResumeTiming();
-    eds_callbacks_->onConfigUpdate(resources, "");
+    grpc_mux_->grpcStreamForTest().onReceiveMessage(std::move(response));
     ASSERT(initialized_);
+    ASSERT(cluster_->prioritySet().hostSetsPerPriority()[1]->hostsPerLocality().get()[0].size() ==
+           num_hosts);
   }
 
   benchmark::State& state_;
+  const bool v2_config_;
+  const std::string type_url_;
   bool initialized_{};
   Stats::IsolatedStoreImpl stats_;
+  Config::SubscriptionStats subscription_stats_;
   Ssl::MockContextManager ssl_context_manager_;
   envoy::config::cluster::v3::Cluster eds_cluster_;
   NiceMock<MockClusterManager> cm_;
@@ -127,6 +150,10 @@ public:
   NiceMock<ThreadLocal::MockInstance> tls_;
   ProtobufMessage::MockValidationVisitor validation_visitor_;
   Api::ApiPtr api_;
+  Grpc::MockAsyncClient* async_client_;
+  NiceMock<Grpc::MockAsyncStream> async_stream_;
+  std::shared_ptr<Config::GrpcMuxImpl> grpc_mux_;
+  std::unique_ptr<Config::GrpcSubscriptionImpl> subscription_;
 };
 
 } // namespace Upstream
@@ -137,8 +164,8 @@ static void priorityAndLocalityWeighted(benchmark::State& state) {
   Envoy::Logger::Context logging_state(spdlog::level::warn,
                                        Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
   for (auto _ : state) {
-    Envoy::Upstream::EdsSpeedTest speed_test(state);
-    speed_test.priorityAndLocalityWeightedHelper(state.range(0), state.range(1), state.range(2));
+    Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(0));
+    speed_test.priorityAndLocalityWeightedHelper(state.range(1), state.range(2));
   }
 }
 


### PR DESCRIPTION
A lot of the overhead we see in
https://github.com/envoyproxy/envoy/issues/11362 has to do with the
overhead from the GrpcMuxImpl ingestion path, and helps put the EDS
cluster overhead in context.

This patch adds a GrpcMuxImpl and GrpcSubscription to the test,
allowing a fairly realistic cost of EDS update to be obtained.

Below is the example output. We're seeing v3 costs ~3.2x of the v2
ingestion. Future patches will narrow this.

---------------------------------------------------------------------------------
Benchmark                                       Time             CPU
Iterations
---------------------------------------------------------------------------------
priorityAndLocalityWeighted/0/0/2000      6277063 ns      6276456 ns
113
priorityAndLocalityWeighted/1/0/2000     20236878 ns     20236505 ns
35
priorityAndLocalityWeighted/0/1/2000      4589757 ns      4588833 ns
154
priorityAndLocalityWeighted/1/1/2000     14853274 ns     14850006 ns
42
priorityAndLocalityWeighted/0/0/4096     11865838 ns     11865314 ns
59
priorityAndLocalityWeighted/1/0/4096     39787876 ns     39787716 ns
18
priorityAndLocalityWeighted/0/1/4096      8186874 ns      8185724 ns
87
priorityAndLocalityWeighted/1/1/4096     29376139 ns     29374980 ns
24
priorityAndLocalityWeighted/0/0/32768   110248743 ns    110246101 ns
6
priorityAndLocalityWeighted/1/0/32768   343826306 ns    343761359 ns
2
priorityAndLocalityWeighted/0/1/32768    76962915 ns     76953406 ns
7
priorityAndLocalityWeighted/1/1/32768   254426231 ns    254401890 ns
3
priorityAndLocalityWeighted/0/0/100000  352576987 ns    352550994 ns
2
priorityAndLocalityWeighted/1/0/100000 1100804152 ns   1100646263 ns
1
priorityAndLocalityWeighted/0/1/100000  253870688 ns    253857626 ns
3
priorityAndLocalityWeighted/1/1/100000  808080918 ns    808028852 ns
1

Risk level: Low (test only)
Testing: Added ASSERTs to validate that we're loaded all the hosts at
  the end of the benchmark.

Signed-off-by: Harvey Tuch <htuch@google.com>