### PR TITLE
build: Enable -Wc++20-extensions on clang builds.

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -48,7 +48,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],
            }) + select({
-               repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand"],
+               repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand", "-Wc++20-extensions"],
                repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
                "//conditions:default": [],
            }) + select({


### PR DESCRIPTION
Commit Message: build: Enable -Wc++20-extensions on clang builds.
Additional Description: Prevent breakages due to accidental use of features that are not widely available yet, including C99 designated initializers which are part of the draft C++20 standard.
Risk Level: n/a
Testing: n/a, build config changes only.
Docs Changes: n/a
Release Notes: n/a
Fixes #11804