### PR TITLE
conn_pool: test refactors

### DIFF
--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -18,8 +18,8 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::InSequence;
 using testing::Invoke;
+using testing::InvokeWithoutArgs;
 using testing::NiceMock;
 using testing::Property;
 using testing::Return;
@@ -65,21 +65,21 @@ struct ConnPoolCallbacks : public Tcp::ConnectionPool::Callbacks {
 };
 
 /**
- * A test version of OriginalConnPoolImpl that allows for mocking.
+ * A wrapper around a ConnectionPoolImpl which tracks when the bridge between
+ * the pool and the consumer of the connection is released and destroyed.
  */
-class ConnPoolImplForTest : public OriginalConnPoolImpl {
+class ConnPoolBase : public Tcp::ConnectionPool::Instance {
 public:
-  ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
-                      NiceMock<Event::MockTimer>* upstream_ready_timer)
-      : OriginalConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, nullptr,
-                             nullptr),
-        mock_dispatcher_(dispatcher), mock_upstream_ready_timer_(upstream_ready_timer) {}
+  ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
+               NiceMock<Event::MockTimer>* upstream_ready_timer, bool test_new_connection_pool);
 
-  ~ConnPoolImplForTest() override {
-    EXPECT_EQ(0U, ready_conns_.size());
-    EXPECT_EQ(0U, busy_conns_.size());
-    EXPECT_EQ(0U, pending_requests_.size());
+  void addDrainedCallback(DrainedCb cb) { conn_pool_->addDrainedCallback(cb); }
+  void drainConnections() { conn_pool_->drainConnections(); }
+  void closeConnections() { conn_pool_->closeConnections(); }
+  ConnectionPool::Cancellable* newConnection(Tcp::ConnectionPool::Callbacks& callbacks) {
+    return conn_pool_->newConnection(callbacks);
   }
+  Upstream::HostDescriptionConstSharedPtr host() const { return conn_pool_->host(); }
 
   MOCK_METHOD(void, onConnReleasedForTest, ());
   MOCK_METHOD(void, onConnDestroyedForTest, ());
@@ -103,81 +103,129 @@ public:
             [&](Network::ReadFilterSharedPtr filter) -> void { test_conn.filter_ = filter; }));
     EXPECT_CALL(*test_conn.connection_, connect());
     EXPECT_CALL(*test_conn.connect_timer_, enableTimer(_, _));
+
+    ON_CALL(*test_conn.connection_, close(Network::ConnectionCloseType::NoFlush))
+        .WillByDefault(InvokeWithoutArgs([test_conn]() -> void {
+          test_conn.connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+        }));
   }
 
-  void expectEnableUpstreamReady() {
-    EXPECT_FALSE(upstream_ready_enabled_);
-    EXPECT_CALL(*mock_upstream_ready_timer_, enableTimer(_, _)).Times(1).RetiresOnSaturation();
-  }
+  void expectEnableUpstreamReady(bool run);
 
-  void expectAndRunUpstreamReady() {
-    EXPECT_TRUE(upstream_ready_enabled_);
-    mock_upstream_ready_timer_->invokeCallback();
-    EXPECT_FALSE(upstream_ready_enabled_);
-  }
-
+  std::unique_ptr<Tcp::ConnectionPool::Instance> conn_pool_;
   Event::MockDispatcher& mock_dispatcher_;
   NiceMock<Event::MockTimer>* mock_upstream_ready_timer_;
   std::vector<TestConnection> test_conns_;
+  Network::ConnectionCallbacks* callbacks_ = nullptr;
+  bool test_new_connection_pool_;
 
 protected:
-  void onConnReleased(OriginalConnPoolImpl::ActiveConn& conn) override {
-    for (auto& test_conn : test_conns_) {
-      if (conn.conn_.get() == test_conn.connection_) {
-        onConnReleasedForTest();
-        break;
-      }
+  class ConnPoolImplForTest : public OriginalConnPoolImpl {
+  public:
+    ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
+                        ConnPoolBase& parent)
+        : OriginalConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, nullptr,
+                               nullptr),
+          parent_(parent) {}
+
+    ~ConnPoolImplForTest() override {
+      EXPECT_EQ(0U, ready_conns_.size());
+      EXPECT_EQ(0U, busy_conns_.size());
+      EXPECT_EQ(0U, pending_requests_.size());
     }
 
-    OriginalConnPoolImpl::onConnReleased(conn);
-  }
-
-  void onConnDestroyed(OriginalConnPoolImpl::ActiveConn& conn) override {
-    for (auto i = test_conns_.begin(); i != test_conns_.end(); i++) {
-      if (conn.conn_.get() == i->connection_) {
-        onConnDestroyedForTest();
-        test_conns_.erase(i);
-        break;
-      }
+    void onConnReleased(OriginalConnPoolImpl::ActiveConn& conn) override {
+      parent_.onConnReleasedForTest();
+      OriginalConnPoolImpl::onConnReleased(conn);
     }
 
-    OriginalConnPoolImpl::onConnDestroyed(conn);
-  }
+    void onConnDestroyed(OriginalConnPoolImpl::ActiveConn& conn) override {
+      parent_.onConnDestroyedForTest();
+      OriginalConnPoolImpl::onConnDestroyed(conn);
+    }
+    void expectEnableUpstreamReady(bool run) {
+      if (!run) {
+        EXPECT_FALSE(upstream_ready_enabled_);
+        EXPECT_CALL(*parent_.mock_upstream_ready_timer_, enableTimer(_, _))
+            .Times(1)
+            .RetiresOnSaturation();
+      } else {
+        EXPECT_TRUE(upstream_ready_enabled_);
+        parent_.mock_upstream_ready_timer_->invokeCallback();
+        EXPECT_FALSE(upstream_ready_enabled_);
+      }
+    }
+    ConnPoolBase& parent_;
+  };
 };
+
+ConnPoolBase::ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
+                           NiceMock<Event::MockTimer>* upstream_ready_timer,
+                           bool test_new_connection_pool)
+    : mock_dispatcher_(dispatcher), mock_upstream_ready_timer_(upstream_ready_timer),
+      test_new_connection_pool_(test_new_connection_pool) {
+  // TODO(alyssarwilk) remove this assert and test the old and the new when it lands.
+  ASSERT(!test_new_connection_pool_);
+  if (!test_new_connection_pool_) {
+    conn_pool_ = std::make_unique<ConnPoolImplForTest>(dispatcher, host, *this);
+  }
+}
+
+void ConnPoolBase::expectEnableUpstreamReady(bool run) {
+  if (!test_new_connection_pool_) {
+    dynamic_cast<ConnPoolImplForTest*>(conn_pool_.get())->expectEnableUpstreamReady(run);
+  } else {
+    if (!run) {
+      EXPECT_CALL(*mock_upstream_ready_timer_, enableTimer(_, _)).Times(1).RetiresOnSaturation();
+    } else {
+      mock_upstream_ready_timer_->invokeCallback();
+    }
+  }
+}
 
 /**
  * Test fixture for connection pool tests.
  */
-class TcpConnPoolImplTest : public testing::Test {
+class TcpConnPoolImplTest : public testing::TestWithParam<bool> {
 public:
   TcpConnPoolImplTest()
-      : upstream_ready_timer_(new NiceMock<Event::MockTimer>(&dispatcher_)),
+      : test_new_connection_pool_(GetParam()),
+        upstream_ready_timer_(new NiceMock<Event::MockTimer>(&dispatcher_)),
         host_(Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000")),
-        conn_pool_(dispatcher_, host_, upstream_ready_timer_) {}
-
-  ~TcpConnPoolImplTest() override {
-    EXPECT_TRUE(TestUtility::gaugesZeroed(cluster_->stats_store_.gauges()));
+        conn_pool_(dispatcher_, host_, upstream_ready_timer_, test_new_connection_pool_) {
+    // TODO(alyssarwilk) remove this assert and test the old and the new when it lands.
+    ASSERT(!test_new_connection_pool_);
   }
 
+  ~TcpConnPoolImplTest() override {
+    EXPECT_TRUE(TestUtility::gaugesZeroed(cluster_->stats_store_.gauges()))
+        << TestUtility::nonZeroedGauges(cluster_->stats_store_.gauges());
+  }
+
+  bool test_new_connection_pool_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   NiceMock<Event::MockTimer>* upstream_ready_timer_;
   Upstream::HostSharedPtr host_;
-  ConnPoolImplForTest conn_pool_;
+  ConnPoolBase conn_pool_;
   NiceMock<Runtime::MockLoader> runtime_;
 };
 
 /**
  * Test fixture for connection pool destructor tests.
  */
-class TcpConnPoolImplDestructorTest : public testing::Test {
+class TcpConnPoolImplDestructorTest : public testing::TestWithParam<bool> {
 public:
   TcpConnPoolImplDestructorTest()
-      : upstream_ready_timer_(new NiceMock<Event::MockTimer>(&dispatcher_)),
-        conn_pool_{new OriginalConnPoolImpl(
-            dispatcher_, Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000"),
-            Upstream::ResourcePriority::Default, nullptr, nullptr)} {}
-
+      : test_new_connection_pool_(GetParam()),
+        upstream_ready_timer_(new NiceMock<Event::MockTimer>(&dispatcher_)) {
+    host_ = Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000");
+    ASSERT(!test_new_connection_pool_);
+    if (!test_new_connection_pool_) {
+      conn_pool_ = std::make_unique<OriginalConnPoolImpl>(
+          dispatcher_, host_, Upstream::ResourcePriority::Default, nullptr, nullptr);
+    }
+  }
   ~TcpConnPoolImplDestructorTest() override = default;
 
   void prepareConn() {
@@ -195,12 +243,14 @@ public:
     connection_->raiseEvent(Network::ConnectionEvent::Connected);
   }
 
+  bool test_new_connection_pool_;
+  Upstream::HostConstSharedPtr host_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   NiceMock<Event::MockTimer>* upstream_ready_timer_;
   NiceMock<Event::MockTimer>* connect_timer_;
   NiceMock<Network::MockClientConnection>* connection_;
-  std::unique_ptr<OriginalConnPoolImpl> conn_pool_;
+  std::unique_ptr<Tcp::ConnectionPool::Instance> conn_pool_;
   std::unique_ptr<ConnPoolCallbacks> callbacks_;
 };
 
@@ -265,14 +315,13 @@ struct ActiveTestConn {
   bool completed_{};
 };
 
-TEST_F(TcpConnPoolImplTest, HostAccessor) { EXPECT_EQ(conn_pool_.host(), host_); }
+TEST_P(TcpConnPoolImplTest, HostAccessor) { EXPECT_EQ(conn_pool_.host(), host_); }
 
 /**
  * Verify that connections are drained when requested.
  */
-TEST_F(TcpConnPoolImplTest, DrainConnections) {
+TEST_P(TcpConnPoolImplTest, DrainConnections) {
   cluster_->resetResourceManager(3, 1024, 1024, 1, 1);
-  InSequence s;
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
   ActiveTestConn c2(*this, 1, ActiveTestConn::Type::CreateConnection);
@@ -281,32 +330,35 @@ TEST_F(TcpConnPoolImplTest, DrainConnections) {
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   c1.releaseConn();
 
-  // This will destroy the ready connection and set requests remaining to 1 on the busy and pending
-  // connections.
-  EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
-  conn_pool_.drainConnections();
-  dispatcher_.clearDeferredDeleteList();
+  {
+    // This will destroy the ready connection and set requests remaining to 1 on the busy and
+    // pending connections.
+    EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
+    conn_pool_.drainConnections();
+    dispatcher_.clearDeferredDeleteList();
+  }
+  {
+    // This will destroy the busy connection when the response finishes.
+    EXPECT_CALL(conn_pool_, onConnReleasedForTest());
+    EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
+    c2.releaseConn();
+    dispatcher_.clearDeferredDeleteList();
+  }
+  {
+    // This will destroy the pending connection when the response finishes.
+    c3.completeConnection();
 
-  // This will destroy the busy connection when the response finishes.
-  EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
-  c2.releaseConn();
-  dispatcher_.clearDeferredDeleteList();
-
-  // This will destroy the pending connection when the response finishes.
-  c3.conn_index_ = 0; // c1/c2 have been deleted from test_conns_.
-  c3.completeConnection();
-
-  EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
-  c3.releaseConn();
-  dispatcher_.clearDeferredDeleteList();
+    EXPECT_CALL(conn_pool_, onConnReleasedForTest());
+    EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
+    c3.releaseConn();
+    dispatcher_.clearDeferredDeleteList();
+  }
 }
 
 /**
  * Test all timing stats are set.
  */
-TEST_F(TcpConnPoolImplTest, VerifyTimingStats) {
+TEST_P(TcpConnPoolImplTest, VerifyTimingStats) {
   EXPECT_CALL(cluster_->stats_store_,
               deliverHistogramToSinks(Property(&Stats::Metric::name, "upstream_cx_connect_ms"), _));
   EXPECT_CALL(cluster_->stats_store_,
@@ -326,7 +378,7 @@ TEST_F(TcpConnPoolImplTest, VerifyTimingStats) {
 /**
  * Test that buffer limits are set.
  */
-TEST_F(TcpConnPoolImplTest, VerifyBufferLimits) {
+TEST_P(TcpConnPoolImplTest, VerifyBufferLimits) {
   ConnPoolCallbacks callbacks;
   conn_pool_.expectConnCreate();
   EXPECT_CALL(*cluster_, perConnectionBufferLimitBytes()).WillOnce(Return(8192));
@@ -344,10 +396,9 @@ TEST_F(TcpConnPoolImplTest, VerifyBufferLimits) {
 /**
  * Test that upstream callback fire for assigned connections.
  */
-TEST_F(TcpConnPoolImplTest, UpstreamCallbacks) {
+TEST_P(TcpConnPoolImplTest, UpstreamCallbacks) {
   Buffer::OwnedImpl buffer;
 
-  InSequence s;
   ConnectionPool::MockUpstreamCallbacks callbacks;
 
   // Create connection, set UpstreamCallbacks
@@ -381,10 +432,9 @@ TEST_F(TcpConnPoolImplTest, UpstreamCallbacks) {
 /**
  * Test that upstream callback close event fires for assigned connections.
  */
-TEST_F(TcpConnPoolImplTest, UpstreamCallbacksCloseEvent) {
+TEST_P(TcpConnPoolImplTest, UpstreamCallbacksCloseEvent) {
   Buffer::OwnedImpl buffer;
 
-  InSequence s;
   ConnectionPool::MockUpstreamCallbacks callbacks;
 
   // Create connection, set UpstreamCallbacks
@@ -401,10 +451,8 @@ TEST_F(TcpConnPoolImplTest, UpstreamCallbacksCloseEvent) {
 /**
  * Test that a connection pool functions without upstream callbacks.
  */
-TEST_F(TcpConnPoolImplTest, NoUpstreamCallbacks) {
+TEST_P(TcpConnPoolImplTest, NoUpstreamCallbacks) {
   Buffer::OwnedImpl buffer;
-
-  InSequence s;
 
   // Create connection.
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
@@ -420,8 +468,7 @@ TEST_F(TcpConnPoolImplTest, NoUpstreamCallbacks) {
  * Tests a request that generates a new connection, completes, and then a second request that uses
  * the same connection.
  */
-TEST_F(TcpConnPoolImplTest, MultipleRequestAndResponse) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, MultipleRequestAndResponse) {
 
   // Request 1 should kick off a new connection.
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
@@ -444,8 +491,7 @@ TEST_F(TcpConnPoolImplTest, MultipleRequestAndResponse) {
 /**
  * Tests ConnectionState assignment, lookup and destruction.
  */
-TEST_F(TcpConnPoolImplTest, ConnectionStateLifecycle) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, ConnectionStateLifecycle) {
 
   bool state_destroyed = false;
 
@@ -483,7 +529,7 @@ TEST_F(TcpConnPoolImplTest, ConnectionStateLifecycle) {
 /**
  * Test when we overflow max pending requests.
  */
-TEST_F(TcpConnPoolImplTest, MaxPendingRequests) {
+TEST_P(TcpConnPoolImplTest, MaxPendingRequests) {
   cluster_->resetResourceManager(1, 1, 1024, 1, 1);
 
   ConnPoolCallbacks callbacks;
@@ -511,8 +557,7 @@ TEST_F(TcpConnPoolImplTest, MaxPendingRequests) {
  * Tests a connection failure before a request is bound which should result in the pending request
  * getting purged.
  */
-TEST_F(TcpConnPoolImplTest, RemoteConnectFailure) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, RemoteConnectFailure) {
 
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks;
@@ -537,8 +582,7 @@ TEST_F(TcpConnPoolImplTest, RemoteConnectFailure) {
  * Tests a connection failure before a request is bound which should result in the pending request
  * getting purged.
  */
-TEST_F(TcpConnPoolImplTest, LocalConnectFailure) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, LocalConnectFailure) {
 
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks;
@@ -562,8 +606,7 @@ TEST_F(TcpConnPoolImplTest, LocalConnectFailure) {
 /**
  * Tests a connect timeout. Also test that we can add a new request during ejection processing.
  */
-TEST_F(TcpConnPoolImplTest, ConnectTimeout) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, ConnectTimeout) {
 
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks1;
@@ -594,8 +637,7 @@ TEST_F(TcpConnPoolImplTest, ConnectTimeout) {
 /**
  * Test cancelling before the request is bound to a connection.
  */
-TEST_F(TcpConnPoolImplTest, CancelBeforeBound) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, CancelBeforeBound) {
 
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks;
@@ -615,8 +657,7 @@ TEST_F(TcpConnPoolImplTest, CancelBeforeBound) {
 /**
  * Test cancelling before the request is bound to a connection, with connection close.
  */
-TEST_F(TcpConnPoolImplTest, CancelAndCloseBeforeBound) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, CancelAndCloseBeforeBound) {
 
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks;
@@ -634,8 +675,7 @@ TEST_F(TcpConnPoolImplTest, CancelAndCloseBeforeBound) {
 /**
  * Test an upstream disconnection while there is a bound request.
  */
-TEST_F(TcpConnPoolImplTest, DisconnectWhileBound) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, DisconnectWhileBound) {
 
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks;
@@ -656,9 +696,8 @@ TEST_F(TcpConnPoolImplTest, DisconnectWhileBound) {
 /**
  * Test upstream disconnection of one request while another is pending.
  */
-TEST_F(TcpConnPoolImplTest, DisconnectWhilePending) {
+TEST_P(TcpConnPoolImplTest, DisconnectWhilePending) {
   cluster_->resetResourceManager(1, 1024, 1024, 1, 1);
-  InSequence s;
 
   // First request connected.
   ConnPoolCallbacks callbacks;
@@ -682,26 +721,24 @@ TEST_F(TcpConnPoolImplTest, DisconnectWhilePending) {
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   dispatcher_.clearDeferredDeleteList();
 
-  // test_conns_[0] was replaced with a new connection
-  EXPECT_CALL(*conn_pool_.test_conns_[0].connect_timer_, disableTimer());
+  // test_conns_[1] is the new connection
+  EXPECT_CALL(*conn_pool_.test_conns_[1].connect_timer_, disableTimer());
   EXPECT_CALL(callbacks2.pool_ready_, ready());
-  conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  conn_pool_.test_conns_[1].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   callbacks2.conn_data_.reset();
 
   // Disconnect
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
-  conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  conn_pool_.test_conns_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
 }
 
 /**
  * Test that we correctly handle reaching max connections.
  */
-TEST_F(TcpConnPoolImplTest, MaxConnections) {
-  InSequence s;
-
+TEST_P(TcpConnPoolImplTest, MaxConnections) {
   // Request 1 should kick off a new connection.
   ConnPoolCallbacks callbacks;
   conn_pool_.expectConnCreate();
@@ -722,11 +759,11 @@ TEST_F(TcpConnPoolImplTest, MaxConnections) {
 
   // Finishing request 1 will immediately bind to request 2.
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  conn_pool_.expectEnableUpstreamReady();
+  conn_pool_.expectEnableUpstreamReady(false);
   EXPECT_CALL(callbacks2.pool_ready_, ready());
   callbacks.conn_data_.reset();
 
-  conn_pool_.expectAndRunUpstreamReady();
+  conn_pool_.expectEnableUpstreamReady(true);
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
   callbacks2.conn_data_.reset();
 
@@ -739,8 +776,7 @@ TEST_F(TcpConnPoolImplTest, MaxConnections) {
 /**
  * Test when we reach max requests per connection.
  */
-TEST_F(TcpConnPoolImplTest, MaxRequestsPerConnection) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, MaxRequestsPerConnection) {
 
   cluster_->max_requests_per_connection_ = 1;
 
@@ -766,9 +802,8 @@ TEST_F(TcpConnPoolImplTest, MaxRequestsPerConnection) {
 /*
  * Test that multiple connections can be assigned at once.
  */
-TEST_F(TcpConnPoolImplTest, ConcurrentConnections) {
+TEST_P(TcpConnPoolImplTest, ConcurrentConnections) {
   cluster_->resetResourceManager(2, 1024, 1024, 1, 1);
-  InSequence s;
 
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
   ActiveTestConn c2(*this, 1, ActiveTestConn::Type::CreateConnection);
@@ -776,11 +811,11 @@ TEST_F(TcpConnPoolImplTest, ConcurrentConnections) {
 
   // Finish c1, which gets c3 going.
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  conn_pool_.expectEnableUpstreamReady();
+  conn_pool_.expectEnableUpstreamReady(false);
   c3.expectNewConn();
   c1.releaseConn();
 
-  conn_pool_.expectAndRunUpstreamReady();
+  conn_pool_.expectEnableUpstreamReady(true);
   EXPECT_CALL(conn_pool_, onConnReleasedForTest()).Times(2);
   c2.releaseConn();
   c3.releaseConn();
@@ -795,8 +830,7 @@ TEST_F(TcpConnPoolImplTest, ConcurrentConnections) {
 /**
  * Tests ConnectionState lifecycle with multiple concurrent connections.
  */
-TEST_F(TcpConnPoolImplTest, ConnectionStateWithConcurrentConnections) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, ConnectionStateWithConcurrentConnections) {
 
   int state_destroyed = 0;
   auto* s1 = new TestConnectionState(1, [&]() -> void { state_destroyed |= 1; });
@@ -814,11 +848,11 @@ TEST_F(TcpConnPoolImplTest, ConnectionStateWithConcurrentConnections) {
 
   // Finish c1, which gets c3 going.
   EXPECT_CALL(conn_pool_, onConnReleasedForTest());
-  conn_pool_.expectEnableUpstreamReady();
+  conn_pool_.expectEnableUpstreamReady(false);
   c3.expectNewConn();
   c1.releaseConn();
 
-  conn_pool_.expectAndRunUpstreamReady();
+  conn_pool_.expectEnableUpstreamReady(true);
 
   // c3 now has the state set by c1.
   EXPECT_EQ(s1, c3.callbacks_.conn_data_->connectionStateTyped<TestConnectionState>());
@@ -846,8 +880,7 @@ TEST_F(TcpConnPoolImplTest, ConnectionStateWithConcurrentConnections) {
 /**
  * Tests that the DrainCallback is invoked when the number of connections goes to zero.
  */
-TEST_F(TcpConnPoolImplTest, DrainCallback) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, DrainCallback) {
   ReadyWatcher drained;
 
   EXPECT_CALL(drained, ready());
@@ -869,8 +902,7 @@ TEST_F(TcpConnPoolImplTest, DrainCallback) {
 /**
  * Test draining a connection pool that has a pending connection.
  */
-TEST_F(TcpConnPoolImplTest, DrainWhileConnecting) {
-  InSequence s;
+TEST_P(TcpConnPoolImplTest, DrainWhileConnecting) {
   ReadyWatcher drained;
 
   ConnPoolCallbacks callbacks;
@@ -883,7 +915,6 @@ TEST_F(TcpConnPoolImplTest, DrainWhileConnecting) {
   EXPECT_CALL(*conn_pool_.test_conns_[0].connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(drained, ready());
   conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
-
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   dispatcher_.clearDeferredDeleteList();
 }
@@ -891,12 +922,11 @@ TEST_F(TcpConnPoolImplTest, DrainWhileConnecting) {
 /**
  * Test that the DrainCallback is invoked when a connection is closed.
  */
-TEST_F(TcpConnPoolImplTest, DrainOnClose) {
+TEST_P(TcpConnPoolImplTest, DrainOnClose) {
   ReadyWatcher drained;
   EXPECT_CALL(drained, ready());
   conn_pool_.addDrainedCallback([&]() -> void { drained.ready(); });
 
-  InSequence s;
   ActiveTestConn c1(*this, 0, ActiveTestConn::Type::CreateConnection);
 
   ConnectionPool::MockUpstreamCallbacks callbacks;
@@ -917,7 +947,7 @@ TEST_F(TcpConnPoolImplTest, DrainOnClose) {
 /**
  * Test that pending connections are closed when the connection pool is destroyed.
  */
-TEST_F(TcpConnPoolImplDestructorTest, TestPendingConnectionsAreClosed) {
+TEST_P(TcpConnPoolImplDestructorTest, TestPendingConnectionsAreClosed) {
   connection_ = new NiceMock<Network::MockClientConnection>();
   connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillOnce(Return(connection_));
@@ -936,7 +966,7 @@ TEST_F(TcpConnPoolImplDestructorTest, TestPendingConnectionsAreClosed) {
 /**
  * Test that busy connections are closed when the connection pool is destroyed.
  */
-TEST_F(TcpConnPoolImplDestructorTest, TestBusyConnectionsAreClosed) {
+TEST_P(TcpConnPoolImplDestructorTest, TestBusyConnectionsAreClosed) {
   prepareConn();
 
   EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
@@ -947,7 +977,7 @@ TEST_F(TcpConnPoolImplDestructorTest, TestBusyConnectionsAreClosed) {
 /**
  * Test that ready connections are closed when the connection pool is destroyed.
  */
-TEST_F(TcpConnPoolImplDestructorTest, TestReadyConnectionsAreClosed) {
+TEST_P(TcpConnPoolImplDestructorTest, TestReadyConnectionsAreClosed) {
   prepareConn();
 
   // Transition connection to ready list
@@ -957,6 +987,9 @@ TEST_F(TcpConnPoolImplDestructorTest, TestReadyConnectionsAreClosed) {
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   conn_pool_.reset();
 }
+
+INSTANTIATE_TEST_SUITE_P(ConnectionPools, TcpConnPoolImplTest, testing::Values(false));
+INSTANTIATE_TEST_SUITE_P(ConnectionPools, TcpConnPoolImplDestructorTest, testing::Values(false));
 
 } // namespace Tcp
 } // namespace Envoy

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -73,13 +73,13 @@ public:
   ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
                NiceMock<Event::MockTimer>* upstream_ready_timer, bool test_new_connection_pool);
 
-  void addDrainedCallback(DrainedCb cb) { conn_pool_->addDrainedCallback(cb); }
-  void drainConnections() { conn_pool_->drainConnections(); }
-  void closeConnections() { conn_pool_->closeConnections(); }
-  ConnectionPool::Cancellable* newConnection(Tcp::ConnectionPool::Callbacks& callbacks) {
+  void addDrainedCallback(DrainedCb cb) override { conn_pool_->addDrainedCallback(cb); }
+  void drainConnections() override { conn_pool_->drainConnections(); }
+  void closeConnections() override { conn_pool_->closeConnections(); }
+  ConnectionPool::Cancellable* newConnection(Tcp::ConnectionPool::Callbacks& callbacks) override {
     return conn_pool_->newConnection(callbacks);
   }
-  Upstream::HostDescriptionConstSharedPtr host() const { return conn_pool_->host(); }
+  Upstream::HostDescriptionConstSharedPtr host() const override { return conn_pool_->host(); }
 
   MOCK_METHOD(void, onConnReleasedForTest, ());
   MOCK_METHOD(void, onConnDestroyedForTest, ());


### PR DESCRIPTION
Splitting out a test refactor from an already large PR
Making the connection pool test parameterized so we can test with old and new pools.

Risk Level: n/a (test only)
Testing: yes
Docs Changes: no
Release Notes: no
Part of #11528
