### PR TITLE
build: Cross-compilation for aarch64

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -46,6 +46,10 @@ configure_make(
         # https://github.com/envoyproxy/envoy/issues/6084
         # TODO(htuch): Remove when #6084 is fixed
         "//bazel:asan_build": {"ENVOY_CONFIG_ASAN": "1"},
+        "//bazel/toolchains:gcc_aarch64_cross_cfg": {
+            "CC": "gcc",
+            "CROSS": "aarch64-linux-gnu-",
+        },
         "//conditions:default": {},
     }),
     lib_source = "@com_github_luajit_luajit//:all",
@@ -66,6 +70,10 @@ configure_make(
         # https://github.com/envoyproxy/envoy/issues/6084
         # TODO(htuch): Remove when #6084 is fixed
         "//bazel:asan_build": {"ENVOY_CONFIG_ASAN": "1"},
+        "//bazel/toolchains:gcc_aarch64_cross_cfg": {
+            "CC": "gcc",
+            "CROSS": "aarch64-linux-gnu-",
+        },
         "//conditions:default": {},
     }),
     lib_source = "@com_github_moonjit_moonjit//:all",

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -16,6 +16,7 @@ configure_make(
         "--disable-libunwind",
     ] + select({
         "//bazel:apple": ["AR=/usr/bin/ar"],
+        "//bazel/toolchains:gcc_aarch64_cross_cfg": ["--host aarch64-linux-gnu"],
         "//conditions:default": [],
     }),
     lib_source = "@com_github_gperftools_gperftools//:all",

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -1,3 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_toolchain")
+load(":gcc_aarch64_cross_toolchain_config.bzl", "gcc_aarch64_cross_toolchain_config_rule")
+
 licenses(["notice"])  # Apache 2
 
 platform(
@@ -14,4 +17,44 @@ platform(
           value: "standard"
         }
         """,
+)
+
+platform(
+    name = "gcc_aarch64_cross",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+gcc_aarch64_cross_toolchain_config_rule(name = "gcc_aarch64_cross_toolchain_config")
+
+filegroup(
+    name = "gcc_aarch64_cross_toolchain_files",
+    srcs = glob([
+        "aarch64-none-linux-gnu/**",
+        "libexec/**",
+        "lib/gcc/aarch64-none-linux-gnu/**",
+        "include/**",
+    ]),
+    visibility = ["//visibility:private"],
+)
+
+cc_toolchain(
+    name = "gcc_aarch64_cross_cc_toolchain",
+    all_files = ":gcc_aarch64_cross_toolchain_files",
+    compiler_files = ":gcc_aarch64_cross_toolchain_files",
+    dwp_files = ":empty",
+    linker_files = ":gcc_aarch64_cross_toolchain_files",
+    objcopy_files = ":gcc_aarch64_cross_toolchain_files",
+    strip_files = ":gcc_aarch64_cross_toolchain_files",
+    supports_param_files = 1,
+    toolchain_config = ":gcc_aarch64_cross_toolchain_config",
+    toolchain_identifier = "aarch64-linux-gnu",
+)
+
+toolchain(
+    name = "gcc_aarch64_cross_toolchain",
+    target_compatible_with = ["@platforms//cpu:aarch64"],
+    toolchain = ":gcc_aarch64_cross_cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -26,6 +26,13 @@ platform(
     ],
 )
 
+config_setting(
+    name = "gcc_aarch64_cross_cfg",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+    ],
+)
+
 gcc_aarch64_cross_toolchain_config_rule(name = "gcc_aarch64_cross_toolchain_config")
 
 filegroup(

--- a/bazel/toolchains/gcc_aarch64_cross_toolchain_config.bzl
+++ b/bazel/toolchains/gcc_aarch64_cross_toolchain_config.bzl
@@ -86,6 +86,10 @@ def _impl(ctx):
                             # signed characters. Using signed char by default
                             # fixes that.
                             "-fsigned-char",
+                            # Disable assembly code in BoringSSL.
+                            # TODO(mrostecki): Fix BoringSSL assembly code for
+                            # aarch64.
+                            "-DOPENSSL_NO_ASM",
                         ],
                     ),
                 ],

--- a/bazel/toolchains/gcc_aarch64_cross_toolchain_config.bzl
+++ b/bazel/toolchains/gcc_aarch64_cross_toolchain_config.bzl
@@ -80,6 +80,12 @@ def _impl(ctx):
                             "-D__TIME__=\"redacted\"",
                             "-no-canonical-prefixes",
                             "-fno-canonical-system-headers",
+                            # GCC uses unsigned char by default for all non-x86
+                            # architectures which breaks opentracing-cpp and
+                            # lightstep-tracer-cpp builds, as they are using
+                            # signed characters. Using signed char by default
+                            # fixes that.
+                            "-fsigned-char",
                         ],
                     ),
                 ],

--- a/bazel/toolchains/gcc_aarch64_cross_toolchain_config.bzl
+++ b/bazel/toolchains/gcc_aarch64_cross_toolchain_config.bzl
@@ -1,0 +1,337 @@
+# this is based on https://github.com/tensorflow/tensorflow/tree/86e649bf6f25dd72c2a6e5d11b33a4764e133c8c/third_party/toolchains/embedded/arm-linux
+# but it's made to work with GCC 9 for aarch64, and with armhf removed
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+    "with_feature_set",
+)
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+def _impl(ctx):
+    abi_libc_version = "aarch64"
+    abi_version = "aarch64"
+    action_configs = []
+    artifact_name_patterns = []
+    host_system_name = "aarch64"
+    make_variables = []
+    target_cpu = "aarch64"
+    target_libc = "aarch64"
+    target_system_name = "aarch64"
+    toolchain_identifier = "aarch64-linux-gnu"
+    compiler = "compiler"
+    cc_target_os = None
+    builtin_sysroot = None
+
+    sysroot_feature = feature(
+        name = "sysroot",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["--sysroot=%{sysroot}"],
+                        expand_if_available = "sysroot",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    unfiltered_compile_flags_feature = feature(
+        name = "unfiltered_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Wno-builtin-macro-redefined",
+                            "-D__DATE__=\"redacted\"",
+                            "-D__TIMESTAMP__=\"redacted\"",
+                            "-D__TIME__=\"redacted\"",
+                            "-no-canonical-prefixes",
+                            "-fno-canonical-system-headers",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    default_compile_flags_feature = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [flag_group(flags = ["-g"])],
+                with_features = [with_feature_set(features = ["dbg"])],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-g0",
+                            "-O2",
+                            "-DNDEBUG",
+                            "-ffunction-sections",
+                            "-fdata-sections",
+                        ],
+                    ),
+                ],
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-isystem",
+                            "/usr/aarch64-linux-gnu/include/c++/9",
+                            "-isystem",
+                            "/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu",
+                            "-isystem",
+                            "/usr/aarch64-linux-gnu/include/c++/9/backward",
+                            "-isystem",
+                            "/usr/lib/gcc-cross/aarch64-linux-gnu/9/include",
+                            "-isystem",
+                            "/usr/aarch64-linux-gnu/include",
+                            "-isystem",
+                            "/usr/include",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    default_link_flags_feature = feature(
+        name = "default_link_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-lstdc++",
+                            "-Wl,-z,relro,-z,now",
+                            "-no-canonical-prefixes",
+                            "-pass-exit-codes",
+                            "-Wl,--build-id=md5",
+                            "-Wl,--hash-style=gnu",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-Wl,--gc-sections"])],
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+        ],
+    )
+
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+
+    user_compile_flags_feature = feature(
+        name = "user_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_compile_flags}"],
+                        iterate_over = "user_compile_flags",
+                        expand_if_available = "user_compile_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # obtained with `docker run docker.io/cilium/image-compilers:ac609e4c5a77e9c4c92e096b8c96a49b78d5c869 bash -c 'echo | $(aarch64-linux-gnu-gcc -print-prog-name=cc1plus) -v'`
+    cxx_builtin_include_directories = [
+        "/usr/aarch64-linux-gnu/include/c++/9",
+        "/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu",
+        "/usr/aarch64-linux-gnu/include/c++/9/backward",
+        "/usr/lib/gcc-cross/aarch64-linux-gnu/9/include",
+        "/usr/aarch64-linux-gnu/include",
+        "/usr/include",
+    ]
+
+    features = [
+        default_compile_flags_feature,
+        default_link_flags_feature,
+        supports_dynamic_linker_feature,
+        supports_pic_feature,
+        feature(name = "opt"),
+        feature(name = "dbg"),
+        user_compile_flags_feature,
+        sysroot_feature,
+        unfiltered_compile_flags_feature,
+    ]
+
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "/usr/bin/aarch64-linux-gnu-gcc",
+        ),
+        tool_path(
+            name = "ld",
+            path = "/usr/bin/aarch64-linux-gnu-ld",
+        ),
+        tool_path(
+            name = "ar",
+            path = "/usr/bin/aarch64-linux-gnu-ar",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/usr/bin/aarch64-linux-gnu-cpp",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/usr/bin/aarch64-linux-gnu-gcov",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/usr/bin/aarch64-linux-gnu-nm",
+        ),
+        tool_path(
+            name = "objcopy",
+            path = "/usr/bin/aarch64-linux-gnu-objcopy",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/usr/bin/aarch64-linux-gnu-objdump",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/usr/bin/aarch64-linux-gnu-strip",
+        ),
+    ]
+
+    return [
+        cc_common.create_cc_toolchain_config_info(
+            abi_libc_version = abi_libc_version,
+            abi_version = abi_version,
+            action_configs = action_configs,
+            artifact_name_patterns = artifact_name_patterns,
+            builtin_sysroot = builtin_sysroot,
+            cc_target_os = cc_target_os,
+            compiler = compiler,
+            ctx = ctx,
+            cxx_builtin_include_directories = cxx_builtin_include_directories,
+            features = features,
+            host_system_name = host_system_name,
+            make_variables = make_variables,
+            target_cpu = target_cpu,
+            target_libc = target_libc,
+            target_system_name = target_system_name,
+            tool_paths = tool_paths,
+            toolchain_identifier = toolchain_identifier,
+        ),
+    ]
+
+gcc_aarch64_cross_toolchain_config_rule = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+    #executable = True,
+)


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

**Commit Message:**
Add Bazel config to cross-compile for AArch64
**Additional Description:**
This pull request introduces a new toolchain for aarch64 and allows to cross-compile Envoy for aarch64. Apart from the toolchain, this PR contains few minor and non-risky changes which made it possible to build for ARM. Please review per commit.
**Risk Level:**
Low
**Testing:**
Tested manually by building with the new toolchain:
```
bazel build \
      --incompatible_enable_cc_toolchain_resolution \
      --platforms=//bazel/toolchains:gcc_aarch64_cross \
      --extra_toolchains=//bazel/toolchains:gcc_aarch64_cross_toolchain \
      --record_rule_instantiation_callstack \
      --define boringssl=fips \
      //source/exe:envoy-static
```
**Docs Changes:**
N/A
**Release Notes:**
Add cross-compilation for aarch64
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]

Co-Authored-By: Ilya Dmitrichenko <errordeveloper@gmail.com> (@errordeveloper)