### PR TITLE
test: shard http2_integration_test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -329,6 +329,7 @@ envoy_cc_test(
         "http2_integration_test.cc",
         "http2_integration_test.h",
     ],
+    shard_count = 4,
     tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",


### PR DESCRIPTION
This should mitigate TSAN timeout.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
