### PR TITLE
build: optimize builds in RBE

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -1,6 +1,7 @@
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains_config")
+load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
 load("@upb//bazel:repository_defs.bzl", upb_bazel_version_repository = "bazel_version_repository")
@@ -18,6 +19,13 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     gazelle_dependencies()
     apple_rules_dependencies()
     upb_bazel_version_repository(name = "upb_bazel_version")
+
+    custom_exec_properties(
+        name = "envoy_large_machine_exec_property",
+        constants = {
+            "LARGE_MACHINE": create_rbe_exec_properties_dict(labels = dict(size = "large")),
+        },
+    )
 
     go_repository(
         name = "org_golang_google_grpc",

--- a/bazel/external/fmtlib.BUILD
+++ b/bazel/external/fmtlib.BUILD
@@ -4,9 +4,6 @@ licenses(["notice"])  # Apache 2
 
 cc_library(
     name = "fmtlib",
-    srcs = glob([
-        "fmt/*.cc",
-    ]),
     hdrs = glob([
         "include/fmt/*.h",
     ]),

--- a/bazel/external/spdlog.BUILD
+++ b/bazel/external/spdlog.BUILD
@@ -5,7 +5,6 @@ licenses(["notice"])  # Apache 2
 cc_library(
     name = "spdlog",
     hdrs = glob([
-        "include/**/*.cc",
         "include/**/*.h",
     ]),
     defines = ["SPDLOG_FMT_EXTERNAL"],

--- a/bazel/external/wee8.BUILD
+++ b/bazel/external/wee8.BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@envoy_large_machine_exec_property//:constants.bzl", "LARGE_MACHINE")
 load(":genrule_cmd.bzl", "genrule_cmd")
 
 licenses(["notice"])  # Apache 2
@@ -26,4 +27,5 @@ genrule(
         "libwee8.a",
     ],
     cmd = genrule_cmd("@envoy//bazel/external:wee8.genrule_cmd"),
+    exec_properties = LARGE_MACHINE,
 )

--- a/bazel/foreign_cc/luajit.patch
+++ b/bazel/foreign_cc/luajit.patch
@@ -58,7 +58,7 @@ index 0000000..9c71271
 --- /dev/null
 +++ b/build.py
 @@ -0,0 +1,56 @@
-+#!/usr/bin/env python
++#!/usr/bin/env python3
 +
 +import argparse
 +import os
@@ -93,7 +93,7 @@ index 0000000..9c71271
 +      with open("clang-asan-blocklist.txt", "w") as f:
 +        f.write("fun:*\n")
 +
-+    os.system('make V=1 PREFIX="{}" install'.format(args.prefix))
++    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
 +
 +def win_main():
 +    src_dir = os.path.dirname(os.path.realpath(__file__))

--- a/bazel/foreign_cc/moonjit.patch
+++ b/bazel/foreign_cc/moonjit.patch
@@ -49,7 +49,7 @@ index 0000000..9c71271
 --- /dev/null
 +++ b/build.py
 @@ -0,0 +1,56 @@
-+#!/usr/bin/env python
++#!/usr/bin/env python3
 +
 +import argparse
 +import os
@@ -84,7 +84,7 @@ index 0000000..9c71271
 +      with open("clang-asan-blocklist.txt", "w") as f:
 +        f.write("fun:*\n")
 +
-+    os.system('make V=1 PREFIX="{}" install'.format(args.prefix))
++    os.system('make -j{} V=1 PREFIX="{}" install'.format(os.cpu_count(), args.prefix))
 +
 +def win_main():
 +    src_dir = os.path.dirname(os.path.realpath(__file__))

--- a/configs/BUILD
+++ b/configs/BUILD
@@ -13,7 +13,6 @@ envoy_py_test_binary(
     srcs = ["configgen.py"],
     data = glob([
         "*.yaml",
-        "*.json",
     ]),
     external_deps = ["jinja2"],
 )


### PR DESCRIPTION
- schedule wee8 build in larger machines with size=large label
- luajit/moonjit make with `-j`
- delete empty globs (partly addresses #9492) 

Risk Level: Low (people building v8 with RBE need setup size=large worker pool)
Testing: CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
