### PR TITLE
As the comments in code say, the computation of timestamp is wrong. Fix it

### DIFF
--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -153,14 +153,10 @@ void AuthenticatorImpl::startVerify() {
     return;
   }
 
-  // TODO(qiwzhang): Cross-platform-wise the below unix_timestamp code is wrong as the
-  // epoch is not guaranteed to be defined as the unix epoch. We should use
-  // the abseil time functionality instead or use the jwt_verify_lib to check
-  // the validity of a JWT.
   // Check "exp" claim.
-  const uint64_t unix_timestamp =
-      std::chrono::duration_cast<std::chrono::seconds>(timeSource().systemTime().time_since_epoch())
-          .count();
+  const uint64_t unix_timestamp = std::chrono::time_point_cast<std::chrono::seconds>(timeSource().systemTime())
+                           .time_since_epoch()
+                           .count();
   // If the nbf claim does *not* appear in the JWT, then the nbf field is defaulted
   // to 0.
   if (jwt_->nbf_ > unix_timestamp) {


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
