### PR TITLE
Issue #11259: API to Expose Histogram Raw Bins

### DIFF
--- a/api/envoy/config/metrics/v3/stats.proto
+++ b/api/envoy/config/metrics/v3/stats.proto
@@ -36,6 +36,7 @@ message StatsSink {
   // * :ref:`envoy.stat_sinks.dog_statsd <envoy_api_msg_config.metrics.v3.DogStatsdSink>`
   // * :ref:`envoy.stat_sinks.metrics_service <envoy_api_msg_config.metrics.v3.MetricsServiceConfig>`
   // * :ref:`envoy.stat_sinks.hystrix <envoy_api_msg_config.metrics.v3.HystrixSink>`
+  // * :ref:`envoy.stat_sinks.circonus <envoy_api_msg_config.metrics.v3.CirconusSink>`
   //
   // Sinks optionally support tagged/multiple dimensional metrics.
   string name = 1;

--- a/api/envoy/config/metrics/v3/stats_circonus.proto
+++ b/api/envoy/config/metrics/v3/stats_circonus.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.metrics.v3;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.metrics.v3";
+option java_outer_classname = "StatsCirconusProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// Stats configuration proto schema for built-in *envoy.stat_sinks.circonus* sink.
+// The sink is actually a no-op other than registering a new admin handler
+//
+// Note that only a single sink should be configured.
+// [#extension: envoy.stat_sinks.circonus]
+message CirconusSink {
+}

--- a/api/envoy/config/metrics/v4alpha/stats.proto
+++ b/api/envoy/config/metrics/v4alpha/stats.proto
@@ -36,6 +36,7 @@ message StatsSink {
   // * :ref:`envoy.stat_sinks.dog_statsd <envoy_api_msg_config.metrics.v4alpha.DogStatsdSink>`
   // * :ref:`envoy.stat_sinks.metrics_service <envoy_api_msg_config.metrics.v4alpha.MetricsServiceConfig>`
   // * :ref:`envoy.stat_sinks.hystrix <envoy_api_msg_config.metrics.v4alpha.HystrixSink>`
+  // * :ref:`envoy.stat_sinks.circonus <envoy_api_msg_config.metrics.v4alpha.CirconusSink>`
   //
   // Sinks optionally support tagged/multiple dimensional metrics.
   string name = 1;

--- a/api/envoy/config/metrics/v4alpha/stats_circonus.proto
+++ b/api/envoy/config/metrics/v4alpha/stats_circonus.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package envoy.config.metrics.v4alpha;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.metrics.v4alpha";
+option java_outer_classname = "StatsCirconusProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// Stats configuration proto schema for built-in *envoy.stat_sinks.circonus* sink.
+// The sink is actually a no-op other than registering a new admin handler
+//
+// Note that only a single sink should be configured.
+// [#extension: envoy.stat_sinks.circonus]
+message CirconusSink {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.metrics.v3.CirconusSink";
+}

--- a/include/envoy/stats/histogram.h
+++ b/include/envoy/stats/histogram.h
@@ -135,6 +135,20 @@ public:
   virtual void merge() PURE;
 
   /**
+   * Retrieves the interval histogram for the flush interval encoded in {@code base64}.
+   *
+   * @param bb The byte buffer that receives the encoded data
+   */
+  virtual void intervalHistogram(std::vector<std::uint8_t>& bb) const PURE;
+
+  /**
+   * Retrieves the cumulative histogram for the flush interval encoded in {@code base64}.
+   *
+   * @param bb The byte buffer that receives the encoded data
+   */
+  virtual void cumulativeHistogram(std::vector<std::uint8_t>& bb) const PURE;
+
+  /**
    * Returns the interval histogram summary statistics for the flush interval.
    */
   virtual const HistogramStatistics& intervalStatistics() const PURE;

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -100,6 +100,8 @@ public:
    */
   void merge() override;
 
+  void intervalHistogram(std::vector<std::uint8_t>& bb) const override;
+  void cumulativeHistogram(std::vector<std::uint8_t>& bb) const override;
   const HistogramStatistics& intervalStatistics() const override { return interval_statistics_; }
   const HistogramStatistics& cumulativeStatistics() const override {
     return cumulative_statistics_;

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -131,6 +131,7 @@ EXTENSIONS = {
     # Stat sinks
     #
 
+    "envoy.stat_sinks.circonus":                        "//source/extensions/stat_sinks/circonus:config",
     "envoy.stat_sinks.dog_statsd":                      "//source/extensions/stat_sinks/dog_statsd:config",
     "envoy.stat_sinks.hystrix":                         "//source/extensions/stat_sinks/hystrix:config",
     "envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",

--- a/source/extensions/stat_sinks/circonus/BUILD
+++ b/source/extensions/stat_sinks/circonus/BUILD
@@ -1,0 +1,45 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    security_posture = "data_plane_agnostic",
+    deps = [
+        ":circonus_lib",
+        "//include/envoy/registry",
+        "//source/common/network:address_lib",
+        "//source/common/network:resolver_lib",
+        "//source/extensions/stat_sinks:well_known_names",
+        "//source/server:configuration_lib",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "circonus_lib",
+    srcs = ["circonus_stat_view.cc"],
+    hdrs = ["circonus_stat_view.h", "circonus_stat_sink.h"],
+    deps = [
+        "//include/envoy/server:admin_interface",
+        "//include/envoy/server:instance_interface",
+        "//include/envoy/stats:stats_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/config:well_known_names",
+        "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
+        "//source/common/stats:symbol_table_lib",
+        "//source/common/stats:utility_lib",
+        "@com_github_circonus_labs_libcircllhist//:libcircllhist",
+    ],
+)

--- a/source/extensions/stat_sinks/circonus/circonus_stat_sink.h
+++ b/source/extensions/stat_sinks/circonus/circonus_stat_sink.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "extensions/stat_sinks/circonus/circonus_stat_view.h"
+
+#include <memory>
+#include <vector>
+
+#include "envoy/server/admin.h"
+#include "envoy/server/instance.h"
+#include "envoy/stats/histogram.h"
+#include "envoy/stats/sink.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace Circonus {
+
+/**
+ * A no-op stat-store that is only used for configuration and setup
+ */
+class CirconusStatSink final : public Stats::Sink {
+public:
+  explicit CirconusStatSink(Server::Instance& server)
+      : admin_view_(std::make_unique<CirconusStatView>(server)) {}
+  virtual ~CirconusStatSink() override = default;
+
+  virtual void flush(Stats::MetricSnapshot& /* snapshot */) override{};
+  virtual void onHistogramComplete(const Stats::Histogram& /* histogram */,
+                                   std::uint64_t /* value */) override{};
+
+private:
+  CirconusStatViewPtr admin_view_;
+};
+
+} // namespace Circonus
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/stat_sinks/circonus/circonus_stat_sink.h
+++ b/source/extensions/stat_sinks/circonus/circonus_stat_sink.h
@@ -20,7 +20,7 @@ namespace Circonus {
  */
 class CirconusStatSink final : public Stats::Sink {
 public:
-  explicit CirconusStatSink(Server::Instance& server)
+  explicit CirconusStatSink(Server::Configuration::ServerFactoryContext& server)
       : admin_view_(std::make_unique<CirconusStatView>(server)) {}
   virtual ~CirconusStatSink() override = default;
 

--- a/source/extensions/stat_sinks/circonus/circonus_stat_view.cc
+++ b/source/extensions/stat_sinks/circonus/circonus_stat_view.cc
@@ -1,0 +1,102 @@
+#include "extensions/stat_sinks/circonus/circonus_stat_view.h"
+
+#include <google/protobuf/util/internal/json_objectwriter.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <iostream>
+
+#include "common/buffer/buffer_impl.h"
+#include "common/config/well_known_names.h"
+#include "common/http/headers.h"
+#include "common/http/utility.h"
+#include "common/stats/utility.h"
+
+#include "circllhist.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace Circonus {
+
+namespace {
+const char* METRIC_HISTOGRAM_CUMULATIVE = "H";
+const char* METRIC_HISTOGRAM = "h";
+
+const char* chooseHistogramsType(absl::string_view path_and_query) {
+  const auto qp = Envoy::Http::Utility::parseQueryString(path_and_query);
+  auto found = qp.find("histogram_type");
+
+  if (found != qp.end() && found->second == "cumulative") {
+    return METRIC_HISTOGRAM_CUMULATIVE;
+  }
+
+  return METRIC_HISTOGRAM;
+}
+} // namespace
+
+CirconusStatView::CirconusStatView(Server::Instance& server) : server_(server) {
+  server.admin().addHandler("/stats/circonus", "Display Circonus metrics on the admin console",
+                            MAKE_ADMIN_HANDLER(handlerAdminStats), false, false);
+}
+
+Http::Code CirconusStatView::handlerAdminStats(absl::string_view path_and_query,
+                                               Http::ResponseHeaderMap& response_headers,
+                                               Buffer::Instance& response,
+                                               Server::AdminStream& /* admin_stream */) {
+  response_headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
+  response.add(makeJsonBody(chooseHistogramsType(path_and_query)));
+  return Http::Code::OK;
+}
+
+std::string CirconusStatView::makeJsonBody(const char* histogram_type) {
+  const auto& stats = server_.stats();
+  const auto histograms = stats.histograms();
+  auto& bb = bb_;
+  std::string json;
+  google::protobuf::io::StringOutputStream sos{&json};
+  google::protobuf::io::CodedOutputStream cos{&sos};
+  google::protobuf::util::converter::JsonObjectWriter w{" ", &cos};
+
+  w.StartObject("");
+
+  for (const auto& counter : stats.counters()) {
+    w.StartObject(counter->name());
+    w.RenderString("_type", "L");
+    w.RenderUint64("_value", counter->value());
+    w.EndObject();
+  }
+
+  for (const auto& gauge : stats.gauges()) {
+    w.StartObject(gauge->name());
+    w.RenderString("_type", "L");
+    w.RenderUint64("_value", gauge->value());
+    w.EndObject();
+  }
+
+  for (const auto& parent_histogram : stats.histograms()) {
+    const auto& stat_name = parent_histogram->statName();
+
+    if (!stat_name.empty()) {
+      const auto stat_name_as_string =
+          std::string(reinterpret_cast<const char*>(stat_name.data()), stat_name.dataSize());
+
+      if (histogram_type == METRIC_HISTOGRAM) {
+        parent_histogram->intervalHistogram(bb);
+      } else {
+        parent_histogram->cumulativeHistogram(bb);
+      }
+
+      w.StartObject(stat_name_as_string);
+      w.RenderString("_type", histogram_type);
+      w.RenderString("_value", reinterpret_cast<const char*>(&bb[0]));
+      w.EndObject();
+    }
+  }
+
+  w.EndObject();
+  return json;
+}
+
+} // namespace Circonus
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/stat_sinks/circonus/circonus_stat_view.h
+++ b/source/extensions/stat_sinks/circonus/circonus_stat_view.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "envoy/server/admin.h"
+#include "envoy/server/instance.h"
+#include "envoy/stats/histogram.h"
+#include "envoy/stats/sink.h"
+
+#include "common/stats/symbol_table_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace Circonus {
+
+class CirconusStatView final {
+public:
+  explicit CirconusStatView(Server::Instance& server);
+
+private:
+  Http::Code handlerAdminStats(absl::string_view path_and_query,
+                               Http::ResponseHeaderMap& response_headers,
+                               Buffer::Instance& response, Server::AdminStream& admin_stream);
+  std::string makeJsonBody(const char* histogram_type);
+
+private:
+  Server::Instance& server_;
+  std::vector<std::uint8_t> bb_;
+};
+
+using CirconusStatViewPtr = std::unique_ptr<CirconusStatView>;
+
+} // namespace Circonus
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/stat_sinks/circonus/circonus_stat_view.h
+++ b/source/extensions/stat_sinks/circonus/circonus_stat_view.h
@@ -17,7 +17,7 @@ namespace Circonus {
 
 class CirconusStatView final {
 public:
-  explicit CirconusStatView(Server::Instance& server);
+  explicit CirconusStatView(Server::Configuration::ServerFactoryContext& server);
 
 private:
   Http::Code handlerAdminStats(absl::string_view path_and_query,
@@ -26,7 +26,7 @@ private:
   std::string makeJsonBody(const char* histogram_type);
 
 private:
-  Server::Instance& server_;
+  Server::Configuration::ServerFactoryContext& server_;
   std::vector<std::uint8_t> bb_;
 };
 

--- a/source/extensions/stat_sinks/circonus/config.cc
+++ b/source/extensions/stat_sinks/circonus/config.cc
@@ -1,0 +1,34 @@
+#include "extensions/stat_sinks/circonus/config.h"
+#include "extensions/stat_sinks/circonus/circonus_stat_sink.h"
+
+#include <memory>
+
+#include "envoy/config/metrics/v3/stats_circonus.pb.h"
+#include "envoy/registry/registry.h"
+
+#include "common/network/resolver_impl.h"
+
+#include "extensions/stat_sinks/well_known_names.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace Circonus {
+
+Stats::SinkPtr CirconusSinkFactory::createStatsSink(const Protobuf::Message& /* config */,
+                                                    Server::Instance& server) {
+  return std::make_unique<CirconusStatSink>(server);
+}
+
+std::string CirconusSinkFactory::name() const { return StatsSinkNames::get().Circonus; }
+
+ProtobufTypes::MessagePtr CirconusSinkFactory::createEmptyConfigProto() {
+  return std::make_unique<envoy::config::metrics::v3::CirconusSink>();
+}
+
+REGISTER_FACTORY(CirconusSinkFactory, Server::Configuration::StatsSinkFactory);
+
+} // namespace Circonus
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/stat_sinks/circonus/config.cc
+++ b/source/extensions/stat_sinks/circonus/config.cc
@@ -16,7 +16,7 @@ namespace StatSinks {
 namespace Circonus {
 
 Stats::SinkPtr CirconusSinkFactory::createStatsSink(const Protobuf::Message& /* config */,
-                                                    Server::Instance& server) {
+                                                    Server::Configuration::ServerFactoryContext& server) {
   return std::make_unique<CirconusStatSink>(server);
 }
 

--- a/source/extensions/stat_sinks/circonus/config.h
+++ b/source/extensions/stat_sinks/circonus/config.h
@@ -21,8 +21,9 @@ class CirconusSinkFactory final : Logger::Loggable<Logger::Id::config>,
 public:
   virtual ~CirconusSinkFactory() override = default;
 
-  virtual Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                         Server::Instance& server) override;
+  virtual Stats::SinkPtr
+  createStatsSink(const Protobuf::Message& config,
+                  Server::Configuration::ServerFactoryContext& server) override;
   virtual ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   virtual std::string name() const override;
 };

--- a/source/extensions/stat_sinks/circonus/config.h
+++ b/source/extensions/stat_sinks/circonus/config.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/config/typed_config.h"
+#include "envoy/server/instance.h"
+#include "server/configuration_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace Circonus {
+
+/**
+ * Stats sink configuration for {@code Circonus}.  Unlike other
+ * sinks this factory registers an admin handler suitable for
+ * polling
+ */
+class CirconusSinkFactory final : Logger::Loggable<Logger::Id::config>,
+                                  public Server::Configuration::StatsSinkFactory {
+public:
+  virtual ~CirconusSinkFactory() override = default;
+
+  virtual Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
+                                         Server::Instance& server) override;
+  virtual ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+  virtual std::string name() const override;
+};
+
+} // namespace Circonus
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/stat_sinks/well_known_names.h
+++ b/source/extensions/stat_sinks/well_known_names.h
@@ -22,6 +22,8 @@ public:
   const std::string MetricsService = "envoy.stat_sinks.metrics_service";
   // Hystrix sink
   const std::string Hystrix = "envoy.stat_sinks.hystrix";
+  // Circonus sink
+  const std::string Circonus = "envoy.stat_sinks.circonus";
 };
 
 using StatsSinkNames = ConstSingleton<StatsSinkNameValues>;

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -243,6 +243,8 @@ public:
   MOCK_METHOD(void, recordValue, (uint64_t value));
   MOCK_METHOD(const HistogramStatistics&, cumulativeStatistics, (), (const));
   MOCK_METHOD(const HistogramStatistics&, intervalStatistics, (), (const));
+  MOCK_METHOD(void, intervalHistogram, (std::vector<std::uint8_t>& bb), (const));
+  MOCK_METHOD(void, cumulativeHistogram, (std::vector<std::uint8_t>& bb), (const));
 
   // RefcountInterface
   void incRefCount() override { refcount_helper_.incRefCount(); }


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:

Add support to expose raw histogram bins from the administrative console in a dedicated `circonus` page.

Additional Description:

This PR does not include a change log or tests, those will be added after getting feedback

Risk Level: Low
Testing: manual testing (for now)
Docs Changes:
Release Notes:
Fixes #11259 

