### PR TITLE
build: fix go-control-plane mirror

### DIFF
--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -40,8 +40,8 @@ def generateProtobufs(output):
     # Example output directory:
     # go_out/envoy/config/bootstrap/v2
     rule_dir, proto = rule.decode()[len('@envoy_api//'):].rsplit(':', 1)
-    input_dir = os.path.join(bazel_bin, 'external', 'envoy_api', rule_dir, 'linux_amd64_stripped',
-                             proto + '%', IMPORT_BASE, rule_dir)
+    input_dir = os.path.join(bazel_bin, 'external', 'envoy_api', rule_dir, proto + '_', IMPORT_BASE,
+                             rule_dir)
     input_files = glob.glob(os.path.join(input_dir, '*.go'))
     output_dir = os.path.join(output, rule_dir)
 
@@ -80,7 +80,7 @@ def findLastSyncSHA(repo):
 
 def updatedSinceSHA(repo, last_sha):
   # Determine if there are changes to API since last SHA
-  return git(None, 'rev-list', '%s..HEAD' % last_sha, 'api/envoy').split()
+  return git(None, 'rev-list', '%s..HEAD' % last_sha).split()
 
 
 def writeRevisionInfo(repo, sha):
@@ -97,6 +97,7 @@ def syncGoProtobufs(output, repo):
   git(repo, 'rm', '-r', 'envoy')
   # Copy subtree at envoy from output to repo
   shutil.copytree(os.path.join(output, 'envoy'), dst)
+  git(repo, 'add', 'envoy')
 
 
 def publishGoProtobufs(repo, sha):
@@ -108,17 +109,22 @@ def publishGoProtobufs(repo, sha):
   git(repo, 'push', 'origin', BRANCH)
 
 
+def updated(repo):
+  return len(
+      [f for f in git(repo, 'diff', 'HEAD', '--name-only').splitlines() if f != 'envoy/COMMIT']) > 0
+
+
 if __name__ == "__main__":
   workspace = check_output(['bazel', 'info', 'workspace']).decode().strip()
   output = os.path.join(workspace, OUTPUT_BASE)
   generateProtobufs(output)
   repo = os.path.join(workspace, REPO_BASE)
   cloneGoProtobufs(repo)
+  syncGoProtobufs(output, repo)
   last_sha = findLastSyncSHA(repo)
   changes = updatedSinceSHA(repo, last_sha)
-  if changes:
+  if updated(repo):
     print('Changes detected: %s' % changes)
     new_sha = changes[0]
-    syncGoProtobufs(output, repo)
     writeRevisionInfo(repo, new_sha)
     publishGoProtobufs(repo, new_sha)


### PR DESCRIPTION
Fix go-control-plane broken by #11581, which changes the output directory layout.

Change the script to detect generated code change instead of detecting `envoy/api` change.

Risk Level: Med
Testing: local
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
