### PR TITLE
dependencies: Bump go version

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -8,7 +8,7 @@ load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install
 load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
 
 # go version for rules_go
-GO_VERSION = "1.13.12"
+GO_VERSION = "1.14.4"
 
 def envoy_dependency_imports(go_version = GO_VERSION):
     rules_foreign_cc_dependencies()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -8,7 +8,7 @@ load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install
 load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
 
 # go version for rules_go
-GO_VERSION = "1.13.5"
+GO_VERSION = "1.13.12"
 
 def envoy_dependency_imports(go_version = GO_VERSION):
     rules_foreign_cc_dependencies()

--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -23,8 +23,9 @@ cd ../
 
 # Test grpc bridge example
 # install go
-curl -O https://storage.googleapis.com/golang/go1.13.5.linux-amd64.tar.gz
-tar -xf go1.13.5.linux-amd64.tar.gz
+GO_VERSION="1.14.4"
+curl -O https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz
+tar -xf go$GO_VERSION.linux-amd64.tar.gz
 sudo mv go /usr/local
 export PATH=$PATH:/usr/local/go/bin
 export GOPATH=$HOME/go


### PR DESCRIPTION
Commit Message:
dependencies: Bump go version

rules_go version we are using supports the latest 1.13 line go 1.13.12
Additional Description: N/A
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A