### PR TITLE
server: add scaled timer utility class

### DIFF
--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -146,3 +146,15 @@ envoy_cc_library(
         "//include/envoy/event:dispatcher_interface",
     ],
 )
+
+envoy_cc_library(
+    name = "scaled_timer_lib",
+    srcs = ["scaled_timer.cc"],
+    hdrs = ["scaled_timer.h"],
+    deps = [
+        "//include/envoy/common:time_interface",
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/event:timer_interface",
+        "//source/common/common:scope_tracker",
+    ],
+)

--- a/source/common/event/scaled_timer.cc
+++ b/source/common/event/scaled_timer.cc
@@ -1,0 +1,207 @@
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/timer.h"
+#include "common/event/scaled_timer.h"
+#include <algorithm>
+#include <chrono>
+
+namespace Envoy {
+namespace Event {
+
+class ScaledTimerManager::ScaledTimerImpl final : public Timer {
+public:
+  struct ActiveTimer {
+    const MonotonicTime start;
+    const std::chrono::microseconds delay;
+    const ScopeTrackedObject* object;
+  };
+
+  ScaledTimerImpl(ScaledTimerManager& manager, TimerCb callback);
+
+  ~ScaledTimerImpl() override;
+
+  /**
+   * Run the timer callback on the given dispatcher.
+   */
+  void dispatch(Dispatcher& dispatcher);
+  const absl::optional<ActiveTimer>& active() const;
+
+  // Timer impl:
+  void enableTimer(const std::chrono::milliseconds& delay,
+                   const ScopeTrackedObject* object) override;
+
+  void enableHRTimer(const std::chrono::microseconds& delay,
+                     const ScopeTrackedObject* object) override;
+
+  bool enabled() override { return active_.has_value(); }
+
+  void disableTimer() override;
+
+private:
+  ScaledTimerManager& manager_;
+  const TimerCb callback_;
+  absl::optional<ActiveTimer> active_;
+};
+
+ScaledTimerManager::ScaledTimerImpl::ScaledTimerImpl(ScaledTimerManager& manager, TimerCb callback)
+    : manager_(manager), callback_(std::move(callback)) {}
+
+ScaledTimerManager::ScaledTimerImpl::~ScaledTimerImpl() {
+  if (active_.has_value()) {
+    manager_.descheduleTimer(this);
+  }
+}
+
+void ScaledTimerManager::ScaledTimerImpl::enableTimer(const std::chrono::milliseconds& delay,
+                                                      const ScopeTrackedObject* object) {
+  if (active_.has_value()) {
+    disableTimer();
+  }
+  active_.emplace(ActiveTimer{
+      .start = manager_.dispatcher_.timeSource().monotonicTime(),
+      .delay = delay,
+      .object = object,
+  });
+  manager_.scheduleTimer(this);
+}
+
+void ScaledTimerManager::ScaledTimerImpl::enableHRTimer(const std::chrono::microseconds& delay,
+                                                        const ScopeTrackedObject* object) {
+  if (active_.has_value()) {
+    disableTimer();
+  }
+  active_.emplace(ActiveTimer{
+      .start = manager_.dispatcher_.timeSource().monotonicTime(),
+      .delay = delay,
+      .object = object,
+  });
+  manager_.scheduleTimer(this);
+}
+
+void ScaledTimerManager::ScaledTimerImpl::disableTimer() {
+  manager_.descheduleTimer(this);
+  active_.reset();
+}
+
+void ScaledTimerManager::ScaledTimerImpl::dispatch(Dispatcher& dispatcher) {
+  ASSERT(active_.has_value());
+  if (active_->object == nullptr) {
+    callback_();
+  } else {
+    ScopeTrackerScopeState scope(active_->object, dispatcher);
+    callback_();
+  }
+  active_.reset();
+}
+
+const absl::optional<ScaledTimerManager::ScaledTimerImpl::ActiveTimer>&
+ScaledTimerManager::ScaledTimerImpl::active() const {
+  return active_;
+}
+
+ScaledTimerManager::ScaledTimerManager(Dispatcher& dispatcher)
+    : dispatcher_(dispatcher),
+      dispatch_timer_(dispatcher.createTimer([this] { dispatchCallback(); })), timers_(1.0) {}
+
+Event::TimerPtr ScaledTimerManager::createTimer(TimerCb callback) {
+  return std::make_unique<ScaledTimerImpl>(*this, std::move(callback));
+}
+
+void ScaledTimerManager::setDurationScaleFactor(double scale_factor) {
+  timers_.setScaleFactor(scale_factor);
+  internalScheduleTimer();
+}
+
+ScaledTimerManager::ScaledTimerList::ScaledTimerList(double scale_factor)
+    : timers_(Compare{.scale_factor = scale_factor}) {}
+
+void ScaledTimerManager::ScaledTimerList::addActive(ScaledTimerImpl* timer) {
+  ASSERT(timer->active().has_value());
+  timers_.insert(timer);
+}
+
+void ScaledTimerManager::ScaledTimerList::removeActive(ScaledTimerImpl* timer) {
+  ASSERT(timer->active().has_value());
+  timers_.erase(timer);
+}
+
+void ScaledTimerManager::ScaledTimerList::setScaleFactor(double scale_factor) {
+  std::set<ScaledTimerImpl*, Compare> reordered(timers_.begin(), timers_.end(),
+                                                Compare{.scale_factor = scale_factor});
+  std::swap(reordered, timers_);
+}
+
+absl::optional<ScaledTimerManager::ScaledTimerImpl*>
+ScaledTimerManager::ScaledTimerList::pop(MonotonicTime now) {
+  if (timers_.empty()) {
+    return absl::nullopt;
+  }
+
+  auto* timer = *timers_.begin();
+  if (timers_.key_comp().targetTime(timer) <= now) {
+    timers_.erase(timers_.begin());
+    return timer;
+  }
+  return absl::nullopt;
+}
+
+absl::optional<MonotonicTime> ScaledTimerManager::ScaledTimerList::firstScheduleTime() const {
+  if (timers_.empty()) {
+    return absl::nullopt;
+  }
+  return timers_.key_comp().targetTime(*timers_.begin());
+}
+
+MonotonicTime
+ScaledTimerManager::ScaledTimerList::Compare::targetTime(const ScaledTimerImpl* timer) const {
+  ASSERT(timer->active().has_value());
+
+  auto scaled_delay = timer->active()->delay * scale_factor;
+  return timer->active()->start +
+         std::chrono::duration_cast<std::chrono::microseconds>(scaled_delay);
+}
+
+bool ScaledTimerManager::ScaledTimerList::Compare::operator()(const ScaledTimerImpl* lhs,
+                                                              const ScaledTimerImpl* rhs) const {
+  return targetTime(lhs) < targetTime(rhs);
+}
+
+void ScaledTimerManager::scheduleTimer(ScaledTimerImpl* timer) {
+  ASSERT(timer->active().has_value());
+
+  timers_.addActive(timer);
+  internalScheduleTimer();
+}
+
+void ScaledTimerManager::descheduleTimer(ScaledTimerImpl* timer) {
+  ASSERT(timer->active().has_value());
+  timers_.removeActive(timer);
+  internalScheduleTimer();
+}
+
+void ScaledTimerManager::dispatchCallback() {
+  // Find all timers that are ready to be handled and dispatch them.
+  const auto now = dispatcher_.timeSource().monotonicTime();
+  for (auto timer = timers_.pop(now); timer.has_value(); timer = timers_.pop(now)) {
+    timer.value()->dispatch(dispatcher_);
+  }
+
+  internalScheduleTimer();
+}
+
+void ScaledTimerManager::internalScheduleTimer() {
+  auto next_time = timers_.firstScheduleTime();
+  if (!next_time.has_value()) {
+    dispatch_timer_->disableTimer();
+    return;
+  }
+  const MonotonicTime now = dispatcher_.timeSource().monotonicTime();
+  const auto target_delay = std::chrono::duration_cast<std::chrono::microseconds>(*next_time - now);
+
+  if (target_delay > std::chrono::microseconds::zero()) {
+    dispatch_timer_->enableHRTimer(target_delay);
+  } else {
+    dispatch_timer_->enableHRTimer(std::chrono::microseconds::zero());
+  }
+}
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/scaled_timer.h
+++ b/source/common/event/scaled_timer.h
@@ -1,0 +1,71 @@
+#include "envoy/common/time.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/timer.h"
+#include "envoy/common/scope_tracker.h"
+#include "common/common/scope_tracker.h"
+#include "envoy/common/time.h"
+#include <chrono>
+
+namespace Envoy {
+namespace Event {
+/**
+ * Utility class for maintaining a list of timers whose durations can be scaled by an arbitrary
+ * value. The timer objects returned by createTimer() must not outlive the manager.
+ */
+class ScaledTimerManager {
+public:
+  ScaledTimerManager(Dispatcher& dispatcher);
+  /**
+   * Creates a timer that will fire the given callback when triggered. The returned timer object
+   * must not outlive the dispatcher.
+   */
+  TimerPtr createTimer(TimerCb callback);
+  /**
+   * Sets the scale factor for the duration. A value of 0 will cause all timers to be triggered
+   * immediately, and a value of 1 will cause them to schedule at the usual time.
+   * @param scale the scale factor to apply; must be between 0 and 1.
+   */
+  void setDurationScaleFactor(double scale);
+
+private:
+  // Forward-declare impl class; this is defined in the .cc file.
+  class ScaledTimerImpl;
+
+  class ScaledTimerList {
+  public:
+    ScaledTimerList(double scale_factor);
+    void addActive(ScaledTimerImpl* tracker);
+    void removeActive(ScaledTimerImpl* tracker);
+    void setScaleFactor(double scale_factor);
+    absl::optional<ScaledTimerImpl*> pop(MonotonicTime now);
+    absl::optional<MonotonicTime> firstScheduleTime() const;
+
+  private:
+    struct Compare {
+      MonotonicTime targetTime(const ScaledTimerImpl* timer) const;
+      bool operator()(const ScaledTimerImpl* lhs, const ScaledTimerImpl* rhs) const;
+      double scale_factor;
+    };
+
+    std::set<ScaledTimerImpl*, Compare> timers_;
+  };
+
+  void scheduleTimer(ScaledTimerImpl* tracker);
+  void descheduleTimer(ScaledTimerImpl* tracker);
+
+  /**
+   * Called by the internal timer when the next tracked timer is ready to be triggered.
+   */
+  void dispatchCallback();
+  /**
+   * Internal helper method that updates `dispatch_timer_` based on the current scale value.
+   */
+  void internalScheduleTimer();
+
+  Dispatcher& dispatcher_;
+  const TimerPtr dispatch_timer_;
+  ScaledTimerList timers_;
+};
+
+} // namespace Event
+} // namespace Envoy

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -37,3 +37,13 @@ envoy_cc_test(
         "//test/test_common:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "scaled_timer_test",
+    srcs = ["scaled_timer_test.cc"],
+    deps = [
+        "//source/common/event:scaled_timer_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/test_common:simulated_time_system_lib",
+    ]
+)

--- a/test/common/event/scaled_timer_test.cc
+++ b/test/common/event/scaled_timer_test.cc
@@ -1,0 +1,226 @@
+#include "common/event/scaled_timer.h"
+
+#include "envoy/event/timer.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/mocks/event/mocks.h"
+
+#include "gtest/gtest.h"
+#include <chrono>
+
+namespace Envoy {
+namespace Event {
+namespace {
+
+using testing::_;
+using testing::AnyNumber;
+using testing::ByMove;
+using testing::DoAll;
+using testing::InSequence;
+using testing::InvokeArgument;
+using testing::MockFunction;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnNew;
+using testing::ReturnRef;
+using testing::SaveArg;
+
+class ScaledTimerManagerTest : public testing::Test {
+public:
+  ScaledTimerManagerTest() {
+    ON_CALL(dispatcher_, createTimer_)
+        .WillByDefault(DoAll(SaveArg<0>(&timer_cb_), ReturnNew<NiceMock<MockTimer>>()));
+  }
+
+  SimulatedTimeSystem simulated_time;
+  MockDispatcher dispatcher_;
+  TimerCb timer_cb_;
+};
+
+TEST_F(ScaledTimerManagerTest, CreatesDispatcherTimer) {
+  EXPECT_CALL(dispatcher_, createTimer_).WillOnce(ReturnNew<NiceMock<MockTimer>>());
+
+  ScaledTimerManager manager(dispatcher_);
+}
+
+TEST_F(ScaledTimerManagerTest, CreateSingleScaledTimer) {
+  MockFunction<void()> cb;
+  auto timer = std::make_unique<MockTimer>();
+
+  EXPECT_CALL(*timer, enableHRTimer(std::chrono::microseconds(5 * 1000 * 1000), _));
+  EXPECT_CALL(*timer, disableTimer);
+  EXPECT_CALL(dispatcher_, createTimer_)
+      .WillOnce(DoAll(SaveArg<0>(&timer_cb_), Return(ByMove(timer.release()))));
+
+  EXPECT_CALL(cb, Call());
+
+  ScaledTimerManager manager(dispatcher_);
+
+  auto scaled_timer = manager.createTimer(cb.AsStdFunction());
+  scaled_timer->enableTimer(std::chrono::seconds(5));
+
+  dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(5));
+  timer_cb_();
+}
+
+TEST_F(ScaledTimerManagerTest, CreateAndDeleteTimer) {
+  MockFunction<void()> cb;
+  auto timer = std::make_unique<MockTimer>();
+
+  EXPECT_CALL(dispatcher_, createTimer_)
+      .WillOnce(DoAll(SaveArg<0>(&timer_cb_), Return(ByMove(timer.release()))));
+
+  ScaledTimerManager manager(dispatcher_);
+
+  {
+    auto scaled_timer = manager.createTimer(cb.AsStdFunction());
+    scaled_timer.reset();
+  }
+}
+
+TEST_F(ScaledTimerManagerTest, EnableAndDisableTimer) {
+  MockFunction<void()> cb;
+  auto timer = std::make_unique<MockTimer>();
+
+  EXPECT_CALL(*timer, enableHRTimer(std::chrono::microseconds(5 * 1000 * 1000), _));
+  EXPECT_CALL(*timer, disableTimer).Times(2);
+  EXPECT_CALL(dispatcher_, createTimer_)
+      .WillOnce(DoAll(SaveArg<0>(&timer_cb_), Return(ByMove(timer.release()))));
+
+  ScaledTimerManager manager(dispatcher_);
+
+  auto scaled_timer = manager.createTimer(cb.AsStdFunction());
+  scaled_timer->enableTimer(std::chrono::seconds(5));
+  scaled_timer->disableTimer();
+
+  dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(5));
+  timer_cb_();
+}
+
+TEST_F(ScaledTimerManagerTest, EnableMultipleTimers) {
+  auto timer = std::make_unique<MockTimer>();
+
+  EXPECT_CALL(*timer, enableHRTimer(std::chrono::microseconds(1 * 1000 * 1000), _))
+      .Times(
+          // Expect one call as each timer is enabled, then another one after the first timer fires,
+          // then the last one after the second timer fires.
+          3 + 1 + 1);
+  EXPECT_CALL(*timer, disableTimer);
+  EXPECT_CALL(dispatcher_, createTimer_)
+      .WillOnce(DoAll(SaveArg<0>(&timer_cb_), Return(ByMove(timer.release()))));
+
+  MockFunction<void(int)> cb;
+  {
+    InSequence s;
+    EXPECT_CALL(cb, Call(1));
+    EXPECT_CALL(cb, Call(2));
+    EXPECT_CALL(cb, Call(3));
+  }
+
+  ScaledTimerManager manager(dispatcher_);
+
+  std::vector<TimerPtr> timers;
+  for (int i = 1; i <= 3; i++) {
+    timers.push_back(manager.createTimer([i, &cb] { cb.Call(i); }));
+    timers.back()->enableTimer(std::chrono::seconds(i));
+  }
+
+  for (int i = 0; i < 3; i++) {
+    dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(1));
+    timer_cb_();
+  }
+}
+
+// Test that if timers are scheduled for some times in the future, and then the scaling factor
+// changes, the timers will trigger earlier than scheduled.
+TEST_F(ScaledTimerManagerTest, ScaleMultipleTimers) {
+  auto timer = std::make_unique<MockTimer>();
+
+  // Expect 3 calls with the original 10-second timeout, then, when the scaling factor is changed, a
+  // single 1-second timeout for each managed timer.
+  EXPECT_CALL(*timer, enableHRTimer(std::chrono::microseconds(10 * 1000 * 1000), _)).Times(3);
+  EXPECT_CALL(*timer, enableHRTimer(std::chrono::microseconds(1 * 1000 * 1000), _)).Times(3);
+  EXPECT_CALL(*timer, disableTimer);
+  EXPECT_CALL(dispatcher_, createTimer_)
+      .WillOnce(DoAll(SaveArg<0>(&timer_cb_), Return(ByMove(timer.release()))));
+
+  MockFunction<void(int)> cb;
+  {
+    InSequence s;
+    EXPECT_CALL(cb, Call(1));
+    EXPECT_CALL(cb, Call(2));
+    EXPECT_CALL(cb, Call(3));
+  }
+
+  ScaledTimerManager manager(dispatcher_);
+
+  std::vector<TimerPtr> timers;
+  for (int i = 1; i <= 3; i++) {
+    timers.push_back(manager.createTimer([i, &cb] { cb.Call(i); }));
+    timers.back()->enableTimer(std::chrono::seconds(10 * i));
+  }
+
+  // Each duration will be treated as if it was 10% of the original requested value.
+  manager.setDurationScaleFactor(0.1);
+
+  for (int i = 0; i < 3; i++) {
+    dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(1));
+    timer_cb_();
+  }
+}
+
+// If two timers are scheduled at different times with different timeouts, they can be reordered by
+// a change in the scale factor.
+TEST_F(ScaledTimerManagerTest, TimersReorderedByScaling) {
+  auto timer = std::make_unique<MockTimer>();
+  std::chrono::microseconds timer_delay;
+
+  EXPECT_CALL(*timer, enableHRTimer).Times(AnyNumber()).WillRepeatedly(SaveArg<0>(&timer_delay));
+  EXPECT_CALL(*timer, disableTimer);
+  EXPECT_CALL(dispatcher_, createTimer_)
+      .WillOnce(DoAll(SaveArg<0>(&timer_cb_), Return(ByMove(timer.release()))));
+
+  MockFunction<void(char)> cb;
+  {
+    InSequence s;
+    EXPECT_CALL(cb, Call('A'));
+    EXPECT_CALL(cb, Call('B'));
+  }
+
+  ScaledTimerManager manager(dispatcher_);
+
+  auto first_timer = manager.createTimer([&cb] { cb.Call('A'); });
+  auto second_timer = manager.createTimer([&cb] { cb.Call('B'); });
+
+  // Let t0 be the starting time. Set timer A at t0 + 20s
+  first_timer->enableTimer(std::chrono::seconds(20));
+
+  // Advance the clock to t1 = t0 + 10s.
+  dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(10));
+
+  // Set timer B at t1 + 5s = t0 + 15s, so that it would fire before timer A.
+  second_timer->enableTimer(std::chrono::seconds(5));
+
+  // Adjust the scale factor so that timer A will fire at t0 + (.6 * 20s) = t1 + 2s, and timer B will
+  // fire at t1 + (.6 * 5s) = t1 + 3s.
+  manager.setDurationScaleFactor(0.6);
+
+  // At this point, the timer should be set for 2 seconds. Advancing by that much will trigger timer
+  // A but not timer B.
+  EXPECT_EQ(timer_delay, std::chrono::seconds(2));
+  dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(2));
+  timer_cb_();
+
+  EXPECT_FALSE(first_timer->enabled());
+  EXPECT_TRUE(second_timer->enabled());
+
+  // Advance the timer again by another second, which should trigger timer B.
+  EXPECT_EQ(timer_delay, std::chrono::seconds(1));
+  dispatcher_.time_system_.timeSystem().advanceTimeWait(std::chrono::seconds(1));
+  timer_cb_();
+
+  EXPECT_FALSE(second_timer->enabled());
+}
+
+} // namespace
+} // namespace Event
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: 
Add a ScaledTimer utility class for producing Envoy::Event::Timer objects whose durations can be scaled en-masse by adjusting the scale factor on the manager. This class will be used to implement timer scaling for the OverloadManagerImpl based on load.

Additional Description:

Risk Level: low - the code is tested but not integrated
Testing: wrote unit test
Docs Changes: none
Release Notes: none
#11427 
/cc @antoniovicente 