### PR TITLE
Adds manual DNS resolution on Windows for the address 'localhost'

### DIFF
--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -57,6 +57,14 @@ private:
      * @param addrinfo structure to store address info.
      */
     void onAresGetAddrInfoCallback(int status, int timeouts, ares_addrinfo* addrinfo);
+
+
+    /**
+     * Manually resolves the address "localhost".
+     * @param family currently AF_INET and AF_INET6 are supported.
+     */
+    void onManualResolution(int family);
+
     /**
      * wrapper function of call to ares_getaddrinfo.
      * @param family currently AF_INET and AF_INET6 are supported.

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -100,7 +100,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "dns_impl_test",
     srcs = ["dns_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:address_interface",


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Commit Message:
Adds manual DNS resolution on Windows for the address 'localhost'
See:  https://github.com/c-ares/c-ares/issues/85
Additional Description:

On Windows localhost is not added by default on `Windows\System32\drivers\etc\hosts` and as a result the resolution of the string `'localhost'` fails causing the dns_impl tests to fail.

In this PR we address this issue by adding a manual resolution for localhost on. Similar approach is also taken by other large scale project that take a dependency on c-ares. E.g. grpc that adds similar resolution in  https://github.com/grpc/grpc/pull/16420

Test output:
```
[----------] Global test environment tear-down
[==========] 39 tests from 5 test suites ran. (1399 ms total)
[  PASSED  ] 39 tests.
```


Risk Level:
N/A
Testing:
N/A