### PR TITLE
dynamic_forward_proxy: SNI based Dynamic Forward Proxy Circuit Breakers

### DIFF
--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -22,6 +22,8 @@ ProxyFilterConfig::ProxyFilterConfig(
 
 ProxyFilter::ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)) {}
 
+ProxyFilter::~ProxyFilter() { circuit_breaker_.reset(); }
+
 using LoadDnsCacheEntryStatus = Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus;
 
 Network::FilterStatus ProxyFilter::onNewConnection() {
@@ -33,14 +35,23 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
     return Network::FilterStatus::Continue;
   }
 
-  // TODO(lizan): implement circuit breaker in SNI dynamic forward proxy like it is in HTTP:
-  // https://github.com/envoyproxy/envoy/blob/master/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc#L65
+  circuit_breaker_ = config_->cache().canCreateDnsRequest(absl::nullopt);
+
+  if (circuit_breaker_ == nullptr) {
+    ENVOY_CONN_LOG(debug, "pending request overflow", read_callbacks_->connection());
+    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+    return Network::FilterStatus::StopIteration;
+  }
 
   uint32_t default_port = config_->port();
 
   auto result = config_->cache().loadDnsCacheEntry(sni, default_port, *this);
 
   cache_load_handle_ = std::move(result.handle_);
+  if (cache_load_handle_ == nullptr) {
+    circuit_breaker_.reset();
+  }
+
   switch (result.status_) {
   case LoadDnsCacheEntryStatus::InCache: {
     ASSERT(cache_load_handle_ == nullptr);
@@ -66,6 +77,8 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
 
 void ProxyFilter::onLoadDnsCacheComplete() {
   ENVOY_CONN_LOG(debug, "load DNS cache complete, continuing", read_callbacks_->connection());
+  ASSERT(circuit_breaker_ != nullptr);
+  circuit_breaker_.reset();
   read_callbacks_->continueReading();
 }
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -22,8 +22,6 @@ ProxyFilterConfig::ProxyFilterConfig(
 
 ProxyFilter::ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)) {}
 
-ProxyFilter::~ProxyFilter() { circuit_breaker_.reset(); }
-
 using LoadDnsCacheEntryStatus = Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus;
 
 Network::FilterStatus ProxyFilter::onNewConnection() {

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
@@ -40,7 +40,7 @@ class ProxyFilter
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
   ProxyFilter(ProxyFilterConfigSharedPtr config);
-  ~ProxyFilter() override;
+
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance&, bool) override {
     return Network::FilterStatus::Continue;

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
@@ -40,7 +40,7 @@ class ProxyFilter
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
   ProxyFilter(ProxyFilterConfigSharedPtr config);
-  ~ProxyFilter();
+  ~ProxyFilter() override;
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance&, bool) override {
     return Network::FilterStatus::Continue;

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
@@ -40,6 +40,7 @@ class ProxyFilter
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
   ProxyFilter(ProxyFilterConfigSharedPtr config);
+  ~ProxyFilter();
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance&, bool) override {
     return Network::FilterStatus::Continue;
@@ -54,6 +55,7 @@ public:
 
 private:
   const ProxyFilterConfigSharedPtr config_;
+  Upstream::ResourceAutoIncDecPtr circuit_breaker_;
   Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryHandlePtr cache_load_handle_;
   Network::ReadFilterCallbacks* read_callbacks_{};
 };

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -23,12 +23,12 @@ public:
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(),
                             ConfigHelper::tcpProxyConfig()) {}
 
-  void setup(uint64_t max_hosts = 1024) {
+  void setup(uint64_t max_hosts = 1024, uint32_t max_pending_requests = 1024) {
     setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
 
     config_helper_.addListenerFilter(ConfigHelper::tlsInspectorFilter());
 
-    config_helper_.addConfigModifier([this, max_hosts](
+    config_helper_.addConfigModifier([this, max_hosts, max_pending_requests](
                                          envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       // Switch predefined cluster_0 to CDS filesystem sourcing.
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
@@ -43,10 +43,12 @@ typed_config:
     name: foo
     dns_lookup_family: {}
     max_hosts: {}
+    dns_cache_circuit_breaker:
+      max_pending_requests: {}
   port_value: {}
 )EOF",
                       Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts,
-                      fake_upstreams_[0]->localAddress()->ip()->port());
+                      max_pending_requests, fake_upstreams_[0]->localAddress()->ip()->port());
       config_helper_.addNetworkFilter(filter);
     });
 
@@ -56,8 +58,8 @@ typed_config:
     cluster_.set_name("cluster_0");
     cluster_.set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
 
-    const std::string cluster_type_config =
-        fmt::format(R"EOF(
+    const std::string cluster_type_config = fmt::format(
+        R"EOF(
 name: envoy.clusters.dynamic_forward_proxy
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
@@ -65,8 +67,10 @@ typed_config:
     name: foo
     dns_lookup_family: {}
     max_hosts: {}
+    dns_cache_circuit_breaker:
+      max_pending_requests: {}
 )EOF",
-                    Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts);
+        Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts, max_pending_requests);
 
     TestUtility::loadFromYaml(cluster_type_config, *cluster_.mutable_cluster_type());
 
@@ -129,5 +133,17 @@ TEST_P(SniDynamicProxyFilterIntegrationTest, UpstreamTls) {
   response->waitForEndStream();
   checkSimpleRequestSuccess(0, 0, response.get());
 }
+
+TEST_P(SniDynamicProxyFilterIntegrationTest, CircuitBraekerInvokedUpstreamTls) {
+  setup(1024, 0);
+
+  codec_client_ = makeRawHttpConnection(
+      makeSslClientConnection(Ssl::ClientSslTransportOptions().setSni("localhost")), absl::nullopt);
+  ASSERT_FALSE(codec_client_->connected());
+
+  EXPECT_EQ(1, test_server_->gauge("dns_cache.foo.circuit_breakers.rq_pending_open"));
+  EXPECT_EQ(1, test_server_->counter("dns_cache.foo.dns_rq_pending_overflow")->value());
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -140,8 +140,6 @@ TEST_P(SniDynamicProxyFilterIntegrationTest, CircuitBraekerInvokedUpstreamTls) {
   codec_client_ = makeRawHttpConnection(
       makeSslClientConnection(Ssl::ClientSslTransportOptions().setSni("localhost")), absl::nullopt);
   ASSERT_FALSE(codec_client_->connected());
-
-  EXPECT_EQ(1, test_server_->gauge("dns_cache.foo.circuit_breakers.rq_pending_open"));
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.dns_rq_pending_overflow")->value());
 }
 

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -134,7 +134,7 @@ TEST_P(SniDynamicProxyFilterIntegrationTest, UpstreamTls) {
   checkSimpleRequestSuccess(0, 0, response.get());
 }
 
-TEST_P(SniDynamicProxyFilterIntegrationTest, CircuitBraekerInvokedUpstreamTls) {
+TEST_P(SniDynamicProxyFilterIntegrationTest, CircuitBreakerInvokedUpstreamTls) {
   setup(1024, 0);
 
   codec_client_ = makeRawHttpConnection(

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -40,10 +40,6 @@ public:
     // Allow for an otherwise strict mock.
     ON_CALL(callbacks_, connection()).WillByDefault(ReturnRef(connection_));
     EXPECT_CALL(callbacks_, connection()).Times(AtLeast(0));
-
-    // Configure max pending to 1 so we can test circuit breaking.
-    // TODO(lizan): implement circuit breaker in SNI dynamic forward proxy
-    cm_.thread_local_cluster_.cluster_.info_->resetResourceManager(0, 1, 0, 0, 0);
   }
 
   ~SniDynamicProxyFilterTest() override {

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -62,6 +62,7 @@ public:
   std::unique_ptr<ProxyFilter> filter_;
   Network::MockReadFilterCallbacks callbacks_;
   NiceMock<Network::MockConnection> connection_;
+  NiceMock<Upstream::MockBasicResourceLimit> pending_requests_;
 };
 
 // No SNI handling.
@@ -72,6 +73,10 @@ TEST_F(SniDynamicProxyFilterTest, NoSNI) {
 
 TEST_F(SniDynamicProxyFilterTest, LoadDnsCache) {
   EXPECT_CALL(connection_, requestedServerName()).WillRepeatedly(Return("foo"));
+  Upstream::ResourceAutoIncDec* circuit_breakers_{
+      new Upstream::ResourceAutoIncDec(pending_requests_)};
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("foo"), 443, _))
@@ -86,6 +91,10 @@ TEST_F(SniDynamicProxyFilterTest, LoadDnsCache) {
 
 TEST_F(SniDynamicProxyFilterTest, LoadDnsInCache) {
   EXPECT_CALL(connection_, requestedServerName()).WillRepeatedly(Return("foo"));
+  Upstream::ResourceAutoIncDec* circuit_breakers_{
+      new Upstream::ResourceAutoIncDec(pending_requests_)};
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("foo"), 443, _))
       .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::InCache, nullptr}));
 
@@ -95,8 +104,19 @@ TEST_F(SniDynamicProxyFilterTest, LoadDnsInCache) {
 // Cache overflow.
 TEST_F(SniDynamicProxyFilterTest, CacheOverflow) {
   EXPECT_CALL(connection_, requestedServerName()).WillRepeatedly(Return("foo"));
+  Upstream::ResourceAutoIncDec* circuit_breakers_{
+      new Upstream::ResourceAutoIncDec(pending_requests_)};
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_))
+      .WillOnce(Return(circuit_breakers_));
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_(Eq("foo"), 443, _))
       .WillOnce(Return(MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Overflow, nullptr}));
+  EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+}
+
+TEST_F(SniDynamicProxyFilterTest, CircuitBreakerInvoked) {
+  EXPECT_CALL(connection_, requestedServerName()).WillRepeatedly(Return("foo"));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_(_)).WillOnce(Return(nullptr));
   EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 }


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Add DNS Cache circuit breakers to SNI based dynamic forward proxy
Additional Description:
Risk Level: Low
Testing: Unit / Integration
Docs Changes: Required
Release Notes: Required
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
