### PR TITLE
Ratelimit: Add default value to dynamic metadata action

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1484,6 +1484,10 @@ message RateLimit {
       // Metadata struct that defines the key and path to retrieve the string value. A match will
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
+
+      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // no value is present under the metadata_key then no descriptor is generated.
+      string default_value = 3;
     }
 
     oneof action_specifier {

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1485,7 +1485,7 @@ message RateLimit {
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
 
-      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // An optional value to use if *metadata_key* is empty. If not set and
       // no value is present under the metadata_key then no descriptor is generated.
       string default_value = 3;
     }

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1466,6 +1466,10 @@ message RateLimit {
       // Metadata struct that defines the key and path to retrieve the string value. A match will
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
+
+      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // no value is present under the metadata_key then no descriptor is generated.
+      string default_value = 3;
     }
 
     oneof action_specifier {

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1467,7 +1467,7 @@ message RateLimit {
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
 
-      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // An optional value to use if *metadata_key* is empty. If not set and
       // no value is present under the metadata_key then no descriptor is generated.
       string default_value = 3;
     }

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1497,7 +1497,7 @@ message RateLimit {
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
 
-      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // An optional value to use if *metadata_key* is empty. If not set and
       // no value is present under the metadata_key then no descriptor is generated.
       string default_value = 3;
     }

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1496,6 +1496,10 @@ message RateLimit {
       // Metadata struct that defines the key and path to retrieve the string value. A match will
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
+
+      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // no value is present under the metadata_key then no descriptor is generated.
+      string default_value = 3;
     }
 
     oneof action_specifier {

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1494,6 +1494,10 @@ message RateLimit {
       // Metadata struct that defines the key and path to retrieve the string value. A match will
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
+
+      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // no value is present under the metadata_key then no descriptor is generated.
+      string default_value = 3;
     }
 
     oneof action_specifier {

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1495,7 +1495,7 @@ message RateLimit {
       // only happen if the value in the dynamic metadata is of type string.
       type.metadata.v3.MetadataKey metadata_key = 2 [(validate.rules).message = {required: true}];
 
-      // An optional value to use if no value is queried from the metadata_key. If not set and
+      // An optional value to use if *metadata_key* is empty. If not set and
       // no value is present under the metadata_key then no descriptor is generated.
       string default_value = 3;
     }

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -125,6 +125,7 @@ public:
 private:
   const Envoy::Config::MetadataKey metadata_key_;
   const std::string descriptor_key_;
+  const std::string default_value_;
 };
 
 /**

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -480,6 +480,7 @@ filter_metadata:
               testing::ContainerEq(descriptors_));
 }
 
+// Tests that the default_value is used in the descriptor when the metadata_key is empty.
 TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataNoMatchWithDefaultValue) {
   const std::string yaml = R"EOF(
 actions:
@@ -571,7 +572,7 @@ filter_metadata:
 
   EXPECT_TRUE(descriptors_.empty());
 }
-
+// Tests that no descriptor is generated when both the metadata_key and default_value are empty.
 TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataAndDefaultValueEmpty) {
   const std::string yaml = R"EOF(
 actions:

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -453,6 +453,7 @@ TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataMatch) {
 actions:
 - dynamic_metadata:
     descriptor_key: fake_key
+    default_value: fake_value
     metadata_key:
       key: 'envoy.xxx'
       path:
@@ -476,6 +477,38 @@ filter_metadata:
                                          &metadata);
 
   EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"fake_key", "foo"}}}}),
+              testing::ContainerEq(descriptors_));
+}
+
+TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataNoMatchWithDefaultValue) {
+  const std::string yaml = R"EOF(
+actions:
+- dynamic_metadata:
+    descriptor_key: fake_key
+    default_value: fake_value
+    metadata_key:
+      key: 'envoy.xxx'
+      path:
+      - key: test
+      - key: prop
+  )EOF";
+
+  setupTest(yaml);
+
+  std::string metadata_yaml = R"EOF(
+filter_metadata:
+  envoy.xxx:
+    another_key:
+      prop: foo
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  TestUtility::loadFromYaml(metadata_yaml, metadata);
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         &metadata);
+
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"fake_key", "fake_value"}}}}),
               testing::ContainerEq(descriptors_));
 }
 
@@ -527,6 +560,37 @@ actions:
 filter_metadata:
   envoy.xxx:
     test:
+      prop: ""
+  )EOF";
+
+  envoy::config::core::v3::Metadata metadata;
+  TestUtility::loadFromYaml(metadata_yaml, metadata);
+
+  rate_limit_entry_->populateDescriptors(route_, descriptors_, "", header_, default_remote_address_,
+                                         &metadata);
+
+  EXPECT_TRUE(descriptors_.empty());
+}
+
+TEST_F(RateLimitPolicyEntryTest, DynamicMetaDataAndDefaultValueEmpty) {
+  const std::string yaml = R"EOF(
+actions:
+- dynamic_metadata:
+    descriptor_key: fake_key
+    default_value: ""
+    metadata_key:
+      key: 'envoy.xxx'
+      path:
+      - key: test
+      - key: prop
+  )EOF";
+
+  setupTest(yaml);
+
+  std::string metadata_yaml = R"EOF(
+filter_metadata:
+  envoy.xxx:
+    another_key:
       prop: ""
   )EOF";
 


### PR DESCRIPTION
Modified dynamic_metadata action to now accept an optional default
value for instances where no value is queried from the dynamic metadata.

Signed-off-by: Clara Andrew-Wani <candrewwani@gmail.com>

Risk Level: low
Testing: unit test
Docs Changes:
Release Notes:
Fixes #11849 