### PR TITLE
[fuzz] fix router filter bugs

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -149,14 +149,11 @@ InternalRedirectPolicyImpl::InternalRedirectPolicyImpl(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(policy_config, max_internal_redirects, 1)),
       enabled_(true), allow_cross_scheme_redirect_(policy_config.allow_cross_scheme_redirect()) {
   for (const auto& predicate : policy_config.predicates()) {
-    const std::string type{
-        TypeUtil::typeUrlToDescriptorFullName(predicate.typed_config().type_url())};
-    auto* factory =
-        Registry::FactoryRegistry<InternalRedirectPredicateFactory>::getFactoryByType(type);
-
-    auto config = factory->createEmptyConfigProto();
+    auto& factory =
+        Envoy::Config::Utility::getAndCheckFactory<InternalRedirectPredicateFactory>(predicate);
+    auto config = factory.createEmptyConfigProto();
     Envoy::Config::Utility::translateOpaqueConfig(predicate.typed_config(), {}, validator, *config);
-    predicate_factories_.emplace_back(factory, std::move(config));
+    predicate_factories_.emplace_back(&factory, std::move(config));
   }
 }
 

--- a/test/common/router/route_corpus/internal_redirect_nullderef
+++ b/test/common/router/route_corpus/internal_redirect_nullderef
@@ -1,0 +1,23 @@
+config {
+  virtual_hosts {
+    name: "q"
+    domains: ""
+    routes {
+      match {
+        path: ""
+      }
+      route {
+        cluster: "."
+        internal_redirect_policy {
+          predicates {
+            name: ":"
+            typed_config {
+              value: "-"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+random_value: 1

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/router_buffering
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/router_buffering
@@ -1,0 +1,74 @@
+config {
+  name: "envoy.router"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+    value: "*\023x-envoy-max-retries"
+  }
+}
+data {
+  headers {
+    headers {
+      key: "x-envoy-max-retries"
+      value: "?"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+      value: "ffffffffffffffffffffffffffffffffffffffffffvfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+      value: "ffffffffffffffffffffffffffffffffffffffffffvfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+      value: "&&&&&&&&&&&"
+    }
+    headers {
+      key: "fff\002fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbffffffffffffffffmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      value: "&&&&&&&&&&&"
+    }
+    headers {
+      key: "="
+      value: "ffffffffffffffffffffffffffffffffffffffffffvfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  }
+  trailers {
+    headers {
+      key: "x-envoy-max!-retries"
+      value: "&"
+    }
+    headers {
+      key: "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC"
+      value: "&&&&&&&&&&&"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+    }
+    headers {
+      key: "x-env-max-retries"
+      value: "fff\002fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbffffffffffffffffmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+      value: "ffffffffffffffffffffffffffffffffffffffffffvfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+      value: "fff\002ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmtmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm}mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmfffffffffffffffffffffffffffffffffffffffffffffffffffffmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm}mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmffffffffffffffffffffffffffffffff"
+    }
+    headers {
+      key: "x-envoy-m_x-retries"
+      value: "x-envoy-max-retries"
+    }
+    headers {
+      key: "x-envoy-max-retries"
+      value: "?"
+    }
+  }
+  proto_body {
+    message {
+      type_url: "type.googleapis.com/google.protobuf.Empty"
+    }
+    chunk_size: 32
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -53,6 +53,8 @@ protected:
   void sendTrailers(FilterType* filter, const test::fuzz::HttpData& data) = delete;
 
 private:
+  // This keeps track of when a filter will stop decoding due to direct responses.
+  bool enabled_ = true;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback_;
   std::shared_ptr<Network::MockDnsResolver> resolver_{std::make_shared<Network::MockDnsResolver>()};


### PR DESCRIPTION
Commit Message: Fixes two router filter related fuzz bugs. 
Additional Description:
1. The first doesn't catch empty type urls in the protos, which leads to a null dereference. This PR uses config utility functions to get the factory for `InternalRedirectPredicateFactory` which will properly handle (throw) the error in the constructor.
2. The second is a case where router filter returns `StopIteration` due to a bad request and sends a local reply to stop decoding, but the fuzzer did not handle direct responses and continued to decode data.

Risk Level: Low
Testing: Corpus entries added as regression.
Fixes:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23161
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23045

Signed-off-by: Asra Ali <asraa@google.com>
