### PR TITLE
jwt_authn: fix a header name typo

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -19,7 +19,7 @@ namespace {
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
     access_control_request_method_handle(Http::CustomHeaders::get().AccessControlRequestMethod);
 Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    origin_handle(Http::CustomHeaders::get().AccessControlRequestMethod);
+    origin_handle(Http::CustomHeaders::get().Origin);
 
 bool isCorsPreflightRequest(const Http::RequestHeaderMap& headers) {
   return headers.getMethodValue() == Http::Headers::get().MethodValues.Options &&

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -110,6 +110,33 @@ TEST_F(FilterTest, CorsPreflight) {
   EXPECT_EQ(0U, mock_config_->stats().denied_.value());
 }
 
+TEST_F(FilterTest, CorsPreflightMssingOrigin) {
+  auto headers = Http::TestRequestHeaderMapImpl{
+      {":method", "OPTIONS"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+      {"access-control-request-method", "GET"},
+  };
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(1U, mock_config_->stats().allowed_.value());
+  // Should not be bypassed by cors_preflight since missing origin.
+  EXPECT_EQ(0U, mock_config_->stats().cors_preflight_bypassed_.value());
+  EXPECT_EQ(0U, mock_config_->stats().denied_.value());
+}
+
+TEST_F(FilterTest, CorsPreflightMssingAccessControlRequestMethod) {
+  auto headers = Http::TestRequestHeaderMapImpl{
+      {":method", "OPTIONS"},    {":path", "/"}, {":scheme", "http"}, {":authority", "host"},
+      {"origin", "test-origin"},
+  };
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(1U, mock_config_->stats().allowed_.value());
+  // Should not be bypassed by cors_preflight since missing access-control-request-method.
+  EXPECT_EQ(0U, mock_config_->stats().cors_preflight_bypassed_.value());
+  EXPECT_EQ(0U, mock_config_->stats().denied_.value());
+}
+
 // This test verifies the setPayload call is handled correctly
 TEST_F(FilterTest, TestSetPayloadCall) {
   setupMockConfig();


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

There is a typo in this merged [PR](https://github.com/envoyproxy/envoy/pull/11791).

Risk Level: None
Testing:  added two unit-tests
Docs Changes: None
Release Notes: None
