### PR TITLE
api: Back-port SelfConfigSource.transport_api_version field to v2.

### DIFF
--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -106,6 +106,9 @@ message AggregatedConfigSource {
 // set in :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` can be used to
 // specify that other data can be obtained from the same server.
 message SelfConfigSource {
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.

--- a/generated_api_shadow/envoy/api/v2/core/config_source.proto
+++ b/generated_api_shadow/envoy/api/v2/core/config_source.proto
@@ -106,6 +106,9 @@ message AggregatedConfigSource {
 // set in :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` can be used to
 // specify that other data can be obtained from the same server.
 message SelfConfigSource {
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Back-port SelfConfigSource.transport_api_version field to v2.
Additional Description: Back-port #11754 to the v2 API.  This will make it easier for users to migrate to v3.
Risk Level: Low
Testing: N/A
Docs Changes: Inline in PR
Release Notes: N/A

As discussed with @htuch.