### PR TITLE
Use `ABSL_` prefixed thread annotations.

### DIFF
--- a/source/common/common/lock_guard.h
+++ b/source/common/common/lock_guard.h
@@ -39,7 +39,7 @@ private:
 
 // At the moment, TryLockGuard is very hard to annotate correctly, I
 // believe due to limitations in clang. At the moment there are no
-// GUARDED_BY variables for any tryLocks in the codebase, so it's
+// ABSL_GUARDED_BY variables for any tryLocks in the codebase, so it's
 // easiest just to leave it out. In a future clang release it's
 // possible we can enable this. See also the commented-out block
 // in ThreadTest.TestTryLockGuard in test/common/common/thread_test.cc.
@@ -64,7 +64,7 @@ public:
   /**
    * Destruction of the TryLockGuard unlocks the lock, if it was locked.
    */
-  ~TryLockGuard() DISABLE_TRYLOCKGUARD_ANNOTATION(UNLOCK_FUNCTION()) {
+  ~TryLockGuard() DISABLE_TRYLOCKGUARD_ANNOTATION(ABSL_UNLOCK_FUNCTION()) {
     if (is_locked_) {
       lock_.unlock();
     }
@@ -73,7 +73,7 @@ public:
   /**
    * @return bool whether the lock was successfully acquired.
    */
-  bool tryLock() DISABLE_TRYLOCKGUARD_ANNOTATION(EXCLUSIVE_TRYLOCK_FUNCTION(true)) {
+  bool tryLock() DISABLE_TRYLOCKGUARD_ANNOTATION(ABSL_EXCLUSIVE_TRYLOCK_FUNCTION(true)) {
     is_locked_ = lock_.tryLock();
     return is_locked_;
   }

--- a/source/common/grpc/google_grpc_context.h
+++ b/source/common/grpc/google_grpc_context.h
@@ -21,7 +21,7 @@ public:
 private:
   struct InstanceTracker {
     Thread::MutexBasicLockable mutex_;
-    uint64_t live_instances_ GUARDED_BY(mutex_) = 0;
+    uint64_t live_instances_ ABSL_GUARDED_BY(mutex_) = 0;
   };
 
   static InstanceTracker& instanceTracker();

--- a/source/common/network/connection_balancer_impl.h
+++ b/source/common/network/connection_balancer_impl.h
@@ -24,7 +24,7 @@ public:
 
 private:
   absl::Mutex lock_;
-  std::vector<BalancedConnectionHandler*> handlers_ GUARDED_BY(lock_);
+  std::vector<BalancedConnectionHandler*> handlers_ ABSL_GUARDED_BY(lock_);
 };
 
 /**

--- a/source/common/stats/allocator_impl.cc
+++ b/source/common/stats/allocator_impl.cc
@@ -96,7 +96,7 @@ public:
    * our ref-count decrement hits zero. The counters and gauges are held in
    * distinct sets so we virtualize this removal helper.
    */
-  virtual void removeFromSetLockHeld() EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) PURE;
+  virtual void removeFromSetLockHeld() ABSL_EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) PURE;
 
 protected:
   AllocatorImpl& alloc_;
@@ -121,7 +121,7 @@ public:
               const StatNameTagVector& stat_name_tags)
       : StatsSharedImpl(name, alloc, tag_extracted_name, stat_name_tags) {}
 
-  void removeFromSetLockHeld() EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) override {
+  void removeFromSetLockHeld() ABSL_EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) override {
     const size_t count = alloc_.counters_.erase(statName());
     ASSERT(count == 1);
   }
@@ -165,7 +165,7 @@ public:
     }
   }
 
-  void removeFromSetLockHeld() override EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) {
+  void removeFromSetLockHeld() override ABSL_EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) {
     const size_t count = alloc_.gauges_.erase(statName());
     ASSERT(count == 1);
   }
@@ -234,7 +234,7 @@ public:
                   const StatNameTagVector& stat_name_tags)
       : StatsSharedImpl(name, alloc, tag_extracted_name, stat_name_tags) {}
 
-  void removeFromSetLockHeld() EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) override {
+  void removeFromSetLockHeld() ABSL_EXCLUSIVE_LOCKS_REQUIRED(alloc_.mutex_) override {
     const size_t count = alloc_.text_readouts_.erase(statName());
     ASSERT(count == 1);
   }

--- a/source/common/stats/allocator_impl.h
+++ b/source/common/stats/allocator_impl.h
@@ -72,18 +72,18 @@ private:
     bool operator()(const Metric* a, StatName b) const { return a->statName() == b; }
   };
 
-  void removeCounterFromSetLockHeld(Counter* counter) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-  void removeGaugeFromSetLockHeld(Gauge* gauge) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-  void removeTextReadoutFromSetLockHeld(Counter* counter) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void removeCounterFromSetLockHeld(Counter* counter) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void removeGaugeFromSetLockHeld(Gauge* gauge) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void removeTextReadoutFromSetLockHeld(Counter* counter) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // An unordered set of HeapStatData pointers which keys off the key()
   // field in each object. This necessitates a custom comparator and hasher, which key off of the
   // StatNamePtr's own StatNamePtrHash and StatNamePtrCompare operators.
   template <class StatType>
   using StatSet = absl::flat_hash_set<StatType*, HeapStatHash, HeapStatCompare>;
-  StatSet<Counter> counters_ GUARDED_BY(mutex_);
-  StatSet<Gauge> gauges_ GUARDED_BY(mutex_);
-  StatSet<TextReadout> text_readouts_ GUARDED_BY(mutex_);
+  StatSet<Counter> counters_ ABSL_GUARDED_BY(mutex_);
+  StatSet<Gauge> gauges_ ABSL_GUARDED_BY(mutex_);
+  StatSet<TextReadout> text_readouts_ ABSL_GUARDED_BY(mutex_);
 
   SymbolTable& symbol_table_;
 

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -162,7 +162,7 @@ std::vector<absl::string_view> SymbolTableImpl::decodeStrings(const SymbolTable:
   Encoding::decodeTokens(
       array, size,
       [this, &strings](Symbol symbol)
-          NO_THREAD_SAFETY_ANALYSIS { strings.push_back(fromSymbol(symbol)); },
+          ABSL_NO_THREAD_SAFETY_ANALYSIS { strings.push_back(fromSymbol(symbol)); },
       [&strings](absl::string_view str) { strings.push_back(str); });
   return strings;
 }
@@ -184,7 +184,7 @@ void SymbolTableImpl::Encoding::appendToMemBlock(StatName stat_name,
 }
 
 SymbolTableImpl::SymbolTableImpl()
-    // Have to be explicitly initialized, if we want to use the GUARDED_BY macro.
+    // Have to be explicitly initialized, if we want to use the ABSL_GUARDED_BY macro.
     : next_symbol_(FirstValidSymbol), monotonic_counter_(FirstValidSymbol) {}
 
 SymbolTableImpl::~SymbolTableImpl() {
@@ -294,7 +294,7 @@ uint64_t SymbolTableImpl::getRecentLookups(const RecentLookupsFn& iter) const {
     Thread::LockGuard lock(lock_);
     recent_lookups_.forEach(
         [&name_count_map](absl::string_view str, uint64_t count)
-            NO_THREAD_SAFETY_ANALYSIS { name_count_map[std::string(str)] += count; });
+            ABSL_NO_THREAD_SAFETY_ANALYSIS { name_count_map[std::string(str)] += count; });
     total += recent_lookups_.total();
   }
 
@@ -388,13 +388,13 @@ Symbol SymbolTableImpl::toSymbol(absl::string_view sv) {
 }
 
 absl::string_view SymbolTableImpl::fromSymbol(const Symbol symbol) const
-    EXCLUSIVE_LOCKS_REQUIRED(lock_) {
+    ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
   auto search = decode_map_.find(symbol);
   RELEASE_ASSERT(search != decode_map_.end(), "no such symbol");
   return search->second->toStringView();
 }
 
-void SymbolTableImpl::newSymbol() EXCLUSIVE_LOCKS_REQUIRED(lock_) {
+void SymbolTableImpl::newSymbol() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
   if (pool_.empty()) {
     next_symbol_ = ++monotonic_counter_;
   } else {

--- a/source/common/stats/symbol_table_impl.h
+++ b/source/common/stats/symbol_table_impl.h
@@ -237,7 +237,7 @@ private:
    * @param sv the individual string to be encoded as a symbol.
    * @return Symbol the encoded string.
    */
-  Symbol toSymbol(absl::string_view sv) EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  Symbol toSymbol(absl::string_view sv) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   /**
    * Convenience function for decode(), decoding one symbol at a time.
@@ -245,7 +245,7 @@ private:
    * @param symbol the individual symbol to be decoded.
    * @return absl::string_view the decoded string.
    */
-  absl::string_view fromSymbol(Symbol symbol) const EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  absl::string_view fromSymbol(Symbol symbol) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   /**
    * Stages a new symbol for use. To be called after a successful insertion.
@@ -268,7 +268,7 @@ private:
 
   // Stores the symbol to be used at next insertion. This should exist ahead of insertion time so
   // that if insertion succeeds, the value written is the correct one.
-  Symbol next_symbol_ GUARDED_BY(lock_);
+  Symbol next_symbol_ ABSL_GUARDED_BY(lock_);
 
   // If the free pool is exhausted, we monotonically increase this counter.
   Symbol monotonic_counter_;
@@ -278,14 +278,14 @@ private:
   // Using absl::string_view lets us only store the complete string once, in the decode map.
   using EncodeMap = absl::flat_hash_map<absl::string_view, SharedSymbol>;
   using DecodeMap = absl::flat_hash_map<Symbol, InlineStringPtr>;
-  EncodeMap encode_map_ GUARDED_BY(lock_);
-  DecodeMap decode_map_ GUARDED_BY(lock_);
+  EncodeMap encode_map_ ABSL_GUARDED_BY(lock_);
+  DecodeMap decode_map_ ABSL_GUARDED_BY(lock_);
 
   // Free pool of symbols for re-use.
   // TODO(ambuc): There might be an optimization here relating to storing ranges of freed symbols
   // using an Envoy::IntervalSet.
-  std::stack<Symbol> pool_ GUARDED_BY(lock_);
-  RecentLookups recent_lookups_ GUARDED_BY(lock_);
+  std::stack<Symbol> pool_ ABSL_GUARDED_BY(lock_);
+  RecentLookups recent_lookups_ ABSL_GUARDED_BY(lock_);
 };
 
 // Base class for holding the backing-storing for a StatName. The two derived
@@ -818,7 +818,7 @@ private:
 
   const std::string name_;
   Stats::SymbolTable& symbol_table_;
-  Stats::StatNamePool pool_ GUARDED_BY(mutex_);
+  Stats::StatNamePool pool_ ABSL_GUARDED_BY(mutex_);
   mutable absl::Mutex mutex_;
   using StringStatNameMap = absl::flat_hash_map<std::string, Stats::StatName>;
   StringStatNameMap builtin_stat_names_;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -115,7 +115,7 @@ public:
   uint32_t use_count() const override { return refcount_helper_.use_count(); }
 
 private:
-  bool usedLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(merge_lock_);
+  bool usedLockHeld() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(merge_lock_);
 
   Histogram::Unit unit_;
   Store& parent_;
@@ -125,7 +125,7 @@ private:
   HistogramStatisticsImpl interval_statistics_;
   HistogramStatisticsImpl cumulative_statistics_;
   mutable Thread::MutexBasicLockable merge_lock_;
-  std::list<TlsHistogramSharedPtr> tls_histograms_ GUARDED_BY(merge_lock_);
+  std::list<TlsHistogramSharedPtr> tls_histograms_ ABSL_GUARDED_BY(merge_lock_);
   bool merged_;
   RefcountHelper refcount_helper_;
 };
@@ -424,7 +424,7 @@ private:
   Event::Dispatcher* main_thread_dispatcher_{};
   ThreadLocal::SlotPtr tls_;
   mutable Thread::MutexBasicLockable lock_;
-  absl::flat_hash_set<ScopeImpl*> scopes_ GUARDED_BY(lock_);
+  absl::flat_hash_set<ScopeImpl*> scopes_ ABSL_GUARDED_BY(lock_);
   ScopePtr default_scope_;
   std::list<std::reference_wrapper<Sink>> timer_sinks_;
   TagProducerPtr tag_producer_;

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -197,7 +197,7 @@ private:
   };
 
   absl::Mutex mutex_;
-  SlotArraySharedPtr slot_array_ GUARDED_BY(mutex_);
+  SlotArraySharedPtr slot_array_ ABSL_GUARDED_BY(mutex_);
   ClusterSlotsSharedPtr current_cluster_slot_;
   ShardVectorSharedPtr shard_vector_;
   Runtime::RandomGenerator& random_;

--- a/source/extensions/common/redis/cluster_refresh_manager_impl.h
+++ b/source/extensions/common/redis/cluster_refresh_manager_impl.h
@@ -93,7 +93,7 @@ private:
   Event::Dispatcher& main_thread_dispatcher_;
   Upstream::ClusterManager& cm_;
   TimeSource& time_source_;
-  std::map<std::string, ClusterInfoSharedPtr> info_map_ GUARDED_BY(map_mutex_);
+  std::map<std::string, ClusterInfoSharedPtr> info_map_ ABSL_GUARDED_BY(map_mutex_);
   Thread::MutexBasicLockable map_mutex_;
 };
 

--- a/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
+++ b/source/extensions/filters/http/cache/simple_http_cache/simple_http_cache.h
@@ -33,7 +33,7 @@ public:
   void insert(const Key& key, Http::ResponseHeaderMapPtr&& response_headers, std::string&& body);
 
   absl::Mutex mutex_;
-  absl::flat_hash_map<Key, Entry, MessageUtil, MessageUtil> map_ GUARDED_BY(mutex_);
+  absl::flat_hash_map<Key, Entry, MessageUtil, MessageUtil> map_ ABSL_GUARDED_BY(mutex_);
 };
 
 } // namespace Cache

--- a/source/extensions/quic_listeners/quiche/platform/flags_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/flags_impl.h
@@ -91,7 +91,7 @@ public:
 
 private:
   mutable absl::Mutex mutex_;
-  T value_ GUARDED_BY(mutex_);
+  T value_ ABSL_GUARDED_BY(mutex_);
   T default_value_;
 };
 

--- a/source/extensions/quic_listeners/quiche/platform/quic_mutex_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mutex_impl.h
@@ -24,27 +24,27 @@ namespace quic {
 #define QUIC_ASSERT_SHARED_LOCK_IMPL ABSL_ASSERT_SHARED_LOCK
 
 // A class wrapping a non-reentrant mutex.
-class LOCKABLE QUIC_EXPORT_PRIVATE QuicLockImpl {
+class ABSL_LOCKABLE QUIC_EXPORT_PRIVATE QuicLockImpl {
 public:
   QuicLockImpl() = default;
   QuicLockImpl(const QuicLockImpl&) = delete;
   QuicLockImpl& operator=(const QuicLockImpl&) = delete;
 
   // Block until mu_ is free, then acquire it exclusively.
-  void WriterLock() EXCLUSIVE_LOCK_FUNCTION() { mu_.WriterLock(); }
+  void WriterLock() ABSL_EXCLUSIVE_LOCK_FUNCTION() { mu_.WriterLock(); }
 
   // Release mu_. Caller must hold it exclusively.
-  void WriterUnlock() UNLOCK_FUNCTION() { mu_.WriterUnlock(); }
+  void WriterUnlock() ABSL_UNLOCK_FUNCTION() { mu_.WriterUnlock(); }
 
   // Block until mu_ is free or shared, then acquire a share of it.
-  void ReaderLock() SHARED_LOCK_FUNCTION() { mu_.ReaderLock(); }
+  void ReaderLock() ABSL_SHARED_LOCK_FUNCTION() { mu_.ReaderLock(); }
 
   // Release mu_. Caller could hold it in shared mode.
-  void ReaderUnlock() UNLOCK_FUNCTION() { mu_.ReaderUnlock(); }
+  void ReaderUnlock() ABSL_UNLOCK_FUNCTION() { mu_.ReaderUnlock(); }
 
   // Returns immediately if current thread holds mu_ in at least shared
   // mode. Otherwise, reports an error by crashing with a diagnostic.
-  void AssertReaderHeld() const ASSERT_SHARED_LOCK() { mu_.AssertReaderHeld(); }
+  void AssertReaderHeld() const ABSL_ASSERT_SHARED_LOCK() { mu_.AssertReaderHeld(); }
 
 private:
   absl::Mutex mu_;

--- a/source/extensions/quic_listeners/quiche/platform/quic_mutex_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mutex_impl.h
@@ -24,7 +24,7 @@ namespace quic {
 #define QUIC_ASSERT_SHARED_LOCK_IMPL ABSL_ASSERT_SHARED_LOCK
 
 // A class wrapping a non-reentrant mutex.
-class ABSL_LOCKABLE QUIC_EXPORT_PRIVATE QuicLockImpl {
+class QUIC_LOCKABLE_IMPL QUIC_EXPORT_PRIVATE QuicLockImpl {
 public:
   QuicLockImpl() = default;
   QuicLockImpl(const QuicLockImpl&) = delete;

--- a/source/extensions/quic_listeners/quiche/platform/quic_mutex_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mutex_impl.h
@@ -31,20 +31,25 @@ public:
   QuicLockImpl& operator=(const QuicLockImpl&) = delete;
 
   // Block until mu_ is free, then acquire it exclusively.
-  void WriterLock() ABSL_EXCLUSIVE_LOCK_FUNCTION() { mu_.WriterLock(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void WriterLock() QUIC_EXCLUSIVE_LOCK_FUNCTION_IMPL() { mu_.WriterLock(); }
 
   // Release mu_. Caller must hold it exclusively.
-  void WriterUnlock() ABSL_UNLOCK_FUNCTION() { mu_.WriterUnlock(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void WriterUnlock() QUIC_UNLOCK_FUNCTION_IMPL() { mu_.WriterUnlock(); }
 
   // Block until mu_ is free or shared, then acquire a share of it.
-  void ReaderLock() ABSL_SHARED_LOCK_FUNCTION() { mu_.ReaderLock(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void ReaderLock() QUIC_SHARED_LOCK_FUNCTION_IMPL() { mu_.ReaderLock(); }
 
   // Release mu_. Caller could hold it in shared mode.
-  void ReaderUnlock() ABSL_UNLOCK_FUNCTION() { mu_.ReaderUnlock(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void ReaderUnlock() QUIC_UNLOCK_FUNCTION_IMPL() { mu_.ReaderUnlock(); }
 
   // Returns immediately if current thread holds mu_ in at least shared
   // mode. Otherwise, reports an error by crashing with a diagnostic.
-  void AssertReaderHeld() const ABSL_ASSERT_SHARED_LOCK() { mu_.AssertReaderHeld(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void AssertReaderHeld() const QUIC_ASSERT_SHARED_LOCK_IMPL() { mu_.AssertReaderHeld(); }
 
 private:
   absl::Mutex mu_;

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -58,7 +58,7 @@ class ProcessSharedMutex : public Thread::BasicLockable {
 public:
   ProcessSharedMutex(pthread_mutex_t& mutex) : mutex_(mutex) {}
 
-  void lock() EXCLUSIVE_LOCK_FUNCTION() override {
+  void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() override {
     // Deal with robust handling here. If the other process dies without unlocking, we are going
     // to die shortly but try to make sure that we can handle any signals, etc. that happen without
     // getting into a further messed up state.
@@ -69,7 +69,7 @@ public:
     }
   }
 
-  bool tryLock() EXCLUSIVE_TRYLOCK_FUNCTION(true) override {
+  bool tryLock() ABSL_EXCLUSIVE_TRYLOCK_FUNCTION(true) override {
     int rc = pthread_mutex_trylock(&mutex_);
     if (rc == EBUSY) {
       return false;
@@ -83,7 +83,7 @@ public:
     return true;
   }
 
-  void unlock() UNLOCK_FUNCTION() override {
+  void unlock() ABSL_UNLOCK_FUNCTION() override {
     int rc = pthread_mutex_unlock(&mutex_);
     ASSERT(rc == 0);
   }

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -76,7 +76,7 @@ public:
 
 private:
   mutable absl::Mutex mu_;
-  std::vector<SpanData> spans_ GUARDED_BY(mu_);
+  std::vector<SpanData> spans_ ABSL_GUARDED_BY(mu_);
 };
 
 // Use a Singleton SpanCatcher.

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -233,7 +233,7 @@ protected:
   }
 
   virtual Stats::Counter* getCounterLockHeld(const std::string& name)
-      EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
     auto it = counters_.find(name);
     if (it != counters_.end()) {
       return it->second;

--- a/test/test_common/global.h
+++ b/test/test_common/global.h
@@ -88,7 +88,8 @@ private:
   std::string describeActiveSingletonsHelper();
 
   Thread::MutexBasicLockable map_mutex_;
-  absl::flat_hash_map<std::string, std::weak_ptr<Singleton>> singleton_map_ GUARDED_BY(map_mutex_);
+  absl::flat_hash_map<std::string, std::weak_ptr<Singleton>>
+      singleton_map_ ABSL_GUARDED_BY(map_mutex_);
 };
 
 /**

--- a/test/test_common/only_one_thread.h
+++ b/test/test_common/only_one_thread.h
@@ -20,7 +20,7 @@ public:
 
 private:
   ThreadFactory& thread_factory_;
-  ThreadId thread_advancing_time_ GUARDED_BY(mutex_);
+  ThreadId thread_advancing_time_ ABSL_GUARDED_BY(mutex_);
   mutable MutexBasicLockable mutex_;
 };
 

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -71,9 +71,9 @@ public:
     return armed_ || base_timer_->enabled();
   }
 
-  void disableTimerLockHeld() EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_);
+  void disableTimerLockHeld() ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_);
 
-  void setTimeLockHeld(MonotonicTime time) EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
+  void setTimeLockHeld(MonotonicTime time) ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
     time_ = time;
   }
 
@@ -82,7 +82,7 @@ public:
    * typically via Dispatcher::run().
    */
   void activateLockHeld(const ScopeTrackedObject* scope = nullptr)
-      EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
     ASSERT(armed_);
     armed_ = false;
     if (pending_) {
@@ -101,7 +101,7 @@ public:
     base_timer_->enableTimer(duration, scope);
   }
 
-  MonotonicTime time() const EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
+  MonotonicTime time() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
     ASSERT(armed_);
     return time_;
   }
@@ -125,16 +125,16 @@ private:
 
   TimerPtr base_timer_;
   SimulatedTimeSystemHelper& time_system_;
-  MonotonicTime time_ GUARDED_BY(time_system_.mutex_);
+  MonotonicTime time_ ABSL_GUARDED_BY(time_system_.mutex_);
   const uint64_t index_;
-  bool armed_ GUARDED_BY(time_system_.mutex_);
-  bool pending_ GUARDED_BY(time_system_.mutex_);
+  bool armed_ ABSL_GUARDED_BY(time_system_.mutex_);
+  bool pending_ ABSL_GUARDED_BY(time_system_.mutex_);
 };
 
 // Compare two alarms, based on wakeup time and insertion order. Returns true if
 // a comes before b.
 bool SimulatedTimeSystemHelper::CompareAlarms::operator()(const Alarm* a, const Alarm* b) const
-    EXCLUSIVE_LOCKS_REQUIRED(a->time_system_.mutex_, b->time_system_.mutex_) {
+    ABSL_EXCLUSIVE_LOCKS_REQUIRED(a->time_system_.mutex_, b->time_system_.mutex_) {
   if (a != b) {
     if (a->time() < b->time()) {
       return true;
@@ -241,7 +241,8 @@ void SimulatedTimeSystemHelper::advanceTimeWait(const Duration& duration) {
   waitForNoPendingLockHeld();
 }
 
-void SimulatedTimeSystemHelper::waitForNoPendingLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
+void SimulatedTimeSystemHelper::waitForNoPendingLockHeld() const
+    ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
   mutex_.Await(absl::Condition(
       +[](const uint32_t* pending_alarms) -> bool { return *pending_alarms == 0; },
       &pending_alarms_));
@@ -249,7 +250,7 @@ void SimulatedTimeSystemHelper::waitForNoPendingLockHeld() const EXCLUSIVE_LOCKS
 
 Thread::CondVar::WaitStatus SimulatedTimeSystemHelper::waitFor(
     Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-    const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+    const Duration& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
   only_one_thread_.checkOneThread();
 
   // TODO(#10568): This real-time polling delay should not be necessary. Without
@@ -295,14 +296,15 @@ Thread::CondVar::WaitStatus SimulatedTimeSystemHelper::waitFor(
   return Thread::CondVar::WaitStatus::Timeout;
 }
 
-MonotonicTime SimulatedTimeSystemHelper::alarmTimeLockHeld(Alarm* alarm) NO_THREAD_SAFETY_ANALYSIS {
+MonotonicTime
+SimulatedTimeSystemHelper::alarmTimeLockHeld(Alarm* alarm) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // We disable thread-safety analysis as the compiler can't detect that
   // alarm_->timeSystem() == this, so we must be holding the right mutex.
   ASSERT(&(alarm->timeSystem()) == this);
   return alarm->time();
 }
 
-void SimulatedTimeSystemHelper::alarmActivateLockHeld(Alarm* alarm) NO_THREAD_SAFETY_ANALYSIS {
+void SimulatedTimeSystemHelper::alarmActivateLockHeld(Alarm* alarm) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // We disable thread-safety analysis as the compiler can't detect that
   // alarm_->timeSystem() == this, so we must be holding the right mutex.
   ASSERT(&(alarm->timeSystem()) == this);
@@ -315,7 +317,7 @@ int64_t SimulatedTimeSystemHelper::nextIndex() {
 }
 
 void SimulatedTimeSystemHelper::addAlarmLockHeld(
-    Alarm* alarm, const std::chrono::microseconds& duration) NO_THREAD_SAFETY_ANALYSIS {
+    Alarm* alarm, const std::chrono::microseconds& duration) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   ASSERT(&(alarm->timeSystem()) == this);
   alarm->setTimeLockHeld(monotonic_time_ + duration);
   alarms_.insert(alarm);

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -30,7 +30,7 @@ public:
   void advanceTimeAsync(const Duration& duration) override;
   Thread::CondVar::WaitStatus
   waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
+          const Duration& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
 
   // TimeSource
   SystemTime systemTime() override;
@@ -78,10 +78,10 @@ private:
    * @param monotonic_time The desired new current time.
    */
   void setMonotonicTimeLockHeld(const MonotonicTime& monotonic_time)
-      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
-  MonotonicTime alarmTimeLockHeld(Alarm* alarm) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-  void alarmActivateLockHeld(Alarm* alarm) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  MonotonicTime alarmTimeLockHeld(Alarm* alarm) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void alarmActivateLockHeld(Alarm* alarm) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // The simulation keeps a unique ID for each alarm to act as a deterministic
   // tie-breaker for alarm-ordering.
@@ -89,25 +89,25 @@ private:
 
   // Adds/removes an alarm.
   void addAlarmLockHeld(Alarm*, const std::chrono::microseconds& duration)
-      EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-  void removeAlarmLockHeld(Alarm*) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void removeAlarmLockHeld(Alarm*) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Keeps track of how many alarms have been activated but not yet called,
   // which helps waitFor() determine when to give up and declare a timeout.
-  void incPendingLockHeld() EXCLUSIVE_LOCKS_REQUIRED(mutex_) { ++pending_alarms_; }
+  void incPendingLockHeld() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) { ++pending_alarms_; }
   void decPending() {
     absl::MutexLock lock(&mutex_);
     --pending_alarms_;
   }
-  void waitForNoPendingLockHeld() const EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void waitForNoPendingLockHeld() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   RealTimeSource real_time_source_; // Used to initialize monotonic_time_ and system_time_;
-  MonotonicTime monotonic_time_ GUARDED_BY(mutex_);
-  SystemTime system_time_ GUARDED_BY(mutex_);
-  AlarmSet alarms_ GUARDED_BY(mutex_);
-  uint64_t index_ GUARDED_BY(mutex_);
+  MonotonicTime monotonic_time_ ABSL_GUARDED_BY(mutex_);
+  SystemTime system_time_ ABSL_GUARDED_BY(mutex_);
+  AlarmSet alarms_ ABSL_GUARDED_BY(mutex_);
+  uint64_t index_ ABSL_GUARDED_BY(mutex_);
   mutable absl::Mutex mutex_;
-  uint32_t pending_alarms_ GUARDED_BY(mutex_);
+  uint32_t pending_alarms_ ABSL_GUARDED_BY(mutex_);
   Thread::OnlyOneThread only_one_thread_;
 };
 

--- a/test/test_common/test_time.h
+++ b/test/test_common/test_time.h
@@ -16,7 +16,7 @@ public:
   void advanceTimeWait(const Duration& duration) override;
   Thread::CondVar::WaitStatus
   waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
+          const Duration& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) override;
 
   // Event::TimeSystem
   Event::SchedulerPtr createScheduler(Scheduler& base_scheduler) override {

--- a/test/test_common/test_time_system.h
+++ b/test/test_common/test_time_system.h
@@ -58,11 +58,12 @@ public:
    */
   virtual Thread::CondVar::WaitStatus
   waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) PURE;
+          const Duration& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) PURE;
 
   template <class D>
-  Thread::CondVar::WaitStatus waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-                                      const D& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) {
+  Thread::CondVar::WaitStatus
+  waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
+          const D& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) {
     return waitFor(mutex, condvar, std::chrono::duration_cast<Duration>(duration));
   }
 };
@@ -91,7 +92,7 @@ public:
   TestTimeSystem& timeSystem(const MakeTimeSystemFn& make_time_system);
 
 private:
-  std::unique_ptr<TestTimeSystem> time_system_ GUARDED_BY(mutex_);
+  std::unique_ptr<TestTimeSystem> time_system_ ABSL_GUARDED_BY(mutex_);
   Thread::MutexBasicLockable mutex_;
 };
 
@@ -109,7 +110,7 @@ public:
 
   Thread::CondVar::WaitStatus
   waitFor(Thread::MutexBasicLockable& mutex, Thread::CondVar& condvar,
-          const Duration& duration) noexcept EXCLUSIVE_LOCKS_REQUIRED(mutex) override {
+          const Duration& duration) noexcept ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex) override {
     return timeSystem().waitFor(mutex, condvar, duration);
   }
 


### PR DESCRIPTION
Signed-off-by: Ashley Hedberg <ahedberg@google.com>

Commit Message: Use `ABSL_` prefixed thread annotations consistently.
Additional Description: Envoy currently uses a mix of `ABSL_`-prefixed and non-`ABSL_`-prefixed thread annotations. Abseil is renaming its thread-safety analysis attributes per [Clang's guidance](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#reference-guide) to define macros for them, so the non-ABSL names will go away eventually.
Risk Level: Low
Testing: existing
Docs Changes: n/a
Release Notes: n/a
