### PR TITLE
test: fixing a flake

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -160,7 +160,7 @@ The full command might look something like
 ```
 bazel test //test/integration:http2_upstream_integration_test \
 --test_arg=--gtest_filter="IpVersions/Http2UpstreamIntegrationTest.RouterRequestAndResponseWithBodyNoBuffer/IPv6" \
---jobs 60 --local_ram_resources=100000000000 --local_cpu_resources=100000000000 --runs_per_test=1000 --test_arg="-l trace"
+--jobs 60 --local_ram_resources=1000000000 --local_cpu_resources=1000000000 --runs_per_test=1000 --test_arg="-l trace"
 ```
 
 ## Debugging test flakes

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -992,6 +992,10 @@ TEST_P(ProtocolIntegrationTest, 304WithBody) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
+  if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
+    // The invalid data will trigger disconnect.
+    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+  }
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
   waitForNextUpstreamRequest();


### PR DESCRIPTION
When the backend sends invalid data, it may (based on timing) pick up the disconnect.
Also fixing the flake instructions now that bazel cares how large those numbers are.

Risk Level: n/a (test only)
Testing: 2k runs now pass cleanly
Docs Changes: updated deflake instructions to work again.
Release Notes: no
