### PR TITLE
android: Disable getifaddrs call for old NDK versions

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -235,3 +235,15 @@ struct mmsghdr {
   unsigned int msg_len;
 };
 #endif
+
+#define SUPPORTS_GETIFADDRS
+#ifdef WIN32
+#undef SUPPORTS_GETIFADDRS
+#endif
+
+// https://android.googlesource.com/platform/prebuilts/ndk/+/dev/platform/sysroot/usr/include/ifaddrs.h
+#ifdef __ANDROID_API__
+#if __ANDROID_API__ < 24
+#undef SUPPORTS_GETIFADDRS
+#endif // __ANDROID_API__ < 24
+#endif // ifdef __ANDROID_API__

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -190,13 +190,25 @@ void Utility::throwWithMalformedIp(absl::string_view ip_address) {
   throw EnvoyException(absl::StrCat("malformed IP address: ", ip_address));
 }
 
+#define SUPPORTS_GETIFADDRS
+#ifdef WIN32
+#undef SUPPORTS_GETIFADDRS
+#endif
+
+// https://android.googlesource.com/platform/prebuilts/ndk/+/dev/platform/sysroot/usr/include/ifaddrs.h
+#ifdef __ANDROID_API__
+#if __ANDROID_API__ < 24
+#undef SUPPORTS_GETIFADDRS
+#endif // __ANDROID_API__ < 24
+#endif // ifdef __ANDROID_API__
+
 // TODO(hennna): Currently getLocalAddress does not support choosing between
 // multiple interfaces and addresses not returned by getifaddrs. In addition,
 // the default is to return a loopback address of type version. This function may
 // need to be updated in the future. Discussion can be found at Github issue #939.
 Address::InstanceConstSharedPtr Utility::getLocalAddress(const Address::IpVersion version) {
   Address::InstanceConstSharedPtr ret;
-#ifndef WIN32
+#ifdef SUPPORTS_GETIFADDRS
   struct ifaddrs* ifaddr;
   struct ifaddrs* ifa;
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -190,18 +190,6 @@ void Utility::throwWithMalformedIp(absl::string_view ip_address) {
   throw EnvoyException(absl::StrCat("malformed IP address: ", ip_address));
 }
 
-#define SUPPORTS_GETIFADDRS
-#ifdef WIN32
-#undef SUPPORTS_GETIFADDRS
-#endif
-
-// https://android.googlesource.com/platform/prebuilts/ndk/+/dev/platform/sysroot/usr/include/ifaddrs.h
-#ifdef __ANDROID_API__
-#if __ANDROID_API__ < 24
-#undef SUPPORTS_GETIFADDRS
-#endif // __ANDROID_API__ < 24
-#endif // ifdef __ANDROID_API__
-
 // TODO(hennna): Currently getLocalAddress does not support choosing between
 // multiple interfaces and addresses not returned by getifaddrs. In addition,
 // the default is to return a loopback address of type version. This function may


### PR DESCRIPTION
`getifaddrs` and `freeifaddrs` were added in Android NDK API version 24.
This patch skips that logic, as was being done for WIN32, if that's your
target version.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>