### PR TITLE
router: consume all retry related headers

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,6 +9,24 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* access loggers: applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature `envoy.reloadable_features.disallow_unbounded_access_logs` to false.
+* build: run as non-root inside Docker containers. Existing behaviour can be restored by setting the environment variable `ENVOY_UID` to `0`. `ENVOY_UID` and `ENVOY_GID` can be used to set the envoy user's `uid` and `gid` respectively.
+* header to metadata: on_header_missing rules with empty values are now rejected (they were skipped before).
+* health check: in the health check filter the :ref:`percentage of healthy servers in upstream clusters <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` is now interpreted as an integer.
+* hot restart: added the option :option:`--use-dynamic-base-id` to select an unused base ID at startup and the option :option:`--base-id-path` to write the base id to a file (for reuse with later hot restarts).
+* http: changed early error path for HTTP/1.1 so that responses consistently flow through the http connection manager, and the http filter chains. This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.early_errors_via_hcm` to false.
+* http: fixed several bugs with applying correct connection close behavior across the http connection manager, health checker, and connection pool. This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_connection_close` to false.
+* http: fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.
+  Can be reverted temporarily by setting runtime feature `envoy.reloadable_features.fix_upgrade_response` to false.
+* http: stopped overwriting `date` response headers. Responses without a `date` header will still have the header properly set. This behavior can be temporarily reverted by setting `envoy.reloadable_features.preserve_upstream_date` to false.
+* http: stopped adding a synthetic path to CONNECT requests, meaning unconfigured CONNECT requests will now return 404 instead of 403. This behavior can be temporarily reverted by setting `envoy.reloadable_features.stop_faking_paths` to false.
+* http: stopped allowing upstream 1xx or 204 responses with Transfer-Encoding or non-zero Content-Length headers. Content-Length of 0 is allowed, but stripped. This behavior can be temporarily reverted by setting `envoy.reloadable_features.strict_1xx_and_204_response_headers` to false.
+* http: upstream connections will now automatically set ALPN when this value is not explicitly set elsewhere (e.g. on the upstream TLS config). This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.http_default_alpn` to false.
+* listener: fixed a bug where when a static listener fails to be added to a worker, the listener was not removed from the active listener list.
+* router: allow retries of streaming or incomplete requests. This removes stat `rq_retry_skipped_request_not_complete`.
+* router: allow retries by default when upstream responds with :ref:`x-envoy-overloaded <config_http_filters_router_x-envoy-overloaded_set>`.
+* router: now consumes all retry related headers to prevent them from being propagated to the upstream. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.consume_all_retry_headers` to false.
+
 Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,22 +9,6 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
-* access loggers: applied existing buffer limits to access logs, as well as :ref:`stats <config_access_log_stats>` for logged / dropped logs. This can be reverted temporarily by setting runtime feature `envoy.reloadable_features.disallow_unbounded_access_logs` to false.
-* build: run as non-root inside Docker containers. Existing behaviour can be restored by setting the environment variable `ENVOY_UID` to `0`. `ENVOY_UID` and `ENVOY_GID` can be used to set the envoy user's `uid` and `gid` respectively.
-* header to metadata: on_header_missing rules with empty values are now rejected (they were skipped before).
-* health check: in the health check filter the :ref:`percentage of healthy servers in upstream clusters <envoy_api_field_config.filter.http.health_check.v2.HealthCheck.cluster_min_healthy_percentages>` is now interpreted as an integer.
-* hot restart: added the option :option:`--use-dynamic-base-id` to select an unused base ID at startup and the option :option:`--base-id-path` to write the base id to a file (for reuse with later hot restarts).
-* http: changed early error path for HTTP/1.1 so that responses consistently flow through the http connection manager, and the http filter chains. This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.early_errors_via_hcm` to false.
-* http: fixed several bugs with applying correct connection close behavior across the http connection manager, health checker, and connection pool. This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_connection_close` to false.
-* http: fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.
-  Can be reverted temporarily by setting runtime feature `envoy.reloadable_features.fix_upgrade_response` to false.
-* http: stopped overwriting `date` response headers. Responses without a `date` header will still have the header properly set. This behavior can be temporarily reverted by setting `envoy.reloadable_features.preserve_upstream_date` to false.
-* http: stopped adding a synthetic path to CONNECT requests, meaning unconfigured CONNECT requests will now return 404 instead of 403. This behavior can be temporarily reverted by setting `envoy.reloadable_features.stop_faking_paths` to false.
-* http: stopped allowing upstream 1xx or 204 responses with Transfer-Encoding or non-zero Content-Length headers. Content-Length of 0 is allowed, but stripped. This behavior can be temporarily reverted by setting `envoy.reloadable_features.strict_1xx_and_204_response_headers` to false.
-* http: upstream connections will now automatically set ALPN when this value is not explicitly set elsewhere (e.g. on the upstream TLS config). This behavior may be temporarily reverted by setting runtime feature `envoy.reloadable_features.http_default_alpn` to false.
-* listener: fixed a bug where when a static listener fails to be added to a worker, the listener was not removed from the active listener list.
-* router: allow retries of streaming or incomplete requests. This removes stat `rq_retry_skipped_request_not_complete`.
-* router: allow retries by default when upstream responds with :ref:`x-envoy-overloaded <config_http_filters_router_x-envoy-overloaded_set>`.
 * router: now consumes all retry related headers to prevent them from being propagated to the upstream. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.consume_all_retry_headers` to false.
 
 Bug Fixes

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -252,6 +252,7 @@ envoy_cc_library(
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
+        "//source/common/runtime:runtime_features_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -62,6 +62,7 @@ constexpr const char* runtime_features[] = {
     // Begin alphabetically sorted section.
     "envoy.reloadable_features.activate_fds_next_event_loop",
     "envoy.deprecated_features.allow_deprecated_extension_names",
+    "envoy.reloadable_features.consume_all_retry_headers",
     "envoy.reloadable_features.disallow_unbounded_access_logs",
     "envoy.reloadable_features.early_errors_via_hcm",
     "envoy.reloadable_features.enable_deprecated_v2_api_warning",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -161,6 +161,7 @@ envoy_cc_test(
         "//test/mocks/router:router_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
     ],

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -12,6 +12,7 @@
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -760,9 +761,6 @@ TEST_F(RouterRetryStateImplTest, MaxRetriesHeader) {
                                                  {"x-envoy-retry-grpc-on", "cancelled"},
                                                  {"x-envoy-max-retries", "3"}};
   setup(request_headers);
-  EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
-  EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
-  EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
   EXPECT_TRUE(state_->enabled());
 
   expectTimerCreateAndEnable();
@@ -936,9 +934,6 @@ TEST_F(RouterRetryStateImplTest, ZeroMaxRetriesHeader) {
                                                  {"x-envoy-retry-grpc-on", "cancelled"},
                                                  {"x-envoy-max-retries", "0"}};
   setup(request_headers);
-  EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
-  EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
-  EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
   EXPECT_TRUE(state_->enabled());
 
   EXPECT_EQ(RetryStatus::NoRetryLimitExceeded,
@@ -1125,6 +1120,104 @@ TEST_F(RouterRetryStateImplTest, ParseRetryGrpcOn) {
   result = RetryStateImpl::parseRetryGrpcOn(config);
   EXPECT_EQ(result.first, 96);
   EXPECT_FALSE(result.second);
+}
+
+TEST_F(RouterRetryStateImplTest, RemoveAllRetryHeaders) {
+  // Make sure retry related headers are removed when the policy is enabled.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "5xx,retriable-header-names,retriable-status-codes"},
+        {"x-envoy-retry-grpc-on", "resource-exhausted"},
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback"},
+        {"x-envoy-retriable-status-codes", "418,420"},
+        {"x-envoy-max-retries", "7"},
+        {"x-envoy-hedge-on-per-try-timeout", "true"},
+        {"x-envoy-upstream-rq-per-try-timeout-ms", "2"},
+    };
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retriable-header-names"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retriable-status-codes"));
+    EXPECT_FALSE(request_headers.has("x-envoy-hedge-on-per-try-timeout"));
+    EXPECT_FALSE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
+  }
+
+  // Make sure retry related headers are removed even if the policy is disabled.
+  {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback"},
+        {"x-envoy-retriable-status-codes", "418,420"},
+        {"x-envoy-max-retries", "7"},
+        {"x-envoy-hedge-on-per-try-timeout", "true"},
+        {"x-envoy-upstream-rq-per-try-timeout-ms", "2"},
+    };
+    setup(request_headers);
+    EXPECT_EQ(nullptr, state_);
+
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retriable-header-names"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retriable-status-codes"));
+    EXPECT_FALSE(request_headers.has("x-envoy-hedge-on-per-try-timeout"));
+    EXPECT_FALSE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
+  }
+
+  // Repeat Policy is enabled case with runtime flag disabled.
+  {
+    TestScopedRuntime scoped_runtime;
+    Runtime::LoaderSingleton::getExisting()->mergeValues(
+        {{"envoy.reloadable_features.consume_all_retry_headers", "false"}});
+
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retry-on", "5xx,retriable-header-names,retriable-status-codes"},
+        {"x-envoy-retry-grpc-on", "resource-exhausted"},
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback"},
+        {"x-envoy-retriable-status-codes", "418,420"},
+        {"x-envoy-max-retries", "7"},
+        {"x-envoy-hedge-on-per-try-timeout", "true"},
+        {"x-envoy-upstream-rq-per-try-timeout-ms", "2"},
+    };
+    setup(request_headers);
+    EXPECT_TRUE(state_->enabled());
+
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
+    EXPECT_TRUE(request_headers.has("x-envoy-retriable-header-names"));
+    EXPECT_TRUE(request_headers.has("x-envoy-retriable-status-codes"));
+    EXPECT_TRUE(request_headers.has("x-envoy-hedge-on-per-try-timeout"));
+    EXPECT_TRUE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
+  }
+
+  // Repeat Policy is disabled case with runtime flag disabled.
+  {
+    TestScopedRuntime scoped_runtime;
+    Runtime::LoaderSingleton::getExisting()->mergeValues(
+        {{"envoy.reloadable_features.consume_all_retry_headers", "false"}});
+
+    Http::TestRequestHeaderMapImpl request_headers{
+        {"x-envoy-retriable-header-names", "X-Upstream-Pushback"},
+        {"x-envoy-retriable-status-codes", "418,420"},
+        {"x-envoy-max-retries", "7"},
+        {"x-envoy-hedge-on-per-try-timeout", "true"},
+        {"x-envoy-upstream-rq-per-try-timeout-ms", "2"},
+    };
+    setup(request_headers);
+    EXPECT_EQ(nullptr, state_);
+
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-retry-grpc-on"));
+    EXPECT_FALSE(request_headers.has("x-envoy-max-retries"));
+    EXPECT_TRUE(request_headers.has("x-envoy-retriable-header-names"));
+    EXPECT_TRUE(request_headers.has("x-envoy-retriable-status-codes"));
+    EXPECT_TRUE(request_headers.has("x-envoy-hedge-on-per-try-timeout"));
+    EXPECT_TRUE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
+  }
 }
 
 } // namespace

--- a/test/common/router/retry_state_impl_test.cc
+++ b/test/common/router/retry_state_impl_test.cc
@@ -1167,7 +1167,7 @@ TEST_F(RouterRetryStateImplTest, RemoveAllRetryHeaders) {
     EXPECT_FALSE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
   }
 
-  // Repeat Policy is enabled case with runtime flag disabled.
+  // Repeat policy is enabled case with runtime flag disabled.
   {
     TestScopedRuntime scoped_runtime;
     Runtime::LoaderSingleton::getExisting()->mergeValues(
@@ -1194,7 +1194,7 @@ TEST_F(RouterRetryStateImplTest, RemoveAllRetryHeaders) {
     EXPECT_TRUE(request_headers.has("x-envoy-upstream-rq-per-try-timeout-ms"));
   }
 
-  // Repeat Policy is disabled case with runtime flag disabled.
+  // Repeat policy is disabled case with runtime flag disabled.
   {
     TestScopedRuntime scoped_runtime;
     Runtime::LoaderSingleton::getExisting()->mergeValues(


### PR DESCRIPTION
Signed-off-by: Martin Matusiak <numerodix@gmail.com>

Commit Message: router: consume all retry related headers
Additional Description: Update the router to consume all retry related headers, to prevent them being propagated to the upstream.
Risk Level: low
Testing: Added new unit tests & did manual testing (with the runtime feature both on and off).
Docs Changes: None
Release Notes: Added
Runtime guard: envoy.reloadable_features.consume_all_retry_headers


I was testing retries when I discovered what seems like a bug with the handling of retry headers. If I make a request setting lots of different retry related headers like so:

```
curl -v \
  -H 'x-envoy-retry-on: retriable-status-codes,retriable-header-names' \
  -H 'x-envoy-retriable-status-codes: 500' \
  -H 'x-envoy-retriable-header-names: X-Retry-Always' \
  -H 'x-envoy-max-retries: 2' \
  -H 'x-envoy-hedge-on-per-try-timeout: true' \
  -H 'x-envoy-upstream-rq-per-try-timeout-ms: 2' \
localhost:8080
```

`:8080` is envoy proxying to a trivial http server that just echoes what it receives. What I'm seeing envoy send is:

```
host: localhost:8080
user-agent: curl/7.68.0
accept: */*
x-envoy-retriable-status-codes: 500
x-envoy-retriable-header-names: X-Retry-Always
x-forwarded-for: 192.168.1.110
x-forwarded-proto: http
x-envoy-internal: true
x-request-id: fdc5b240-d3e5-4ec3-8c2e-5ceaa15901eb
content-length: 0
```

Most of the `x-envoy-XXX` headers have been removed/consumed by the retry implementation, but `x-envoy-retriable-status-codes` and `x-envoy-retriable-header-names` have not.

I see two issues with this:

- This behavior does not seem "hygienic". Envoy is not ignoring these headers (eg. because they are untrusted, or because it doesn't think they are meant for itself), it is acting on them. But it is also letting them propagate.
- These headers could be used (inadvertently or intentionally) to control the "next" envoy. If upstream is also an envoy, and has configured `retry_on: retriable_status_codes,retriable_header_names` then its policy could be partly overridden.
