### PR TITLE
tests: fix admission control filter test

### DIFF
--- a/test/extensions/filters/http/admission_control/admission_control_filter_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_filter_test.cc
@@ -149,7 +149,7 @@ success_criteria:
   EXPECT_CALL(controller_, requestSuccessCount()).Times(0);
 
   // We expect no rejections.
-  Http::RequestHeaderMapImpl request_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 


### PR DESCRIPTION
Test added by #11414 uses RequestHeaderMapImpl constructor made private
in #11546

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
