### PR TITLE
Add CLANG_FORMAT to .devcontainer env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,8 @@
     "llvm-vs-code-extensions.vscode-clangd",
     "webfreak.debug",
     "ms-python.python"
-  ]
+  ],
+  "containerEnv": {
+    "CLANG_FORMAT": "clang-format"
+  }
 }


### PR DESCRIPTION
Commit Message: Add CLANG_FORMAT to .devcontainer env
Additional Description: Fixes issues running tools such as `check_format.py` within the terminal in a VSCode dev-container.
Risk Level: low
Testing: manually in vscode
Docs Changes: none
Release Notes: none
