### PR TITLE
api: Add transport_api_version to SelfConfigSource.

### DIFF
--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -110,6 +110,10 @@ message AggregatedConfigSource {
 // specify that other data can be obtained from the same server.
 message SelfConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.SelfConfigSource";
+
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -112,6 +112,10 @@ message AggregatedConfigSource {
 message SelfConfigSource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.core.v3.SelfConfigSource";
+
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.

--- a/generated_api_shadow/envoy/config/core/v3/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v3/config_source.proto
@@ -110,6 +110,10 @@ message AggregatedConfigSource {
 // specify that other data can be obtained from the same server.
 message SelfConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.SelfConfigSource";
+
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.

--- a/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
@@ -112,6 +112,10 @@ message AggregatedConfigSource {
 message SelfConfigSource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.core.v3.SelfConfigSource";
+
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Add transport_api_version to SelfConfigSource.
Additional Description: This will allow configuring the version of LRS independently from the version of xDS in the `lrs_server` field in `Cluster` messages.
Risk Level: Low
Testing: N/A
Docs Changes: Inline in PR
Release Notes: N/A