### PR TITLE
[ssl] Clarify ssl ownership semantics between SslSocket and SslSocket…

### DIFF
--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -47,14 +47,13 @@ SslSocket::SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
     : transport_socket_options_(transport_socket_options),
       ctx_(std::dynamic_pointer_cast<ContextImpl>(ctx)), state_(SocketState::PreHandshake) {
   bssl::UniquePtr<SSL> ssl = ctx_->newSsl(transport_socket_options_.get());
-  ssl_ = ssl.get();
   info_ = std::make_shared<SslSocketInfo>(std::move(ssl), ctx_);
 
   if (state == InitialState::Client) {
-    SSL_set_connect_state(ssl_);
+    SSL_set_connect_state(rawSsl());
   } else {
     ASSERT(state == InitialState::Server);
-    SSL_set_accept_state(ssl_);
+    SSL_set_accept_state(rawSsl());
   }
 }
 
@@ -65,11 +64,11 @@ void SslSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& c
   // Associate this SSL connection with all the certificates (with their potentially different
   // private key methods).
   for (auto const& provider : ctx_->getPrivateKeyMethodProviders()) {
-    provider->registerPrivateKeyMethod(ssl_, *this, callbacks_->connection().dispatcher());
+    provider->registerPrivateKeyMethod(rawSsl(), *this, callbacks_->connection().dispatcher());
   }
 
   BIO* bio = BIO_new_socket(callbacks_->ioHandle().fd(), 0);
-  SSL_set_bio(ssl_, bio, bio);
+  SSL_set_bio(rawSsl(), bio, bio);
 }
 
 SslSocket::ReadResult SslSocket::sslReadIntoSlice(Buffer::RawSlice& slice) {
@@ -77,7 +76,7 @@ SslSocket::ReadResult SslSocket::sslReadIntoSlice(Buffer::RawSlice& slice) {
   uint8_t* mem = static_cast<uint8_t*>(slice.mem_);
   size_t remaining = slice.len_;
   while (remaining > 0) {
-    int rc = SSL_read(ssl_, mem, remaining);
+    int rc = SSL_read(rawSsl(), mem, remaining);
     ENVOY_CONN_LOG(trace, "ssl read returns: {}", callbacks_->connection(), rc);
     if (rc > 0) {
       ASSERT(static_cast<size_t>(rc) <= remaining);
@@ -124,7 +123,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       }
       if (result.error_.has_value()) {
         keep_reading = false;
-        int err = SSL_get_error(ssl_, result.error_.value());
+        int err = SSL_get_error(rawSsl(), result.error_.value());
         switch (err) {
         case SSL_ERROR_WANT_READ:
           break;
@@ -171,11 +170,11 @@ void SslSocket::onPrivateKeyMethodComplete() {
 
 PostIoAction SslSocket::doHandshake() {
   ASSERT(state_ != SocketState::HandshakeComplete && state_ != SocketState::ShutdownSent);
-  int rc = SSL_do_handshake(ssl_);
+  int rc = SSL_do_handshake(rawSsl());
   if (rc == 1) {
     ENVOY_CONN_LOG(debug, "handshake complete", callbacks_->connection());
     state_ = SocketState::HandshakeComplete;
-    ctx_->logHandshake(ssl_);
+    ctx_->logHandshake(rawSsl());
     callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
 
     // It's possible that we closed during the handshake callback.
@@ -183,7 +182,7 @@ PostIoAction SslSocket::doHandshake() {
                ? PostIoAction::KeepOpen
                : PostIoAction::Close;
   } else {
-    int err = SSL_get_error(ssl_, rc);
+    int err = SSL_get_error(rawSsl(), rc);
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
@@ -255,7 +254,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
     // it again with the same parameters. This is done by tracking last write size, but not write
     // data, since linearize() will return the same undrained data anyway.
     ASSERT(bytes_to_write <= write_buffer.length());
-    int rc = SSL_write(ssl_, write_buffer.linearize(bytes_to_write), bytes_to_write);
+    int rc = SSL_write(rawSsl(), write_buffer.linearize(bytes_to_write), bytes_to_write);
     ENVOY_CONN_LOG(trace, "ssl write returns: {}", callbacks_->connection(), rc);
     if (rc > 0) {
       ASSERT(rc == static_cast<int>(bytes_to_write));
@@ -263,7 +262,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       write_buffer.drain(rc);
       bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
     } else {
-      int err = SSL_get_error(ssl_, rc);
+      int err = SSL_get_error(rawSsl(), rc);
       switch (err) {
       case SSL_ERROR_WANT_WRITE:
         bytes_to_retry_ = bytes_to_write;
@@ -294,7 +293,7 @@ void SslSocket::shutdownSsl() {
   ASSERT(state_ != SocketState::PreHandshake);
   if (state_ != SocketState::ShutdownSent &&
       callbacks_->connection().state() != Network::Connection::State::Closed) {
-    int rc = SSL_shutdown(ssl_);
+    int rc = SSL_shutdown(rawSsl());
     ENVOY_CONN_LOG(debug, "SSL shutdown: rc={}", callbacks_->connection(), rc);
     drainErrorQueue();
     state_ = SocketState::ShutdownSent;
@@ -316,7 +315,7 @@ SslSocketInfo::SslSocketInfo(bssl::UniquePtr<SSL> ssl, ContextImplSharedPtr ctx)
 }
 
 bool SslSocketInfo::peerCertificatePresented() const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   return cert != nullptr;
 }
 
@@ -331,7 +330,7 @@ absl::Span<const std::string> SslSocketInfo::uriSanLocalCertificate() const {
   }
 
   // The cert object is not owned.
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_certificate(ssl());
   if (!cert) {
     ASSERT(cached_uri_san_local_certificate_.empty());
     return cached_uri_san_local_certificate_;
@@ -345,7 +344,7 @@ absl::Span<const std::string> SslSocketInfo::dnsSansLocalCertificate() const {
     return cached_dns_san_local_certificate_;
   }
 
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_certificate(ssl());
   if (!cert) {
     ASSERT(cached_dns_san_local_certificate_.empty());
     return cached_dns_san_local_certificate_;
@@ -358,7 +357,7 @@ const std::string& SslSocketInfo::sha256PeerCertificateDigest() const {
   if (!cached_sha_256_peer_certificate_digest_.empty()) {
     return cached_sha_256_peer_certificate_digest_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_sha_256_peer_certificate_digest_.empty());
     return cached_sha_256_peer_certificate_digest_;
@@ -376,7 +375,7 @@ const std::string& SslSocketInfo::urlEncodedPemEncodedPeerCertificate() const {
   if (!cached_url_encoded_pem_encoded_peer_certificate_.empty()) {
     return cached_url_encoded_pem_encoded_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_url_encoded_pem_encoded_peer_certificate_.empty());
     return cached_url_encoded_pem_encoded_peer_certificate_;
@@ -399,7 +398,7 @@ const std::string& SslSocketInfo::urlEncodedPemEncodedPeerCertificateChain() con
     return cached_url_encoded_pem_encoded_peer_cert_chain_;
   }
 
-  STACK_OF(X509)* cert_chain = SSL_get_peer_full_cert_chain(ssl_.get());
+  STACK_OF(X509)* cert_chain = SSL_get_peer_full_cert_chain(ssl());
   if (cert_chain == nullptr) {
     ASSERT(cached_url_encoded_pem_encoded_peer_cert_chain_.empty());
     return cached_url_encoded_pem_encoded_peer_cert_chain_;
@@ -429,7 +428,7 @@ absl::Span<const std::string> SslSocketInfo::uriSanPeerCertificate() const {
     return cached_uri_san_peer_certificate_;
   }
 
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_uri_san_peer_certificate_.empty());
     return cached_uri_san_peer_certificate_;
@@ -443,7 +442,7 @@ absl::Span<const std::string> SslSocketInfo::dnsSansPeerCertificate() const {
     return cached_dns_san_peer_certificate_;
   }
 
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_dns_san_peer_certificate_.empty());
     return cached_dns_san_peer_certificate_;
@@ -455,7 +454,7 @@ absl::Span<const std::string> SslSocketInfo::dnsSansPeerCertificate() const {
 void SslSocket::closeSocket(Network::ConnectionEvent) {
   // Unregister the SSL connection object from private key method providers.
   for (auto const& provider : ctx_->getPrivateKeyMethodProviders()) {
-    provider->unregisterPrivateKeyMethod(ssl_);
+    provider->unregisterPrivateKeyMethod(rawSsl());
   }
 
   // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
@@ -469,12 +468,12 @@ void SslSocket::closeSocket(Network::ConnectionEvent) {
 std::string SslSocket::protocol() const {
   const unsigned char* proto;
   unsigned int proto_len;
-  SSL_get0_alpn_selected(ssl_, &proto, &proto_len);
+  SSL_get0_alpn_selected(rawSsl(), &proto, &proto_len);
   return std::string(reinterpret_cast<const char*>(proto), proto_len);
 }
 
 uint16_t SslSocketInfo::ciphersuiteId() const {
-  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl_.get());
+  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl());
   if (cipher == nullptr) {
     return 0xffff;
   }
@@ -486,7 +485,7 @@ uint16_t SslSocketInfo::ciphersuiteId() const {
 }
 
 std::string SslSocketInfo::ciphersuiteString() const {
-  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl_.get());
+  const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl());
   if (cipher == nullptr) {
     return {};
   }
@@ -498,12 +497,12 @@ const std::string& SslSocketInfo::tlsVersion() const {
   if (!cached_tls_version_.empty()) {
     return cached_tls_version_;
   }
-  cached_tls_version_ = SSL_get_version(ssl_.get());
+  cached_tls_version_ = SSL_get_version(ssl());
   return cached_tls_version_;
 }
 
 absl::optional<std::string> SslSocketInfo::x509Extension(absl::string_view extension_name) const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     return absl::nullopt;
   }
@@ -516,7 +515,7 @@ const std::string& SslSocketInfo::serialNumberPeerCertificate() const {
   if (!cached_serial_number_peer_certificate_.empty()) {
     return cached_serial_number_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_serial_number_peer_certificate_.empty());
     return cached_serial_number_peer_certificate_;
@@ -529,7 +528,7 @@ const std::string& SslSocketInfo::issuerPeerCertificate() const {
   if (!cached_issuer_peer_certificate_.empty()) {
     return cached_issuer_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_issuer_peer_certificate_.empty());
     return cached_issuer_peer_certificate_;
@@ -542,7 +541,7 @@ const std::string& SslSocketInfo::subjectPeerCertificate() const {
   if (!cached_subject_peer_certificate_.empty()) {
     return cached_subject_peer_certificate_;
   }
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     ASSERT(cached_subject_peer_certificate_.empty());
     return cached_subject_peer_certificate_;
@@ -555,7 +554,7 @@ const std::string& SslSocketInfo::subjectLocalCertificate() const {
   if (!cached_subject_local_certificate_.empty()) {
     return cached_subject_local_certificate_;
   }
-  X509* cert = SSL_get_certificate(ssl_.get());
+  X509* cert = SSL_get_certificate(ssl());
   if (!cert) {
     ASSERT(cached_subject_local_certificate_.empty());
     return cached_subject_local_certificate_;
@@ -565,7 +564,7 @@ const std::string& SslSocketInfo::subjectLocalCertificate() const {
 }
 
 absl::optional<SystemTime> SslSocketInfo::validFromPeerCertificate() const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     return absl::nullopt;
   }
@@ -573,7 +572,7 @@ absl::optional<SystemTime> SslSocketInfo::validFromPeerCertificate() const {
 }
 
 absl::optional<SystemTime> SslSocketInfo::expirationPeerCertificate() const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
   if (!cert) {
     return absl::nullopt;
   }
@@ -584,7 +583,7 @@ const std::string& SslSocketInfo::sessionId() const {
   if (!cached_session_id_.empty()) {
     return cached_session_id_;
   }
-  SSL_SESSION* session = SSL_get_session(ssl_.get());
+  SSL_SESSION* session = SSL_get_session(ssl());
   if (session == nullptr) {
     ASSERT(cached_session_id_.empty());
     return cached_session_id_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -76,8 +76,7 @@ public:
   std::string ciphersuiteString() const override;
   const std::string& tlsVersion() const override;
   absl::optional<std::string> x509Extension(absl::string_view extension_name) const override;
-
-  SSL* rawSslForTest() const { return ssl_.get(); }
+  SSL* ssl() const { return ssl_.get(); }
 
   bssl::UniquePtr<SSL> ssl_;
 
@@ -97,6 +96,8 @@ private:
   mutable std::string cached_tls_version_;
   mutable SslExtendedSocketInfoImpl extended_socket_info_;
 };
+
+using SslSocketInfoConstSharedPtr = std::shared_ptr<const SslSocketInfo>;
 
 class SslSocket : public Network::TransportSocket,
                   public Envoy::Ssl::PrivateKeyConnectionCallbacks,
@@ -118,7 +119,10 @@ public:
   // Ssl::PrivateKeyConnectionCallbacks
   void onPrivateKeyMethodComplete() override;
 
-  SSL* rawSslForTest() const { return ssl_; }
+  SSL* rawSslForTest() const { return rawSsl(); }
+
+protected:
+  SSL* rawSsl() const { return info_->ssl_.get(); }
 
 private:
   struct ReadResult {
@@ -141,8 +145,7 @@ private:
   std::string failure_reason_;
   SocketState state_;
 
-  SSL* ssl_;
-  Ssl::ConnectionInfoConstSharedPtr info_;
+  SslSocketInfoConstSharedPtr info_;
 };
 
 class ClientSslSocketFactory : public Network::TransportSocketFactory,

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -340,8 +340,7 @@ TEST_P(ProxyFilterIntegrationTest, UpstreamTls) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ("localhost",
-               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ("localhost", SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 
   upstream_request_->encodeHeaders(default_response_headers_, true);
   response->waitForEndStream();
@@ -366,7 +365,7 @@ TEST_P(ProxyFilterIntegrationTest, UpstreamTlsWithIpHost) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 
   upstream_request_->encodeHeaders(default_response_headers_, true);
   response->waitForEndStream();

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -79,8 +79,7 @@ TEST_P(AutoSniIntegrationTest, BasicAutoSniTest) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ("localhost",
-               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ("localhost", SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 }
 
 TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
@@ -97,7 +96,7 @@ TEST_P(AutoSniIntegrationTest, PassingNotDNS) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ(nullptr, SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 }
 
 TEST_P(AutoSniIntegrationTest, PassingHostWithoutPort) {
@@ -116,8 +115,7 @@ TEST_P(AutoSniIntegrationTest, PassingHostWithoutPort) {
   const Extensions::TransportSockets::Tls::SslSocketInfo* ssl_socket =
       dynamic_cast<const Extensions::TransportSockets::Tls::SslSocketInfo*>(
           fake_upstream_connection_->connection().ssl().get());
-  EXPECT_STREQ("example.com",
-               SSL_get_servername(ssl_socket->rawSslForTest(), TLSEXT_NAMETYPE_host_name));
+  EXPECT_STREQ("example.com", SSL_get_servername(ssl_socket->ssl(), TLSEXT_NAMETYPE_host_name));
 }
 
 } // namespace

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -606,7 +606,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
   if (!options.clientSession().empty()) {
     const SslSocketInfo* ssl_socket =
         dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-    SSL* client_ssl_socket = ssl_socket->rawSslForTest();
+    SSL* client_ssl_socket = ssl_socket->ssl();
     SSL_CTX* client_ssl_context = SSL_get_SSL_CTX(client_ssl_socket);
     SSL_SESSION* client_ssl_session =
         SSL_SESSION_from_bytes(reinterpret_cast<const uint8_t*>(options.clientSession().data()),
@@ -649,7 +649,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
       EXPECT_EQ(options.expectedClientCertUri(), server_connection->ssl()->uriSanPeerCertificate());
       const SslSocketInfo* ssl_socket =
           dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-      SSL* client_ssl_socket = ssl_socket->rawSslForTest();
+      SSL* client_ssl_socket = ssl_socket->ssl();
       if (!options.expectedProtocolVersion().empty()) {
         EXPECT_EQ(options.expectedProtocolVersion(), client_connection->ssl()->tlsVersion());
       }
@@ -664,7 +664,7 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
       absl::optional<std::string> server_ssl_requested_server_name;
       const SslSocketInfo* server_ssl_socket =
           dynamic_cast<const SslSocketInfo*>(server_connection->ssl().get());
-      SSL* server_ssl = server_ssl_socket->rawSslForTest();
+      SSL* server_ssl = server_ssl_socket->ssl();
       auto requested_server_name = SSL_get_servername(server_ssl, TLSEXT_NAMETYPE_host_name);
       if (requested_server_name != nullptr) {
         server_ssl_requested_server_name = std::string(requested_server_name);
@@ -2511,7 +2511,7 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   const SslSocketInfo* ssl_socket =
       dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
   SSL_set_cert_cb(
-      ssl_socket->rawSslForTest(),
+      ssl_socket->ssl(),
       [](SSL* ssl, void*) -> int {
         STACK_OF(X509_NAME)* list = SSL_get_client_CA_list(ssl);
         EXPECT_NE(nullptr, list);
@@ -2624,7 +2624,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
         const SslSocketInfo* ssl_socket =
             dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-        ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
+        ssl_session = SSL_get1_session(ssl_socket->ssl());
         EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
         if (expected_lifetime_hint) {
           auto lifetime_hint = SSL_SESSION_get_ticket_lifetime_hint(ssl_session);
@@ -2647,7 +2647,7 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   const SslSocketInfo* ssl_socket =
       dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-  SSL_set_session(ssl_socket->rawSslForTest(), ssl_session);
+  SSL_set_session(ssl_socket->ssl(), ssl_session);
   SSL_SESSION_free(ssl_session);
 
   client_connection->connect();
@@ -2753,7 +2753,7 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
 
         const SslSocketInfo* ssl_socket =
             dynamic_cast<const SslSocketInfo*>(server_connection->ssl().get());
-        SSL* server_ssl_socket = ssl_socket->rawSslForTest();
+        SSL* server_ssl_socket = ssl_socket->ssl();
         SSL_CTX* server_ssl_context = SSL_get_SSL_CTX(server_ssl_socket);
         if (expect_support) {
           EXPECT_EQ(0, (SSL_CTX_get_options(server_ssl_context) & SSL_OP_NO_TICKET));
@@ -3207,7 +3207,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
         const SslSocketInfo* ssl_socket =
             dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-        ssl_session = SSL_get1_session(ssl_socket->rawSslForTest());
+        ssl_session = SSL_get1_session(ssl_socket->ssl());
         EXPECT_TRUE(SSL_SESSION_is_resumable(ssl_session));
         server_connection->close(Network::ConnectionCloseType::NoFlush);
         client_connection->close(Network::ConnectionCloseType::NoFlush);
@@ -3226,7 +3226,7 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   client_connection->addConnectionCallbacks(client_connection_callbacks);
   const SslSocketInfo* ssl_socket =
       dynamic_cast<const SslSocketInfo*>(client_connection->ssl().get());
-  SSL_set_session(ssl_socket->rawSslForTest(), ssl_session);
+  SSL_set_session(ssl_socket->ssl(), ssl_session);
   SSL_SESSION_free(ssl_session);
 
   client_connection->connect();


### PR DESCRIPTION
Signed-off-by: James Buckland jbuckland@google.com

Commit Message: This PR clarifies some ownership semantics between SslSocket and SslSocketInfo

Additional Description: Namely, SslSocket no longer holds a SSL*; instead, it relies on the already-kept SslSocketInfo struct and its already-public ssl() accessor. Now SSL* is owned by exactly one class (SslSocketInfo). This PR is necessary for a future PR which asks SslSocketInfo to temporarily relinquish ownership of that SSL*. I am happy to hold off on submitting this PR until that one is approved and ready to submit.

Risk Level: Low
Testing: Minimal -- method names change but not functionality.
Docs Changes: None.
Release Notes: n/a