### PR TITLE
Lua: Change the TLS callback function type of ThreadLocalState to Upd…

### DIFF
--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -71,8 +71,9 @@ int ThreadLocalState::getGlobalRef(uint64_t slot) {
 }
 
 uint64_t ThreadLocalState::registerGlobal(const std::string& global) {
-  tls_slot_->runOnAllThreads([this, global]() {
-    LuaThreadLocal& tls = tls_slot_->getTyped<LuaThreadLocal>();
+  tls_slot_->runOnAllThreads([global](ThreadLocal::ThreadLocalObjectSharedPtr ptr) -> auto {
+    ASSERT(std::dynamic_pointer_cast<LuaThreadLocal>(ptr));
+    LuaThreadLocal& tls = *std::dynamic_pointer_cast<LuaThreadLocal>(ptr);
     lua_getglobal(tls.state_.get(), global.c_str());
     if (lua_isfunction(tls.state_.get(), -1)) {
       tls.global_slots_.push_back(luaL_ref(tls.state_.get(), LUA_REGISTRYINDEX));
@@ -81,6 +82,7 @@ uint64_t ThreadLocalState::registerGlobal(const std::string& global) {
       lua_pop(tls.state_.get(), 1);
       tls.global_slots_.push_back(LUA_REFNIL);
     }
+    return ptr;
   });
 
   return current_global_slot_++;

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -386,8 +386,12 @@ public:
    * all threaded workers.
    */
   template <class T> void registerType() {
-    tls_slot_->runOnAllThreads(
-        [this]() { T::registerType(tls_slot_->getTyped<LuaThreadLocal>().state_.get()); });
+    tls_slot_->runOnAllThreads([](ThreadLocal::ThreadLocalObjectSharedPtr ptr) -> auto {
+      ASSERT(std::dynamic_pointer_cast<LuaThreadLocal>(ptr));
+      LuaThreadLocal& tls = *std::dynamic_pointer_cast<LuaThreadLocal>(ptr);
+      T::registerType(tls.state_.get());
+      return ptr;
+    });
   }
 
   /**


### PR DESCRIPTION
…ateCb

Signed-off-by: wbpcode <comems@msn.com>

Change the type of ThreadLocalState's TLS callback to UpdateCb. Through this method, you can avoid capturing `this` (ThreadLocalState instance) in the callback function, and avoid memory security problems caused by the inconsistency between the lifetime of the ThreadLocalSate instance and the lifetime of the callback function.

**This modification is at least harmless.** 

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
