### PR TITLE
ci: downgrading coverage to debug

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -129,7 +129,7 @@ build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
 build:coverage --test_tag_filters=-nocoverage
 build:coverage --instrumentation_filter="//source(?!/common/chromium_url|/extensions/quic_listeners/quiche/platform)[/:],//include[/:]"
-coverage:test-coverage --test_arg="-l trace"
+coverage:test-coverage --test_arg="-l debug"
 coverage:fuzz-coverage --config=asan-fuzzer
 coverage:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
 


### PR DESCRIPTION
ci showed a failure in Protocols/DownstreamProtocolIntegrationTest.ManyRequestHeadersTimeout/IPv4_Http2Downstream_HttpUpstream
(https://dev.azure.com/cncf/4684fb3d-0389-4e0b-8251-221942316e06/_apis/build/builds/44319/logs/73)
which involved nghttp2 dumping 340024 lines of logs at trace level.  None of these log at debug.
downgrading coverage build to debug to reduce logspam and hopefully resolve the timeout.

Risk Level: low
Testing: checking CI
Docs Changes: n/a
Release Notes: n/a
