### PR TITLE
http1: allow duplicated chunked header

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -63,7 +63,7 @@ HeaderKeyFormatterPtr formatter(const Http::Http1Settings& settings) {
 }
 
 bool isChunked(absl::string_view header_value) {
-  for (auto single_encoding : absl::StrSplit(header_value, ",")) {
+  for (auto single_encoding : absl::StrSplit(header_value, ',')) {
     if (!absl::EqualsIgnoreCase(single_encoding, Headers::get().TransferEncodingValues.Chunked)) {
       return false;
     }


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>
Commit Message:
Allow `transfer-encoding: chunked` appears repeatedly in the header.

Additional Description:
Initially reported in https://github.com/istio/istio/issues/24753
I don't find RFC declare duplicated chunked as a failure.
I also confirmed by feeding curl with the duplicated `transfer-encoding: chunked`. No error is reported.

Risk Level: LOW
Testing: unit test
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
