### PR TITLE
admission control: Use less iterations in integration test

### DIFF
--- a/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
@@ -95,7 +95,7 @@ TEST_P(AdmissionControlIntegrationTest, HttpTest) {
 
   // Drop the success rate to a very low value.
   ENVOY_LOG(info, "dropping success rate");
-  for (int i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 300; ++i) {
     sendRequestWithReturnCode("500");
   }
 
@@ -103,7 +103,7 @@ TEST_P(AdmissionControlIntegrationTest, HttpTest) {
   double throttle_count = 0;
   double request_count = 0;
   ENVOY_LOG(info, "validating throttling rate");
-  for (int i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 300; ++i) {
     auto response = sendRequestWithReturnCode("500");
     auto rc = response->headers().Status()->value().getStringView();
     if (rc == "503") {
@@ -133,14 +133,14 @@ TEST_P(AdmissionControlIntegrationTest, GrpcTest) {
   initialize();
 
   // Drop the success rate to a very low value.
-  for (int i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 300; ++i) {
     sendGrpcRequestWithReturnCode(14);
   }
 
   // Measure throttling rate from the admission control filter.
   double throttle_count = 0;
   double request_count = 0;
-  for (int i = 0; i < 1000; ++i) {
+  for (int i = 0; i < 300; ++i) {
     auto response = sendGrpcRequestWithReturnCode(10);
 
     // When the filter is throttling, it returns an HTTP code 503 and the GRPC status is unset.


### PR DESCRIPTION
The admission control integration test occasionally times out when running through CI with a TSAN build (#11758). To address this, the admission control integration test now performs less iterations.

Local testing does not exhibit the timeouts observed in CI after ~1000 runs. Prior to this patch it was easily reproduced.
```
//test/extensions/filters/http/admission_control:admission_control_integration_test PASSED in 99.0s
  Stats over 1000 runs: max = 99.0s, min = 96.1s, avg = 97.7s, dev = 0.4s
```

Risk Level: Negligible
Testing: 1000 TSAN runs of integration test
Docs Changes: n/a
Release Notes: n/a
