### PR TITLE
RETURN_IF_ERROR macro to provide early exit based on Status value

### DIFF
--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -109,5 +109,36 @@ ABSL_MUST_USE_RESULT bool isCodecClientError(const Status& status);
  */
 Http::Code getPrematureResponseHttpCode(const Status& status);
 
+/**
+ * Macro that checks return value of expression that results in Status and returns from
+ * the current function is status is not OK.
+ *
+ * Example usage:
+ *   Status foo() {
+ *     RETURN_IF_ERROR(bar());
+ *     return okStatus();
+ *   }
+ */
+
+#define RETURN_IF_ERROR(expr)                                                                      \
+  if (::Envoy::Http::Details::StatusAdapter adapter{(expr)}) {                                     \
+  } else                                                                                           \
+    return std::move(adapter.status_)
+
+namespace Details {
+// Helper class to convert `Status` to `bool` so it can be used inside `if` statements.
+struct StatusAdapter {
+  StatusAdapter(const Status& status) : status_(status) {}
+  StatusAdapter(Status&& status) : status_(std::move(status)) {}
+
+  StatusAdapter(const StatusAdapter&) = delete;
+  StatusAdapter& operator=(const StatusAdapter&) = delete;
+
+  explicit operator bool() const { return status_.ok(); }
+
+  Status status_;
+};
+} // namespace Details
+
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -122,8 +122,9 @@ Http::Code getPrematureResponseHttpCode(const Status& status);
 
 #define RETURN_IF_ERROR(expr)                                                                      \
   if (::Envoy::Http::Details::StatusAdapter adapter{(expr)}) {                                     \
-  } else                                                                                           \
-    return std::move(adapter.status_)
+  } else {                                                                                         \
+    return std::move(adapter.status_);                                                             \
+  }
 
 namespace Details {
 // Helper class to convert `Status` to `bool` so it can be used inside `if` statements.

--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -121,10 +121,12 @@ Http::Code getPrematureResponseHttpCode(const Status& status);
  */
 
 #define RETURN_IF_ERROR(expr)                                                                      \
-  if (::Envoy::Http::Details::StatusAdapter adapter{(expr)}) {                                     \
-  } else {                                                                                         \
-    return std::move(adapter.status_);                                                             \
-  }
+  do {                                                                                             \
+    if (::Envoy::Http::Details::StatusAdapter adapter{(expr)}) {                                   \
+    } else {                                                                                       \
+      return std::move(adapter.status_);                                                           \
+    }                                                                                              \
+  } while(false)
 
 namespace Details {
 // Helper class to convert `Status` to `bool` so it can be used inside `if` statements.

--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -126,7 +126,7 @@ Http::Code getPrematureResponseHttpCode(const Status& status);
     } else {                                                                                       \
       return std::move(adapter.status_);                                                           \
     }                                                                                              \
-  } while(false)
+  } while (false)
 
 namespace Details {
 // Helper class to convert `Status` to `bool` so it can be used inside `if` statements.


### PR DESCRIPTION
Commit Message:
RETURN_IF_ERROR macro to provide early exit from function based on Status value.

Additional Description:
Example of using this macro:

```C++
// BEFORE:
auto status = foo();
if (!status.ok()) {
  return status;
}

// AFTER:
RETURN_IF_ERROR(foo());
```
Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
