### PR TITLE
build: Update spdlog to 1.6.1

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -154,9 +154,9 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     com_github_gabime_spdlog = dict(
-        sha256 = "afd18f62d1bc466c60bef088e6b637b0284be88c515cedc59ad4554150af6043",
-        strip_prefix = "spdlog-1.4.0",
-        urls = ["https://github.com/gabime/spdlog/archive/v1.4.0.tar.gz"],
+        sha256 = "378a040d91f787aec96d269b0c39189f58a6b852e4cbf9150ccfacbe85ebbbfc",
+        strip_prefix = "spdlog-1.6.1",
+        urls = ["https://github.com/gabime/spdlog/archive/v1.6.1.tar.gz"],
         use_category = ["observability"],
         cpe = "N/A",
     ),

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -715,6 +715,9 @@ void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
     return;
   case spdlog::level::off:
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return;
+  case spdlog::level::n_levels:
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 


### PR DESCRIPTION
**Commit Message:**
build: Update spdlog to 1.6.1
**Additional Description:**
Update spdlog to 1.6.1 and prevent the -Werror=switch after that update.
**Risk Level:**
Low
**Testing:**
None, the current tests are enough.
**Docs Changes:**
n/a
**Release Notes:**
n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
