### PR TITLE
stats: in integration test, round up approximate expectations to allow for platform variations.

### DIFF
--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -287,7 +287,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 44491);
-  EXPECT_MEMORY_LE(m_per_cluster, 44811);
+  EXPECT_MEMORY_LE(m_per_cluster, 46000); // Round up to allow platform variations.
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
@@ -350,7 +350,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 36603);
-  EXPECT_MEMORY_LE(m_per_cluster, 36923);
+  EXPECT_MEMORY_LE(m_per_cluster, 37000); // Round up to allow platform variations.
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
@@ -392,7 +392,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_host, 1380);
-  EXPECT_MEMORY_LE(m_per_host, 1655);
+  EXPECT_MEMORY_LE(m_per_host, 1700); // Round up to allow platform variations.
 }
 
 } // namespace

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -350,7 +350,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 36603);
-  EXPECT_MEMORY_LE(m_per_cluster, 37000); // Round up to allow platform variations.
+  EXPECT_MEMORY_LE(m_per_cluster, 38000); // Round up to allow platform variations.
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
@@ -392,7 +392,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_host, 1380);
-  EXPECT_MEMORY_LE(m_per_host, 1700); // Round up to allow platform variations.
+  EXPECT_MEMORY_LE(m_per_host, 1800); // Round up to allow platform variations.
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: Someone had set the bounds too tight for approximate memory checks, making the test brittle to platform variations. This PR adds some slack as well as comments explaining why.
Additional Description:
Risk Level: low
Testing: just the one test
Docs Changes: n/a
Release Notes: n/a
