### PR TITLE
Ratelimit: Add dynamic metadata to ratelimit actions

### DIFF
--- a/api/envoy/config/route/v3/BUILD
+++ b/api/envoy/config/route/v3/BUILD
@@ -11,6 +11,7 @@ api_proto_package(
         "//envoy/api/v2/route:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
+        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/proxy_protocol.proto";
 import "envoy/type/matcher/v3/regex.proto";
 import "envoy/type/matcher/v3/string.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/range.proto";
@@ -1340,7 +1341,7 @@ message VirtualCluster {
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RateLimit";
 
-  // [#next-free-field: 7]
+  // [#next-free-field: 8]
   message Action {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RateLimit.Action";
@@ -1454,6 +1455,19 @@ message RateLimit {
       repeated HeaderMatcher headers = 3 [(validate.rules).repeated = {min_items: 1}];
     }
 
+    // The following descriptor entry is appended when the dynamic metadata contains a key value:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("<descriptor_key>", "<value_queried_from_metadata>")
+    message DynamicMetaData {
+      // The key to use in the descriptor entry.
+      string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
+
+      // Metadata struct that defines the key and path to retrieve the value.
+      type.metadata.v3.MetadataKey metadata_key = 2;
+    }
+
     oneof action_specifier {
       option (validate.required) = true;
 
@@ -1474,6 +1488,8 @@ message RateLimit {
 
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
+
+      DynamicMetaData dynamic_metadata = 7;
     }
   }
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1465,7 +1465,7 @@ message RateLimit {
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
       // Metadata struct that defines the key and path to retrieve the value.
-      type.metadata.v3.MetadataKey metadata_key = 2;
+      type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 
     oneof action_specifier {
@@ -1489,6 +1489,7 @@ message RateLimit {
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
 
+      // Rate limit on dynamic metadata.
       DynamicMetaData dynamic_metadata = 7;
     }
   }

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1464,7 +1464,8 @@ message RateLimit {
       // The key to use in the descriptor entry.
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-      // Metadata struct that defines the key and path to retrieve the value.
+      // Metadata struct that defines the key and path to retrieve the string value. A match will
+      // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 

--- a/api/envoy/config/route/v4alpha/BUILD
+++ b/api/envoy/config/route/v4alpha/BUILD
@@ -10,6 +10,7 @@ api_proto_package(
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
+        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1449,7 +1449,7 @@ message RateLimit {
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
       // Metadata struct that defines the key and path to retrieve the value.
-      type.metadata.v3.MetadataKey metadata_key = 2;
+      type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 
     oneof action_specifier {
@@ -1473,6 +1473,7 @@ message RateLimit {
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
 
+      // Rate limit on dynamic metadata.
       DynamicMetaData dynamic_metadata = 7;
     }
   }

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1448,7 +1448,8 @@ message RateLimit {
       // The key to use in the descriptor entry.
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-      // Metadata struct that defines the key and path to retrieve the value.
+      // Metadata struct that defines the key and path to retrieve the string value. A match will
+      // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/config/core/v4alpha/proxy_protocol.proto";
 import "envoy/type/matcher/v4alpha/regex.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/range.proto";
@@ -1321,7 +1322,7 @@ message VirtualCluster {
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RateLimit";
 
-  // [#next-free-field: 7]
+  // [#next-free-field: 8]
   message Action {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RateLimit.Action";
@@ -1435,6 +1436,22 @@ message RateLimit {
       repeated HeaderMatcher headers = 3 [(validate.rules).repeated = {min_items: 1}];
     }
 
+    // The following descriptor entry is appended when the dynamic metadata contains a key value:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("<descriptor_key>", "<value_queried_from_metadata>")
+    message DynamicMetaData {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.config.route.v3.RateLimit.Action.DynamicMetaData";
+
+      // The key to use in the descriptor entry.
+      string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
+
+      // Metadata struct that defines the key and path to retrieve the value.
+      type.metadata.v3.MetadataKey metadata_key = 2;
+    }
+
     oneof action_specifier {
       option (validate.required) = true;
 
@@ -1455,6 +1472,8 @@ message RateLimit {
 
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
+
+      DynamicMetaData dynamic_metadata = 7;
     }
   }
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -103,6 +103,7 @@ New Features
   tracing is not forced.
 * router: add support for RESPONSE_FLAGS and RESPONSE_CODE_DETAILS :ref:`header formatters
   <config_http_conn_man_headers_custom_request_headers>`.
+* router: add support for use of dynamic metadata :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` as a ratelimit action.
 * router: allow Rate Limiting Service to be called in case of missing request header for a descriptor if the :ref:`skip_if_absent <envoy_v3_api_field_config.route.v3.RateLimit.Action.RequestHeaders.skip_if_absent>` field is set to true.
 * router: more fine grained internal redirect configs are added to the :ref:`internal_redirect_policy
   <envoy_v3_api_field_config.route.v3.RouteAction.internal_redirect_policy>` field.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -97,13 +97,13 @@ New Features
 * metrics service: added added :ref:`API version <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
 * network filters: added a :ref:`postgres proxy filter <config_network_filters_postgres_proxy>`.
 * network filters: added a :ref:`rocketmq proxy filter <config_network_filters_rocketmq_proxy>`.
+* ratelimit: add support for use of dynamic metadata :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` as a ratelimit action.
 * ratelimit: added :ref:`API version <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
 * request_id: added to :ref:`always_set_request_id_in_response setting <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.always_set_request_id_in_response>`
   to set :ref:`x-request-id <config_http_conn_man_headers_x-request-id>` header in response even if
   tracing is not forced.
 * router: add support for RESPONSE_FLAGS and RESPONSE_CODE_DETAILS :ref:`header formatters
   <config_http_conn_man_headers_custom_request_headers>`.
-* router: add support for use of dynamic metadata :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` as a ratelimit action.
 * router: allow Rate Limiting Service to be called in case of missing request header for a descriptor if the :ref:`skip_if_absent <envoy_v3_api_field_config.route.v3.RateLimit.Action.RequestHeaders.skip_if_absent>` field is set to true.
 * router: more fine grained internal redirect configs are added to the :ref:`internal_redirect_policy
   <envoy_v3_api_field_config.route.v3.RouteAction.internal_redirect_policy>` field.

--- a/generated_api_shadow/envoy/config/route/v3/BUILD
+++ b/generated_api_shadow/envoy/config/route/v3/BUILD
@@ -11,6 +11,7 @@ api_proto_package(
         "//envoy/api/v2/route:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
+        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/proxy_protocol.proto";
 import "envoy/type/matcher/v3/regex.proto";
 import "envoy/type/matcher/v3/string.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/range.proto";
@@ -1352,7 +1353,7 @@ message VirtualCluster {
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RateLimit";
 
-  // [#next-free-field: 7]
+  // [#next-free-field: 8]
   message Action {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RateLimit.Action";
@@ -1466,6 +1467,19 @@ message RateLimit {
       repeated HeaderMatcher headers = 3 [(validate.rules).repeated = {min_items: 1}];
     }
 
+    // The following descriptor entry is appended when the dynamic metadata contains a key value:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("<descriptor_key>", "<value_queried_from_metadata>")
+    message DynamicMetaData {
+      // The key to use in the descriptor entry.
+      string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
+
+      // Metadata struct that defines the key and path to retrieve the value.
+      type.metadata.v3.MetadataKey metadata_key = 2;
+    }
+
     oneof action_specifier {
       option (validate.required) = true;
 
@@ -1486,6 +1500,8 @@ message RateLimit {
 
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
+
+      DynamicMetaData dynamic_metadata = 7;
     }
   }
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1476,7 +1476,8 @@ message RateLimit {
       // The key to use in the descriptor entry.
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-      // Metadata struct that defines the key and path to retrieve the value.
+      // Metadata struct that defines the key and path to retrieve the string value. A match will
+      // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1477,7 +1477,7 @@ message RateLimit {
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
       // Metadata struct that defines the key and path to retrieve the value.
-      type.metadata.v3.MetadataKey metadata_key = 2;
+      type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 
     oneof action_specifier {
@@ -1501,6 +1501,7 @@ message RateLimit {
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
 
+      // Rate limit on dynamic metadata.
       DynamicMetaData dynamic_metadata = 7;
     }
   }

--- a/generated_api_shadow/envoy/config/route/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/route/v4alpha/BUILD
@@ -10,6 +10,7 @@ api_proto_package(
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
+        "//envoy/type/metadata/v3:pkg",
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1476,7 +1476,8 @@ message RateLimit {
       // The key to use in the descriptor entry.
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-      // Metadata struct that defines the key and path to retrieve the value.
+      // Metadata struct that defines the key and path to retrieve the string value. A match will
+      // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/config/core/v4alpha/proxy_protocol.proto";
 import "envoy/type/matcher/v4alpha/regex.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
+import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/range.proto";
@@ -1349,7 +1350,7 @@ message VirtualCluster {
 message RateLimit {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RateLimit";
 
-  // [#next-free-field: 7]
+  // [#next-free-field: 8]
   message Action {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RateLimit.Action";
@@ -1463,6 +1464,22 @@ message RateLimit {
       repeated HeaderMatcher headers = 3 [(validate.rules).repeated = {min_items: 1}];
     }
 
+    // The following descriptor entry is appended when the dynamic metadata contains a key value:
+    //
+    // .. code-block:: cpp
+    //
+    //   ("<descriptor_key>", "<value_queried_from_metadata>")
+    message DynamicMetaData {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.config.route.v3.RateLimit.Action.DynamicMetaData";
+
+      // The key to use in the descriptor entry.
+      string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
+
+      // Metadata struct that defines the key and path to retrieve the value.
+      type.metadata.v3.MetadataKey metadata_key = 2;
+    }
+
     oneof action_specifier {
       option (validate.required) = true;
 
@@ -1483,6 +1500,8 @@ message RateLimit {
 
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
+
+      DynamicMetaData dynamic_metadata = 7;
     }
   }
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1477,7 +1477,7 @@ message RateLimit {
       string descriptor_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
       // Metadata struct that defines the key and path to retrieve the value.
-      type.metadata.v3.MetadataKey metadata_key = 2;
+      type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
     }
 
     oneof action_specifier {
@@ -1501,6 +1501,7 @@ message RateLimit {
       // Rate limit on the existence of request headers.
       HeaderValueMatch header_value_match = 6;
 
+      // Rate limit on dynamic metadata.
       DynamicMetaData dynamic_metadata = 7;
     }
   }

--- a/include/envoy/router/BUILD
+++ b/include/envoy/router/BUILD
@@ -92,6 +92,7 @@ envoy_cc_library(
         "//include/envoy/http:filter_interface",
         "//include/envoy/http:header_map_interface",
         "//include/envoy/ratelimit:ratelimit_interface",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/include/envoy/router/router_ratelimit.h
+++ b/include/envoy/router/router_ratelimit.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/ratelimit/ratelimit.h"
@@ -25,12 +26,14 @@ public:
    * @param local_service_cluster supplies the name of the local service cluster.
    * @param headers supplies the header for the request.
    * @param remote_address supplies the trusted downstream address for the connection.
+   * @param dynamic_metadata supplies the dynamic metadata for the request
    * @return true if the RateLimitAction populated the descriptor.
    */
-  virtual bool populateDescriptor(const RouteEntry& route, RateLimit::Descriptor& descriptor,
-                                  const std::string& local_service_cluster,
-                                  const Http::HeaderMap& headers,
-                                  const Network::Address::Instance& remote_address) const PURE;
+  virtual bool
+  populateDescriptor(const RouteEntry& route, RateLimit::Descriptor& descriptor,
+                     const std::string& local_service_cluster, const Http::HeaderMap& headers,
+                     const Network::Address::Instance& remote_address,
+                     const envoy::config::core::v3::Metadata* dynamic_metadata) const PURE;
 };
 
 using RateLimitActionPtr = std::unique_ptr<RateLimitAction>;
@@ -59,12 +62,13 @@ public:
    * @param local_service_cluster supplies the name of the local service cluster.
    * @param headers supplies the header for the request.
    * @param remote_address supplies the trusted downstream address for the connection.
+   * @param dynamic_metadata supplies the dynamic metadata for the request.
    */
-  virtual void populateDescriptors(const RouteEntry& route,
-                                   std::vector<RateLimit::Descriptor>& descriptors,
-                                   const std::string& local_service_cluster,
-                                   const Http::HeaderMap& headers,
-                                   const Network::Address::Instance& remote_address) const PURE;
+  virtual void
+  populateDescriptors(const RouteEntry& route, std::vector<RateLimit::Descriptor>& descriptors,
+                      const std::string& local_service_cluster, const Http::HeaderMap& headers,
+                      const Network::Address::Instance& remote_address,
+                      const envoy::config::core::v3::Metadata* dynamic_metadata) const PURE;
 };
 
 /**

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -325,8 +325,10 @@ envoy_cc_library(
         "//include/envoy/router:router_ratelimit_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:empty_string",
+        "//source/common/config:metadata_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -5,10 +5,12 @@
 #include <string>
 #include <vector>
 
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/route/v3/route_components.pb.h"
 #include "envoy/router/router.h"
 #include "envoy/router/router_ratelimit.h"
 
+#include "common/config/metadata.h"
 #include "common/http/header_utility.h"
 
 namespace Envoy {
@@ -22,7 +24,8 @@ public:
   // Router::RateLimitAction
   bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address) const override;
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 };
 
 /**
@@ -33,7 +36,8 @@ public:
   // Router::RateLimitAction
   bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address) const override;
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 };
 
 /**
@@ -48,7 +52,8 @@ public:
   // Router::RateLimitAction
   bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address) const override;
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 
 private:
   const Http::LowerCaseString header_name_;
@@ -64,7 +69,8 @@ public:
   // Router::RateLimitAction
   bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address) const override;
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 };
 
 /**
@@ -78,10 +84,28 @@ public:
   // Router::RateLimitAction
   bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address) const override;
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 
 private:
   const std::string descriptor_value_;
+};
+
+/**
+ * Action for dynamic metadata rate limiting.
+ */
+class DynamicMetaDataAction : public RateLimitAction {
+public:
+  DynamicMetaDataAction(const envoy::config::route::v3::RateLimit::Action::DynamicMetaData& action);
+  // Router::RateLimitAction
+  bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
+                          const std::string& local_service_cluster, const Http::HeaderMap& headers,
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
+
+private:
+  const Envoy::Config::MetadataKey metadata_key_;
+  const std::string descriptor_key_;
 };
 
 /**
@@ -95,7 +119,8 @@ public:
   // Router::RateLimitAction
   bool populateDescriptor(const Router::RouteEntry& route, RateLimit::Descriptor& descriptor,
                           const std::string& local_service_cluster, const Http::HeaderMap& headers,
-                          const Network::Address::Instance& remote_address) const override;
+                          const Network::Address::Instance& remote_address,
+                          const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 
 private:
   const std::string descriptor_value_;
@@ -113,10 +138,12 @@ public:
   // Router::RateLimitPolicyEntry
   uint64_t stage() const override { return stage_; }
   const std::string& disableKey() const override { return disable_key_; }
-  void populateDescriptors(const Router::RouteEntry& route,
-                           std::vector<Envoy::RateLimit::Descriptor>& descriptors,
-                           const std::string& local_service_cluster, const Http::HeaderMap&,
-                           const Network::Address::Instance& remote_address) const override;
+  void
+  populateDescriptors(const Router::RouteEntry& route,
+                      std::vector<Envoy::RateLimit::Descriptor>& descriptors,
+                      const std::string& local_service_cluster, const Http::HeaderMap&,
+                      const Network::Address::Instance& remote_address,
+                      const envoy::config::core::v3::Metadata* dynamic_metadata) const override;
 
 private:
   const std::string disable_key_;

--- a/source/extensions/filters/http/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/http/ratelimit/ratelimit.cc
@@ -201,7 +201,8 @@ void Filter::populateRateLimitDescriptors(const Router::RateLimitPolicy& rate_li
       continue;
     }
     rate_limit.populateDescriptors(*route_entry, descriptors, config_->localInfo().clusterName(),
-                                   headers, *callbacks_->streamInfo().downstreamRemoteAddress());
+                                   headers, *callbacks_->streamInfo().downstreamRemoteAddress(),
+                                   &callbacks_->streamInfo().dynamicMetadata());
   }
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -89,6 +89,7 @@ public:
   Http::TestRequestHeaderMapImpl header_;
   const RouteEntry* route_;
   Network::Address::Ipv4Instance default_remote_address_{"10.0.0.1"};
+  const envoy::config::core::v3::Metadata* dynamic_metadata;
 };
 
 TEST_F(RateLimitConfiguration, NoApplicableRateLimit) {
@@ -169,7 +170,8 @@ virtual_hosts:
 
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
-    rate_limit.populateDescriptors(*route_, descriptors, "", header_, default_remote_address_);
+    rate_limit.populateDescriptors(*route_, descriptors, "", header_, default_remote_address_,
+                                   dynamic_metadata);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
               testing::ContainerEq(descriptors));
@@ -202,7 +204,7 @@ virtual_hosts:
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_,
-                                   default_remote_address_);
+                                   default_remote_address_, dynamic_metadata);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"destination_cluster", "www2test"}}}}),
               testing::ContainerEq(descriptors));
@@ -241,7 +243,7 @@ virtual_hosts:
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_,
-                                   default_remote_address_);
+                                   default_remote_address_, dynamic_metadata);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
                   {{{{"destination_cluster", "www2test"}}},
@@ -254,7 +256,7 @@ virtual_hosts:
 
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_,
-                                   default_remote_address_);
+                                   default_remote_address_, dynamic_metadata);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
               testing::ContainerEq(descriptors));
@@ -275,6 +277,7 @@ public:
   NiceMock<MockRouteEntry> route_;
   std::vector<Envoy::RateLimit::Descriptor> descriptors_;
   Network::Address::Ipv4Instance default_remote_address_{"10.0.0.1"};
+  const envoy::config::core::v3::Metadata* dynamic_metadata;
 };
 
 TEST_F(RateLimitPolicyEntryTest, RateLimitPolicyEntryMembers) {
@@ -299,8 +302,8 @@ actions:
 
   setupTest(yaml);
 
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_,
-                                         default_remote_address_);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         dynamic_metadata);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -315,7 +318,8 @@ actions:
   setupTest(yaml);
 
   Network::Address::PipeInstance pipe_address("/hello");
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, pipe_address);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, pipe_address,
+                                         dynamic_metadata);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -328,7 +332,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>({{{{"source_cluster", "service_cluster"}}}}),
       testing::ContainerEq(descriptors_));
@@ -343,7 +347,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>({{{{"destination_cluster", "fake_cluster"}}}}),
       testing::ContainerEq(descriptors_));
@@ -361,7 +365,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"my_header_name", "test_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -385,7 +389,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"my_header_name", "test_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -409,7 +413,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-test", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -425,7 +429,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -438,10 +442,132 @@ actions:
 
   setupTest(yaml);
 
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_,
-                                         default_remote_address_);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         dynamic_metadata);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"generic_key", "fake_key"}}}}),
               testing::ContainerEq(descriptors_));
+}
+
+TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataMatch) {
+  const std::string yaml = R"EOF(
+actions:
+- dynamic_metadata:
+    descriptor_key: fake_key
+    metadata_key:
+      key: 'envoy.xxx'
+      path:
+      - key: test
+      - key: prop
+  )EOF";
+
+  setupTest(yaml);
+
+  std::string metadata_yaml = R"EOF(
+filter_metadata:
+  envoy.xxx:
+    test:
+      prop: foo
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  TestUtility::loadFromYaml(metadata_yaml, metadata);
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         &metadata);
+
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"fake_key", "foo"}}}}),
+              testing::ContainerEq(descriptors_));
+}
+
+TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataNoMatch) {
+  const std::string yaml = R"EOF(
+actions:
+- dynamic_metadata:
+    descriptor_key: fake_key
+    metadata_key:
+      key: 'envoy.xxx'
+      path:
+      - key: test
+      - key: prop
+  )EOF";
+
+  setupTest(yaml);
+
+  std::string metadata_yaml = R"EOF(
+filter_metadata:
+  envoy.xxx:
+    another_key:
+      prop: foo
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  TestUtility::loadFromYaml(metadata_yaml, metadata);
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         &metadata);
+
+  EXPECT_TRUE(descriptors_.empty());
+}
+
+TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataEmptyValue) {
+  const std::string yaml = R"EOF(
+actions:
+- dynamic_metadata:
+    descriptor_key: fake_key
+    metadata_key:
+      key: 'envoy.xxx'
+      path:
+      - key: test
+      - key: prop
+  )EOF";
+
+  setupTest(yaml);
+
+  std::string metadata_yaml = R"EOF(
+filter_metadata:
+  envoy.xxx:
+    test:
+      prop: ""
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  TestUtility::loadFromYaml(metadata_yaml, metadata);
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         &metadata);
+
+  EXPECT_TRUE(descriptors_.empty());
+}
+
+TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataNonStringMatch) {
+  const std::string yaml = R"EOF(
+actions:
+- dynamic_metadata:
+    descriptor_key: fake_key
+    metadata_key:
+      key: 'envoy.xxx'
+      path:
+      - key: test
+      - key: prop
+  )EOF";
+
+  setupTest(yaml);
+
+  std::string metadata_yaml = R"EOF(
+filter_metadata:
+  envoy.xxx:
+    test:
+      prop:
+        foo: bar
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  TestUtility::loadFromYaml(metadata_yaml, metadata);
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         &metadata);
+
+  EXPECT_TRUE(descriptors_.empty());
 }
 
 TEST_F(RateLimitPolicyEntryTest, HeaderValueMatch) {
@@ -457,7 +583,8 @@ actions:
   setupTest(yaml);
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
+                                         dynamic_metadata);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -475,7 +602,8 @@ actions:
   setupTest(yaml);
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
+                                         dynamic_metadata);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -493,7 +621,8 @@ actions:
   setupTest(yaml);
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
+                                         dynamic_metadata);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -512,7 +641,8 @@ actions:
   setupTest(yaml);
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
-  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_);
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
+                                         dynamic_metadata);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -526,7 +656,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>(
           {{{{"destination_cluster", "fake_cluster"}, {"source_cluster", "service_cluster"}}}}),
@@ -547,7 +677,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_);
+                                         default_remote_address_, dynamic_metadata);
   EXPECT_TRUE(descriptors_.empty());
 }
 

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -89,7 +89,7 @@ public:
   Http::TestRequestHeaderMapImpl header_;
   const RouteEntry* route_;
   Network::Address::Ipv4Instance default_remote_address_{"10.0.0.1"};
-  const envoy::config::core::v3::Metadata* dynamic_metadata;
+  const envoy::config::core::v3::Metadata* dynamic_metadata_;
 };
 
 TEST_F(RateLimitConfiguration, NoApplicableRateLimit) {
@@ -171,7 +171,7 @@ virtual_hosts:
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "", header_, default_remote_address_,
-                                   dynamic_metadata);
+                                   dynamic_metadata_);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
               testing::ContainerEq(descriptors));
@@ -204,7 +204,7 @@ virtual_hosts:
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_,
-                                   default_remote_address_, dynamic_metadata);
+                                   default_remote_address_, dynamic_metadata_);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"destination_cluster", "www2test"}}}}),
               testing::ContainerEq(descriptors));
@@ -243,7 +243,7 @@ virtual_hosts:
   std::vector<Envoy::RateLimit::Descriptor> descriptors;
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_,
-                                   default_remote_address_, dynamic_metadata);
+                                   default_remote_address_, dynamic_metadata_);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
                   {{{{"destination_cluster", "www2test"}}},
@@ -256,7 +256,7 @@ virtual_hosts:
 
   for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
     rate_limit.populateDescriptors(*route_, descriptors, "service_cluster", header_,
-                                   default_remote_address_, dynamic_metadata);
+                                   default_remote_address_, dynamic_metadata_);
   }
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
               testing::ContainerEq(descriptors));
@@ -277,7 +277,7 @@ public:
   NiceMock<MockRouteEntry> route_;
   std::vector<Envoy::RateLimit::Descriptor> descriptors_;
   Network::Address::Ipv4Instance default_remote_address_{"10.0.0.1"};
-  const envoy::config::core::v3::Metadata* dynamic_metadata;
+  const envoy::config::core::v3::Metadata* dynamic_metadata_;
 };
 
 TEST_F(RateLimitPolicyEntryTest, RateLimitPolicyEntryMembers) {
@@ -303,7 +303,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -319,7 +319,7 @@ actions:
 
   Network::Address::PipeInstance pipe_address("/hello");
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, pipe_address,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -332,7 +332,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>({{{{"source_cluster", "service_cluster"}}}}),
       testing::ContainerEq(descriptors_));
@@ -347,7 +347,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>({{{{"destination_cluster", "fake_cluster"}}}}),
       testing::ContainerEq(descriptors_));
@@ -365,7 +365,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"my_header_name", "test_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -389,7 +389,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"my_header_name", "test_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -413,7 +413,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-test", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -429,7 +429,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -443,7 +443,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"generic_key", "fake_key"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -584,7 +584,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -603,7 +603,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -622,7 +622,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "not_same_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"header_match", "fake_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
@@ -642,7 +642,7 @@ actions:
   Http::TestRequestHeaderMapImpl header{{"x-header-name", "test_value"}};
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header, default_remote_address_,
-                                         dynamic_metadata);
+                                         dynamic_metadata_);
   EXPECT_TRUE(descriptors_.empty());
 }
 
@@ -656,7 +656,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_THAT(
       std::vector<Envoy::RateLimit::Descriptor>(
           {{{{"destination_cluster", "fake_cluster"}, {"source_cluster", "service_cluster"}}}}),
@@ -677,7 +677,7 @@ actions:
   setupTest(yaml);
 
   rate_limit_entry_->populateDescriptors(route_, descriptors_, "service_cluster", header_,
-                                         default_remote_address_, dynamic_metadata);
+                                         default_remote_address_, dynamic_metadata_);
   EXPECT_TRUE(descriptors_.empty());
 }
 

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -155,8 +155,8 @@ TEST_F(HttpRateLimitFilterTest, NoApplicableRateLimit) {
 TEST_F(HttpRateLimitFilterTest, NoDescriptor) {
   SetUpTest(filter_config_);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(1);
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(1);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(1);
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(1);
   EXPECT_CALL(*client_, limit(_, _, _, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -190,7 +190,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -236,7 +236,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithHeaders) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -291,7 +291,7 @@ TEST_F(HttpRateLimitFilterTest, ImmediateOkResponse) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(*client_, limit(_, "foo",
@@ -321,7 +321,7 @@ TEST_F(HttpRateLimitFilterTest, ImmediateErrorResponse) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(*client_, limit(_, "foo",
@@ -356,7 +356,7 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponse) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _))
       .WillOnce(
@@ -389,7 +389,7 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
   SetUpTest(fail_close_config_);
   InSequence s;
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _))
       .WillOnce(
@@ -420,7 +420,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponse) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _))
       .WillOnce(
@@ -460,7 +460,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseWithHeaders) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _))
       .WillOnce(
@@ -512,7 +512,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponseRuntimeDisabled) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _))
       .WillOnce(
@@ -554,7 +554,7 @@ TEST_F(HttpRateLimitFilterTest, ResetDuringCall) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
   EXPECT_CALL(*client_, limit(_, _, _, _))
       .WillOnce(
@@ -576,7 +576,7 @@ TEST_F(HttpRateLimitFilterTest, RouteRateLimitDisabledForRouteKey) {
   ON_CALL(runtime_.snapshot_, featureEnabled("ratelimit.test_key.http_filter_enabled", 100))
       .WillByDefault(Return(false));
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(0);
   EXPECT_CALL(*client_, limit(_, _, _, _)).Times(0);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
@@ -596,7 +596,7 @@ TEST_F(HttpRateLimitFilterTest, VirtualHostRateLimitDisabledForRouteKey) {
   ON_CALL(runtime_.snapshot_, featureEnabled("ratelimit.test_vh_key.http_filter_enabled", 100))
       .WillByDefault(Return(false));
 
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(0);
   EXPECT_CALL(*client_, limit(_, _, _, _)).Times(0);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
@@ -618,8 +618,8 @@ TEST_F(HttpRateLimitFilterTest, IncorrectRequestType) {
   )EOF";
   SetUpTest(internal_filter_config);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(0);
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(0);
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(0);
   EXPECT_CALL(*client_, limit(_, _, _, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -639,8 +639,8 @@ TEST_F(HttpRateLimitFilterTest, IncorrectRequestType) {
   SetUpTest(external_filter_config);
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(0);
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(0);
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(0);
   EXPECT_CALL(*client_, limit(_, _, _, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -666,7 +666,7 @@ TEST_F(HttpRateLimitFilterTest, InternalRequestType) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -711,7 +711,7 @@ TEST_F(HttpRateLimitFilterTest, ExternalRequestType) {
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
       .Times(1);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
@@ -751,7 +751,7 @@ TEST_F(HttpRateLimitFilterTest, ExcludeVirtualHost) {
   InSequence s;
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_, includeVirtualHostRateLimits())

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -184,7 +184,8 @@ public:
   MOCK_METHOD(void, populateDescriptors,
               (const RouteEntry& route, std::vector<Envoy::RateLimit::Descriptor>& descriptors,
                const std::string& local_service_cluster, const Http::HeaderMap& headers,
-               const Network::Address::Instance& remote_address),
+               const Network::Address::Instance& remote_address,
+               const envoy::config::core::v3::Metadata* dynamic_metadata),
               (const));
 
   uint64_t stage_{};


### PR DESCRIPTION
Commit Message: Modifies ratelimit filter to be able to use information
from the dynamic metadata as one of its actions.

Signed-off-by: Clara Andrew-Wani <candrewwani@gmail.com>

Risk Level:
Testing:  unit tests
Docs Changes: Updated rate limit actions to now include dynamic metadata
Release Notes:  
Fixes #11593 
