### PR TITLE
Windows: test compilation refresh

### DIFF
--- a/source/extensions/quic_listeners/quiche/envoy_quic_alarm.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_alarm.cc
@@ -19,7 +19,8 @@ void EnvoyQuicAlarm::SetImpl() {
   // in QUICHE, and we are working on the fix. Once QUICHE is fixed of expecting this behavior, we
   // no longer need to round up the duration.
   // TODO(antoniovicente) improve the timer behavior in such case.
-  timer_->enableHRTimer(std::chrono::microseconds(std::max(1l, duration.ToMicroseconds())));
+  timer_->enableHRTimer(
+      std::chrono::microseconds(std::max(static_cast<int64_t>(1), duration.ToMicroseconds())));
 }
 
 void EnvoyQuicAlarm::UpdateImpl() {

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -74,6 +74,8 @@ envoy_cc_test(
 envoy_cc_test(
     name = "watermark_buffer_test",
     srcs = ["watermark_buffer_test.cc"],
+    # Fails on windows with cr/lf yaml file checkouts
+    tags = ["fails_on_windows"],
     deps = [
         ":utility_lib",
         "//source/common/buffer:buffer_lib",

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -902,16 +902,14 @@ TEST(HeaderMapImplTest, Lookup) {
 
 TEST(HeaderMapImplTest, Get) {
   {
-    auto headers =
-        TestRequestHeaderMapImpl({{Headers::get().Path, "/"}, {LowerCaseString("hello"), "world"}});
+    auto headers = TestRequestHeaderMapImpl({{Headers::get().Path.get(), "/"}, {"hello", "world"}});
     EXPECT_EQ("/", headers.get(LowerCaseString(":path"))->value().getStringView());
     EXPECT_EQ("world", headers.get(LowerCaseString("hello"))->value().getStringView());
     EXPECT_EQ(nullptr, headers.get(LowerCaseString("foo")));
   }
 
   {
-    auto headers =
-        TestRequestHeaderMapImpl({{Headers::get().Path, "/"}, {LowerCaseString("hello"), "world"}});
+    auto headers = TestRequestHeaderMapImpl({{Headers::get().Path.get(), "/"}, {"hello", "world"}});
     // There is not HeaderMap method to set a header and copy both the key and value.
     const LowerCaseString path(":path");
     headers.setReferenceKey(path, "/new_path");
@@ -933,7 +931,7 @@ TEST(HeaderMapImplTest, CreateHeaderMapFromIterator) {
 }
 
 TEST(HeaderMapImplTest, TestHeaderList) {
-  std::array<Http::LowerCaseString, 2> keys{Headers::get().Path, LowerCaseString("hello")};
+  std::array<std::string, 2> keys{Headers::get().Path.get(), "hello"};
   std::array<std::string, 2> values{"/", "world"};
 
   auto headers = TestRequestHeaderMapImpl({{keys[0], values[0]}, {keys[1], values[1]}});
@@ -1173,11 +1171,11 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
 
   // Starting with a normal header
   {
-    auto headers = TestRequestHeaderMapImpl({{Headers::get().ContentType, "text/plain"},
-                                             {Headers::get().Method, "GET"},
-                                             {Headers::get().Path, "/"},
-                                             {LowerCaseString("hello"), "world"},
-                                             {Headers::get().Host, "host"}});
+    auto headers = TestRequestHeaderMapImpl({{Headers::get().ContentType.get(), "text/plain"},
+                                             {Headers::get().Method.get(), "GET"},
+                                             {Headers::get().Path.get(), "/"},
+                                             {"hello", "world"},
+                                             {Headers::get().Host.get(), "host"}});
 
     InSequence seq;
     EXPECT_CALL(cb, Call(":method", "GET"));
@@ -1197,11 +1195,11 @@ TEST(HeaderMapImplTest, PseudoHeaderOrder) {
 
   // Starting with a pseudo-header
   {
-    auto headers = TestRequestHeaderMapImpl({{Headers::get().Path, "/"},
-                                             {Headers::get().ContentType, "text/plain"},
-                                             {Headers::get().Method, "GET"},
-                                             {LowerCaseString("hello"), "world"},
-                                             {Headers::get().Host, "host"}});
+    auto headers = TestRequestHeaderMapImpl({{Headers::get().Path.get(), "/"},
+                                             {Headers::get().ContentType.get(), "text/plain"},
+                                             {Headers::get().Method.get(), "GET"},
+                                             {"hello", "world"},
+                                             {Headers::get().Host.get(), "host"}});
 
     InSequence seq;
     EXPECT_CALL(cb, Call(":path", "/"));

--- a/test/common/runtime/BUILD
+++ b/test/common/runtime/BUILD
@@ -42,6 +42,8 @@ envoy_cc_test(
     name = "runtime_impl_test",
     srcs = ["runtime_impl_test.cc"],
     data = glob(["test_data/**"]) + ["filesystem_setup.sh"],
+    # Fails on windows with cr/lf yaml file checkouts
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/config:runtime_utility_lib",
         "//source/common/runtime:runtime_lib",

--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -63,6 +63,8 @@ envoy_cc_test(
     name = "main_common_test",
     srcs = ["main_common_test.cc"],
     data = ["//test/config/integration:google_com_proxy_port_0"],
+    # Fails on windows with cr/lf yaml file checkouts
+    tags = ["fails_on_windows"],
     deps = [
         "//source/common/api:api_lib",
         "//source/exe:envoy_main_common_lib",

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -14,7 +14,9 @@
 #include "gtest/gtest.h"
 
 using Envoy::Http::HeaderValueOf;
-using std::string_literals::operator""s;
+
+// for ::operator""s (which Windows compiler does not support):
+using namespace std::string_literals;
 
 namespace Envoy {
 namespace {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -757,13 +757,6 @@ public:
     }
     header_map_->verifyByteSizeInternalForTest();
   }
-  TestHeaderMapImplBase(
-      const std::initializer_list<std::pair<Http::LowerCaseString, std::string>>& values) {
-    for (auto& value : values) {
-      header_map_->addCopy(value.first, value.second);
-    }
-    header_map_->verifyByteSizeInternalForTest();
-  }
   TestHeaderMapImplBase(const TestHeaderMapImplBase& rhs)
       : TestHeaderMapImplBase(*rhs.header_map_) {}
   TestHeaderMapImplBase(const HeaderMap& rhs) {


### PR DESCRIPTION
Commit Message:
Windows: test compilation refresh

- Remove TestHeaderMapImplBase constructor that takes a list of
std::pair<LowerCaseString, std::string>
  - MSVC erroneously treats this as ambiguous. It appears the explicit
  attribute of the LowerCaseString constructor is incorrectly discarded.
  We are able to reproduce this in a minimal example and see that MSVC is wrong
  here: https://godbolt.org/z/VjgsAi
  - To mitigate, remove LowerCaseString based constructor since it is
  only used in tests, tests always use std::string
- Correct use of long in envoy_quic_alarm.cc, explicitly cast to int64_t
(long on Windows is 32 bits)
- `using std::string_literal::operator""s` is erroneously rejected by
MSVC, throwing error C4455.
  - Instead, simply utilize the namespace and continue to use the
  operator as is
  - operator usage could be replaced by `std::string (const char* s,
  size_t n)` constructor
  - See https://developercommunity.visualstudio.com/content/problem/270349/warning-c4455-issued-when-using-standardized-liter.html
  and other related duplicate issues that have not yet been resolved.
- Tag tests that fail due to yaml parsing of cf/lf line endings as failing, see https://github.com/envoyproxy/envoy/issues/11659

Additional Description: N/A
Risk Level: Low
Testing: Fixes test compilation on Windows, should be a no-op for other platforms
Docs Changes: N/A
Release Notes: N/A
