### PR TITLE
docs: fix description of cluster dns resolution counters #11305

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -89,9 +89,9 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   membership_total, Gauge, Current cluster membership total
   retry_or_shadow_abandoned, Counter, Total number of times shadowing or retry buffering was canceled due to buffer limits
   config_reload, Counter, Total API fetches that resulted in a config reload due to a different config
-  update_attempt, Counter, Total cluster membership update attempts
-  update_success, Counter, Total cluster membership update successes
-  update_failure, Counter, Total cluster membership update failures
+  update_attempt, Counter, Total attempted cluster membership updates by service discovery
+  update_success, Counter, Total successful cluster membership updates by service discovery
+  update_failure, Counter, Total failed cluster membership updates by service discovery
   update_empty, Counter, Total cluster membership updates ending with empty cluster load assignment and continuing with previous config
   update_no_rebuild, Counter, Total successful cluster membership updates that didn't result in any cluster load balancing structure rebuilds
   version, Gauge, Hash of the contents from the last successful API fetch

--- a/docs/root/intro/arch_overview/upstream/service_discovery.rst
+++ b/docs/root/intro/arch_overview/upstream/service_discovery.rst
@@ -48,6 +48,8 @@ will be used as the cluster's DNS refresh rate. :ref:`dns_refresh_rate <envoy_v3
 defaults to 5000ms if not specified. The :ref:`dns_failure_refresh_rate <envoy_v3_api_field_config.cluster.v3.Cluster.dns_failure_refresh_rate>`
 controls the refresh frequency during failures, and, if not configured, the DNS refresh rate will be used.
 
+DNS resolving emits :ref:`cluster statistics <config_cluster_manager_cluster_stats>` fields *update_attempt*, *update_success* and *update_failure*.
+
 .. _arch_overview_service_discovery_types_logical_dns:
 
 Logical DNS
@@ -76,6 +78,8 @@ For logical DNS cluster, if the TTL of first record is 0, :ref:`dns_refresh_rate
 will be used as the cluster's DNS refresh rate. :ref:`dns_refresh_rate <envoy_v3_api_field_config.cluster.v3.Cluster.dns_refresh_rate>`
 defaults to 5000ms if not specified. The :ref:`dns_failure_refresh_rate <envoy_v3_api_field_config.cluster.v3.Cluster.dns_failure_refresh_rate>`
 controls the refresh frequency during failures, and, if not configured, the DNS refresh rate will be used.
+
+DNS resolving emits :ref:`cluster statistics <config_cluster_manager_cluster_stats>` fields *update_attempt*, *update_success* and *update_failure*.
 
 .. _arch_overview_service_discovery_types_original_destination:
 


### PR DESCRIPTION
Commit Message: fix description of cluster dns resolution counters
Risk Level: Low
Docs Changes: fixes the description of cluster dns resolution counters based upon input from #11305
Fixes: #11305 