### PR TITLE
bazel: Fix to avoid effects of any whitespaces in PATH when creating clang.bazelrc

### DIFF
--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -14,7 +14,7 @@ export PATH="$(${LLVM_PREFIX}/bin/llvm-config --bindir):${PATH}"
 RT_LIBRARY_PATH="$(dirname $(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1))"
 
 echo "# Generated file, do not edit. If you want to disable clang, just delete this file.
-build:clang --action_env=PATH=${PATH}
+build:clang --action_env='PATH=${PATH}'
 build:clang --action_env=CC=clang
 build:clang --action_env=CXX=clang++
 build:clang --action_env=LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -17,15 +17,15 @@ echo "# Generated file, do not edit. If you want to disable clang, just delete t
 build:clang --action_env='PATH=${PATH}'
 build:clang --action_env=CC=clang
 build:clang --action_env=CXX=clang++
-build:clang --action_env=LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config
-build:clang --repo_env=LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config
-build:clang --linkopt=-L$(llvm-config --libdir)
-build:clang --linkopt=-Wl,-rpath,$(llvm-config --libdir)
+build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
+build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
+build:clang --linkopt='-L$(llvm-config --libdir)'
+build:clang --linkopt='-Wl,-rpath,$(llvm-config --libdir)'
 
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
 build:clang-asan --copt=-fsanitize=vptr,function
 build:clang-asan --linkopt=-fsanitize=vptr,function
-build:clang-asan --linkopt=-L${RT_LIBRARY_PATH}
+build:clang-asan --linkopt='-L${RT_LIBRARY_PATH}'
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone-x86_64.a
 build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx-x86_64.a
 " > ${BAZELRC_FILE}


### PR DESCRIPTION
Signed-off-by: Kotaro Inoue <k.musaino@gmail.com>

This fixes some errors due to containing some whitespaces in PATH.
I encountered `target names may not start with '/'`, and I found that this comes from some whitespaces contained in $PATH.
I confirmed this issue on Ubuntu on WSL1, however, it is a general issue and could occur in other platforms.

Commit Message: Fix to avoid effects of any whitespaces in PATH when creating clang.bazelrc
Additional Description: This fixes some errors due to containing some whitespaces in PATH.
Risk Level: Low
Testing: Yes (confirmed that build worked well with generated clang.bazelrc)
