### PR TITLE
examples: fixed fault-injection delay demo

### DIFF
--- a/examples/fault-injection/docker-compose.yaml
+++ b/examples/fault-injection/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
     ports:
       - 9211:9211
       - 9901:9901
+    # Run Envoy as root to grant access to /dev/stdout
     environment:
       ENVOY_UID: 0
   backend:

--- a/examples/fault-injection/docker-compose.yaml
+++ b/examples/fault-injection/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
     ports:
       - 9211:9211
       - 9901:9901
+    environment:
+      ENVOY_UID: 0
   backend:
     image: kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
     networks:

--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -36,6 +36,11 @@ static_resources:
                 percentage:
                   numerator: 0
                   denominator: HUNDRED
+              delay:
+                fixed_delay: 3s
+                percentage:
+                  numerator: 0
+                  denominator: HUNDRED
           - name: envoy.filters.http.router
             typed_config: {}
   clusters:


### PR DESCRIPTION
Description:
fault injection example did not work for delay option. After gdb debugging it was discovered that fault injection config requires `delay` part to be present. Without `delay` part Envoy assumes that Delay is disabled and does not scan RTDS for delay config updates.

Risk Level:
Low: 

Testing:
Did manual testing as described in https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/fault_injection

Docs Changes:
No

Release Notes:
No

Fixes: #11095 