### PR TITLE
added modify[En,De]codingHeaders(), and getTcpInfo() methods

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -132,7 +132,11 @@ struct msghdr {
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#ifdef ENABLE_TCP_INFO
+#include <linux/tcp.h>
+#else
 #include <netinet/tcp.h>
+#endif
 #include <sys/ioctl.h>
 #include <sys/mman.h> // for mode_t
 #include <sys/socket.h>

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -241,6 +241,12 @@ public:
   virtual void modifyDecodingBuffer(std::function<void(Buffer::Instance&)> callback) PURE;
 
   /**
+   * Allows modifying the decoding header. May only be called before any header has been continued
+   * past the calling filter.
+   */
+  virtual void modifyDecodingHeaders(std::function<void(Http::HeaderMap&)> callback) PURE;
+
+  /**
    * Add buffered body data. This method is used in advanced cases where returning
    * StopIterationAndBuffer from decodeData() is not sufficient.
    *
@@ -577,6 +583,12 @@ public:
    * past the calling filter.
    */
   virtual void modifyEncodingBuffer(std::function<void(Buffer::Instance&)> callback) PURE;
+
+  /**
+   * Allows modifying the encoding header. May only be called before any header has been continued
+   * past the calling filter.
+   */
+  virtual void modifyEncodingHeaders(std::function<void(Http::HeaderMap&)> callback) PURE;
 
   /**
    * Add buffered body data. This method is used in advanced cases where returning

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -139,6 +139,19 @@ public:
    */
   virtual void noDelay(bool enable) PURE;
 
+#ifdef ENABLE_TCP_INFO
+  struct TCPInfo
+  {
+    uint32_t cwnd;      /* congestion window (packets) */
+    uint32_t in_flight; /* packets "in flight" */
+    uint32_t min_rtt;   /* minimum RTT in microsecond */
+    uint32_t rtt;       /* RTT in microsecond */
+    uint64_t delivery_rate;  /* bytes per second */
+  };
+
+  virtual absl::optional<TCPInfo> getTCPInfo() const PURE;
+#endif
+
   /**
    * Disable socket reads on the connection, applying external back pressure. When reads are
    * enabled again if there is data still in the input buffer it will be re-dispatched through

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -344,6 +344,9 @@ private:
   void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
+  void modifyDecodingHeaders(std::function<void(Http::HeaderMap&)>) override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
   void sendLocalReply(Code code, absl::string_view body,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -278,6 +278,11 @@ private:
       callback(*parent_.buffered_request_data_.get());
     }
 
+    void modifyDecodingHeaders(std::function<void(Http::HeaderMap&)> callback) override {
+      ASSERT(parent_.state_.latest_data_decoding_filter_ == this);
+      callback(*parent_.request_headers_.get());
+    }
+
     void sendLocalReply(Code code, absl::string_view body,
                         std::function<void(ResponseHeaderMap& headers)> modify_headers,
                         const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
@@ -392,6 +397,10 @@ private:
     void modifyEncodingBuffer(std::function<void(Buffer::Instance&)> callback) override {
       ASSERT(parent_.state_.latest_data_encoding_filter_ == this);
       callback(*parent_.buffered_response_data_.get());
+    }
+    void modifyEncodingHeaders(std::function<void(Http::HeaderMap&)> callback) override {
+      ASSERT(parent_.state_.latest_data_encoding_filter_ == this);
+      callback(*parent_.response_headers_.get());
     }
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
       // TODO(mattklein123): At some point we might want to actually wrap this interface but for now

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -63,6 +63,9 @@ public:
   void close(ConnectionCloseType type) override;
   std::string nextProtocol() const override { return transport_socket_->protocol(); }
   void noDelay(bool enable) override;
+#ifdef ENABLE_TCP_INFO
+  absl::optional<Connection::TCPInfo> getTCPInfo() const override;
+#endif
   void readDisable(bool disable) override;
   void detectEarlyCloseWhenReadDisabled(bool value) override { detect_early_close_ = value; }
   bool readEnabled() const override;

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -100,6 +100,9 @@ protected:
       uint64_t id() const override { return 12345; }
       std::string nextProtocol() const override { return EMPTY_STRING; }
       void noDelay(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+#ifdef ENABLE_TCP_INFO
+      absl::optional<Connection::TCPInfo> getTCPInfo() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+#endif
       void readDisable(bool) override {}
       void detectEarlyCloseWhenReadDisabled(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
       bool readEnabled() const override { return true; }


### PR DESCRIPTION
Commit Message:
While there're modifyEncodingData() and modifyDecodingData() features,
a feature for header modificaiton is missing. This feature can be useful
for HTTP filters that would like to redirect destination of a message
based on load, latency, bw condition, etc.
Linux > 2.4 provides TCP statistics via TCP_INFO socket option. The
stats can be used by external HTTP filters to take proper action based
on various metrics such as minRTT, congestion window, etc. We propose
getTcpInfo() in connection implementation as an experimental mode,
turned on/off by --copt="-D ENABLE_TCP_INFO=1" bazel argument.

Additional Description:
Risk Level: Low
Testing: along with "//test/", we have tested on AKS environment.
Docs Changes: N/A
Release Notes: N/A
