### PR TITLE
check_format: use shutil to find binaries

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -218,11 +218,7 @@ def readFile(path):
 # lookPath searches for the given executable in all directories in PATH
 # environment variable. If it cannot be found, empty string is returned.
 def lookPath(executable):
-  for path_dir in os.environ["PATH"].split(os.pathsep):
-    executable_path = os.path.expanduser(os.path.join(path_dir, executable))
-    if os.path.exists(executable_path):
-      return executable_path
-  return ""
+    return shutil.which(executable) or ''
 
 
 # pathExists checks whether the given path exists. This function assumes that

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -218,7 +218,7 @@ def readFile(path):
 # lookPath searches for the given executable in all directories in PATH
 # environment variable. If it cannot be found, empty string is returned.
 def lookPath(executable):
-    return shutil.which(executable) or ''
+  return shutil.which(executable) or ''
 
 
 # pathExists checks whether the given path exists. This function assumes that


### PR DESCRIPTION
Signed-off-by: Utsav Shah <utsav@dropbox.com>

Commit Message: The `lookPath` function is buggy and crashes for some malformed `$PATH` entries on macOS. We can use `shutil.which()` to find binaries in `$PATH` reliably. `shutil.which()` is available since Python3.3, which is pretty old now (released in 2012).

Risk Level: N/A
Testing: Ran it locally