### PR TITLE
dns_filter: fix incorrect validation annotation

### DIFF
--- a/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
@@ -51,7 +51,9 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
-    // A list of DNS servers to which we can forward queries
+    // A list of DNS servers to which we can forward queries. If not
+    // specified, Envoy will use the ambient DNS resolvers in the
+    // system.
     repeated config.core.v3.Address upstream_resolvers = 2;
 
     // Controls how many outstanding external lookup contexts the filter tracks.

--- a/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
@@ -52,8 +52,7 @@ message DnsFilterConfig {
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
     // A list of DNS servers to which we can forward queries
-    repeated config.core.v3.Address upstream_resolvers = 2
-        [(validate.rules).repeated = {min_items: 1}];
+    repeated config.core.v3.Address upstream_resolvers = 2;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external

--- a/api/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
@@ -62,8 +62,7 @@ message DnsFilterConfig {
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
     // A list of DNS servers to which we can forward queries
-    repeated config.core.v4alpha.Address upstream_resolvers = 2
-        [(validate.rules).repeated = {min_items: 1}];
+    repeated config.core.v4alpha.Address upstream_resolvers = 2;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external

--- a/api/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
+++ b/api/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
@@ -61,7 +61,9 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
-    // A list of DNS servers to which we can forward queries
+    // A list of DNS servers to which we can forward queries. If not
+    // specified, Envoy will use the ambient DNS resolvers in the
+    // system.
     repeated config.core.v4alpha.Address upstream_resolvers = 2;
 
     // Controls how many outstanding external lookup contexts the filter tracks.

--- a/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
+++ b/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v3alpha/dns_filter.proto
@@ -51,9 +51,10 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
-    // A list of DNS servers to which we can forward queries
-    repeated config.core.v3.Address upstream_resolvers = 2
-        [(validate.rules).repeated = {min_items: 1}];
+    // A list of DNS servers to which we can forward queries. If not
+    // specified, Envoy will use the ambient DNS resolvers in the
+    // system.
+    repeated config.core.v3.Address upstream_resolvers = 2;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external

--- a/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
+++ b/generated_api_shadow/envoy/extensions/filters/udp/dns_filter/v4alpha/dns_filter.proto
@@ -61,9 +61,10 @@ message DnsFilterConfig {
     // number of retries multiplied by the resolver_timeout.
     google.protobuf.Duration resolver_timeout = 1 [(validate.rules).duration = {gte {seconds: 1}}];
 
-    // A list of DNS servers to which we can forward queries
-    repeated config.core.v4alpha.Address upstream_resolvers = 2
-        [(validate.rules).repeated = {min_items: 1}];
+    // A list of DNS servers to which we can forward queries. If not
+    // specified, Envoy will use the ambient DNS resolvers in the
+    // system.
+    repeated config.core.v4alpha.Address upstream_resolvers = 2;
 
     // Controls how many outstanding external lookup contexts the filter tracks.
     // The context structure allows the filter to respond to every query even if the external


### PR DESCRIPTION
Signed-off-by: Shriram Rajagopalan <rshriram@tetrate.io>

Commit Message: The upstream resolver list should not be mandatory as it won't allow Envoy to default
to the ambient DNS resolvers to resolve hosts not found in the static dns table.

Risk Level: Low