### PR TITLE
stats: remove local shadow variables and manual clearing of parent status.

### DIFF
--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -78,17 +78,9 @@ HealthCheckerImplBase::~HealthCheckerImplBase() {
   }
 }
 
-void HealthCheckerImplBase::decHealthy() {
-  ASSERT(local_process_healthy_ > 0);
-  local_process_healthy_--;
-  refreshHealthyStat();
-}
+void HealthCheckerImplBase::decHealthy() { stats_.healthy_.sub(1); }
 
-void HealthCheckerImplBase::decDegraded() {
-  ASSERT(local_process_degraded_ > 0);
-  local_process_degraded_--;
-  refreshHealthyStat();
-}
+void HealthCheckerImplBase::decDegraded() { stats_.degraded_.sub(1); }
 
 HealthCheckerStats HealthCheckerImplBase::generateStats(Stats::Scope& scope) {
   std::string prefix("health_check.");
@@ -96,15 +88,9 @@ HealthCheckerStats HealthCheckerImplBase::generateStats(Stats::Scope& scope) {
                                    POOL_GAUGE_PREFIX(scope, prefix))};
 }
 
-void HealthCheckerImplBase::incHealthy() {
-  local_process_healthy_++;
-  refreshHealthyStat();
-}
+void HealthCheckerImplBase::incHealthy() { stats_.healthy_.add(1); }
 
-void HealthCheckerImplBase::incDegraded() {
-  local_process_degraded_++;
-  refreshHealthyStat();
-}
+void HealthCheckerImplBase::incDegraded() { stats_.degraded_.add(1); }
 
 std::chrono::milliseconds HealthCheckerImplBase::interval(HealthState state,
                                                           HealthTransition changed_state) const {
@@ -187,20 +173,7 @@ void HealthCheckerImplBase::onClusterMemberUpdate(const HostVector& hosts_added,
   }
 }
 
-void HealthCheckerImplBase::refreshHealthyStat() {
-  // Each hot restarted process health checks independently. To make the stats easier to read,
-  // we assume that both processes will converge and the last one that writes wins for the host.
-  stats_.healthy_.set(local_process_healthy_);
-  stats_.degraded_.set(local_process_degraded_);
-}
-
 void HealthCheckerImplBase::runCallbacks(HostSharedPtr host, HealthTransition changed_state) {
-  // When a parent process shuts down, it will kill all of the active health checking sessions,
-  // which will decrement the healthy count and the healthy stat in the parent. If the child is
-  // stable and does not update, the healthy stat will be wrong. This routine is called any time
-  // any HC happens against a host so just refresh the healthy stat here so that it is correct.
-  refreshHealthyStat();
-
   for (const HostStatusCb& cb : callbacks_) {
     cb(host, changed_state);
   }

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -135,7 +135,6 @@ private:
   std::chrono::milliseconds intervalWithJitter(uint64_t base_time_ms,
                                                std::chrono::milliseconds interval_jitter) const;
   void onClusterMemberUpdate(const HostVector& hosts_added, const HostVector& hosts_removed);
-  void refreshHealthyStat();
   void runCallbacks(HostSharedPtr host, HealthTransition changed_state);
   void setUnhealthyCrossThread(const HostSharedPtr& host);
   static std::shared_ptr<const Network::TransportSocketOptionsImpl>
@@ -155,8 +154,6 @@ private:
   const std::chrono::milliseconds unhealthy_edge_interval_;
   const std::chrono::milliseconds healthy_edge_interval_;
   std::unordered_map<HostSharedPtr, ActiveHealthCheckSessionPtr> active_sessions_;
-  uint64_t local_process_healthy_{};
-  uint64_t local_process_degraded_{};
   const std::shared_ptr<const Network::TransportSocketOptionsImpl> transport_socket_options_;
   const MetadataConstSharedPtr transport_socket_match_metadata_;
 };


### PR DESCRIPTION
Commit Message: Remove superfluous shadow gauge values from the health-checker, as tracking child-values separately is now done in all gauges, so that parent contributions can be erased when the parents exit.
Additional Description:
Risk Level: medium -- semantics are not super-clear to me but I think this looks right.
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
