### PR TITLE
tls: improve wildcard matching

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -31,6 +31,7 @@ Minor Behavior Changes
 * listener: fixed a bug where when a static listener fails to be added to a worker, the listener was not removed from the active listener list.
 * router: allow retries of streaming or incomplete requests. This removes stat `rq_retry_skipped_request_not_complete`.
 * router: allow retries by default when upstream responds with :ref:`x-envoy-overloaded <config_http_filters_router_x-envoy-overloaded_set>`.
+* tls: fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_wildcard_matching` to false.
 
 Bug Fixes
 ---------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -10,6 +10,7 @@ Incompatible Behavior Changes
 * client_ssl_auth: the `auth_ip_white_list` stat has been renamed to
   :ref:`auth_ip_allowlist <config_network_filters_client_ssl_auth_stats>`.
 * router: path_redirect now keeps query string by default. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.preserve_query_string_in_path_redirects` to false.
+* tls: fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_wildcard_matching` to false.
 
 Minor Behavior Changes
 ----------------------
@@ -31,7 +32,6 @@ Minor Behavior Changes
 * listener: fixed a bug where when a static listener fails to be added to a worker, the listener was not removed from the active listener list.
 * router: allow retries of streaming or incomplete requests. This removes stat `rq_retry_skipped_request_not_complete`.
 * router: allow retries by default when upstream responds with :ref:`x-envoy-overloaded <config_http_filters_router_x-envoy-overloaded_set>`.
-* tls: fixed a bug where wilcard matching for "\*.foo.com" also matched domains of the form "a.b.foo.com". This behavior can be temporarily reverted by setting runtime feature `envoy.reloadable_features.fix_wildcard_matching` to false.
 
 Bug Fixes
 ---------

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -68,6 +68,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.enable_dns_cache_circuit_breakers",
     "envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher",
     "envoy.reloadable_features.fix_upgrade_response",
+    "envoy.reloadable_features.fix_wildcard_matching",
     "envoy.reloadable_features.fixed_connection_close",
     "envoy.reloadable_features.http_default_alpn",
     "envoy.reloadable_features.listener_in_place_filterchain_update",

--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -109,6 +109,7 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/network:address_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/stats:symbol_table_lib",
         "//source/common/stats:utility_lib",
         "//source/extensions/transport_sockets/tls/private_key:private_key_manager_lib",

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -85,6 +85,7 @@ envoy_cc_test(
         "//test/mocks/ssl:ssl_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",


### PR DESCRIPTION
Patching in 11885 with runtime guards and release notes

Risk Level: Medium (changes to cert matching) 
Testing: new unit test
Docs Changes: n/a
Release Notes: inline
Runtime guard: envoy.reloadable_features.fix_wildcard_matching

Co-authored-by: Yann Soubeyrand <yann.soubeyrand@camptocamp.com>
Signed-off-by: Alyssa Wilk <alyssar@chromium.org>
Signed-off-by: Yann Soubeyrand <yann.soubeyrand@camptocamp.com>