### PR TITLE
health_check filter: optimize predicate by eliminating floating point…

### DIFF
--- a/api/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/api/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -37,6 +37,11 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy or degraded in order for the filter to return a 200.
+  //
+  // .. note::
+  //
+  //    This value is interpreted as an integer by truncating, so 12.50% will be calculated
+  //    as if it were 12%.
   map<string, type.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/api/envoy/extensions/filters/http/health_check/v3/health_check.proto
+++ b/api/envoy/extensions/filters/http/health_check/v3/health_check.proto
@@ -38,6 +38,11 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy or degraded in order for the filter to return a 200.
+  //
+  // .. note::
+  //
+  //    This value is interpreted as an integer by truncating, so 12.50% will be calculated
+  //    as if it were 12%.
   map<string, type.v3.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/api/envoy/extensions/filters/http/health_check/v4alpha/health_check.proto
+++ b/api/envoy/extensions/filters/http/health_check/v4alpha/health_check.proto
@@ -38,6 +38,11 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy or degraded in order for the filter to return a 200.
+  //
+  // .. note::
+  //
+  //    This value is interpreted as an integer by truncating, so 12.50% will be calculated
+  //    as if it were 12%.
   map<string, type.v3.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -14,6 +14,7 @@ Minor Behavior Changes
 
 * access loggers: applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature `envoy.reloadable_features.disallow_unbounded_access_logs` to false.
 * build: run as non-root inside Docker containers. Existing behaviour can be restored by setting the environment variable `ENVOY_UID` to `0`. `ENVOY_UID` and `ENVOY_GID` can be used to set the envoy user's `uid` and `gid` respectively.
+* health check: in the health check filter the :ref:`percentage of healthy servers in upstream clusters <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` is now interpreted as an integer.
 * hot restart: added the option :option:`--use-dynamic-base-id` to select an unused base ID at startup and the option :option:`--base-id-path` to write the base id to a file (for reuse with later hot restarts).
 * http: fixed several bugs with applying correct connection close behavior across the http connection manager, health checker, and connection pool. This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_connection_close` to false.
 * http: fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.

--- a/generated_api_shadow/envoy/config/filter/http/health_check/v2/health_check.proto
+++ b/generated_api_shadow/envoy/config/filter/http/health_check/v2/health_check.proto
@@ -37,6 +37,11 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy or degraded in order for the filter to return a 200.
+  //
+  // .. note::
+  //
+  //    This value is interpreted as an integer by truncating, so 12.50% will be calculated
+  //    as if it were 12%.
   map<string, type.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/generated_api_shadow/envoy/extensions/filters/http/health_check/v3/health_check.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/health_check/v3/health_check.proto
@@ -38,6 +38,11 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy or degraded in order for the filter to return a 200.
+  //
+  // .. note::
+  //
+  //    This value is interpreted as an integer by truncating, so 12.50% will be calculated
+  //    as if it were 12%.
   map<string, type.v3.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/generated_api_shadow/envoy/extensions/filters/http/health_check/v4alpha/health_check.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/health_check/v4alpha/health_check.proto
@@ -38,6 +38,11 @@ message HealthCheck {
   // If operating in non-pass-through mode, specifies a set of upstream cluster
   // names and the minimum percentage of servers in each of those clusters that
   // must be healthy or degraded in order for the filter to return a 200.
+  //
+  // .. note::
+  //
+  //    This value is interpreted as an integer by truncating, so 12.50% will be calculated
+  //    as if it were 12%.
   map<string, type.v3.Percent> cluster_min_healthy_percentages = 4;
 
   // Specifies a set of health check request headers to match on. The health check filter will

--- a/source/extensions/filters/http/health_check/health_check.cc
+++ b/source/extensions/filters/http/health_check/health_check.cc
@@ -134,7 +134,7 @@ void HealthCheckFilter::onComplete() {
       for (const auto& item : *cluster_min_healthy_percentages_) {
         details = &RcDetails::get().HealthCheckClusterHealthy;
         const std::string& cluster_name = item.first;
-        const double min_healthy_percentage = item.second;
+        const uint64_t min_healthy_percentage = static_cast<uint64_t>(item.second);
         auto* cluster = clusterManager.get(cluster_name);
         if (cluster == nullptr) {
           // If the cluster does not exist at all, consider the service unhealthy.
@@ -148,7 +148,7 @@ void HealthCheckFilter::onComplete() {
         if (membership_total == 0) {
           // If the cluster exists but is empty, consider the service unhealthy unless
           // the specified minimum percent healthy for the cluster happens to be zero.
-          if (min_healthy_percentage == 0.0) {
+          if (min_healthy_percentage == 0UL) {
             continue;
           } else {
             final_status = Http::Code::ServiceUnavailable;
@@ -158,10 +158,8 @@ void HealthCheckFilter::onComplete() {
         }
         // In the general case, consider the service unhealthy if fewer than the
         // specified percentage of the servers in the cluster are available (healthy + degraded).
-        // TODO(brian-pane) switch to purely integer-based math here, because the
-        //                  int-to-float conversions and floating point division are slow.
-        if ((stats.membership_healthy_.value() + stats.membership_degraded_.value()) <
-            membership_total * min_healthy_percentage / 100.0) {
+        if ((100UL * (stats.membership_healthy_.value() + stats.membership_degraded_.value())) <
+            membership_total * min_healthy_percentage) {
           final_status = Http::Code::ServiceUnavailable;
           details = &RcDetails::get().HealthCheckClusterUnhealthy;
           break;


### PR DESCRIPTION
This PR fixes a TODO in the health check filter by translating the floating point arithmetic to integer arithmetic instead.

The performance gain is minimal. I wrote a bench test where I isolate the predicate in the if statement to compare the two implementations:

The results (with `--benchmark_repetitions=100`):
BM_IsHealthyOrig_mean         4.53 ns
BM_IsHealthyOpt_mean          4.17 ns

I also adapted one of the test cases from the health check filter test suite and made it into a bench test so I can exercise the filter code itself.

The results (with `--benchmark_repetitions=100`):
BM_DecodeHeaders_mean        60887 ns  (existing code)
BM_DecodeHeaders_mean        60682 ns  (optimized)

The bench test can be found on this branch:
https://github.com/numerodix/envoy/blob/8657a2bdf5511cff1a6db58bc35631e5b5570f95/test/extensions/filters/http/health_check/health_check_speed_test.cc

I also compared the two predicate implementations in https://godbolt.org/ and the optimized version (x86-64/clang-10 with -O3) produces fewer instructions. The difference can be seen here:
existing: https://github.com/numerodix/envoy/blob/8657a2bdf5511cff1a6db58bc35631e5b5570f95/orig#L20
optimized: https://github.com/numerodix/envoy/blob/8657a2bdf5511cff1a6db58bc35631e5b5570f95/opt#L9

Risk level: Medium (modification of existing filter)
Testing: Re-ran the health check filter tests. This is a refactoring and the existing test suite has several test cases exercising this logic, so I did not add any new ones.

Signed-off-by: Martin Matusiak <numerodix@gmail.com>