### PR TITLE
test: Use benchmark build and test target framework for lc_trie_speed_test

### DIFF
--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -4,7 +4,6 @@ load(
     "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -312,7 +311,7 @@ envoy_cc_fuzz_test(
     ],
 )
 
-envoy_cc_test_binary(
+envoy_cc_benchmark_binary(
     name = "lc_trie_speed_test",
     srcs = ["lc_trie_speed_test.cc"],
     external_deps = [
@@ -322,6 +321,11 @@ envoy_cc_test_binary(
         "//source/common/network:lc_trie_lib",
         "//source/common/network:utility_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "lc_trie_speed_test_benchmark_test",
+    benchmark_binary = "lc_trie_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/network/lc_trie_speed_test.cc
+++ b/test/common/network/lc_trie_speed_test.cc
@@ -5,30 +5,61 @@
 
 namespace {
 
-std::vector<Envoy::Network::Address::InstanceConstSharedPtr> addresses;
+struct AddressInputs {
+  AddressInputs() {
+    // Random test addresses from RFC 5737 netblocks
+    static const std::string test_addresses[] = {
+        "192.0.2.225",   "198.51.100.55", "198.51.100.105", "192.0.2.150",   "203.0.113.162",
+        "203.0.113.110", "203.0.113.99",  "198.51.100.23",  "198.51.100.24", "203.0.113.12"};
+    for (const auto& address : test_addresses) {
+      addresses_.push_back(Envoy::Network::Utility::parseInternetAddress(address));
+    }
+  }
 
-std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>> tag_data;
+  std::vector<Envoy::Network::Address::InstanceConstSharedPtr> addresses_;
+};
 
-std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
-    tag_data_nested_prefixes;
+struct CidrInputs {
+  CidrInputs() {
+    // Construct three sets of prefixes: one consisting of 1,024 addresses in an
+    // RFC 5737 netblock, another consisting of those same addresses plus
+    // 0.0.0.0/0 (to exercise the LC Trie's support for nested prefixes),
+    // and finally a set containing only 0.0.0.0/0.
+    for (int i = 0; i < 32; i++) {
+      for (int j = 0; j < 32; j++) {
+        tag_data_.emplace_back(
+            std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+                {"tag_1",
+                 {Envoy::Network::Address::CidrRange::create(
+                     fmt::format("192.0.{}.{}/32", i, j))}}));
+      }
+    }
+    tag_data_nested_prefixes_ = tag_data_;
+    tag_data_nested_prefixes_.emplace_back(
+        std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+            {"tag_0", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
+    tag_data_minimal_.emplace_back(
+        std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
+            {"tag_1", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
+  }
 
-std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
-    tag_data_minimal;
-
-std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie;
-
-std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_nested_prefixes;
-
-std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_minimal;
+  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>> tag_data_;
+  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
+      tag_data_nested_prefixes_;
+  std::vector<std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>>
+      tag_data_minimal_;
+};
 
 } // namespace
 
 namespace Envoy {
 
 static void BM_LcTrieConstruct(benchmark::State& state) {
+  CidrInputs inputs;
+
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(inputs.tag_data_);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -36,9 +67,12 @@ static void BM_LcTrieConstruct(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstruct);
 
 static void BM_LcTrieConstructNested(benchmark::State& state) {
+  CidrInputs inputs;
+
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_nested_prefixes);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(
+        inputs.tag_data_nested_prefixes_);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -46,10 +80,11 @@ static void BM_LcTrieConstructNested(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstructNested);
 
 static void BM_LcTrieConstructMinimal(benchmark::State& state) {
+  CidrInputs inputs;
 
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
   for (auto _ : state) {
-    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_minimal);
+    trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(inputs.tag_data_minimal_);
   }
   benchmark::DoNotOptimize(trie);
 }
@@ -57,12 +92,17 @@ static void BM_LcTrieConstructMinimal(benchmark::State& state) {
 BENCHMARK(BM_LcTrieConstructMinimal);
 
 static void BM_LcTrieLookup(benchmark::State& state) {
+  CidrInputs cidr_inputs;
+  AddressInputs address_inputs;
+  std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie =
+      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(cidr_inputs.tag_data_);
+
   static size_t i = 0;
   size_t output_tags = 0;
   for (auto _ : state) {
     i++;
-    i %= addresses.size();
-    output_tags += lc_trie->getData(addresses[i]).size();
+    i %= address_inputs.addresses_.size();
+    output_tags += lc_trie->getData(address_inputs.addresses_[i]).size();
   }
   benchmark::DoNotOptimize(output_tags);
 }
@@ -70,12 +110,18 @@ static void BM_LcTrieLookup(benchmark::State& state) {
 BENCHMARK(BM_LcTrieLookup);
 
 static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
+  CidrInputs cidr_inputs;
+  AddressInputs address_inputs;
+  std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_nested_prefixes =
+      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(
+          cidr_inputs.tag_data_nested_prefixes_);
+
   static size_t i = 0;
   size_t output_tags = 0;
   for (auto _ : state) {
     i++;
-    i %= addresses.size();
-    output_tags += lc_trie_nested_prefixes->getData(addresses[i]).size();
+    i %= address_inputs.addresses_.size();
+    output_tags += lc_trie_nested_prefixes->getData(address_inputs.addresses_[i]).size();
   }
   benchmark::DoNotOptimize(output_tags);
 }
@@ -83,12 +129,17 @@ static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
 BENCHMARK(BM_LcTrieLookupWithNestedPrefixes);
 
 static void BM_LcTrieLookupMinimal(benchmark::State& state) {
+  CidrInputs cidr_inputs;
+  AddressInputs address_inputs;
+  std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_minimal =
+      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(cidr_inputs.tag_data_minimal_);
+
   static size_t i = 0;
   size_t output_tags = 0;
   for (auto _ : state) {
     i++;
-    i %= addresses.size();
-    output_tags += lc_trie_minimal->getData(addresses[i]).size();
+    i %= address_inputs.addresses_.size();
+    output_tags += lc_trie_minimal->getData(address_inputs.addresses_[i]).size();
   }
   benchmark::DoNotOptimize(output_tags);
 }
@@ -96,45 +147,3 @@ static void BM_LcTrieLookupMinimal(benchmark::State& state) {
 BENCHMARK(BM_LcTrieLookupMinimal);
 
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-
-  // Random test addresses from RFC 5737 netblocks
-  static const std::string test_addresses[] = {
-      "192.0.2.225",   "198.51.100.55", "198.51.100.105", "192.0.2.150",   "203.0.113.162",
-      "203.0.113.110", "203.0.113.99",  "198.51.100.23",  "198.51.100.24", "203.0.113.12"};
-  for (const auto& address : test_addresses) {
-    addresses.push_back(Envoy::Network::Utility::parseInternetAddress(address));
-  }
-
-  // Construct three sets of prefixes: one consisting of 1,024 addresses in an
-  // RFC 5737 netblock, another consisting of those same addresses plus
-  // 0.0.0.0/0 (to exercise the LC Trie's support for nested prefixes),
-  // and finally a set containing only 0.0.0.0/0.
-  for (int i = 0; i < 32; i++) {
-    for (int j = 0; j < 32; j++) {
-      tag_data.emplace_back(std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-          {"tag_1",
-           {Envoy::Network::Address::CidrRange::create(fmt::format("192.0.{}.{}/32", i, j))}}));
-    }
-  }
-  tag_data_nested_prefixes = tag_data;
-  tag_data_nested_prefixes.emplace_back(
-      std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-          {"tag_0", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
-  tag_data_minimal.emplace_back(
-      std::pair<std::string, std::vector<Envoy::Network::Address::CidrRange>>(
-          {"tag_1", {Envoy::Network::Address::CidrRange::create("0.0.0.0/0")}}));
-
-  lc_trie = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data);
-  lc_trie_nested_prefixes =
-      std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_nested_prefixes);
-  lc_trie_minimal = std::make_unique<Envoy::Network::LcTrie::LcTrie<std::string>>(tag_data_minimal);
-
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/network/lc_trie_speed_test.cc
+++ b/test/common/network/lc_trie_speed_test.cc
@@ -54,7 +54,7 @@ struct CidrInputs {
 
 namespace Envoy {
 
-static void BM_LcTrieConstruct(benchmark::State& state) {
+static void lcTrieConstruct(benchmark::State& state) {
   CidrInputs inputs;
 
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
@@ -64,9 +64,9 @@ static void BM_LcTrieConstruct(benchmark::State& state) {
   benchmark::DoNotOptimize(trie);
 }
 
-BENCHMARK(BM_LcTrieConstruct);
+BENCHMARK(lcTrieConstruct);
 
-static void BM_LcTrieConstructNested(benchmark::State& state) {
+static void lcTrieConstructNested(benchmark::State& state) {
   CidrInputs inputs;
 
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
@@ -77,9 +77,9 @@ static void BM_LcTrieConstructNested(benchmark::State& state) {
   benchmark::DoNotOptimize(trie);
 }
 
-BENCHMARK(BM_LcTrieConstructNested);
+BENCHMARK(lcTrieConstructNested);
 
-static void BM_LcTrieConstructMinimal(benchmark::State& state) {
+static void lcTrieConstructMinimal(benchmark::State& state) {
   CidrInputs inputs;
 
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> trie;
@@ -89,9 +89,9 @@ static void BM_LcTrieConstructMinimal(benchmark::State& state) {
   benchmark::DoNotOptimize(trie);
 }
 
-BENCHMARK(BM_LcTrieConstructMinimal);
+BENCHMARK(lcTrieConstructMinimal);
 
-static void BM_LcTrieLookup(benchmark::State& state) {
+static void lcTrieLookup(benchmark::State& state) {
   CidrInputs cidr_inputs;
   AddressInputs address_inputs;
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie =
@@ -107,9 +107,9 @@ static void BM_LcTrieLookup(benchmark::State& state) {
   benchmark::DoNotOptimize(output_tags);
 }
 
-BENCHMARK(BM_LcTrieLookup);
+BENCHMARK(lcTrieLookup);
 
-static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
+static void lcTrieLookupWithNestedPrefixes(benchmark::State& state) {
   CidrInputs cidr_inputs;
   AddressInputs address_inputs;
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_nested_prefixes =
@@ -126,9 +126,9 @@ static void BM_LcTrieLookupWithNestedPrefixes(benchmark::State& state) {
   benchmark::DoNotOptimize(output_tags);
 }
 
-BENCHMARK(BM_LcTrieLookupWithNestedPrefixes);
+BENCHMARK(lcTrieLookupWithNestedPrefixes);
 
-static void BM_LcTrieLookupMinimal(benchmark::State& state) {
+static void lcTrieLookupMinimal(benchmark::State& state) {
   CidrInputs cidr_inputs;
   AddressInputs address_inputs;
   std::unique_ptr<Envoy::Network::LcTrie::LcTrie<std::string>> lc_trie_minimal =
@@ -144,6 +144,6 @@ static void BM_LcTrieLookupMinimal(benchmark::State& state) {
   benchmark::DoNotOptimize(output_tags);
 }
 
-BENCHMARK(BM_LcTrieLookupMinimal);
+BENCHMARK(lcTrieLookupMinimal);
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: test: Convert lc_trie_speed_test to benchmark cc binary and test framework
Additional Description:
Risk Level: n/a test-only
Testing: enabled test for fixed benchmark
Docs Changes: n/a
Release Notes: n/a
