### PR TITLE
http: further header map cleanups

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -263,9 +263,6 @@ private:
  * processing. This allows O(1) access to these headers without even a hash lookup.
  */
 #define INLINE_REQ_HEADERS(HEADER_FUNC)                                                            \
-  HEADER_FUNC(Accept)                                                                              \
-  HEADER_FUNC(AcceptEncoding)                                                                      \
-  HEADER_FUNC(Authorization)                                                                       \
   HEADER_FUNC(ClientTraceId)                                                                       \
   HEADER_FUNC(EnvoyDownstreamServiceCluster)                                                       \
   HEADER_FUNC(EnvoyDownstreamServiceNode)                                                          \
@@ -290,15 +287,11 @@ private:
   HEADER_FUNC(ForwardedClientCert)                                                                 \
   HEADER_FUNC(ForwardedFor)                                                                        \
   HEADER_FUNC(ForwardedProto)                                                                      \
-  HEADER_FUNC(GrpcAcceptEncoding)                                                                  \
   HEADER_FUNC(GrpcTimeout)                                                                         \
   HEADER_FUNC(Host)                                                                                \
   HEADER_FUNC(Method)                                                                              \
-  HEADER_FUNC(OtSpanContext)                                                                       \
-  HEADER_FUNC(Origin)                                                                              \
   HEADER_FUNC(Path)                                                                                \
   HEADER_FUNC(Protocol)                                                                            \
-  HEADER_FUNC(Referer)                                                                             \
   HEADER_FUNC(Scheme)                                                                              \
   HEADER_FUNC(TE)                                                                                  \
   HEADER_FUNC(UserAgent)
@@ -308,7 +301,6 @@ private:
  */
 #define INLINE_RESP_HEADERS(HEADER_FUNC)                                                           \
   HEADER_FUNC(Date)                                                                                \
-  HEADER_FUNC(Etag)                                                                                \
   HEADER_FUNC(EnvoyDegraded)                                                                       \
   HEADER_FUNC(EnvoyImmediateHealthCheckFail)                                                       \
   HEADER_FUNC(EnvoyRateLimited)                                                                    \
@@ -317,16 +309,13 @@ private:
   HEADER_FUNC(EnvoyUpstreamServiceTime)                                                            \
   HEADER_FUNC(Location)                                                                            \
   HEADER_FUNC(Server)                                                                              \
-  HEADER_FUNC(Status)                                                                              \
-  HEADER_FUNC(Vary)
+  HEADER_FUNC(Status)
 
 /**
  * Default O(1) request and response headers.
  */
 #define INLINE_REQ_RESP_HEADERS(HEADER_FUNC)                                                       \
-  HEADER_FUNC(CacheControl)                                                                        \
   HEADER_FUNC(Connection)                                                                          \
-  HEADER_FUNC(ContentEncoding)                                                                     \
   HEADER_FUNC(ContentLength)                                                                       \
   HEADER_FUNC(ContentType)                                                                         \
   HEADER_FUNC(EnvoyAttemptCount)                                                                   \

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -75,7 +75,7 @@ void SignerImpl::sign(Http::RequestHeaderMap& headers, const std::string& conten
   const auto authorization_header = createAuthorizationHeader(
       credentials.accessKeyId().value(), credential_scope, canonical_headers, signature);
   ENVOY_LOG(debug, "Signing request with: {}", authorization_header);
-  headers.addCopy(Http::Headers::get().Authorization, authorization_header);
+  headers.addCopy(Http::CustomHeaders::get().Authorization, authorization_header);
 }
 
 std::string SignerImpl::createContentHash(Http::RequestMessage& message, bool sign_body) const {

--- a/source/extensions/compression/gzip/compressor/config.h
+++ b/source/extensions/compression/gzip/compressor/config.h
@@ -33,7 +33,7 @@ public:
   Envoy::Compression::Compressor::CompressorPtr createCompressor() override;
   const std::string& statsPrefix() const override { return gzipStatsPrefix(); }
   const std::string& contentEncoding() const override {
-    return Http::Headers::get().ContentEncodingValues.Gzip;
+    return Http::CustomHeaders::get().ContentEncodingValues.Gzip;
   }
 
 private:

--- a/source/extensions/compression/gzip/decompressor/config.h
+++ b/source/extensions/compression/gzip/decompressor/config.h
@@ -31,7 +31,7 @@ public:
   Envoy::Compression::Decompressor::DecompressorPtr createDecompressor() override;
   const std::string& statsPrefix() const override { return gzipStatsPrefix(); }
   const std::string& contentEncoding() const override {
-    return Http::Headers::get().ContentEncodingValues.Gzip;
+    return Http::CustomHeaders::get().ContentEncodingValues.Gzip;
   }
 
 private:

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -13,6 +13,9 @@ namespace Filters {
 namespace Common {
 namespace Expr {
 
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    referer_handle(Http::CustomHeaders::get().Referer);
+
 absl::optional<CelValue> convertHeaderEntry(const Http::HeaderEntry* header) {
   if (header == nullptr) {
     return {};
@@ -106,7 +109,7 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
     } else if (value == Method) {
       return convertHeaderEntry(headers_.value_->Method());
     } else if (value == Referer) {
-      return convertHeaderEntry(headers_.value_->Referer());
+      return convertHeaderEntry(headers_.value_->getInline(referer_handle.handle()));
     } else if (value == ID) {
       return convertHeaderEntry(headers_.value_->RequestId());
     } else if (value == UserAgent) {

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -153,8 +153,8 @@ MatcherSharedPtr
 ClientConfig::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
                                 const bool disable_lowercase_string_matcher) {
   const std::vector<Http::LowerCaseString> keys{
-      {Http::Headers::get().Authorization, Http::Headers::get().Method, Http::Headers::get().Path,
-       Http::Headers::get().Host}};
+      {Http::CustomHeaders::get().Authorization, Http::Headers::get().Method,
+       Http::Headers::get().Path, Http::Headers::get().Host}};
 
   std::vector<Matchers::StringMatcherPtr> matchers(
       createStringMatchers(list, disable_lowercase_string_matcher));

--- a/source/extensions/filters/http/cache/cache_filter_utils.cc
+++ b/source/extensions/filters/http/cache/cache_filter_utils.cc
@@ -7,24 +7,29 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    authorization_handle(Http::CustomHeaders::get().Authorization);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+    cache_control_handle(Http::CustomHeaders::get().Referer);
+
 bool CacheFilterUtils::isCacheableRequest(const Http::RequestHeaderMap& headers) {
   const absl::string_view method = headers.getMethodValue();
   const absl::string_view forwarded_proto = headers.getForwardedProtoValue();
   const Http::HeaderValues& header_values = Http::Headers::get();
   // TODO(toddmgreer): Also serve HEAD requests from cache.
   // TODO(toddmgreer): Check all the other cache-related headers.
-  return headers.Path() && headers.Host() && !headers.Authorization() &&
+  return headers.Path() && headers.Host() && !headers.getInline(authorization_handle.handle()) &&
          (method == header_values.MethodValues.Get) &&
          (forwarded_proto == header_values.SchemeValues.Http ||
           forwarded_proto == header_values.SchemeValues.Https);
 }
 
 bool CacheFilterUtils::isCacheableResponse(const Http::ResponseHeaderMap& headers) {
-  const absl::string_view cache_control = headers.getCacheControlValue();
+  const absl::string_view cache_control = headers.getInlineValue(cache_control_handle.handle());
   // TODO(toddmgreer): fully check for cacheability. See for example
   // https://github.com/apache/incubator-pagespeed-mod/blob/master/pagespeed/kernel/http/caching_headers.h.
   return !StringUtil::caseFindToken(cache_control, ",",
-                                    Http::Headers::get().CacheControlValues.Private);
+                                    Http::CustomHeaders::get().CacheControlValues.Private);
 }
 
 } // namespace Cache

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -17,6 +17,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    request_cache_control_handle(Http::CustomHeaders::get().CacheControl);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+    response_cache_control_handle(Http::CustomHeaders::get().CacheControl);
+
 std::ostream& operator<<(std::ostream& os, CacheEntryStatus status) {
   switch (status) {
   case CacheEntryStatus::Ok:
@@ -38,7 +43,8 @@ std::ostream& operator<<(std::ostream& os, const AdjustedByteRange& range) {
 }
 
 LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, SystemTime timestamp)
-    : timestamp_(timestamp), request_cache_control_(request_headers.getCacheControlValue()) {
+    : timestamp_(timestamp), request_cache_control_(request_headers.getInlineValue(
+                                 request_cache_control_handle.handle())) {
   // These ASSERTs check prerequisites. A request without these headers can't be looked up in cache;
   // CacheFilter doesn't create LookupRequests for such requests.
   ASSERT(request_headers.Path(), "Can't form cache lookup key for malformed Http::RequestHeaderMap "
@@ -73,7 +79,8 @@ bool LookupRequest::isFresh(const Http::ResponseHeaderMap& response_headers) con
   if (!response_headers.Date()) {
     return false;
   }
-  const Http::HeaderEntry* cache_control_header = response_headers.CacheControl();
+  const Http::HeaderEntry* cache_control_header =
+      response_headers.getInline(response_cache_control_handle.handle());
   if (cache_control_header) {
     const SystemTime::duration effective_max_age =
         HttpCacheUtils::effectiveMaxAge(cache_control_header->value().getStringView());

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -15,6 +15,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Csrf {
 
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    origin_handle(Http::CustomHeaders::get().Origin);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    referer_handle(Http::CustomHeaders::get().Referer);
+
 struct RcDetailsValues {
   const std::string OriginMismatch = "csrf_origin_mismatch";
 };
@@ -43,11 +48,11 @@ absl::string_view hostAndPort(const absl::string_view header) {
 }
 
 absl::string_view sourceOriginValue(const Http::RequestHeaderMap& headers) {
-  const absl::string_view origin = hostAndPort(headers.getOriginValue());
+  const absl::string_view origin = hostAndPort(headers.getInlineValue(origin_handle.handle()));
   if (origin != EMPTY_STRING) {
     return origin;
   }
-  return hostAndPort(headers.getRefererValue());
+  return hostAndPort(headers.getInlineValue(referer_handle.handle()));
 }
 
 absl::string_view targetOriginValue(const Http::RequestHeaderMap& headers) {

--- a/source/extensions/filters/http/decompressor/decompressor_filter.cc
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.cc
@@ -3,12 +3,22 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/common/empty_string.h"
 #include "common/common/macros.h"
-#include "common/http/headers.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Decompressor {
+
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    accept_encoding_handle(Http::CustomHeaders::get().AcceptEncoding);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    cache_control_request_handle(Http::CustomHeaders::get().CacheControl);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    content_encoding_request_handle(Http::CustomHeaders::get().ContentEncoding);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+    cache_control_response_handle(Http::CustomHeaders::get().CacheControl);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+    content_encoding_response_handle(Http::CustomHeaders::get().ContentEncoding);
 
 DecompressorFilterConfig::DecompressorFilterConfig(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
@@ -60,10 +70,10 @@ Http::FilterHeadersStatus DecompressorFilter::decodeHeaders(Http::RequestHeaderM
   //      the upstream that this hop is able to decompress responses via the Accept-Encoding header.
   if (config_->responseDirectionConfig().decompressionEnabled() &&
       config_->requestDirectionConfig().advertiseAcceptEncoding()) {
-    headers.appendAcceptEncoding(config_->contentEncoding(), ",");
+    headers.appendInline(accept_encoding_handle.handle(), config_->contentEncoding(), ",");
     ENVOY_STREAM_LOG(debug,
                      "DecompressorFilter::decodeHeaders advertise Accept-Encoding with value '{}'",
-                     *decoder_callbacks_, headers.AcceptEncoding()->value().getStringView());
+                     *decoder_callbacks_, headers.getInlineValue(accept_encoding_handle.handle()));
   }
 
   //   2. If request decompression is enabled, then decompress the request.
@@ -93,30 +103,6 @@ Http::FilterDataStatus DecompressorFilter::encodeData(Buffer::Instance& data, bo
                          *encoder_callbacks_, data);
 }
 
-Http::FilterHeadersStatus DecompressorFilter::maybeInitDecompress(
-    const DecompressorFilterConfig::DirectionConfig& direction_config,
-    Compression::Decompressor::DecompressorPtr& decompressor,
-    Http::StreamFilterCallbacks& callbacks, Http::RequestOrResponseHeaderMap& headers) {
-  if (direction_config.decompressionEnabled() && !hasCacheControlNoTransform(headers) &&
-      contentEncodingMatches(headers)) {
-    direction_config.stats().decompressed_.inc();
-    decompressor = config_->makeDecompressor();
-
-    // Update headers.
-    headers.removeContentLength();
-    modifyContentEncoding(headers);
-
-    ENVOY_STREAM_LOG(debug, "do decompress {}: {}", callbacks, direction_config.logString(),
-                     headers);
-  } else {
-    direction_config.stats().not_decompressed_.inc();
-    ENVOY_STREAM_LOG(debug, "do not decompress {}: {}", callbacks, direction_config.logString(),
-                     headers);
-  }
-
-  return Http::FilterHeadersStatus::Continue;
-}
-
 Http::FilterDataStatus DecompressorFilter::maybeDecompress(
     const DecompressorFilterConfig::DirectionConfig& direction_config,
     const Compression::Decompressor::DecompressorPtr& decompressor,
@@ -137,36 +123,28 @@ Http::FilterDataStatus DecompressorFilter::maybeDecompress(
   return Http::FilterDataStatus::Continue;
 }
 
-bool DecompressorFilter::hasCacheControlNoTransform(
-    Http::RequestOrResponseHeaderMap& headers) const {
-  return headers.CacheControl()
-             ? StringUtil::caseFindToken(headers.CacheControl()->value().getStringView(), ",",
-                                         Http::Headers::get().CacheControlValues.NoTransform)
-             : false;
+template <>
+Http::CustomInlineHeaderRegistry::Handle<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+DecompressorFilter::getCacheControlHandle() {
+  return cache_control_request_handle.handle();
 }
 
-/**
- * Content-Encoding matches if the configured encoding is the first value in the comma-delimited
- * Content-Encoding header, regardless of spacing and casing.
- */
-bool DecompressorFilter::contentEncodingMatches(Http::RequestOrResponseHeaderMap& headers) const {
-  if (headers.ContentEncoding()) {
-    absl::string_view coding = StringUtil::trim(
-        StringUtil::cropRight(headers.ContentEncoding()->value().getStringView(), ","));
-    return StringUtil::CaseInsensitiveCompare()(config_->contentEncoding(), coding);
-  }
-  return false;
+template <>
+Http::CustomInlineHeaderRegistry::Handle<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+DecompressorFilter::getCacheControlHandle() {
+  return cache_control_response_handle.handle();
 }
 
-void DecompressorFilter::modifyContentEncoding(Http::RequestOrResponseHeaderMap& headers) const {
-  const auto all_codings = StringUtil::trim(headers.ContentEncoding()->value().getStringView());
-  const auto remaining_codings = StringUtil::trim(StringUtil::cropLeft(all_codings, ","));
+template <>
+Http::CustomInlineHeaderRegistry::Handle<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+DecompressorFilter::getContentEncodingHandle() {
+  return content_encoding_request_handle.handle();
+}
 
-  if (remaining_codings != all_codings) {
-    headers.setContentEncoding(remaining_codings);
-  } else {
-    headers.removeContentEncoding();
-  }
+template <>
+Http::CustomInlineHeaderRegistry::Handle<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+DecompressorFilter::getContentEncodingHandle() {
+  return content_encoding_response_handle.handle();
 }
 
 } // namespace Decompressor

--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -6,6 +6,7 @@
 #include "envoy/http/filter.h"
 
 #include "common/common/macros.h"
+#include "common/http/headers.h"
 #include "common/runtime/runtime_protos.h"
 
 #include "extensions/filters/http/common/pass_through_filter.h"
@@ -126,22 +127,75 @@ public:
   Http::FilterDataStatus encodeData(Buffer::Instance&, bool) override;
 
 private:
+  template <class HeaderType>
   Http::FilterHeadersStatus
   maybeInitDecompress(const DecompressorFilterConfig::DirectionConfig& direction_config,
                       Compression::Decompressor::DecompressorPtr& decompressor,
-                      Http::StreamFilterCallbacks& callbacks,
-                      Http::RequestOrResponseHeaderMap& headers);
+                      Http::StreamFilterCallbacks& callbacks, HeaderType& headers) {
+    if (direction_config.decompressionEnabled() && !hasCacheControlNoTransform(headers) &&
+        contentEncodingMatches(headers)) {
+      direction_config.stats().decompressed_.inc();
+      decompressor = config_->makeDecompressor();
+
+      // Update headers.
+      headers.removeContentLength();
+      modifyContentEncoding(headers);
+
+      ENVOY_STREAM_LOG(debug, "do decompress {}: {}", callbacks, direction_config.logString(),
+                       headers);
+    } else {
+      direction_config.stats().not_decompressed_.inc();
+      ENVOY_STREAM_LOG(debug, "do not decompress {}: {}", callbacks, direction_config.logString(),
+                       headers);
+    }
+
+    return Http::FilterHeadersStatus::Continue;
+  }
 
   Http::FilterDataStatus
   maybeDecompress(const DecompressorFilterConfig::DirectionConfig& direction_config,
                   const Compression::Decompressor::DecompressorPtr& decompressor,
                   Http::StreamFilterCallbacks& callbacks, Buffer::Instance& input_buffer) const;
 
-  // TODO(junr03): these do not need to be member functions. They can all be part of a static
-  // utility class. Moreover, they can be shared between compressor and decompressor.
-  bool hasCacheControlNoTransform(Http::RequestOrResponseHeaderMap& headers) const;
-  bool contentEncodingMatches(Http::RequestOrResponseHeaderMap& headers) const;
-  void modifyContentEncoding(Http::RequestOrResponseHeaderMap& headers) const;
+  // TODO(junr03): These can be shared between compressor and decompressor.
+  template <Http::CustomInlineHeaderRegistry::Type Type>
+  static Http::CustomInlineHeaderRegistry::Handle<Type> getCacheControlHandle();
+  template <class HeaderType> static bool hasCacheControlNoTransform(HeaderType& headers) {
+    const auto handle = getCacheControlHandle<HeaderType::header_map_type>();
+    return headers.getInline(handle)
+               ? StringUtil::caseFindToken(
+                     headers.getInlineValue(handle), ",",
+                     Http::CustomHeaders::get().CacheControlValues.NoTransform)
+               : false;
+  }
+
+  /**
+   * Content-Encoding matches if the configured encoding is the first value in the comma-delimited
+   * Content-Encoding header, regardless of spacing and casing.
+   */
+  template <Http::CustomInlineHeaderRegistry::Type Type>
+  static Http::CustomInlineHeaderRegistry::Handle<Type> getContentEncodingHandle();
+  template <class HeaderType> bool contentEncodingMatches(HeaderType& headers) const {
+    const auto handle = getContentEncodingHandle<HeaderType::header_map_type>();
+    if (headers.getInline(handle)) {
+      absl::string_view coding =
+          StringUtil::trim(StringUtil::cropRight(headers.getInlineValue(handle), ","));
+      return StringUtil::CaseInsensitiveCompare()(config_->contentEncoding(), coding);
+    }
+    return false;
+  }
+
+  template <class HeaderType> static void modifyContentEncoding(HeaderType& headers) {
+    const auto handle = getContentEncodingHandle<HeaderType::header_map_type>();
+    const auto all_codings = StringUtil::trim(headers.getInlineValue(handle));
+    const auto remaining_codings = StringUtil::trim(StringUtil::cropLeft(all_codings, ","));
+
+    if (remaining_codings != all_codings) {
+      headers.setInline(handle, remaining_codings);
+    } else {
+      headers.removeInline(handle);
+    }
+  }
 
   DecompressorFilterConfigSharedPtr config_;
   Compression::Decompressor::DecompressorPtr request_decompressor_{};

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -16,6 +16,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1ReverseBridge {
 
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    accept_handle(Http::CustomHeaders::get().Accept);
+
 struct RcDetailsValues {
   // The gRPC HTTP/1 reverse bridge failed because the body payload was too
   // small to be a gRPC frame.
@@ -93,7 +96,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     // gRPC content type variations such as application/grpc+proto.
     content_type_ = std::string(headers.getContentTypeValue());
     headers.setContentType(upstream_content_type_);
-    headers.setAccept(upstream_content_type_);
+    headers.setInline(accept_handle.handle(), upstream_content_type_);
 
     if (withhold_grpc_frames_) {
       // Adjust the content-length header to account for us removing the gRPC frame header.

--- a/source/extensions/filters/http/gzip/gzip_filter.cc
+++ b/source/extensions/filters/http/gzip/gzip_filter.cc
@@ -28,7 +28,7 @@ GzipFilterConfig::GzipFilterConfig(const envoy::extensions::filters::http::gzip:
                                    const std::string& stats_prefix, Stats::Scope& scope,
                                    Runtime::Loader& runtime)
     : CompressorFilterConfig(compressorConfig(gzip), stats_prefix + "gzip.", scope, runtime,
-                             Http::Headers::get().ContentEncodingValues.Gzip),
+                             Http::CustomHeaders::get().ContentEncodingValues.Gzip),
       compression_level_(compressionLevelEnum(gzip.compression_level())),
       compression_strategy_(compressionStrategyEnum(gzip.compression_strategy())),
       memory_level_(memoryLevelUint(gzip.memory_level().value())),

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -153,7 +153,7 @@ void ExtractorImpl::addProvider(const JwtProvider& provider) {
   }
   // If not specified, use default locations.
   if (provider.from_headers().empty() && provider.from_params().empty()) {
-    addHeaderConfig(provider.issuer(), Http::Headers::get().Authorization,
+    addHeaderConfig(provider.issuer(), Http::CustomHeaders::get().Authorization,
                     JwtConstValues::get().BearerPrefix);
     addQueryParamConfig(provider.issuer(), JwtConstValues::get().AccessTokenParam);
   }

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -17,12 +17,14 @@ namespace JwtAuthn {
 namespace {
 
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    access_control_request_method(Http::Headers::get().AccessControlRequestMethod);
+    access_control_request_method_handle(Http::CustomHeaders::get().AccessControlRequestMethod);
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    origin_handle(Http::CustomHeaders::get().AccessControlRequestMethod);
 
 bool isCorsPreflightRequest(const Http::RequestHeaderMap& headers) {
   return headers.getMethodValue() == Http::Headers::get().MethodValues.Options &&
-         headers.Origin() && !headers.Origin()->value().empty() &&
-         !headers.getInlineValue(access_control_request_method.handle()).empty();
+         !headers.getInlineValue(origin_handle.handle()).empty() &&
+         !headers.getInlineValue(access_control_request_method_handle.handle()).empty();
 }
 
 } // namespace

--- a/source/server/admin/utils.cc
+++ b/source/server/admin/utils.cc
@@ -23,18 +23,19 @@ envoy::admin::v3::ServerInfo::State serverState(Init::Manager::State state,
 
 void populateFallbackResponseHeaders(Http::Code code, Http::ResponseHeaderMap& header_map) {
   header_map.setStatus(std::to_string(enumToInt(code)));
-  const auto& headers = Http::Headers::get();
   if (header_map.ContentType() == nullptr) {
     // Default to text-plain if unset.
-    header_map.setReferenceContentType(headers.ContentTypeValues.TextUtf8);
+    header_map.setReferenceContentType(Http::Headers::get().ContentTypeValues.TextUtf8);
   }
   // Default to 'no-cache' if unset, but not 'no-store' which may break the back button.
-  if (header_map.CacheControl() == nullptr) {
-    header_map.setReferenceCacheControl(headers.CacheControlValues.NoCacheMaxAge0);
+  if (header_map.get(Http::CustomHeaders::get().CacheControl) == nullptr) {
+    header_map.setReference(Http::CustomHeaders::get().CacheControl,
+                            Http::CustomHeaders::get().CacheControlValues.NoCacheMaxAge0);
   }
 
   // Under no circumstance should browsers sniff content-type.
-  header_map.addReference(headers.XContentTypeOptions, headers.XContentTypeOptionValues.Nosniff);
+  header_map.addReference(Http::Headers::get().XContentTypeOptions,
+                          Http::Headers::get().XContentTypeOptionValues.Nosniff);
 }
 
 // Helper method to get filter parameter, or report an error for an invalid regex.

--- a/test/common/grpc/grpc_client_integration_test.cc
+++ b/test/common/grpc/grpc_client_integration_test.cc
@@ -413,14 +413,13 @@ public:
   void expectExtraHeaders(FakeStream& fake_stream) override {
     AssertionResult result = fake_stream.waitForHeadersComplete();
     RELEASE_ASSERT(result, result.message());
-    Http::TestRequestHeaderMapImpl stream_headers(fake_stream.headers());
+    std::vector<absl::string_view> auth_headers;
+    Http::HeaderUtility::getAllOfHeader(fake_stream.headers(), "authorization", auth_headers);
     if (!access_token_value_.empty()) {
-      if (access_token_value_2_.empty()) {
-        EXPECT_EQ("Bearer " + access_token_value_, stream_headers.get_("authorization"));
-      } else {
-        EXPECT_EQ("Bearer " + access_token_value_ + ",Bearer " + access_token_value_2_,
-                  stream_headers.get_("authorization"));
-      }
+      EXPECT_EQ("Bearer " + access_token_value_, auth_headers[0]);
+    }
+    if (!access_token_value_2_.empty()) {
+      EXPECT_EQ("Bearer " + access_token_value_2_, auth_headers[1]);
     }
   }
 

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -445,20 +445,20 @@ TEST(HeaderMapImplTest, InlineAppend) {
 TEST(HeaderMapImplTest, MoveIntoInline) {
   TestRequestHeaderMapImpl headers;
   HeaderString key;
-  key.setCopy(Headers::get().CacheControl.get());
+  key.setCopy(Headers::get().EnvoyRetryOn.get());
   HeaderString value;
   value.setCopy("hello");
   headers.addViaMove(std::move(key), std::move(value));
-  EXPECT_EQ("cache-control", headers.CacheControl()->key().getStringView());
-  EXPECT_EQ("hello", headers.getCacheControlValue());
+  EXPECT_EQ("x-envoy-retry-on", headers.EnvoyRetryOn()->key().getStringView());
+  EXPECT_EQ("hello", headers.getEnvoyRetryOnValue());
 
   HeaderString key2;
-  key2.setCopy(Headers::get().CacheControl.get());
+  key2.setCopy(Headers::get().EnvoyRetryOn.get());
   HeaderString value2;
   value2.setCopy("there");
   headers.addViaMove(std::move(key2), std::move(value2));
-  EXPECT_EQ("cache-control", headers.CacheControl()->key().getStringView());
-  EXPECT_EQ("hello,there", headers.getCacheControlValue());
+  EXPECT_EQ("x-envoy-retry-on", headers.EnvoyRetryOn()->key().getStringView());
+  EXPECT_EQ("hello,there", headers.getEnvoyRetryOnValue());
 }
 
 TEST(HeaderMapImplTest, Remove) {
@@ -787,19 +787,19 @@ TEST(HeaderMapImplTest, AddCopy) {
   EXPECT_EQ("42", headers.get(lcKey3)->value().getStringView());
   EXPECT_EQ(2UL, headers.get(lcKey3)->value().size());
 
-  LowerCaseString cache_control("cache-control");
-  headers.addCopy(cache_control, "max-age=1345");
-  EXPECT_EQ("max-age=1345", headers.get(cache_control)->value().getStringView());
-  EXPECT_EQ("max-age=1345", headers.getCacheControlValue());
-  headers.addCopy(cache_control, "public");
-  EXPECT_EQ("max-age=1345,public", headers.get(cache_control)->value().getStringView());
-  headers.addCopy(cache_control, "");
-  EXPECT_EQ("max-age=1345,public", headers.get(cache_control)->value().getStringView());
-  headers.addCopy(cache_control, 123);
-  EXPECT_EQ("max-age=1345,public,123", headers.get(cache_control)->value().getStringView());
-  headers.addCopy(cache_control, std::numeric_limits<uint64_t>::max());
+  LowerCaseString envoy_retry_on("x-envoy-retry-on");
+  headers.addCopy(envoy_retry_on, "max-age=1345");
+  EXPECT_EQ("max-age=1345", headers.get(envoy_retry_on)->value().getStringView());
+  EXPECT_EQ("max-age=1345", headers.getEnvoyRetryOnValue());
+  headers.addCopy(envoy_retry_on, "public");
+  EXPECT_EQ("max-age=1345,public", headers.get(envoy_retry_on)->value().getStringView());
+  headers.addCopy(envoy_retry_on, "");
+  EXPECT_EQ("max-age=1345,public", headers.get(envoy_retry_on)->value().getStringView());
+  headers.addCopy(envoy_retry_on, 123);
+  EXPECT_EQ("max-age=1345,public,123", headers.get(envoy_retry_on)->value().getStringView());
+  headers.addCopy(envoy_retry_on, std::numeric_limits<uint64_t>::max());
   EXPECT_EQ("max-age=1345,public,123,18446744073709551615",
-            headers.get(cache_control)->value().getStringView());
+            headers.get(envoy_retry_on)->value().getStringView());
 }
 
 TEST(HeaderMapImplTest, Equality) {

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -149,7 +149,8 @@ TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
   // Check allowed request headers.
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Method.get()));
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Host.get()));
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Authorization.get()));
+  EXPECT_TRUE(
+      config_->requestHeaderMatchers()->matches(Http::CustomHeaders::get().Authorization.get()));
   EXPECT_FALSE(config_->requestHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(baz.get()));
 
@@ -159,7 +160,7 @@ TEST_F(ExtAuthzHttpClientTest, ClientConfig) {
   EXPECT_FALSE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Path.get()));
   EXPECT_FALSE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Host.get()));
   EXPECT_TRUE(config_->clientHeaderMatchers()->matches(Http::Headers::get().WWWAuthenticate.get()));
-  EXPECT_FALSE(config_->clientHeaderMatchers()->matches(Http::Headers::get().Origin.get()));
+  EXPECT_FALSE(config_->clientHeaderMatchers()->matches(Http::CustomHeaders::get().Origin.get()));
   EXPECT_TRUE(config_->clientHeaderMatchers()->matches(foo.get()));
 
   // Check allowed upstream headers.
@@ -191,7 +192,8 @@ TEST_F(ExtAuthzHttpClientTest, TestDefaultAllowedHeaders) {
   // Check allowed request headers.
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Method.get()));
   EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Host.get()));
-  EXPECT_TRUE(config_->requestHeaderMatchers()->matches(Http::Headers::get().Authorization.get()));
+  EXPECT_TRUE(
+      config_->requestHeaderMatchers()->matches(Http::CustomHeaders::get().Authorization.get()));
   EXPECT_FALSE(config_->requestHeaderMatchers()->matches(Http::Headers::get().ContentLength.get()));
 
   // Check allowed client headers.

--- a/test/extensions/filters/http/cache/cache_filter_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_utils_test.cc
@@ -56,7 +56,8 @@ TEST_F(IsCacheableRequestTest, ForwardedProtoHeader) {
 TEST_F(IsCacheableRequestTest, AuthorizationHeader) {
   Http::TestRequestHeaderMapImpl request_headers = cacheable_request_headers;
   EXPECT_TRUE(CacheFilterUtils::isCacheableRequest(request_headers));
-  request_headers.setAuthorization("basic YWxhZGRpbjpvcGVuc2VzYW1l");
+  request_headers.setCopy(Http::CustomHeaders::get().Authorization,
+                          "basic YWxhZGRpbjpvcGVuc2VzYW1l");
   EXPECT_FALSE(CacheFilterUtils::isCacheableRequest(request_headers));
 }
 

--- a/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/filters/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -24,7 +24,7 @@ protected:
     request_headers_.setMethod("GET");
     request_headers_.setHost("example.com");
     request_headers_.setForwardedProto("https");
-    request_headers_.setCacheControl("max-age=3600");
+    request_headers_.setCopy(Http::CustomHeaders::get().CacheControl, "max-age=3600");
   }
 
   // Performs a cache lookup.
@@ -160,7 +160,7 @@ TEST_F(SimpleHttpCacheTest, Stale) {
 }
 
 TEST_F(SimpleHttpCacheTest, RequestSmallMinFresh) {
-  request_headers_.setReferenceKey(Http::Headers::get().CacheControl, "min-fresh=1000");
+  request_headers_.setReferenceKey(Http::CustomHeaders::get().CacheControl, "min-fresh=1000");
   const std::string request_path("Name");
   LookupContextPtr name_lookup_context = lookup(request_path);
   EXPECT_EQ(CacheEntryStatus::Unusable, lookup_result_.cache_entry_status_);
@@ -174,7 +174,7 @@ TEST_F(SimpleHttpCacheTest, RequestSmallMinFresh) {
 }
 
 TEST_F(SimpleHttpCacheTest, ResponseStaleWithRequestLargeMaxStale) {
-  request_headers_.setReferenceKey(Http::Headers::get().CacheControl, "max-stale=9000");
+  request_headers_.setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-stale=9000");
 
   const std::string request_path("Name");
   LookupContextPtr name_lookup_context = lookup(request_path);

--- a/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_integration_test.cc
@@ -36,8 +36,11 @@ public:
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().getStatusValue());
-    EXPECT_EQ(Http::Headers::get().ContentEncodingValues.Gzip,
-              response->headers().getContentEncodingValue());
+    EXPECT_EQ(Http::CustomHeaders::get().ContentEncodingValues.Gzip,
+              response->headers()
+                  .get(Http::CustomHeaders::get().ContentEncoding)
+                  ->value()
+                  .getStringView());
     EXPECT_EQ(Http::Headers::get().TransferEncodingValues.Chunked,
               response->headers().getTransferEncodingValue());
 
@@ -58,7 +61,7 @@ public:
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().getStatusValue());
-    ASSERT_TRUE(response->headers().ContentEncoding() == nullptr);
+    ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) == nullptr);
     ASSERT_EQ(content_length, response->body().size());
     EXPECT_EQ(response->body(), std::string(content_length, 'a'));
   }
@@ -183,7 +186,9 @@ TEST_P(CompressorIntegrationTest, UpstreamResponseAlreadyEncoded) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_EQ("br", response->headers().getContentEncodingValue());
+  ASSERT_EQ(
+      "br",
+      response->headers().get(Http::CustomHeaders::get().ContentEncoding)->value().getStringView());
   EXPECT_EQ(128U, response->body().size());
 }
 
@@ -207,7 +212,7 @@ TEST_P(CompressorIntegrationTest, NotEnoughContentLength) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_TRUE(response->headers().ContentEncoding() == nullptr);
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) == nullptr);
   EXPECT_EQ(10U, response->body().size());
 }
 
@@ -230,7 +235,7 @@ TEST_P(CompressorIntegrationTest, EmptyResponse) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("204", response->headers().getStatusValue());
-  ASSERT_TRUE(response->headers().ContentEncoding() == nullptr);
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) == nullptr);
   EXPECT_EQ(0U, response->body().size());
 }
 
@@ -285,14 +290,16 @@ TEST_P(CompressorIntegrationTest, AcceptanceFullConfigChunkedResponse) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_EQ("gzip", response->headers().getContentEncodingValue());
+  ASSERT_EQ(
+      "gzip",
+      response->headers().get(Http::CustomHeaders::get().ContentEncoding)->value().getStringView());
   ASSERT_EQ("chunked", response->headers().getTransferEncodingValue());
 }
 
 /**
  * Verify Vary header values are preserved.
  */
-TEST_P(CompressorIntegrationTest, AcceptanceFullConfigVeryHeader) {
+TEST_P(CompressorIntegrationTest, AcceptanceFullConfigVaryHeader) {
   initializeFilter(default_config);
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
                                                  {":path", "/test/long/url"},
@@ -309,7 +316,10 @@ TEST_P(CompressorIntegrationTest, AcceptanceFullConfigVeryHeader) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_EQ("gzip", response->headers().getContentEncodingValue());
-  ASSERT_EQ("Cookie, Accept-Encoding", response->headers().getVaryValue());
+  ASSERT_EQ(
+      "gzip",
+      response->headers().get(Http::CustomHeaders::get().ContentEncoding)->value().getStringView());
+  ASSERT_EQ("Cookie, Accept-Encoding",
+            response->headers().get(Http::CustomHeaders::get().Vary)->value().getStringView());
 }
 } // namespace Envoy

--- a/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
+++ b/test/extensions/filters/http/decompressor/decompressor_filter_test.cc
@@ -114,9 +114,11 @@ decompressor_library:
     // The filter removes the decompressor's content encoding from the Content-Encoding header.
     if (expected_content_encoding.has_value()) {
       EXPECT_EQ(expected_content_encoding.value(),
-                headers_after_filter->ContentEncoding()->value().getStringView());
+                headers_after_filter->get(Http::CustomHeaders::get().ContentEncoding)
+                    ->value()
+                    .getStringView());
     } else {
-      EXPECT_EQ(nullptr, headers_after_filter->ContentEncoding());
+      EXPECT_EQ(nullptr, headers_after_filter->get(Http::CustomHeaders::get().ContentEncoding));
     }
 
     // The filter adds the decompressor's content encoding to the Accept-Encoding header on the
@@ -342,7 +344,7 @@ TEST_P(DecompressorFilterTest, NoDecompressionContentEncodingNotCurrent) {
 TEST_P(DecompressorFilterTest, NoResponseDecompressionNoTransformPresent) {
   EXPECT_CALL(*decompressor_factory_, createDecompressor()).Times(0);
   Http::TestRequestHeaderMapImpl headers_before_filter{
-      {"cache-control", Http::Headers::get().CacheControlValues.NoTransform},
+      {"cache-control", Http::CustomHeaders::get().CacheControlValues.NoTransform},
       {"content-encoding", "mock"},
       {"content-length", "256"}};
   std::unique_ptr<Http::RequestOrResponseHeaderMap> headers_after_filter =
@@ -355,8 +357,8 @@ TEST_P(DecompressorFilterTest, NoResponseDecompressionNoTransformPresent) {
 TEST_P(DecompressorFilterTest, NoResponseDecompressionNoTransformPresentInList) {
   EXPECT_CALL(*decompressor_factory_, createDecompressor()).Times(0);
   Http::TestRequestHeaderMapImpl headers_before_filter{
-      {"cache-control", fmt::format("{}, {}", Http::Headers::get().CacheControlValues.NoCache,
-                                    Http::Headers::get().CacheControlValues.NoTransform)},
+      {"cache-control", fmt::format("{}, {}", Http::CustomHeaders::get().CacheControlValues.NoCache,
+                                    Http::CustomHeaders::get().CacheControlValues.NoTransform)},
       {"content-encoding", "mock"},
       {"content-length", "256"}};
   std::unique_ptr<Http::RequestOrResponseHeaderMap> headers_after_filter =

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_integration_test.cc
@@ -141,7 +141,7 @@ TEST_P(ReverseBridgeIntegrationTest, EnabledRoute) {
   EXPECT_THAT(upstream_request_->headers(),
               HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
   EXPECT_THAT(upstream_request_->headers(),
-              HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+              HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
 
   // Respond to the request.
   Http::TestResponseHeaderMapImpl response_headers;

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -60,7 +60,8 @@ TEST_F(ReverseBridgeTest, InvalidGrpcRequest) {
 
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "20"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -174,7 +175,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestNoManageFrameHeader) {
 
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "25"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -234,7 +236,8 @@ TEST_F(ReverseBridgeTest, GrpcRequest) {
 
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "20"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -313,7 +316,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestNoContentLength) {
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
 
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
     // Ensure that we don't insert a content-length header.
     EXPECT_EQ(nullptr, headers.ContentLength());
   }
@@ -396,7 +400,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestHeaderOnlyResponse) {
 
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "20"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -441,7 +446,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestInternalError) {
         {{"content-type", "application/grpc"}, {":path", "/testing.ExampleService/SendData"}});
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -516,7 +522,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestBadResponseNoContentType) {
         {{"content-type", "application/grpc"}, {":path", "/testing.ExampleService/SendData"}});
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -566,7 +573,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestBadResponse) {
         {{"content-type", "application/grpc"}, {":path", "/testing.ExampleService/SendData"}});
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -656,7 +664,8 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteEnabled) {
 
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "20"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {
@@ -742,7 +751,8 @@ TEST_F(ReverseBridgeTest, RouteWithTrailers) {
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentType, "application/x-protobuf"));
     EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().ContentLength, "20"));
-    EXPECT_THAT(headers, HeaderValueOf(Http::Headers::get().Accept, "application/x-protobuf"));
+    EXPECT_THAT(headers,
+                HeaderValueOf(Http::CustomHeaders::get().Accept, "application/x-protobuf"));
   }
 
   {

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -95,13 +95,13 @@ public:
             [=](Buffer::Instance& data, bool) { EXPECT_EQ(expected_message, data.toString()); }));
   }
 
-  void expectRequiredGrpcUpstreamHeaders(const Http::RequestHeaderMap& request_headers) {
+  void expectRequiredGrpcUpstreamHeaders(const Http::TestRequestHeaderMapImpl& request_headers) {
     EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc, request_headers.getContentTypeValue());
     // Ensure we never send content-length upstream
     EXPECT_EQ(nullptr, request_headers.ContentLength());
     EXPECT_EQ(Http::Headers::get().TEValues.Trailers, request_headers.getTEValue());
-    EXPECT_EQ(Http::Headers::get().GrpcAcceptEncodingValues.Default,
-              request_headers.getGrpcAcceptEncodingValue());
+    EXPECT_EQ(Http::CustomHeaders::get().GrpcAcceptEncodingValues.Default,
+              request_headers.get_(Http::CustomHeaders::get().GrpcAcceptEncoding));
   }
 
   Stats::TestSymbolTable symbol_table_;
@@ -261,7 +261,7 @@ TEST_P(GrpcWebFilterTest, StatsErrorResponse) {
 TEST_P(GrpcWebFilterTest, Unary) {
   // Tests request headers.
   request_headers_.addCopy(Http::Headers::get().ContentType, request_content_type());
-  request_headers_.addCopy(Http::Headers::get().Accept, request_accept());
+  request_headers_.addCopy(Http::CustomHeaders::get().Accept, request_accept());
   request_headers_.addCopy(Http::Headers::get().ContentLength, uint64_t(8));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, false));

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -36,9 +36,12 @@ public:
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().getStatusValue());
-    ASSERT_TRUE(response->headers().ContentEncoding() != nullptr);
-    EXPECT_EQ(Http::Headers::get().ContentEncodingValues.Gzip,
-              response->headers().getContentEncodingValue());
+    ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) != nullptr);
+    EXPECT_EQ(Http::CustomHeaders::get().ContentEncodingValues.Gzip,
+              response->headers()
+                  .get(Http::CustomHeaders::get().ContentEncoding)
+                  ->value()
+                  .getStringView());
     ASSERT_TRUE(response->headers().TransferEncoding() != nullptr);
     EXPECT_EQ(Http::Headers::get().TransferEncodingValues.Chunked,
               response->headers().getTransferEncodingValue());
@@ -60,7 +63,7 @@ public:
     EXPECT_EQ(0U, upstream_request_->bodyLength());
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().getStatusValue());
-    ASSERT_TRUE(response->headers().ContentEncoding() == nullptr);
+    ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) == nullptr);
     ASSERT_EQ(content_length, response->body().size());
     EXPECT_EQ(response->body(), std::string(content_length, 'a'));
   }
@@ -204,7 +207,9 @@ TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(UpstreamResponseAlreadyEncod
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_EQ("br", response->headers().getContentEncodingValue());
+  ASSERT_EQ(
+      "br",
+      response->headers().get(Http::CustomHeaders::get().ContentEncoding)->value().getStringView());
   EXPECT_EQ(128U, response->body().size());
 }
 
@@ -228,7 +233,7 @@ TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(NotEnoughContentLength)) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_TRUE(response->headers().ContentEncoding() == nullptr);
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) == nullptr);
   EXPECT_EQ(10U, response->body().size());
 }
 
@@ -251,7 +256,7 @@ TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(EmptyResponse)) {
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("204", response->headers().getStatusValue());
-  ASSERT_TRUE(response->headers().ContentEncoding() == nullptr);
+  ASSERT_TRUE(response->headers().get(Http::CustomHeaders::get().ContentEncoding) == nullptr);
   EXPECT_EQ(0U, response->body().size());
 }
 
@@ -306,14 +311,16 @@ TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(AcceptanceFullConfigChunkedR
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_EQ("gzip", response->headers().getContentEncodingValue());
+  ASSERT_EQ(
+      "gzip",
+      response->headers().get(Http::CustomHeaders::get().ContentEncoding)->value().getStringView());
   ASSERT_EQ("chunked", response->headers().getTransferEncodingValue());
 }
 
 /**
  * Verify Vary header values are preserved.
  */
-TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(AcceptanceFullConfigVeryHeader)) {
+TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(AcceptanceFullConfigVaryHeader)) {
   initializeFilter(default_config);
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
                                                  {":path", "/test/long/url"},
@@ -330,7 +337,10 @@ TEST_P(GzipIntegrationTest, DEPRECATED_FEATURE_TEST(AcceptanceFullConfigVeryHead
   EXPECT_EQ(0U, upstream_request_->bodyLength());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
-  ASSERT_EQ("gzip", response->headers().getContentEncodingValue());
-  ASSERT_EQ("Cookie, Accept-Encoding", response->headers().getVaryValue());
+  ASSERT_EQ(
+      "gzip",
+      response->headers().get(Http::CustomHeaders::get().ContentEncoding)->value().getStringView());
+  ASSERT_EQ("Cookie, Accept-Encoding",
+            response->headers().get(Http::CustomHeaders::get().Vary)->value().getStringView());
 }
 } // namespace Envoy

--- a/test/extensions/filters/http/gzip/gzip_filter_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_test.cc
@@ -81,7 +81,8 @@ protected:
     feedBuffer(content_length);
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
     EXPECT_EQ("", headers.get_("content-length"));
-    EXPECT_EQ(Http::Headers::get().ContentEncodingValues.Gzip, headers.get_("content-encoding"));
+    EXPECT_EQ(Http::CustomHeaders::get().ContentEncodingValues.Gzip,
+              headers.get_("content-encoding"));
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, !with_trailers));
     if (with_trailers) {
       Buffer::OwnedImpl trailers_buffer;

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -106,7 +106,7 @@ TEST_F(AuthenticatorTest, TestOkJWTandCache) {
 
     EXPECT_EQ(headers.get_("sec-istio-auth-userinfo"), ExpectedPayloadValue);
     // Verify the token is removed.
-    EXPECT_FALSE(headers.Authorization());
+    EXPECT_FALSE(headers.has(Http::CustomHeaders::get().Authorization));
   }
 }
 
@@ -128,7 +128,7 @@ TEST_F(AuthenticatorTest, TestForwardJwt) {
   expectVerifyStatus(Status::Ok, headers);
 
   // Verify the token is NOT removed.
-  EXPECT_TRUE(headers.Authorization());
+  EXPECT_TRUE(headers.has(Http::CustomHeaders::get().Authorization));
 
   // Payload not set by default
   EXPECT_EQ(out_name_, "");

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -112,7 +112,7 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocation) {
 
   // Test token remove
   tokens[0]->removeJwt(headers);
-  EXPECT_FALSE(headers.Authorization());
+  EXPECT_FALSE(headers.has(Http::CustomHeaders::get().Authorization));
 }
 
 // Test extracting JWT as Bearer token from the default header location: "Authorization" -

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -114,7 +114,7 @@ TEST_P(LocalJwksIntegrationTest, WithGoodToken) {
   EXPECT_TRUE(payload_entry != nullptr);
   EXPECT_EQ(payload_entry->value().getStringView(), ExpectedPayloadValue);
   // Verify the token is removed.
-  EXPECT_FALSE(upstream_request_->headers().Authorization());
+  EXPECT_EQ(nullptr, upstream_request_->headers().get(Http::CustomHeaders::get().Authorization));
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   response->waitForEndStream();
   ASSERT_TRUE(response->complete());
@@ -392,7 +392,7 @@ TEST_P(RemoteJwksIntegrationTest, WithGoodToken) {
   EXPECT_TRUE(payload_entry != nullptr);
   EXPECT_EQ(payload_entry->value().getStringView(), ExpectedPayloadValue);
   // Verify the token is removed.
-  EXPECT_FALSE(upstream_request_->headers().Authorization());
+  EXPECT_EQ(nullptr, upstream_request_->headers().get(Http::CustomHeaders::get().Authorization));
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
 

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -527,7 +527,7 @@ TEST_F(HystrixSinkTest, HystrixEventStreamHandler) {
 
   // Check that response_headers has been set correctly
   EXPECT_EQ(response_headers.ContentType()->value(), "text/event-stream");
-  EXPECT_EQ(response_headers.CacheControl()->value(), "no-cache");
+  EXPECT_EQ(response_headers.get_("cache-control"), "no-cache");
   EXPECT_EQ(response_headers.Connection()->value(), "close");
   EXPECT_EQ(response_headers.get_("access-control-allow-origin"), "*");
   EXPECT_THAT(response_headers.get_("access-control-allow-headers"), HasSubstr("Accept"));

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -175,7 +175,7 @@ TEST_F(OpenTracingDriverTest, InjectFailure) {
 
     const auto span_context_injection_error_count =
         stats_.counter("tracing.opentracing.span_context_injection_error").value();
-    EXPECT_EQ(nullptr, request_headers_.OtSpanContext());
+    EXPECT_FALSE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
     span->injectContext(request_headers_);
 
     EXPECT_EQ(span_context_injection_error_count + 1,

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -618,24 +618,24 @@ TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
 
     // Supply bogus context, that will be simply ignored.
     const std::string invalid_context = "notvalidcontext";
-    request_headers_.setOtSpanContext(invalid_context);
+    request_headers_.setCopy(Http::CustomHeaders::get().OtSpanContext, invalid_context);
     stats_.counter("tracing.opentracing.span_context_extraction_error").reset();
     driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
                        {Tracing::Reason::Sampling, true});
     EXPECT_EQ(1U, stats_.counter("tracing.opentracing.span_context_extraction_error").value());
 
-    std::string injected_ctx(request_headers_.getOtSpanContextValue());
+    std::string injected_ctx(request_headers_.get_(Http::CustomHeaders::get().OtSpanContext));
     EXPECT_FALSE(injected_ctx.empty());
 
     // Supply empty context.
-    request_headers_.removeOtSpanContext();
+    request_headers_.remove(Http::CustomHeaders::get().OtSpanContext);
     Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
                                                start_time_, {Tracing::Reason::Sampling, true});
 
-    EXPECT_EQ(nullptr, request_headers_.OtSpanContext());
+    EXPECT_FALSE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
     span->injectContext(request_headers_);
 
-    injected_ctx = std::string(request_headers_.getOtSpanContextValue());
+    injected_ctx = std::string(request_headers_.get_(Http::CustomHeaders::get().OtSpanContext));
     EXPECT_FALSE(injected_ctx.empty());
 
     // Context can be parsed fine.
@@ -647,9 +647,9 @@ TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
     // Supply parent context, request_headers has properly populated x-ot-span-context.
     Tracing::SpanPtr span_with_parent = driver_->startSpan(
         config_, request_headers_, operation_name_, start_time_, {Tracing::Reason::Sampling, true});
-    request_headers_.removeOtSpanContext();
+    request_headers_.remove(Http::CustomHeaders::get().OtSpanContext);
     span_with_parent->injectContext(request_headers_);
-    injected_ctx = std::string(request_headers_.getOtSpanContextValue());
+    injected_ctx = std::string(request_headers_.get_(Http::CustomHeaders::get().OtSpanContext));
     EXPECT_FALSE(injected_ctx.empty());
   }
 }
@@ -684,9 +684,9 @@ TEST_F(LightStepDriverTest, MultiplePropagationModes) {
   Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
 
-  EXPECT_EQ(nullptr, request_headers_.OtSpanContext());
+  EXPECT_FALSE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
   span->injectContext(request_headers_);
-  EXPECT_TRUE(request_headers_.has("x-ot-span-context"));
+  EXPECT_TRUE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
   EXPECT_TRUE(request_headers_.has("ot-tracer-traceid"));
   EXPECT_TRUE(request_headers_.has("x-b3-traceid"));
   EXPECT_TRUE(request_headers_.has("traceparent"));
@@ -709,8 +709,10 @@ TEST_F(LightStepDriverTest, SpawnChild) {
   childViaHeaders->injectContext(base1);
   childViaSpawn->injectContext(base2);
 
-  std::string base1_context = Base64::decode(std::string(base1.getOtSpanContextValue()));
-  std::string base2_context = Base64::decode(std::string(base2.getOtSpanContextValue()));
+  std::string base1_context =
+      Base64::decode(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)));
+  std::string base2_context =
+      Base64::decode(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)));
 
   EXPECT_FALSE(base1_context.empty());
   EXPECT_FALSE(base2_context.empty());

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -620,7 +620,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
   // Test effective setTag()
   // ====
 
-  request_headers_.removeOtSpanContext();
+  request_headers_.remove(Http::CustomHeaders::get().OtSpanContext);
 
   // New span will have a CS annotation
   Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
@@ -643,7 +643,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
   const std::string parent_id = Hex::uint64ToHex(generateRandom64());
   const std::string context = trace_id + ";" + span_id + ";" + parent_id + ";" + CLIENT_SEND;
 
-  request_headers_.setOtSpanContext(context);
+  request_headers_.setCopy(Http::CustomHeaders::get().OtSpanContext, context);
 
   // New span will have an SR annotation
   Tracing::SpanPtr span2 = driver_->startSpan(config_, request_headers_, operation_name_,

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -138,7 +138,7 @@ route_config:
             key: "x-foo"
             value: "value1"
         - header:
-            key: "authorization"
+            key: "user-agent"
             value: "token1"
       routes:
         - match: { prefix: "/test" }
@@ -149,7 +149,7 @@ route_config:
                 key: "x-foo"
                 value: "value2"
             - header:
-                key: "authorization"
+                key: "user-agent"
                 value: "token2"
     - name: path-sanitization
       domains: ["path-sanitization.com"]
@@ -997,14 +997,14 @@ TEST_P(HeaderIntegrationTest, TestAppendSameHeaders) {
           {":path", "/test"},
           {":scheme", "http"},
           {":authority", "append-same-headers.com"},
-          {"authorization", "token3"},
+          {"user-agent", "token3"},
           {"x-foo", "value3"},
       },
       Http::TestRequestHeaderMapImpl{
           {":authority", "append-same-headers.com"},
           {":path", "/test"},
           {":method", "GET"},
-          {"authorization", "token3,token2,token1"},
+          {"user-agent", "token3,token2,token1"},
           {"x-foo", "value3"},
           {"x-foo", "value2"},
           {"x-foo", "value1"},

--- a/test/integration/header_prefix_integration_test.cc
+++ b/test/integration/header_prefix_integration_test.cc
@@ -12,7 +12,10 @@ namespace Envoy {
 // bootstrap proto it's too late to set it.
 //
 // Instead, set the value early and regression test the bootstrap proto's validation of prefix
-// injection.
+// injection. We also register a custom header to make sure that registered headers interact well
+// with the prefix override.
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    cache_control_handle(Http::CustomHeaders::get().CacheControl);
 
 static const char* custom_prefix_ = "x-custom";
 

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -577,8 +577,8 @@ TEST_P(IntegrationTest, TestInlineHeaders) {
                                 "GET / HTTP/1.1\r\n"
                                 "Host: foo.com\r\n"
                                 "Foo: bar\r\n"
-                                "Cache-control: public\r\n"
-                                "Cache-control: 123\r\n"
+                                "User-Agent: public\r\n"
+                                "User-Agent: 123\r\n"
                                 "Eep: baz\r\n\r\n",
                                 &response, true);
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 200 OK\r\n"));
@@ -587,7 +587,7 @@ TEST_P(IntegrationTest, TestInlineHeaders) {
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
-  EXPECT_EQ(upstream_headers->CacheControl()->value(), "public,123");
+  EXPECT_EQ(upstream_headers->get_("User-Agent"), "public,123");
   ASSERT_TRUE(upstream_headers->get(Envoy::Http::LowerCaseString("foo")) != nullptr);
   EXPECT_EQ("bar",
             upstream_headers->get(Envoy::Http::LowerCaseString("foo"))->value().getStringView());


### PR DESCRIPTION
- Move more headers from default O(1) headers to extensions
- Fix an issue where envoy header prefix override is used
  with custom registered headers not working.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
