### PR TITLE
test: add missing mocks to fix test compile error with gcc 9

### DIFF
--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -72,8 +72,11 @@ public:
 
   MOCK_METHOD(void, start, ());
   MOCK_METHOD(void, pause, (const std::string& type_url));
+  MOCK_METHOD(void, pause, (const std::vector<std::string> type_urls));
   MOCK_METHOD(void, resume, (const std::string& type_url));
+  MOCK_METHOD(void, resume, (const std::vector<std::string> type_urls));
   MOCK_METHOD(bool, paused, (const std::string& type_url), (const));
+  MOCK_METHOD(bool, paused, (const std::vector<std::string> type_urls), (const));
 
   MOCK_METHOD(void, addSubscription,
               (const std::set<std::string>& resources, const std::string& type_url,


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/11300 added some methods without updating the mocks, which causes test compilation fail under gcc 9. This adds the missing mocks.

Commit Message:
Add mocks to MockGrpcMuxWatch. follow-up to #11300.

Additional Description:
Risk Level: Low - just added some mocks.
