### PR TITLE
network: fd usage cleanup in listener and io handle

### DIFF
--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -75,6 +75,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "io_handle_interface",
     hdrs = ["io_handle.h"],
+    external_deps = ["abseil_optional"],
     deps = [
         ":address_interface",
         "//include/envoy/api:io_error_interface",

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -8,6 +8,7 @@
 #include "envoy/network/address.h"
 
 #include "absl/container/fixed_array.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Buffer {
@@ -193,7 +194,7 @@ public:
    * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
    * is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallIntResult domain(int& domain) PURE;
+  virtual absl::optional<int> domain() PURE;
 
   /**
    * Get local address (ip:port pair)

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -180,17 +180,32 @@ public:
                                           socklen_t* optlen) PURE;
 
   /**
-   * Get local address to which handle is bound (see man 2 getsockname)
-   */
-  virtual Api::SysCallIntResult getLocalAddress(sockaddr* address, socklen_t* addrlen) PURE;
-
-  /**
    * Toggle blocking behavior
    * @param blocking flag to set/unset blocking state
    * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
    * is successful, errno_ shouldn't be used.
    */
   virtual Api::SysCallIntResult setBlocking(bool blocking) PURE;
+
+  /**
+   * Get domain used by underlying socket (see man 2 socket)
+   * @param domain updated to the underlying socket's domain if call is successful
+   * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
+   * is successful, errno_ shouldn't be used.
+   */
+  virtual Api::SysCallIntResult domain(int& domain) PURE;
+
+  /**
+   * Get local address (ip:port pair)
+   * @return local address as @ref Address::InstanceConstSharedPtr
+   */
+  virtual Address::InstanceConstSharedPtr localAddress() PURE;
+
+  /**
+   * Get peer's address (ip:port pair)
+   * @return peer's address as @ref Address::InstanceConstSharedPtr
+   */
+  virtual Address::InstanceConstSharedPtr peerAddress() PURE;
 };
 
 using IoHandlePtr = std::unique_ptr<IoHandle>;

--- a/include/envoy/network/socket.h
+++ b/include/envoy/network/socket.h
@@ -258,25 +258,17 @@ public:
                              const Address::InstanceConstSharedPtr addr) PURE;
 
   /**
+   * Wrap socket file descriptor in IoHandle
+   * @param fd socket file descriptor to be wrapped
+   * @return @ref Network::IoHandlePtr that wraps the socket file descriptor
+   */
+  virtual IoHandlePtr socket(os_fd_t fd) PURE;
+
+  /**
    * Returns true if the given family is supported on this machine.
    * @param domain the IP family.
    */
   virtual bool ipFamilySupported(int domain) PURE;
-
-  /**
-   * Obtain an address from a bound file descriptor. Raises an EnvoyException on failure.
-   * @param fd socket file descriptor
-   * @return InstanceConstSharedPtr for bound address.
-   */
-  virtual Address::InstanceConstSharedPtr addressFromFd(os_fd_t fd) PURE;
-
-  /**
-   * Obtain the address of the peer of the socket with the specified file descriptor.
-   * Raises an EnvoyException on failure.
-   * @param fd socket file descriptor
-   * @return InstanceConstSharedPtr for peer address.
-   */
-  virtual Address::InstanceConstSharedPtr peerAddressFromFd(os_fd_t fd) PURE;
 };
 
 } // namespace Network

--- a/source/common/network/base_listener_impl.cc
+++ b/source/common/network/base_listener_impl.cc
@@ -15,10 +15,6 @@
 namespace Envoy {
 namespace Network {
 
-Address::InstanceConstSharedPtr BaseListenerImpl::getLocalAddress(os_fd_t fd) {
-  return SocketInterfaceSingleton::get().addressFromFd(fd);
-}
-
 BaseListenerImpl::BaseListenerImpl(Event::DispatcherImpl& dispatcher, SocketSharedPtr socket)
     : local_address_(nullptr), dispatcher_(dispatcher), socket_(std::move(socket)) {
   const auto ip = socket_->localAddress()->ip();

--- a/source/common/network/base_listener_impl.h
+++ b/source/common/network/base_listener_impl.h
@@ -23,8 +23,6 @@ public:
   BaseListenerImpl(Event::DispatcherImpl& dispatcher, SocketSharedPtr socket);
 
 protected:
-  virtual Address::InstanceConstSharedPtr getLocalAddress(os_fd_t fd);
-
   Address::InstanceConstSharedPtr local_address_;
   Event::DispatcherImpl& dispatcher_;
   const SocketSharedPtr socket_;

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -391,7 +391,7 @@ Api::SysCallIntResult IoSocketHandleImpl::setBlocking(bool blocking) {
   return Api::OsSysCallsSingleton::get().setsocketblocking(fd_, blocking);
 }
 
-Api::SysCallIntResult IoSocketHandleImpl::domain(int& domain) {
+absl::optional<int> IoSocketHandleImpl::domain() {
   sockaddr_storage addr;
   socklen_t len = sizeof(addr);
   Api::SysCallIntResult result;
@@ -400,10 +400,10 @@ Api::SysCallIntResult IoSocketHandleImpl::domain(int& domain) {
       fd_, reinterpret_cast<struct sockaddr*>(&addr), &len);
 
   if (result.rc_ == 0) {
-    domain = addr.ss_family;
+    return {addr.ss_family};
   }
 
-  return result;
+  return absl::nullopt;
 }
 
 Address::InstanceConstSharedPtr IoSocketHandleImpl::localAddress() {

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -426,7 +426,7 @@ Address::InstanceConstSharedPtr IoSocketHandleImpl::localAddress() {
     // listening. So we can't use RELEASE_ASSERT and instead must throw an
     // exception
     if (SOCKET_FAILURE(result.rc_)) {
-      throw EnvoyException(fmt::format("getsockopt failed for '{}': ({}) {}", fd, result.errno_,
+      throw EnvoyException(fmt::format("getsockopt failed for '{}': ({}) {}", fd_, result.errno_,
                                        strerror(result.errno_)));
     }
 #else

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -387,12 +387,82 @@ Api::SysCallIntResult IoSocketHandleImpl::getOption(int level, int optname, void
   return Api::OsSysCallsSingleton::get().getsockopt(fd_, level, optname, optval, optlen);
 }
 
-Api::SysCallIntResult IoSocketHandleImpl::getLocalAddress(sockaddr* address, socklen_t* addrlen) {
-  return Api::OsSysCallsSingleton::get().getsockname(fd_, address, addrlen);
-}
-
 Api::SysCallIntResult IoSocketHandleImpl::setBlocking(bool blocking) {
   return Api::OsSysCallsSingleton::get().setsocketblocking(fd_, blocking);
+}
+
+Api::SysCallIntResult IoSocketHandleImpl::domain(int& domain) {
+  sockaddr_storage addr;
+  socklen_t len = sizeof(addr);
+  Api::SysCallIntResult result;
+
+  result = Api::OsSysCallsSingleton::get().getsockname(
+      fd_, reinterpret_cast<struct sockaddr*>(&addr), &len);
+
+  if (result.rc_ == 0) {
+    domain = addr.ss_family;
+  }
+
+  return result;
+}
+
+Address::InstanceConstSharedPtr IoSocketHandleImpl::localAddress() {
+  sockaddr_storage ss;
+  socklen_t ss_len = sizeof(ss);
+  auto& os_sys_calls = Api::OsSysCallsSingleton::get();
+  Api::SysCallIntResult result =
+      os_sys_calls.getsockname(fd_, reinterpret_cast<sockaddr*>(&ss), &ss_len);
+  if (result.rc_ != 0) {
+    throw EnvoyException(fmt::format("getsockname failed for '{}': ({}) {}", fd_, result.errno_,
+                                     strerror(result.errno_)));
+  }
+  int socket_v6only = 0;
+  if (ss.ss_family == AF_INET6) {
+    socklen_t size_int = sizeof(socket_v6only);
+    result = os_sys_calls.getsockopt(fd_, IPPROTO_IPV6, IPV6_V6ONLY, &socket_v6only, &size_int);
+#ifdef WIN32
+    // On Windows, it is possible for this getsockopt() call to fail.
+    // This can happen if the address we are trying to connect to has nothing
+    // listening. So we can't use RELEASE_ASSERT and instead must throw an
+    // exception
+    if (SOCKET_FAILURE(result.rc_)) {
+      throw EnvoyException(fmt::format("getsockopt failed for '{}': ({}) {}", fd, result.errno_,
+                                       strerror(result.errno_)));
+    }
+#else
+    RELEASE_ASSERT(result.rc_ == 0, "");
+#endif
+  }
+  return Address::addressFromSockAddr(ss, ss_len, socket_v6only);
+}
+
+Address::InstanceConstSharedPtr IoSocketHandleImpl::peerAddress() {
+  sockaddr_storage ss;
+  socklen_t ss_len = sizeof ss;
+  auto& os_sys_calls = Api::OsSysCallsSingleton::get();
+  Api::SysCallIntResult result =
+      os_sys_calls.getpeername(fd_, reinterpret_cast<sockaddr*>(&ss), &ss_len);
+  if (result.rc_ != 0) {
+    throw EnvoyException(
+        fmt::format("getpeername failed for '{}': {}", fd_, strerror(result.errno_)));
+  }
+#ifdef __APPLE__
+  if (ss_len == sizeof(sockaddr) && ss.ss_family == AF_UNIX)
+#else
+  if (ss_len == sizeof(sa_family_t) && ss.ss_family == AF_UNIX)
+#endif
+  {
+    // For Unix domain sockets, can't find out the peer name, but it should match our own
+    // name for the socket (i.e. the path should match, barring any namespace or other
+    // mechanisms to hide things, of which there are many).
+    ss_len = sizeof ss;
+    result = os_sys_calls.getsockname(fd_, reinterpret_cast<sockaddr*>(&ss), &ss_len);
+    if (result.rc_ != 0) {
+      throw EnvoyException(
+          fmt::format("getsockname failed for '{}': {}", fd_, strerror(result.errno_)));
+    }
+  }
+  return Address::addressFromSockAddr(ss, ss_len);
 }
 
 } // namespace Network

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -52,7 +52,7 @@ public:
                                   socklen_t optlen) override;
   Api::SysCallIntResult getOption(int level, int optname, void* optval, socklen_t* optlen) override;
   Api::SysCallIntResult setBlocking(bool blocking) override;
-  Api::SysCallIntResult domain(int& domain) override;
+  absl::optional<int> domain() override;
   Address::InstanceConstSharedPtr localAddress() override;
   Address::InstanceConstSharedPtr peerAddress() override;
 

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -51,8 +51,10 @@ public:
   Api::SysCallIntResult setOption(int level, int optname, const void* optval,
                                   socklen_t optlen) override;
   Api::SysCallIntResult getOption(int level, int optname, void* optval, socklen_t* optlen) override;
-  Api::SysCallIntResult getLocalAddress(sockaddr* address, socklen_t* addrlen) override;
   Api::SysCallIntResult setBlocking(bool blocking) override;
+  Api::SysCallIntResult domain(int& domain) override;
+  Address::InstanceConstSharedPtr localAddress() override;
+  Address::InstanceConstSharedPtr peerAddress() override;
 
 private:
   // Converts a SysCallSizeResult to IoCallUint64Result.

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -21,14 +21,13 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
                                   int remote_addr_len, void* arg) {
   ListenerImpl* listener = static_cast<ListenerImpl*>(arg);
 
-  // Create the IoSocketHandleImpl for the fd here.
-  IoHandlePtr io_handle = std::make_unique<IoSocketHandleImpl>(fd);
+  // Wrap raw socket fd in IoHandle.
+  IoHandlePtr io_handle = SocketInterfaceSingleton::get().socket(fd);
 
   // Get the local address from the new socket if the listener is listening on IP ANY
   // (e.g., 0.0.0.0 for IPv4) (local_address_ is nullptr in this case).
   const Address::InstanceConstSharedPtr& local_address =
-      listener->local_address_ ? listener->local_address_
-                               : listener->getLocalAddress(io_handle->fd());
+      listener->local_address_ ? listener->local_address_ : io_handle->localAddress();
 
   // The accept() call that filled in remote_addr doesn't fill in more than the sa_family field
   // for Unix domain sockets; apparently there isn't a mechanism in the kernel to get the
@@ -39,7 +38,7 @@ void ListenerImpl::listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr*
   // IPv4 local_address was created from an IPv6 mapped IPv4 address.
   const Address::InstanceConstSharedPtr& remote_address =
       (remote_addr->sa_family == AF_UNIX)
-          ? SocketInterfaceSingleton::get().peerAddressFromFd(io_handle->fd())
+          ? io_handle->peerAddress()
           : Address::addressFromSockAddr(*reinterpret_cast<const sockaddr_storage*>(remote_addr),
                                          remote_addr_len,
                                          local_address->ip()->version() == Address::IpVersion::v6);

--- a/source/common/network/socket_interface_impl.h
+++ b/source/common/network/socket_interface_impl.h
@@ -13,9 +13,8 @@ public:
   IoHandlePtr socket(Socket::Type socket_type, Address::Type addr_type,
                      Address::IpVersion version) override;
   IoHandlePtr socket(Socket::Type socket_type, const Address::InstanceConstSharedPtr addr) override;
+  IoHandlePtr socket(os_fd_t fd) override;
   bool ipFamilySupported(int domain) override;
-  Address::InstanceConstSharedPtr addressFromFd(os_fd_t fd) override;
-  Address::InstanceConstSharedPtr peerAddressFromFd(os_fd_t fd) override;
 };
 
 using SocketInterfaceSingleton = InjectableSingleton<SocketInterface>;

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -81,7 +81,7 @@ public:
   Api::SysCallIntResult setBlocking(bool blocking) override {
     return io_handle_.setBlocking(blocking);
   }
-  Api::SysCallIntResult domain(int& domain) override { return io_handle_.domain(domain); }
+  absl::optional<int> domain() override { return io_handle_.domain(); }
   Network::Address::InstanceConstSharedPtr localAddress() override {
     return io_handle_.localAddress();
   }

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -78,11 +78,15 @@ public:
                                   socklen_t* optlen) override {
     return io_handle_.getOption(level, optname, optval, optlen);
   }
-  Api::SysCallIntResult getLocalAddress(sockaddr* address, socklen_t* addrlen) override {
-    return io_handle_.getLocalAddress(address, addrlen);
-  }
   Api::SysCallIntResult setBlocking(bool blocking) override {
     return io_handle_.setBlocking(blocking);
+  }
+  Api::SysCallIntResult domain(int& domain) override { return io_handle_.domain(domain); }
+  Network::Address::InstanceConstSharedPtr localAddress() override {
+    return io_handle_.localAddress();
+  }
+  Network::Address::InstanceConstSharedPtr peerAddress() override {
+    return io_handle_.peerAddress();
   }
 
 private:

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -153,8 +153,6 @@ TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->connect();
 
-  EXPECT_CALL(listener, getLocalAddress(_)).WillOnce(Return(local_dst_address));
-
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource());
   EXPECT_CALL(listener_callbacks, onAccept_(_))
       .WillOnce(Invoke([&](Network::ConnectionSocketPtr& socket) -> void {
@@ -198,11 +196,6 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
       local_dst_address, Network::Address::InstanceConstSharedPtr(),
       Network::Test::createRawBufferSocket(), nullptr);
   client_connection->connect();
-
-  EXPECT_CALL(listener, getLocalAddress(_))
-      .WillOnce(Invoke([](os_fd_t fd) -> Address::InstanceConstSharedPtr {
-        return SocketInterfaceSingleton::get().addressFromFd(fd);
-      }));
 
   StreamInfo::StreamInfoImpl stream_info(dispatcher_->timeSource());
   EXPECT_CALL(listener_callbacks, onAccept_(_))
@@ -249,10 +242,6 @@ TEST_P(ListenerImplTest, DisableAndEnableListener) {
   // When the listener is re-enabled, the pending connection should be accepted.
   listener.enable();
 
-  EXPECT_CALL(listener, getLocalAddress(_))
-      .WillOnce(Invoke([](os_fd_t fd) -> Address::InstanceConstSharedPtr {
-        return SocketInterfaceSingleton::get().addressFromFd(fd);
-      }));
   EXPECT_CALL(listener_callbacks, onAccept_(_)).WillOnce(Invoke([&](ConnectionSocketPtr&) -> void {
     client_connection->close(ConnectionCloseType::NoFlush);
   }));

--- a/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
+++ b/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
@@ -58,8 +58,7 @@ TEST_F(QuicIoHandleWrapperTest, DelegateIoHandleCalls) {
   wrapper_->sendmsg(&slice, 1, 0, /*self_ip=*/nullptr, *addr);
 
   EXPECT_CALL(os_sys_calls_, getsockname(_, _, _)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
-  int domain;
-  wrapper_->domain(domain);
+  wrapper_->domain();
 
   EXPECT_CALL(os_sys_calls_, getsockopt_(_, _, _, _, _)).WillOnce(Return(0));
   EXPECT_CALL(os_sys_calls_, getsockname(_, _, _))

--- a/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
+++ b/test/extensions/quic_listeners/quiche/quic_io_handle_wrapper_test.cc
@@ -57,6 +57,27 @@ TEST_F(QuicIoHandleWrapperTest, DelegateIoHandleCalls) {
   EXPECT_CALL(os_sys_calls_, sendmsg(fd, _, 0)).WillOnce(Return(Api::SysCallSizeResult{5u, 0}));
   wrapper_->sendmsg(&slice, 1, 0, /*self_ip=*/nullptr, *addr);
 
+  EXPECT_CALL(os_sys_calls_, getsockname(_, _, _)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+  int domain;
+  wrapper_->domain(domain);
+
+  EXPECT_CALL(os_sys_calls_, getsockopt_(_, _, _, _, _)).WillOnce(Return(0));
+  EXPECT_CALL(os_sys_calls_, getsockname(_, _, _))
+      .WillOnce(Invoke([](os_fd_t, sockaddr* addr, socklen_t* addrlen) -> Api::SysCallIntResult {
+        addr->sa_family = AF_INET6;
+        *addrlen = sizeof(sockaddr_in6);
+        return Api::SysCallIntResult{0, 0};
+      }));
+  addr = wrapper_->localAddress();
+
+  EXPECT_CALL(os_sys_calls_, getpeername(_, _, _))
+      .WillOnce(Invoke([](os_fd_t, sockaddr* addr, socklen_t* addrlen) -> Api::SysCallIntResult {
+        addr->sa_family = AF_INET6;
+        *addrlen = sizeof(sockaddr_in6);
+        return Api::SysCallIntResult{0, 0};
+      }));
+  addr = wrapper_->peerAddress();
+
   Network::IoHandle::RecvMsgOutput output(1, nullptr);
   EXPECT_CALL(os_sys_calls_, recvmsg(fd, _, 0)).WillOnce(Invoke([](os_fd_t, msghdr* msg, int) {
     sockaddr_storage ss;

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -36,8 +36,10 @@ public:
               (int level, int optname, const void* optval, socklen_t optlen));
   MOCK_METHOD(Api::SysCallIntResult, getOption,
               (int level, int optname, void* optval, socklen_t* optlen));
-  MOCK_METHOD(Api::SysCallIntResult, getLocalAddress, (sockaddr * address, socklen_t* addrlen));
   MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool blocking));
+  MOCK_METHOD(Api::SysCallIntResult, domain, (int& domain));
+  MOCK_METHOD(Address::InstanceConstSharedPtr, localAddress, ());
+  MOCK_METHOD(Address::InstanceConstSharedPtr, peerAddress, ());
 };
 
 } // namespace Network

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -37,7 +37,7 @@ public:
   MOCK_METHOD(Api::SysCallIntResult, getOption,
               (int level, int optname, void* optval, socklen_t* optlen));
   MOCK_METHOD(Api::SysCallIntResult, setBlocking, (bool blocking));
-  MOCK_METHOD(Api::SysCallIntResult, domain, (int& domain));
+  MOCK_METHOD(absl::optional<int>, domain, ());
   MOCK_METHOD(Address::InstanceConstSharedPtr, localAddress, ());
   MOCK_METHOD(Address::InstanceConstSharedPtr, peerAddress, ());
 };


### PR DESCRIPTION
- move local and peer address accessors from socket interface to io handle
- add io handle domain accessor
- let socket interface decide the type of io handle to wrap accepted fds into.

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a