### PR TITLE
event: add scaled timer

### DIFF
--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -60,6 +60,43 @@ public:
 
 using TimerPtr = std::unique_ptr<Timer>;
 
+class ScaledTimer {
+public:
+  virtual ~ScaledTimer() = default;
+
+  /**
+   * Disable a pending timeout without destroying the underlying timer.
+   */
+  virtual void disableTimer() PURE;
+
+  /**
+   * Enable a pending timeout. If a timeout is already pending, it will be reset to the new timeout.
+   *
+   * @param min_ms supplies the minimum duration of the alarm in milliseconds.
+   * @param max_ms supplies the maximum duration of the alarm in milliseconds.
+   * @param object supplies an optional scope for the duration of the alarm.
+   */
+  virtual void enableTimer(const std::chrono::milliseconds& min_ms,
+                           const std::chrono::milliseconds& max_ms,
+                           const ScopeTrackedObject* object = nullptr) PURE;
+
+  /**
+   * Enable a pending high resolution timeout. If a timeout is already pending, it will be reset to
+   * the new timeout.
+   *
+   * @param min_us supplies the minimum duration of the alarm in microseconds.
+   * @param max_us supplies the maximum duration of the alarm in microseconds.
+   * @param object supplies an optional scope for the duration of the alarm.
+   */
+  virtual void enableHRTimer(const std::chrono::microseconds& min_us,
+                             const std::chrono::microseconds& max_us,
+                             const ScopeTrackedObject* object = nullptr) PURE;
+  /**
+   * Return whether the timer is currently armed.
+   */
+  virtual bool enabled() PURE;
+};
+
 class Scheduler {
 public:
   virtual ~Scheduler() = default;

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -140,6 +140,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "scaled_timer_lib",
+    srcs = ["scaled_timer_impl.cc"],
+    hdrs = ["scaled_timer_impl.h"],
+    deps = [
+        "//include/envoy/event:timer_interface",
+        "//source/common/common:scope_tracker",
+    ],
+)
+
+envoy_cc_library(
     name = "deferred_task",
     hdrs = ["deferred_task.h"],
     deps = [

--- a/source/common/event/scaled_timer_impl.cc
+++ b/source/common/event/scaled_timer_impl.cc
@@ -1,0 +1,78 @@
+#include "common/event/scaled_timer_impl.h"
+#include <chrono>
+
+namespace Envoy {
+namespace Event {
+namespace {
+
+void resetTimer(Timer& timer, const ScopeTrackedObject* scope, std::chrono::milliseconds d) {
+  timer.enableTimer(d, scope);
+}
+
+void resetTimer(Timer& timer, const ScopeTrackedObject* scope, std::chrono::microseconds d) {
+  timer.enableHRTimer(d, scope);
+}
+
+} // namespace
+
+ScaledTimerImpl::ScaledTimerImpl(Dispatcher& dispatcher, TimerCb cb, double scale_factor)
+    : scale_factor_(scale_factor > 1      ? 1
+                    : !(scale_factor > 0) ? 0
+                                          : scale_factor),
+      timer_(dispatcher.createTimer(std::move(cb))), time_source_(dispatcher.timeSource()) {}
+
+void ScaledTimerImpl::enableTimer(const std::chrono::milliseconds& min,
+                                  const std::chrono::milliseconds& max,
+                                  const ScopeTrackedObject* scope) {
+  ASSERT(max >= min);
+  enabled_.last_enabled = time_source_.monotonicTime();
+  enabled_.interval = Enabled::Interval<std::chrono::milliseconds>(min, max);
+  enabled_.scope = scope;
+  timer_->enableTimer(
+      std::chrono::duration_cast<std::chrono::milliseconds>(scale_factor_ * (max - min)) + min,
+      scope);
+}
+
+void ScaledTimerImpl::enableHRTimer(const std::chrono::microseconds& min,
+                                    const std::chrono::microseconds& max,
+                                    const ScopeTrackedObject* scope) {
+  ASSERT(max >= min);
+  enabled_.last_enabled = time_source_.monotonicTime();
+  enabled_.interval = Enabled::Interval<std::chrono::microseconds>(min, max);
+  enabled_.scope = scope;
+  timer_->enableHRTimer(
+      std::chrono::duration_cast<std::chrono::microseconds>(scale_factor_ * (max - min)) + min,
+      scope);
+}
+
+void ScaledTimerImpl::disableTimer() { timer_->disableTimer(); }
+
+bool ScaledTimerImpl::enabled() { return timer_->enabled(); }
+
+void ScaledTimerImpl::setScaleFactor(double scale_factor) {
+  scale_factor_ = scale_factor > 1 ? 1 : !(scale_factor > 0) ? 0 : scale_factor;
+
+  if (!timer_->enabled()) {
+    return;
+  }
+
+  auto visitor = [this](auto& interval) -> void {
+    using T = typename std::remove_reference_t<decltype(interval)>::value_type;
+
+    const auto trigger_time =
+        std::chrono::duration_cast<T>(scale_factor_ * (interval.max - interval.min)) +
+        interval.min + enabled_.last_enabled;
+
+    const T delay = std::chrono::duration_cast<T>(trigger_time - time_source_.monotonicTime());
+    resetTimer(*timer_, enabled_.scope, std::max(T::zero(), delay));
+  };
+
+  absl::visit(visitor, enabled_.interval);
+}
+
+ScaledTimerImpl::Enabled::Enabled()
+    : interval(Enabled::Interval<std::chrono::milliseconds>(std::chrono::milliseconds::zero(),
+                                                            std::chrono::milliseconds::zero())) {}
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/scaled_timer_impl.h
+++ b/source/common/event/scaled_timer_impl.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <chrono>
+
+#include "envoy/common/scope_tracker.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/timer.h"
+
+#include "absl/types/variant.h"
+
+namespace Envoy {
+namespace Event {
+
+class ScaledTimerImpl : public ScaledTimer {
+public:
+  ScaledTimerImpl(Dispatcher& dispatcher, TimerCb cb, double scale_factor);
+
+  // ScaledTimer
+  void disableTimer() override;
+
+  void enableTimer(const std::chrono::milliseconds& min, const std::chrono::milliseconds& max,
+                   const ScopeTrackedObject* scope) override;
+  void enableHRTimer(const std::chrono::microseconds& min, const std::chrono::microseconds& max,
+                     const ScopeTrackedObject* object) override;
+
+  bool enabled() override;
+
+  /**
+   * Adjusts the scale factor for the timeout, which is used to interpolate between the min and max
+   * values set when the timer is enabled. A value of 0 causes the timer to use the minimum; a value
+   * of 1 uses the maximum.
+   *
+   * This method is only provided on the impl because it should not be used by consumers of the
+   * timer, only producers.
+   * @param scale_factor The scale factor, which will be clipped to the range [0, 1].
+   */
+  void setScaleFactor(double scale_factor);
+
+private:
+  struct Enabled {
+    Enabled();
+    template <typename T> struct Interval {
+      using value_type = T;
+      Interval(T min, T max) : min(min), max(max) {}
+      T min, max;
+    };
+
+    MonotonicTime last_enabled;
+    absl::variant<Interval<std::chrono::milliseconds>, Interval<std::chrono::microseconds>>
+        interval;
+    const ScopeTrackedObject* scope;
+  };
+
+  double scale_factor_;
+  TimerPtr timer_;
+  TimeSource& time_source_;
+
+  Enabled enabled_;
+};
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -8,6 +8,17 @@
 
 namespace Envoy {
 namespace Event {
+namespace {
+
+void resetTimer(TimerImpl& timer, std::chrono::milliseconds d) {
+  timer.enableTimer(d, timer.scope());
+}
+
+void resetTimer(TimerImpl& timer, std::chrono::microseconds d) {
+  timer.enableHRTimer(d, timer.scope());
+}
+
+} // namespace
 
 TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Dispatcher& dispatcher)
     : cb_(cb), dispatcher_(dispatcher) {
@@ -52,6 +63,59 @@ void TimerImpl::internalEnableTimer(const timeval& tv, const ScopeTrackedObject*
 }
 
 bool TimerImpl::enabled() { return 0 != evtimer_pending(&raw_event_, nullptr); }
+
+ScaledTimerImpl::ScaledTimerImpl(Libevent::BasePtr& libevent, TimerCb cb,
+                                 Event::Dispatcher& dispatcher, double scale_factor)
+    : scale_factor_(scale_factor > 1 ? 1 : !(scale_factor > 0) ? 0 : scale_factor),
+      timer_(libevent, cb, dispatcher) {}
+
+void ScaledTimerImpl::enableTimer(const std::chrono::milliseconds& min,
+                                  const std::chrono::milliseconds& max,
+                                  const ScopeTrackedObject* scope) {
+  ASSERT(max >= min);
+  enabled_.last_enabled = timer_.dispatcher().timeSource().monotonicTime();
+  enabled_.interval = Enabled::Interval<std::chrono::milliseconds>(min, max);
+  timer_.enableTimer(
+      std::chrono::duration_cast<std::chrono::milliseconds>(scale_factor_ * (max - min)) + min,
+      scope);
+}
+
+void ScaledTimerImpl::enableHRTimer(const std::chrono::microseconds& min,
+                                    const std::chrono::microseconds& max,
+                                    const ScopeTrackedObject* scope) {
+  ASSERT(max >= min);
+  enabled_.last_enabled = timer_.dispatcher().timeSource().monotonicTime();
+  enabled_.interval = Enabled::Interval<std::chrono::microseconds>(min, max);
+  timer_.enableHRTimer(
+      std::chrono::duration_cast<std::chrono::microseconds>(scale_factor_ * (max - min)) + min,
+      scope);
+}
+
+void ScaledTimerImpl::disableTimer() { timer_.disableTimer(); }
+
+bool ScaledTimerImpl::enabled() { return timer_.enabled(); }
+
+void ScaledTimerImpl::setScaleFactor(double scale_factor) {
+  scale_factor_ = scale_factor > 1 ? 1 : !(scale_factor > 0) ? 0 : scale_factor;
+
+  if (!timer_.enabled()) {
+    return;
+  }
+
+  auto visitor = [this](auto& interval) -> void {
+    using T = typename std::remove_reference_t<decltype(interval)>::value_type;
+
+    const auto trigger_time =
+        std::chrono::duration_cast<T>(scale_factor_ * (interval.max - interval.min)) +
+        interval.min + enabled_.last_enabled;
+
+    const T delay = std::chrono::duration_cast<T>(trigger_time -
+                                                  timer_.dispatcher().timeSource().monotonicTime());
+    resetTimer(timer_, std::max(T::zero(), delay));
+  };
+
+  absl::visit(visitor, enabled_.interval);
+}
 
 } // namespace Event
 } // namespace Envoy

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -63,12 +63,6 @@ public:
 
   bool enabled() override;
 
-  /**
-   * Provide access to the dispatcher and scope for ScaledTimerImpl below.
-   */
-  Dispatcher& dispatcher() const { return dispatcher_; };
-  const ScopeTrackedObject* scope() const { return object_; }
-
 private:
   TimerCb cb_;
   Dispatcher& dispatcher_;
@@ -77,51 +71,6 @@ private:
   // both set this to null.
   std::atomic<const ScopeTrackedObject*> object_{};
   void internalEnableTimer(const timeval& tv, const ScopeTrackedObject* scope);
-};
-
-class ScaledTimerImpl : public ScaledTimer {
-public:
-  ScaledTimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Event::Dispatcher& dispatcher,
-                  double scale_factor);
-
-  // ScaledTimer
-  void disableTimer() override;
-
-  void enableTimer(const std::chrono::milliseconds& min, const std::chrono::milliseconds& max,
-                   const ScopeTrackedObject* scope) override;
-  void enableHRTimer(const std::chrono::microseconds& min, const std::chrono::microseconds& max,
-                     const ScopeTrackedObject* object) override;
-
-  bool enabled() override;
-
-  /**
-   * Adjusts the scale factor for the timeout, which is used to interpolate between the min and max
-   * values set when the timer is enabled. A value of 0 causes the timer to use the minimum; a value
-   * of 1 uses the maximum.
-   *
-   * This method is only provided on the impl because it should not be used by consumers of the
-   * timer, only producers.
-   * @param scale_factor The scale factor, which will be clipped to the range [0, 1].
-   */
-  void setScaleFactor(double scale_factor);
-
-private:
-  struct Enabled {
-    template <typename T> struct Interval {
-      using value_type = T;
-      Interval(T min, T max) : min(min), max(max) {}
-      T min, max;
-    };
-
-    MonotonicTime last_enabled;
-    absl::variant<Interval<std::chrono::milliseconds>, Interval<std::chrono::microseconds>>
-        interval;
-  };
-
-  double scale_factor_;
-
-  TimerImpl timer_;
-  Enabled enabled_;
 };
 
 } // namespace Event


### PR DESCRIPTION
Commit Message:
Add a ScaledTimer interface and impl that can be used to produce timers with min
and max timeout values. The choice of the actual duration is used is made by the
producer, independent of the user of the timer object.

Additional Description: this code provides a direct libevent-based alternative to #11773. The code isn't used anywhere, hence the low risk level.

Risk Level: low
Testing: built code
Docs Changes: none
Release Notes: none
#11427

/cc @htuch, @antoniovicente 