### PR TITLE
test: Fix flakiness in ProtocolIntegrationTest.RetryStreamingReset caused by FakeUpstream use-after-free.

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -73,6 +73,10 @@ void FakeStream::decodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) {
   }
 }
 
+void FakeStream::postToConnectionThread(std::function<void()> cb) {
+  parent_.connection().dispatcher().post(cb);
+}
+
 void FakeStream::encode100ContinueHeaders(const Http::ResponseHeaderMap& headers) {
   std::shared_ptr<Http::ResponseHeaderMap> headers_copy(
       Http::createHeaderMap<Http::ResponseHeaderMapImpl>(headers));

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -60,6 +60,11 @@ public:
     Thread::LockGuard lock(lock_);
     return end_stream_;
   }
+
+  // Execute a callback using the dispatcher associated with the FakeStream's connection. This
+  // allows execution of non-interrupted sequences of operations on the fake stream which may run
+  // into trouble if client-side events are interleaved.
+  void postToConnectionThread(std::function<void()> cb);
   void encode100ContinueHeaders(const Http::ResponseHeaderMap& headers);
   void encodeHeaders(const Http::HeaderMap& headers, bool end_stream);
   void encodeData(uint64_t size, bool end_stream);


### PR DESCRIPTION
Commit Message: test: Fix flakiness in ProtocolIntegrationTest.RetryStreamingReset caused by FakeUpstream use-after-free.
Additional Description:
FakeUpstream crashes due an use after free if the proxy resets the fake stream between the time the 503 headers are sent by the fake upstream and when the fake upstream sends the reset.  Executing the header and stream reset serialization in the fake upstream thread guarantees that no fd events are processed between the time the headers and encoded and stream is reset, eliminating the possibility of this test-only crash.

Test can be easily reproduced by adding a sleep between upstream_request_->encodeHeaders(...) and upstream_request_->encodeResetStream()
Risk Level: n/a test only changes
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #11652