### PR TITLE
build: Use -Wc++2a-extensions instead of -Wc++20-extensions to maintain ability to build with clang9

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -48,7 +48,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],
            }) + select({
-               repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand", "-Wc++20-extensions"],
+               repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand", "-Wc++2a-extensions"],
                repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
                "//conditions:default": [],
            }) + select({


### PR DESCRIPTION
Commit Message: build: Use -Wc++2a-extensions instead of -Wc++20-extensions to maintain ability to build with clang9
Additional Description: -Wc++2a-extensions is accepted by clang9 and provides warnings equivalent to -Wc++20-extensions on clang10 and clang11. Note that -Wc++2a-extensions does not warn about designated initializers on clang9 but does on clang10 and later.
Risk Level: low, build warning tweaks
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #11828 