### PR TITLE
test: deflake coverage take two

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1096,7 +1096,7 @@ void HttpIntegrationTest::testManyRequestHeaders(std::chrono::milliseconds time)
   // This test uses an Http::HeaderMapImpl instead of an Http::TestHeaderMapImpl to avoid
   // time-consuming asserts when using a large number of headers.
   max_request_headers_kb_ = 96;
-  max_request_headers_count_ = 20005;
+  max_request_headers_count_ = 10005;
 
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -1112,7 +1112,7 @@ void HttpIntegrationTest::testManyRequestHeaders(std::chrono::milliseconds time)
        {Http::Headers::get().Scheme, "http"},
        {Http::Headers::get().Host, "host"}});
 
-  for (int i = 0; i < 20000; i++) {
+  for (int i = 0; i < 10000; i++) {
     big_headers->addCopy(Http::LowerCaseString(std::to_string(i)), std::string(0, 'a'));
   }
   initialize();

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1444,7 +1444,12 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersAccepted) {
 // time-consuming byte size validations that will cause this test to timeout.
 TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersTimeout) {
   // Set timeout for 5 seconds, and ensure that a request with 10k+ headers can be sent.
-  testManyRequestHeaders(std::chrono::milliseconds(5000));
+  auto time = std::chrono::milliseconds(5000);
+#ifdef ENVOY_CONFIG_COVERAGE
+  // Scale up for coverage, due to flakes.
+  time = std::chrono::milliseconds(10000);
+#endif
+  testManyRequestHeaders(time);
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersAccepted) {

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1444,12 +1444,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersAccepted) {
 // time-consuming byte size validations that will cause this test to timeout.
 TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersTimeout) {
   // Set timeout for 5 seconds, and ensure that a request with 10k+ headers can be sent.
-  auto time = std::chrono::milliseconds(5000);
-#ifdef ENVOY_CONFIG_COVERAGE
-  // Scale up for coverage, due to flakes.
-  time = std::chrono::milliseconds(10000);
-#endif
-  testManyRequestHeaders(time);
+  testManyRequestHeaders(std::chrono::milliseconds(5000));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersAccepted) {


### PR DESCRIPTION
Making the known-slow many header test slightly less slow in the hopes of reducing timeouts.

Additional Description:
example failure 
 https://dev.azure.com/cncf/4684fb3d-0389-4e0b-8251-221942316e06/_apis/build/builds/44351/logs/32
it looks like it's making steady progress, just taking more than 5s. 

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
