### PR TITLE
docs: clarify xcode reqs for macOS build

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -92,7 +92,7 @@ for how to update or override dependencies.
     ```
     _notes_: `coreutils` is used for `realpath`, `gmd5sum` and `gsha256sum`
 
-    Xcode is also required to build Envoy on macOS.
+    The full version of Xcode (not just Command Line Tools) is also required to build Envoy on macOS.
     Envoy compiles and passes tests with the version of clang installed by Xcode 11.1:
     Apple clang version 11.0.0 (clang-1100.0.33.8).
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -176,8 +176,7 @@ The macOS CI build is part of the [CircleCI](https://circleci.com/gh/envoyproxy/
 Dependencies are installed by the `ci/mac_ci_setup.sh` script, via [Homebrew](https://brew.sh),
 which is pre-installed on the CircleCI macOS image. The dependencies are cached are re-installed
 on every build. The `ci/mac_ci_steps.sh` script executes the specific commands that
-build and test Envoy. If Envoy cannot be built (`error: /Library/Developer/CommandLineTools/usr/bin/libtool: no output file specified (specify with -o output)`),
-ensure that Xcode is installed.
+build and test Envoy. Note that the full version of Xcode (not just Command Line Tools) is required.
 
 # Coverity Scan Build Flow
 


### PR DESCRIPTION
Commit Message: Clarify the version of Xcode required to build envoy on macOS
Additional Description: I incorrectly assumed that the Xcode Command Line Tools would be sufficient here, but that was not the case.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A