### PR TITLE
dynamic-forward-proxy: Add option to allow disabling auto_sni and auto_san_validation

### DIFF
--- a/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
@@ -27,4 +27,9 @@ message ClusterConfig {
   // <envoy_api_field_extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig.dns_cache_config>`.
   common.dynamic_forward_proxy.v3.DnsCacheConfig dns_cache_config = 1
       [(validate.rules).message = {required: true}];
+
+  // If true allow the cluster configuration to disable the auto_sni and auto_san_validation options
+  // in the :ref:`cluster's upstream_http_protocol_options
+  // <envoy_api_field_config.cluster.v3.Cluster.upstream_http_protocol_options>`
+  bool allow_insecure_cluster_options = 2;
 }

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -61,6 +61,7 @@ New Features
 * config: added :ref:`version_text <config_cluster_manager_cds>` stat that reflects xDS version.
 * decompressor: generic :ref:`decompressor <config_http_filters_decompressor>` filter exposed to users.
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
+* dynamic forward proxy: added :ref:`allow_insecure_cluster_options<envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_insecure_cluster_options>` to allow disabling of auto_san_validation and auto_sni.
 * ext_authz filter: added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3 deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows to force deny for protected path while filter gets disabled, by setting this key to true.
 * ext_authz filter: added API version field for both :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.transport_api_version>`
   and :ref:`Network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.transport_api_version>` filters to explicitly set the version of gRPC service endpoint and message to be used.

--- a/generated_api_shadow/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
+++ b/generated_api_shadow/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
@@ -27,4 +27,9 @@ message ClusterConfig {
   // <envoy_api_field_extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig.dns_cache_config>`.
   common.dynamic_forward_proxy.v3.DnsCacheConfig dns_cache_config = 1
       [(validate.rules).message = {required: true}];
+
+  // If true allow the cluster configuration to disable the auto_sni and auto_san_validation options
+  // in the :ref:`cluster's upstream_http_protocol_options
+  // <envoy_api_field_config.cluster.v3.Cluster.upstream_http_protocol_options>`
+  bool allow_insecure_cluster_options = 2;
 }

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -201,8 +201,9 @@ ClusterFactory::createClusterWithConfig(
       context.stats());
   envoy::config::cluster::v3::Cluster cluster_config = cluster;
   if (cluster_config.has_upstream_http_protocol_options()) {
-    if (!cluster_config.upstream_http_protocol_options().auto_sni() ||
-        !cluster_config.upstream_http_protocol_options().auto_san_validation()) {
+    if (!proto_config.allow_insecure_cluster_options() &&
+        (!cluster_config.upstream_http_protocol_options().auto_sni() ||
+         !cluster_config.upstream_http_protocol_options().auto_san_validation())) {
       throw EnvoyException(
           "dynamic_forward_proxy cluster must have auto_sni and auto_san_validation true when "
           "configured with upstream_http_protocol_options");

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -297,6 +297,23 @@ upstream_http_protocol_options: {}
       "configured with upstream_http_protocol_options");
 }
 
+TEST_F(ClusterFactoryTest, InsecureUpstreamHttpProtocolOptions) {
+  const std::string yaml_config = TestEnvironment::substitute(R"EOF(
+name: name
+connect_timeout: 0.25s
+cluster_type:
+  name: dynamic_forward_proxy
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+    allow_insecure_cluster_options: true
+    dns_cache_config:
+      name: foo
+upstream_http_protocol_options: {}
+)EOF");
+
+  createCluster(yaml_config);
+}
+
 } // namespace DynamicForwardProxy
 } // namespace Clusters
 } // namespace Extensions


### PR DESCRIPTION
This adds the option allow_insecure_cluster_options to the dynamic forward proxy's cluster configuration. Enabling this flag allows disabling auto_sni and auto_san_validation in the cluster's UpstreamHttpProtocolOptions, which was previously disallowed.

This allows use where e.g. automatic adding of an exact SAN matcher for the original authority is undesirable, while preserving the existing "safe
by default" behaviour for most use cases.

Risk Level: Low
Testing: Unit+manual
Docs Changes: inline with proto: https://github.com/envoyproxy/envoy/pull/11685/files#diff-358b6943b6f148fb3be2d9c44cc20124
Release Notes: https://github.com/envoyproxy/envoy/pull/11685/files#diff-0ec5c857b4b6fbbb72b2ffc5275b15ef
