### PR TITLE
repokitteh: tighten API path expression.

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -17,13 +17,13 @@ use(
     },
     {
       "owner": "envoyproxy/api-shepherds!",
-      "path": "api/",
+      "path": "api/envoy/",
       "label": "api",
       "github_status_label": "any API change",
     },
     {
       "owner": "envoyproxy/api-watchers",
-      "path": "api/",
+      "path": "api/envoy/",
     },
   ],
 )


### PR DESCRIPTION
Reduce the number of false positives we see during review. API shepherds
were being flagged on files in include/envoy/api for example.

Signed-off-by: Harvey Tuch <htuch@google.com>