### PR TITLE
[WIP] router: support cluster picking via filter state and fallback

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -539,7 +539,7 @@ message CorsPolicy {
   core.v3.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 35]
+// [#next-free-field: 36]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -819,7 +819,7 @@ message RouteAction {
     // A list of selectors that will be iterated in order. If a selector is unable to return an
     // active cluster, the next selector in the list will be attempted. If an active cluster can't
     // be found after iterating this list, an error response will be returned to the client.
-    ClusterSelectorRepeatedWrapper cluster_selectors = 4;
+    ClusterSelectorRepeatedWrapper cluster_selectors = 35;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -754,6 +754,42 @@ message RouteAction {
 
   reserved "request_mirror_policy";
 
+  message ClusterSelector {
+    // Indicates the upstream cluster to which the request should be routed
+    // to.
+    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+
+    // Envoy will determine the cluster to route to by reading the value of the
+    // HTTP header named by cluster_header from the request headers. If the
+    // header is not found or the referenced cluster does not exist, Envoy will
+    // return a 404 response.
+    //
+    // .. attention::
+    //
+    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+    string cluster_header = 2
+        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster. See
+    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+    // for additional documentation.
+    WeightedCluster weighted_clusters = 3;
+
+    // Envoy will determine the cluster to route to by reading the value of the filter state
+    // referenced by the key specified in this field. If the key is not found or the referenced
+    // cluster does not exist, Envoy will return an error response.
+    string cluster_filter_state_key = 4 [(validate.rules).string = {min.bytes: 1}];
+  }
+
+  // A wrapper to enable repeated |ClusterSelector|s in a oneof.
+  message ClusterSelectorRepeatedWrapper {
+    repeated ClusterSelector cluster_selectors = 1;
+  }
+
+  // NOTE: This oneof can be deprecated for a `repeated ClusterSelector`.
   oneof cluster_specifier {
     option (validate.required) = true;
 
@@ -779,6 +815,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // A list of selectors that will be iterated in order. If a selector is unable to return an
+    // active cluster, the next selector in the list will be attempted. If an active cluster can't
+    // be found after iterating this list, an error response will be returned to the client.
+    ClusterSelectorRepeatedWrapper cluster_selectors = 4;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -750,10 +750,6 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
-  reserved 12, 18, 19, 16, 22, 21, 10;
-
-  reserved "request_mirror_policy";
-
   message ClusterSelector {
     // Indicates the upstream cluster to which the request should be routed
     // to.
@@ -781,13 +777,17 @@ message RouteAction {
     // Envoy will determine the cluster to route to by reading the value of the filter state
     // referenced by the key specified in this field. If the key is not found or the referenced
     // cluster does not exist, Envoy will return an error response.
-    string cluster_filter_state_key = 4 [(validate.rules).string = {min.bytes: 1}];
+    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
   }
 
   // A wrapper to enable repeated |ClusterSelector|s in a oneof.
   message ClusterSelectorRepeatedWrapper {
     repeated ClusterSelector cluster_selectors = 1;
   }
+
+  reserved 12, 18, 19, 16, 22, 21, 10;
+
+  reserved "request_mirror_policy";
 
   // NOTE: This oneof can be deprecated for a `repeated ClusterSelector`.
   oneof cluster_specifier {

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -777,6 +777,9 @@ message RouteAction {
     // Envoy will determine the cluster to route to by reading the value of the filter state
     // referenced by the key specified in this field. If the key is not found or the referenced
     // cluster does not exist, Envoy will return an error response.
+    // NOTE: the `FilterState::Object` pointed to by the key must implement
+    // `serializeAsString()`; the returned value is expected to be the cluster
+    // name.
     string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
   }
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -767,8 +767,9 @@ message RouteAction {
       //
       //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
       //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
-      string cluster_header = 2
-          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      string cluster_header = 2 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
 
       // Multiple upstream clusters can be specified for a given route. The
       // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -751,41 +751,45 @@ message RouteAction {
   }
 
   message ClusterSelector {
-    // Indicates the upstream cluster to which the request should be routed
-    // to.
-    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+    oneof selector {
+      option (validate.required) = true;
 
-    // Envoy will determine the cluster to route to by reading the value of the
-    // HTTP header named by cluster_header from the request headers. If the
-    // header is not found or the referenced cluster does not exist, Envoy will
-    // return a 404 response.
-    //
-    // .. attention::
-    //
-    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
-    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
-    string cluster_header = 2
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      // Indicates the upstream cluster to which the request should be routed
+      // to.
+      string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
-    // Multiple upstream clusters can be specified for a given route. The
-    // request is routed to one of the upstream clusters based on weights
-    // assigned to each cluster. See
-    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
-    // for additional documentation.
-    WeightedCluster weighted_clusters = 3;
+      // Envoy will determine the cluster to route to by reading the value of the
+      // HTTP header named by cluster_header from the request headers. If the
+      // header is not found or the referenced cluster does not exist, Envoy will
+      // return a 404 response.
+      //
+      // .. attention::
+      //
+      //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+      //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+      string cluster_header = 2
+          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
-    // Envoy will determine the cluster to route to by reading the value of the filter state
-    // referenced by the key specified in this field. If the key is not found or the referenced
-    // cluster does not exist, Envoy will return an error response.
-    // NOTE: the `FilterState::Object` pointed to by the key must implement
-    // `serializeAsString()`; the returned value is expected to be the cluster
-    // name.
-    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+      // Multiple upstream clusters can be specified for a given route. The
+      // request is routed to one of the upstream clusters based on weights
+      // assigned to each cluster. See
+      // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+      // for additional documentation.
+      WeightedCluster weighted_clusters = 3;
+
+      // Envoy will determine the cluster to route to by reading the value of the filter state
+      // referenced by the key specified in this field. If the key is not found or the referenced
+      // cluster does not exist, Envoy will return an error response.
+      // NOTE: the `FilterState::Object` pointed to by the key must implement
+      // `serializeAsString()`; the returned value is expected to be the cluster
+      // name.
+      string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+    }
   }
 
   // A wrapper to enable repeated |ClusterSelector|s in a oneof.
   message ClusterSelectorRepeatedWrapper {
-    repeated ClusterSelector cluster_selectors = 1;
+    repeated ClusterSelector cluster_selectors = 1 [(validate.rules).repeated = {min_items: 1}];
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10;

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -542,7 +542,7 @@ message CorsPolicy {
   core.v4alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 35]
+// [#next-free-field: 36]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RouteAction";
 
@@ -747,10 +747,52 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
+  message ClusterSelector {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.route.v3.RouteAction.ClusterSelector";
+
+    // Indicates the upstream cluster to which the request should be routed
+    // to.
+    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+
+    // Envoy will determine the cluster to route to by reading the value of the
+    // HTTP header named by cluster_header from the request headers. If the
+    // header is not found or the referenced cluster does not exist, Envoy will
+    // return a 404 response.
+    //
+    // .. attention::
+    //
+    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+    string cluster_header = 2
+        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster. See
+    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+    // for additional documentation.
+    WeightedCluster weighted_clusters = 3;
+
+    // Envoy will determine the cluster to route to by reading the value of the filter state
+    // referenced by the key specified in this field. If the key is not found or the referenced
+    // cluster does not exist, Envoy will return an error response.
+    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+  }
+
+  // A wrapper to enable repeated |ClusterSelector|s in a oneof.
+  message ClusterSelectorRepeatedWrapper {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.route.v3.RouteAction.ClusterSelectorRepeatedWrapper";
+
+    repeated ClusterSelector cluster_selectors = 1;
+  }
+
   reserved 12, 18, 19, 16, 22, 21, 10, 26, 31;
 
   reserved "request_mirror_policy", "internal_redirect_action", "max_internal_redirects";
 
+  // NOTE: This oneof can be deprecated for a `repeated ClusterSelector`.
   oneof cluster_specifier {
     option (validate.required) = true;
 
@@ -776,6 +818,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // A list of selectors that will be iterated in order. If a selector is unable to return an
+    // active cluster, the next selector in the list will be attempted. If an active cluster can't
+    // be found after iterating this list, an error response will be returned to the client.
+    ClusterSelectorRepeatedWrapper cluster_selectors = 35;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -751,33 +751,41 @@ message RouteAction {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.ClusterSelector";
 
-    // Indicates the upstream cluster to which the request should be routed
-    // to.
-    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+    oneof selector {
+      option (validate.required) = true;
 
-    // Envoy will determine the cluster to route to by reading the value of the
-    // HTTP header named by cluster_header from the request headers. If the
-    // header is not found or the referenced cluster does not exist, Envoy will
-    // return a 404 response.
-    //
-    // .. attention::
-    //
-    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
-    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
-    string cluster_header = 2
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      // Indicates the upstream cluster to which the request should be routed
+      // to.
+      string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
-    // Multiple upstream clusters can be specified for a given route. The
-    // request is routed to one of the upstream clusters based on weights
-    // assigned to each cluster. See
-    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
-    // for additional documentation.
-    WeightedCluster weighted_clusters = 3;
+      // Envoy will determine the cluster to route to by reading the value of the
+      // HTTP header named by cluster_header from the request headers. If the
+      // header is not found or the referenced cluster does not exist, Envoy will
+      // return a 404 response.
+      //
+      // .. attention::
+      //
+      //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+      //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+      string cluster_header = 2 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
 
-    // Envoy will determine the cluster to route to by reading the value of the filter state
-    // referenced by the key specified in this field. If the key is not found or the referenced
-    // cluster does not exist, Envoy will return an error response.
-    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+      // Multiple upstream clusters can be specified for a given route. The
+      // request is routed to one of the upstream clusters based on weights
+      // assigned to each cluster. See
+      // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+      // for additional documentation.
+      WeightedCluster weighted_clusters = 3;
+
+      // Envoy will determine the cluster to route to by reading the value of the filter state
+      // referenced by the key specified in this field. If the key is not found or the referenced
+      // cluster does not exist, Envoy will return an error response.
+      // NOTE: the `FilterState::Object` pointed to by the key must implement
+      // `serializeAsString()`; the returned value is expected to be the cluster
+      // name.
+      string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+    }
   }
 
   // A wrapper to enable repeated |ClusterSelector|s in a oneof.
@@ -785,7 +793,7 @@ message RouteAction {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.ClusterSelectorRepeatedWrapper";
 
-    repeated ClusterSelector cluster_selectors = 1;
+    repeated ClusterSelector cluster_selectors = 1 [(validate.rules).repeated = {min_items: 1}];
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10, 26, 31;

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -551,7 +551,7 @@ message CorsPolicy {
       [deprecated = true, (validate.rules).repeated = {items {string {max_bytes: 1024}}}];
 }
 
-// [#next-free-field: 35]
+// [#next-free-field: 36]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -761,8 +761,44 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
+  message ClusterSelector {
+    // Indicates the upstream cluster to which the request should be routed
+    // to.
+    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+
+    // Envoy will determine the cluster to route to by reading the value of the
+    // HTTP header named by cluster_header from the request headers. If the
+    // header is not found or the referenced cluster does not exist, Envoy will
+    // return a 404 response.
+    //
+    // .. attention::
+    //
+    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+    string cluster_header = 2
+        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster. See
+    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+    // for additional documentation.
+    WeightedCluster weighted_clusters = 3;
+
+    // Envoy will determine the cluster to route to by reading the value of the filter state
+    // referenced by the key specified in this field. If the key is not found or the referenced
+    // cluster does not exist, Envoy will return an error response.
+    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+  }
+
+  // A wrapper to enable repeated |ClusterSelector|s in a oneof.
+  message ClusterSelectorRepeatedWrapper {
+    repeated ClusterSelector cluster_selectors = 1;
+  }
+
   reserved 12, 18, 19, 16, 22, 21;
 
+  // NOTE: This oneof can be deprecated for a `repeated ClusterSelector`.
   oneof cluster_specifier {
     option (validate.required) = true;
 
@@ -788,6 +824,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // A list of selectors that will be iterated in order. If a selector is unable to return an
+    // active cluster, the next selector in the list will be attempted. If an active cluster can't
+    // be found after iterating this list, an error response will be returned to the client.
+    ClusterSelectorRepeatedWrapper cluster_selectors = 35;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -762,38 +762,46 @@ message RouteAction {
   }
 
   message ClusterSelector {
-    // Indicates the upstream cluster to which the request should be routed
-    // to.
-    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+    oneof selector {
+      option (validate.required) = true;
 
-    // Envoy will determine the cluster to route to by reading the value of the
-    // HTTP header named by cluster_header from the request headers. If the
-    // header is not found or the referenced cluster does not exist, Envoy will
-    // return a 404 response.
-    //
-    // .. attention::
-    //
-    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
-    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
-    string cluster_header = 2
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      // Indicates the upstream cluster to which the request should be routed
+      // to.
+      string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
-    // Multiple upstream clusters can be specified for a given route. The
-    // request is routed to one of the upstream clusters based on weights
-    // assigned to each cluster. See
-    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
-    // for additional documentation.
-    WeightedCluster weighted_clusters = 3;
+      // Envoy will determine the cluster to route to by reading the value of the
+      // HTTP header named by cluster_header from the request headers. If the
+      // header is not found or the referenced cluster does not exist, Envoy will
+      // return a 404 response.
+      //
+      // .. attention::
+      //
+      //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+      //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+      string cluster_header = 2 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
 
-    // Envoy will determine the cluster to route to by reading the value of the filter state
-    // referenced by the key specified in this field. If the key is not found or the referenced
-    // cluster does not exist, Envoy will return an error response.
-    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+      // Multiple upstream clusters can be specified for a given route. The
+      // request is routed to one of the upstream clusters based on weights
+      // assigned to each cluster. See
+      // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+      // for additional documentation.
+      WeightedCluster weighted_clusters = 3;
+
+      // Envoy will determine the cluster to route to by reading the value of the filter state
+      // referenced by the key specified in this field. If the key is not found or the referenced
+      // cluster does not exist, Envoy will return an error response.
+      // NOTE: the `FilterState::Object` pointed to by the key must implement
+      // `serializeAsString()`; the returned value is expected to be the cluster
+      // name.
+      string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+    }
   }
 
   // A wrapper to enable repeated |ClusterSelector|s in a oneof.
   message ClusterSelectorRepeatedWrapper {
-    repeated ClusterSelector cluster_selectors = 1;
+    repeated ClusterSelector cluster_selectors = 1 [(validate.rules).repeated = {min_items: 1}];
   }
 
   reserved 12, 18, 19, 16, 22, 21;

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -542,7 +542,7 @@ message CorsPolicy {
   core.v4alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 35]
+// [#next-free-field: 36]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RouteAction";
 
@@ -756,10 +756,52 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
+  message ClusterSelector {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.route.v3.RouteAction.ClusterSelector";
+
+    // Indicates the upstream cluster to which the request should be routed
+    // to.
+    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+
+    // Envoy will determine the cluster to route to by reading the value of the
+    // HTTP header named by cluster_header from the request headers. If the
+    // header is not found or the referenced cluster does not exist, Envoy will
+    // return a 404 response.
+    //
+    // .. attention::
+    //
+    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+    string cluster_header = 2
+        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+    // Multiple upstream clusters can be specified for a given route. The
+    // request is routed to one of the upstream clusters based on weights
+    // assigned to each cluster. See
+    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+    // for additional documentation.
+    WeightedCluster weighted_clusters = 3;
+
+    // Envoy will determine the cluster to route to by reading the value of the filter state
+    // referenced by the key specified in this field. If the key is not found or the referenced
+    // cluster does not exist, Envoy will return an error response.
+    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+  }
+
+  // A wrapper to enable repeated |ClusterSelector|s in a oneof.
+  message ClusterSelectorRepeatedWrapper {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.route.v3.RouteAction.ClusterSelectorRepeatedWrapper";
+
+    repeated ClusterSelector cluster_selectors = 1;
+  }
+
   reserved 12, 18, 19, 16, 22, 21, 10;
 
   reserved "request_mirror_policy";
 
+  // NOTE: This oneof can be deprecated for a `repeated ClusterSelector`.
   oneof cluster_specifier {
     option (validate.required) = true;
 
@@ -785,6 +827,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // A list of selectors that will be iterated in order. If a selector is unable to return an
+    // active cluster, the next selector in the list will be attempted. If an active cluster can't
+    // be found after iterating this list, an error response will be returned to the client.
+    ClusterSelectorRepeatedWrapper cluster_selectors = 35;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -760,33 +760,41 @@ message RouteAction {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.ClusterSelector";
 
-    // Indicates the upstream cluster to which the request should be routed
-    // to.
-    string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
+    oneof selector {
+      option (validate.required) = true;
 
-    // Envoy will determine the cluster to route to by reading the value of the
-    // HTTP header named by cluster_header from the request headers. If the
-    // header is not found or the referenced cluster does not exist, Envoy will
-    // return a 404 response.
-    //
-    // .. attention::
-    //
-    //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
-    //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
-    string cluster_header = 2
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      // Indicates the upstream cluster to which the request should be routed
+      // to.
+      string cluster = 1 [(validate.rules).string = {min_bytes: 1}];
 
-    // Multiple upstream clusters can be specified for a given route. The
-    // request is routed to one of the upstream clusters based on weights
-    // assigned to each cluster. See
-    // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
-    // for additional documentation.
-    WeightedCluster weighted_clusters = 3;
+      // Envoy will determine the cluster to route to by reading the value of the
+      // HTTP header named by cluster_header from the request headers. If the
+      // header is not found or the referenced cluster does not exist, Envoy will
+      // return a 404 response.
+      //
+      // .. attention::
+      //
+      //   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+      //   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+      string cluster_header = 2 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
 
-    // Envoy will determine the cluster to route to by reading the value of the filter state
-    // referenced by the key specified in this field. If the key is not found or the referenced
-    // cluster does not exist, Envoy will return an error response.
-    string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+      // Multiple upstream clusters can be specified for a given route. The
+      // request is routed to one of the upstream clusters based on weights
+      // assigned to each cluster. See
+      // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
+      // for additional documentation.
+      WeightedCluster weighted_clusters = 3;
+
+      // Envoy will determine the cluster to route to by reading the value of the filter state
+      // referenced by the key specified in this field. If the key is not found or the referenced
+      // cluster does not exist, Envoy will return an error response.
+      // NOTE: the `FilterState::Object` pointed to by the key must implement
+      // `serializeAsString()`; the returned value is expected to be the cluster
+      // name.
+      string cluster_filter_state_key = 4 [(validate.rules).string = {min_bytes: 1}];
+    }
   }
 
   // A wrapper to enable repeated |ClusterSelector|s in a oneof.
@@ -794,7 +802,7 @@ message RouteAction {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.ClusterSelectorRepeatedWrapper";
 
-    repeated ClusterSelector cluster_selectors = 1;
+    repeated ClusterSelector cluster_selectors = 1 [(validate.rules).repeated = {min_items: 1}];
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10;


### PR DESCRIPTION
NOTE: this is a WIP PR to get feedback on a proposed API change to `RouteAction`.

This change introduces the following modifications to the routing API:

1. Support cluster picking via filter state.
2. Add a repeated field that enables fallback logic to be configured for cluster picking; e.g., if `cluster_header` fails to find an active cluster, the next selector in the list will be attempted.