### PR TITLE
Convert std::pair CategoryDescription to struct for better readability

### DIFF
--- a/source/common/common/perf_annotation.cc
+++ b/source/common/common/perf_annotation.cc
@@ -34,7 +34,7 @@ PerfAnnotationContext::PerfAnnotationContext() = default;
 
 void PerfAnnotationContext::record(std::chrono::nanoseconds duration, absl::string_view category,
                                    absl::string_view description) {
-  CategoryDescription key((std::string(category)), (std::string(description)));
+  CategoryDescription key = {std::string(category), std::string(description)};
   {
 #if PERF_THREAD_SAFE
     Thread::LockGuard lock(mutex_);
@@ -112,8 +112,8 @@ std::string PerfAnnotationContext::toString() {
     columns[4].push_back(nanoseconds_string(stats.min_));
     columns[5].push_back(nanoseconds_string(stats.max_));
     const CategoryDescription& category_description = p->first;
-    columns[6].push_back(category_description.first);
-    columns[7].push_back(category_description.second);
+    columns[6].push_back(category_description.category);
+    columns[7].push_back(category_description.description);
     for (size_t i = 0; i < num_columns; ++i) {
       widths[i] = std::max(widths[i], columns[i].back().size());
     }

--- a/source/common/common/perf_annotation.h
+++ b/source/common/common/perf_annotation.h
@@ -117,7 +117,14 @@ private:
    */
   PerfAnnotationContext();
 
-  using CategoryDescription = std::pair<std::string, std::string>;
+  struct CategoryDescription {
+    std::string category;
+    std::string description;
+
+    bool operator==(const CategoryDescription& other) const {
+      return category == other.category && description == other.description;
+    }
+  };
 
   struct DurationStats {
     std::chrono::nanoseconds total_{0};
@@ -128,7 +135,7 @@ private:
 
   struct Hash {
     size_t operator()(const CategoryDescription& a) const {
-      return std::hash<std::string>()(a.first) + 13 * std::hash<std::string>()(a.second);
+      return std::hash<std::string>()(a.category) + 13 * std::hash<std::string>()(a.description);
     }
   };
 


### PR DESCRIPTION
Signed-off-by: Yifan Yang <needyyang@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: This is to enable semantically meaningful variable names for better readability. 
Additional Description:
Risk Level: Minimal (Should have no behavioral changes). 
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
