### PR TITLE
Support dynamic limit override in ratelimit filter

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1497,6 +1497,24 @@ message RateLimit {
     }
   }
 
+  message Override {
+    // Fetches the override from the dynamic metadata.
+    message DynamicMetadata {
+      // Metadata struct that defines the key and path to retrieve the struct value.
+      // The value must be a struct containing an integer "requests_per_unit" property
+      // and a "unit" property with a value parseable to :ref:`RateLimitUnit
+      // enum <envoy_api_enum_type.v3.RateLimitUnit>`
+      type.metadata.v3.MetadataKey metadata_key = 1 [(validate.rules).message = {required: true}];
+    }
+
+    oneof override_specifier {
+      option (validate.required) = true;
+
+      // Limit override from dynamic metadata.
+      DynamicMetadata dynamic_metadata = 1;
+    }
+  }
+
   // Refers to the stage set in the filter. The rate limit configuration only
   // applies to filters with the same stage number. The default stage number is
   // 0.
@@ -1516,6 +1534,12 @@ message RateLimit {
   // configuration. See :ref:`composing actions
   // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
   repeated Action actions = 3 [(validate.rules).repeated = {min_items: 1}];
+
+  // An optional limit override to be appended to the descriptor produced by this
+  // rate limit configuration. If the override value is invalid or cannot be resolved
+  // from metadata, no override is provided. See :ref:`rate limit override
+  // <config_http_filters_rate_limit_rate_limit_override>` for more information.
+  Override limit = 4;
 }
 
 // .. attention::

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1479,6 +1479,30 @@ message RateLimit {
     }
   }
 
+  message Override {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.route.v3.RateLimit.Override";
+
+    // Fetches the override from the dynamic metadata.
+    message DynamicMetadata {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.config.route.v3.RateLimit.Override.DynamicMetadata";
+
+      // Metadata struct that defines the key and path to retrieve the struct value.
+      // The value must be a struct containing an integer "requests_per_unit" property
+      // and a "unit" property with a value parseable to :ref:`RateLimitUnit
+      // enum <envoy_api_enum_type.v3.RateLimitUnit>`
+      type.metadata.v3.MetadataKey metadata_key = 1 [(validate.rules).message = {required: true}];
+    }
+
+    oneof override_specifier {
+      option (validate.required) = true;
+
+      // Limit override from dynamic metadata.
+      DynamicMetadata dynamic_metadata = 1;
+    }
+  }
+
   // Refers to the stage set in the filter. The rate limit configuration only
   // applies to filters with the same stage number. The default stage number is
   // 0.
@@ -1498,6 +1522,12 @@ message RateLimit {
   // configuration. See :ref:`composing actions
   // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
   repeated Action actions = 3 [(validate.rules).repeated = {min_items: 1}];
+
+  // An optional limit override to be appended to the descriptor produced by this
+  // rate limit configuration. If the override value is invalid or cannot be resolved
+  // from metadata, no override is provided. See :ref:`rate limit override
+  // <config_http_filters_rate_limit_rate_limit_override>` for more information.
+  Override limit = 4;
 }
 
 // .. attention::

--- a/api/envoy/extensions/common/ratelimit/v3/BUILD
+++ b/api/envoy/extensions/common/ratelimit/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/api/v2/ratelimit:pkg",
+        "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/extensions/common/ratelimit/v3/ratelimit.proto
+++ b/api/envoy/extensions/common/ratelimit/v3/ratelimit.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.common.ratelimit.v3;
 
+import "envoy/type/v3/ratelimit_unit.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -54,6 +56,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // The idea behind the API is that (1)/(2)/(3) and (4)/(5) can be sent in 1 request if desired.
 // This enables building complex application scenarios with a generic backend.
+//
+// Optionally the descriptor can contain a limit override under a "limit" key, that specifies
+// the number of requests per unit to use instead of the number configured in the
+// rate limiting service.
 message RateLimitDescriptor {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.ratelimit.RateLimitDescriptor";
@@ -69,6 +75,20 @@ message RateLimitDescriptor {
     string value = 2 [(validate.rules).string = {min_bytes: 1}];
   }
 
+  // Override rate limit to apply to this descriptor instead of the limit
+  // configured in the rate limit service. See :ref:`rate limit override
+  // <config_http_filters_rate_limit_rate_limit_override>` for more information.
+  message RateLimitOverride {
+    // The number of requests per unit of time.
+    uint32 requests_per_unit = 1;
+
+    // The unit of time.
+    type.v3.RateLimitUnit unit = 2 [(validate.rules).enum = {defined_only: true}];
+  }
+
   // Descriptor entries.
   repeated Entry entries = 1 [(validate.rules).repeated = {min_items: 1}];
+
+  // Optional rate limit override to supply to the ratelimit service.
+  RateLimitOverride limit = 2;
 }

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -69,6 +69,8 @@ message RateLimitResponse {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.service.ratelimit.v2.RateLimitResponse.RateLimit";
 
+    // Identifies the unit of of time for rate limit.
+    // [#comment: replace by envoy/type/v3/ratelimit_unit.proto in v4]
     enum Unit {
       // The time unit is not known.
       UNKNOWN = 0;

--- a/api/envoy/type/v3/ratelimit_unit.proto
+++ b/api/envoy/type/v3/ratelimit_unit.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package envoy.type.v3;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.type.v3";
+option java_outer_classname = "RatelimitUnitProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Ratelimit Time Unit]
+
+// Identifies the unit of of time for rate limit.
+enum RateLimitUnit {
+  // The time unit is not known.
+  UNKNOWN = 0;
+
+  // The time unit representing a second.
+  SECOND = 1;
+
+  // The time unit representing a minute.
+  MINUTE = 2;
+
+  // The time unit representing an hour.
+  HOUR = 3;
+
+  // The time unit representing a day.
+  DAY = 4;
+}

--- a/docs/root/api-v3/types/types.rst
+++ b/docs/root/api-v3/types/types.rst
@@ -10,6 +10,7 @@ Types
   ../type/v3/http_status.proto
   ../type/v3/percent.proto
   ../type/v3/range.proto
+  ../type/v3/ratelimit_unit.proto
   ../type/v3/semantic_version.proto
   ../type/v3/token_bucket.proto
   ../type/matcher/v3/metadata.proto

--- a/docs/root/configuration/advanced/well_known_dynamic_metadata.rst
+++ b/docs/root/configuration/advanced/well_known_dynamic_metadata.rst
@@ -18,3 +18,7 @@ The following Envoy filters emit dynamic metadata that other filters can leverag
 * :ref:`Role Based Access Control (RBAC) Filter <config_http_filters_rbac_dynamic_metadata>`
 * :ref:`Role Based Access Control (RBAC) Network Filter <config_network_filters_rbac_dynamic_metadata>`
 * :ref:`ZooKeeper Proxy Filter <config_network_filters_zookeeper_proxy_dynamic_metadata>`
+
+The following Envoy filters can be configured to consume dynamic metadata emitted by other filters.
+
+* :ref:`RateLimit Filter limit override <config_http_filters_rate_limit_override_dynamic_metadata>`

--- a/docs/root/configuration/http/http_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_filter.rst
@@ -105,7 +105,12 @@ The following configuration
          path:
              - key: test
 
-Will lookup the value of the dynamic metadata, and if it contains the following structure:
+.. _config_http_filters_rate_limit_override_dynamic_metadata:
+
+Will lookup the value of the dynamic metadata. The value must be a structure with integer field
+"requests_per_unit" and a string field "unit" which is parseable to :ref:`RateLimitUnit enum
+<envoy_v3_api_enum_type.v3.RateLimitUnit>`. For example, with the following dynamic metadata
+the rate limit override of 42 requests per hour will be appended to the rate limit descriptor.
 
 .. code-block:: yaml
 
@@ -113,8 +118,6 @@ Will lookup the value of the dynamic metadata, and if it contains the following 
       test:
           requests_per_unit: 42
           unit: HOUR
-
-The rate limit override of 42 requests per hour will be appended to the rate limit descriptor.
 
 Statistics
 ----------

--- a/docs/root/configuration/http/http_filters/rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_filter.rst
@@ -75,6 +75,47 @@ the following descriptor is generated:
   ("remote_address", "<trusted address from x-forwarded-for>")
   ("source_cluster", "from_cluster")
 
+.. _config_http_filters_rate_limit_rate_limit_override:
+
+Rate Limit Override
+-------------------
+
+A :ref:`rate limit action <envoy_v3_api_msg_config.route.v3.RateLimit>` can optionally contain
+a :ref:`limit override <envoy_v3_api_msg_config.route.v3.RateLimit.Override>`. The limit value
+will be appended to the descriptor produced by the action and sent to the ratelimit service,
+overriding the static service configuration.
+
+The override can be configured to be taken from the :ref:`Dynamic Metadata
+<envoy_v3_api_msg_config.core.v3.Metadata>` under a specified :ref: `key
+<envoy_v3_api_msg_config.type.metadata.v3.MetadataKey>`. If the value is misconfigured
+or key does not exist, the override configuration is ignored.
+
+Example 3
+^^^^^^^^^
+
+The following configuration
+
+.. code-block:: yaml
+
+  actions:
+      - {generic_key: {descriptor_value: some_value}}
+  limit:
+     metadata_key:
+         key: test.filter.key
+         path:
+             - key: test
+
+Will lookup the value of the dynamic metadata, and if it contains the following structure:
+
+.. code-block:: yaml
+
+  test.filter.key:
+      test:
+          requests_per_unit: 42
+          unit: HOUR
+
+The rate limit override of 42 requests per hour will be appended to the rate limit descriptor.
+
 Statistics
 ----------
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -107,6 +107,7 @@ New Features
 * network filters: added a :ref:`rocketmq proxy filter <config_network_filters_rocketmq_proxy>`.
 * ratelimit: add support for use of dynamic metadata :ref:`dynamic_metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` as a ratelimit action.
 * ratelimit: added :ref:`API version <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
+* ratelimit: support specifying dynamic overrides in rate limit descriptors using :ref:`limit override <envoy_v3_api_field_config.route.v3.RateLimit.limit>` config.
 * redis: added acl support :ref:`downstream_auth_username <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.downstream_auth_username>` for downstream client ACL authentication, and :ref:`auth_username <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProtocolOptions.auth_username>` to configure authentication usernames for upstream Redis 6+ server clusters with ACL enabled.
 * regex: added support for enforcing max program size via runtime and stats to monitor program size for :ref:`Google RE2 <envoy_v3_api_field_type.matcher.v3.RegexMatcher.GoogleRE2.max_program_size>`.
 * request_id: added to :ref:`always_set_request_id_in_response setting <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.always_set_request_id_in_response>`

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1509,6 +1509,24 @@ message RateLimit {
     }
   }
 
+  message Override {
+    // Fetches the override from the dynamic metadata.
+    message DynamicMetadata {
+      // Metadata struct that defines the key and path to retrieve the struct value.
+      // The value must be a struct containing an integer "requests_per_unit" property
+      // and a "unit" property with a value parseable to :ref:`RateLimitUnit
+      // enum <envoy_api_enum_type.v3.RateLimitUnit>`
+      type.metadata.v3.MetadataKey metadata_key = 1 [(validate.rules).message = {required: true}];
+    }
+
+    oneof override_specifier {
+      option (validate.required) = true;
+
+      // Limit override from dynamic metadata.
+      DynamicMetadata dynamic_metadata = 1;
+    }
+  }
+
   // Refers to the stage set in the filter. The rate limit configuration only
   // applies to filters with the same stage number. The default stage number is
   // 0.
@@ -1528,6 +1546,12 @@ message RateLimit {
   // configuration. See :ref:`composing actions
   // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
   repeated Action actions = 3 [(validate.rules).repeated = {min_items: 1}];
+
+  // An optional limit override to be appended to the descriptor produced by this
+  // rate limit configuration. If the override value is invalid or cannot be resolved
+  // from metadata, no override is provided. See :ref:`rate limit override
+  // <config_http_filters_rate_limit_rate_limit_override>` for more information.
+  Override limit = 4;
 }
 
 // .. attention::

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1507,6 +1507,30 @@ message RateLimit {
     }
   }
 
+  message Override {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.route.v3.RateLimit.Override";
+
+    // Fetches the override from the dynamic metadata.
+    message DynamicMetadata {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.config.route.v3.RateLimit.Override.DynamicMetadata";
+
+      // Metadata struct that defines the key and path to retrieve the struct value.
+      // The value must be a struct containing an integer "requests_per_unit" property
+      // and a "unit" property with a value parseable to :ref:`RateLimitUnit
+      // enum <envoy_api_enum_type.v3.RateLimitUnit>`
+      type.metadata.v3.MetadataKey metadata_key = 1 [(validate.rules).message = {required: true}];
+    }
+
+    oneof override_specifier {
+      option (validate.required) = true;
+
+      // Limit override from dynamic metadata.
+      DynamicMetadata dynamic_metadata = 1;
+    }
+  }
+
   // Refers to the stage set in the filter. The rate limit configuration only
   // applies to filters with the same stage number. The default stage number is
   // 0.
@@ -1526,6 +1550,12 @@ message RateLimit {
   // configuration. See :ref:`composing actions
   // <config_http_filters_rate_limit_composing_actions>` for additional documentation.
   repeated Action actions = 3 [(validate.rules).repeated = {min_items: 1}];
+
+  // An optional limit override to be appended to the descriptor produced by this
+  // rate limit configuration. If the override value is invalid or cannot be resolved
+  // from metadata, no override is provided. See :ref:`rate limit override
+  // <config_http_filters_rate_limit_rate_limit_override>` for more information.
+  Override limit = 4;
 }
 
 // .. attention::

--- a/generated_api_shadow/envoy/extensions/common/ratelimit/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/common/ratelimit/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/api/v2/ratelimit:pkg",
+        "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/common/ratelimit/v3/ratelimit.proto
+++ b/generated_api_shadow/envoy/extensions/common/ratelimit/v3/ratelimit.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.common.ratelimit.v3;
 
+import "envoy/type/v3/ratelimit_unit.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -54,6 +56,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // The idea behind the API is that (1)/(2)/(3) and (4)/(5) can be sent in 1 request if desired.
 // This enables building complex application scenarios with a generic backend.
+//
+// Optionally the descriptor can contain a limit override under a "limit" key, that specifies
+// the number of requests per unit to use instead of the number configured in the
+// rate limiting service.
 message RateLimitDescriptor {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.ratelimit.RateLimitDescriptor";
@@ -69,6 +75,20 @@ message RateLimitDescriptor {
     string value = 2 [(validate.rules).string = {min_bytes: 1}];
   }
 
+  // Override rate limit to apply to this descriptor instead of the limit
+  // configured in the rate limit service. See :ref:`rate limit override
+  // <config_http_filters_rate_limit_rate_limit_override>` for more information.
+  message RateLimitOverride {
+    // The number of requests per unit of time.
+    uint32 requests_per_unit = 1;
+
+    // The unit of time.
+    type.v3.RateLimitUnit unit = 2 [(validate.rules).enum = {defined_only: true}];
+  }
+
   // Descriptor entries.
   repeated Entry entries = 1 [(validate.rules).repeated = {min_items: 1}];
+
+  // Optional rate limit override to supply to the ratelimit service.
+  RateLimitOverride limit = 2;
 }

--- a/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
@@ -69,6 +69,8 @@ message RateLimitResponse {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.service.ratelimit.v2.RateLimitResponse.RateLimit";
 
+    // Identifies the unit of of time for rate limit.
+    // [#comment: replace by envoy/type/v3/ratelimit_unit.proto in v4]
     enum Unit {
       // The time unit is not known.
       UNKNOWN = 0;

--- a/generated_api_shadow/envoy/type/v3/ratelimit_unit.proto
+++ b/generated_api_shadow/envoy/type/v3/ratelimit_unit.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package envoy.type.v3;
+
+import "udpa/annotations/status.proto";
+
+option java_package = "io.envoyproxy.envoy.type.v3";
+option java_outer_classname = "RatelimitUnitProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Ratelimit Time Unit]
+
+// Identifies the unit of of time for rate limit.
+enum RateLimitUnit {
+  // The time unit is not known.
+  UNKNOWN = 0;
+
+  // The time unit representing a second.
+  SECOND = 1;
+
+  // The time unit representing a minute.
+  MINUTE = 2;
+
+  // The time unit representing an hour.
+  HOUR = 3;
+
+  // The time unit representing a day.
+  DAY = 4;
+}

--- a/include/envoy/ratelimit/BUILD
+++ b/include/envoy/ratelimit/BUILD
@@ -11,4 +11,7 @@ envoy_package()
 envoy_cc_library(
     name = "ratelimit_interface",
     hdrs = ["ratelimit.h"],
+    deps = [
+        "@envoy_api//envoy/type/v3:pkg_cc_proto",
+    ],
 )

--- a/include/envoy/ratelimit/ratelimit.h
+++ b/include/envoy/ratelimit/ratelimit.h
@@ -3,8 +3,20 @@
 #include <string>
 #include <vector>
 
+#include "envoy/type/v3/ratelimit_unit.pb.h"
+
+#include "absl/types/optional.h"
+
 namespace Envoy {
 namespace RateLimit {
+
+/**
+ * An optional dynamic override for the rate limit. See ratelimit.proto
+ */
+struct RateLimitOverride {
+  uint32_t requests_per_unit_;
+  envoy::type::v3::RateLimitUnit unit_;
+};
 
 /**
  * A single rate limit request descriptor entry. See ratelimit.proto.
@@ -19,6 +31,7 @@ struct DescriptorEntry {
  */
 struct Descriptor {
   std::vector<DescriptorEntry> entries_;
+  absl::optional<RateLimitOverride> limit_ = absl::nullopt;
 };
 
 } // namespace RateLimit

--- a/include/envoy/router/router_ratelimit.h
+++ b/include/envoy/router/router_ratelimit.h
@@ -12,6 +12,26 @@
 
 namespace Envoy {
 namespace Router {
+
+/**
+ * Base interface for generic rate limit override action.
+ */
+class RateLimitOverrideAction {
+public:
+  virtual ~RateLimitOverrideAction() = default;
+
+  /**
+   * Potentially populate the descriptors 'limit' property with a RateLimitOverride instance
+   * @param descriptor supplies the descriptor to optionally fill.
+   * @param metadata supplies the dynamic metadata for the request.
+   * @return true if RateLimitOverride was set in the descriptor.
+   */
+  virtual bool populateOverride(RateLimit::Descriptor& descriptor,
+                                const envoy::config::core::v3::Metadata* metadata) const PURE;
+};
+
+using RateLimitOverrideActionPtr = std::unique_ptr<RateLimitOverrideAction>;
+
 /**
  * Base interface for generic rate limit action.
  */

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -13,8 +13,27 @@
 #include "common/config/metadata.h"
 #include "common/http/header_utility.h"
 
+#include "absl/types/optional.h"
+
 namespace Envoy {
 namespace Router {
+
+/**
+ * Populate rate limit override from dynamic metadata.
+ */
+class DynamicMetadataRateLimitOverride : public RateLimitOverrideAction {
+public:
+  DynamicMetadataRateLimitOverride(
+      const envoy::config::route::v3::RateLimit::Override::DynamicMetadata& config)
+      : metadata_key_(config.metadata_key()) {}
+
+  // Router::RateLimitOverrideAction
+  bool populateOverride(RateLimit::Descriptor& descriptor,
+                        const envoy::config::core::v3::Metadata* metadata) const override;
+
+private:
+  const Envoy::Config::MetadataKey metadata_key_;
+};
 
 /**
  * Action for source cluster rate limiting.
@@ -149,6 +168,7 @@ private:
   const std::string disable_key_;
   uint64_t stage_;
   std::vector<RateLimitActionPtr> actions_;
+  absl::optional<RateLimitOverrideActionPtr> limit_override_ = absl::nullopt;
 };
 
 /**

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -51,6 +51,12 @@ void GrpcClientImpl::createRequest(envoy::service::ratelimit::v3::RateLimitReque
       new_entry->set_key(entry.key_);
       new_entry->set_value(entry.value_);
     }
+    if (descriptor.limit_) {
+      envoy::extensions::common::ratelimit::v3::RateLimitDescriptor_RateLimitOverride* new_limit =
+          new_descriptor->mutable_limit();
+      new_limit->set_requests_per_unit(descriptor.limit_.value().requests_per_unit_);
+      new_limit->set_unit(descriptor.limit_.value().unit_);
+    }
   }
 }
 

--- a/test/mocks/ratelimit/mocks.h
+++ b/test/mocks/ratelimit/mocks.h
@@ -10,12 +10,16 @@
 namespace Envoy {
 namespace RateLimit {
 
+inline bool operator==(const RateLimitOverride& lhs, const RateLimitOverride& rhs) {
+  return lhs.requests_per_unit_ == rhs.requests_per_unit_ && lhs.unit_ == rhs.unit_;
+}
+
 inline bool operator==(const DescriptorEntry& lhs, const DescriptorEntry& rhs) {
   return lhs.key_ == rhs.key_ && lhs.value_ == rhs.value_;
 }
 
 inline bool operator==(const Descriptor& lhs, const Descriptor& rhs) {
-  return lhs.entries_ == rhs.entries_;
+  return lhs.entries_ == rhs.entries_ && lhs.limit_ == rhs.limit_;
 }
 
 } // namespace RateLimit


### PR DESCRIPTION
Signed-off-by: Petr Pchelko <ppchelko@wikimedia.org>

Commit Message: Support dynamic limit override in ratelimit filter
Additional Description: Provides a way to specify dynamic rate limit override in the rate limit descriptor from static value or from dynamic metadata. New type, RateLimitUnit was created to share across config protocol and rate limit service protocol. A PR for the reference implementation of the rate limit service will follow after the API changes are discussed and accepted.
Risk Level: low
Testing: unit tests
Docs Changes: Documented new proto messages. Added a section on rate limit overrides to rate_limit_filter.rst
Release Notes:
Fixes #11595 
