### PR TITLE
[ssl] Clarify ssl ownership semantics between SslSocket and SslSocketInfo

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,18 +9,22 @@ tasks:
     name: "RBE"
     platform: ubuntu1804
     test_targets:
-      - "//test/..."
+      - "//test/common/common/..."
+      - "//test/integration/..."
+      - "//test/exe/..."
     test_flags:
-      - "--config=remote-clang"
+      - "--config=remote-clang-libc++"
       - "--config=remote-ci"
       - "--jobs=75"
   coverage:
     name: "Coverage"
     platform: ubuntu1804
+    shell_commands:
+      - "bazel/setup_clang.sh /usr/lib/llvm-10"
     test_targets:
+      - "//test/common/common/..."
       - "//test/integration/..."
       - "//test/exe/..."
     test_flags:
-      - "--action_env=CC=clang"
-      - "--action_env=CXX=clang++"
       - "--config=coverage"
+      - "--config=clang"

--- a/api/envoy/api/v2/core/config_source.proto
+++ b/api/envoy/api/v2/core/config_source.proto
@@ -106,6 +106,9 @@ message AggregatedConfigSource {
 // set in :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` can be used to
 // specify that other data can be obtained from the same server.
 message SelfConfigSource {
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.

--- a/api/envoy/config/bootstrap/v3/BUILD
+++ b/api/envoy/config/bootstrap/v3/BUILD
@@ -16,5 +16,6 @@ api_proto_package(
         "//envoy/config/trace/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -19,7 +19,10 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -36,7 +39,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 22]
+// [#next-free-field: 24]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -62,6 +65,7 @@ message Bootstrap {
     repeated envoy.extensions.transport_sockets.tls.v3.Secret secrets = 3;
   }
 
+  // [#next-free-field: 7]
   message DynamicResources {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v2.Bootstrap.DynamicResources";
@@ -72,10 +76,18 @@ message Bootstrap {
     // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
     core.v3.ConfigSource lds_config = 1;
 
+    // Resource locator for listener collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator lds_resources_locator = 5;
+
     // All post-bootstrap :ref:`Cluster <envoy_api_msg_config.cluster.v3.Cluster>` definitions are
     // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
     // configuration source.
     core.v3.ConfigSource cds_config = 2;
+
+    // Resource locator for cluster collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cds_resources_locator = 6;
 
     // A single :ref:`ADS <config_overview_ads>` source may be optionally
     // specified. This must have :ref:`api_type
@@ -186,6 +198,30 @@ message Bootstrap {
   // Specifies optional bootstrap extensions to be instantiated at startup time.
   // Each item contains extension specific configuration.
   repeated core.v3.TypedExtensionConfig bootstrap_extensions = 21;
+
+  // Configuration sources that will participate in
+  // *udpa.core.v1.ResourceLocator* authority resolution. The algorithm is as
+  // follows:
+  // 1. The authority field is taken from the *udpa.core.v1.ResourceLocator*, call
+  //    this *resource_authority*.
+  // 2. *resource_authority* is compared against the authorities in any peer
+  //    *ConfigSource*. The peer *ConfigSource* is the configuration source
+  //    message which would have been used unconditionally for resolution
+  //    with opaque resource names. If there is a match with an authority, the
+  //    peer *ConfigSource* message is used.
+  // 3. *resource_authority* is compared sequentially with the authorities in
+  //    each configuration source in *config_sources*. The first *ConfigSource*
+  //    to match wins.
+  // 4. As a fallback, if no configuration source matches, then
+  //    *default_config_source* is used.
+  // 5. If *default_config_source* is not specified, resolution fails.
+  // [#not-implemented-hide:]
+  repeated core.v3.ConfigSource config_sources = 22;
+
+  // Default configuration source for *udpa.core.v1.ResourceLocator* if all
+  // other resolution fails.
+  // [#not-implemented-hide:]
+  core.v3.ConfigSource default_config_source = 23;
 }
 
 // Administration interface :ref:`operations documentation
@@ -353,7 +389,12 @@ message RuntimeLayer {
         "envoy.config.bootstrap.v2.RuntimeLayer.RtdsLayer";
 
     // Resource to subscribe to at *rtds_config* for the RTDS layer.
-    string name = 1;
+    string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+    // Resource locator for RTDS layer. This is mutually exclusive to *name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator rtds_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
     // RTDS configuration source.
     core.v3.ConfigSource rtds_config = 2;

--- a/api/envoy/config/bootstrap/v4alpha/BUILD
+++ b/api/envoy/config/bootstrap/v4alpha/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/config/overload/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -18,6 +18,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -35,7 +37,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 22]
+// [#next-free-field: 24]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v3.Bootstrap";
@@ -61,6 +63,7 @@ message Bootstrap {
     repeated envoy.extensions.transport_sockets.tls.v4alpha.Secret secrets = 3;
   }
 
+  // [#next-free-field: 7]
   message DynamicResources {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v3.Bootstrap.DynamicResources";
@@ -71,10 +74,18 @@ message Bootstrap {
     // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
     core.v4alpha.ConfigSource lds_config = 1;
 
+    // Resource locator for listener collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator lds_resources_locator = 5;
+
     // All post-bootstrap :ref:`Cluster <envoy_api_msg_config.cluster.v4alpha.Cluster>` definitions are
     // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
     // configuration source.
     core.v4alpha.ConfigSource cds_config = 2;
+
+    // Resource locator for cluster collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cds_resources_locator = 6;
 
     // A single :ref:`ADS <config_overview_ads>` source may be optionally
     // specified. This must have :ref:`api_type
@@ -178,6 +189,30 @@ message Bootstrap {
   // Specifies optional bootstrap extensions to be instantiated at startup time.
   // Each item contains extension specific configuration.
   repeated core.v4alpha.TypedExtensionConfig bootstrap_extensions = 21;
+
+  // Configuration sources that will participate in
+  // *udpa.core.v1.ResourceLocator* authority resolution. The algorithm is as
+  // follows:
+  // 1. The authority field is taken from the *udpa.core.v1.ResourceLocator*, call
+  //    this *resource_authority*.
+  // 2. *resource_authority* is compared against the authorities in any peer
+  //    *ConfigSource*. The peer *ConfigSource* is the configuration source
+  //    message which would have been used unconditionally for resolution
+  //    with opaque resource names. If there is a match with an authority, the
+  //    peer *ConfigSource* message is used.
+  // 3. *resource_authority* is compared sequentially with the authorities in
+  //    each configuration source in *config_sources*. The first *ConfigSource*
+  //    to match wins.
+  // 4. As a fallback, if no configuration source matches, then
+  //    *default_config_source* is used.
+  // 5. If *default_config_source* is not specified, resolution fails.
+  // [#not-implemented-hide:]
+  repeated core.v4alpha.ConfigSource config_sources = 22;
+
+  // Default configuration source for *udpa.core.v1.ResourceLocator* if all
+  // other resolution fails.
+  // [#not-implemented-hide:]
+  core.v4alpha.ConfigSource default_config_source = 23;
 }
 
 // Administration interface :ref:`operations documentation
@@ -344,8 +379,14 @@ message RuntimeLayer {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v3.RuntimeLayer.RtdsLayer";
 
-    // Resource to subscribe to at *rtds_config* for the RTDS layer.
-    string name = 1;
+    oneof name_specifier {
+      // Resource to subscribe to at *rtds_config* for the RTDS layer.
+      string name = 1;
+
+      // Resource locator for RTDS layer. This is mutually exclusive to *name*.
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator rtds_resource_locator = 3;
+    }
 
     // RTDS configuration source.
     core.v4alpha.ConfigSource rtds_config = 2;

--- a/api/envoy/config/cluster/v3/BUILD
+++ b/api/envoy/config/cluster/v3/BUILD
@@ -13,5 +13,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -19,7 +19,11 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -31,6 +35,12 @@ option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Cluster configuration]
+
+// Cluster list collections. Entries are *Cluster* resources or references.
+// [#not-implemented-hide:]
+message ClusterCollection {
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // Configuration for a single upstream cluster.
 // [#next-free-field: 49]
@@ -178,7 +188,12 @@ message Cluster {
     // Optional alternative to cluster name to present to EDS. This does not
     // have the same restrictions as cluster name, i.e. it may be arbitrary
     // length.
-    string service_name = 2;
+    string service_name = 2 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+    // Resource locator for EDS. This is mutually exclusive to *service_name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator eds_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
   }
 
   // Optionally divide the endpoints in this cluster into subsets defined by

--- a/api/envoy/config/cluster/v4alpha/BUILD
+++ b/api/envoy/config/cluster/v4alpha/BUILD
@@ -12,5 +12,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -19,6 +19,9 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -31,6 +34,15 @@ option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
 
 // [#protodoc-title: Cluster configuration]
+
+// Cluster list collections. Entries are *Cluster* resources or references.
+// [#not-implemented-hide:]
+message ClusterCollection {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.cluster.v3.ClusterCollection";
+
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // Configuration for a single upstream cluster.
 // [#next-free-field: 49]
@@ -175,10 +187,16 @@ message Cluster {
     // Configuration for the source of EDS updates for this Cluster.
     core.v4alpha.ConfigSource eds_config = 1;
 
-    // Optional alternative to cluster name to present to EDS. This does not
-    // have the same restrictions as cluster name, i.e. it may be arbitrary
-    // length.
-    string service_name = 2;
+    oneof name_specifier {
+      // Optional alternative to cluster name to present to EDS. This does not
+      // have the same restrictions as cluster name, i.e. it may be arbitrary
+      // length.
+      string service_name = 2;
+
+      // Resource locator for EDS. This is mutually exclusive to *service_name*.
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator eds_resource_locator = 3;
+    }
   }
 
   // Optionally divide the endpoints in this cluster into subsets defined by

--- a/api/envoy/config/core/v3/BUILD
+++ b/api/envoy/config/core/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -7,6 +7,8 @@ import "envoy/config/core/v3/grpc_service.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/authority.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -52,13 +54,23 @@ message ApiConfigSource {
     // the v2 protos is used.
     REST = 1;
 
-    // gRPC v2 API.
+    // SotW gRPC service.
     GRPC = 2;
 
     // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
     // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
     // with every update, the xDS server only sends what has changed since the last update.
     DELTA_GRPC = 3;
+
+    // SotW xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_GRPC = 5;
+
+    // Delta xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_DELTA_GRPC = 6;
   }
 
   // API type (gRPC, REST, delta gRPC)
@@ -136,9 +148,16 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.ConfigSource";
+
+  // Authorities that this config source may be used for. An authority specified
+  // in a *udpa.core.v1.ResourceLocator* is resolved to a *ConfigSource* prior
+  // to configuration fetch. This field provides the association between
+  // authority name and configuration source.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.Authority authorities = 7;
 
   oneof config_source_specifier {
     option (validate.required) = true;

--- a/api/envoy/config/core/v4alpha/BUILD
+++ b/api/envoy/config/core/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -7,6 +7,8 @@ import "envoy/config/core/v4alpha/grpc_service.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/authority.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -53,13 +55,23 @@ message ApiConfigSource {
     // the v2 protos is used.
     REST = 1;
 
-    // gRPC v2 API.
+    // SotW gRPC service.
     GRPC = 2;
 
     // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
     // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
     // with every update, the xDS server only sends what has changed since the last update.
     DELTA_GRPC = 3;
+
+    // SotW xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_GRPC = 5;
+
+    // Delta xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_DELTA_GRPC = 6;
   }
 
   // API type (gRPC, REST, delta gRPC)
@@ -138,9 +150,16 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.core.v3.ConfigSource";
+
+  // Authorities that this config source may be used for. An authority specified
+  // in a *udpa.core.v1.ResourceLocator* is resolved to a *ConfigSource* prior
+  // to configuration fetch. This field provides the association between
+  // authority name and configuration source.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.Authority authorities = 7;
 
   oneof config_source_specifier {
     option (validate.required) = true;

--- a/api/envoy/config/listener/v3/BUILD
+++ b/api/envoy/config/listener/v3/BUILD
@@ -13,5 +13,6 @@ api_proto_package(
         "//envoy/config/listener/v2:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -14,6 +14,8 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -26,6 +28,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Listener configuration]
 // Listener :ref:`configuration overview <config_listeners>`
+
+// Listener list collections. Entries are *Listener* resources or references.
+// [#not-implemented-hide:]
+message ListenerCollection {
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // [#next-free-field: 23]
 message Listener {

--- a/api/envoy/config/listener/v4alpha/BUILD
+++ b/api/envoy/config/listener/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/listener/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/listener/v4alpha/listener.proto
+++ b/api/envoy/config/listener/v4alpha/listener.proto
@@ -14,6 +14,8 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -26,6 +28,15 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // [#protodoc-title: Listener configuration]
 // Listener :ref:`configuration overview <config_listeners>`
+
+// Listener list collections. Entries are *Listener* resources or references.
+// [#not-implemented-hide:]
+message ListenerCollection {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.listener.v3.ListenerCollection";
+
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // [#next-free-field: 23]
 message Listener {

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -615,6 +615,10 @@ message RouteAction {
       string header_name = 1 [
         (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
       ];
+
+      // If specified, the request header value will be rewritten and used
+      // to produce the hash key.
+      type.matcher.v3.RegexMatchAndSubstitute regex_rewrite = 2;
     }
 
     // Envoy supports two types of cookie affinity:

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -608,6 +608,10 @@ message RouteAction {
       string header_name = 1 [
         (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
       ];
+
+      // If specified, the request header value will be rewritten and used
+      // to produce the hash key.
+      type.matcher.v4alpha.RegexMatchAndSubstitute regex_rewrite = 2;
     }
 
     // Envoy supports two types of cookie affinity:

--- a/api/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
+++ b/api/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
@@ -18,9 +18,16 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Dynamic forward proxy common configuration]
 
+// Configuration of circuit breakers for resolver.
+message DnsCacheCircuitBreakers {
+  // The maximum number of pending requests that Envoy will allow to the
+  // resolver. If not specified, the default is 1024.
+  google.protobuf.UInt32Value max_pending_requests = 1;
+}
+
 // Configuration for the dynamic forward proxy DNS cache. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DnsCacheConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.common.dynamic_forward_proxy.v2alpha.DnsCacheConfig";
@@ -83,4 +90,9 @@ message DnsCacheConfig {
   // this is used as the cache's DNS refresh rate when DNS requests are failing. If this setting is
   // not specified, the failure refresh rate defaults to the dns_refresh_rate.
   config.cluster.v3.Cluster.RefreshRate dns_failure_refresh_rate = 6;
+
+  // The config of circuit breakers for resolver. It provides a configurable threshold.
+  // If `envoy.reloadable_features.enable_dns_cache_circuit_breakers` is enabled,
+  // envoy will use dns cache circuit breakers with default settings even if this value is not set.
+  DnsCacheCircuitBreakers dns_cache_circuit_breaker = 7;
 }

--- a/api/envoy/extensions/common/tap/v3/BUILD
+++ b/api/envoy/extensions/common/tap/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/tap/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/common/tap/v3/common.proto
+++ b/api/envoy/extensions/common/tap/v3/common.proto
@@ -5,6 +5,9 @@ package envoy.extensions.common.tap.v3;
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/tap/v3/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -30,7 +33,12 @@ message CommonExtensionConfig {
     config.core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
 
     // Tap config to request from XDS server.
-    string name = 2 [(validate.rules).string = {min_bytes: 1}];
+    string name = 2 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+    // Resource locator for TAP. This is mutually exclusive to *name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator tap_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
   }
 
   oneof config_type {

--- a/api/envoy/extensions/common/tap/v4alpha/BUILD
+++ b/api/envoy/extensions/common/tap/v4alpha/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/tap/v4alpha:pkg",
         "//envoy/extensions/common/tap/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/common/tap/v4alpha/common.proto
+++ b/api/envoy/extensions/common/tap/v4alpha/common.proto
@@ -5,6 +5,8 @@ package envoy.extensions.common.tap.v4alpha;
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/tap/v4alpha/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -30,8 +32,14 @@ message CommonExtensionConfig {
     config.core.v4alpha.ConfigSource config_source = 1
         [(validate.rules).message = {required: true}];
 
-    // Tap config to request from XDS server.
-    string name = 2 [(validate.rules).string = {min_bytes: 1}];
+    oneof name_specifier {
+      // Tap config to request from XDS server.
+      string name = 2;
+
+      // Resource locator for TAP. This is mutually exclusive to *name*.
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator tap_resource_locator = 3;
+    }
   }
 
   oneof config_type {

--- a/api/envoy/extensions/filters/http/lua/v3/BUILD
+++ b/api/envoy/extensions/filters/http/lua/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/lua/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/api/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.lua.v3;
 
+import "envoy/config/core/v3/base.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -24,4 +26,37 @@ message Lua {
   // be properly escaped. YAML configuration may be easier to read since YAML supports multi-line
   // strings so complex scripts can be easily expressed inline in the configuration.
   string inline_code = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // Map of named Lua source codes that can be referenced in :ref:` LuaPerRoute
+  // <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>`. The Lua source codes can be
+  // loaded from inline string or local files.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //   source_codes:
+  //     hello.lua:
+  //       inline_string: |
+  //         function envoy_on_response(response_handle)
+  //           -- Do something.
+  //         end
+  //     world.lua:
+  //       filename: /etc/lua/world.lua
+  //
+  map<string, config.core.v3.DataSource> source_codes = 2;
+}
+
+message LuaPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the Lua filter for this particular vhost or route. If disabled is specified in
+    // multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+
+    // A name of a Lua source code stored in
+    // :ref:`Lua.source_codes <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.source_codes>`.
+    string name = 2 [(validate.rules).string = {min_len: 1}];
+  }
 }

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -18,7 +18,10 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -612,7 +615,13 @@ message Rds {
   // API. This allows an Envoy configuration with multiple HTTP listeners (and
   // associated HTTP connection manager filters) to use different route
   // configurations.
-  string route_config_name = 2 [(validate.rules).string = {min_bytes: 1}];
+  string route_config_name = 2
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+  // Resource locator for RDS. This is mutually exclusive to *route_config_name*.
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator rds_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 }
 
 // This message is used to work around the limitations with 'oneof' and repeated fields.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -18,6 +18,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -614,11 +616,17 @@ message Rds {
   // Configuration source specifier for RDS.
   config.core.v4alpha.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
 
-  // The name of the route configuration. This name will be passed to the RDS
-  // API. This allows an Envoy configuration with multiple HTTP listeners (and
-  // associated HTTP connection manager filters) to use different route
-  // configurations.
-  string route_config_name = 2 [(validate.rules).string = {min_bytes: 1}];
+  oneof name_specifier {
+    // The name of the route configuration. This name will be passed to the RDS
+    // API. This allows an Envoy configuration with multiple HTTP listeners (and
+    // associated HTTP connection manager filters) to use different route
+    // configurations.
+    string route_config_name = 2;
+
+    // Resource locator for RDS. This is mutually exclusive to *route_config_name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator rds_resource_locator = 3;
+  }
 }
 
 // This message is used to work around the limitations with 'oneof' and repeated fields.

--- a/api/envoy/extensions/transport_sockets/tls/v3/BUILD
+++ b/api/envoy/extensions/transport_sockets/tls/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/transport_sockets/tls/v3/secret.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/secret.proto
@@ -6,6 +6,9 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -30,7 +33,12 @@ message SdsSecretConfig {
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
   // When both name and config are specified, then secret can be fetched and/or reloaded via
   // SDS. When only name is specified, then secret will be loaded from static resources.
-  string name = 1;
+  string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+  // Resource locator for SDS. This is mutually exclusive to *name*.
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator sds_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
   config.core.v3.ConfigSource sds_config = 2;
 }

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/BUILD
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/secret.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/secret.proto
@@ -6,6 +6,8 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -29,10 +31,16 @@ message SdsSecretConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig";
 
-  // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  // When both name and config are specified, then secret can be fetched and/or reloaded via
-  // SDS. When only name is specified, then secret will be loaded from static resources.
-  string name = 1;
+  oneof name_specifier {
+    // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
+    // When both name and config are specified, then secret can be fetched and/or reloaded via
+    // SDS. When only name is specified, then secret will be loaded from static resources.
+    string name = 1;
+
+    // Resource locator for SDS. This is mutually exclusive to *name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator sds_resource_locator = 3;
+  }
 
   config.core.v4alpha.ConfigSource sds_config = 2;
 }

--- a/api/envoy/service/discovery/v3/BUILD
+++ b/api/envoy/service/discovery/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/service/discovery/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -7,6 +7,10 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+import "udpa/core/v1/resource_name.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 
@@ -140,7 +144,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 10]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DeltaDiscoveryRequest";
 
@@ -148,7 +152,9 @@ message DeltaDiscoveryRequest {
   config.core.v3.Node node = 1;
 
   // Type of the resource that is being requested, e.g.
-  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment".
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This does not need to be set if
+  // resources are only referenced via *udpa_resource_subscribe* and
+  // *udpa_resources_unsubscribe*.
   string type_url = 2;
 
   // DeltaDiscoveryRequests allow the client to add or remove individual
@@ -174,8 +180,21 @@ message DeltaDiscoveryRequest {
   // A list of Resource names to add to the list of tracked resources.
   repeated string resource_names_subscribe = 3;
 
+  // As with *resource_names_subscribe* but used when subscribing to resources indicated
+  // by a *udpa.core.v1.ResourceLocator*. The directives in the resource locator
+  // are ignored and the context parameters are matched with
+  // *context_param_specifier* specific semantics.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_subscribe = 8;
+
   // A list of Resource names to remove from the list of tracked resources.
   repeated string resource_names_unsubscribe = 4;
+
+  // As with *resource_names_unsubscribe* but used when unsubscribing to resources indicated by a
+  // *udpa.core.v1.ResourceLocator*. This must match a previously subscribed
+  // resource locator provided in *udpa_resources_subscribe*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_unsubscribe = 9;
 
   // Informs the server of the versions of the resources the xDS client knows of, to enable the
   // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
@@ -199,7 +218,7 @@ message DeltaDiscoveryRequest {
   google.rpc.Status error_detail = 7;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DeltaDiscoveryResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.DeltaDiscoveryResponse";
@@ -215,22 +234,34 @@ message DeltaDiscoveryResponse {
 
   // Type URL for resources. Identifies the xDS API when muxing over ADS.
   // Must be consistent with the type_url in the Any within 'resources' if 'resources' is non-empty.
+  // This does not need to be set if *udpa_removed_resources* is used instead of
+  // *removed_resources*.
   string type_url = 4;
 
   // Resources names of resources that have be deleted and to be removed from the xDS Client.
   // Removed resources for missing resources can be ignored.
   repeated string removed_resources = 6;
 
+  // As with *removed_resources* but used when a removed resource was named in
+  // its *Resource*s with a *udpa.core.v1.ResourceName*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceName udpa_removed_resources = 7;
+
   // The nonce provides a way for DeltaDiscoveryRequests to uniquely
   // reference a DeltaDiscoveryResponse when (N)ACKing. The nonce is required.
   string nonce = 5;
 }
 
+// [#next-free-field: 6]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
   // The resource's name, to distinguish it from others of the same type of resource.
-  string name = 3;
+  string name = 3 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+  // Used instead of *name* when a resource with a *udpa.core.v1.ResourceName* is delivered.
+  udpa.core.v1.ResourceName udpa_resource_name = 5
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
   // The aliases are a list of other names that this resource can go by.
   repeated string aliases = 4;

--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -77,7 +77,7 @@ API flow
 For typical HTTP routing scenarios, the core resource types for the client's configuration are
 `Listener`, `RouteConfiguration`, `Cluster`, and `ClusterLoadAssignment`. Each `Listener` resource
 may point to a `RouteConfiguration` resource, which may point to one or more `Cluster` resources,
-and each Cluster` resource may point to a `ClusterLoadAssignment` resource.
+and each `Cluster` resource may point to a `ClusterLoadAssignment` resource.
 
 Envoy fetches all `Listener` and `Cluster` resources at startup. It then fetches whatever
 `RouteConfiguration` and `ClusterLoadAssignment` resources that are required by the `Listener` and

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -48,7 +48,7 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:windows_fastbuild_build": [],
                repository + "//bazel:windows_dbg_build": [],
            }) + select({
-               repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand", "-Wc++20-extensions"],
+               repository + "//bazel:clang_build": ["-fno-limit-debug-info", "-Wgnu-conditional-omitted-operand", "-Wc++2a-extensions"],
                repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
                "//conditions:default": [],
            }) + select({

--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -32,6 +32,13 @@ host when forwarding. See the example below within the configured routes.
   the certificate chain. Additionally, Envoy will automatically perform SAN verification for the
   resolved host name as well as specify the host name via SNI.
 
+.. _dns_cache_circuit_breakers:
+
+  Dynamic forward proxy uses circuit breakers built in to the DNS cache with the configuration
+  of :ref:`DNS cache circuit breakers <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_cache_circuit_breaker>`. By default, this behavior is enabled by the runtime feature `envoy.reloadable_features.enable_dns_cache_circuit_breakers`.
+  If this runtime feature is disabled, cluster circuit breakers will be used even when setting the configuration
+  of :ref:`DNS cache circuit breakers <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_cache_circuit_breaker>`.
+
 .. code-block:: yaml
 
   admin:
@@ -119,3 +126,14 @@ namespace.
   host_added, Counter, Number of hosts that have been added to the cache.
   host_removed, Counter, Number of hosts that have been removed from the cache.
   num_hosts, Gauge, Number of hosts that are currently in the cache.
+  dns_rq_pending_overflow, Counter, Number of dns pending request overflow.
+
+The dynamic forward proxy DNS cache circuit breakers outputs statistics in the dns_cache.<dns_cache_name>.circuit_breakers*
+namespace.
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  rq_pending_open, Gauge, Whether the requests circuit breaker is closed (0) or open (1)
+  rq_pending_remaining, Gauge, Number of remaining requests until the circuit breaker opens

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -128,6 +128,7 @@ New Features
 * request_id: added to :ref:`always_set_request_id_in_response setting <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.always_set_request_id_in_response>`
   to set :ref:`x-request-id <config_http_conn_man_headers_x-request-id>` header in response even if
   tracing is not forced.
+* router: add regex substitution support for header based hashing.
 * router: add support for RESPONSE_FLAGS and RESPONSE_CODE_DETAILS :ref:`header formatters
   <config_http_conn_man_headers_custom_request_headers>`.
 * router: allow Rate Limiting Service to be called in case of missing request header for a descriptor if the :ref:`skip_if_absent <envoy_v3_api_field_config.route.v3.RateLimit.Action.RequestHeaders.skip_if_absent>` field is set to true.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -79,6 +79,9 @@ New Features
 * config: added :ref:`version_text <config_cluster_manager_cds>` stat that reflects xDS version.
 * decompressor: generic :ref:`decompressor <config_http_filters_decompressor>` filter exposed to users.
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
+* dynamic forward proxy: added configurable :ref:`circuit breakers <dns_cache_circuit_breakers>` for resolver on DNS cache.
+  This behavior can be temporarily disabled by the runtime feature `envoy.reloadable_features.enable_dns_cache_circuit_breakers`.
+  If this runtime feature is disabled, the upstream circuit breakers for the cluster will be used even if the :ref:`DNS Cache circuit breakers <dns_cache_circuit_breakers>` are configured.
 * dynamic forward proxy: added :ref:`allow_insecure_cluster_options<envoy_v3_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.allow_insecure_cluster_options>` to allow disabling of auto_san_validation and auto_sni.
 * ext_authz filter: added :ref:`v2 deny_at_disable <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.deny_at_disable>`, :ref:`v3 deny_at_disable <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.deny_at_disable>`. This allows to force deny for protected path while filter gets disabled, by setting this key to true.
 * ext_authz filter: added API version field for both :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.transport_api_version>`
@@ -158,3 +161,4 @@ Deprecated
   in :ref:`predicates <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`.
 * File access logger fields :ref:`format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.format>`, :ref:`json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.json_format>` and :ref:`typed_json_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.typed_json_format>` are deprecated in favor of :ref:`log_format <envoy_v3_api_field_extensions.access_loggers.file.v3.FileAccessLog.log_format>`.
 * A warning is now logged when v2 xDS api is used. This behavior can be temporarily disabled by setting `envoy.reloadable_features.enable_deprecated_v2_api_warning` to `false`.
+* Using cluster circuit breakers for DNS Cache is now deprecated in favor of :ref:`DNS cache circuit breakers <dns_cache_circuit_breakers>`. This behavior can be temporarily disabled by setting `envoy.reloadable_features.enable_dns_cache_circuit_breakers` to `false`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -110,6 +110,7 @@ New Features
   interested in; behavior is allowed based on new "envoy.lrs.supports_send_all_clusters" capability
   in :ref:`client_features<envoy_v3_api_field_config.core.v3.Node.client_features>` field.
 * lrs: updated to allow to explicitly set the API version of gRPC service endpoint and message to be used.
+* lua: added :ref:`per route config <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>` for Lua filter.
 * lua: added tracing to the ``httpCall()`` API.
 * metrics service: added added :ref:`API version <envoy_v3_api_field_config.metrics.v3.MetricsServiceConfig.transport_api_version>` to explicitly set the version of gRPC service endpoint and message to be used.
 * network filters: added a :ref:`postgres proxy filter <config_network_filters_postgres_proxy>`.

--- a/examples/cors/backend/front-envoy.yaml
+++ b/examples/cors/backend/front-envoy.yaml
@@ -15,7 +15,7 @@ static_resources:
             - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
-                path: "/var/log/access.log"
+                path: /dev/stdout
           route_config:
             name: local_route
             virtual_hosts:

--- a/examples/cors/frontend/front-envoy.yaml
+++ b/examples/cors/frontend/front-envoy.yaml
@@ -15,7 +15,7 @@ static_resources:
             - name: envoy.access_loggers.file
               typed_config:
                 "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
-                path: "/var/log/access.log"
+                path: /dev/stdout
           route_config:
             name: local_route
             virtual_hosts:

--- a/generated_api_shadow/envoy/api/v2/core/config_source.proto
+++ b/generated_api_shadow/envoy/api/v2/core/config_source.proto
@@ -106,6 +106,9 @@ message AggregatedConfigSource {
 // set in :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` can be used to
 // specify that other data can be obtained from the same server.
 message SelfConfigSource {
+  // API version for xDS transport protocol. This describes the xDS gRPC/REST
+  // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
+  ApiVersion transport_api_version = 1 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Rate Limit settings to be applied for discovery requests made by Envoy.

--- a/generated_api_shadow/envoy/config/bootstrap/v3/BUILD
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/BUILD
@@ -16,5 +16,6 @@ api_proto_package(
         "//envoy/config/trace/v3:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
@@ -19,7 +19,10 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -36,7 +39,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 22]
+// [#next-free-field: 24]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -62,6 +65,7 @@ message Bootstrap {
     repeated envoy.extensions.transport_sockets.tls.v3.Secret secrets = 3;
   }
 
+  // [#next-free-field: 7]
   message DynamicResources {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v2.Bootstrap.DynamicResources";
@@ -72,10 +76,18 @@ message Bootstrap {
     // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
     core.v3.ConfigSource lds_config = 1;
 
+    // Resource locator for listener collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator lds_resources_locator = 5;
+
     // All post-bootstrap :ref:`Cluster <envoy_api_msg_config.cluster.v3.Cluster>` definitions are
     // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
     // configuration source.
     core.v3.ConfigSource cds_config = 2;
+
+    // Resource locator for cluster collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cds_resources_locator = 6;
 
     // A single :ref:`ADS <config_overview_ads>` source may be optionally
     // specified. This must have :ref:`api_type
@@ -184,6 +196,30 @@ message Bootstrap {
   // Specifies optional bootstrap extensions to be instantiated at startup time.
   // Each item contains extension specific configuration.
   repeated core.v3.TypedExtensionConfig bootstrap_extensions = 21;
+
+  // Configuration sources that will participate in
+  // *udpa.core.v1.ResourceLocator* authority resolution. The algorithm is as
+  // follows:
+  // 1. The authority field is taken from the *udpa.core.v1.ResourceLocator*, call
+  //    this *resource_authority*.
+  // 2. *resource_authority* is compared against the authorities in any peer
+  //    *ConfigSource*. The peer *ConfigSource* is the configuration source
+  //    message which would have been used unconditionally for resolution
+  //    with opaque resource names. If there is a match with an authority, the
+  //    peer *ConfigSource* message is used.
+  // 3. *resource_authority* is compared sequentially with the authorities in
+  //    each configuration source in *config_sources*. The first *ConfigSource*
+  //    to match wins.
+  // 4. As a fallback, if no configuration source matches, then
+  //    *default_config_source* is used.
+  // 5. If *default_config_source* is not specified, resolution fails.
+  // [#not-implemented-hide:]
+  repeated core.v3.ConfigSource config_sources = 22;
+
+  // Default configuration source for *udpa.core.v1.ResourceLocator* if all
+  // other resolution fails.
+  // [#not-implemented-hide:]
+  core.v3.ConfigSource default_config_source = 23;
 
   Runtime hidden_envoy_deprecated_runtime = 11
       [deprecated = true, (envoy.annotations.disallowed_by_default) = true];
@@ -354,7 +390,12 @@ message RuntimeLayer {
         "envoy.config.bootstrap.v2.RuntimeLayer.RtdsLayer";
 
     // Resource to subscribe to at *rtds_config* for the RTDS layer.
-    string name = 1;
+    string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+    // Resource locator for RTDS layer. This is mutually exclusive to *name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator rtds_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
     // RTDS configuration source.
     core.v3.ConfigSource rtds_config = 2;

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/BUILD
@@ -16,5 +16,6 @@ api_proto_package(
         "//envoy/config/trace/v4alpha:pkg",
         "//envoy/extensions/transport_sockets/tls/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -19,6 +19,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -36,7 +38,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 22]
+// [#next-free-field: 24]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v3.Bootstrap";
@@ -62,6 +64,7 @@ message Bootstrap {
     repeated envoy.extensions.transport_sockets.tls.v4alpha.Secret secrets = 3;
   }
 
+  // [#next-free-field: 7]
   message DynamicResources {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v3.Bootstrap.DynamicResources";
@@ -72,10 +75,18 @@ message Bootstrap {
     // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
     core.v4alpha.ConfigSource lds_config = 1;
 
+    // Resource locator for listener collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator lds_resources_locator = 5;
+
     // All post-bootstrap :ref:`Cluster <envoy_api_msg_config.cluster.v4alpha.Cluster>` definitions are
     // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
     // configuration source.
     core.v4alpha.ConfigSource cds_config = 2;
+
+    // Resource locator for cluster collection.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cds_resources_locator = 6;
 
     // A single :ref:`ADS <config_overview_ads>` source may be optionally
     // specified. This must have :ref:`api_type
@@ -186,6 +197,30 @@ message Bootstrap {
   // Specifies optional bootstrap extensions to be instantiated at startup time.
   // Each item contains extension specific configuration.
   repeated core.v4alpha.TypedExtensionConfig bootstrap_extensions = 21;
+
+  // Configuration sources that will participate in
+  // *udpa.core.v1.ResourceLocator* authority resolution. The algorithm is as
+  // follows:
+  // 1. The authority field is taken from the *udpa.core.v1.ResourceLocator*, call
+  //    this *resource_authority*.
+  // 2. *resource_authority* is compared against the authorities in any peer
+  //    *ConfigSource*. The peer *ConfigSource* is the configuration source
+  //    message which would have been used unconditionally for resolution
+  //    with opaque resource names. If there is a match with an authority, the
+  //    peer *ConfigSource* message is used.
+  // 3. *resource_authority* is compared sequentially with the authorities in
+  //    each configuration source in *config_sources*. The first *ConfigSource*
+  //    to match wins.
+  // 4. As a fallback, if no configuration source matches, then
+  //    *default_config_source* is used.
+  // 5. If *default_config_source* is not specified, resolution fails.
+  // [#not-implemented-hide:]
+  repeated core.v4alpha.ConfigSource config_sources = 22;
+
+  // Default configuration source for *udpa.core.v1.ResourceLocator* if all
+  // other resolution fails.
+  // [#not-implemented-hide:]
+  core.v4alpha.ConfigSource default_config_source = 23;
 }
 
 // Administration interface :ref:`operations documentation
@@ -352,8 +387,14 @@ message RuntimeLayer {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.bootstrap.v3.RuntimeLayer.RtdsLayer";
 
-    // Resource to subscribe to at *rtds_config* for the RTDS layer.
-    string name = 1;
+    oneof name_specifier {
+      // Resource to subscribe to at *rtds_config* for the RTDS layer.
+      string name = 1;
+
+      // Resource locator for RTDS layer. This is mutually exclusive to *name*.
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator rtds_resource_locator = 3;
+    }
 
     // RTDS configuration source.
     core.v4alpha.ConfigSource rtds_config = 2;

--- a/generated_api_shadow/envoy/config/cluster/v3/BUILD
+++ b/generated_api_shadow/envoy/config/cluster/v3/BUILD
@@ -14,5 +14,6 @@ api_proto_package(
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -20,7 +20,11 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -32,6 +36,12 @@ option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Cluster configuration]
+
+// Cluster list collections. Entries are *Cluster* resources or references.
+// [#not-implemented-hide:]
+message ClusterCollection {
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // Configuration for a single upstream cluster.
 // [#next-free-field: 49]
@@ -178,7 +188,12 @@ message Cluster {
     // Optional alternative to cluster name to present to EDS. This does not
     // have the same restrictions as cluster name, i.e. it may be arbitrary
     // length.
-    string service_name = 2;
+    string service_name = 2 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+    // Resource locator for EDS. This is mutually exclusive to *service_name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator eds_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
   }
 
   // Optionally divide the endpoints in this cluster into subsets defined by

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/BUILD
@@ -12,5 +12,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -19,6 +19,9 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -31,6 +34,15 @@ option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
 
 // [#protodoc-title: Cluster configuration]
+
+// Cluster list collections. Entries are *Cluster* resources or references.
+// [#not-implemented-hide:]
+message ClusterCollection {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.cluster.v3.ClusterCollection";
+
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // Configuration for a single upstream cluster.
 // [#next-free-field: 49]
@@ -175,10 +187,16 @@ message Cluster {
     // Configuration for the source of EDS updates for this Cluster.
     core.v4alpha.ConfigSource eds_config = 1;
 
-    // Optional alternative to cluster name to present to EDS. This does not
-    // have the same restrictions as cluster name, i.e. it may be arbitrary
-    // length.
-    string service_name = 2;
+    oneof name_specifier {
+      // Optional alternative to cluster name to present to EDS. This does not
+      // have the same restrictions as cluster name, i.e. it may be arbitrary
+      // length.
+      string service_name = 2;
+
+      // Resource locator for EDS. This is mutually exclusive to *service_name*.
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator eds_resource_locator = 3;
+    }
   }
 
   // Optionally divide the endpoints in this cluster into subsets defined by

--- a/generated_api_shadow/envoy/config/core/v3/BUILD
+++ b/generated_api_shadow/envoy/config/core/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/core/v3/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v3/config_source.proto
@@ -7,6 +7,8 @@ import "envoy/config/core/v3/grpc_service.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/authority.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -52,13 +54,23 @@ message ApiConfigSource {
     // the v2 protos is used.
     REST = 1;
 
-    // gRPC v2 API.
+    // SotW gRPC service.
     GRPC = 2;
 
     // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
     // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
     // with every update, the xDS server only sends what has changed since the last update.
     DELTA_GRPC = 3;
+
+    // SotW xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_GRPC = 5;
+
+    // Delta xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_DELTA_GRPC = 6;
   }
 
   // API type (gRPC, REST, delta gRPC)
@@ -136,9 +148,16 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.ConfigSource";
+
+  // Authorities that this config source may be used for. An authority specified
+  // in a *udpa.core.v1.ResourceLocator* is resolved to a *ConfigSource* prior
+  // to configuration fetch. This field provides the association between
+  // authority name and configuration source.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.Authority authorities = 7;
 
   oneof config_source_specifier {
     option (validate.required) = true;

--- a/generated_api_shadow/envoy/config/core/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/core/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
@@ -7,6 +7,8 @@ import "envoy/config/core/v4alpha/grpc_service.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/authority.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -53,13 +55,23 @@ message ApiConfigSource {
     // the v2 protos is used.
     REST = 1;
 
-    // gRPC v2 API.
+    // SotW gRPC service.
     GRPC = 2;
 
     // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
     // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
     // with every update, the xDS server only sends what has changed since the last update.
     DELTA_GRPC = 3;
+
+    // SotW xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_GRPC = 5;
+
+    // Delta xDS gRPC with ADS. All resources which resolve to this configuration source will be
+    // multiplexed on a single connection to an ADS endpoint.
+    // [#not-implemented-hide:]
+    AGGREGATED_DELTA_GRPC = 6;
   }
 
   // API type (gRPC, REST, delta gRPC)
@@ -138,9 +150,16 @@ message RateLimitSettings {
 // <arch_overview_service_discovery>` etc. may either be sourced from the
 // filesystem or from an xDS API source. Filesystem configs are watched with
 // inotify for updates.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ConfigSource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.core.v3.ConfigSource";
+
+  // Authorities that this config source may be used for. An authority specified
+  // in a *udpa.core.v1.ResourceLocator* is resolved to a *ConfigSource* prior
+  // to configuration fetch. This field provides the association between
+  // authority name and configuration source.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.Authority authorities = 7;
 
   oneof config_source_specifier {
     option (validate.required) = true;

--- a/generated_api_shadow/envoy/config/listener/v3/BUILD
+++ b/generated_api_shadow/envoy/config/listener/v3/BUILD
@@ -14,5 +14,6 @@ api_proto_package(
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/listener/v3/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/listener.proto
@@ -14,6 +14,8 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -26,6 +28,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Listener configuration]
 // Listener :ref:`configuration overview <config_listeners>`
+
+// Listener list collections. Entries are *Listener* resources or references.
+// [#not-implemented-hide:]
+message ListenerCollection {
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // [#next-free-field: 23]
 message Listener {

--- a/generated_api_shadow/envoy/config/listener/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/listener/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
@@ -14,6 +14,8 @@ import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/collection_entry.proto";
+
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -26,6 +28,15 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // [#protodoc-title: Listener configuration]
 // Listener :ref:`configuration overview <config_listeners>`
+
+// Listener list collections. Entries are *Listener* resources or references.
+// [#not-implemented-hide:]
+message ListenerCollection {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.listener.v3.ListenerCollection";
+
+  udpa.core.v1.CollectionEntry entries = 1;
+}
 
 // [#next-free-field: 23]
 message Listener {

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -626,6 +626,10 @@ message RouteAction {
       string header_name = 1 [
         (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
       ];
+
+      // If specified, the request header value will be rewritten and used
+      // to produce the hash key.
+      type.matcher.v3.RegexMatchAndSubstitute regex_rewrite = 2;
     }
 
     // Envoy supports two types of cookie affinity:

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -617,6 +617,10 @@ message RouteAction {
       string header_name = 1 [
         (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
       ];
+
+      // If specified, the request header value will be rewritten and used
+      // to produce the hash key.
+      type.matcher.v4alpha.RegexMatchAndSubstitute regex_rewrite = 2;
     }
 
     // Envoy supports two types of cookie affinity:

--- a/generated_api_shadow/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
+++ b/generated_api_shadow/envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto
@@ -18,9 +18,16 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Dynamic forward proxy common configuration]
 
+// Configuration of circuit breakers for resolver.
+message DnsCacheCircuitBreakers {
+  // The maximum number of pending requests that Envoy will allow to the
+  // resolver. If not specified, the default is 1024.
+  google.protobuf.UInt32Value max_pending_requests = 1;
+}
+
 // Configuration for the dynamic forward proxy DNS cache. See the :ref:`architecture overview
 // <arch_overview_http_dynamic_forward_proxy>` for more information.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DnsCacheConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.common.dynamic_forward_proxy.v2alpha.DnsCacheConfig";
@@ -83,4 +90,9 @@ message DnsCacheConfig {
   // this is used as the cache's DNS refresh rate when DNS requests are failing. If this setting is
   // not specified, the failure refresh rate defaults to the dns_refresh_rate.
   config.cluster.v3.Cluster.RefreshRate dns_failure_refresh_rate = 6;
+
+  // The config of circuit breakers for resolver. It provides a configurable threshold.
+  // If `envoy.reloadable_features.enable_dns_cache_circuit_breakers` is enabled,
+  // envoy will use dns cache circuit breakers with default settings even if this value is not set.
+  DnsCacheCircuitBreakers dns_cache_circuit_breaker = 7;
 }

--- a/generated_api_shadow/envoy/extensions/common/tap/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/common/tap/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/tap/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/common/tap/v3/common.proto
+++ b/generated_api_shadow/envoy/extensions/common/tap/v3/common.proto
@@ -5,6 +5,9 @@ package envoy.extensions.common.tap.v3;
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/tap/v3/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -30,7 +33,12 @@ message CommonExtensionConfig {
     config.core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
 
     // Tap config to request from XDS server.
-    string name = 2 [(validate.rules).string = {min_bytes: 1}];
+    string name = 2 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+    // Resource locator for TAP. This is mutually exclusive to *name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator tap_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
   }
 
   oneof config_type {

--- a/generated_api_shadow/envoy/extensions/common/tap/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/common/tap/v4alpha/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/tap/v4alpha:pkg",
         "//envoy/extensions/common/tap/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/common/tap/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/extensions/common/tap/v4alpha/common.proto
@@ -5,6 +5,8 @@ package envoy.extensions.common.tap.v4alpha;
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/tap/v4alpha/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -30,8 +32,14 @@ message CommonExtensionConfig {
     config.core.v4alpha.ConfigSource config_source = 1
         [(validate.rules).message = {required: true}];
 
-    // Tap config to request from XDS server.
-    string name = 2 [(validate.rules).string = {min_bytes: 1}];
+    oneof name_specifier {
+      // Tap config to request from XDS server.
+      string name = 2;
+
+      // Resource locator for TAP. This is mutually exclusive to *name*.
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator tap_resource_locator = 3;
+    }
   }
 
   oneof config_type {

--- a/generated_api_shadow/envoy/extensions/filters/http/lua/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/lua/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/lua/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/generated_api_shadow/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.http.lua.v3;
 
+import "envoy/config/core/v3/base.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -24,4 +26,37 @@ message Lua {
   // be properly escaped. YAML configuration may be easier to read since YAML supports multi-line
   // strings so complex scripts can be easily expressed inline in the configuration.
   string inline_code = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // Map of named Lua source codes that can be referenced in :ref:` LuaPerRoute
+  // <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>`. The Lua source codes can be
+  // loaded from inline string or local files.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //   source_codes:
+  //     hello.lua:
+  //       inline_string: |
+  //         function envoy_on_response(response_handle)
+  //           -- Do something.
+  //         end
+  //     world.lua:
+  //       filename: /etc/lua/world.lua
+  //
+  map<string, config.core.v3.DataSource> source_codes = 2;
+}
+
+message LuaPerRoute {
+  oneof override {
+    option (validate.required) = true;
+
+    // Disable the Lua filter for this particular vhost or route. If disabled is specified in
+    // multiple per-filter-configs, the most specific one will be used.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
+
+    // A name of a Lua source code stored in
+    // :ref:`Lua.source_codes <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.source_codes>`.
+    string name = 2 [(validate.rules).string = {min_len: 1}];
+  }
 }

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -18,7 +18,10 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -617,7 +620,13 @@ message Rds {
   // API. This allows an Envoy configuration with multiple HTTP listeners (and
   // associated HTTP connection manager filters) to use different route
   // configurations.
-  string route_config_name = 2 [(validate.rules).string = {min_bytes: 1}];
+  string route_config_name = 2
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+  // Resource locator for RDS. This is mutually exclusive to *route_config_name*.
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator rds_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 }
 
 // This message is used to work around the limitations with 'oneof' and repeated fields.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -18,6 +18,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
@@ -614,11 +616,17 @@ message Rds {
   // Configuration source specifier for RDS.
   config.core.v4alpha.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
 
-  // The name of the route configuration. This name will be passed to the RDS
-  // API. This allows an Envoy configuration with multiple HTTP listeners (and
-  // associated HTTP connection manager filters) to use different route
-  // configurations.
-  string route_config_name = 2 [(validate.rules).string = {min_bytes: 1}];
+  oneof name_specifier {
+    // The name of the route configuration. This name will be passed to the RDS
+    // API. This allows an Envoy configuration with multiple HTTP listeners (and
+    // associated HTTP connection manager filters) to use different route
+    // configurations.
+    string route_config_name = 2;
+
+    // Resource locator for RDS. This is mutually exclusive to *route_config_name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator rds_resource_locator = 3;
+  }
 }
 
 // This message is used to work around the limitations with 'oneof' and repeated fields.

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/secret.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/secret.proto
@@ -6,6 +6,9 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -30,7 +33,12 @@ message SdsSecretConfig {
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
   // When both name and config are specified, then secret can be fetched and/or reloaded via
   // SDS. When only name is specified, then secret will be loaded from static resources.
-  string name = 1;
+  string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+  // Resource locator for SDS. This is mutually exclusive to *name*.
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator sds_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
   config.core.v3.ConfigSource sds_config = 2;
 }

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/secret.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/secret.proto
@@ -6,6 +6,8 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/common.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -29,10 +31,16 @@ message SdsSecretConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig";
 
-  // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  // When both name and config are specified, then secret can be fetched and/or reloaded via
-  // SDS. When only name is specified, then secret will be loaded from static resources.
-  string name = 1;
+  oneof name_specifier {
+    // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
+    // When both name and config are specified, then secret can be fetched and/or reloaded via
+    // SDS. When only name is specified, then secret will be loaded from static resources.
+    string name = 1;
+
+    // Resource locator for SDS. This is mutually exclusive to *name*.
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator sds_resource_locator = 3;
+  }
 
   config.core.v4alpha.ConfigSource sds_config = 2;
 }

--- a/generated_api_shadow/envoy/service/discovery/v3/BUILD
+++ b/generated_api_shadow/envoy/service/discovery/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/service/discovery/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -7,6 +7,10 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/any.proto";
 import "google/rpc/status.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+import "udpa/core/v1/resource_name.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 
@@ -140,7 +144,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 10]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DeltaDiscoveryRequest";
 
@@ -148,7 +152,9 @@ message DeltaDiscoveryRequest {
   config.core.v3.Node node = 1;
 
   // Type of the resource that is being requested, e.g.
-  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment".
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This does not need to be set if
+  // resources are only referenced via *udpa_resource_subscribe* and
+  // *udpa_resources_unsubscribe*.
   string type_url = 2;
 
   // DeltaDiscoveryRequests allow the client to add or remove individual
@@ -174,8 +180,21 @@ message DeltaDiscoveryRequest {
   // A list of Resource names to add to the list of tracked resources.
   repeated string resource_names_subscribe = 3;
 
+  // As with *resource_names_subscribe* but used when subscribing to resources indicated
+  // by a *udpa.core.v1.ResourceLocator*. The directives in the resource locator
+  // are ignored and the context parameters are matched with
+  // *context_param_specifier* specific semantics.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_subscribe = 8;
+
   // A list of Resource names to remove from the list of tracked resources.
   repeated string resource_names_unsubscribe = 4;
+
+  // As with *resource_names_unsubscribe* but used when unsubscribing to resources indicated by a
+  // *udpa.core.v1.ResourceLocator*. This must match a previously subscribed
+  // resource locator provided in *udpa_resources_subscribe*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_unsubscribe = 9;
 
   // Informs the server of the versions of the resources the xDS client knows of, to enable the
   // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
@@ -199,7 +218,7 @@ message DeltaDiscoveryRequest {
   google.rpc.Status error_detail = 7;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DeltaDiscoveryResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.DeltaDiscoveryResponse";
@@ -215,22 +234,34 @@ message DeltaDiscoveryResponse {
 
   // Type URL for resources. Identifies the xDS API when muxing over ADS.
   // Must be consistent with the type_url in the Any within 'resources' if 'resources' is non-empty.
+  // This does not need to be set if *udpa_removed_resources* is used instead of
+  // *removed_resources*.
   string type_url = 4;
 
   // Resources names of resources that have be deleted and to be removed from the xDS Client.
   // Removed resources for missing resources can be ignored.
   repeated string removed_resources = 6;
 
+  // As with *removed_resources* but used when a removed resource was named in
+  // its *Resource*s with a *udpa.core.v1.ResourceName*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceName udpa_removed_resources = 7;
+
   // The nonce provides a way for DeltaDiscoveryRequests to uniquely
   // reference a DeltaDiscoveryResponse when (N)ACKing. The nonce is required.
   string nonce = 5;
 }
 
+// [#next-free-field: 6]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
   // The resource's name, to distinguish it from others of the same type of resource.
-  string name = 3;
+  string name = 3 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
+
+  // Used instead of *name* when a resource with a *udpa.core.v1.ResourceName* is delivered.
+  udpa.core.v1.ResourceName udpa_resource_name = 5
+      [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
   // The aliases are a list of other names that this resource can go by.
   repeated string aliases = 4;

--- a/include/envoy/common/resource.h
+++ b/include/envoy/common/resource.h
@@ -2,6 +2,8 @@
 
 #include "envoy/common/pure.h"
 
+#include "absl/types/optional.h"
+
 #pragma once
 
 namespace Envoy {
@@ -43,5 +45,7 @@ public:
    */
   virtual uint64_t count() const PURE;
 };
+
+using ResourceLimitOptRef = absl::optional<std::reference_wrapper<ResourceLimit>>;
 
 } // namespace Envoy

--- a/include/envoy/router/route_config_update_receiver.h
+++ b/include/envoy/router/route_config_update_receiver.h
@@ -78,7 +78,7 @@ public:
   virtual absl::optional<RouteConfigProvider::ConfigInfo> configInfo() const PURE;
 
   /**
-   * @return envoy::api::v2::RouteConfiguration& current RouteConfiguration.
+   * @return envoy::config::route::v3::RouteConfiguration& current RouteConfiguration.
    */
   virtual const envoy::config::route::v3::RouteConfiguration& routeConfiguration() PURE;
 

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -165,7 +165,7 @@ public:
   // Called by derived classes any time a request is completed or destroyed for any reason.
   void onRequestClosed(Envoy::ConnectionPool::ActiveClient& client, bool delay_attaching_request);
 
-  const Upstream::HostConstSharedPtr& host() { return host_; }
+  const Upstream::HostConstSharedPtr& host() const { return host_; }
   Event::Dispatcher& dispatcher() { return dispatcher_; }
   Upstream::ResourcePriority priority() const { return priority_; }
   const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() { return socket_options_; }
@@ -181,6 +181,7 @@ protected:
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
   const Network::TransportSocketOptionsSharedPtr transport_socket_options_;
 
+protected:
   std::list<Instance::DrainedCb> drained_callbacks_;
   std::list<PendingRequestPtr> pending_requests_;
 

--- a/source/common/http/hash_policy.cc
+++ b/source/common/http/hash_policy.cc
@@ -2,6 +2,8 @@
 
 #include "envoy/config/route/v3/route_components.pb.h"
 
+#include "common/common/matchers.h"
+#include "common/common/regex.h"
 #include "common/http/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -21,8 +23,15 @@ private:
 
 class HeaderHashMethod : public HashMethodImplBase {
 public:
-  HeaderHashMethod(const std::string& header_name, bool terminal)
-      : HashMethodImplBase(terminal), header_name_(header_name) {}
+  HeaderHashMethod(const envoy::config::route::v3::RouteAction::HashPolicy::Header& header,
+                   bool terminal)
+      : HashMethodImplBase(terminal), header_name_(header.header_name()) {
+    if (header.has_regex_rewrite()) {
+      const auto& rewrite_spec = header.regex_rewrite();
+      regex_rewrite_ = Regex::Utility::parseRegex(rewrite_spec.pattern());
+      regex_rewrite_substitution_ = rewrite_spec.substitution();
+    }
+  }
 
   absl::optional<uint64_t> evaluate(const Network::Address::Instance*,
                                     const RequestHeaderMap& headers,
@@ -32,13 +41,20 @@ public:
 
     const HeaderEntry* header = headers.get(header_name_);
     if (header) {
-      hash = HashUtil::xxHash64(header->value().getStringView());
+      if (regex_rewrite_ != nullptr) {
+        hash = HashUtil::xxHash64(regex_rewrite_->replaceAll(header->value().getStringView(),
+                                                             regex_rewrite_substitution_));
+      } else {
+        hash = HashUtil::xxHash64(header->value().getStringView());
+      }
     }
     return hash;
   }
 
 private:
   const LowerCaseString header_name_;
+  Regex::CompiledMatcherPtr regex_rewrite_{};
+  std::string regex_rewrite_substitution_{};
 };
 
 class CookieHashMethod : public HashMethodImplBase {
@@ -145,7 +161,7 @@ HashPolicyImpl::HashPolicyImpl(
     switch (hash_policy->policy_specifier_case()) {
     case envoy::config::route::v3::RouteAction::HashPolicy::PolicySpecifierCase::kHeader:
       hash_impls_.emplace_back(
-          new HeaderHashMethod(hash_policy->header().header_name(), hash_policy->terminal()));
+          new HeaderHashMethod(hash_policy->header(), hash_policy->terminal()));
       break;
     case envoy::config::route::v3::RouteAction::HashPolicy::PolicySpecifierCase::kCookie: {
       absl::optional<std::chrono::seconds> ttl;

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -262,8 +262,9 @@ public:
 
   template <class MessageType>
   static void loadFromYamlAndValidate(const std::string& yaml, MessageType& message,
-                                      ProtobufMessage::ValidationVisitor& validation_visitor) {
-    loadFromYaml(yaml, message, validation_visitor);
+                                      ProtobufMessage::ValidationVisitor& validation_visitor,
+                                      bool avoid_boosting = false) {
+    loadFromYaml(yaml, message, validation_visitor, !avoid_boosting);
     validate(message, validation_visitor);
   }
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -65,6 +65,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.disallow_unbounded_access_logs",
     "envoy.reloadable_features.early_errors_via_hcm",
     "envoy.reloadable_features.enable_deprecated_v2_api_warning",
+    "envoy.reloadable_features.enable_dns_cache_circuit_breakers",
     "envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher",
     "envoy.reloadable_features.fix_upgrade_response",
     "envoy.reloadable_features.fixed_connection_close",

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -88,6 +88,8 @@ constexpr const char* runtime_features[] = {
 constexpr const char* disabled_runtime_features[] = {
     // Sentinel and test flag.
     "envoy.reloadable_features.test_feature_false",
+    // TODO(alyssawilk) flip true after the release.
+    "envoy.reloadable_features.new_tcp_connection_pool",
 };
 
 RuntimeFeatures::RuntimeFeatures() {

--- a/source/common/tcp/BUILD
+++ b/source/common/tcp/BUILD
@@ -10,8 +10,14 @@ envoy_package()
 
 envoy_cc_library(
     name = "conn_pool_lib",
-    srcs = ["original_conn_pool.cc"],
-    hdrs = ["original_conn_pool.h"],
+    srcs = [
+        "conn_pool.cc",
+        "original_conn_pool.cc",
+    ],
+    hdrs = [
+        "conn_pool.h",
+        "original_conn_pool.h",
+    ],
     external_deps = ["abseil_optional"],
     deps = [
         "//include/envoy/event:deferred_deletable",
@@ -24,6 +30,7 @@ envoy_cc_library(
         "//include/envoy/upstream:upstream_interface",
         "//source/common/common:linked_object",
         "//source/common/common:utility_lib",
+        "//source/common/http:conn_pool_base_lib",
         "//source/common/network:filter_lib",
         "//source/common/network:utility_lib",
         "//source/common/stats:timespan_lib",

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -1,0 +1,69 @@
+#include "common/tcp/conn_pool.h"
+
+#include <memory>
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/timer.h"
+#include "envoy/upstream/upstream.h"
+
+#include "common/stats/timespan_impl.h"
+#include "common/upstream/upstream_impl.h"
+
+namespace Envoy {
+namespace Tcp {
+
+ActiveTcpClient::ActiveTcpClient(ConnPoolImpl& parent, const Upstream::HostConstSharedPtr& host,
+                                 uint64_t concurrent_request_limit)
+    : Envoy::ConnectionPool::ActiveClient(parent, host->cluster().maxRequestsPerConnection(),
+                                          concurrent_request_limit),
+      parent_(parent) {
+  Upstream::Host::CreateConnectionData data = host->createConnection(
+      parent_.dispatcher(), parent_.socketOptions(), parent_.transportSocketOptions());
+  real_host_description_ = data.host_description_;
+  connection_ = std::move(data.connection_);
+  connection_->addConnectionCallbacks(*this);
+  connection_->detectEarlyCloseWhenReadDisabled(false);
+  connection_->addReadFilter(std::make_shared<ConnReadFilter>(*this));
+  connection_->connect();
+}
+
+ActiveTcpClient::~ActiveTcpClient() {
+  // Handle the case where deferred delete results in the ActiveClient being destroyed before
+  // TcpConnectionData. Make sure the TcpConnectionData will not refer to this ActiveTcpClient
+  // and handle clean up normally done in clearCallbacks()
+  if (tcp_connection_data_) {
+    ASSERT(state_ == ActiveClient::State::CLOSED);
+    tcp_connection_data_->release();
+    parent_.onRequestClosed(*this, true);
+    parent_.checkForDrained();
+  }
+  parent_.onConnDestroyed();
+}
+
+void ActiveTcpClient::clearCallbacks() {
+  if (state_ == Envoy::ConnectionPool::ActiveClient::State::BUSY ||
+      state_ == Envoy::ConnectionPool::ActiveClient::State::DRAINING) {
+    parent_.onConnReleased(*this);
+  }
+  callbacks_ = nullptr;
+  tcp_connection_data_ = nullptr;
+  parent_.onRequestClosed(*this, true);
+  parent_.checkForDrained();
+}
+
+void ActiveTcpClient::onEvent(Network::ConnectionEvent event) {
+  Envoy::ConnectionPool::ActiveClient::onEvent(event);
+  // Do not pass the Connected event to TCP proxy sessions.
+  // The tcp proxy filter synthesizes its own Connected event in onPoolReadyBase
+  // and receiving it twice causes problems.
+  // TODO(alyssawilk) clean this up in a follow-up. It's confusing.
+  if (callbacks_ && event != Network::ConnectionEvent::Connected) {
+    callbacks_->onEvent(event);
+    // After receiving a disconnect event, the owner of callbacks_ will likely self-destruct.
+    // Clear the pointer to avoid using it again.
+    callbacks_ = nullptr;
+  }
+}
+
+} // namespace Tcp
+} // namespace Envoy

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <list>
+#include <memory>
+
+#include "envoy/event/deferred_deletable.h"
+#include "envoy/event/timer.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/filter.h"
+#include "envoy/stats/timespan.h"
+#include "envoy/tcp/conn_pool.h"
+#include "envoy/upstream/upstream.h"
+
+#include "common/common/linked_object.h"
+#include "common/common/logger.h"
+#include "common/http/conn_pool_base.h"
+#include "common/network/filter_impl.h"
+
+namespace Envoy {
+namespace Tcp {
+
+class ConnPoolImpl;
+
+struct TcpAttachContext : public Envoy::ConnectionPool::AttachContext {
+  TcpAttachContext(Tcp::ConnectionPool::Callbacks* callbacks) : callbacks_(callbacks) {}
+  Tcp::ConnectionPool::Callbacks* callbacks_;
+};
+
+class TcpPendingRequest : public Envoy::ConnectionPool::PendingRequest {
+public:
+  TcpPendingRequest(Envoy::ConnectionPool::ConnPoolImplBase& parent, TcpAttachContext& context)
+      : Envoy::ConnectionPool::PendingRequest(parent), context_(context) {}
+  Envoy::ConnectionPool::AttachContext& context() override { return context_; }
+
+  TcpAttachContext context_;
+};
+
+class ActiveTcpClient : public Envoy::ConnectionPool::ActiveClient {
+public:
+  struct ConnReadFilter : public Network::ReadFilterBaseImpl {
+    ConnReadFilter(ActiveTcpClient& parent) : parent_(parent) {}
+
+    // Network::ReadFilter
+    Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override {
+      parent_.onUpstreamData(data, end_stream);
+      return Network::FilterStatus::StopIteration;
+    }
+    ActiveTcpClient& parent_;
+  };
+
+  // This acts as the bridge between the ActiveTcpClient and an individual TCP connection.
+  class TcpConnectionData : public Envoy::Tcp::ConnectionPool::ConnectionData {
+  public:
+    TcpConnectionData(ActiveTcpClient& parent, Network::ClientConnection& connection)
+        : parent_(&parent), connection_(connection) {
+      parent_->tcp_connection_data_ = this;
+    }
+    ~TcpConnectionData() override {
+      // Generally it is the case that TcpConnectionData will be destroyed before the
+      // ActiveTcpClient. Because ordering on the deferred delete list is not guaranteed in the
+      // case of a disconnect, make sure parent_ is valid before doing clean-up.
+      if (parent_) {
+        parent_->clearCallbacks();
+      }
+    }
+
+    Network::ClientConnection& connection() override { return connection_; }
+    void setConnectionState(ConnectionPool::ConnectionStatePtr&& state) override {
+      parent_->connection_state_ = std::move(state);
+    }
+
+    void addUpstreamCallbacks(ConnectionPool::UpstreamCallbacks& callbacks) override {
+      parent_->callbacks_ = &callbacks;
+    }
+    void release() { parent_ = nullptr; }
+
+  protected:
+    ConnectionPool::ConnectionState* connectionState() override {
+      return parent_->connection_state_.get();
+    }
+
+  private:
+    ActiveTcpClient* parent_;
+    Network::ClientConnection& connection_;
+  };
+
+  ActiveTcpClient(ConnPoolImpl& parent, const Upstream::HostConstSharedPtr& host,
+                  uint64_t concurrent_request_limit);
+  ~ActiveTcpClient() override;
+
+  // Override the default's of Envoy::ConnectionPool::ActiveClient for class-specific functions.
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferHighWatermark() override { callbacks_->onAboveWriteBufferHighWatermark(); }
+  void onBelowWriteBufferLowWatermark() override { callbacks_->onBelowWriteBufferLowWatermark(); }
+
+  void close() override { connection_->close(Network::ConnectionCloseType::NoFlush); }
+  size_t numActiveRequests() const override { return callbacks_ ? 1 : 0; }
+  bool closingWithIncompleteRequest() const override { return false; }
+  uint64_t id() const override { return connection_->id(); }
+
+  void onUpstreamData(Buffer::Instance& data, bool end_stream) {
+    if (callbacks_) {
+      callbacks_->onUpstreamData(data, end_stream);
+    } else {
+      close();
+    }
+  }
+  void clearCallbacks();
+
+  ConnPoolImpl& parent_;
+  Upstream::HostDescriptionConstSharedPtr real_host_description_;
+  ConnectionPool::UpstreamCallbacks* callbacks_{};
+  Network::ClientConnectionPtr connection_;
+  ConnectionPool::ConnectionStatePtr connection_state_;
+  TcpConnectionData* tcp_connection_data_{};
+};
+
+class ConnPoolImpl : public Envoy::ConnectionPool::ConnPoolImplBase,
+                     public Tcp::ConnectionPool::Instance {
+public:
+  ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
+               Upstream::ResourcePriority priority,
+               const Network::ConnectionSocket::OptionsSharedPtr& options,
+               Network::TransportSocketOptionsSharedPtr transport_socket_options)
+      : Envoy::ConnectionPool::ConnPoolImplBase(host, priority, dispatcher, options,
+                                                transport_socket_options),
+        upstream_ready_cb_(dispatcher.createSchedulableCallback([this]() {
+          upstream_ready_enabled_ = false;
+          onUpstreamReady();
+        })) {}
+  ~ConnPoolImpl() override { destructAllConnections(); }
+
+  void addDrainedCallback(DrainedCb cb) override { addDrainedCallbackImpl(cb); }
+  void drainConnections() override {
+    drainConnectionsImpl();
+    // Legacy behavior for the TCP connection pool marks all connecting clients
+    // as draining.
+    for (auto& connecting_client : connecting_clients_) {
+      if (connecting_client->remaining_requests_ > 1) {
+        uint64_t old_limit = connecting_client->effectiveConcurrentRequestLimit();
+        connecting_client->remaining_requests_ = 1;
+        if (connecting_client->effectiveConcurrentRequestLimit() < old_limit) {
+          connecting_request_capacity_ -=
+              (old_limit - connecting_client->effectiveConcurrentRequestLimit());
+        }
+      }
+    }
+  }
+
+  void closeConnections() override {
+    for (auto* list : {&ready_clients_, &busy_clients_, &connecting_clients_}) {
+      while (!list->empty()) {
+        list->front()->close();
+      }
+    }
+  }
+  ConnectionPool::Cancellable* newConnection(Tcp::ConnectionPool::Callbacks& callbacks) override {
+    TcpAttachContext context(&callbacks);
+    return Envoy::ConnectionPool::ConnPoolImplBase::newStream(context);
+  }
+
+  ConnectionPool::Cancellable*
+  newPendingRequest(Envoy::ConnectionPool::AttachContext& context) override {
+    Envoy::ConnectionPool::PendingRequestPtr pending_request =
+        std::make_unique<TcpPendingRequest>(*this, typedContext<TcpAttachContext>(context));
+    pending_request->moveIntoList(std::move(pending_request), pending_requests_);
+    return pending_requests_.front().get();
+  }
+
+  Upstream::HostDescriptionConstSharedPtr host() const override {
+    return Envoy::ConnectionPool::ConnPoolImplBase::host();
+  }
+
+  Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override {
+    return std::make_unique<ActiveTcpClient>(*this, Envoy::ConnectionPool::ConnPoolImplBase::host(),
+                                             1);
+  }
+
+  void onPoolReady(Envoy::ConnectionPool::ActiveClient& client,
+                   Envoy::ConnectionPool::AttachContext& context) override {
+    ActiveTcpClient* tcp_client = static_cast<ActiveTcpClient*>(&client);
+    auto* callbacks = typedContext<TcpAttachContext>(context).callbacks_;
+    std::unique_ptr<Envoy::Tcp::ConnectionPool::ConnectionData> connection_data =
+        std::make_unique<ActiveTcpClient::TcpConnectionData>(*tcp_client, *tcp_client->connection_);
+    callbacks->onPoolReady(std::move(connection_data), tcp_client->real_host_description_);
+  }
+
+  void onPoolFailure(const Upstream::HostDescriptionConstSharedPtr& host_description,
+                     absl::string_view, ConnectionPool::PoolFailureReason reason,
+                     Envoy::ConnectionPool::AttachContext& context) override {
+    auto* callbacks = typedContext<TcpAttachContext>(context).callbacks_;
+    callbacks->onPoolFailure(reason, host_description);
+  }
+
+  // These two functions exist for testing parity between old and new Tcp Connection Pools.
+  virtual void onConnReleased(Envoy::ConnectionPool::ActiveClient& client) {
+    if (client.state_ == Envoy::ConnectionPool::ActiveClient::State::BUSY) {
+      if (!pending_requests_.empty() && !upstream_ready_enabled_) {
+        upstream_ready_cb_->scheduleCallbackCurrentIteration();
+      }
+    }
+  }
+  virtual void onConnDestroyed() {}
+
+protected:
+  Event::SchedulableCallbackPtr upstream_ready_cb_;
+  bool upstream_ready_enabled_{};
+};
+
+} // namespace Tcp
+} // namespace Envoy

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -353,6 +353,7 @@ protected:
 
   void initialize(Network::ReadFilterCallbacks& callbacks, bool set_connection_stats);
   Network::FilterStatus initializeUpstreamConnection();
+  bool maybeTunnel(const std::string& cluster_name);
   void onConnectTimeout();
   void onDownstreamEvent(Network::ConnectionEvent event);
   void onUpstreamData(Buffer::Instance& data, bool end_stream);

--- a/source/common/upstream/resource_manager_impl.h
+++ b/source/common/upstream/resource_manager_impl.h
@@ -16,6 +16,53 @@
 namespace Envoy {
 namespace Upstream {
 
+struct ManagedResourceImpl : public BasicResourceLimitImpl {
+  ManagedResourceImpl(uint64_t max, Runtime::Loader& runtime, const std::string& runtime_key,
+                      Stats::Gauge& open_gauge, Stats::Gauge& remaining)
+      : BasicResourceLimitImpl(max, runtime, runtime_key), open_gauge_(open_gauge),
+        remaining_(remaining) {
+    remaining_.set(max);
+  }
+
+  // Upstream::Resource
+  bool canCreate() override { return current_ < max(); }
+  void inc() override {
+    BasicResourceLimitImpl::inc();
+    updateRemaining();
+    open_gauge_.set(BasicResourceLimitImpl::canCreate() ? 0 : 1);
+  }
+  void decBy(uint64_t amount) override {
+    BasicResourceLimitImpl::decBy(amount);
+    updateRemaining();
+    open_gauge_.set(BasicResourceLimitImpl::canCreate() ? 0 : 1);
+  }
+
+  /**
+   * We set the gauge instead of incrementing and decrementing because,
+   * though atomics are used, it is possible for the current resource count
+   * to be greater than the supplied max.
+   */
+  void updateRemaining() {
+    /**
+     * We cannot use std::max here because max() and current_ are
+     * unsigned and subtracting them may overflow.
+     */
+    const uint64_t current_copy = current_;
+    remaining_.set(max() > current_copy ? max() - current_copy : 0);
+  }
+
+  /**
+   * A gauge to notify the live circuit breaker state. The gauge is set to 0
+   * to notify that the circuit breaker is not yet triggered.
+   */
+  Stats::Gauge& open_gauge_;
+
+  /**
+   * The number of resources remaining before the circuit breaker opens.
+   */
+  Stats::Gauge& remaining_;
+};
+
 /**
  * Implementation of ResourceManager.
  * NOTE: This implementation makes some assumptions which favor simplicity over correctness.
@@ -53,54 +100,6 @@ public:
   ResourceLimit& connectionPools() override { return connection_pools_; }
 
 private:
-  struct ManagedResourceImpl : public BasicResourceLimitImpl {
-    ManagedResourceImpl(uint64_t max, Runtime::Loader& runtime, const std::string& runtime_key,
-                        Stats::Gauge& open_gauge, Stats::Gauge& remaining)
-        : BasicResourceLimitImpl(max, runtime, runtime_key), open_gauge_(open_gauge),
-          remaining_(remaining) {
-      remaining_.set(max);
-    }
-
-    ~ManagedResourceImpl() override { ASSERT(count() == 0); }
-
-    void inc() override {
-      BasicResourceLimitImpl::inc();
-      updateRemaining();
-      open_gauge_.set(BasicResourceLimitImpl::canCreate() ? 0 : 1);
-    }
-
-    void decBy(uint64_t amount) override {
-      BasicResourceLimitImpl::decBy(amount);
-      updateRemaining();
-      open_gauge_.set(BasicResourceLimitImpl::canCreate() ? 0 : 1);
-    }
-
-    /**
-     * We set the gauge instead of incrementing and decrementing because,
-     * though atomics are used, it is possible for the current resource count
-     * to be greater than the supplied max.
-     */
-    void updateRemaining() {
-      /**
-       * We cannot use std::max here because max() and current_ are
-       * unsigned and subtracting them may overflow.
-       */
-      const uint64_t current_copy = current_;
-      remaining_.set(max() > current_copy ? max() - current_copy : 0);
-    }
-
-    /**
-     * A gauge to notify the live circuit breaker state. The gauge is set to 0
-     * to notify that the circuit breaker is not yet triggered.
-     */
-    Stats::Gauge& open_gauge_;
-
-    /**
-     * The number of resources remaining before the circuit breaker opens.
-     */
-    Stats::Gauge& remaining_;
-  };
-
   class RetryBudgetImpl : public ResourceLimit {
   public:
     RetryBudgetImpl(absl::optional<double> budget_percent,

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -198,7 +198,7 @@ ClusterFactory::createClusterWithConfig(
     Stats::ScopePtr&& stats_scope) {
   Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactoryImpl cache_manager_factory(
       context.singletonManager(), context.dispatcher(), context.tls(), context.random(),
-      context.stats());
+      context.runtime(), context.stats());
   envoy::config::cluster::v3::Cluster cluster_config = cluster;
   if (cluster_config.has_upstream_http_protocol_options()) {
     if (!proto_config.allow_insecure_cluster_options() &&

--- a/source/extensions/common/dynamic_forward_proxy/BUILD
+++ b/source/extensions/common/dynamic_forward_proxy/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/singleton:manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
+        "//include/envoy/upstream:resource_manager_interface",
         "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )
@@ -37,12 +38,29 @@ envoy_cc_library(
     hdrs = ["dns_cache_impl.h"],
     deps = [
         ":dns_cache_interface",
+        ":dns_cache_resource_manager",
         "//include/envoy/network:dns_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:cleanup_lib",
         "//source/common/config:utility_lib",
         "//source/common/network:utility_lib",
         "//source/common/upstream:upstream_lib",
+        "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "dns_cache_resource_manager",
+    srcs = ["dns_cache_resource_manager.cc"],
+    hdrs = ["dns_cache_resource_manager.h"],
+    deps = [
+        ":dns_cache_interface",
+        "//include/envoy/common:resource_interface",
+        "//include/envoy/stats:stats_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:basic_resource_lib",
+        "//source/common/runtime:runtime_lib",
+        "//source/common/upstream:resource_manager_lib",
         "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -16,13 +16,14 @@ namespace DynamicForwardProxy {
 
 DnsCacheImpl::DnsCacheImpl(
     Event::Dispatcher& main_thread_dispatcher, ThreadLocal::SlotAllocator& tls,
-    Runtime::RandomGenerator& random, Stats::Scope& root_scope,
+    Runtime::RandomGenerator& random, Runtime::Loader& loader, Stats::Scope& root_scope,
     const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config)
     : main_thread_dispatcher_(main_thread_dispatcher),
       dns_lookup_family_(Upstream::getDnsLookupFamilyFromEnum(config.dns_lookup_family())),
       resolver_(main_thread_dispatcher.createDnsResolver({}, false)), tls_slot_(tls.allocateSlot()),
       scope_(root_scope.createScope(fmt::format("dns_cache.{}.", config.name()))),
-      stats_{ALL_DNS_CACHE_STATS(POOL_COUNTER(*scope_), POOL_GAUGE(*scope_))},
+      stats_(generateDnsCacheStats(*scope_)),
+      resource_manager_(*scope_, loader, config.name(), config.dns_cache_circuit_breaker()),
       refresh_interval_(PROTOBUF_GET_MS_OR_DEFAULT(config, dns_refresh_rate, 60000)),
       failure_backoff_strategy_(
           Config::Utility::prepareDnsRefreshStrategy<
@@ -44,6 +45,10 @@ DnsCacheImpl::~DnsCacheImpl() {
   for (auto update_callbacks : update_callbacks_) {
     update_callbacks->cancel();
   }
+}
+
+DnsCacheStats DnsCacheImpl::generateDnsCacheStats(Stats::Scope& scope) {
+  return {ALL_DNS_CACHE_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope))};
 }
 
 DnsCacheImpl::LoadDnsCacheEntryResult
@@ -70,6 +75,20 @@ DnsCacheImpl::loadDnsCacheEntry(absl::string_view host, uint16_t default_port,
             std::make_unique<LoadDnsCacheEntryHandleImpl>(tls_host_info.pending_resolutions_, host,
                                                           callbacks)};
   }
+}
+
+Upstream::ResourceAutoIncDecPtr
+DnsCacheImpl::canCreateDnsRequest(ResourceLimitOptRef pending_requests) {
+  const auto has_pending_requests = pending_requests.has_value();
+  auto& current_pending_requests =
+      has_pending_requests ? pending_requests->get() : resource_manager_.pendingRequests();
+  if (!current_pending_requests.canCreate()) {
+    if (!has_pending_requests) {
+      stats_.dns_rq_pending_overflow_.inc();
+    }
+    return nullptr;
+  }
+  return std::make_unique<Upstream::ResourceAutoIncDec>(current_pending_requests);
 }
 
 absl::flat_hash_map<std::string, DnsHostInfoSharedPtr> DnsCacheImpl::hosts() {

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -27,8 +27,8 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
     return existing_cache->second.cache_;
   }
 
-  DnsCacheSharedPtr new_cache =
-      std::make_shared<DnsCacheImpl>(main_thread_dispatcher_, tls_, random_, root_scope_, config);
+  DnsCacheSharedPtr new_cache = std::make_shared<DnsCacheImpl>(
+      main_thread_dispatcher_, tls_, random_, loader_, root_scope_, config);
   caches_.emplace(config.name(), ActiveCache{config, new_cache});
   return new_cache;
 }
@@ -36,12 +36,12 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
 DnsCacheManagerSharedPtr getCacheManager(Singleton::Manager& singleton_manager,
                                          Event::Dispatcher& main_thread_dispatcher,
                                          ThreadLocal::SlotAllocator& tls,
-                                         Runtime::RandomGenerator& random,
+                                         Runtime::RandomGenerator& random, Runtime::Loader& loader,
                                          Stats::Scope& root_scope) {
   return singleton_manager.getTyped<DnsCacheManager>(
       SINGLETON_MANAGER_REGISTERED_NAME(dns_cache_manager),
-      [&main_thread_dispatcher, &tls, &random, &root_scope] {
-        return std::make_shared<DnsCacheManagerImpl>(main_thread_dispatcher, tls, random,
+      [&main_thread_dispatcher, &tls, &random, &loader, &root_scope] {
+        return std::make_shared<DnsCacheManagerImpl>(main_thread_dispatcher, tls, random, loader,
                                                      root_scope);
       });
 }

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
@@ -14,9 +14,10 @@ namespace DynamicForwardProxy {
 class DnsCacheManagerImpl : public DnsCacheManager, public Singleton::Instance {
 public:
   DnsCacheManagerImpl(Event::Dispatcher& main_thread_dispatcher, ThreadLocal::SlotAllocator& tls,
-                      Runtime::RandomGenerator& random, Stats::Scope& root_scope)
+                      Runtime::RandomGenerator& random, Runtime::Loader& loader,
+                      Stats::Scope& root_scope)
       : main_thread_dispatcher_(main_thread_dispatcher), tls_(tls), random_(random),
-        root_scope_(root_scope) {}
+        loader_(loader), root_scope_(root_scope) {}
 
   // DnsCacheManager
   DnsCacheSharedPtr getCache(
@@ -35,6 +36,7 @@ private:
   Event::Dispatcher& main_thread_dispatcher_;
   ThreadLocal::SlotAllocator& tls_;
   Runtime::RandomGenerator& random_;
+  Runtime::Loader& loader_;
   Stats::Scope& root_scope_;
   absl::flat_hash_map<std::string, ActiveCache> caches_;
 };
@@ -43,12 +45,12 @@ class DnsCacheManagerFactoryImpl : public DnsCacheManagerFactory {
 public:
   DnsCacheManagerFactoryImpl(Singleton::Manager& singleton_manager, Event::Dispatcher& dispatcher,
                              ThreadLocal::SlotAllocator& tls, Runtime::RandomGenerator& random,
-                             Stats::Scope& root_scope)
+                             Runtime::Loader& loader, Stats::Scope& root_scope)
       : singleton_manager_(singleton_manager), dispatcher_(dispatcher), tls_(tls), random_(random),
-        root_scope_(root_scope) {}
+        loader_(loader), root_scope_(root_scope) {}
 
   DnsCacheManagerSharedPtr get() override {
-    return getCacheManager(singleton_manager_, dispatcher_, tls_, random_, root_scope_);
+    return getCacheManager(singleton_manager_, dispatcher_, tls_, random_, loader_, root_scope_);
   }
 
 private:
@@ -56,6 +58,7 @@ private:
   Event::Dispatcher& dispatcher_;
   ThreadLocal::SlotAllocator& tls_;
   Runtime::RandomGenerator& random_;
+  Runtime::Loader& loader_;
   Stats::Scope& root_scope_;
 };
 

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager.cc
@@ -1,0 +1,26 @@
+#include "extensions/common/dynamic_forward_proxy/dns_cache_resource_manager.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace DynamicForwardProxy {
+
+DnsCacheResourceManagerImpl::DnsCacheResourceManagerImpl(
+    Stats::Scope& scope, Runtime::Loader& loader, const std::string& config_name,
+    const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheCircuitBreakers& cb_config)
+    : cb_stats_(generateDnsCacheCircuitBreakersStats(scope)),
+      pending_requests_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(cb_config, max_pending_requests, 1024),
+                        loader, fmt::format("dns_cache.{}.circuit_breakers", config_name),
+                        cb_stats_.rq_pending_open_, cb_stats_.rq_pending_remaining_) {}
+
+DnsCacheCircuitBreakersStats
+DnsCacheResourceManagerImpl::generateDnsCacheCircuitBreakersStats(Stats::Scope& scope) {
+  std::string stat_prefix = "circuit_breakers";
+  return {ALL_DNS_CACHE_CIRCUIT_BREAKERS_STATS(POOL_GAUGE_PREFIX(scope, stat_prefix),
+                                               POOL_GAUGE_PREFIX(scope, stat_prefix))};
+}
+
+} // namespace DynamicForwardProxy
+} // namespace Common
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.pb.h"
+#include "envoy/runtime/runtime.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
+#include "envoy/upstream/resource_manager.h"
+
+#include "common/common/assert.h"
+#include "common/common/basic_resource_impl.h"
+#include "common/upstream/resource_manager_impl.h"
+
+#include "extensions/common/dynamic_forward_proxy/dns_cache.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace DynamicForwardProxy {
+
+class DnsCacheResourceManagerImpl : public DnsCacheResourceManager {
+public:
+  DnsCacheResourceManagerImpl(
+      Stats::Scope& scope, Runtime::Loader& loader, const std::string& config_name,
+      const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheCircuitBreakers&
+          cb_config);
+
+  static DnsCacheCircuitBreakersStats generateDnsCacheCircuitBreakersStats(Stats::Scope& scope);
+  // Envoy::Upstream::DnsCacheResourceManager
+  ResourceLimit& pendingRequests() override { return pending_requests_; }
+  DnsCacheCircuitBreakersStats& stats() override { return cb_stats_; }
+
+private:
+  DnsCacheCircuitBreakersStats cb_stats_;
+  Upstream::ManagedResourceImpl pending_requests_;
+};
+
+} // namespace DynamicForwardProxy
+} // namespace Common
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/source/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     hdrs = ["proxy_filter.h"],
     deps = [
         "//include/envoy/http:filter_interface",
+        "//source/common/runtime:runtime_features_lib",
         "//source/extensions/common/dynamic_forward_proxy:dns_cache_interface",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.cc
@@ -16,7 +16,7 @@ Http::FilterFactoryCb DynamicForwardProxyFilterFactory::createFilterFactoryFromP
     const std::string&, Server::Configuration::FactoryContext& context) {
   Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactoryImpl cache_manager_factory(
       context.singletonManager(), context.dispatcher(), context.threadLocal(), context.random(),
-      context.scope());
+      context.runtime(), context.scope());
   ProxyFilterConfigSharedPtr filter_config(std::make_shared<ProxyFilterConfig>(
       proto_config, cache_manager_factory, context.clusterManager()));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -3,6 +3,8 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
 
+#include "common/runtime/runtime_features.h"
+
 #include "extensions/common/dynamic_forward_proxy/dns_cache.h"
 #include "extensions/filters/http/well_known_names.h"
 
@@ -53,16 +55,25 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
   }
   cluster_info_ = cluster->info();
 
-  auto& resource = cluster_info_->resourceManager(route_entry->priority()).pendingRequests();
-  if (!resource.canCreate()) {
-    ENVOY_STREAM_LOG(debug, "pending request overflow", *decoder_callbacks_);
-    cluster_info_->stats().upstream_rq_pending_overflow_.inc();
-    decoder_callbacks_->sendLocalReply(
+  const bool should_use_dns_cache_circuit_breakers =
+      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_dns_cache_circuit_breakers");
+
+  circuit_breaker_ = config_->cache().canCreateDnsRequest(
+      !should_use_dns_cache_circuit_breakers
+          ? absl::make_optional(std::reference_wrapper<ResourceLimit>(
+                cluster_info_->resourceManager(route_entry->priority()).pendingRequests()))
+          : absl::nullopt);
+
+  if (circuit_breaker_ == nullptr) {
+    if (!should_use_dns_cache_circuit_breakers) {
+      cluster_info_->stats().upstream_rq_pending_overflow_.inc();
+    }
+    ENVOY_STREAM_LOG(debug, "pending request overflow", *this->decoder_callbacks_);
+    this->decoder_callbacks_->sendLocalReply(
         Http::Code::ServiceUnavailable, ResponseStrings::get().PendingRequestOverflow, nullptr,
         absl::nullopt, ResponseStrings::get().PendingRequestOverflow);
     return Http::FilterHeadersStatus::StopIteration;
   }
-  circuit_breaker_ = std::make_unique<Upstream::ResourceAutoIncDec>(resource);
 
   uint16_t default_port = 80;
   if (cluster_info_->transportSocketMatcher()

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -49,7 +49,7 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers,
     context_extensions = maybe_merged_per_route_config.value().takeContextExtensions();
   }
 
-  // If metadata_context_namespaces is specified, pass matching metadata to the ext_authz service
+  // If metadata_context_namespaces is specified, pass matching metadata to the ext_authz service.
   envoy::config::core::v3::Metadata metadata_context;
   const auto& request_metadata = callbacks_->streamInfo().dynamicMetadata().filter_metadata();
   for (const auto& context_key : config_->metadataContextNamespaces()) {
@@ -180,8 +180,19 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     }
     for (const auto& header : response->headers_to_append) {
       const Http::HeaderEntry* header_to_modify = request_headers_->get(header.first);
-      if (header_to_modify) {
+      // TODO(dio): Add a flag to allow appending non-existent headers, without setting it first
+      // (via `headers_to_add`). For example, given:
+      // 1. Original headers {"original": "true"}
+      // 2. Response headers from the authorization servers {{"append": "1"}, {"append": "2"}}
+      //
+      // Currently it is not possible to add {{"append": "1"}, {"append": "2"}} (the intended
+      // combined headers: {{"original": "true"}, {"append": "1"}, {"append": "2"}}) to the request
+      // to upstream server by only sets `headers_to_append`.
+      if (header_to_modify != nullptr) {
         ENVOY_STREAM_LOG(trace, "'{}':'{}'", *callbacks_, header.first.get(), header.second);
+        // The current behavior of appending is by combining entries with the same key, into one
+        // entry. The value of that combined entry is separated by ",".
+        // TODO(dio): Consider to use addCopy instead.
         request_headers_->appendCopy(header.first, header.second);
       }
     }
@@ -220,13 +231,13 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
          &callbacks = *callbacks_](Http::HeaderMap& response_headers) -> void {
           ENVOY_STREAM_LOG(trace,
                            "ext_authz filter added header(s) to the local response:", callbacks);
-          // First remove all headers requested by the ext_authz filter,
-          // to ensure that they will override existing headers
+          // Firstly, remove all headers requested by the ext_authz filter, to ensure that they will
+          // override existing headers.
           for (const auto& header : headers) {
             response_headers.remove(header.first);
           }
-          // Then set all of the requested headers, allowing the
-          // same header to be set multiple times, e.g. `Set-Cookie`
+          // Then set all of the requested headers, allowing the same header to be set multiple
+          // times, e.g. `Set-Cookie`.
           for (const auto& header : headers) {
             ENVOY_STREAM_LOG(trace, " '{}':'{}'", callbacks, header.first.get(), header.second);
             response_headers.addCopy(header.first, header.second);

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -23,12 +23,14 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:enum_to_int",
+        "//source/common/config:datasource_lib",
         "//source/common/crypto:utility_lib",
         "//source/common/http:message_lib",
         "//source/extensions/common:utility_lib",
         "//source/extensions/filters/common/lua:lua_lib",
         "//source/extensions/filters/common/lua:wrappers_lib",
         "//source/extensions/filters/http:well_known_names",
+        "@envoy_api//envoy/extensions/filters/http/lua/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -15,10 +15,17 @@ Http::FilterFactoryCb LuaFilterConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::lua::v3::Lua& proto_config, const std::string&,
     Server::Configuration::FactoryContext& context) {
   FilterConfigConstSharedPtr filter_config(new FilterConfig{
-      proto_config.inline_code(), context.threadLocal(), context.clusterManager()});
+      proto_config, context.threadLocal(), context.clusterManager(), context.api()});
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Filter>(filter_config));
   };
+}
+
+Router::RouteSpecificFilterConfigConstSharedPtr
+LuaFilterConfig::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::lua::v3::LuaPerRoute& proto_config,
+    Server::Configuration::ServerFactoryContext& context, ProtobufMessage::ValidationVisitor&) {
+  return std::make_shared<FilterConfigPerRoute>(proto_config, context.threadLocal(), context.api());
 }
 
 /**

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -14,7 +14,9 @@ namespace Lua {
 /**
  * Config registration for the Lua filter. @see NamedHttpFilterConfigFactory.
  */
-class LuaFilterConfig : public Common::FactoryBase<envoy::extensions::filters::http::lua::v3::Lua> {
+class LuaFilterConfig
+    : public Common::FactoryBase<envoy::extensions::filters::http::lua::v3::Lua,
+                                 envoy::extensions::filters::http::lua::v3::LuaPerRoute> {
 public:
   LuaFilterConfig() : FactoryBase(HttpFilterNames::get().Lua) {}
 
@@ -22,6 +24,11 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::lua::v3::Lua& proto_config, const std::string&,
       Server::Configuration::FactoryContext& context) override;
+
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::lua::v3::LuaPerRoute& proto_config,
+      Server::Configuration::ServerFactoryContext& context,
+      ProtobufMessage::ValidationVisitor& validator) override;
 };
 
 } // namespace Lua

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -8,6 +8,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 #include "common/common/enum_to_int.h"
+#include "common/config/datasource.h"
 #include "common/crypto/utility.h"
 #include "common/http/message_impl.h"
 
@@ -141,6 +142,32 @@ Http::AsyncClient::Request* makeHttpCall(lua_State* state, Filter& filter,
                                                                          callbacks, options);
 }
 } // namespace
+
+PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotAllocator& tls)
+    : lua_state_(lua_code, tls) {
+  lua_state_.registerType<Filters::Common::Lua::BufferWrapper>();
+  lua_state_.registerType<Filters::Common::Lua::MetadataMapWrapper>();
+  lua_state_.registerType<Filters::Common::Lua::MetadataMapIterator>();
+  lua_state_.registerType<Filters::Common::Lua::ConnectionWrapper>();
+  lua_state_.registerType<Filters::Common::Lua::SslConnectionWrapper>();
+  lua_state_.registerType<HeaderMapWrapper>();
+  lua_state_.registerType<HeaderMapIterator>();
+  lua_state_.registerType<StreamInfoWrapper>();
+  lua_state_.registerType<DynamicMetadataMapWrapper>();
+  lua_state_.registerType<DynamicMetadataMapIterator>();
+  lua_state_.registerType<StreamHandleWrapper>();
+  lua_state_.registerType<PublicKeyWrapper>();
+
+  request_function_slot_ = lua_state_.registerGlobal("envoy_on_request");
+  if (lua_state_.getGlobalRef(request_function_slot_) == LUA_REFNIL) {
+    ENVOY_LOG(info, "envoy_on_request() function not found. Lua filter will not hook requests.");
+  }
+
+  response_function_slot_ = lua_state_.registerGlobal("envoy_on_response");
+  if (lua_state_.getGlobalRef(response_function_slot_) == LUA_REFNIL) {
+    ENVOY_LOG(info, "envoy_on_response() function not found. Lua filter will not hook responses.");
+  }
+}
 
 StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
                                          Http::HeaderMap& headers, bool end_stream, Filter& filter,
@@ -569,32 +596,29 @@ int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
   return 1;
 }
 
-FilterConfig::FilterConfig(const std::string& lua_code, ThreadLocal::SlotAllocator& tls,
-                           Upstream::ClusterManager& cluster_manager)
-    : cluster_manager_(cluster_manager), lua_state_(lua_code, tls) {
-  lua_state_.registerType<Filters::Common::Lua::BufferWrapper>();
-  lua_state_.registerType<Filters::Common::Lua::MetadataMapWrapper>();
-  lua_state_.registerType<Filters::Common::Lua::MetadataMapIterator>();
-  lua_state_.registerType<Filters::Common::Lua::ConnectionWrapper>();
-  lua_state_.registerType<Filters::Common::Lua::SslConnectionWrapper>();
-  lua_state_.registerType<HeaderMapWrapper>();
-  lua_state_.registerType<HeaderMapIterator>();
-  lua_state_.registerType<StreamInfoWrapper>();
-  lua_state_.registerType<DynamicMetadataMapWrapper>();
-  lua_state_.registerType<DynamicMetadataMapIterator>();
-  lua_state_.registerType<StreamHandleWrapper>();
-  lua_state_.registerType<PublicKeyWrapper>();
-
-  request_function_slot_ = lua_state_.registerGlobal("envoy_on_request");
-  if (lua_state_.getGlobalRef(request_function_slot_) == LUA_REFNIL) {
-    ENVOY_LOG(info, "envoy_on_request() function not found. Lua filter will not hook requests.");
+FilterConfig::FilterConfig(const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
+                           ThreadLocal::SlotAllocator& tls,
+                           Upstream::ClusterManager& cluster_manager, Api::Api& api)
+    : cluster_manager_(cluster_manager) {
+  auto global_setup_ptr = std::make_unique<PerLuaCodeSetup>(proto_config.inline_code(), tls);
+  if (global_setup_ptr) {
+    per_lua_code_setups_map_[GLOBAL_SCRIPT_NAME] = std::move(global_setup_ptr);
   }
 
-  response_function_slot_ = lua_state_.registerGlobal("envoy_on_response");
-  if (lua_state_.getGlobalRef(response_function_slot_) == LUA_REFNIL) {
-    ENVOY_LOG(info, "envoy_on_response() function not found. Lua filter will not hook responses.");
+  for (const auto& source : proto_config.source_codes()) {
+    const std::string code = Config::DataSource::read(source.second, true, api);
+    auto per_lua_code_setup_ptr = std::make_unique<PerLuaCodeSetup>(code, tls);
+    if (!per_lua_code_setup_ptr) {
+      continue;
+    }
+    per_lua_code_setups_map_[source.first] = std::move(per_lua_code_setup_ptr);
   }
 }
+
+FilterConfigPerRoute::FilterConfigPerRoute(
+    const envoy::extensions::filters::http::lua::v3::LuaPerRoute& config,
+    ThreadLocal::SlotAllocator&, Api::Api&)
+    : disabled_(config.disabled()), name_(config.name()) {}
 
 void Filter::onDestroy() {
   destroyed_ = true;
@@ -609,12 +633,14 @@ void Filter::onDestroy() {
 Http::FilterHeadersStatus Filter::doHeaders(StreamHandleRef& handle,
                                             Filters::Common::Lua::CoroutinePtr& coroutine,
                                             FilterCallbacks& callbacks, int function_ref,
-                                            Http::HeaderMap& headers, bool end_stream) {
+                                            PerLuaCodeSetup* setup, Http::HeaderMap& headers,
+                                            bool end_stream) {
   if (function_ref == LUA_REFNIL) {
     return Http::FilterHeadersStatus::Continue;
   }
+  ASSERT(setup);
+  coroutine = setup->createCoroutine();
 
-  coroutine = config_->createCoroutine();
   handle.reset(StreamHandleWrapper::create(coroutine->luaState(), *coroutine, headers, end_stream,
                                            *this, callbacks),
                true);

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "envoy/extensions/filters/http/lua/v3/lua.pb.h"
 #include "envoy/http/filter.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/crypto/utility.h"
+#include "common/http/utility.h"
 
 #include "extensions/common/utility.h"
 #include "extensions/filters/common/lua/wrappers.h"
@@ -14,6 +16,31 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Lua {
+
+constexpr char GLOBAL_SCRIPT_NAME[] = "GLOBAL";
+
+class PerLuaCodeSetup : Logger::Loggable<Logger::Id::lua> {
+public:
+  PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotAllocator& tls);
+
+  Extensions::Filters::Common::Lua::CoroutinePtr createCoroutine() {
+    return lua_state_.createCoroutine();
+  }
+
+  int requestFunctionRef() { return lua_state_.getGlobalRef(request_function_slot_); }
+  int responseFunctionRef() { return lua_state_.getGlobalRef(response_function_slot_); }
+
+  uint64_t runtimeBytesUsed() { return lua_state_.runtimeBytesUsed(); }
+  void runtimeGC() { return lua_state_.runtimeGC(); }
+
+private:
+  uint64_t request_function_slot_{};
+  uint64_t response_function_slot_{};
+
+  Filters::Common::Lua::ThreadLocalState lua_state_;
+};
+
+using PerLuaCodeSetupPtr = std::unique_ptr<PerLuaCodeSetup>;
 
 /**
  * Callbacks used by a stream handler to access the filter.
@@ -299,23 +326,66 @@ public:
  */
 class FilterConfig : Logger::Loggable<Logger::Id::lua> {
 public:
-  FilterConfig(const std::string& lua_code, ThreadLocal::SlotAllocator& tls,
-               Upstream::ClusterManager& cluster_manager);
-  Filters::Common::Lua::CoroutinePtr createCoroutine() { return lua_state_.createCoroutine(); }
-  int requestFunctionRef() { return lua_state_.getGlobalRef(request_function_slot_); }
-  int responseFunctionRef() { return lua_state_.getGlobalRef(response_function_slot_); }
-  uint64_t runtimeBytesUsed() { return lua_state_.runtimeBytesUsed(); }
-  void runtimeGC() { return lua_state_.runtimeGC(); }
+  FilterConfig(const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
+               ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cluster_manager,
+               Api::Api& api);
+
+  PerLuaCodeSetup* perLuaCodeSetup(const std::string& name) const {
+    const auto iter = per_lua_code_setups_map_.find(name);
+    if (iter != per_lua_code_setups_map_.end()) {
+      return iter->second.get();
+    }
+    return nullptr;
+  }
 
   Upstream::ClusterManager& cluster_manager_;
 
 private:
-  Filters::Common::Lua::ThreadLocalState lua_state_;
-  uint64_t request_function_slot_;
-  uint64_t response_function_slot_;
+  absl::flat_hash_map<std::string, PerLuaCodeSetupPtr> per_lua_code_setups_map_;
 };
 
 using FilterConfigConstSharedPtr = std::shared_ptr<FilterConfig>;
+
+/**
+ * Route configuration for the filter.
+ */
+class FilterConfigPerRoute : public Router::RouteSpecificFilterConfig {
+public:
+  FilterConfigPerRoute(const envoy::extensions::filters::http::lua::v3::LuaPerRoute& config,
+                       ThreadLocal::SlotAllocator& tls, Api::Api& api);
+
+  bool disabled() const { return disabled_; }
+  const std::string& name() const { return name_; }
+
+private:
+  const bool disabled_;
+  const std::string name_;
+};
+
+namespace {
+
+PerLuaCodeSetup* getPerLuaCodeSetup(const FilterConfig* filter_config,
+                                    Http::StreamFilterCallbacks* callbacks) {
+  const FilterConfigPerRoute* config_per_route = nullptr;
+  if (callbacks && callbacks->route()) {
+    config_per_route = Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfigPerRoute>(
+        HttpFilterNames::get().Lua, callbacks->route());
+  }
+
+  if (config_per_route != nullptr) {
+    if (config_per_route->disabled()) {
+      return nullptr;
+    } else if (!config_per_route->name().empty()) {
+      ASSERT(filter_config);
+      return filter_config->perLuaCodeSetup(config_per_route->name());
+    }
+    return nullptr;
+  }
+  ASSERT(filter_config);
+  return filter_config->perLuaCodeSetup(GLOBAL_SCRIPT_NAME);
+}
+
+} // namespace
 
 // TODO(mattklein123): Filter stats.
 
@@ -336,8 +406,10 @@ public:
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override {
-    return doHeaders(request_stream_wrapper_, request_coroutine_, decoder_callbacks_,
-                     config_->requestFunctionRef(), headers, end_stream);
+    PerLuaCodeSetup* setup = getPerLuaCodeSetup(config_.get(), decoder_callbacks_.callbacks_);
+    const int function_ref = setup ? setup->requestFunctionRef() : LUA_REFNIL;
+    return doHeaders(request_stream_wrapper_, request_coroutine_, decoder_callbacks_, function_ref,
+                     setup, headers, end_stream);
   }
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override {
     return doData(request_stream_wrapper_, data, end_stream);
@@ -355,8 +427,10 @@ public:
   }
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
                                           bool end_stream) override {
+    PerLuaCodeSetup* setup = getPerLuaCodeSetup(config_.get(), decoder_callbacks_.callbacks_);
+    const int function_ref = setup ? setup->responseFunctionRef() : LUA_REFNIL;
     return doHeaders(response_stream_wrapper_, response_coroutine_, encoder_callbacks_,
-                     config_->responseFunctionRef(), headers, end_stream);
+                     function_ref, setup, headers, end_stream);
   }
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override {
     return doData(response_stream_wrapper_, data, end_stream);
@@ -421,7 +495,8 @@ private:
   Http::FilterHeadersStatus doHeaders(StreamHandleRef& handle,
                                       Filters::Common::Lua::CoroutinePtr& coroutine,
                                       FilterCallbacks& callbacks, int function_ref,
-                                      Http::HeaderMap& headers, bool end_stream);
+                                      PerLuaCodeSetup* setup, Http::HeaderMap& headers,
+                                      bool end_stream);
   Http::FilterDataStatus doData(StreamHandleRef& handle, Buffer::Instance& data, bool end_stream);
   Http::FilterTrailersStatus doTrailers(StreamHandleRef& handle, Http::HeaderMap& trailers);
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/config.cc
@@ -20,7 +20,7 @@ SniDynamicForwardProxyNetworkFilterConfigFactory::createFilterFactoryFromProtoTy
 
   Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactoryImpl cache_manager_factory(
       context.singletonManager(), context.dispatcher(), context.threadLocal(), context.random(),
-      context.scope());
+      context.runtime(), context.scope());
   ProxyFilterConfigSharedPtr filter_config(std::make_shared<ProxyFilterConfig>(
       proto_config, cache_manager_factory, context.clusterManager()));
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -47,14 +47,13 @@ SslSocket::SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
     : transport_socket_options_(transport_socket_options),
       ctx_(std::dynamic_pointer_cast<ContextImpl>(ctx)), state_(SocketState::PreHandshake) {
   bssl::UniquePtr<SSL> ssl = ctx_->newSsl(transport_socket_options_.get());
-  ssl_ = ssl.get();
   info_ = std::make_shared<SslSocketInfo>(std::move(ssl), ctx_);
 
   if (state == InitialState::Client) {
-    SSL_set_connect_state(ssl_);
+    SSL_set_connect_state(rawSsl());
   } else {
     ASSERT(state == InitialState::Server);
-    SSL_set_accept_state(ssl_);
+    SSL_set_accept_state(rawSsl());
   }
 }
 
@@ -65,11 +64,11 @@ void SslSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& c
   // Associate this SSL connection with all the certificates (with their potentially different
   // private key methods).
   for (auto const& provider : ctx_->getPrivateKeyMethodProviders()) {
-    provider->registerPrivateKeyMethod(ssl_, *this, callbacks_->connection().dispatcher());
+    provider->registerPrivateKeyMethod(rawSsl(), *this, callbacks_->connection().dispatcher());
   }
 
   BIO* bio = BIO_new_socket(callbacks_->ioHandle().fd(), 0);
-  SSL_set_bio(ssl_, bio, bio);
+  SSL_set_bio(rawSsl(), bio, bio);
 }
 
 SslSocket::ReadResult SslSocket::sslReadIntoSlice(Buffer::RawSlice& slice) {
@@ -77,7 +76,7 @@ SslSocket::ReadResult SslSocket::sslReadIntoSlice(Buffer::RawSlice& slice) {
   uint8_t* mem = static_cast<uint8_t*>(slice.mem_);
   size_t remaining = slice.len_;
   while (remaining > 0) {
-    int rc = SSL_read(ssl_, mem, remaining);
+    int rc = SSL_read(rawSsl(), mem, remaining);
     ENVOY_CONN_LOG(trace, "ssl read returns: {}", callbacks_->connection(), rc);
     if (rc > 0) {
       ASSERT(static_cast<size_t>(rc) <= remaining);
@@ -124,7 +123,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       }
       if (result.error_.has_value()) {
         keep_reading = false;
-        int err = SSL_get_error(ssl_, result.error_.value());
+        int err = SSL_get_error(rawSsl(), result.error_.value());
         switch (err) {
         case SSL_ERROR_WANT_READ:
           break;
@@ -171,11 +170,11 @@ void SslSocket::onPrivateKeyMethodComplete() {
 
 PostIoAction SslSocket::doHandshake() {
   ASSERT(state_ != SocketState::HandshakeComplete && state_ != SocketState::ShutdownSent);
-  int rc = SSL_do_handshake(ssl_);
+  int rc = SSL_do_handshake(rawSsl());
   if (rc == 1) {
     ENVOY_CONN_LOG(debug, "handshake complete", callbacks_->connection());
     state_ = SocketState::HandshakeComplete;
-    ctx_->logHandshake(ssl_);
+    ctx_->logHandshake(rawSsl());
     callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
 
     // It's possible that we closed during the handshake callback.
@@ -183,7 +182,7 @@ PostIoAction SslSocket::doHandshake() {
                ? PostIoAction::KeepOpen
                : PostIoAction::Close;
   } else {
-    int err = SSL_get_error(ssl_, rc);
+    int err = SSL_get_error(rawSsl(), rc);
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
@@ -255,7 +254,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
     // it again with the same parameters. This is done by tracking last write size, but not write
     // data, since linearize() will return the same undrained data anyway.
     ASSERT(bytes_to_write <= write_buffer.length());
-    int rc = SSL_write(ssl_, write_buffer.linearize(bytes_to_write), bytes_to_write);
+    int rc = SSL_write(rawSsl(), write_buffer.linearize(bytes_to_write), bytes_to_write);
     ENVOY_CONN_LOG(trace, "ssl write returns: {}", callbacks_->connection(), rc);
     if (rc > 0) {
       ASSERT(rc == static_cast<int>(bytes_to_write));
@@ -263,7 +262,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       write_buffer.drain(rc);
       bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
     } else {
-      int err = SSL_get_error(ssl_, rc);
+      int err = SSL_get_error(rawSsl(), rc);
       switch (err) {
       case SSL_ERROR_WANT_WRITE:
         bytes_to_retry_ = bytes_to_write;
@@ -294,7 +293,7 @@ void SslSocket::shutdownSsl() {
   ASSERT(state_ != SocketState::PreHandshake);
   if (state_ != SocketState::ShutdownSent &&
       callbacks_->connection().state() != Network::Connection::State::Closed) {
-    int rc = SSL_shutdown(ssl_);
+    int rc = SSL_shutdown(rawSsl());
     ENVOY_CONN_LOG(debug, "SSL shutdown: rc={}", callbacks_->connection(), rc);
     drainErrorQueue();
     state_ = SocketState::ShutdownSent;
@@ -316,7 +315,7 @@ SslSocketInfo::SslSocketInfo(bssl::UniquePtr<SSL> ssl, ContextImplSharedPtr ctx)
 }
 
 bool SslSocketInfo::peerCertificatePresented() const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   return cert != nullptr;
 }
 
@@ -331,7 +330,7 @@ absl::Span<const std::string> SslSocketInfo::uriSanLocalCertificate() const {
   }
 
   // The cert object is not owned.
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_certificate(ssl());
   if (!cert) {
     ASSERT(cached_uri_san_local_certificate_.empty());
     return cached_uri_san_local_certificate_;
@@ -345,7 +344,7 @@ absl::Span<const std::string> SslSocketInfo::dnsSansLocalCertificate() const {
     return cached_dns_san_local_certificate_;
   }
 
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_certificate(ssl());
   if (!cert) {
     ASSERT(cached_dns_san_local_certificate_.empty());
     return cached_dns_san_local_certificate_;
@@ -358,7 +357,7 @@ const std::string& SslSocketInfo::sha256PeerCertificateDigest() const {
   if (!cached_sha_256_peer_certificate_digest_.empty()) {
     return cached_sha_256_peer_certificate_digest_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_sha_256_peer_certificate_digest_.empty());
     return cached_sha_256_peer_certificate_digest_;
@@ -376,7 +375,7 @@ const std::string& SslSocketInfo::urlEncodedPemEncodedPeerCertificate() const {
   if (!cached_url_encoded_pem_encoded_peer_certificate_.empty()) {
     return cached_url_encoded_pem_encoded_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_url_encoded_pem_encoded_peer_certificate_.empty());
     return cached_url_encoded_pem_encoded_peer_certificate_;
@@ -399,7 +398,7 @@ const std::string& SslSocketInfo::urlEncodedPemEncodedPeerCertificateChain() con
     return cached_url_encoded_pem_encoded_peer_cert_chain_;
   }
 
-  STACK_OF(X509)* cert_chain = SSL_get_peer_full_cert_chain(ssl_.get());
+  STACK_OF(X509)* cert_chain = SSL_get_peer_full_cert_chain(ssl());
   if (cert_chain == nullptr) {
     ASSERT(cached_url_encoded_pem_encoded_peer_cert_chain_.empty());
     return cached_url_encoded_pem_encoded_peer_cert_chain_;
@@ -429,7 +428,7 @@ absl::Span<const std::string> SslSocketInfo::uriSanPeerCertificate() const {
     return cached_uri_san_peer_certificate_;
   }
 
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_uri_san_peer_certificate_.empty());
     return cached_uri_san_peer_certificate_;
@@ -443,7 +442,7 @@ absl::Span<const std::string> SslSocketInfo::dnsSansPeerCertificate() const {
     return cached_dns_san_peer_certificate_;
   }
 
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_dns_san_peer_certificate_.empty());
     return cached_dns_san_peer_certificate_;
@@ -455,7 +454,7 @@ absl::Span<const std::string> SslSocketInfo::dnsSansPeerCertificate() const {
 void SslSocket::closeSocket(Network::ConnectionEvent) {
   // Unregister the SSL connection object from private key method providers.
   for (auto const& provider : ctx_->getPrivateKeyMethodProviders()) {
-    provider->unregisterPrivateKeyMethod(ssl_);
+    provider->unregisterPrivateKeyMethod(rawSsl());
   }
 
   // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
@@ -469,12 +468,12 @@ void SslSocket::closeSocket(Network::ConnectionEvent) {
 std::string SslSocket::protocol() const {
   const unsigned char* proto;
   unsigned int proto_len;
-  SSL_get0_alpn_selected(ssl_, &proto, &proto_len);
+  SSL_get0_alpn_selected(rawSsl(), &proto, &proto_len);
   return std::string(reinterpret_cast<const char*>(proto), proto_len);
 }
 
 uint16_t SslSocketInfo::ciphersuiteId() const {
-  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl_.get());
+  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl());
   if (cipher == nullptr) {
     return 0xffff;
   }
@@ -486,7 +485,7 @@ uint16_t SslSocketInfo::ciphersuiteId() const {
 }
 
 std::string SslSocketInfo::ciphersuiteString() const {
-  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl_.get());
+  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl());
   if (cipher == nullptr) {
     return {};
   }
@@ -498,12 +497,12 @@ const std::string& SslSocketInfo::tlsVersion() const {
   if (!cached_tls_version_.empty()) {
     return cached_tls_version_;
   }
-  cached_tls_version_ = SSL_get_version(ssl_.get());
+  cached_tls_version_ = SSL_get_version(ssl());
   return cached_tls_version_;
 }
 
 absl::optional<std::string> SslSocketInfo::x509Extension(absl::string_view extension_name) const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     return absl::nullopt;
   }
@@ -516,7 +515,7 @@ const std::string& SslSocketInfo::serialNumberPeerCertificate() const {
   if (!cached_serial_number_peer_certificate_.empty()) {
     return cached_serial_number_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_serial_number_peer_certificate_.empty());
     return cached_serial_number_peer_certificate_;
@@ -529,7 +528,7 @@ const std::string& SslSocketInfo::issuerPeerCertificate() const {
   if (!cached_issuer_peer_certificate_.empty()) {
     return cached_issuer_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_issuer_peer_certificate_.empty());
     return cached_issuer_peer_certificate_;
@@ -542,7 +541,7 @@ const std::string& SslSocketInfo::subjectPeerCertificate() const {
   if (!cached_subject_peer_certificate_.empty()) {
     return cached_subject_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_subject_peer_certificate_.empty());
     return cached_subject_peer_certificate_;
@@ -555,7 +554,7 @@ const std::string& SslSocketInfo::subjectLocalCertificate() const {
   if (!cached_subject_local_certificate_.empty()) {
     return cached_subject_local_certificate_;
   }
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_certificate(ssl());
   if (!cert) {
     ASSERT(cached_subject_local_certificate_.empty());
     return cached_subject_local_certificate_;
@@ -565,7 +564,7 @@ const std::string& SslSocketInfo::subjectLocalCertificate() const {
 }
 
 absl::optional<SystemTime> SslSocketInfo::validFromPeerCertificate() const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     return absl::nullopt;
   }
@@ -573,7 +572,7 @@ absl::optional<SystemTime> SslSocketInfo::validFromPeerCertificate() const {
 }
 
 absl::optional<SystemTime> SslSocketInfo::expirationPeerCertificate() const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     return absl::nullopt;
   }
@@ -584,7 +583,7 @@ const std::string& SslSocketInfo::sessionId() const {
   if (!cached_session_id_.empty()) {
     return cached_session_id_;
   }
-  SSL_SESSION* session = SSL_get_session(ssl_.get());
+  SSL_SESSION* session = SSL_get_session(ssl());
   if (session == nullptr) {
     ASSERT(cached_session_id_.empty());
     return cached_session_id_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -76,8 +76,7 @@ public:
   std::string ciphersuiteString() const override;
   const std::string& tlsVersion() const override;
   absl::optional<std::string> x509Extension(absl::string_view extension_name) const override;
-
-  SSL* rawSslForTest() const { return ssl_.get(); }
+  SSL* ssl() const { return ssl_.get(); }
 
   bssl::UniquePtr<SSL> ssl_;
 
@@ -97,6 +96,8 @@ private:
   mutable std::string cached_tls_version_;
   mutable SslExtendedSocketInfoImpl extended_socket_info_;
 };
+
+using SslSocketInfoConstSharedPtr = std::shared_ptr<const SslSocketInfo>;
 
 class SslSocket : public Network::TransportSocket,
                   public Envoy::Ssl::PrivateKeyConnectionCallbacks,
@@ -118,7 +119,7 @@ public:
   // Ssl::PrivateKeyConnectionCallbacks
   void onPrivateKeyMethodComplete() override;
 
-  SSL* rawSslForTest() const { return ssl_; }
+  SSL* rawSsl() const { return info_->ssl_.get(); }
 
 private:
   struct ReadResult {
@@ -141,8 +142,7 @@ private:
   std::string failure_reason_;
   SocketState state_;
 
-  SSL* ssl_;
-  Ssl::ConnectionInfoConstSharedPtr info_;
+  SslSocketInfoConstSharedPtr info_;
 };
 
 class ClientSslSocketFactory : public Network::TransportSocketFactory,

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -119,6 +119,9 @@ public:
   // Ssl::PrivateKeyConnectionCallbacks
   void onPrivateKeyMethodComplete() override;
 
+  SSL* rawSslForTest() const { return rawSsl(); }
+
+protected:
   SSL* rawSsl() const { return info_->ssl_.get(); }
 
 private:

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -280,7 +280,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "addr_family_aware_socket_option_impl_test",
     srcs = ["addr_family_aware_socket_option_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":socket_option_test",
         "//source/common/network:addr_family_aware_socket_option_lib",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -289,7 +289,6 @@ envoy_cc_test(
     name = "router_upstream_log_test",
     srcs = ["router_upstream_log_test.cc"],
     external_deps = ["abseil_optional"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/network:utility_lib",

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -1,5 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_cc_test_binary",
@@ -236,7 +238,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "thread_local_store_speed_test",
     srcs = ["thread_local_store_speed_test.cc"],
     external_deps = [
@@ -254,6 +256,11 @@ envoy_cc_test_binary(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
     ],
+)
+
+envoy_benchmark_test(
+    name = "thread_local_store_speed_test_benchmark_test",
+    benchmark_binary = "thread_local_store_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -3,6 +3,7 @@
 
 #include "common/event/dispatcher_impl.h"
 #include "common/network/utility.h"
+#include "common/tcp/conn_pool.h"
 #include "common/tcp/original_conn_pool.h"
 #include "common/upstream/upstream_impl.h"
 
@@ -121,15 +122,31 @@ public:
   bool test_new_connection_pool_;
 
 protected:
-  class ConnPoolImplForTest : public OriginalConnPoolImpl {
+  class ConnPoolImplForTest : public ConnPoolImpl {
   public:
     ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
                         ConnPoolBase& parent)
+        : ConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, nullptr, nullptr),
+          parent_(parent) {}
+
+    void onConnReleased(Envoy::ConnectionPool::ActiveClient& client) override {
+      ConnPoolImpl::onConnReleased(client);
+      parent_.onConnReleasedForTest();
+    }
+
+    void onConnDestroyed() override { parent_.onConnDestroyedForTest(); }
+    ConnPoolBase& parent_;
+  };
+
+  class OriginalConnPoolImplForTest : public OriginalConnPoolImpl {
+  public:
+    OriginalConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
+                                ConnPoolBase& parent)
         : OriginalConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, nullptr,
                                nullptr),
           parent_(parent) {}
 
-    ~ConnPoolImplForTest() override {
+    ~OriginalConnPoolImplForTest() override {
       EXPECT_EQ(0U, ready_conns_.size());
       EXPECT_EQ(0U, busy_conns_.size());
       EXPECT_EQ(0U, pending_requests_.size());
@@ -165,16 +182,16 @@ ConnPoolBase::ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostShar
                            bool test_new_connection_pool)
     : mock_dispatcher_(dispatcher), mock_upstream_ready_cb_(upstream_ready_cb),
       test_new_connection_pool_(test_new_connection_pool) {
-  // TODO(alyssarwilk) remove this assert and test the old and the new when it lands.
-  ASSERT(!test_new_connection_pool_);
-  if (!test_new_connection_pool_) {
+  if (test_new_connection_pool_) {
     conn_pool_ = std::make_unique<ConnPoolImplForTest>(dispatcher, host, *this);
+  } else {
+    conn_pool_ = std::make_unique<OriginalConnPoolImplForTest>(dispatcher, host, *this);
   }
 }
 
 void ConnPoolBase::expectEnableUpstreamReady(bool run) {
   if (!test_new_connection_pool_) {
-    dynamic_cast<ConnPoolImplForTest*>(conn_pool_.get())->expectEnableUpstreamReady(run);
+    dynamic_cast<OriginalConnPoolImplForTest*>(conn_pool_.get())->expectEnableUpstreamReady(run);
   } else {
     if (!run) {
       EXPECT_CALL(*mock_upstream_ready_cb_, scheduleCallbackCurrentIteration())
@@ -195,10 +212,7 @@ public:
       : test_new_connection_pool_(GetParam()),
         upstream_ready_cb_(new NiceMock<Event::MockSchedulableCallback>(&dispatcher_)),
         host_(Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000")),
-        conn_pool_(dispatcher_, host_, upstream_ready_cb_, test_new_connection_pool_) {
-    // TODO(alyssarwilk) remove this assert and test the old and the new when it lands.
-    ASSERT(!test_new_connection_pool_);
-  }
+        conn_pool_(dispatcher_, host_, upstream_ready_cb_, test_new_connection_pool_) {}
 
   ~TcpConnPoolImplTest() override {
     EXPECT_TRUE(TestUtility::gaugesZeroed(cluster_->stats_store_.gauges()))
@@ -223,8 +237,10 @@ public:
       : test_new_connection_pool_(GetParam()),
         upstream_ready_cb_(new NiceMock<Event::MockSchedulableCallback>(&dispatcher_)) {
     host_ = Upstream::makeTestHost(cluster_, "tcp://127.0.0.1:9000");
-    ASSERT(!test_new_connection_pool_);
-    if (!test_new_connection_pool_) {
+    if (test_new_connection_pool_) {
+      conn_pool_ = std::make_unique<ConnPoolImpl>(
+          dispatcher_, host_, Upstream::ResourcePriority::Default, nullptr, nullptr);
+    } else {
       conn_pool_ = std::make_unique<OriginalConnPoolImpl>(
           dispatcher_, host_, Upstream::ResourcePriority::Default, nullptr, nullptr);
     }
@@ -914,10 +930,18 @@ TEST_P(TcpConnPoolImplTest, DrainWhileConnecting) {
   EXPECT_NE(nullptr, handle);
 
   conn_pool_.addDrainedCallback([&]() -> void { drained.ready(); });
-  handle->cancel(ConnectionPool::CancelPolicy::Default);
-  EXPECT_CALL(*conn_pool_.test_conns_[0].connection_, close(Network::ConnectionCloseType::NoFlush));
-  EXPECT_CALL(drained, ready());
-  conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  if (test_new_connection_pool_) {
+    // The shared connection pool removes and closes connecting clients if there are no
+    // pending requests.
+    EXPECT_CALL(drained, ready());
+    handle->cancel(ConnectionPool::CancelPolicy::Default);
+  } else {
+    handle->cancel(ConnectionPool::CancelPolicy::Default);
+    EXPECT_CALL(*conn_pool_.test_conns_[0].connection_,
+                close(Network::ConnectionCloseType::NoFlush));
+    EXPECT_CALL(drained, ready());
+    conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
+  }
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   dispatcher_.clearDeferredDeleteList();
 }
@@ -945,6 +969,74 @@ TEST_P(TcpConnPoolImplTest, DrainOnClose) {
 
   EXPECT_CALL(conn_pool_, onConnDestroyedForTest());
   dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Test connecting_request_capacity logic.
+ */
+TEST_P(TcpConnPoolImplTest, RequestCapacity) {
+  if (!test_new_connection_pool_) {
+    return;
+  }
+  cluster_->resetResourceManager(5, 1024, 1024, 1, 1);
+  cluster_->max_requests_per_connection_ = 100;
+
+  ConnPoolCallbacks callbacks1;
+  ConnPoolCallbacks callbacks2;
+  Tcp::ConnectionPool::Cancellable* handle1;
+  Tcp::ConnectionPool::Cancellable* handle2;
+  {
+    // Request 1 should kick off a new connection.
+    conn_pool_.expectConnCreate();
+    handle1 = conn_pool_.newConnection(callbacks1);
+    EXPECT_NE(nullptr, handle1);
+  }
+  {
+    // Request 2 should kick off a new connection.
+    conn_pool_.expectConnCreate();
+    handle2 = conn_pool_.newConnection(callbacks2);
+    EXPECT_NE(nullptr, handle2);
+  }
+
+  // This should set the number of requests remaining to 1 on the active
+  // connections, and the connecting_request_capacity to 2 as well.
+  conn_pool_.drainConnections();
+
+  // Cancel the connections. Because neither used CloseExcess, the two connections should persist.
+  handle1->cancel(ConnectionPool::CancelPolicy::Default);
+  handle2->cancel(ConnectionPool::CancelPolicy::Default);
+
+  Tcp::ConnectionPool::Cancellable* handle3;
+  Tcp::ConnectionPool::Cancellable* handle4;
+  Tcp::ConnectionPool::Cancellable* handle5;
+  ConnPoolCallbacks callbacks3;
+  ConnPoolCallbacks callbacks4;
+  ConnPoolCallbacks callbacks5;
+
+  {
+    // The next two requests will use the connections in progress, bringing
+    // connecting_request_capacity to zero.
+    handle3 = conn_pool_.newConnection(callbacks3);
+    EXPECT_NE(nullptr, handle3);
+
+    handle4 = conn_pool_.newConnection(callbacks4);
+    EXPECT_NE(nullptr, handle4);
+  }
+  {
+    // With connecting_request_capacity zero, a request for a new connection
+    // will kick off connection #3.
+    conn_pool_.expectConnCreate();
+    handle5 = conn_pool_.newConnection(callbacks5);
+    EXPECT_NE(nullptr, handle5);
+  }
+
+  // Clean up remaining connections.
+  handle3->cancel(ConnectionPool::CancelPolicy::Default);
+  handle4->cancel(ConnectionPool::CancelPolicy::Default);
+  handle5->cancel(ConnectionPool::CancelPolicy::Default);
+  conn_pool_.test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  conn_pool_.test_conns_[1].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  conn_pool_.test_conns_[2].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
 /**
@@ -990,9 +1082,8 @@ TEST_P(TcpConnPoolImplDestructorTest, TestReadyConnectionsAreClosed) {
   EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
   conn_pool_.reset();
 }
-
-INSTANTIATE_TEST_SUITE_P(ConnectionPools, TcpConnPoolImplTest, testing::Values(false));
-INSTANTIATE_TEST_SUITE_P(ConnectionPools, TcpConnPoolImplDestructorTest, testing::Values(false));
+INSTANTIATE_TEST_SUITE_P(ConnectionPools, TcpConnPoolImplTest, testing::Bool());
+INSTANTIATE_TEST_SUITE_P(ConnectionPools, TcpConnPoolImplDestructorTest, testing::Bool());
 
 } // namespace Tcp
 } // namespace Envoy

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -133,7 +133,6 @@ envoy_benchmark_test(
 envoy_cc_test(
     name = "health_checker_impl_test",
     srcs = ["health_checker_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":utility_lib",
         "//source/common/buffer:buffer_lib",
@@ -399,7 +398,6 @@ envoy_benchmark_test(
     name = "load_balancer_benchmark_test",
     timeout = "long",
     benchmark_binary = "load_balancer_benchmark",
-    tags = ["fails_on_windows"],
 )
 
 envoy_cc_test(

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -20,9 +20,10 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
-envoy::config::bootstrap::v3::Bootstrap parseBootstrapFromV3Yaml(const std::string& yaml) {
+envoy::config::bootstrap::v3::Bootstrap parseBootstrapFromV3Yaml(const std::string& yaml,
+                                                                 bool avoid_boosting = true) {
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
-  TestUtility::loadFromYaml(yaml, bootstrap, true);
+  TestUtility::loadFromYaml(yaml, bootstrap, true, avoid_boosting);
   return bootstrap;
 }
 
@@ -200,7 +201,7 @@ TEST_F(ClusterManagerImplTest, MultipleProtocolCluster) {
   checkConfigDump(R"EOF(
 static_clusters:
   - cluster:
-      "@type": type.googleapis.com/envoy.api.v2.Cluster
+      "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       name: http12_cluster
       connect_timeout: 0.250s
       lb_policy: ROUND_ROBIN
@@ -442,7 +443,7 @@ TEST_F(ClusterManagerImplTest, OriginalDstLbRestriction2) {
                 port_value: 11001
   )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Yaml(yaml, false)), EnvoyException,
                             "cluster: LB policy hidden_envoy_deprecated_ORIGINAL_DST_LB is not "
                             "valid for Cluster type STATIC. "
                             "'ORIGINAL_DST_LB' is allowed only with cluster type 'ORIGINAL_DST'");
@@ -559,7 +560,7 @@ TEST_F(ClusterManagerImplTest, SubsetLoadBalancerOriginalDstRestriction) {
         - keys: [ "x" ]
   )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Yaml(yaml)), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(create(parseBootstrapFromV3Yaml(yaml, false)), EnvoyException,
                             "cluster: LB policy hidden_envoy_deprecated_ORIGINAL_DST_LB cannot be "
                             "combined with lb_subset_config");
 }
@@ -1226,8 +1227,8 @@ TEST_F(ClusterManagerImplTest, ModifyWarmingCluster) {
        connect_timeout: 0.25s
        hosts:
        - socket_address:
-           address: "127.0.0.1"
-           port_value: 11001
+          address: "127.0.0.1"
+          port_value: 11001
      last_updated:
        seconds: 1234567891
        nanos: 234000000
@@ -1259,8 +1260,8 @@ TEST_F(ClusterManagerImplTest, ModifyWarmingCluster) {
        connect_timeout: 0.25s
        hosts:
        - socket_address:
-           address: "127.0.0.1"
-           port_value: 11002
+          address: "127.0.0.1"
+          port_value: 11002
      last_updated:
        seconds: 1234567891
        nanos: 234000000

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -124,6 +124,14 @@ makeLocalityWeights(std::initializer_list<uint32_t> locality_weights) {
 }
 
 inline envoy::config::core::v3::HealthCheck
+parseHealthCheckFromV3Yaml(const std::string& yaml_string, bool avoid_boosting = true) {
+  envoy::config::core::v3::HealthCheck health_check;
+  TestUtility::loadFromYamlAndValidate(yaml_string, health_check, false, avoid_boosting);
+  return health_check;
+}
+
+// For DEPRECATED TEST CASES
+inline envoy::config::core::v3::HealthCheck
 parseHealthCheckFromV2Yaml(const std::string& yaml_string) {
   envoy::config::core::v3::HealthCheck health_check;
   TestUtility::loadFromYamlAndValidate(yaml_string, health_check);

--- a/test/extensions/common/aws/BUILD
+++ b/test/extensions/common/aws/BUILD
@@ -76,7 +76,6 @@ envoy_cc_test(
     srcs = [
         "aws_metadata_fetcher_integration_test.cc",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:fmt_lib",
         "//source/extensions/common/aws:utility_lib",

--- a/test/extensions/common/dynamic_forward_proxy/BUILD
+++ b/test/extensions/common/dynamic_forward_proxy/BUILD
@@ -21,7 +21,23 @@ envoy_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "dns_cache_resource_manager_test",
+    srcs = ["dns_cache_resource_manager_test.cc"],
+    deps = [
+        ":mocks",
+        "//source/common/config:utility_lib",
+        "//source/extensions/common/dynamic_forward_proxy:dns_cache_impl",
+        "//source/extensions/common/dynamic_forward_proxy:dns_cache_resource_manager",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )
@@ -31,7 +47,8 @@ envoy_cc_mock(
     srcs = ["mocks.cc"],
     hdrs = ["mocks.h"],
     deps = [
-        "//source/extensions/common/dynamic_forward_proxy:dns_cache_interface",
+        "//source/extensions/common/dynamic_forward_proxy:dns_cache_impl",
+        "//test/mocks/upstream:upstream_mocks",
         "@envoy_api//envoy/extensions/common/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -11,6 +11,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 using testing::InSequence;
@@ -30,7 +31,8 @@ public:
     config_.set_dns_lookup_family(envoy::config::cluster::v3::Cluster::V4_ONLY);
 
     EXPECT_CALL(dispatcher_, createDnsResolver(_, _)).WillOnce(Return(resolver_));
-    dns_cache_ = std::make_unique<DnsCacheImpl>(dispatcher_, tls_, random_, store_, config_);
+    dns_cache_ =
+        std::make_unique<DnsCacheImpl>(dispatcher_, tls_, random_, loader_, store_, config_);
     update_callbacks_handle_ = dns_cache_->addUpdateCallbacks(update_callbacks_);
   }
 
@@ -59,6 +61,7 @@ public:
   std::shared_ptr<Network::MockDnsResolver> resolver_{std::make_shared<Network::MockDnsResolver>()};
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<Runtime::MockRandomGenerator> random_;
+  NiceMock<Runtime::MockLoader> loader_;
   Stats::IsolatedStoreImpl store_;
   std::unique_ptr<DnsCache> dns_cache_;
   MockUpdateCallbacks update_callbacks_;
@@ -642,13 +645,40 @@ TEST_F(DnsCacheImplTest, MaxHostOverflow) {
   EXPECT_EQ(1, TestUtility::findCounter(store_, "dns_cache.foo.host_overflow")->value());
 }
 
+TEST_F(DnsCacheImplTest, CircuitBreakersNotInvoked) {
+  initialize();
+
+  auto raii_ptr = dns_cache_->canCreateDnsRequest(absl::nullopt);
+  EXPECT_NE(raii_ptr.get(), nullptr);
+}
+
+TEST_F(DnsCacheImplTest, DnsCacheCircuitBreakersOverflow) {
+  config_.mutable_dns_cache_circuit_breaker()->mutable_max_pending_requests()->set_value(0);
+  initialize();
+
+  auto raii_ptr = dns_cache_->canCreateDnsRequest(absl::nullopt);
+  EXPECT_EQ(raii_ptr.get(), nullptr);
+  EXPECT_EQ(1, TestUtility::findCounter(store_, "dns_cache.foo.dns_rq_pending_overflow")->value());
+}
+
+TEST_F(DnsCacheImplTest, ClustersCircuitBreakersOverflow) {
+  initialize();
+  NiceMock<Upstream::MockBasicResourceLimit> pending_requests_;
+
+  EXPECT_CALL(pending_requests_, canCreate()).WillOnce(Return(false));
+  auto raii_ptr = dns_cache_->canCreateDnsRequest(pending_requests_);
+  EXPECT_EQ(raii_ptr.get(), nullptr);
+  EXPECT_EQ(0, TestUtility::findCounter(store_, "dns_cache.foo.dns_rq_pending_overflow")->value());
+}
+
 // DNS cache manager config tests.
 TEST(DnsCacheManagerImplTest, LoadViaConfig) {
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<ThreadLocal::MockInstance> tls;
   NiceMock<Runtime::MockRandomGenerator> random;
+  NiceMock<Runtime::MockLoader> loader;
   Stats::IsolatedStoreImpl store;
-  DnsCacheManagerImpl cache_manager(dispatcher, tls, random, store);
+  DnsCacheManagerImpl cache_manager(dispatcher, tls, random, loader, store);
 
   envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig config1;
   config1.set_name("foo");

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_resource_manager_test.cc
@@ -1,0 +1,77 @@
+#include "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.pb.h"
+
+#include "common/config/utility.h"
+
+#include "extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
+#include "extensions/common/dynamic_forward_proxy/dns_cache_resource_manager.h"
+
+#include "test/extensions/common/dynamic_forward_proxy/mocks.h"
+#include "test/mocks/runtime/mocks.h"
+#include "test/mocks/stats/mocks.h"
+#include "test/test_common/utility.h"
+
+using testing::_;
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace DynamicForwardProxy {
+namespace {
+
+class DnsCacheResourceManagerTest : public testing::Test {
+public:
+  DnsCacheResourceManagerTest() { ON_CALL(store_, gauge(_, _)).WillByDefault(ReturnRef(gauge_)); }
+
+  void setupResourceManager(std::string& config_yaml) {
+    envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheCircuitBreakers cb_config;
+    TestUtility::loadFromYaml(config_yaml, cb_config);
+
+    resource_manager_ =
+        std::make_unique<DnsCacheResourceManagerImpl>(store_, loader_, "dummy", cb_config);
+  }
+
+  void cleanup() {
+    auto& pending_requests = resource_manager_->pendingRequests();
+    while (pending_requests.count() != 0) {
+      pending_requests.dec();
+    }
+  }
+
+  std::unique_ptr<DnsCacheResourceManager> resource_manager_;
+  NiceMock<Stats::MockStore> store_;
+  NiceMock<Stats::MockGauge> gauge_;
+  NiceMock<Runtime::MockLoader> loader_;
+};
+
+TEST_F(DnsCacheResourceManagerTest, CheckDnsResource) {
+  std::string config_yaml = R"EOF(
+    max_pending_requests: 3
+  )EOF";
+  setupResourceManager(config_yaml);
+
+  auto& pending_requests = resource_manager_->pendingRequests();
+  EXPECT_EQ(3, pending_requests.max());
+  EXPECT_EQ(0, pending_requests.count());
+  EXPECT_TRUE(pending_requests.canCreate());
+
+  pending_requests.inc();
+  EXPECT_EQ(1, pending_requests.count());
+  EXPECT_TRUE(pending_requests.canCreate());
+
+  pending_requests.inc();
+  pending_requests.inc();
+  EXPECT_EQ(3, pending_requests.count());
+  EXPECT_FALSE(pending_requests.canCreate());
+
+  pending_requests.dec();
+  EXPECT_EQ(2, pending_requests.count());
+  EXPECT_TRUE(pending_requests.canCreate());
+
+  cleanup();
+}
+} // namespace
+} // namespace DynamicForwardProxy
+} // namespace Common
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/common/dynamic_forward_proxy/mocks.cc
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.cc
@@ -10,7 +10,14 @@ namespace Extensions {
 namespace Common {
 namespace DynamicForwardProxy {
 
-MockDnsCache::MockDnsCache() = default;
+MockDnsCacheResourceManager::MockDnsCacheResourceManager() {
+  ON_CALL(*this, pendingRequests()).WillByDefault(ReturnRef(pending_requests_));
+}
+MockDnsCacheResourceManager::~MockDnsCacheResourceManager() = default;
+
+MockDnsCache::MockDnsCache() {
+  ON_CALL(*this, canCreateDnsRequest_(_)).WillByDefault(Return(nullptr));
+}
 MockDnsCache::~MockDnsCache() = default;
 
 MockLoadDnsCacheEntryHandle::MockLoadDnsCacheEntryHandle() = default;

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -2,14 +2,29 @@
 
 #include "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.pb.h"
 
-#include "extensions/common/dynamic_forward_proxy/dns_cache.h"
+#include "extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
+
+#include "test/mocks/upstream/mocks.h"
 
 #include "gmock/gmock.h"
+
+using testing::NiceMock;
 
 namespace Envoy {
 namespace Extensions {
 namespace Common {
 namespace DynamicForwardProxy {
+
+class MockDnsCacheResourceManager : public DnsCacheResourceManager {
+public:
+  MockDnsCacheResourceManager();
+  ~MockDnsCacheResourceManager() override;
+
+  MOCK_METHOD(ResourceLimit&, pendingRequests, ());
+  MOCK_METHOD(DnsCacheCircuitBreakersStats&, stats, ());
+
+  NiceMock<Upstream::MockBasicResourceLimit> pending_requests_;
+};
 
 class MockDnsCache : public DnsCache {
 public:
@@ -26,6 +41,11 @@ public:
     MockLoadDnsCacheEntryResult result = loadDnsCacheEntry_(host, default_port, callbacks);
     return {result.status_, LoadDnsCacheEntryHandlePtr{result.handle_}};
   }
+  Upstream::ResourceAutoIncDecPtr
+  canCreateDnsRequest(ResourceLimitOptRef pending_requests) override {
+    Upstream::ResourceAutoIncDec* raii_ptr = canCreateDnsRequest_(pending_requests);
+    return std::unique_ptr<Upstream::ResourceAutoIncDec>(raii_ptr);
+  }
   MOCK_METHOD(MockLoadDnsCacheEntryResult, loadDnsCacheEntry_,
               (absl::string_view host, uint16_t default_port,
                LoadDnsCacheEntryCallbacks& callbacks));
@@ -37,6 +57,7 @@ public:
               (UpdateCallbacks & callbacks));
 
   MOCK_METHOD((absl::flat_hash_map<std::string, DnsHostInfoSharedPtr>), hosts, ());
+  MOCK_METHOD(Upstream::ResourceAutoIncDec*, canCreateDnsRequest_, (ResourceLimitOptRef));
 };
 
 class MockLoadDnsCacheEntryHandle : public DnsCache::LoadDnsCacheEntryHandle {
@@ -55,7 +76,7 @@ public:
   MOCK_METHOD(DnsCacheSharedPtr, getCache,
               (const envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig& config));
 
-  std::shared_ptr<MockDnsCache> dns_cache_{new MockDnsCache()};
+  std::shared_ptr<NiceMock<MockDnsCache>> dns_cache_{new NiceMock<MockDnsCache>()};
 };
 
 class MockDnsHostInfo : public DnsHostInfo {

--- a/test/extensions/filters/http/common/compressor/BUILD
+++ b/test/extensions/filters/http/common/compressor/BUILD
@@ -1,7 +1,8 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -25,7 +26,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "compressor_filter_speed_test",
     srcs = ["compressor_filter_speed_test.cc"],
     external_deps = [
@@ -43,4 +44,9 @@ envoy_cc_test_binary(
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/compressor/v3:pkg_cc_proto",
     ],
+)
+
+envoy_benchmark_test(
+    name = "compressor_filter_speed_test_benchmark_test",
+    benchmark_binary = "compressor_filter_speed_test",
 )

--- a/test/extensions/filters/http/common/compressor/compressor_filter_speed_test.cc
+++ b/test/extensions/filters/http/common/compressor/compressor_filter_speed_test.cc
@@ -291,5 +291,3 @@ BENCHMARK(compressChunks1024)->DenseRange(0, 8, 1)->UseManualTime()->Unit(benchm
 } // namespace HttpFilters
 } // namespace Extensions
 } // namespace Envoy
-
-BENCHMARK_MAIN();

--- a/test/extensions/filters/http/cors/BUILD
+++ b/test/extensions/filters/http/cors/BUILD
@@ -30,7 +30,6 @@ envoy_extension_cc_test(
     name = "cors_filter_integration_test",
     srcs = ["cors_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.cors",
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",

--- a/test/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -16,11 +16,14 @@ envoy_extension_cc_test(
     srcs = ["proxy_filter_test.cc"],
     extension_name = "envoy.filters.http.dynamic_forward_proxy",
     deps = [
+        "//source/common/stats:isolated_store_lib",
+        "//source/extensions/common/dynamic_forward_proxy:dns_cache_impl",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/dynamic_forward_proxy:config",
         "//test/extensions/common/dynamic_forward_proxy:mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -103,6 +103,110 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyFilterIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
+class ProxyFilterCircuitBreakerIntegrationTest : public ProxyFilterIntegrationTest {
+public:
+  ProxyFilterCircuitBreakerIntegrationTest() = default;
+
+  void setup(uint64_t max_hosts = 1024, uint32_t max_pending_requests = 0) {
+    setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
+
+    const std::string filter = fmt::format(R"EOF(
+name: dynamic_forward_proxy
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+  dns_cache_config:
+    name: foo
+    dns_lookup_family: {}
+    max_hosts: {}
+    dns_cache_circuit_breaker:
+      max_pending_requests: {}
+)EOF",
+                                           Network::Test::ipVersionToDnsFamily(GetParam()),
+                                           max_hosts, max_pending_requests);
+    config_helper_.addFilter(filter);
+
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // Switch predefined cluster_0 to CDS filesystem sourcing.
+      bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
+      bootstrap.mutable_static_resources()->clear_clusters();
+    });
+
+    // Enable dns cache circuit breakers.
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_dns_cache_circuit_breakers",
+                                      "true");
+
+    // Set validate_clusters to false to allow us to reference a CDS cluster.
+    config_helper_.addConfigModifier(
+        [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+               hcm) { hcm.mutable_route_config()->mutable_validate_clusters()->set_value(false); });
+
+    // Setup the initial CDS cluster.
+    cluster_.mutable_connect_timeout()->CopyFrom(
+        Protobuf::util::TimeUtil::MillisecondsToDuration(100));
+    cluster_.set_name("cluster_0");
+    cluster_.set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+
+    if (upstream_tls_) {
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+      auto* validation_context =
+          tls_context.mutable_common_tls_context()->mutable_validation_context();
+      validation_context->mutable_trusted_ca()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
+      cluster_.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
+      cluster_.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
+    }
+
+    const std::string cluster_type_config = fmt::format(
+        R"EOF(
+  name: envoy.clusters.dynamic_forward_proxy
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+    dns_cache_config:
+      name: foo
+      dns_lookup_family: {}
+      max_hosts: {}
+      dns_cache_circuit_breaker:
+        max_pending_requests: {}
+  )EOF",
+        Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts, max_pending_requests);
+
+    TestUtility::loadFromYaml(cluster_type_config, *cluster_.mutable_cluster_type());
+
+    // Load the CDS cluster and wait for it to initialize.
+    cds_helper_.setCds({cluster_});
+
+    HttpIntegrationTest::initialize();
+    test_server_->waitForCounterEq("cluster_manager.cluster_added", 1);
+    test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 0);
+
+    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyFilterCircuitBreakerIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(ProxyFilterCircuitBreakerIntegrationTest, Basic) {
+  setup();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  const Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "POST"},
+      {":path", "/test/long/url"},
+      {":scheme", "http"},
+      {":authority",
+       fmt::format("localhost:{}", fake_upstreams_[0]->localAddress()->ip()->port())}};
+
+  auto response = codec_client_->makeRequestWithBody(request_headers, 1024);
+  response->waitForEndStream();
+  EXPECT_EQ(1, test_server_->gauge("dns_cache.foo.circuit_breakers.rq_pending_open"));
+  EXPECT_EQ(1, test_server_->counter("dns_cache.foo.dns_rq_pending_overflow")->value());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("503", response->headers().Status()->value().getStringView());
+}
+
 // A basic test where we pause a request to lookup localhost, and then do another request which
 // should hit the TLS cache.
 TEST_P(ProxyFilterIntegrationTest, RequestWithBody) {

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -340,8 +340,7 @@ TEST_P(ProxyFilterIntegrationTest, UpstreamTls) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ("localhost",
-               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ("localhost", SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 
   upstream_request_->encodeHeaders(default_response_headers_, true);
   response->waitForEndStream();
@@ -366,7 +365,7 @@ TEST_P(ProxyFilterIntegrationTest, UpstreamTlsWithIpHost) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 
   upstream_request_->encodeHeaders(default_response_headers_, true);
   response->waitForEndStream();

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -1,5 +1,6 @@
 #include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
 
+#include "extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
 #include "extensions/filters/http/dynamic_forward_proxy/proxy_filter.h"
 #include "extensions/filters/http/well_known_names.h"
 
@@ -7,6 +8,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/mocks/upstream/transport_socket_match.h"
+#include "test/test_common/test_runtime.h"
 
 using testing::AtLeast;
 using testing::Eq;
@@ -65,14 +67,19 @@ public:
   std::unique_ptr<ProxyFilter> filter_;
   Http::MockStreamDecoderFilterCallbacks callbacks_;
   Http::TestRequestHeaderMapImpl request_headers_{{":authority", "foo"}};
+  NiceMock<Upstream::MockBasicResourceLimit> pending_requests_;
 };
 
 // Default port 80 if upstream TLS not configured.
 TEST_F(ProxyFilterTest, HttpDefaultPort) {
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
   InSequence s;
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(false));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
@@ -87,10 +94,14 @@ TEST_F(ProxyFilterTest, HttpDefaultPort) {
 
 // Default port 443 if upstream TLS is configured.
 TEST_F(ProxyFilterTest, HttpsDefaultPort) {
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
   InSequence s;
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(true));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
@@ -105,10 +116,14 @@ TEST_F(ProxyFilterTest, HttpsDefaultPort) {
 
 // Cache overflow.
 TEST_F(ProxyFilterTest, CacheOverflow) {
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
   InSequence s;
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(true));
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("foo"), 443, _))
       .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Overflow, nullptr}));
@@ -124,10 +139,18 @@ TEST_F(ProxyFilterTest, CacheOverflow) {
 
 // Circuit breaker overflow
 TEST_F(ProxyFilterTest, CircuitBreakerOverflow) {
+  // Disable dns cache circuit breakers because which we expect to be used cluster circuit breakers.
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.enable_dns_cache_circuit_breakers", "false"}});
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
   InSequence s;
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(true));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
@@ -141,6 +164,7 @@ TEST_F(ProxyFilterTest, CircuitBreakerOverflow) {
   filter2->setDecoderFilterCallbacks(callbacks_);
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_));
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable,
                                          Eq("Dynamic forward proxy pending request overflow"), _, _,
                                          Eq("Dynamic forward proxy pending request overflow")));
@@ -150,6 +174,46 @@ TEST_F(ProxyFilterTest, CircuitBreakerOverflow) {
             filter2->decodeHeaders(request_headers_, false));
 
   EXPECT_EQ(1,
+            cm_.thread_local_cluster_.cluster_.info_->stats_.upstream_rq_pending_overflow_.value());
+  filter2->onDestroy();
+  EXPECT_CALL(*handle, onDestroy());
+  filter_->onDestroy();
+}
+
+// Circuit breaker overflow with DNS Cache resource manager
+TEST_F(ProxyFilterTest, CircuitBreakerOverflowWithDnsCacheResourceManager) {
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
+  InSequence s;
+
+  EXPECT_CALL(callbacks_, route());
+  EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
+  EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(true));
+  Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
+      new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("foo"), 443, _))
+      .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Loading, handle}));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers_, false));
+
+  // Create a second filter for a 2nd request.
+  auto filter2 = std::make_unique<ProxyFilter>(filter_config_);
+  filter2->setDecoderFilterCallbacks(callbacks_);
+  EXPECT_CALL(callbacks_, route());
+  EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_));
+  EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable,
+                                         Eq("Dynamic forward proxy pending request overflow"), _, _,
+                                         Eq("Dynamic forward proxy pending request overflow")));
+  EXPECT_CALL(callbacks_, encodeHeaders_(_, false));
+  EXPECT_CALL(callbacks_, encodeData(_, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter2->decodeHeaders(request_headers_, false));
+
+  // Cluster circuit breaker overflow counter won't be incremented.
+  EXPECT_EQ(0,
             cm_.thread_local_cluster_.cluster_.info_->stats_.upstream_rq_pending_overflow_.value());
   filter2->onDestroy();
   EXPECT_CALL(*handle, onDestroy());
@@ -174,6 +238,8 @@ TEST_F(ProxyFilterTest, NoCluster) {
 }
 
 TEST_F(ProxyFilterTest, HostRewrite) {
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
   InSequence s;
 
   envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig proto_config;
@@ -182,6 +248,8 @@ TEST_F(ProxyFilterTest, HostRewrite) {
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(false));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
@@ -198,6 +266,8 @@ TEST_F(ProxyFilterTest, HostRewrite) {
 }
 
 TEST_F(ProxyFilterTest, HostRewriteViaHeader) {
+  Upstream::ResourceAutoIncDec* circuit_breakers_(
+      new Upstream::ResourceAutoIncDec(pending_requests_));
   InSequence s;
 
   envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig proto_config;
@@ -206,6 +276,8 @@ TEST_F(ProxyFilterTest, HostRewriteViaHeader) {
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*transport_socket_factory_, implementsSecureTransport()).WillOnce(Return(false));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -19,6 +19,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/http/lua:lua_filter_lib",
+        "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/ssl:ssl_mocks",

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -8,6 +8,7 @@
 
 #include "extensions/filters/http/lua/lua_filter.h"
 
+#include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/ssl/mocks.h"
@@ -72,9 +73,22 @@ public:
 
   ~LuaHttpFilterTest() override { filter_->onDestroy(); }
 
+  // Quickly set up a global configuration. In order to avoid extensive modification of existing
+  // test cases, the existing configuration methods must be compatible.
   void setup(const std::string& lua_code) {
-    config_ = std::make_shared<FilterConfig>(lua_code, tls_, cluster_manager_);
+    envoy::extensions::filters::http::lua::v3::Lua proto_config;
+    proto_config.set_inline_code(lua_code);
+    envoy::extensions::filters::http::lua::v3::LuaPerRoute per_route_proto_config;
+    setupConfig(proto_config, per_route_proto_config);
     setupFilter();
+  }
+
+  void setupConfig(envoy::extensions::filters::http::lua::v3::Lua& proto_config,
+                   envoy::extensions::filters::http::lua::v3::LuaPerRoute& per_route_proto_config) {
+    // Setup filter config for Lua filter.
+    config_ = std::make_shared<FilterConfig>(proto_config, tls_, cluster_manager_, api_);
+    // Setup per route config for Lua filter.
+    per_route_config_ = std::make_shared<FilterConfigPerRoute>(per_route_proto_config, tls_, api_);
   }
 
   void setupFilter() {
@@ -96,8 +110,10 @@ public:
   }
 
   NiceMock<ThreadLocal::MockInstance> tls_;
+  NiceMock<Api::MockApi> api_;
   Upstream::MockClusterManager cluster_manager_;
   std::shared_ptr<FilterConfig> config_;
+  std::shared_ptr<FilterConfigPerRoute> per_route_config_;
   std::unique_ptr<TestFilter> filter_;
   Http::MockStreamDecoderFilterCallbacks decoder_callbacks_;
   Http::MockStreamEncoderFilterCallbacks encoder_callbacks_;
@@ -183,6 +199,12 @@ public:
       end
     end
   )EOF"};
+
+  const std::string ADD_HEADERS_SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("hello", "world")
+    end
+  )EOF"};
 };
 
 // Bad code in initial config.
@@ -193,7 +215,12 @@ TEST(LuaHttpFilterConfigTest, BadCode) {
 
   NiceMock<ThreadLocal::MockInstance> tls;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
-  EXPECT_THROW_WITH_MESSAGE(FilterConfig(SCRIPT, tls, cluster_manager),
+  NiceMock<Api::MockApi> api;
+
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  proto_config.set_inline_code(SCRIPT);
+
+  EXPECT_THROW_WITH_MESSAGE(FilterConfig(proto_config, tls, cluster_manager, api),
                             Filters::Common::Lua::LuaException,
                             "script load error: [string \"...\"]:3: '=' expected near '<eof>'");
 }
@@ -1415,8 +1442,9 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
   setup(SCRIPT);
 
   // Perform a GC and snap bytes currently used by the runtime.
-  config_->runtimeGC();
-  const uint64_t mem_use_at_start = config_->runtimeBytesUsed();
+  auto script_config = config_->perLuaCodeSetup(GLOBAL_SCRIPT_NAME);
+  script_config->runtimeGC();
+  const uint64_t mem_use_at_start = script_config->runtimeBytesUsed();
 
   uint64_t num_loops = 2000;
 #if defined(__has_feature) && (__has_feature(thread_sanitizer))
@@ -1444,8 +1472,8 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
   //       to do a soft comparison here. In my own testing, without a fix for #3570, the memory
   //       usage after is at least 20x higher after 2000 iterations so we just check to see if it's
   //       within 2x.
-  config_->runtimeGC();
-  EXPECT_TRUE(config_->runtimeBytesUsed() < mem_use_at_start * 2);
+  script_config->runtimeGC();
+  EXPECT_TRUE(script_config->runtimeBytesUsed() < mem_use_at_start * 2);
 }
 
 // Respond with bad status.
@@ -1921,6 +1949,99 @@ TEST_F(LuaHttpFilterTest, SignatureVerify) {
   EXPECT_CALL(*filter_,
               scriptLog(spdlog::level::trace, StrEq("Failed to verify digest. Error code: 0")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
+// Test whether the route configuration can properly disable the Lua filter.
+TEST_F(LuaHttpFilterTest, LuaFilterDisabled) {
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  proto_config.set_inline_code(ADD_HEADERS_SCRIPT);
+  envoy::extensions::filters::http::lua::v3::LuaPerRoute per_route_proto_config;
+  per_route_proto_config.set_disabled(true);
+
+  setupConfig(proto_config, per_route_proto_config);
+  setupFilter();
+
+  EXPECT_CALL(decoder_callbacks_, clearRouteCache());
+
+  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig(HttpFilterNames::get().Lua))
+      .WillByDefault(Return(nullptr));
+
+  Http::TestRequestHeaderMapImpl request_headers_1{{":path", "/"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_1, true));
+  EXPECT_EQ("world", request_headers_1.get_("hello"));
+
+  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig(HttpFilterNames::get().Lua))
+      .WillByDefault(Return(per_route_config_.get()));
+
+  Http::TestRequestHeaderMapImpl request_headers_2{{":path", "/"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_2, true));
+  EXPECT_EQ(nullptr, request_headers_2.get(Http::LowerCaseString("hello")));
+}
+
+// Test whether the route can directly reuse the Lua code in the global configuration.
+TEST_F(LuaHttpFilterTest, LuaFilterRefSourceCodes) {
+  const std::string SCRIPT_FOR_ROUTE_ONE{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("route_info", "This request is routed by ROUTE_ONE");
+    end
+  )EOF"};
+  const std::string SCRIPT_FOR_ROUTE_TWO{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("route_info", "This request is routed by ROUTE_TWO");
+    end
+  )EOF"};
+  EXPECT_CALL(decoder_callbacks_, clearRouteCache());
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  proto_config.set_inline_code(ADD_HEADERS_SCRIPT);
+  envoy::config::core::v3::DataSource source1, source2;
+  source1.set_inline_string(SCRIPT_FOR_ROUTE_ONE);
+  source2.set_inline_string(SCRIPT_FOR_ROUTE_TWO);
+  proto_config.mutable_source_codes()->insert({"route_one.lua", source1});
+  proto_config.mutable_source_codes()->insert({"route_two.lua", source2});
+
+  envoy::extensions::filters::http::lua::v3::LuaPerRoute per_route_proto_config;
+  per_route_proto_config.set_name("route_two.lua");
+
+  setupConfig(proto_config, per_route_proto_config);
+  setupFilter();
+
+  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig(HttpFilterNames::get().Lua))
+      .WillByDefault(Return(per_route_config_.get()));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ("This request is routed by ROUTE_TWO", request_headers.get_("route_info"));
+}
+
+// Lua filter do nothing when the referenced name does not exist.
+TEST_F(LuaHttpFilterTest, LuaFilterRefSourceCodeNotExist) {
+  const std::string SCRIPT_FOR_ROUTE_ONE{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("route_info", "This request is routed by ROUTE_ONE");
+    end
+  )EOF"};
+
+  envoy::extensions::filters::http::lua::v3::Lua proto_config;
+  proto_config.set_inline_code(ADD_HEADERS_SCRIPT);
+  envoy::config::core::v3::DataSource source1;
+  source1.set_inline_string(SCRIPT_FOR_ROUTE_ONE);
+  proto_config.mutable_source_codes()->insert({"route_one.lua", source1});
+
+  envoy::extensions::filters::http::lua::v3::LuaPerRoute per_route_proto_config;
+  // The global source codes do not contain a script named 'route_two.lua'.
+  per_route_proto_config.set_name("route_two.lua");
+
+  setupConfig(proto_config, per_route_proto_config);
+  setupFilter();
+
+  ON_CALL(decoder_callbacks_.route_->route_entry_, perFilterConfig(HttpFilterNames::get().Lua))
+      .WillByDefault(Return(per_route_config_.get()));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+  EXPECT_EQ(nullptr, request_headers.get(Http::LowerCaseString("hello")));
 }
 
 } // namespace

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -29,15 +29,8 @@ public:
   void initializeFilter(const std::string& filter_config, const std::string& domain = "*") {
     config_helper_.addFilter(filter_config);
 
-    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      auto* lua_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      lua_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-      lua_cluster->set_name("lua_cluster");
-
-      auto* alt_cluster = bootstrap.mutable_static_resources()->add_clusters();
-      alt_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
-      alt_cluster->set_name("alt_cluster");
-    });
+    // Create static clusters.
+    createClusters();
 
     config_helper_.addConfigModifier(
         [domain](
@@ -77,6 +70,31 @@ public:
         });
 
     initialize();
+  }
+
+  void initializeWithYaml(const std::string& filter_config, const std::string& route_config) {
+    config_helper_.addFilter(filter_config);
+
+    createClusters();
+    config_helper_.addConfigModifier(
+        [route_config](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
+          TestUtility::loadFromYaml(route_config, *hcm.mutable_route_config(), true);
+        });
+    initialize();
+  }
+
+  void createClusters() {
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* lua_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      lua_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      lua_cluster->set_name("lua_cluster");
+
+      auto* alt_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      alt_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      alt_cluster->set_name("alt_cluster");
+    });
   }
 
   void cleanup() {
@@ -573,6 +591,141 @@ typed_config:
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
 
+  cleanup();
+}
+
+// Test whether LuaPerRoute works properly. Since this test is mainly for configuration, the Lua
+// script can be very simple.
+TEST_P(LuaIntegrationTest, BasicTestOfLuaPerRoute) {
+  const std::string FILTER_AND_CODE =
+      R"EOF(
+name: lua
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+  inline_code: |
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("code", "code_from_global")
+    end
+  source_codes:
+    hello.lua:
+      inline_string: |
+        function envoy_on_request(request_handle)
+          request_handle:headers():add("code", "code_from_hello")
+        end
+    byebye.lua:
+      inline_string: |
+        function envoy_on_request(request_handle)
+          request_handle:headers():add("code", "code_from_byebye")
+        end
+)EOF";
+  const std::string INITIAL_ROUTE_CONFIG =
+      R"EOF(
+name: basic_lua_routes
+virtual_hosts:
+- name: rds_vhost_1
+  domains: ["lua.per.route"]
+  routes:
+  - match:
+      prefix: "/lua/per/route/default"
+    route:
+      cluster: lua_cluster
+  - match:
+      prefix: "/lua/per/route/disabled"
+    route:
+      cluster: lua_cluster
+    typed_per_filter_config:
+      envoy.filters.http.lua:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+        disabled: true
+  - match:
+      prefix: "/lua/per/route/hello"
+    route:
+      cluster: lua_cluster
+    typed_per_filter_config:
+      envoy.filters.http.lua:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+        name: hello.lua
+  - match:
+      prefix: "/lua/per/route/byebye"
+    route:
+      cluster: lua_cluster
+    typed_per_filter_config:
+      envoy.filters.http.lua:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+        name: byebye.lua
+  - match:
+      prefix: "/lua/per/route/nocode"
+    route:
+      cluster: lua_cluster
+    typed_per_filter_config:
+      envoy.filters.http.lua:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute
+        name: nocode.lua
+)EOF";
+
+  initializeWithYaml(FILTER_AND_CODE, INITIAL_ROUTE_CONFIG);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto check_request = [this](const Http::TestRequestHeaderMapImpl& request_headers,
+                              const std::string& expected_value) {
+    auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+    waitForNextUpstreamRequest(1);
+
+    auto* entry = upstream_request_->headers().get(Http::LowerCaseString("code"));
+    if (!expected_value.empty()) {
+      EXPECT_EQ(expected_value, entry->value().getStringView());
+    } else {
+      EXPECT_EQ(nullptr, entry);
+    }
+
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+    response->waitForEndStream();
+
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+  };
+
+  // Lua code defined in 'inline_code' will be executed by default.
+  Http::TestRequestHeaderMapImpl default_headers{{":method", "GET"},
+                                                 {":path", "/lua/per/route/default"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "lua.per.route"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
+  check_request(default_headers, "code_from_global");
+
+  // Test whether LuaPerRoute can disable the Lua filter.
+  Http::TestRequestHeaderMapImpl disabled_headers{{":method", "GET"},
+                                                  {":path", "/lua/per/route/disabled"},
+                                                  {":scheme", "http"},
+                                                  {":authority", "lua.per.route"},
+                                                  {"x-forwarded-for", "10.0.0.1"}};
+  check_request(disabled_headers, "");
+
+  // Test whether LuaPerRoute can correctly reference Lua code defined in filter config.
+  Http::TestRequestHeaderMapImpl hello_headers{{":method", "GET"},
+                                               {":path", "/lua/per/route/hello"},
+                                               {":scheme", "http"},
+                                               {":authority", "lua.per.route"},
+                                               {"x-forwarded-for", "10.0.0.1"}};
+
+  check_request(hello_headers, "code_from_hello");
+
+  Http::TestRequestHeaderMapImpl byebye_headers{{":method", "GET"},
+                                                {":path", "/lua/per/route/byebye"},
+                                                {":scheme", "http"},
+                                                {":authority", "lua.per.route"},
+                                                {"x-forwarded-for", "10.0.0.1"}};
+  check_request(byebye_headers, "code_from_byebye");
+
+  // When the name referenced by LuaPerRoute does not exist, Lua filter does nothing.
+  Http::TestRequestHeaderMapImpl nocode_headers{{":method", "GET"},
+                                                {":path", "/lua/per/route/nocode"},
+                                                {":scheme", "http"},
+                                                {":authority", "lua.per.route"},
+                                                {"x-forwarded-for", "10.0.0.1"}};
+
+  check_request(nocode_headers, "");
   cleanup();
 }
 

--- a/test/extensions/filters/http/router/BUILD
+++ b/test/extensions/filters/http/router/BUILD
@@ -30,7 +30,6 @@ envoy_extension_cc_test(
         "//test/config/integration/certs",
     ],
     extension_name = "envoy.filters.http.router",
-    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/router:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -79,8 +79,7 @@ TEST_P(AutoSniIntegrationTest, BasicAutoSniTest) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ("localhost",
-               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ("localhost", SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 }
 
 TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
@@ -97,7 +96,7 @@ TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 }
 
 TEST_P(AutoSniIntegrationTest, PassingHostWithoutPort) {
@@ -116,8 +115,7 @@ TEST_P(AutoSniIntegrationTest, PassingHostWithoutPort) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ("example.com",
-               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ("example.com", SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 }
 
 } // namespace

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -40,10 +40,10 @@ namespace NetworkFilters {
 namespace HttpConnectionManager {
 
 envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
-parseHttpConnectionManagerFromV2Yaml(const std::string& yaml) {
+parseHttpConnectionManagerFromV2Yaml(const std::string& yaml, bool avoid_boosting = true) {
   envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
       http_connection_manager;
-  TestUtility::loadFromYamlAndValidate(yaml, http_connection_manager);
+  TestUtility::loadFromYamlAndValidate(yaml, http_connection_manager, false, avoid_boosting);
   return http_connection_manager;
 }
 
@@ -172,8 +172,8 @@ http_filters:
 - name: envoy.filters.http.router
   )EOF";
 
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
 
   EXPECT_EQ(128, config.tracingConfig()->max_path_tag_length_);
@@ -379,8 +379,8 @@ http_filters:
   EXPECT_CALL(http_tracer_manager_, getOrCreateHttpTracer(Pointee(ProtoEq(inlined_tracing_config))))
       .WillOnce(Return(http_tracer_));
 
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
 
   // Actual HttpTracer must be obtained from the HttpTracerManager.
@@ -430,8 +430,8 @@ tracing:
   request_headers_for_tags:
   - foo
   )EOF";
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
 
   const Tracing::CustomTagMap& custom_tag_map = config.tracingConfig()->custom_tags_;
@@ -462,8 +462,8 @@ http_filters:
   )EOF";
 
   ON_CALL(context_, direction()).WillByDefault(Return(envoy::config::core::v3::OUTBOUND));
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
   EXPECT_EQ(Tracing::OperationName::Egress, config.tracingConfig()->operation_name_);
 }
@@ -488,8 +488,8 @@ http_filters:
   )EOF";
 
   ON_CALL(context_, direction()).WillByDefault(Return(envoy::config::core::v3::INBOUND));
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
   EXPECT_EQ(Tracing::OperationName::Ingress, config.tracingConfig()->operation_name_);
 }
@@ -507,8 +507,8 @@ TEST_F(HttpConnectionManagerConfigTest, SamplingDefault) {
   - name: envoy.filters.http.router
   )EOF";
 
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
 
   EXPECT_EQ(100, config.tracingConfig()->client_sampling_.numerator());
@@ -542,8 +542,8 @@ TEST_F(HttpConnectionManagerConfigTest, SamplingConfigured) {
   - name: envoy.filters.http.router
   )EOF";
 
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
 
   EXPECT_EQ(1, config.tracingConfig()->client_sampling_.numerator());
@@ -576,8 +576,8 @@ TEST_F(HttpConnectionManagerConfigTest, FractionalSamplingConfigured) {
   - name: envoy.filters.http.router
   )EOF";
 
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
 
   EXPECT_EQ(0, config.tracingConfig()->client_sampling_.numerator());
@@ -688,8 +688,8 @@ TEST_F(HttpConnectionManagerConfigTest, DEPRECATED_FEATURE_TEST(IdleTimeout)) {
   - name: envoy.filters.http.router
   )EOF";
 
-  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
-                                     date_provider_, route_config_provider_manager_,
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string, false),
+                                     context_, date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_);
   EXPECT_EQ(1000, config.idleTimeout().value().count());
 }

--- a/test/extensions/filters/network/rbac/BUILD
+++ b/test/extensions/filters/network/rbac/BUILD
@@ -41,7 +41,6 @@ envoy_extension_cc_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     extension_name = "envoy.filters.network.rbac",
-    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/network/echo:config",
         "//source/extensions/filters/network/rbac:config",

--- a/test/extensions/filters/network/redis_proxy/config_test.cc
+++ b/test/extensions/filters/network/redis_proxy/config_test.cc
@@ -85,7 +85,7 @@ settings:
   )EOF";
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config{};
-  TestUtility::loadFromYamlAndValidate(yaml, proto_config, true);
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config, true, false);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);
@@ -114,7 +114,7 @@ settings:
   )EOF";
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy proto_config{};
-  TestUtility::loadFromYamlAndValidate(yaml, proto_config, true);
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config, true, false);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   RedisProxyFilterConfigFactory factory;
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context);

--- a/test/extensions/health_checkers/redis/config_test.cc
+++ b/test/extensions/health_checkers/redis/config_test.cc
@@ -36,11 +36,11 @@ TEST(HealthCheckerFactoryTest, DEPRECATED_FEATURE_TEST(CreateRedisDeprecated)) {
   NiceMock<Server::Configuration::MockHealthCheckerFactoryContext> context;
 
   RedisHealthCheckerFactory factory;
-  EXPECT_NE(
-      nullptr,
-      dynamic_cast<CustomRedisHealthChecker*>(
-          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
-              .get()));
+  EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
+                         factory
+                             .createCustomHealthChecker(
+                                 Upstream::parseHealthCheckFromV3Yaml(yaml, false), context)
+                             .get()));
 }
 
 TEST(HealthCheckerFactoryTest, CreateRedis) {
@@ -64,7 +64,7 @@ TEST(HealthCheckerFactoryTest, CreateRedis) {
   EXPECT_NE(
       nullptr,
       dynamic_cast<CustomRedisHealthChecker*>(
-          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
+          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV3Yaml(yaml), context)
               .get()));
 }
 
@@ -84,11 +84,11 @@ TEST(HealthCheckerFactoryTest, DEPRECATED_FEATURE_TEST(CreateRedisWithoutKeyDepr
   NiceMock<Server::Configuration::MockHealthCheckerFactoryContext> context;
 
   RedisHealthCheckerFactory factory;
-  EXPECT_NE(
-      nullptr,
-      dynamic_cast<CustomRedisHealthChecker*>(
-          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
-              .get()));
+  EXPECT_NE(nullptr, dynamic_cast<CustomRedisHealthChecker*>(
+                         factory
+                             .createCustomHealthChecker(
+                                 Upstream::parseHealthCheckFromV3Yaml(yaml, false), context)
+                             .get()));
 }
 
 TEST(HealthCheckerFactoryTest, CreateRedisWithoutKey) {
@@ -111,7 +111,7 @@ TEST(HealthCheckerFactoryTest, CreateRedisWithoutKey) {
   EXPECT_NE(
       nullptr,
       dynamic_cast<CustomRedisHealthChecker*>(
-          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
+          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV3Yaml(yaml), context)
               .get()));
 }
 
@@ -136,7 +136,7 @@ TEST(HealthCheckerFactoryTest, CreateRedisWithLogHCFailure) {
   EXPECT_NE(
       nullptr,
       dynamic_cast<CustomRedisHealthChecker*>(
-          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV2Yaml(yaml), context)
+          factory.createCustomHealthChecker(Upstream::parseHealthCheckFromV3Yaml(yaml), context)
               .get()));
 }
 
@@ -165,7 +165,7 @@ TEST(HealthCheckerFactoryTest, CreateRedisViaUpstreamHealthCheckerFactory) {
   EXPECT_NE(nullptr,
             dynamic_cast<CustomRedisHealthChecker*>(
                 Upstream::HealthCheckerFactory::create(
-                    Upstream::parseHealthCheckFromV2Yaml(yaml), cluster, runtime, random,
+                    Upstream::parseHealthCheckFromV3Yaml(yaml), cluster, runtime, random,
                     dispatcher, log_manager, ProtobufMessage::getStrictValidationVisitor(), api)
                     .get()));
 }

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -49,7 +49,7 @@ public:
         "@type": type.googleapis.com/envoy.config.health_checker.redis.v2.Redis
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
@@ -73,7 +73,7 @@ public:
         "@type": type.googleapis.com/envoy.config.health_checker.redis.v2.Redis
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
@@ -97,7 +97,7 @@ public:
         key: foo
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
@@ -106,7 +106,7 @@ public:
         Upstream::HealthCheckEventLoggerPtr(event_logger_), *api_, *this);
   }
 
-  void setupExistsHealthcheckDeprecated() {
+  void setupExistsHealthcheckDeprecated(bool avoid_boosting = true) {
     const std::string yaml = R"EOF(
     timeout: 1s
     interval: 1s
@@ -120,7 +120,7 @@ public:
         key: foo
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml, avoid_boosting);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
@@ -144,7 +144,7 @@ public:
         "@type": type.googleapis.com/envoy.config.health_checker.redis.v2.Redis
     )EOF";
 
-    const auto& health_check_config = Upstream::parseHealthCheckFromV2Yaml(yaml);
+    const auto& health_check_config = Upstream::parseHealthCheckFromV3Yaml(yaml);
     const auto& redis_config = getRedisHealthCheckConfig(
         health_check_config, ProtobufMessage::getStrictValidationVisitor());
 
@@ -398,7 +398,7 @@ TEST_F(RedisHealthCheckerTest, LogInitialFailure) {
 
 TEST_F(RedisHealthCheckerTest, DEPRECATED_FEATURE_TEST(ExistsDeprecated)) {
   InSequence s;
-  setupExistsHealthcheckDeprecated();
+  setupExistsHealthcheckDeprecated(false);
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       Upstream::makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -78,7 +78,6 @@ envoy_extension_cc_test(
         "grpc_alts_handshaker_proto",
         "grpc_alts_transport_security_common_proto",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:utility_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -606,7 +606,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
   if (!options.clientSession().empty()) {
     const SslSocketInfo* ssl_socket =
         dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-    SSL* client_ssl_socket = ssl_socket->rawSslForTest();
+    SSL* client_ssl_socket = ssl_socket->ssl();
     SSL_CTX* client_ssl_context = SSL_get_SSL_CTX(client_ssl_socket);
     SSL_SESSION* client_ssl_session =
         SSL_SESSION_from_bytes(reinterpret_cast<const uint8_t*>(options.clientSession().data()),
@@ -649,7 +649,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
       EXPECT_EQ(options.expectedClientCertUri(), server_connection->ssl()->uriSanPeerCertificate());
       const SslSocketInfo* ssl_socket =
           dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-      SSL* client_ssl_socket = ssl_socket->rawSslForTest();
+      SSL* client_ssl_socket = ssl_socket->ssl();
       if (!options.expectedProtocolVersion().empty()) {
         EXPECT_EQ(options.expectedProtocolVersion(), client_connection->ssl()->tlsVersion());
       }
@@ -664,7 +664,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
       absl::optional<std::string> server_ssl_requested_server_name;
       const SslSocketInfo* server_ssl_socket =
           dynamic_cast<const SslSocketInfo*>(server_connection->ssl().get());
-      SSL* server_ssl = server_ssl_socket->rawSslForTest();
+      SSL* server_ssl = server_ssl_socket->ssl();
       auto requested_server_name = SSL_get_servername(server_ssl, TLSEXT_NAMETYPE_host_name);
       if (requested_server_name != nullptr) {
         server_ssl_requested_server_name = std::string(requested_server_name);
@@ -2511,7 +2511,7 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   const SslSocketInfo* ssl_socket =
       dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
   SSL_set_cert_cb(
-      ssl_socket->rawSslForTest(),
+      ssl_socket->ssl(),
       [](SSL* ssl, void*) -> int {
         STACK_OF(X509_NAME)* list = SSL_get_client_CA_list(ssl);
         EXPECT_NE(nullptr, list);
@@ -2624,7 +2624,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
         const SslSocketInfo* ssl_socket =
             dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-        ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
+        ssl_session = SSL_get1_session(ssl_socket->ssl());
         EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
         if (expected_lifetime_hint) {
           auto lifetime_hint = SSL_SESSION_get_ticket_lifetime_hint(ssl_session);
@@ -2647,7 +2647,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   const SslSocketInfo* ssl_socket =
       dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-  SSL_set_session(ssl_socket->rawSslForTest(), ssl_session);
+  SSL_set_session(ssl_socket->ssl(), ssl_session);
   SSL_SESSION_free(ssl_session);
 
   client_connection->connect();
@@ -2753,7 +2753,7 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
 
         const SslSocketInfo* ssl_socket =
             dynamic_cast<const SslSocketInfo*>(server_connection->ssl().get());
-        SSL* server_ssl_socket = ssl_socket->rawSslForTest();
+        SSL* server_ssl_socket = ssl_socket->ssl();
         SSL_CTX* server_ssl_context = SSL_get_SSL_CTX(server_ssl_socket);
         if (expect_support) {
           EXPECT_EQ(0, (SSL_CTX_get_options(server_ssl_context) & SSL_OP_NO_TICKET));
@@ -3207,7 +3207,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
         const SslSocketInfo* ssl_socket =
             dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-        ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
+        ssl_session = SSL_get1_session(ssl_socket->ssl());
         EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
         server_connection->close(Network::ConnectionCloseType::NoFlush);
         client_connection->close(Network::ConnectionCloseType::NoFlush);
@@ -3226,7 +3226,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   const SslSocketInfo* ssl_socket =
       dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-  SSL_set_session(ssl_socket->rawSslForTest(), ssl_session);
+  SSL_set_session(ssl_socket->ssl(), ssl_session);
   SSL_SESSION_free(ssl_session);
 
   client_connection->connect();

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -186,7 +186,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "cluster_filter_integration_test",
     srcs = ["cluster_filter_integration_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//include/envoy/network:filter_interface",
@@ -200,7 +199,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "custom_cluster_integration_test",
     srcs = ["custom_cluster_integration_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/upstream:load_balancer_lib",
@@ -376,7 +374,6 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/extensions/transport_sockets/tls:context_lib",
@@ -393,7 +390,6 @@ envoy_cc_test(
     srcs = [
         "header_casing_integration_test.cc",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
@@ -748,7 +744,6 @@ envoy_cc_test(
     # The symbol table cluster memory tests take a while to run specially under tsan.
     # Shard it to avoid test timeout.
     shard_count = 2,
-    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//source/common/memory:stats_lib",
@@ -947,7 +942,6 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//source/common/config:api_version_lib",
@@ -994,7 +988,6 @@ envoy_cc_test(
     srcs = [
         "tcp_conn_pool_integration_test.cc",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
         "//include/envoy/server:filter_config_interface",
@@ -1046,6 +1039,7 @@ envoy_cc_test(
     name = "dynamic_validation_integration_test",
     srcs = ["dynamic_validation_integration_test.cc"],
     data = ["//test/config/integration:server_xds_files"],
+    # Fails on windows with cr/lf yaml file checkouts
     tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -1088,7 +1082,6 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/http:header_map_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -942,6 +942,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    shard_count = 2,
     deps = [
         ":integration_lib",
         "//source/common/config:api_version_lib",

--- a/test/integration/ads_integration.h
+++ b/test/integration/ads_integration.h
@@ -10,6 +10,7 @@
 #include "envoy/config/route/v3/route.pb.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
+#include "test/config/utility.h"
 #include "test/integration/http_integration.h"
 
 namespace Envoy {

--- a/test/integration/cx_limit_integration_test.cc
+++ b/test/integration/cx_limit_integration_test.cc
@@ -43,7 +43,6 @@ public:
 
     std::vector<IntegrationTcpClientPtr> tcp_clients;
     std::vector<FakeRawConnectionPtr> raw_conns;
-
     tcp_clients.emplace_back(makeTcpConnection(lookupPort("listener_0")));
     raw_conns.emplace_back();
     ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(raw_conns.back()));
@@ -56,7 +55,8 @@ public:
 
     tcp_clients.emplace_back(makeTcpConnection(lookupPort("listener_0")));
     raw_conns.emplace_back();
-    ASSERT_FALSE(fake_upstreams_[0]->waitForRawConnection(raw_conns.back()));
+    ASSERT_FALSE(
+        fake_upstreams_[0]->waitForRawConnection(raw_conns.back(), std::chrono::milliseconds(500)));
     tcp_clients.back()->waitForDisconnect();
 
     // Get rid of the client that failed to connect.

--- a/test/integration/filter_manager_integration_test.cc
+++ b/test/integration/filter_manager_integration_test.cc
@@ -468,12 +468,12 @@ TEST_P(InjectDataWithEchoFilterIntegrationTest, FilterChainMismatch) {
   initialize();
 
   auto tcp_client = makeTcpConnection(lookupPort("listener_0"));
-  ASSERT_TRUE(tcp_client->write("hello"));
+  ASSERT_TRUE(tcp_client->write("hello", false));
 
   std::string access_log =
       absl::StrCat("NR ", StreamInfo::ResponseCodeDetails::get().FilterChainNotFound);
   EXPECT_THAT(waitForAccessLog(listener_access_log_name_), testing::HasSubstr(access_log));
-  tcp_client->close();
+  tcp_client->waitForDisconnect();
 }
 
 /**

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -9,6 +9,7 @@
 
 #include "common/buffer/buffer_impl.h"
 #include "common/http/header_map_impl.h"
+#include "common/network/socket_option_impl.h"
 
 #include "test/integration/utility.h"
 #include "test/mocks/http/mocks.h"
@@ -1520,7 +1521,13 @@ void Http2FloodMitigationTest::beginSession() {
   // set lower outbound frame limits to make tests run faster
   config_helper_.setOutboundFramesLimits(1000, 100);
   initialize();
-  tcp_client_ = makeTcpConnection(lookupPort("http"));
+  // Set up a raw connection to easily send requests without reading responses. Also, set a small
+  // TCP receive buffer to speed up connection backup.
+  auto options = std::make_shared<Network::Socket::Options>();
+  options->emplace_back(std::make_shared<Network::SocketOptionImpl>(
+      envoy::config::core::v3::SocketOption::STATE_PREBIND,
+      ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_RCVBUF), 1024));
+  tcp_client_ = makeTcpConnection(lookupPort("http"), options);
   startHttp2Session();
 }
 
@@ -1643,6 +1650,7 @@ TEST_P(Http2FloodMitigationTest, Data) {
   // Set large buffer limits so the test is not affected by the flow control.
   config_helper_.setBufferLimits(1024 * 1024 * 1024, 1024 * 1024 * 1024);
   autonomous_upstream_ = true;
+  autonomous_allow_incomplete_streams_ = true;
   beginSession();
   fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -82,7 +82,7 @@ protected:
   void floodServer(absl::string_view host, absl::string_view path,
                    Http2Frame::ResponseStatus expected_http_status, const std::string& flood_stat);
   Http2Frame readFrame();
-  void sendFame(const Http2Frame& frame);
+  void sendFrame(const Http2Frame& frame);
   void setNetworkConnectionBufferSize();
   void beginSession();
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -148,11 +148,10 @@ void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason reason, abs
   }
 }
 
-IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
-                                           Event::TestTimeSystem& time_system,
-                                           MockBufferFactory& factory, uint32_t port,
-                                           Network::Address::IpVersion version,
-                                           bool enable_half_close)
+IntegrationTcpClient::IntegrationTcpClient(
+    Event::Dispatcher& dispatcher, Event::TestTimeSystem& time_system, MockBufferFactory& factory,
+    uint32_t port, Network::Address::IpVersion version, bool enable_half_close,
+    const Network::ConnectionSocket::OptionsSharedPtr& options)
     : time_system_(time_system), payload_reader_(new WaitForPayloadReader(dispatcher)),
       callbacks_(new ConnectionCallbacks(*this)) {
   EXPECT_CALL(factory, create_(_, _, _))
@@ -166,7 +165,7 @@ IntegrationTcpClient::IntegrationTcpClient(Event::Dispatcher& dispatcher,
   connection_ = dispatcher.createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), nullptr);
+      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), options);
 
   ON_CALL(*client_write_buffer_, drain(_))
       .WillByDefault(testing::Invoke(client_write_buffer_, &MockWatermarkBuffer::baseDrain));
@@ -401,9 +400,11 @@ void BaseIntegrationTest::setUpstreamProtocol(FakeHttpConnection::Type protocol)
   }
 }
 
-IntegrationTcpClientPtr BaseIntegrationTest::makeTcpConnection(uint32_t port) {
+IntegrationTcpClientPtr
+BaseIntegrationTest::makeTcpConnection(uint32_t port,
+                                       const Network::ConnectionSocket::OptionsSharedPtr& options) {
   return std::make_unique<IntegrationTcpClient>(*dispatcher_, time_system_, *mock_buffer_factory_,
-                                                port, version_, enable_half_close_);
+                                                port, version_, enable_half_close_, options);
 }
 
 void BaseIntegrationTest::registerPort(const std::string& key, uint32_t port) {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -98,7 +98,8 @@ class IntegrationTcpClient {
 public:
   IntegrationTcpClient(Event::Dispatcher& dispatcher, Event::TestTimeSystem& time_system,
                        MockBufferFactory& factory, uint32_t port,
-                       Network::Address::IpVersion version, bool enable_half_close = false);
+                       Network::Address::IpVersion version, bool enable_half_close,
+                       const Network::ConnectionSocket::OptionsSharedPtr& options);
 
   void close();
   void waitForData(const std::string& data, bool exact_match = true);
@@ -190,7 +191,9 @@ public:
 
   FakeHttpConnection::Type upstreamProtocol() const { return upstream_protocol_; }
 
-  IntegrationTcpClientPtr makeTcpConnection(uint32_t port);
+  IntegrationTcpClientPtr
+  makeTcpConnection(uint32_t port,
+                    const Network::ConnectionSocket::OptionsSharedPtr& options = nullptr);
 
   // Test-wide port map.
   void registerPort(const std::string& key, uint32_t port);

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -238,10 +238,11 @@ public:
     }
   }
 
-  void
+  ABSL_MUST_USE_RESULT AssertionResult
   waitForLoadStatsRequest(const std::vector<envoy::config::endpoint::v3::UpstreamLocalityStats>&
                               expected_locality_stats,
                           uint64_t dropped = 0) {
+    auto end_time = timeSystem().monotonicTime() + TestUtility::DefaultTimeout;
     Protobuf::RepeatedPtrField<envoy::config::endpoint::v3::ClusterStats> expected_cluster_stats;
     if (!expected_locality_stats.empty() || dropped != 0) {
       auto* cluster_stats = expected_cluster_stats.Add();
@@ -288,8 +289,13 @@ public:
                                               "StreamLoadStats", apiVersion()),
           loadstats_stream_->headers().getPathValue());
       EXPECT_EQ("application/grpc", loadstats_stream_->headers().getContentTypeValue());
+      if (timeSystem().monotonicTime() >= end_time) {
+        return TestUtility::assertRepeatedPtrFieldEqual(expected_cluster_stats,
+                                                        loadstats_request.cluster_stats(), true);
+      }
     } while (!TestUtility::assertRepeatedPtrFieldEqual(expected_cluster_stats,
                                                        loadstats_request.cluster_stats(), true));
+    return testing::AssertionSuccess();
   }
 
   void waitForUpstreamResponse(uint32_t endpoint_index, uint32_t response_code = 200) {
@@ -388,7 +394,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   initialize();
 
   waitForLoadStatsStream();
-  waitForLoadStatsRequest({});
+  ASSERT_TRUE(waitForLoadStatsRequest({}));
   loadstats_stream_->startGrpcStream();
 
   // Simple 50%/50% split between dragon/winter localities. Also include an
@@ -402,8 +408,8 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   }
 
   // Verify we do not get empty stats for non-zero priorities.
-  waitForLoadStatsRequest(
-      {localityStats("winter", 2, 0, 0, 2), localityStats("dragon", 2, 0, 0, 2)});
+  ASSERT_TRUE(waitForLoadStatsRequest(
+      {localityStats("winter", 2, 0, 0, 2), localityStats("dragon", 2, 0, 0, 2)}));
 
   EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
   // On slow machines, more than one load stats response may be pushed while we are simulating load.
@@ -421,8 +427,8 @@ TEST_P(LoadStatsIntegrationTest, Success) {
 
   // No locality for priority=1 since there's no "winter" endpoints.
   // The hosts for dragon were received because membership_total is accurate.
-  waitForLoadStatsRequest(
-      {localityStats("winter", 2, 0, 0, 2), localityStats("dragon", 4, 0, 0, 4)});
+  ASSERT_TRUE(waitForLoadStatsRequest(
+      {localityStats("winter", 2, 0, 0, 2), localityStats("dragon", 4, 0, 0, 4)}));
 
   EXPECT_EQ(2, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(3, test_server_->counter("load_reporter.responses")->value());
@@ -437,8 +443,8 @@ TEST_P(LoadStatsIntegrationTest, Success) {
     sendAndReceiveUpstream(i % 2 + 3);
   }
 
-  waitForLoadStatsRequest(
-      {localityStats("winter", 2, 0, 0, 2, 1), localityStats("dragon", 2, 0, 0, 2, 1)});
+  ASSERT_TRUE(waitForLoadStatsRequest(
+      {localityStats("winter", 2, 0, 0, 2, 1), localityStats("dragon", 2, 0, 0, 2, 1)}));
   EXPECT_EQ(3, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(4, test_server_->counter("load_reporter.responses")->value());
   EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
@@ -452,7 +458,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
     sendAndReceiveUpstream(1);
   }
 
-  waitForLoadStatsRequest({localityStats("winter", 1, 0, 0, 1)});
+  ASSERT_TRUE(waitForLoadStatsRequest({localityStats("winter", 1, 0, 0, 1)}));
   EXPECT_EQ(4, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(5, test_server_->counter("load_reporter.responses")->value());
   EXPECT_EQ(0, test_server_->counter("load_reporter.errors")->value());
@@ -465,7 +471,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   sendAndReceiveUpstream(1);
   sendAndReceiveUpstream(1);
 
-  waitForLoadStatsRequest({localityStats("winter", 3, 0, 0, 3)});
+  ASSERT_TRUE(waitForLoadStatsRequest({localityStats("winter", 3, 0, 0, 3)}));
 
   EXPECT_EQ(6, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(6, test_server_->counter("load_reporter.responses")->value());
@@ -479,7 +485,7 @@ TEST_P(LoadStatsIntegrationTest, Success) {
   sendAndReceiveUpstream(1);
   sendAndReceiveUpstream(1);
 
-  waitForLoadStatsRequest({localityStats("winter", 2, 0, 0, 2)});
+  ASSERT_TRUE(waitForLoadStatsRequest({localityStats("winter", 2, 0, 0, 2)}));
 
   EXPECT_EQ(8, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(7, test_server_->counter("load_reporter.responses")->value());
@@ -496,7 +502,7 @@ TEST_P(LoadStatsIntegrationTest, LocalityWeighted) {
   initialize();
 
   waitForLoadStatsStream();
-  waitForLoadStatsRequest({});
+  ASSERT_TRUE(waitForLoadStatsRequest({}));
 
   loadstats_stream_->startGrpcStream();
   requestLoadStatsResponse({"cluster_0"});
@@ -514,8 +520,8 @@ TEST_P(LoadStatsIntegrationTest, LocalityWeighted) {
   sendAndReceiveUpstream(0);
 
   // Verify we get the expect request distribution.
-  waitForLoadStatsRequest(
-      {localityStats("winter", 4, 0, 0, 4), localityStats("dragon", 2, 0, 0, 2)});
+  ASSERT_TRUE(waitForLoadStatsRequest(
+      {localityStats("winter", 4, 0, 0, 4), localityStats("dragon", 2, 0, 0, 2)}));
 
   EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
   // On slow machines, more than one load stats response may be pushed while we are simulating load.
@@ -531,7 +537,7 @@ TEST_P(LoadStatsIntegrationTest, NoLocalLocality) {
   initialize();
 
   waitForLoadStatsStream();
-  waitForLoadStatsRequest({});
+  ASSERT_TRUE(waitForLoadStatsRequest({}));
   loadstats_stream_->startGrpcStream();
 
   // Simple 50%/50% split between dragon/winter localities. Also include an
@@ -548,8 +554,8 @@ TEST_P(LoadStatsIntegrationTest, NoLocalLocality) {
   // order of locality stats is different to the Success case, where winter is
   // the local locality (and hence first in the list as per
   // HostsPerLocality::get()).
-  waitForLoadStatsRequest(
-      {localityStats("dragon", 2, 0, 0, 2), localityStats("winter", 2, 0, 0, 2)});
+  ASSERT_TRUE(waitForLoadStatsRequest(
+      {localityStats("dragon", 2, 0, 0, 2), localityStats("winter", 2, 0, 0, 2)}));
 
   EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
   // On slow machines, more than one load stats response may be pushed while we are simulating load.
@@ -564,7 +570,7 @@ TEST_P(LoadStatsIntegrationTest, Error) {
   initialize();
 
   waitForLoadStatsStream();
-  waitForLoadStatsRequest({});
+  ASSERT_TRUE(waitForLoadStatsRequest({}));
   loadstats_stream_->startGrpcStream();
 
   requestLoadStatsResponse({"cluster_0"});
@@ -576,7 +582,7 @@ TEST_P(LoadStatsIntegrationTest, Error) {
   // This should count as "success" since non-5xx.
   sendAndReceiveUpstream(0, 404);
 
-  waitForLoadStatsRequest({localityStats("winter", 1, 1, 0, 2)});
+  ASSERT_TRUE(waitForLoadStatsRequest({localityStats("winter", 1, 1, 0, 2)}));
 
   EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(2, test_server_->counter("load_reporter.responses")->value());
@@ -590,13 +596,13 @@ TEST_P(LoadStatsIntegrationTest, InProgress) {
   initialize();
 
   waitForLoadStatsStream();
-  waitForLoadStatsRequest({});
+  ASSERT_TRUE(waitForLoadStatsRequest({}));
   loadstats_stream_->startGrpcStream();
   updateClusterLoadAssignment({{0}}, {}, {}, {});
 
   requestLoadStatsResponse({"cluster_0"});
   initiateClientConnection();
-  waitForLoadStatsRequest({localityStats("winter", 0, 0, 1, 1)});
+  ASSERT_TRUE(waitForLoadStatsRequest({localityStats("winter", 0, 0, 1, 1)}));
 
   waitForUpstreamResponse(0, 503);
   cleanupUpstreamAndDownstream();
@@ -618,7 +624,7 @@ TEST_P(LoadStatsIntegrationTest, Dropped) {
   initialize();
 
   waitForLoadStatsStream();
-  waitForLoadStatsRequest({});
+  ASSERT_TRUE(waitForLoadStatsRequest({}));
   loadstats_stream_->startGrpcStream();
 
   updateClusterLoadAssignment({{0}}, {}, {}, {});
@@ -630,7 +636,7 @@ TEST_P(LoadStatsIntegrationTest, Dropped) {
   EXPECT_EQ("503", response_->headers().getStatusValue());
   cleanupUpstreamAndDownstream();
 
-  waitForLoadStatsRequest({}, 1);
+  ASSERT_TRUE(waitForLoadStatsRequest({}, 1));
 
   EXPECT_EQ(1, test_server_->counter("load_reporter.requests")->value());
   EXPECT_LE(2, test_server_->counter("load_reporter.responses")->value());

--- a/test/integration/tcp_proxy_integration_test.h
+++ b/test/integration/tcp_proxy_integration_test.h
@@ -10,10 +10,16 @@
 
 namespace Envoy {
 
-class TcpProxyIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+struct TcpProxyIntegrationTestParams {
+  Network::Address::IpVersion version;
+  bool test_original_version;
+};
+
+class TcpProxyIntegrationTest : public testing::TestWithParam<TcpProxyIntegrationTestParams>,
                                 public BaseIntegrationTest {
 public:
-  TcpProxyIntegrationTest() : BaseIntegrationTest(GetParam(), ConfigHelper::tcpProxyConfig()) {
+  TcpProxyIntegrationTest()
+      : BaseIntegrationTest(GetParam().version, ConfigHelper::tcpProxyConfig()) {
     enable_half_close_ = true;
   }
 

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -96,8 +96,11 @@ public:
 
   MOCK_METHOD(void, start, ());
   MOCK_METHOD(void, pause, (const std::string& type_url));
+  MOCK_METHOD(void, pause, (const std::vector<std::string> type_urls));
   MOCK_METHOD(void, resume, (const std::string& type_url));
+  MOCK_METHOD(void, resume, (const std::vector<std::string> type_urls));
   MOCK_METHOD(bool, paused, (const std::string& type_url), (const));
+  MOCK_METHOD(bool, paused, (const std::vector<std::string> type_urls), (const));
 
   MOCK_METHOD(void, addSubscription,
               (const std::set<std::string>& resources, const std::string& type_url,

--- a/test/mocks/upstream/mocks.cc
+++ b/test/mocks/upstream/mocks.cc
@@ -177,5 +177,10 @@ MockRetryHostPredicate::~MockRetryHostPredicate() = default;
 MockClusterManagerFactory::MockClusterManagerFactory() = default;
 MockClusterManagerFactory::~MockClusterManagerFactory() = default;
 
+MockBasicResourceLimit::MockBasicResourceLimit() {
+  ON_CALL(*this, canCreate()).WillByDefault(Return(true));
+}
+MockBasicResourceLimit::~MockBasicResourceLimit() = default;
+
 } // namespace Upstream
 } // namespace Envoy

--- a/test/mocks/upstream/mocks.h
+++ b/test/mocks/upstream/mocks.h
@@ -433,5 +433,19 @@ public:
     return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Struct()};
   }
 };
+
+class MockBasicResourceLimit : public ResourceLimit {
+public:
+  MockBasicResourceLimit();
+  ~MockBasicResourceLimit() override;
+
+  MOCK_METHOD(bool, canCreate, ());
+  MOCK_METHOD(void, inc, ());
+  MOCK_METHOD(void, dec, ());
+  MOCK_METHOD(void, decBy, (uint64_t));
+  MOCK_METHOD(uint64_t, max, ());
+  MOCK_METHOD(uint64_t, count, (), (const));
+};
+
 } // namespace Upstream
 } // namespace Envoy

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -343,6 +343,7 @@ envoy_cc_test(
         ":server_test_data",
         ":static_validation_test_data",
     ],
+    # Fails on windows with cr/lf yaml file checkouts
     tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:version_lib",

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -1,4 +1,4 @@
-load("//bazel:envoy_build_system.bzl", "envoy_cc_fuzz_test", "envoy_cc_test", "envoy_package")
+load("//bazel:envoy_build_system.bzl", "envoy_cc_fuzz_test", "envoy_cc_test", "envoy_cc_test_library", "envoy_package", "envoy_proto_library")
 load("//source/extensions:all_extensions.bzl", "envoy_all_extensions")
 load("//bazel:repositories.bzl", "PPC_SKIP_TARGETS", "WINDOWS_SKIP_TARGETS")
 
@@ -106,4 +106,35 @@ envoy_cc_fuzz_test(
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),
+)
+
+envoy_proto_library(
+    name = "xds_fuzz_proto",
+    srcs = ["xds_fuzz.proto"],
+)
+
+envoy_cc_test_library(
+    name = "xds_fuzz_lib",
+    srcs = ["xds_fuzz.cc"],
+    hdrs = ["xds_fuzz.h"],
+    deps = [
+        ":xds_fuzz_proto_cc_proto",
+        "//test/integration:http_integration_lib",
+        "@envoy_api//envoy/admin/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_fuzz_test(
+    name = "xds_fuzz_test",
+    srcs = ["xds_fuzz_test.cc"],
+    corpus = "xds_corpus",
+    deps = [
+        ":xds_fuzz_lib",
+        "//source/common/protobuf:utility_lib",
+    ],
 )

--- a/test/server/config_validation/xds_corpus/example0
+++ b/test/server/config_validation/xds_corpus/example0
@@ -1,0 +1,31 @@
+actions {
+  add_listener {
+    listener_num : 0
+    route_num : 0
+  }
+}
+actions {
+  add_route {
+    route_num : 0
+  }
+}
+actions {
+  add_listener {
+    listener_num : 1
+    route_num : 1
+  }
+}
+actions {
+  add_route {
+    route_num : 1
+  }
+}
+actions {
+  add_listener {
+    listener_num : 2
+    route_num : 2
+  }
+}
+config {
+  sotw_or_delta : SOTW
+}

--- a/test/server/config_validation/xds_corpus/example1
+++ b/test/server/config_validation/xds_corpus/example1
@@ -1,0 +1,13 @@
+actions {
+  remove_route {
+    route_num: 1
+  }
+}
+actions {
+  remove_listener {
+    listener_num: 1
+  }
+}
+config {
+  sotw_or_delta: SOTW
+}

--- a/test/server/config_validation/xds_corpus/example2
+++ b/test/server/config_validation/xds_corpus/example2
@@ -1,0 +1,30 @@
+actions {
+  add_listener {
+	listener_num: 1
+	route_num: 1
+  }
+}
+actions {
+  add_route {
+	route_num: 1
+  }
+}
+actions {
+  remove_route {
+	route_num: 1
+  }
+}
+actions {
+  add_route {
+	route_num: 1
+  }
+}
+actions {
+  add_listener {
+	listener_num: 2
+	route_num: 2
+  }
+}
+config {
+  sotw_or_delta : DELTA
+}

--- a/test/server/config_validation/xds_corpus/example3
+++ b/test/server/config_validation/xds_corpus/example3
@@ -1,0 +1,19 @@
+actions {
+  add_route {
+    route_num : 0
+  }
+}
+actions {
+  add_listener {
+    listener_num : 0
+    route_num : 0
+  }
+}
+actions {
+  remove_listener {
+    listener_num : 0
+  }
+}
+config {
+  sotw_or_delta : SOTW
+}

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -1,0 +1,260 @@
+#include "test/server/config_validation/xds_fuzz.h"
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/endpoint/v3/endpoint.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+
+namespace Envoy {
+
+// helper functions to build API responses
+envoy::config::cluster::v3::Cluster XdsFuzzTest::buildCluster(const std::string& name) {
+  return ConfigHelper::buildCluster(name, "ROUND_ROBIN", api_version_);
+};
+
+envoy::config::endpoint::v3::ClusterLoadAssignment
+XdsFuzzTest::buildClusterLoadAssignment(const std::string& name) {
+  return ConfigHelper::buildClusterLoadAssignment(
+      name, Network::Test::getLoopbackAddressString(ip_version_),
+      fake_upstreams_[0]->localAddress()->ip()->port(), api_version_);
+}
+
+envoy::config::listener::v3::Listener XdsFuzzTest::buildListener(uint32_t listener_num,
+                                                                 uint32_t route_num) {
+  std::string name = absl::StrCat("listener_", listener_num % ListenersMax);
+  std::string route = absl::StrCat("route_config_", route_num % RoutesMax);
+  return ConfigHelper::buildListener(
+      name, route, Network::Test::getLoopbackAddressString(ip_version_), "ads_test", api_version_);
+}
+
+envoy::config::route::v3::RouteConfiguration XdsFuzzTest::buildRouteConfig(uint32_t route_num) {
+  std::string route = absl::StrCat("route_config_", route_num % RoutesMax);
+  return ConfigHelper::buildRouteConfig(route, "cluster_0", api_version_);
+}
+
+// helper functions to send API responses
+void XdsFuzzTest::updateListener(
+    const std::vector<envoy::config::listener::v3::Listener>& listeners,
+    const std::vector<envoy::config::listener::v3::Listener>& added_or_updated,
+    const std::vector<std::string>& removed) {
+  ENVOY_LOG_MISC(debug, "Sending Listener DiscoveryResponse version {}", version_);
+  sendDiscoveryResponse<envoy::config::listener::v3::Listener>(Config::TypeUrl::get().Listener,
+                                                               listeners, added_or_updated, removed,
+                                                               std::to_string(version_));
+}
+
+void XdsFuzzTest::updateRoute(
+    const std::vector<envoy::config::route::v3::RouteConfiguration> routes,
+    const std::vector<envoy::config::route::v3::RouteConfiguration>& added_or_updated,
+    const std::vector<std::string>& removed) {
+  ENVOY_LOG_MISC(debug, "Sending Route DiscoveryResponse version {}", version_);
+  sendDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+      Config::TypeUrl::get().RouteConfiguration, routes, added_or_updated, removed,
+      std::to_string(version_));
+}
+
+XdsFuzzTest::XdsFuzzTest(const test::server::config_validation::XdsTestCase& input,
+                         envoy::config::core::v3::ApiVersion api_version)
+    : HttpIntegrationTest(
+          Http::CodecClient::Type::HTTP2, TestEnvironment::getIpVersionsForTest()[0],
+          ConfigHelper::adsBootstrap(input.config().sotw_or_delta() ==
+                                             test::server::config_validation::Config::SOTW
+                                         ? "GRPC"
+                                         : "DELTA_GRPC",
+                                     api_version)),
+      actions_(input.actions()), version_(1), api_version_(api_version),
+      ip_version_(TestEnvironment::getIpVersionsForTest()[0]) {
+  use_lds_ = false;
+  create_xds_upstream_ = true;
+  tls_xds_upstream_ = false;
+
+  if (input.config().sotw_or_delta() == test::server::config_validation::Config::SOTW) {
+    sotw_or_delta_ = Grpc::SotwOrDelta::Sotw;
+  } else {
+    sotw_or_delta_ = Grpc::SotwOrDelta::Delta;
+  }
+}
+
+/**
+ * initialize an envoy configured with a fully dynamic bootstrap with ADS over gRPC
+ */
+void XdsFuzzTest::initialize() {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
+    auto* grpc_service = ads_config->add_grpc_services();
+
+    std::string cluster_name = "ads_cluster";
+    grpc_service->mutable_envoy_grpc()->set_cluster_name(cluster_name);
+    auto* ads_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    ads_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+    ads_cluster->set_name("ads_cluster");
+  });
+  setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
+  HttpIntegrationTest::initialize();
+  if (xds_stream_ == nullptr) {
+    createXdsConnection();
+    AssertionResult result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    xds_stream_->startGrpcStream();
+  }
+}
+
+void XdsFuzzTest::close() {
+  cleanUpXdsConnection();
+  test_server_.reset();
+  fake_upstreams_.clear();
+}
+
+/**
+ * remove a listener from the list of listeners if it exists
+ * @param the listener number to be removed
+ * @return the listener as an optional so that it can be used in a delta request
+ */
+absl::optional<std::string> XdsFuzzTest::removeListener(uint32_t listener_num) {
+  std::string match = absl::StrCat("listener_", listener_num % ListenersMax);
+
+  for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
+    if (it->name() == match) {
+      listeners_.erase(it);
+      return match;
+    }
+  }
+  return {};
+}
+
+/**
+ * remove a route from the list of routes if it exists
+ * @param the route number to be removed
+ * @return the route as an optional so that it can be used in a delta request
+ */
+absl::optional<std::string> XdsFuzzTest::removeRoute(uint32_t route_num) {
+  std::string match = absl::StrCat("route_config_", route_num % RoutesMax);
+  for (auto it = routes_.begin(); it != routes_.end(); ++it) {
+    if (it->name() == match) {
+      routes_.erase(it);
+      return match;
+    }
+  }
+  return {};
+}
+
+/**
+ * wait for a specific ACK, ignoring any other ACKs that are made in the meantime
+ * @param the expected API type url of the ack
+ * @param the expected version number
+ * @return AssertionSuccess() if the ack was received, else an AssertionError()
+ */
+AssertionResult XdsFuzzTest::waitForAck(const std::string& expected_type_url,
+                                        const std::string& expected_version) {
+  if (sotw_or_delta_ == Grpc::SotwOrDelta::Sotw) {
+    API_NO_BOOST(envoy::api::v2::DiscoveryRequest) discovery_request;
+    do {
+      VERIFY_ASSERTION(xds_stream_->waitForGrpcMessage(*dispatcher_, discovery_request));
+      ENVOY_LOG_MISC(info, "Received gRPC message with type {} and version {}",
+                     discovery_request.type_url(), expected_version);
+    } while (expected_type_url != discovery_request.type_url() &&
+             expected_version != discovery_request.version_info());
+  } else {
+    API_NO_BOOST(envoy::api::v2::DeltaDiscoveryRequest) delta_discovery_request;
+    do {
+      VERIFY_ASSERTION(xds_stream_->waitForGrpcMessage(*dispatcher_, delta_discovery_request));
+      ENVOY_LOG_MISC(info, "Received gRPC message with type {}",
+                     delta_discovery_request.type_url());
+    } while (expected_type_url != delta_discovery_request.type_url());
+  }
+  version_++;
+  return AssertionSuccess();
+}
+
+/**
+ * run the sequence of actions defined in the fuzzed protobuf
+ */
+void XdsFuzzTest::replay() {
+  initialize();
+
+  // set up cluster
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", {}, {}, {}, true));
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster,
+                                                             {buildCluster("cluster_0")},
+                                                             {buildCluster("cluster_0")}, {}, "0");
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().ClusterLoadAssignment, "",
+                                      {"cluster_0"}, {"cluster_0"}, {}));
+  sendDiscoveryResponse<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      Config::TypeUrl::get().ClusterLoadAssignment, {buildClusterLoadAssignment("cluster_0")},
+      {buildClusterLoadAssignment("cluster_0")}, {}, "0");
+
+  // the client will not subscribe to the RouteConfiguration type URL until it
+  // receives a listener, and the ACKS it sends back seem to be an empty type
+  // URL so just don't check them until a listener is added
+  bool sent_listener = false;
+
+  for (const auto& action : actions_) {
+    switch (action.action_selector_case()) {
+    case test::server::config_validation::Action::kAddListener: {
+      sent_listener = true;
+      uint32_t listener_num = action.add_listener().listener_num();
+      removeListener(listener_num);
+      auto listener = buildListener(listener_num, action.add_listener().route_num());
+      listeners_.push_back(listener);
+
+      updateListener(listeners_, {listener}, {});
+      // use waitForAck instead of compareDiscoveryRequest as the client makes
+      // additional discoveryRequests at launch that we might not want to
+      // respond to yet
+      EXPECT_TRUE(waitForAck(Config::TypeUrl::get().Listener, std::to_string(version_)));
+      break;
+    }
+    case test::server::config_validation::Action::kRemoveListener: {
+      /* sent_listener = true; */
+      auto removed = removeListener(action.remove_listener().listener_num());
+
+      if (removed) {
+        updateListener(listeners_, {}, {*removed});
+        EXPECT_TRUE(waitForAck(Config::TypeUrl::get().Listener, std::to_string(version_)));
+      }
+
+      break;
+    }
+    case test::server::config_validation::Action::kAddRoute: {
+      uint32_t route_num = action.add_route().route_num();
+      auto removed = removeRoute(route_num);
+      auto route = buildRouteConfig(route_num);
+      routes_.push_back(route);
+
+      if (removed) {
+        // if the route was already in routes_, don't send a duplicate add in delta request
+        updateRoute(routes_, {}, {});
+      } else {
+        updateRoute(routes_, {route}, {});
+      }
+
+      if (sent_listener) {
+        EXPECT_TRUE(
+            waitForAck(Config::TypeUrl::get().RouteConfiguration, std::to_string(version_)));
+      }
+      break;
+    }
+    case test::server::config_validation::Action::kRemoveRoute: {
+      if (sotw_or_delta_ == Grpc::SotwOrDelta::Sotw) {
+        // routes cannot be removed in SOTW updates
+        break;
+      }
+
+      auto removed = removeRoute(action.remove_route().route_num());
+      if (removed) {
+        updateRoute(routes_, {}, {*removed});
+        EXPECT_TRUE(
+            waitForAck(Config::TypeUrl::get().RouteConfiguration, std::to_string(version_)));
+      }
+      break;
+    }
+    default:
+      break;
+    }
+  }
+
+  close();
+}
+
+} // namespace Envoy

--- a/test/server/config_validation/xds_fuzz.h
+++ b/test/server/config_validation/xds_fuzz.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/admin/v3/config_dump.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/endpoint/v3/endpoint.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+
+#include "test/common/grpc/grpc_client_integration.h"
+#include "test/config/utility.h"
+#include "test/integration/http_integration.h"
+#include "test/server/config_validation/xds_fuzz.pb.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+
+class XdsFuzzTest : public HttpIntegrationTest {
+public:
+  XdsFuzzTest(const test::server::config_validation::XdsTestCase& input,
+              envoy::config::core::v3::ApiVersion api_version);
+
+  envoy::config::cluster::v3::Cluster buildCluster(const std::string& name);
+
+  envoy::config::endpoint::v3::ClusterLoadAssignment
+  buildClusterLoadAssignment(const std::string& name);
+
+  envoy::config::listener::v3::Listener buildListener(uint32_t listener_num, uint32_t route_num);
+
+  envoy::config::route::v3::RouteConfiguration buildRouteConfig(uint32_t route_num);
+
+  void updateListener(const std::vector<envoy::config::listener::v3::Listener>& listeners,
+                      const std::vector<envoy::config::listener::v3::Listener>& added_or_updated,
+                      const std::vector<std::string>& removed);
+
+  void
+  updateRoute(const std::vector<envoy::config::route::v3::RouteConfiguration> routes,
+              const std::vector<envoy::config::route::v3::RouteConfiguration>& added_or_updated,
+              const std::vector<std::string>& removed);
+
+  void initialize() override;
+  void replay();
+  void close();
+
+  const size_t ListenersMax = 3;
+  const size_t RoutesMax = 5;
+
+private:
+  absl::optional<std::string> removeListener(uint32_t listener_num);
+  absl::optional<std::string> removeRoute(uint32_t route_num);
+  AssertionResult waitForAck(const std::string& expected_type_url,
+                             const std::string& expected_version);
+
+  Protobuf::RepeatedPtrField<test::server::config_validation::Action> actions_;
+  std::vector<envoy::config::route::v3::RouteConfiguration> routes_;
+  std::vector<envoy::config::listener::v3::Listener> listeners_;
+
+  uint64_t version_;
+  envoy::config::core::v3::ApiVersion api_version_;
+
+  Network::Address::IpVersion ip_version_;
+};
+
+} // namespace Envoy

--- a/test/server/config_validation/xds_fuzz.proto
+++ b/test/server/config_validation/xds_fuzz.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package test.server.config_validation;
+
+import "validate/validate.proto";
+
+message AddListener {
+  // generates a new listener listener_x with number listener_num, which can later be removed by
+  // RemoveListener
+  // if listener_x had already been added, it will update listener_x's route_config
+  uint32 listener_num = 1;
+  // listener_x references route_y, which has number route_num
+  uint32 route_num = 2;
+}
+
+message AddRoute {
+  // generates a new route route_y with number route_num which can later be removed by a RemoveRoute
+  uint32 route_num = 1;
+}
+
+message RemoveListener {
+  // removes listener_x
+  uint32 listener_num = 1;
+}
+
+message RemoveRoute {
+  // removes route_y
+  uint32 route_num = 1;
+}
+
+message Action {
+  oneof action_selector {
+    option (validate.required) = true;
+
+    AddListener add_listener = 1;
+    AddRoute add_route = 2;
+    RemoveListener remove_listener = 3;
+    RemoveRoute remove_route = 4;
+  }
+}
+
+message Config {
+  enum SotwOrDelta {
+    SOTW = 0;
+    DELTA = 1;
+  }
+  SotwOrDelta sotw_or_delta = 1;
+}
+
+message XdsTestCase {
+  repeated Action actions = 1;
+  Config config = 2;
+}

--- a/test/server/config_validation/xds_fuzz_test.cc
+++ b/test/server/config_validation/xds_fuzz_test.cc
@@ -1,0 +1,21 @@
+/* #include "common/protobuf/utility.h" */
+
+#include "test/fuzz/fuzz_runner.h"
+#include "test/server/config_validation/xds_fuzz.h"
+#include "test/server/config_validation/xds_fuzz.pb.validate.h"
+
+namespace Envoy {
+
+DEFINE_PROTO_FUZZER(const test::server::config_validation::XdsTestCase& input) {
+  RELEASE_ASSERT(!TestEnvironment::getIpVersionsForTest().empty(), "");
+  try {
+    TestUtility::validate(input);
+  } catch (const ProtoValidationException& e) {
+    ENVOY_LOG_MISC(debug, "ProtoValidationException: {}", e.what());
+    return;
+  }
+  XdsFuzzTest test(input, envoy::config::core::v3::ApiVersion::V2);
+  test.replay();
+}
+
+} // namespace Envoy

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -550,8 +550,10 @@ public:
   }
 
   static void loadFromYaml(const std::string& yaml, Protobuf::Message& message,
-                           bool preserve_original_type = false) {
-    MessageUtil::loadFromYaml(yaml, message, ProtobufMessage::getStrictValidationVisitor());
+                           bool preserve_original_type = false, bool avoid_boosting = false) {
+    MessageUtil::loadFromYaml(yaml, message, ProtobufMessage::getStrictValidationVisitor(),
+                              !avoid_boosting);
+
     if (!preserve_original_type) {
       Config::VersionConverter::eraseOriginalTypeInformation(message);
     }
@@ -572,9 +574,10 @@ public:
 
   template <class MessageType>
   static void loadFromYamlAndValidate(const std::string& yaml, MessageType& message,
-                                      bool preserve_original_type = false) {
-    MessageUtil::loadFromYamlAndValidate(yaml, message,
-                                         ProtobufMessage::getStrictValidationVisitor());
+                                      bool preserve_original_type = false,
+                                      bool avoid_boosting = false) {
+    MessageUtil::loadFromYamlAndValidate(
+        yaml, message, ProtobufMessage::getStrictValidationVisitor(), avoid_boosting);
     if (!preserve_original_type) {
       Config::VersionConverter::eraseOriginalTypeInformation(message);
     }

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -203,6 +203,10 @@ def GetImportDeps(proto_path):
         if import_path.startswith('udpa/annotations/'):
           imports.append('@com_github_cncf_udpa//udpa/annotations:pkg')
           continue
+        # Special case handling for UDPA core.
+        if import_path.startswith('udpa/core/v1/'):
+          imports.append('@com_github_cncf_udpa//udpa/core/v1:pkg')
+          continue
         # Explicit remapping for external deps, compute paths for envoy/*.
         if import_path in external_proto_deps.EXTERNAL_PROTO_IMPORT_BAZEL_DEP_MAP:
           imports.append(external_proto_deps.EXTERNAL_PROTO_IMPORT_BAZEL_DEP_MAP[import_path])


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

Commit Message: This PR clarifies some ownership semantics between SslSocket and SslSocketInfo

Additional Description: Namely, SslSocket no longer holds a SSL*; instead, it relies on the already-kept SslSocketInfo struct and its already-public ssl() accessor. Now SSL* is owned by exactly one class (SslSocketInfo). This PR is necessary for a future PR which asks SslSocketInfo to temporarily relinquish ownership of that SSL*. I am happy to hold off on submitting this PR until that one is approved and ready to submit.

Risk Level: Low
Testing: Minimal -- method names change but not functionality.
Docs Changes: None.
Release Notes: n/a