### PR TITLE
tls: fix wilcard matching

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -710,7 +710,8 @@ bool ContextImpl::dnsNameMatch(const std::string& dns_name, const char* pattern)
   if (pattern_len > 1 && pattern[0] == '*' && pattern[1] == '.') {
     if (dns_name.length() > pattern_len - 1) {
       const size_t off = dns_name.length() - pattern_len + 1;
-      return dns_name.compare(off, pattern_len - 1, pattern + 1) == 0;
+      return dns_name.substr(0, off).find('.') == std::string::npos &&
+             dns_name.compare(off, pattern_len - 1, pattern + 1) == 0;
     }
   }
 

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -48,7 +48,7 @@ protected:
 TEST_F(SslContextImplTest, TestDnsNameMatching) {
   EXPECT_TRUE(ContextImpl::dnsNameMatch("lyft.com", "lyft.com"));
   EXPECT_TRUE(ContextImpl::dnsNameMatch("a.lyft.com", "*.lyft.com"));
-  EXPECT_TRUE(ContextImpl::dnsNameMatch("a.b.lyft.com", "*.lyft.com"));
+  EXPECT_FALSE(ContextImpl::dnsNameMatch("a.b.lyft.com", "*.lyft.com"));
   EXPECT_FALSE(ContextImpl::dnsNameMatch("foo.test.com", "*.lyft.com"));
   EXPECT_FALSE(ContextImpl::dnsNameMatch("lyft.com", "*.lyft.com"));
   EXPECT_FALSE(ContextImpl::dnsNameMatch("alyft.com", "*.lyft.com"));


### PR DESCRIPTION
Commit Message: Wildcard must match only a single domain component: *.example.com matches foo.example.com but not foo.bar.example.com.
Additional Description: I'm not familiar with Envoy codebase but thought I could provide a first fix attempt which would help someone (possibly me) to finalize the fix.
Risk Level: Low
Testing: none yet
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
