### PR TITLE
dynamic_forward_proxy: graduate HTTP filter to stable.

### DIFF
--- a/source/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/source/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -28,7 +28,6 @@ envoy_cc_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     security_posture = "robust_to_untrusted_downstream",
-    status = "alpha",
     deps = [
         "//include/envoy/registry",
         "//include/envoy/server:filter_config_interface",


### PR DESCRIPTION
Based on conversations with @MattKlein123, this should be mature for production use, so removing
alpha status.

Risk level: Low
Testing: N/A

Signed-off-by: Harvey Tuch <htuch@google.com>