### PR TITLE
test: Randomize the order in which simulated timers scheduled for the same monotonic time execute.

### DIFF
--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -268,10 +268,10 @@ envoy_cc_test_library(
     deps = [
         ":only_one_thread_lib",
         ":test_time_system_interface",
+        ":utility_lib",
         "//source/common/event:event_impl_base_lib",
         "//source/common/event:real_time_system_lib",
         "//source/common/event:timer_lib",
-        "//source/common/runtime:runtime_lib",
     ],
 )
 

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -271,6 +271,7 @@ envoy_cc_test_library(
         "//source/common/event:event_impl_base_lib",
         "//source/common/event:real_time_system_lib",
         "//source/common/event:timer_lib",
+        "//source/common/runtime:runtime_lib",
     ],
 )
 

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -52,8 +52,7 @@ class SimulatedTimeSystemHelper::Alarm : public Timer {
 public:
   Alarm(SimulatedTimeSystemHelper& time_system, CallbackScheduler& cb_scheduler, TimerCb cb)
       : cb_(cb_scheduler.createSchedulableCallback([this, cb] { runAlarm(cb); })),
-        time_system_(time_system), index_(time_system.nextIndex()), armed_(false), pending_(false) {
-  }
+        time_system_(time_system), armed_(false), pending_(false) {}
 
   ~Alarm() override;
 
@@ -71,10 +70,6 @@ public:
   }
 
   void disableTimerLockHeld() ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_);
-
-  void setTimeLockHeld(MonotonicTime time) ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
-    time_ = time;
-  }
 
   /**
    * Activates the timer so it will be run the next time the libevent loop is run,
@@ -98,17 +93,9 @@ public:
     cb_->scheduleCallbackCurrentIteration();
   }
 
-  MonotonicTime time() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(time_system_.mutex_) {
-    ASSERT(armed_);
-    return time_;
-  }
-
   SimulatedTimeSystemHelper& timeSystem() { return time_system_; }
-  uint64_t index() const { return index_; }
 
 private:
-  friend SimulatedTimeSystemHelper::CompareAlarms;
-
   void runAlarm(TimerCb cb) {
     {
       absl::MutexLock lock(&time_system_.mutex_);
@@ -122,24 +109,8 @@ private:
 
   SchedulableCallbackPtr cb_;
   SimulatedTimeSystemHelper& time_system_;
-  MonotonicTime time_ ABSL_GUARDED_BY(time_system_.mutex_);
-  const uint64_t index_;
   bool armed_ ABSL_GUARDED_BY(time_system_.mutex_);
   bool pending_ ABSL_GUARDED_BY(time_system_.mutex_);
-};
-
-// Compare two alarms, based on wakeup time and insertion order. Returns true if
-// a comes before b.
-bool SimulatedTimeSystemHelper::CompareAlarms::operator()(const Alarm* a, const Alarm* b) const
-    ABSL_EXCLUSIVE_LOCKS_REQUIRED(a->time_system_.mutex_, b->time_system_.mutex_) {
-  if (a != b) {
-    if (a->time() < b->time()) {
-      return true;
-    } else if (a->time() == b->time() && a->index() < b->index()) {
-      return true;
-    }
-  }
-  return false;
 };
 
 // Each timer is maintained and ordered by a common TimeSystem, but is
@@ -216,7 +187,7 @@ static int instance_count = 0;
 // will march forward only by calling.advanceTimeAsync().
 SimulatedTimeSystemHelper::SimulatedTimeSystemHelper()
     : monotonic_time_(MonotonicTime(std::chrono::seconds(0))),
-      system_time_(real_time_source_.systemTime()), index_(0), pending_alarms_(0) {
+      system_time_(real_time_source_.systemTime()), pending_alarms_(0) {
   ++instance_count;
   ASSERT(instance_count <= 1);
 }
@@ -291,8 +262,8 @@ Thread::CondVar::WaitStatus SimulatedTimeSystemHelper::waitFor(Thread::MutexBasi
         MonotonicTime next_wakeup = end_time;
         if (!alarms_.empty()) {
           // If there's another alarm pending, sleep forward to it.
-          Alarm* alarm = (*alarms_.begin());
-          next_wakeup = std::min(alarmTimeLockHeld(alarm), next_wakeup);
+          const AlarmRegistration& alarm_registration = *alarms_.begin();
+          next_wakeup = std::min(alarm_registration.time, next_wakeup);
         }
         setMonotonicTimeLockHeld(next_wakeup);
         waitForNoPendingLockHeld();
@@ -308,14 +279,6 @@ Thread::CondVar::WaitStatus SimulatedTimeSystemHelper::waitFor(Thread::MutexBasi
   return Thread::CondVar::WaitStatus::Timeout;
 }
 
-MonotonicTime
-SimulatedTimeSystemHelper::alarmTimeLockHeld(Alarm* alarm) ABSL_NO_THREAD_SAFETY_ANALYSIS {
-  // We disable thread-safety analysis as the compiler can't detect that
-  // alarm_->timeSystem() == this, so we must be holding the right mutex.
-  ASSERT(&(alarm->timeSystem()) == this);
-  return alarm->time();
-}
-
 void SimulatedTimeSystemHelper::alarmActivateLockHeld(Alarm* alarm) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // We disable thread-safety analysis as the compiler can't detect that
   // alarm_->timeSystem() == this, so we must be holding the right mutex.
@@ -323,19 +286,33 @@ void SimulatedTimeSystemHelper::alarmActivateLockHeld(Alarm* alarm) ABSL_NO_THRE
   alarm->activateLockHeld();
 }
 
-int64_t SimulatedTimeSystemHelper::nextIndex() {
-  absl::MutexLock lock(&mutex_);
-  return index_++;
-}
-
 void SimulatedTimeSystemHelper::addAlarmLockHeld(
     Alarm* alarm, const std::chrono::microseconds& duration) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   ASSERT(&(alarm->timeSystem()) == this);
-  alarm->setTimeLockHeld(monotonic_time_ + duration);
-  alarms_.insert(alarm);
+  ASSERT(alarms_.size() == alarm_registrations_map_.size());
+  ASSERT(alarm_registrations_map_.find(alarm) == alarm_registrations_map_.end());
+
+  auto insert_result = alarms_.insert({monotonic_time_ + duration, random_source_.random(), alarm});
+  ASSERT(insert_result.second);
+  alarm_registrations_map_.emplace(alarm, insert_result.first);
+
+  // Sanity check that the parallel data structures used for alarm registration have the same number
+  // of entries.
+  ASSERT(alarms_.size() == alarm_registrations_map_.size());
 }
 
-void SimulatedTimeSystemHelper::removeAlarmLockHeld(Alarm* alarm) { alarms_.erase(alarm); }
+void SimulatedTimeSystemHelper::removeAlarmLockHeld(Alarm* alarm) {
+  ASSERT(alarms_.size() == alarm_registrations_map_.size());
+
+  auto it = alarm_registrations_map_.find(alarm);
+  ASSERT(it != alarm_registrations_map_.end());
+  alarms_.erase(it->second);
+  alarm_registrations_map_.erase(it);
+
+  // Sanity check that the parallel data structures used for alarm registration have the same number
+  // of entries.
+  ASSERT(alarms_.size() == alarm_registrations_map_.size());
+}
 
 SchedulerPtr SimulatedTimeSystemHelper::createScheduler(Scheduler& /*base_scheduler*/,
                                                         CallbackScheduler& cb_scheduler) {
@@ -354,9 +331,8 @@ void SimulatedTimeSystemHelper::setMonotonicTimeLockHeld(const MonotonicTime& mo
     // or removed during the call to activate() so it would not be correct to
     // range-iterate over the set.
     while (!alarms_.empty()) {
-      AlarmSet::iterator pos = alarms_.begin();
-      Alarm* alarm = *pos;
-      MonotonicTime alarm_time = alarmTimeLockHeld(alarm);
+      const AlarmRegistration& alarm_registration = *alarms_.begin();
+      MonotonicTime alarm_time = alarm_registration.time;
       if (alarm_time > monotonic_time) {
         break;
       }
@@ -364,7 +340,8 @@ void SimulatedTimeSystemHelper::setMonotonicTimeLockHeld(const MonotonicTime& mo
       system_time_ +=
           std::chrono::duration_cast<SystemTime::duration>(alarm_time - monotonic_time_);
       monotonic_time_ = alarm_time;
-      alarms_.erase(pos);
+      Alarm* alarm = alarm_registration.alarm;
+      removeAlarmLockHeld(alarm);
       alarmActivateLockHeld(alarm);
     }
     system_time_ +=

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -263,7 +263,7 @@ Thread::CondVar::WaitStatus SimulatedTimeSystemHelper::waitFor(Thread::MutexBasi
         if (!alarms_.empty()) {
           // If there's another alarm pending, sleep forward to it.
           const AlarmRegistration& alarm_registration = *alarms_.begin();
-          next_wakeup = std::min(alarm_registration.time, next_wakeup);
+          next_wakeup = std::min(alarm_registration.time_, next_wakeup);
         }
         setMonotonicTimeLockHeld(next_wakeup);
         waitForNoPendingLockHeld();
@@ -332,7 +332,7 @@ void SimulatedTimeSystemHelper::setMonotonicTimeLockHeld(const MonotonicTime& mo
     // range-iterate over the set.
     while (!alarms_.empty()) {
       const AlarmRegistration& alarm_registration = *alarms_.begin();
-      MonotonicTime alarm_time = alarm_registration.time;
+      MonotonicTime alarm_time = alarm_registration.time_;
       if (alarm_time > monotonic_time) {
         break;
       }
@@ -340,7 +340,7 @@ void SimulatedTimeSystemHelper::setMonotonicTimeLockHeld(const MonotonicTime& mo
       system_time_ +=
           std::chrono::duration_cast<SystemTime::duration>(alarm_time - monotonic_time_);
       monotonic_time_ = alarm_time;
-      Alarm* alarm = alarm_registration.alarm;
+      Alarm* alarm = alarm_registration.alarm_;
       removeAlarmLockHeld(alarm);
       alarmActivateLockHeld(alarm);
     }

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -10,6 +10,8 @@
 #include "test/test_common/test_time_system.h"
 #include "test/test_common/utility.h"
 
+#include "absl/container/flat_hash_map.h"
+
 namespace Envoy {
 namespace Event {
 
@@ -124,7 +126,7 @@ private:
   SystemTime system_time_ ABSL_GUARDED_BY(mutex_);
   TestRandomGenerator random_source_ ABSL_GUARDED_BY(mutex_);
   AlarmSet alarms_ ABSL_GUARDED_BY(mutex_);
-  std::unordered_map<Alarm*, AlarmSet::const_iterator>
+  absl::flat_hash_map<Alarm*, AlarmSet::const_iterator>
       alarm_registrations_map_ ABSL_GUARDED_BY(mutex_);
   mutable absl::Mutex mutex_;
   uint32_t pending_alarms_ ABSL_GUARDED_BY(mutex_);

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -66,6 +66,9 @@ private:
   class Alarm;
   friend class Alarm; // Needed to reference mutex for thread annotations.
   struct AlarmRegistration {
+    AlarmRegistration(MonotonicTime _time, uint64_t _randomness, Alarm* _alarm)
+        : time(_time), randomness(_randomness), alarm(_alarm) {}
+
     MonotonicTime time;
     // Random tie-breaker for alarms scheduled for the same monotonic time used to mimic
     // non-deterministic execution of real alarms scheduled for the same wall time.

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -5,10 +5,10 @@
 #include "common/common/lock_guard.h"
 #include "common/common/thread.h"
 #include "common/common/utility.h"
-#include "common/runtime/runtime_impl.h"
 
 #include "test/test_common/only_one_thread.h"
 #include "test/test_common/test_time_system.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Event {
@@ -115,7 +115,7 @@ private:
   RealTimeSource real_time_source_; // Used to initialize monotonic_time_ and system_time_;
   MonotonicTime monotonic_time_ ABSL_GUARDED_BY(mutex_);
   SystemTime system_time_ ABSL_GUARDED_BY(mutex_);
-  Runtime::RandomGeneratorImpl random_source_ ABSL_GUARDED_BY(mutex_);
+  TestRandomGenerator random_source_ ABSL_GUARDED_BY(mutex_);
   AlarmSet alarms_ ABSL_GUARDED_BY(mutex_);
   std::map<Alarm*, AlarmSet::const_iterator> alarm_registrations_map_ ABSL_GUARDED_BY(mutex_);
   mutable absl::Mutex mutex_;

--- a/test/test_common/simulated_time_system.h
+++ b/test/test_common/simulated_time_system.h
@@ -66,23 +66,23 @@ private:
   class Alarm;
   friend class Alarm; // Needed to reference mutex for thread annotations.
   struct AlarmRegistration {
-    AlarmRegistration(MonotonicTime _time, uint64_t _randomness, Alarm* _alarm)
-        : time(_time), randomness(_randomness), alarm(_alarm) {}
+    AlarmRegistration(MonotonicTime time, uint64_t randomness, Alarm* alarm)
+        : time_(time), randomness_(randomness), alarm_(alarm) {}
 
-    MonotonicTime time;
+    MonotonicTime time_;
     // Random tie-breaker for alarms scheduled for the same monotonic time used to mimic
     // non-deterministic execution of real alarms scheduled for the same wall time.
-    uint64_t randomness;
-    Alarm* alarm;
+    uint64_t randomness_;
+    Alarm* alarm_;
 
     friend bool operator<(const AlarmRegistration& lhs, const AlarmRegistration& rhs) {
-      if (lhs.time != rhs.time) {
-        return lhs.time < rhs.time;
+      if (lhs.time_ != rhs.time_) {
+        return lhs.time_ < rhs.time_;
       }
-      if (lhs.randomness != rhs.randomness) {
-        return lhs.randomness < rhs.randomness;
+      if (lhs.randomness_ != rhs.randomness_) {
+        return lhs.randomness_ < rhs.randomness_;
       }
-      return lhs.alarm < rhs.alarm;
+      return lhs.alarm_ < rhs.alarm_;
     }
   };
   using AlarmSet = std::set<AlarmRegistration>;


### PR DESCRIPTION
Commit Message: test: Randomize the order in which simulated timers scheduled for the same monotonic time execute.
Additional Description: The order in which real timers scheduled for the exact same wall time execute is non-deterministic.  Simulated timer behavior should be as similar as possible as that of real timers.
Risk Level: n/a, test only changes
Testing: unit
Docs Changes: n/a
Release Notes: n/a