### PR TITLE
fuzz: added fuzz test for listener filter original_src

### DIFF
--- a/test/extensions/filters/listener/original_src/BUILD
+++ b/test/extensions/filters/listener/original_src/BUILD
@@ -1,6 +1,8 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_fuzz_test",
     "envoy_package",
+    "envoy_proto_library",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -46,6 +48,26 @@ envoy_extension_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/test_common:printers_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/listener/original_src/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_proto_library(
+    name = "original_src_fuzz_test_proto",
+    srcs = ["original_src_fuzz_test.proto"],
+    deps = [
+        "@envoy_api//envoy/extensions/filters/listener/original_src/v3:pkg",
+    ],
+)
+
+envoy_cc_fuzz_test(
+    name = "original_src_fuzz_test",
+    srcs = ["original_src_fuzz_test.cc"],
+    corpus = "original_src_corpus",
+    deps = [
+        ":original_src_fuzz_test_proto_cc_proto",
+        "//source/extensions/filters/listener/original_src:original_src_lib",
+        "//test/fuzz:utility_lib",
         "@envoy_api//envoy/extensions/filters/listener/original_src/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/listener/original_src/BUILD
+++ b/test/extensions/filters/listener/original_src/BUILD
@@ -67,7 +67,7 @@ envoy_cc_fuzz_test(
     deps = [
         ":original_src_fuzz_test_proto_cc_proto",
         "//source/extensions/filters/listener/original_src:original_src_lib",
-        "//test/fuzz:utility_lib",
+        "//test/mocks/network:network_mocks",
         "@envoy_api//envoy/extensions/filters/listener/original_src/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/listener/original_src/original_src_corpus/ipv4_test
+++ b/test/extensions/filters/listener/original_src/original_src_corpus/ipv4_test
@@ -1,0 +1,7 @@
+config {
+  bind_port: true
+  mark: 0
+}
+
+address: "tcp://1.2.3.4:0"
+

--- a/test/extensions/filters/listener/original_src/original_src_corpus/unix_test
+++ b/test/extensions/filters/listener/original_src/original_src_corpus/unix_test
@@ -1,0 +1,6 @@
+config {
+  bind_port: true
+  mark: 0
+}
+
+address: "unix://domain.socket"

--- a/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
@@ -29,8 +29,7 @@ DEFINE_PROTO_FUZZER(
     return;
   }
 
-  envoy::extensions::filters::listener::original_src::v3::OriginalSrc proto_config =
-      input.config();
+  envoy::extensions::filters::listener::original_src::v3::OriginalSrc proto_config = input.config();
   Config config(proto_config);
   auto filter = std::make_unique<OriginalSrcFilter>(config);
 

--- a/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
@@ -17,8 +17,6 @@ namespace Extensions {
 namespace ListenerFilters {
 namespace OriginalSrc {
 
-using testing::_;
-
 DEFINE_PROTO_FUZZER(
     const envoy::extensions::filters::listener::original_src::OriginalSrcTestCase& input) {
 
@@ -29,10 +27,6 @@ DEFINE_PROTO_FUZZER(
     return;
   }
 
-  envoy::extensions::filters::listener::original_src::v3::OriginalSrc proto_config = input.config();
-  Config config(proto_config);
-  auto filter = std::make_unique<OriginalSrcFilter>(config);
-
   NiceMock<Network::MockListenerFilterCallbacks> callbacks_;
   try {
     callbacks_.socket_.remote_address_ = Network::Utility::resolveUrl(input.address());
@@ -40,6 +34,9 @@ DEFINE_PROTO_FUZZER(
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
     return;
   }
+
+  Config config(input.config());
+  auto filter = std::make_unique<OriginalSrcFilter>(config);
 
   filter->onAccept(callbacks_);
 }

--- a/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
@@ -1,0 +1,51 @@
+#include "envoy/common/exception.h"
+#include "envoy/extensions/filters/listener/original_src/v3/original_src.pb.h"
+
+#include "common/network/utility.h"
+
+#include "extensions/filters/listener/original_src/original_src.h"
+
+#include "test/extensions/filters/listener/original_src/original_src_fuzz_test.pb.validate.h"
+#include "test/fuzz/fuzz_runner.h"
+#include "test/mocks/network/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace ListenerFilters {
+namespace OriginalSrc {
+
+using testing::_;
+
+DEFINE_PROTO_FUZZER(
+    const envoy::extensions::filters::listener::original_src::OriginalSrcTestCase& input) {
+
+  try {
+    TestUtility::validate(input);
+  } catch (const ProtoValidationException& e) {
+    ENVOY_LOG_MISC(debug, "ProtoValidationException: {}", e.what());
+    return;
+  }
+
+  envoy::extensions::filters::listener::original_src::v3::OriginalSrc proto_config =
+      input.config();
+  Config config(proto_config);
+  auto filter = std::make_unique<OriginalSrcFilter>(config);
+
+  NiceMock<Network::MockListenerFilterCallbacks> callbacks_;
+  try {
+    callbacks_.socket_.remote_address_ = Network::Utility::resolveUrl(input.address());
+  } catch (const EnvoyException& e) {
+    ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());
+    return;
+  }
+
+  filter->onAccept(callbacks_);
+}
+
+} // namespace OriginalSrc
+} // namespace ListenerFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
+++ b/test/extensions/filters/listener/original_src/original_src_fuzz_test.cc
@@ -1,4 +1,3 @@
-#include "envoy/common/exception.h"
 #include "envoy/extensions/filters/listener/original_src/v3/original_src.pb.h"
 
 #include "common/network/utility.h"
@@ -10,7 +9,6 @@
 #include "test/mocks/network/mocks.h"
 
 #include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/listener/original_src/original_src_fuzz_test.proto
+++ b/test/extensions/filters/listener/original_src/original_src_fuzz_test.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package envoy.extensions.filters.listener.original_src;
+
+import "envoy/extensions/filters/listener/original_src/v3/original_src.proto";
+import "google/protobuf/empty.proto";
+import "validate/validate.proto";
+
+message OriginalSrcTestCase {
+  envoy.extensions.filters.listener.original_src.v3.OriginalSrc config = 1
+    [(validate.rules).message.required = true];
+  string address = 2;
+}

--- a/test/extensions/filters/listener/original_src/original_src_fuzz_test.proto
+++ b/test/extensions/filters/listener/original_src/original_src_fuzz_test.proto
@@ -8,6 +8,6 @@ import "validate/validate.proto";
 
 message OriginalSrcTestCase {
   envoy.extensions.filters.listener.original_src.v3.OriginalSrc config = 1
-    [(validate.rules).message.required = true];
+      [(validate.rules).message.required = true];
   string address = 2;
 }


### PR DESCRIPTION
Commit Message: Added fuzz test for listener filter original_src
Additional Description:

Created original_src_corpus and populated with valid and invalid testcases
Created original_src_fuzz_test.cc and original_src_fuzz_test.proto, updated BUILD

Risk Level: Low
Testing: ran fuzzer, increased function and line coverage of original_src.cc to 100%
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Arthur Yan <arthuryan@google.com>

/cc @asraa 
/cc @akonradi 
