### PR TITLE
docker, examples: Use tagged alpine image

### DIFF
--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
 
 RUN mkdir -p /etc/envoy
 

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
 
 RUN mkdir -p /etc/envoy
 

--- a/examples/cors/backend/Dockerfile-service
+++ b/examples/cors/backend/Dockerfile-service
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine-dev:latest
 
-RUN apk update && apk add python3 bash
+RUN apk update && apk add py3-pip bash
 RUN pip3 install -q Flask==0.11.1
 RUN mkdir /code
 ADD ./service.py /code/

--- a/examples/cors/frontend/Dockerfile-service
+++ b/examples/cors/frontend/Dockerfile-service
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine-dev:latest
 
-RUN apk update && apk add python3 bash
+RUN apk update && apk add py3-pip bash
 RUN pip3 install -q Flask==0.11.1
 RUN mkdir /code
 ADD ./service.py ./index.html /code/

--- a/examples/csrf/crosssite/Dockerfile-service
+++ b/examples/csrf/crosssite/Dockerfile-service
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine-dev:latest
 
-RUN apk update && apk add python3 bash
+RUN apk update && apk add py3-pip bash
 RUN pip3 install -q Flask==0.11.1
 RUN mkdir /code
 ADD ./crosssite/service.py ./index.html /code/

--- a/examples/csrf/samesite/Dockerfile-service
+++ b/examples/csrf/samesite/Dockerfile-service
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine-dev:latest
 
-RUN apk update && apk add python3 bash
+RUN apk update && apk add py3-pip bash
 RUN pip3 install -q Flask==0.11.1
 RUN mkdir /code
 ADD ./samesite/service.py ./index.html /code/

--- a/examples/front-proxy/Dockerfile-service
+++ b/examples/front-proxy/Dockerfile-service
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine-dev:latest
 
-RUN apk update && apk add python3 bash curl
+RUN apk update && apk add py3-pip bash curl
 RUN pip3 install -q Flask==0.11.1 requests==2.18.4
 RUN mkdir /code
 ADD ./service.py /code

--- a/examples/load-reporting-service/Dockerfile-http-server
+++ b/examples/load-reporting-service/Dockerfile-http-server
@@ -1,6 +1,6 @@
 FROM envoyproxy/envoy-alpine-dev:latest
 
-RUN apk update && apk add python3 bash curl
+RUN apk update && apk add py3-pip bash curl
 RUN mkdir /code
 ADD ./start_service.sh /usr/local/bin/start_service.sh
 COPY . ./code


### PR DESCRIPTION
Commit Message:
 
This patch updates alpine-based images to use the tagged images (alpine-3.12_glibc-2.31) instead of using `latest`. Since the latest change in `frolvlad/alpine-glibc` for `python3` package, examples are also updated to use `py3-pip` instead of `python3` for bootstrapping `Flask`.

Additional Description:

The latest `frolvlad/alpine-glibc` is tagged using alpine-3.12 as its base, in which the pip3 is no longer packed inside the python3 package. Instead, we
should use the py3-pip (https://pkgs.alpinelinux.org/contents?branch=v3.12&name=py3-pip&arch=x86_64&repo=community) package.

alpine-3.11 packs pip3 inside the python3 package: https://pkgs.alpinelinux.org/contents?branch=v3.11&name=python3&arch=x86_64&repo=main,
which is no longer true for alpine-3.12: https://pkgs.alpinelinux.org/contents?branch=v3.12&name=python3&arch=x86_64&repo=main

Risk Level: Low (updating alpine-based image, examples-only)
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Fixes #11679

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>