### PR TITLE
dispatcher: Delay fd activation until the next itertion of the event loop. 

### DIFF
--- a/include/envoy/event/schedulable_cb.h
+++ b/include/envoy/event/schedulable_cb.h
@@ -22,6 +22,13 @@ public:
   virtual void scheduleCallbackCurrentIteration() PURE;
 
   /**
+   * Schedule the callback so it runs in the next iteration of the event loop. There are no
+   * ordering guarantees for callbacks scheduled for the next iteration, not even among
+   * next-iteration callbacks.
+   */
+  virtual void scheduleCallbackNextIteration() PURE;
+
+  /**
    * Cancel pending execution of the callback.
    */
   virtual void cancel() PURE;

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
         "//source/common/network:connection_lib",
         "//source/common/network:dns_lib",
         "//source/common/network:listener_lib",
+        "//source/common/runtime:runtime_features_lib",
     ],
 )
 

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -4,6 +4,7 @@
 
 #include "common/common/assert.h"
 #include "common/event/dispatcher_impl.h"
+#include "common/runtime/runtime_features.h"
 
 #include "event2/event.h"
 
@@ -12,31 +13,59 @@ namespace Event {
 
 FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, os_fd_t fd, FileReadyCb cb,
                              FileTriggerType trigger, uint32_t events)
-    : cb_(cb), fd_(fd), trigger_(trigger) {
+    : cb_(cb), fd_(fd), trigger_(trigger),
+      activate_fd_events_next_event_loop_(Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.activate_fds_next_event_loop")) {
 #ifdef WIN32
   RELEASE_ASSERT(trigger_ == FileTriggerType::Level,
                  "libevent does not support edge triggers on Windows");
 #endif
   assignEvents(events, &dispatcher.base());
   event_add(&raw_event_, nullptr);
+  if (activate_fd_events_next_event_loop_) {
+    activation_cb_ = dispatcher.createSchedulableCallback([this]() {
+      ASSERT(injected_activation_events_ != 0);
+      mergeInjectedEventsAndRunCb(0);
+    });
+  }
 }
 
 void FileEventImpl::activate(uint32_t events) {
-  int libevent_events = 0;
-  if (events & FileReadyType::Read) {
-    libevent_events |= EV_READ;
+  // events is not empty.
+  ASSERT(events != 0);
+  // Only supported event types are set.
+  ASSERT((events & (FileReadyType::Read | FileReadyType::Write | FileReadyType::Closed)) == events);
+
+  if (!activate_fd_events_next_event_loop_) {
+    // Legacy implementation
+    int libevent_events = 0;
+    if (events & FileReadyType::Read) {
+      libevent_events |= EV_READ;
+    }
+
+    if (events & FileReadyType::Write) {
+      libevent_events |= EV_WRITE;
+    }
+
+    if (events & FileReadyType::Closed) {
+      libevent_events |= EV_CLOSED;
+    }
+
+    ASSERT(libevent_events);
+    event_active(&raw_event_, libevent_events, 0);
+    return;
   }
 
-  if (events & FileReadyType::Write) {
-    libevent_events |= EV_WRITE;
+  // Schedule the activation callback so it runs as part of the next loop iteration if it is not
+  // already scheduled.
+  if (injected_activation_events_ == 0) {
+    ASSERT(!activation_cb_->enabled());
+    activation_cb_->scheduleCallbackNextIteration();
   }
+  ASSERT(activation_cb_->enabled());
 
-  if (events & FileReadyType::Closed) {
-    libevent_events |= EV_CLOSED;
-  }
-
-  ASSERT(libevent_events);
-  event_active(&raw_event_, libevent_events, 0);
+  // Merge new events with pending injected events.
+  injected_activation_events_ |= events;
 }
 
 void FileEventImpl::assignEvents(uint32_t events, event_base* base) {
@@ -63,16 +92,34 @@ void FileEventImpl::assignEvents(uint32_t events, event_base* base) {
         }
 
         ASSERT(events != 0);
-        event->cb_(events);
+        event->mergeInjectedEventsAndRunCb(events);
       },
       this);
 }
 
 void FileEventImpl::setEnabled(uint32_t events) {
+  if (activate_fd_events_next_event_loop_ && injected_activation_events_ != 0) {
+    // Clear pending events on updates to the fd event mask to avoid delivering events that are no
+    // longer relevant. Updating the event mask will reset the fd edge trigger state so the proxy
+    // will be able to determine the fd read/write state without need for the injected activation
+    // events.
+    injected_activation_events_ = 0;
+    activation_cb_->cancel();
+  }
+
   auto* base = event_get_base(&raw_event_);
   event_del(&raw_event_);
   assignEvents(events, base);
   event_add(&raw_event_, nullptr);
+}
+
+void FileEventImpl::mergeInjectedEventsAndRunCb(uint32_t events) {
+  if (activate_fd_events_next_event_loop_ && injected_activation_events_ != 0) {
+    events |= injected_activation_events_;
+    injected_activation_events_ = 0;
+    activation_cb_->cancel();
+  }
+  cb_(events);
 }
 
 } // namespace Event

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -39,7 +39,7 @@ private:
   // Latched "envoy.reloadable_features.activate_fds_next_event_loop" runtime feature. If true, fd
   // events scheduled via activate are evaluated in the next iteration of the event loop after
   // polling and activating new fd events.
-  bool activate_fd_events_next_event_loop_;
+  const bool activate_fd_events_next_event_loop_;
 };
 
 } // namespace Event

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -25,10 +25,21 @@ public:
 
 private:
   void assignEvents(uint32_t events, event_base* base);
+  void mergeInjectedEventsAndRunCb(uint32_t events);
 
   FileReadyCb cb_;
   os_fd_t fd_;
   FileTriggerType trigger_;
+
+  // Injected FileReadyType events that were scheduled by recent calls to activate() and are pending
+  // delivery.
+  uint32_t injected_activation_events_{};
+  // Used to schedule delayed event activation. Armed iff pending_activation_events_ != 0.
+  SchedulableCallbackPtr activation_cb_;
+  // Latched "envoy.reloadable_features.activate_fds_next_event_loop" runtime feature. If true, fd
+  // events scheduled via activate are evaluated in the next iteration of the event loop after
+  // polling and activating new fd events.
+  bool activate_fd_events_next_event_loop_;
 };
 
 } // namespace Event

--- a/source/common/event/schedulable_cb_impl.cc
+++ b/source/common/event/schedulable_cb_impl.cc
@@ -24,6 +24,11 @@ void SchedulableCallbackImpl::scheduleCallbackCurrentIteration() {
   event_active(&raw_event_, EV_TIMEOUT, 0);
 }
 
+void SchedulableCallbackImpl::scheduleCallbackNextIteration() {
+  const timeval zero_tv{};
+  event_add(&raw_event_, &zero_tv);
+}
+
 void SchedulableCallbackImpl::cancel() { event_del(&raw_event_); }
 
 bool SchedulableCallbackImpl::enabled() { return 0 != evtimer_pending(&raw_event_, nullptr); }

--- a/source/common/event/schedulable_cb_impl.cc
+++ b/source/common/event/schedulable_cb_impl.cc
@@ -21,10 +21,15 @@ SchedulableCallbackImpl::SchedulableCallbackImpl(Libevent::BasePtr& libevent,
 }
 
 void SchedulableCallbackImpl::scheduleCallbackCurrentIteration() {
+  // event_active directly adds the event to the end of the work queue so it executes in the current
+  // iteration of the event loop.
   event_active(&raw_event_, EV_TIMEOUT, 0);
 }
 
 void SchedulableCallbackImpl::scheduleCallbackNextIteration() {
+  // libevent computes the list of timers to move to the work list after polling for fd events, but
+  // iteration through the work list starts. Zero delay timers added while iterating through the
+  // work list execute on the next iteration of the event loop.
   const timeval zero_tv{};
   event_add(&raw_event_, &zero_tv);
 }

--- a/source/common/event/schedulable_cb_impl.h
+++ b/source/common/event/schedulable_cb_impl.h
@@ -19,6 +19,7 @@ public:
 
   // SchedulableCallback implementation.
   void scheduleCallbackCurrentIteration() override;
+  void scheduleCallbackNextIteration() override;
   void cancel() override;
   bool enabled() override;
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -60,6 +60,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.strict_authority_validation",
     "envoy.reloadable_features.reject_unsupported_transfer_encodings",
     // Begin alphabetically sorted section.
+    "envoy.reloadable_features.activate_fds_next_event_loop",
     "envoy.deprecated_features.allow_deprecated_extension_names",
     "envoy.reloadable_features.disallow_unbounded_access_logs",
     "envoy.reloadable_features.enable_deprecated_v2_api_warning",

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -34,6 +34,7 @@ envoy_cc_test(
         "//source/common/stats:isolated_store_lib",
         "//test/mocks:common_lib",
         "//test/test_common:environment_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -45,7 +45,7 @@ protected:
   }
 };
 
-TEST_F(SchedulableCallbackImplTest, ScheduleAndCancel) {
+TEST_F(SchedulableCallbackImplTest, ScheduleCurrentAndCancel) {
   ReadyWatcher watcher;
 
   auto cb = dispatcher_->createSchedulableCallback([&]() { watcher.ready(); });
@@ -72,17 +72,50 @@ TEST_F(SchedulableCallbackImplTest, ScheduleAndCancel) {
   dispatcher_->run(Dispatcher::RunType::Block);
 }
 
+TEST_F(SchedulableCallbackImplTest, ScheduleNextAndCancel) {
+  ReadyWatcher watcher;
+
+  auto cb = dispatcher_->createSchedulableCallback([&]() { watcher.ready(); });
+
+  // Cancel is a no-op if not scheduled.
+  cb->cancel();
+  dispatcher_->run(Dispatcher::RunType::Block);
+
+  // Callback is not invoked if cancelled before it executes.
+  cb->scheduleCallbackNextIteration();
+  EXPECT_TRUE(cb->enabled());
+  cb->cancel();
+  EXPECT_FALSE(cb->enabled());
+  dispatcher_->run(Dispatcher::RunType::Block);
+
+  // Scheduled callback executes.
+  cb->scheduleCallbackNextIteration();
+  EXPECT_CALL(watcher, ready());
+  dispatcher_->run(Dispatcher::RunType::Block);
+
+  // Callbacks implicitly cancelled if runner is deleted.
+  cb->scheduleCallbackNextIteration();
+  cb.reset();
+  dispatcher_->run(Dispatcher::RunType::Block);
+}
+
 TEST_F(SchedulableCallbackImplTest, ScheduleOrder) {
   ReadyWatcher watcher0;
   createCallback([&]() { watcher0.ready(); });
   ReadyWatcher watcher1;
   createCallback([&]() { watcher1.ready(); });
+  ReadyWatcher watcher2;
+  createCallback([&]() { watcher2.ready(); });
 
-  // Callback run in the order they are scheduled.
-  callbacks_[0]->scheduleCallbackCurrentIteration();
+  // Current iteration callbacks run in the order they are scheduled. Next iteration callbacks run
+  // after current iteration callbacks.
+  callbacks_[0]->scheduleCallbackNextIteration();
   callbacks_[1]->scheduleCallbackCurrentIteration();
-  EXPECT_CALL(watcher0, ready());
+  callbacks_[2]->scheduleCallbackCurrentIteration();
+  InSequence s;
   EXPECT_CALL(watcher1, ready());
+  EXPECT_CALL(watcher2, ready());
+  EXPECT_CALL(watcher0, ready());
   dispatcher_->run(Dispatcher::RunType::Block);
 }
 
@@ -103,6 +136,7 @@ TEST_F(SchedulableCallbackImplTest, ScheduleChainingAndCancellation) {
     callbacks_[2]->scheduleCallbackCurrentIteration();
     callbacks_[3]->scheduleCallbackCurrentIteration();
     callbacks_[4]->scheduleCallbackCurrentIteration();
+    callbacks_[5]->scheduleCallbackNextIteration();
   });
 
   ReadyWatcher watcher2;
@@ -120,14 +154,21 @@ TEST_F(SchedulableCallbackImplTest, ScheduleChainingAndCancellation) {
   ReadyWatcher watcher4;
   createCallback([&]() { watcher4.ready(); });
 
+  ReadyWatcher watcher5;
+  createCallback([&]() { watcher5.ready(); });
+
   // Chained callbacks run in the same event loop iteration, as signaled by a single call to
   // prepare_watcher.ready(). watcher3 and watcher4 are not invoked because cb2 cancels
-  // cb3 and deletes cb4 as part of its execution.
+  // cb3 and deletes cb4 as part of its execution. cb5 runs after a second call to the
+  // prepare callback since it's scheduled for the next iteration.
   callbacks_[0]->scheduleCallbackCurrentIteration();
+  InSequence s;
   EXPECT_CALL(prepare_watcher, ready());
   EXPECT_CALL(watcher0, ready());
   EXPECT_CALL(watcher1, ready());
   EXPECT_CALL(watcher2, ready());
+  EXPECT_CALL(prepare_watcher, ready());
+  EXPECT_CALL(watcher5, ready());
   dispatcher_->run(Dispatcher::RunType::Block);
 }
 

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -168,7 +168,7 @@ TEST_P(FileEventImplActivateTest, ActivateChaining) {
   EXPECT_CALL(fd_event, ready());
   EXPECT_CALL(read_event, ready());
   EXPECT_CALL(write_event, ready());
-  if (activate_fds_next_event_loop()) {
+  if (activateFdsNextEventLoop()) {
     // Second loop iteration: handle write and close events scheduled while handling read.
     EXPECT_CALL(prepare_watcher, ready());
     EXPECT_CALL(fd_event, ready());

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -53,7 +53,7 @@ public:
   FileEventImplActivateTest() : os_sys_calls_(Api::OsSysCallsSingleton::get()) {
     Runtime::LoaderSingleton::getExisting()->mergeValues(
         {{"envoy.reloadable_features.activate_fds_next_event_loop",
-          activate_fds_next_event_loop() ? "true" : "false"}});
+          activateFdsNextEventLoop() ? "true" : "false"}});
   }
 
   static void onWatcherReady(evwatch*, const evwatch_prepare_cb_info*, void* arg) {
@@ -65,7 +65,7 @@ public:
   int domain() {
     return std::get<0>(GetParam()) == Network::Address::IpVersion::v4 ? AF_INET : AF_INET6;
   }
-  bool activate_fds_next_event_loop() { return std::get<1>(GetParam()); }
+  bool activateFdsNextEventLoop() { return std::get<1>(GetParam()); }
 
 protected:
   Api::OsSysCalls& os_sys_calls_;

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -8,6 +8,7 @@
 
 #include "test/mocks/common.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -46,22 +47,37 @@ protected:
   Api::OsSysCalls& os_sys_calls_;
 };
 
-class FileEventImplActivateTest : public testing::TestWithParam<Network::Address::IpVersion> {
+class FileEventImplActivateTest
+    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, bool>> {
 public:
-  FileEventImplActivateTest() : os_sys_calls_(Api::OsSysCallsSingleton::get()) {}
+  FileEventImplActivateTest() : os_sys_calls_(Api::OsSysCallsSingleton::get()) {
+    Runtime::LoaderSingleton::getExisting()->mergeValues(
+        {{"envoy.reloadable_features.activate_fds_next_event_loop",
+          activate_fds_next_event_loop() ? "true" : "false"}});
+  }
+
+  static void onWatcherReady(evwatch*, const evwatch_prepare_cb_info*, void* arg) {
+    // `arg` contains the ReadyWatcher passed in from evwatch_prepare_new.
+    auto watcher = static_cast<ReadyWatcher*>(arg);
+    watcher->ready();
+  }
+
+  int domain() {
+    return std::get<0>(GetParam()) == Network::Address::IpVersion::v4 ? AF_INET : AF_INET6;
+  }
+  bool activate_fds_next_event_loop() { return std::get<1>(GetParam()); }
 
 protected:
   Api::OsSysCalls& os_sys_calls_;
+  TestScopedRuntime scoped_runtime_;
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, FileEventImplActivateTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, FileEventImplActivateTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()), testing::Bool()));
 
 TEST_P(FileEventImplActivateTest, Activate) {
-  os_fd_t fd;
-  int domain = GetParam() == Network::Address::IpVersion::v4 ? AF_INET : AF_INET6;
-  fd = os_sys_calls_.socket(domain, SOCK_STREAM, 0).rc_;
+  os_fd_t fd = os_sys_calls_.socket(domain(), SOCK_STREAM, 0).rc_;
   ASSERT_TRUE(SOCKET_VALID(fd));
 
   Api::ApiPtr api = Api::createApiForTest();
@@ -97,6 +113,149 @@ TEST_P(FileEventImplActivateTest, Activate) {
       trigger, FileReadyType::Read | FileReadyType::Write | FileReadyType::Closed);
 
   file_event->activate(FileReadyType::Read | FileReadyType::Write | FileReadyType::Closed);
+  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+
+  os_sys_calls_.close(fd);
+}
+
+TEST_P(FileEventImplActivateTest, ActivateChaining) {
+  os_fd_t fd = os_sys_calls_.socket(domain(), SOCK_STREAM, 0).rc_;
+  ASSERT_TRUE(SOCKET_VALID(fd));
+
+  Api::ApiPtr api = Api::createApiForTest();
+  DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
+  ReadyWatcher fd_event;
+  ReadyWatcher read_event;
+  ReadyWatcher write_event;
+  ReadyWatcher closed_event;
+
+  ReadyWatcher prepare_watcher;
+  evwatch_prepare_new(&static_cast<DispatcherImpl*>(dispatcher.get())->base(), onWatcherReady,
+                      &prepare_watcher);
+
+#ifdef WIN32
+  const FileTriggerType trigger = FileTriggerType::Level;
+#else
+  const FileTriggerType trigger = FileTriggerType::Edge;
+#endif
+
+  Event::FileEventPtr file_event = dispatcher->createFileEvent(
+      fd,
+      [&](uint32_t events) -> void {
+        fd_event.ready();
+        if (events & FileReadyType::Read) {
+          read_event.ready();
+          file_event->activate(FileReadyType::Write);
+          file_event->activate(FileReadyType::Closed);
+        }
+
+        if (events & FileReadyType::Write) {
+          write_event.ready();
+          file_event->activate(FileReadyType::Closed);
+        }
+
+        if (events & FileReadyType::Closed) {
+          closed_event.ready();
+        }
+      },
+      trigger, FileReadyType::Read | FileReadyType::Write | FileReadyType::Closed);
+
+  testing::InSequence s;
+  // First loop iteration: handle scheduled read event and the real write event produced by poll.
+  // Note that the real and injected events are combined and delivered in a single call to the fd
+  // callback.
+  EXPECT_CALL(prepare_watcher, ready());
+  EXPECT_CALL(fd_event, ready());
+  EXPECT_CALL(read_event, ready());
+  EXPECT_CALL(write_event, ready());
+  if (activate_fds_next_event_loop()) {
+    // Second loop iteration: handle write and close events scheduled while handling read.
+    EXPECT_CALL(prepare_watcher, ready());
+    EXPECT_CALL(fd_event, ready());
+    EXPECT_CALL(write_event, ready());
+    EXPECT_CALL(closed_event, ready());
+    // Third loop iteration: handle close event scheduled while handling write.
+    EXPECT_CALL(prepare_watcher, ready());
+    EXPECT_CALL(fd_event, ready());
+    EXPECT_CALL(closed_event, ready());
+    // Fourth loop iteration: poll returned no new real events.
+    EXPECT_CALL(prepare_watcher, ready());
+  } else {
+    // Same loop iteration activation: handle write and close events scheduled while handling read.
+    EXPECT_CALL(fd_event, ready());
+    EXPECT_CALL(write_event, ready());
+    EXPECT_CALL(closed_event, ready());
+    // Second same loop iteration activation: handle close event scheduled while handling write.
+    EXPECT_CALL(fd_event, ready());
+    EXPECT_CALL(closed_event, ready());
+    // Second loop iteration: poll returned no new real events.
+    EXPECT_CALL(prepare_watcher, ready());
+  }
+
+  file_event->activate(FileReadyType::Read);
+  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+
+  os_sys_calls_.close(fd);
+}
+
+TEST_P(FileEventImplActivateTest, SetEnableCancelsActivate) {
+  os_fd_t fd = os_sys_calls_.socket(domain(), SOCK_STREAM, 0).rc_;
+  ASSERT_TRUE(SOCKET_VALID(fd));
+
+  Api::ApiPtr api = Api::createApiForTest();
+  DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
+  ReadyWatcher fd_event;
+  ReadyWatcher read_event;
+  ReadyWatcher write_event;
+  ReadyWatcher closed_event;
+
+  ReadyWatcher prepare_watcher;
+  evwatch_prepare_new(&static_cast<DispatcherImpl*>(dispatcher.get())->base(), onWatcherReady,
+                      &prepare_watcher);
+
+#ifdef WIN32
+  const FileTriggerType trigger = FileTriggerType::Level;
+#else
+  const FileTriggerType trigger = FileTriggerType::Edge;
+#endif
+
+  Event::FileEventPtr file_event = dispatcher->createFileEvent(
+      fd,
+      [&](uint32_t events) -> void {
+        fd_event.ready();
+        if (events & FileReadyType::Read) {
+          read_event.ready();
+          file_event->activate(FileReadyType::Closed);
+          file_event->setEnabled(FileReadyType::Write | FileReadyType::Closed);
+        }
+
+        if (events & FileReadyType::Write) {
+          write_event.ready();
+        }
+
+        if (events & FileReadyType::Closed) {
+          closed_event.ready();
+        }
+      },
+      trigger, FileReadyType::Read | FileReadyType::Write | FileReadyType::Closed);
+
+  testing::InSequence s;
+  // First loop iteration: handle scheduled read event and the real write event produced by poll.
+  // Note that the real and injected events are combined and delivered in a single call to the fd
+  // callback.
+  EXPECT_CALL(prepare_watcher, ready());
+  EXPECT_CALL(fd_event, ready());
+  EXPECT_CALL(read_event, ready());
+  EXPECT_CALL(write_event, ready());
+  // Second loop iteration: handle real write event after resetting event mask via setEnabled. Close
+  // injected event is discarded by the setEnable call.
+  EXPECT_CALL(prepare_watcher, ready());
+  EXPECT_CALL(fd_event, ready());
+  EXPECT_CALL(write_event, ready());
+  // Third loop iteration: poll returned no new real events.
+  EXPECT_CALL(prepare_watcher, ready());
+
+  file_event->activate(FileReadyType::Read);
   dispatcher->run(Event::Dispatcher::RunType::NonBlock);
 
   os_sys_calls_.close(fd);

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -59,6 +59,7 @@ MockSchedulableCallback::MockSchedulableCallback(MockDispatcher* dispatcher)
       .WillOnce(DoAll(SaveArg<0>(&callback_), Return(this)))
       .RetiresOnSaturation();
   ON_CALL(*this, scheduleCallbackCurrentIteration()).WillByDefault(Assign(&enabled_, true));
+  ON_CALL(*this, scheduleCallbackNextIteration()).WillByDefault(Assign(&enabled_, true));
   ON_CALL(*this, cancel()).WillByDefault(Assign(&enabled_, false));
   ON_CALL(*this, enabled()).WillByDefault(ReturnPointee(&enabled_));
 }

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -187,6 +187,7 @@ public:
 
   // SchedulableCallback
   MOCK_METHOD(void, scheduleCallbackCurrentIteration, ());
+  MOCK_METHOD(void, scheduleCallbackNextIteration, ());
   MOCK_METHOD(void, cancel, ());
   MOCK_METHOD(bool, enabled, ());
 


### PR DESCRIPTION
Commit Message: dispatcher: Delay fd activation until the next itertion of the event loop.
Additional Description: Processing injected fd events in the same loop they are generated can result in high-throughput connections proxying data multiple times per event loop iteration, effectively starving other connections and increasing small request latency.
Risk Level: high, changes to event loop scheduling behavior and fd event delivery
Testing: unit
Docs Changes: n/a
Release Notes: n/a
Runtime guard: envoy.reloadable_features.activate_fds_next_event_loop