### PR TITLE
Add docker docs regarding file/logging permissions

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -160,6 +160,25 @@ for controlling access to an ``envoy`` socket from outside of the container.
 
 If you wish to run the container as the ``root`` user you can set ``ENVOY_UID`` to ``0``.
 
+The ``envoy`` image sends application logs to ``/dev/stdout`` and ``/dev/stderr`` by default, and these
+can be viewed in the container log.
+
+If you send application, admin or access logs to a file output, the ``envoy`` user will require the
+necessary permissions to write to this file. This can be achieved by setting the ``ENVOY_UID`` and/or
+by making the file writeable by the envoy user.
+
+For example, to mount a log folder from the host and make it writable, you can:
+
+.. substitution-code-block:: none
+
+  $ mkdir logs
+  $ chown 777 logs
+  $ docker run -d -v `pwd`/logs:/var/log --name envoy -e ENVOY_UID=777 -p 9901:9901 -p 10000:10000 envoy:v1
+
+You can then configure ``envoy`` to log to files in ``/var/log``
+
+The default ``envoy`` ``uid`` and ``gid`` are ``101``.
+
 
 Sandboxes
 ---------


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Add docker docs regarding file/logging permissions
Additional Description: Explains default container logging and requirements to log to file
Risk Level: low
Testing:
Docs Changes: `docs/root/start/start.rst`
Release Notes: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue] Touch #11836 
[Optional Deprecated:]
