### PR TITLE
http1: pass some encoder flags as params

### DIFF
--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -95,9 +95,8 @@ public:
 
 protected:
   StreamEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter);
-  void setIs1xx(bool value) { is_1xx_ = value; }
-  void setIs204(bool value) { is_204_ = value; }
-  void encodeHeadersBase(const RequestOrResponseHeaderMap& headers, bool end_stream);
+  void encodeHeadersBase(const RequestOrResponseHeaderMap& headers, absl::optional<uint64_t> status,
+                         bool end_stream);
   void encodeTrailersBase(const HeaderMap& headers);
 
   static const std::string CRLF;
@@ -107,11 +106,8 @@ protected:
   uint32_t read_disable_calls_{};
   bool disable_chunk_encoding_ : 1;
   bool chunk_encoding_ : 1;
-  bool processing_100_continue_ : 1;
   bool is_response_to_head_request_ : 1;
   bool is_response_to_connect_request_ : 1;
-  bool is_1xx_ : 1;
-  bool is_204_ : 1;
 
 private:
   /**
@@ -167,16 +163,16 @@ class RequestEncoderImpl : public StreamEncoderImpl, public RequestEncoder {
 public:
   RequestEncoderImpl(ConnectionImpl& connection, HeaderKeyFormatter* header_key_formatter)
       : StreamEncoderImpl(connection, header_key_formatter) {}
-  bool headRequest() { return head_request_; }
-  bool connectRequest() { return connect_request_; }
+  bool upgradeRequest() const { return upgrade_request_; }
+  bool headRequest() const { return head_request_; }
+  bool connectRequest() const { return connect_request_; }
 
   // Http::RequestEncoder
   void encodeHeaders(const RequestHeaderMap& headers, bool end_stream) override;
   void encodeTrailers(const RequestTrailerMap& trailers) override { encodeTrailersBase(trailers); }
 
-  bool upgrade_request_{};
-
 private:
+  bool upgrade_request_{};
   bool head_request_{};
   bool connect_request_{};
 };


### PR DESCRIPTION
Commit Message:
Some flags in the StreamEncoderImpl are only necessary for the
duration of calls to encodeHeadersBase. Remove the fields and
pass response status as an optional value rather than setting
fields ahead of the encodeHeadersBase call.

Additional Description: This refactoring was promised during
review of #11458. This is a little more complicated than
passing a never-chunk-encode bool since the behavior also
covers content-length and may be partially disabled via
the runtime flag added in 11458. Assigned risk level medium
because it's the h1 encoder.

Risk Level: medium
Testing: existing tests pass
Doc Changes: n/a
Release Note: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
