### PR TITLE
bugfix: returning reference to a local object

### DIFF
--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -14,7 +14,8 @@ constexpr absl::string_view EnvoyPayloadUrl = "Envoy";
 absl::string_view statusCodeToString(StatusCode code) {
   switch (code) {
   case StatusCode::Ok:
-    return absl::OkStatus().ToString();
+    static const auto& ok_message = *new std::string(absl::OkStatus().ToString());
+    return ok_message;
   case StatusCode::CodecProtocolError:
     return "CodecProtocolError";
   case StatusCode::BufferFloodError:

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -13,9 +13,10 @@ constexpr absl::string_view EnvoyPayloadUrl = "Envoy";
 
 absl::string_view statusCodeToString(StatusCode code) {
   switch (code) {
-  case StatusCode::Ok:
+  case StatusCode::Ok: {
     static const auto& ok_message = *new std::string(absl::OkStatus().ToString());
     return ok_message;
+  }
   case StatusCode::CodecProtocolError:
     return "CodecProtocolError";
   case StatusCode::BufferFloodError:


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: This line of code is returning a local copy of string and try to construct a string_view object with that local copy. As string_view is non-owning, it will potentially cause a memory use after free issue. This is found by clang when in C++17 absl::string_view uses std::string_view.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
