### PR TITLE
docs - Fix dubbo statistics root value

### DIFF
--- a/docs/root/configuration/listeners/network_filters/dubbo_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/dubbo_proxy_filter.rst
@@ -17,7 +17,7 @@ and parameter value for routing.
 Statistics
 ----------
 
-Every configured dubbo proxy filter has statistics rooted at *redis.<stat_prefix>.* with the
+Every configured dubbo proxy filter has statistics rooted at *dubbo.<stat_prefix>.* with the
 following statistics:
 
 .. csv-table::


### PR DESCRIPTION
Commit Message:

Update the dubbo doc to specify the statistics root as `dubbo.` instead of `redis.` 
(https://github.com/envoyproxy/envoy/blob/5248a4fb7d4c2a3d1fa151f944d3a63f6b7a06cf/source/extensions/filters/network/dubbo_proxy/config.cc#L101)
Commit Message: fix http filter compressor name in example

Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a