### PR TITLE
conn_pool: minor refactors

### DIFF
--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -76,7 +76,7 @@ public:
   /**
    * @return the underlying connection ID.
    */
-  uint64_t id() { return connection_->id(); }
+  uint64_t id() const { return connection_->id(); }
 
   /**
    * @return the underlying codec protocol.

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -105,15 +105,15 @@ void ConnPoolImplBase::attachRequestToClient(ActiveClient& client,
                             nullptr);
     host_->cluster().stats().upstream_rq_pending_overflow_.inc();
   } else {
-    ENVOY_CONN_LOG(debug, "creating stream", *client.codec_client_);
+    ENVOY_CONN_LOG(debug, "creating stream", client);
     RequestEncoder& new_encoder = client.newStreamEncoder(response_decoder);
 
     client.remaining_requests_--;
     if (client.remaining_requests_ == 0) {
-      ENVOY_CONN_LOG(debug, "maximum requests per connection, DRAINING", *client.codec_client_);
+      ENVOY_CONN_LOG(debug, "maximum requests per connection, DRAINING", client);
       host_->cluster().stats().upstream_cx_max_requests_.inc();
       transitionActiveClientState(client, ActiveClient::State::DRAINING);
-    } else if (client.codec_client_->numActiveRequests() >= client.concurrent_request_limit_) {
+    } else if (client.numActiveRequests() >= client.concurrent_request_limit_) {
       transitionActiveClientState(client, ActiveClient::State::BUSY);
     }
 
@@ -129,20 +129,18 @@ void ConnPoolImplBase::attachRequestToClient(ActiveClient& client,
 }
 
 void ConnPoolImplBase::onRequestClosed(ActiveClient& client, bool delay_attaching_request) {
-  ENVOY_CONN_LOG(debug, "destroying stream: {} remaining", *client.codec_client_,
-                 client.codec_client_->numActiveRequests());
+  ENVOY_CONN_LOG(debug, "destroying stream: {} remaining", client, client.numActiveRequests());
   ASSERT(num_active_requests_ > 0);
   num_active_requests_--;
   host_->stats().rq_active_.dec();
   host_->cluster().stats().upstream_rq_active_.dec();
   host_->cluster().resourceManager(priority_).requests().dec();
-  if (client.state_ == ActiveClient::State::DRAINING &&
-      client.codec_client_->numActiveRequests() == 0) {
+  if (client.state_ == ActiveClient::State::DRAINING && client.numActiveRequests() == 0) {
     // Close out the draining client if we no longer have active requests.
     client.codec_client_->close();
   } else if (client.state_ == ActiveClient::State::BUSY) {
     // A request was just ended, so we should be below the limit now.
-    ASSERT(client.codec_client_->numActiveRequests() < client.concurrent_request_limit_);
+    ASSERT(client.numActiveRequests() < client.concurrent_request_limit_);
 
     transitionActiveClientState(client, ActiveClient::State::READY);
     if (!delay_attaching_request) {
@@ -155,7 +153,7 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStream(ResponseDecoder& respon
                                                          ConnectionPool::Callbacks& callbacks) {
   if (!ready_clients_.empty()) {
     ActiveClient& client = *ready_clients_.front();
-    ENVOY_CONN_LOG(debug, "using existing connection", *client.codec_client_);
+    ENVOY_CONN_LOG(debug, "using existing connection", client);
     attachRequestToClient(client, response_decoder, callbacks);
     return nullptr;
   }
@@ -180,7 +178,7 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStream(ResponseDecoder& respon
 void ConnPoolImplBase::onUpstreamReady() {
   while (!pending_requests_.empty() && !ready_clients_.empty()) {
     ActiveClientPtr& client = ready_clients_.front();
-    ENVOY_CONN_LOG(debug, "attaching to next request", *client->codec_client_);
+    ENVOY_CONN_LOG(debug, "attaching to next request", *client);
     // Pending requests are pushed onto the front, so pull from the back.
     attachRequestToClient(*client, pending_requests_.back()->decoder_,
                           pending_requests_.back()->callbacks_);
@@ -192,8 +190,7 @@ bool ConnPoolImplBase::hasActiveConnections() const {
   return (!pending_requests_.empty() || (num_active_requests_ > 0));
 }
 
-std::list<ConnPoolImplBase::ActiveClientPtr>&
-ConnPoolImplBase::owningList(ActiveClient::State state) {
+std::list<ActiveClientPtr>& ConnPoolImplBase::owningList(ActiveClient::State state) {
   switch (state) {
   case ActiveClient::State::CONNECTING:
     return connecting_clients_;
@@ -285,7 +282,7 @@ void ConnPoolImplBase::checkForDrained() {
   }
 }
 
-void ConnPoolImplBase::onConnectionEvent(ConnPoolImplBase::ActiveClient& client,
+void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view failure_reason,
                                          Network::ConnectionEvent event) {
   if (client.state_ == ActiveClient::State::CONNECTING) {
     ASSERT(connecting_request_capacity_ >= client.effectiveConcurrentRequestLimit());
@@ -295,8 +292,7 @@ void ConnPoolImplBase::onConnectionEvent(ConnPoolImplBase::ActiveClient& client,
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
     // The client died.
-    ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", *client.codec_client_,
-                   client.codec_client_->connectionFailureReason());
+    ENVOY_CONN_LOG(debug, "client disconnected, failure reason: {}", client, failure_reason);
 
     Envoy::Upstream::reportUpstreamCxDestroy(host_, event);
     const bool incomplete_request = client.closingWithIncompleteRequest();
@@ -361,17 +357,21 @@ void ConnPoolImplBase::onConnectionEvent(ConnPoolImplBase::ActiveClient& client,
   }
 }
 
-ConnPoolImplBase::PendingRequest::PendingRequest(ConnPoolImplBase& parent, ResponseDecoder& decoder,
-                                                 ConnectionPool::Callbacks& callbacks)
+PendingRequest::PendingRequest(ConnPoolImplBase& parent, ResponseDecoder& decoder,
+                               ConnectionPool::Callbacks& callbacks)
     : parent_(parent), decoder_(decoder), callbacks_(callbacks) {
   parent_.host_->cluster().stats().upstream_rq_pending_total_.inc();
   parent_.host_->cluster().stats().upstream_rq_pending_active_.inc();
   parent_.host_->cluster().resourceManager(parent_.priority_).pendingRequests().inc();
 }
 
-ConnPoolImplBase::PendingRequest::~PendingRequest() {
+PendingRequest::~PendingRequest() {
   parent_.host_->cluster().stats().upstream_rq_pending_active_.dec();
   parent_.host_->cluster().resourceManager(parent_.priority_).pendingRequests().dec();
+}
+
+void PendingRequest::cancel(Envoy::ConnectionPool::CancelPolicy policy) {
+  parent_.onPendingRequestCancel(*this, policy);
 }
 
 ConnectionPool::Cancellable*
@@ -433,9 +433,8 @@ uint64_t translateZeroToUnlimited(uint64_t limit) {
 }
 } // namespace
 
-ConnPoolImplBase::ActiveClient::ActiveClient(ConnPoolImplBase& parent,
-                                             uint64_t lifetime_request_limit,
-                                             uint64_t concurrent_request_limit)
+ActiveClient::ActiveClient(ConnPoolImplBase& parent, uint64_t lifetime_request_limit,
+                           uint64_t concurrent_request_limit)
     : parent_(parent), remaining_requests_(translateZeroToUnlimited(lifetime_request_limit)),
       concurrent_request_limit_(translateZeroToUnlimited(concurrent_request_limit)),
       connect_timer_(parent_.dispatcher_.createTimer([this]() -> void { onConnectTimeout(); })) {
@@ -465,9 +464,9 @@ ConnPoolImplBase::ActiveClient::ActiveClient(ConnPoolImplBase& parent,
        &parent_.host_->cluster().stats().bind_errors_, nullptr});
 }
 
-ConnPoolImplBase::ActiveClient::~ActiveClient() { releaseResources(); }
+ActiveClient::~ActiveClient() { releaseResources(); }
 
-void ConnPoolImplBase::ActiveClient::releaseResources() {
+void ActiveClient::releaseResources() {
   if (!resources_released_) {
     resources_released_ = true;
 
@@ -479,11 +478,15 @@ void ConnPoolImplBase::ActiveClient::releaseResources() {
   }
 }
 
-void ConnPoolImplBase::ActiveClient::onConnectTimeout() {
+void ActiveClient::onConnectTimeout() {
   ENVOY_CONN_LOG(debug, "connect timeout", *codec_client_);
   parent_.host_->cluster().stats().upstream_cx_connect_timeout_.inc();
   timed_out_ = true;
   close();
+}
+
+void ActiveClient::onEvent(Network::ConnectionEvent event) {
+  parent_.onConnectionEvent(*this, codec_client_->connectionFailureReason(), event);
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -13,6 +13,81 @@
 namespace Envoy {
 namespace Http {
 
+class ConnPoolImplBase;
+
+// ActiveClient provides a base class for connection pool clients that handles connection timings
+// as well as managing the connection timeout.
+class ActiveClient : public LinkedObject<ActiveClient>,
+                     public Network::ConnectionCallbacks,
+                     public Event::DeferredDeletable,
+                     protected Logger::Loggable<Logger::Id::pool> {
+public:
+  ActiveClient(ConnPoolImplBase& parent, uint64_t lifetime_request_limit,
+               uint64_t concurrent_request_limit);
+  ~ActiveClient() override;
+
+  void releaseResources();
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+  void onConnectTimeout();
+
+  // Returns the concurrent request limit, accounting for if the total request limit
+  // is less than the concurrent request limit.
+  uint64_t effectiveConcurrentRequestLimit() const {
+    return std::min(remaining_requests_, concurrent_request_limit_);
+  }
+
+  void close() { codec_client_->close(); }
+  uint64_t id() const { return codec_client_->id(); }
+  virtual bool hasActiveRequests() const PURE;
+  virtual bool closingWithIncompleteRequest() const PURE;
+  virtual size_t numActiveRequests() const { return codec_client_->numActiveRequests(); }
+  virtual RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) PURE;
+
+  enum class State {
+    CONNECTING, // Connection is not yet established.
+    READY,      // Additional requests may be immediately dispatched to this connection.
+    BUSY,       // Connection is at its concurrent request limit.
+    DRAINING,   // No more requests can be dispatched to this connection, and it will be closed
+    // when all requests complete.
+    CLOSED // Connection is closed and object is queued for destruction.
+  };
+
+  ConnPoolImplBase& parent_;
+  uint64_t remaining_requests_;
+  const uint64_t concurrent_request_limit_;
+  State state_{State::CONNECTING};
+  CodecClientPtr codec_client_;
+  Upstream::HostDescriptionConstSharedPtr real_host_description_;
+  Stats::TimespanPtr conn_connect_ms_;
+  Stats::TimespanPtr conn_length_;
+  Event::TimerPtr connect_timer_;
+  bool resources_released_{false};
+  bool timed_out_{false};
+};
+
+using ActiveClientPtr = std::unique_ptr<ActiveClient>;
+
+class PendingRequest : public LinkedObject<PendingRequest>, public ConnectionPool::Cancellable {
+public:
+  PendingRequest(ConnPoolImplBase& parent, ResponseDecoder& decoder,
+                 ConnectionPool::Callbacks& callbacks);
+  ~PendingRequest() override;
+
+  // ConnectionPool::Cancellable
+  void cancel(Envoy::ConnectionPool::CancelPolicy policy) override;
+
+  ConnPoolImplBase& parent_;
+  ResponseDecoder& decoder_;
+  ConnectionPool::Callbacks& callbacks_;
+};
+
+using PendingRequestPtr = std::unique_ptr<PendingRequest>;
+
 // Base class that handles request queueing logic shared between connection pool implementations.
 class ConnPoolImplBase : public ConnectionPool::Instance,
                          protected Logger::Loggable<Logger::Id::pool> {
@@ -39,80 +114,6 @@ protected:
   // (due to bottom-up destructor ordering in c++) that access will be invalid.
   void destructAllConnections();
 
-  // ActiveClient provides a base class for connection pool clients that handles connection timings
-  // as well as managing the connection timeout.
-  class ActiveClient : public LinkedObject<ActiveClient>,
-                       public Network::ConnectionCallbacks,
-                       public Event::DeferredDeletable {
-  public:
-    ActiveClient(ConnPoolImplBase& parent, uint64_t lifetime_request_limit,
-                 uint64_t concurrent_request_limit);
-    ~ActiveClient() override;
-
-    void releaseResources();
-
-    // Network::ConnectionCallbacks
-    void onEvent(Network::ConnectionEvent event) override {
-      parent_.onConnectionEvent(*this, event);
-    }
-    void onAboveWriteBufferHighWatermark() override {}
-    void onBelowWriteBufferLowWatermark() override {}
-
-    void onConnectTimeout();
-    void close() { codec_client_->close(); }
-
-    // Returns the concurrent request limit, accounting for if the total request limit
-    // is less than the concurrent request limit.
-    uint64_t effectiveConcurrentRequestLimit() const {
-      return std::min(remaining_requests_, concurrent_request_limit_);
-    }
-
-    virtual bool hasActiveRequests() const PURE;
-    virtual bool closingWithIncompleteRequest() const PURE;
-    virtual RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) PURE;
-
-    enum class State {
-      CONNECTING, // Connection is not yet established.
-      READY,      // Additional requests may be immediately dispatched to this connection.
-      BUSY,       // Connection is at its concurrent request limit.
-      DRAINING,   // No more requests can be dispatched to this connection, and it will be closed
-                  // when all requests complete.
-      CLOSED      // Connection is closed and object is queued for destruction.
-    };
-
-    ConnPoolImplBase& parent_;
-    uint64_t remaining_requests_;
-    const uint64_t concurrent_request_limit_;
-    State state_{State::CONNECTING};
-    CodecClientPtr codec_client_;
-    Upstream::HostDescriptionConstSharedPtr real_host_description_;
-    Stats::TimespanPtr conn_connect_ms_;
-    Stats::TimespanPtr conn_length_;
-    Event::TimerPtr connect_timer_;
-    bool resources_released_{false};
-    bool timed_out_{false};
-  };
-
-  using ActiveClientPtr = std::unique_ptr<ActiveClient>;
-
-  struct PendingRequest : LinkedObject<PendingRequest>, public ConnectionPool::Cancellable {
-    PendingRequest(ConnPoolImplBase& parent, ResponseDecoder& decoder,
-                   ConnectionPool::Callbacks& callbacks);
-    ~PendingRequest() override;
-
-    // ConnectionPool::Cancellable
-    void cancel(Envoy::ConnectionPool::CancelPolicy policy) override {
-      parent_.onPendingRequestCancel(*this, policy);
-    }
-
-    ConnPoolImplBase& parent_;
-    ResponseDecoder& decoder_;
-    ConnectionPool::Callbacks& callbacks_;
-  };
-
-  using PendingRequestPtr = std::unique_ptr<PendingRequest>;
-
-  // Create a new CodecClient.
   virtual CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) PURE;
 
   // Returns a new instance of ActiveClient.
@@ -142,7 +143,8 @@ protected:
   // Changes the state_ of an ActiveClient and moves to the appropriate list.
   void transitionActiveClientState(ActiveClient& client, ActiveClient::State new_state);
 
-  void onConnectionEvent(ActiveClient& client, Network::ConnectionEvent event);
+  void onConnectionEvent(ActiveClient& client, absl::string_view failure_reason,
+                         Network::ConnectionEvent event);
   void checkForDrained();
   void onUpstreamReady();
   void attachRequestToClient(ActiveClient& client, ResponseDecoder& response_decoder,
@@ -157,6 +159,9 @@ public:
   const Upstream::ResourcePriority priority_;
 
 protected:
+  friend class ActiveClient;
+  friend class PendingRequest;
+
   Event::Dispatcher& dispatcher_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
   const Network::TransportSocketOptionsSharedPtr transport_socket_options_;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -35,7 +35,7 @@ ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSha
 
 ConnPoolImpl::~ConnPoolImpl() { destructAllConnections(); }
 
-ConnPoolImplBase::ActiveClientPtr ConnPoolImpl::instantiateActiveClient() {
+ActiveClientPtr ConnPoolImpl::instantiateActiveClient() {
   return std::make_unique<ActiveClient>(*this);
 }
 
@@ -112,7 +112,7 @@ void ConnPoolImpl::StreamWrapper::onDecodeComplete() {
 }
 
 ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
-    : ConnPoolImplBase::ActiveClient(
+    : Envoy::Http::ActiveClient(
           parent, parent.host_->cluster().maxRequestsPerConnection(),
           1 // HTTP1 always has a concurrent-request-limit of 1 per connection.
       ) {

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -17,7 +17,7 @@ namespace Http1 {
  *       address. Higher layer code should handle resolving DNS on error and creating a new pool
  *       bound to a different IP address.
  */
-class ConnPoolImpl : public ConnPoolImplBase {
+class ConnPoolImpl : public Envoy::Http::ConnPoolImplBase {
 public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority,
@@ -33,7 +33,7 @@ public:
   ActiveClientPtr instantiateActiveClient() override;
 
 protected:
-  struct ActiveClient;
+  class ActiveClient;
 
   struct StreamWrapper : public RequestEncoderWrapper,
                          public ResponseDecoderWrapper,
@@ -64,7 +64,8 @@ protected:
 
   using StreamWrapperPtr = std::unique_ptr<StreamWrapper>;
 
-  struct ActiveClient : public ConnPoolImplBase::ActiveClient {
+  class ActiveClient : public Envoy::Http::ActiveClient {
+  public:
     ActiveClient(ConnPoolImpl& parent);
 
     ConnPoolImpl& parent() { return static_cast<ConnPoolImpl&>(parent_); }

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -21,7 +21,7 @@ ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSha
 
 ConnPoolImpl::~ConnPoolImpl() { destructAllConnections(); }
 
-ConnPoolImplBase::ActiveClientPtr ConnPoolImpl::instantiateActiveClient() {
+ActiveClientPtr ConnPoolImpl::instantiateActiveClient() {
   return std::make_unique<ActiveClient>(*this);
 }
 void ConnPoolImpl::onGoAway(ActiveClient& client) {
@@ -65,7 +65,7 @@ uint64_t ConnPoolImpl::maxRequestsPerConnection() {
 }
 
 ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
-    : ConnPoolImplBase::ActiveClient(
+    : Envoy::Http::ActiveClient(
           parent, parent.maxRequestsPerConnection(),
           parent.host_->cluster().http2Options().max_concurrent_streams().value()) {
   codec_client_->setCodecClientCallbacks(*this);

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -16,7 +16,7 @@ namespace Http2 {
  * shifting to a new connection if we reach max streams on the primary. This is a base class
  * used for both the prod implementation as well as the testing one.
  */
-class ConnPoolImpl : public ConnPoolImplBase {
+class ConnPoolImpl : public Envoy::Http::ConnPoolImplBase {
 public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority,
@@ -32,9 +32,10 @@ public:
   ActiveClientPtr instantiateActiveClient() override;
 
 protected:
-  struct ActiveClient : public CodecClientCallbacks,
-                        public Http::ConnectionCallbacks,
-                        public ConnPoolImplBase::ActiveClient {
+  class ActiveClient : public CodecClientCallbacks,
+                       public Http::ConnectionCallbacks,
+                       public Envoy::Http::ActiveClient {
+  public:
     ActiveClient(ConnPoolImpl& parent);
     ~ActiveClient() override = default;
 


### PR DESCRIPTION
Doing some refactors in preparation for the shared TCP-HTTP connection pool:

Moving ActiveClient and PendingRequest out mostly because and I find large classes in large classes unwieldy (feel free to disagree on this one - I admit it's a style thing =P)

Also moving several functions in the connection pool class away from referencing the codec client, which will not be present for the TCP variant

context: https://github.com/envoyproxy/envoy/compare/master...alyssawilk:conn_pool_rebase

Risk Level: Low (fairly small connection pool refactor) 
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Part of https://github.com/envoyproxy/envoy/issues/11528
