### PR TITLE
Add CLANG_FORMAT to devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,8 @@
     "llvm-vs-code-extensions.vscode-clangd",
     "webfreak.debug",
     "ms-python.python"
-  ]
+  ],
+  "containerEnv": {
+    "CLANG_FORMAT": "clang-format"
+  }
 }


### PR DESCRIPTION
Commit Message:Add CLANG_FORMAT to devcontainer.json
Additional Description:Fixes issues running tools such as `check_format.py` which expect to find a clang-format-10 executable in the path.
Risk Level: low
Testing: manual (in VSCode)
Docs Changes: n/a
Release Notes: n/a