### PR TITLE
network: pass addresses to iohandle in connect/bind

### DIFF
--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -148,7 +148,7 @@ public:
    * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
    *   is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallIntResult bind(const sockaddr* address, socklen_t addrlen) PURE;
+  virtual Api::SysCallIntResult bind(Address::InstanceConstSharedPtr address) PURE;
 
   /**
    * Listen on bound handle.
@@ -166,7 +166,7 @@ public:
    * @return a Api::SysCallIntResult with rc_ = 0 for success and rc_ = -1 for failure. If the call
    *   is successful, errno_ shouldn't be used.
    */
-  virtual Api::SysCallIntResult connect(const sockaddr* address, socklen_t addrlen) PURE;
+  virtual Api::SysCallIntResult connect(Address::InstanceConstSharedPtr address) PURE;
 
   /**
    * Set option (see man 2 setsockopt)

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -365,16 +365,16 @@ bool IoSocketHandleImpl::supportsMmsg() const {
   return Api::OsSysCallsSingleton::get().supportsMmsg();
 }
 
-Api::SysCallIntResult IoSocketHandleImpl::bind(const sockaddr* address, socklen_t addrlen) {
-  return Api::OsSysCallsSingleton::get().bind(fd_, address, addrlen);
+Api::SysCallIntResult IoSocketHandleImpl::bind(Address::InstanceConstSharedPtr address) {
+  return Api::OsSysCallsSingleton::get().bind(fd_, address->sockAddr(), address->sockAddrLen());
 }
 
 Api::SysCallIntResult IoSocketHandleImpl::listen(int backlog) {
   return Api::OsSysCallsSingleton::get().listen(fd_, backlog);
 }
 
-Api::SysCallIntResult IoSocketHandleImpl::connect(const sockaddr* address, socklen_t addrlen) {
-  return Api::OsSysCallsSingleton::get().connect(fd_, address, addrlen);
+Api::SysCallIntResult IoSocketHandleImpl::connect(Address::InstanceConstSharedPtr address) {
+  return Api::OsSysCallsSingleton::get().connect(fd_, address->sockAddr(), address->sockAddrLen());
 }
 
 Api::SysCallIntResult IoSocketHandleImpl::setOption(int level, int optname, const void* optval,

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -45,9 +45,9 @@ public:
 
   bool supportsMmsg() const override;
 
-  Api::SysCallIntResult bind(const sockaddr* address, socklen_t addrlen) override;
+  Api::SysCallIntResult bind(Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult listen(int backlog) override;
-  Api::SysCallIntResult connect(const sockaddr* address, socklen_t addrlen) override;
+  Api::SysCallIntResult connect(Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult setOption(int level, int optname, const void* optval,
                                   socklen_t optlen) override;
   Api::SysCallIntResult getOption(int level, int optname, void* optval, socklen_t* optlen) override;

--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -56,7 +56,7 @@ Api::SysCallIntResult SocketImpl::bind(Network::Address::InstanceConstSharedPtr 
       unlink(pipe_sa->sun_path);
     }
     // Not storing a reference to syscalls singleton because of unit test mocks
-    bind_result = io_handle_->bind(address->sockAddr(), address->sockAddrLen());
+    bind_result = io_handle_->bind(address);
     if (pipe->mode() != 0 && !abstract_namespace && bind_result.rc_ == 0) {
       auto set_permissions = Api::OsSysCallsSingleton::get().chmod(pipe_sa->sun_path, pipe->mode());
       if (set_permissions.rc_ != 0) {
@@ -68,7 +68,7 @@ Api::SysCallIntResult SocketImpl::bind(Network::Address::InstanceConstSharedPtr 
     return bind_result;
   }
 
-  bind_result = io_handle_->bind(address->sockAddr(), address->sockAddrLen());
+  bind_result = io_handle_->bind(address);
   if (bind_result.rc_ == 0 && address->ip()->port() == 0) {
     local_address_ = io_handle_->localAddress();
   }
@@ -78,7 +78,7 @@ Api::SysCallIntResult SocketImpl::bind(Network::Address::InstanceConstSharedPtr 
 Api::SysCallIntResult SocketImpl::listen(int backlog) { return io_handle_->listen(backlog); }
 
 Api::SysCallIntResult SocketImpl::connect(const Network::Address::InstanceConstSharedPtr address) {
-  auto result = io_handle_->connect(address->sockAddr(), address->sockAddrLen());
+  auto result = io_handle_->connect(address);
   if (address->type() == Address::Type::Ip) {
     local_address_ = io_handle_->localAddress();
   }

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -63,12 +63,12 @@ public:
     return io_handle_.recvmmsg(slices, self_port, output);
   }
   bool supportsMmsg() const override { return io_handle_.supportsMmsg(); }
-  Api::SysCallIntResult bind(const sockaddr* address, socklen_t addrlen) override {
-    return io_handle_.bind(address, addrlen);
+  Api::SysCallIntResult bind(Network::Address::InstanceConstSharedPtr address) override {
+    return io_handle_.bind(address);
   }
   Api::SysCallIntResult listen(int backlog) override { return io_handle_.listen(backlog); }
-  Api::SysCallIntResult connect(const sockaddr* address, socklen_t addrlen) override {
-    return io_handle_.connect(address, addrlen);
+  Api::SysCallIntResult connect(Network::Address::InstanceConstSharedPtr address) override {
+    return io_handle_.connect(address);
   }
   Api::SysCallIntResult setOption(int level, int optname, const void* optval,
                                   socklen_t optlen) override {

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -29,9 +29,9 @@ public:
   MOCK_METHOD(Api::IoCallUint64Result, recvmmsg,
               (RawSliceArrays & slices, uint32_t self_port, RecvMsgOutput& output));
   MOCK_METHOD(bool, supportsMmsg, (), (const));
-  MOCK_METHOD(Api::SysCallIntResult, bind, (const sockaddr* address, socklen_t addrlen));
+  MOCK_METHOD(Api::SysCallIntResult, bind, (Address::InstanceConstSharedPtr address));
   MOCK_METHOD(Api::SysCallIntResult, listen, (int backlog));
-  MOCK_METHOD(Api::SysCallIntResult, connect, (const sockaddr* address, socklen_t addrlen));
+  MOCK_METHOD(Api::SysCallIntResult, connect, (Address::InstanceConstSharedPtr address));
   MOCK_METHOD(Api::SysCallIntResult, setOption,
               (int level, int optname, const void* optval, socklen_t optlen));
   MOCK_METHOD(Api::SysCallIntResult, getOption,


### PR DESCRIPTION
Let IoHandle decide how to use Addresses, instead of passing the raw
sockaddr struct.

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a