### PR TITLE
Enable envoy images build on Arm CI environments

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -138,8 +138,8 @@ jobs:
       - task: DownloadBuildArtifacts@0
         inputs:
           buildType: current
-          artifactName: "bazel.release.server_only.arm64"
-          itemPattern: "bazel.release.server_only.arm64/envoy_binary.tar.gz"
+          artifactName: "bazel.release.arm64"
+          itemPattern: "bazel.release.arm64/envoy_binary.tar.gz"
           downloadType: single
           targetPath: $(Build.StagingDirectory)
       - bash: |

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -122,8 +122,8 @@ jobs:
         condition: always()
 
   - job: docker
-    displayName: "Linux-x64 docker"
-    dependsOn: ["release"]
+    displayName: "Linux multi-arch docker"
+    dependsOn: ["release","release_arm64"]
     condition: and(succeeded(), eq(variables['PostSubmit'], 'true'), ne(variables['Build.Reason'], 'PullRequest'))
     pool:
       vmImage: "ubuntu-18.04"
@@ -135,10 +135,17 @@ jobs:
           itemPattern: "bazel.release/envoy_binary.tar.gz"
           downloadType: single
           targetPath: $(Build.StagingDirectory)
-
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: current
+          artifactName: "bazel.release.server_only.arm64"
+          itemPattern: "bazel.release.server_only.arm64/envoy_binary.tar.gz"
+          downloadType: single
+          targetPath: $(Build.StagingDirectory)
       - bash: |
           set -e
-          tar zxf $(Build.StagingDirectory)/bazel.release/envoy_binary.tar.gz
+          mkdir -p linux/amd64 && tar zxf $(Build.StagingDirectory)/bazel.release/envoy_binary.tar.gz -C ./linux/amd64
+          mkdir -p linux/arm64 && tar zxf $(Build.StagingDirectory)/bazel.release.server_only.arm64/envoy_binary.tar.gz -C ./linux/arm64
           ci/docker_ci.sh
         workingDirectory: $(Build.SourcesDirectory)
         env:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -145,7 +145,7 @@ jobs:
       - bash: |
           set -e
           mkdir -p linux/amd64 && tar zxf $(Build.StagingDirectory)/bazel.release/envoy_binary.tar.gz -C ./linux/amd64
-          mkdir -p linux/arm64 && tar zxf $(Build.StagingDirectory)/bazel.release.server_only.arm64/envoy_binary.tar.gz -C ./linux/arm64
+          mkdir -p linux/arm64 && tar zxf $(Build.StagingDirectory)/bazel.release.arm64/envoy_binary.tar.gz -C ./linux/arm64
           ci/docker_ci.sh
         workingDirectory: $(Build.SourcesDirectory)
         env:

--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -1,6 +1,5 @@
 ARG BUILD_FROM=ubuntu:18.04
 
-
 # Build stage
 FROM $BUILD_FROM as build
 
@@ -17,7 +16,7 @@ RUN apt-get update \
 
 # Final stage
 FROM $BUILD_FROM
-
+ARG TARGETPLATFORM
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y ca-certificates \
@@ -31,7 +30,7 @@ RUN adduser --group --system envoy
 
 RUN mkdir -p /etc/envoy
 
-ADD build_release_stripped/envoy /usr/local/bin/envoy
+ADD ${TARGETPLATFORM}/build_release_stripped/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 
 EXPOSE 10000

--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -1,8 +1,7 @@
 FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
-ARG TARGETPLATFORM
 RUN mkdir -p /etc/envoy
 
-ADD ${TARGETPLATFORM}/build_release_stripped/envoy /usr/local/bin/envoy
+ADD linux/amd64/build_release_stripped/envoy /usr/local/bin/envoy
 
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 RUN apk add --no-cache shadow su-exec \

--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -1,8 +1,9 @@
 FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
-
+ARG TARGETPLATFORM
 RUN mkdir -p /etc/envoy
 
-ADD build_release_stripped/envoy /usr/local/bin/envoy
+ADD ${TARGETPLATFORM}/build_release_stripped/envoy /usr/local/bin/envoy
+
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 RUN apk add --no-cache shadow su-exec \
         && addgroup -S envoy && adduser --no-create-home -S envoy -G envoy

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -1,8 +1,9 @@
 FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
+ARG TARGETPLATFORM
 
 RUN mkdir -p /etc/envoy
 
-ADD build_release/envoy /usr/local/bin/envoy
+ADD ${TARGETPLATFORM}/build_release/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 RUN apk add --no-cache shadow su-exec \
         && addgroup -S envoy && adduser --no-create-home -S envoy -G envoy

--- a/ci/Dockerfile-envoy-alpine-debug
+++ b/ci/Dockerfile-envoy-alpine-debug
@@ -1,9 +1,7 @@
 FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
-ARG TARGETPLATFORM
-
 RUN mkdir -p /etc/envoy
 
-ADD ${TARGETPLATFORM}/build_release/envoy /usr/local/bin/envoy
+ADD linux/amd64/build_release/envoy /usr/local/bin/envoy
 ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
 RUN apk add --no-cache shadow su-exec \
         && addgroup -S envoy && adduser --no-create-home -S envoy -G envoy

--- a/ci/Dockerfile-envoy-google-vrp
+++ b/ci/Dockerfile-envoy-google-vrp
@@ -1,41 +1,4 @@
-ARG BUILD_FROM=ubuntu:18.04
-
-# Build stage
-FROM $BUILD_FROM as build
-
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y ca-certificates curl gcc libc-dev \
-    && echo "d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891  /tmp/su-exec.c" > /tmp/checksum \
-    && curl -o /tmp/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c \
-    && sha256sum -c /tmp/checksum \
-    && gcc -Wall /tmp/su-exec.c -o/usr/local/bin/su-exec \
-    && chown root:root /usr/local/bin/su-exec \
-    && chmod 0755 /usr/local/bin/su-exec
-
-
-# Final stage
-FROM $BUILD_FROM
-ARG TARGETPLATFORM
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y ca-certificates \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /tmp/* /var/tmp/* \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=build /usr/local/bin/su-exec /usr/local/bin/su-exec
-RUN adduser --group --system envoy
-
-RUN mkdir -p /etc/envoy
-
-ADD ${TARGETPLATFORM}/build_release_stripped/envoy /usr/local/bin/envoy
-ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
-
-EXPOSE 10000
-
-COPY ci/docker-entrypoint.sh /
+FROM envoyproxy/envoy:local
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/ci/Dockerfile-envoy-google-vrp
+++ b/ci/Dockerfile-envoy-google-vrp
@@ -1,4 +1,41 @@
-FROM envoyproxy/envoy:local
+ARG BUILD_FROM=ubuntu:18.04
+
+# Build stage
+FROM $BUILD_FROM as build
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install --no-install-recommends -y ca-certificates curl gcc libc-dev \
+    && echo "d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891  /tmp/su-exec.c" > /tmp/checksum \
+    && curl -o /tmp/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/212b75144bbc06722fbd7661f651390dc47a43d1/su-exec.c \
+    && sha256sum -c /tmp/checksum \
+    && gcc -Wall /tmp/su-exec.c -o/usr/local/bin/su-exec \
+    && chown root:root /usr/local/bin/su-exec \
+    && chmod 0755 /usr/local/bin/su-exec
+
+
+# Final stage
+FROM $BUILD_FROM
+ARG TARGETPLATFORM
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y ca-certificates \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/tmp/* \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local/bin/su-exec /usr/local/bin/su-exec
+RUN adduser --group --system envoy
+
+RUN mkdir -p /etc/envoy
+
+ADD ${TARGETPLATFORM}/build_release_stripped/envoy /usr/local/bin/envoy
+ADD configs/google_com_proxy.v2.yaml /etc/envoy/envoy.yaml
+
+EXPOSE 10000
+
+COPY ci/docker-entrypoint.sh /
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -59,7 +59,6 @@ for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
     build_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local"
 done
 
-
 MASTER_BRANCH="refs/heads/master"
 RELEASE_BRANCH_REGEX="^refs/heads/release/v.*"
 RELEASE_TAG_REGEX="^refs/tags/v.*"

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -14,19 +14,33 @@ config_env(){
     docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
 }
 
-build_push_images(){
+build_images(){
     TYPE=$1
     BUILD_TAG=$2
-    PUSH=$3
 
     # Only build/push envoyproxy/envoy multi-arch images since others still do not support.
     if [ -z "${TYPE}" ]; then
-        docker buildx build --platform linux/arm64,linux/amd64 $PUSH -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+        docker buildx build --platform linux/arm64 -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+        # Export envoyproxy/envoy amd64 image which will be used for building envoyproxy/envoy-google-vrp
+        docker buildx build --platform linux/amd64 -f ci/Dockerfile-envoy"${TYPE}" -o type=docker -t ${BUILD_TAG} .
     elif [ "${TYPE}" == "-google-vrp" ]; then
         # The envoyproxy/envoy-google-vrp is based on envoyproxy/envoy image. So it is built from cache envoyproxy/envoy:local
-        docker buildx build --platform linux/amd64 $PUSH -f ci/Dockerfile-envoy"${TYPE}" --cache-from "${DOCKER_IMAGE_PREFIX}:local" -t ${BUILD_TAG} .
+        docker build -f ci/Dockerfile-envoy"${TYPE}" --cache-from "${DOCKER_IMAGE_PREFIX}:local" -t ${BUILD_TAG} .
     else
-        docker buildx build --platform linux/amd64 $PUSH -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+        docker build -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+    fi
+}
+
+push_images(){
+    TYPE=$1
+    BUILD_TAG=$2
+
+    if [ -z "${TYPE}" ]; then
+        # Only push envoyproxy/envoy multi-arch images since others still do not support.
+        docker buildx build --platform linux/arm64,linux/amd64 --push -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+    else
+        docker tag "${DOCKER_IMAGE_PREFIX}${TYPE}:local" ${BUILD_TAG}
+        docker push ${BUILD_TAG}
     fi
 }
 
@@ -42,7 +56,7 @@ config_env
 # Test the docker build in all cases, but use a local tag that we will overwrite before push in the
 # cases where we do push.
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-    build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local"
+    build_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local"
 done
 
 
@@ -72,16 +86,16 @@ fi
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-    build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}" --push
+    push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"
 
     # Only push latest on master builds.
     if [[ "${AZP_BRANCH}" == "${MASTER_BRANCH}" ]]; then
-        build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest" --push
+        push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
     fi
 
     # Push vX.Y-latest to tag the latest image in a release line
     if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
       RELEASE_LINE=$(echo "$IMAGE_NAME" | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')
-        build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}" --push
+        push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
     fi
 done

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -4,17 +4,47 @@
 # CI logs.
 set -e
 
+# Setting environments for buildx tools
+config_env(){
+    # Qemu configurations
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+    # Remove older build instance
+    docker buildx rm  multi-builder | true
+    docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+}
+
+build_push_images(){
+    TYPE=$1
+    BUILD_TAG=$2
+    PUSH=$3
+
+    # Only build/push envoyproxy/envoy multi-arch images since others still do not support.
+    if [ -z "${TYPE}" ]; then
+        docker buildx build --platform linux/arm64,linux/amd64 $PUSH -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+    elif [ "${TYPE}" == "-google-vrp" ]; then
+        # The envoyproxy/envoy-google-vrp is based on envoyproxy/envoy image. So it is built from cache envoyproxy/envoy:local
+        docker buildx build --platform linux/amd64 $PUSH -f ci/Dockerfile-envoy"${TYPE}" --cache-from "${DOCKER_IMAGE_PREFIX}:local" -t ${BUILD_TAG} .
+    else
+        docker buildx build --platform linux/amd64 $PUSH -f ci/Dockerfile-envoy"${TYPE}" -t ${BUILD_TAG} .
+    fi
+}
+
 # This prefix is altered for the private security images on setec builds.
 DOCKER_IMAGE_PREFIX="${DOCKER_IMAGE_PREFIX:-envoyproxy/envoy}"
 
 # "-google-vrp" must come afer "" to ensure we rebuild the local base image dependency.
 BUILD_TYPES=("" "-alpine" "-alpine-debug" "-google-vrp")
 
+# Configure docker-buildx tools
+config_env
+
 # Test the docker build in all cases, but use a local tag that we will overwrite before push in the
 # cases where we do push.
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-    docker build -f ci/Dockerfile-envoy"${BUILD_TYPE}" -t "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" .
+    build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local"
 done
+
 
 MASTER_BRANCH="refs/heads/master"
 RELEASE_BRANCH_REGEX="^refs/heads/release/v.*"
@@ -42,21 +72,16 @@ fi
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-    docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"
-    docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"
+    build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}" --push
 
     # Only push latest on master builds.
     if [[ "${AZP_BRANCH}" == "${MASTER_BRANCH}" ]]; then
-        docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
-        docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest"
+        build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:latest" --push
     fi
 
     # Push vX.Y-latest to tag the latest image in a release line
     if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
       RELEASE_LINE=$(echo "$IMAGE_NAME" | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1-latest/')
-      docker tag "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}:local" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
-      docker push "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}"
+        build_push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${RELEASE_LINE}" --push
     fi
 done
-
-

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -56,6 +56,7 @@ New Features
 * tap: added :ref:`generic body matcher<envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and responses for text or hex patterns.
 * tcp: switched the TCP connection pool to the new "shared" connection pool, sharing a common code base with HTTP and HTTP/2. Any unexpected behavioral changes can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
 * xds: added :ref:`extension config discovery<envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP filters.
+* build: envoyproxy/envoy arm64 docker images are support in CI system. The buildx tool is used for building multi-arch images on x86 platform.
 
 Deprecated
 ----------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -40,6 +40,7 @@ New Features
 ------------
 
 * access log: added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_access_log_format_response_flags>` as a response flag.
+* build: enable building envoy arm64 images by buildx tool in x86 CI platform.
 * dynamic_forward_proxy: added :ref:`use_tcp_for_dns_lookups<envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` option to use TCP for DNS lookups in order to match the DNS options for :ref:`Clusters<envoy_v3_api_msg_config.cluster.v3.Cluster>`.
 * ext_authz filter: added support for emitting dynamic metadata for both :ref:`HTTP <config_http_filters_ext_authz_dynamic_metadata>` and :ref:`network <config_network_filters_ext_authz_dynamic_metadata>` filters.
 * grpc-json: support specifying `response_body` field in for `google.api.HttpBody` message.
@@ -56,7 +57,6 @@ New Features
 * tap: added :ref:`generic body matcher<envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and responses for text or hex patterns.
 * tcp: switched the TCP connection pool to the new "shared" connection pool, sharing a common code base with HTTP and HTTP/2. Any unexpected behavioral changes can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
 * xds: added :ref:`extension config discovery<envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP filters.
-* build: envoyproxy/envoy arm64 docker images are support in CI system. The buildx tool is used for building multi-arch images on x86 platform.
 
 Deprecated
 ----------


### PR DESCRIPTION
In this patch, it will enable the envoyproxy/envoy arm image to build
in community arm CI environments.
1. Do some modifications in docker_ci.sh script for building arm images by buildx. It will firstly set up environments. Then use the 
    buildx tool to build the envoyproxy/envoy arm images on x86 platform.
2. Modify the docker build job for building multi-arch images. It will firstly download the arm64 and amd64 envoy binaries. Then 
    invoke the docker_ci.sh scripts to generate images.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
In this PR, we enable the envoyproxy/envoy arm64 image on Envoy CI system.
1. For envoyproxy/envoy arm64 images, envoy-alpine, envoy-alpine-debug and envoy-google-vrp still do not support on Arm64 platform since some technical reasons. Only the envoyproxy/envoy is enabled on CI system.
2. In this PR, the buildx tool was used for building multi-arch images on x86 platform. 
3. In addition, the display name of building images job is modified from "Linux-x64 docker" to "Linux multi-arch docker".

[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
