### PR TITLE
test: removing more infinite timeouts

### DIFF
--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1533,12 +1533,12 @@ void Http2FloodMitigationTest::beginSession() {
 
 Http2Frame Http2FloodMitigationTest::readFrame() {
   Http2Frame frame;
-  tcp_client_->waitForData(frame.HeaderSize);
+  EXPECT_TRUE(tcp_client_->waitForData(frame.HeaderSize));
   frame.setHeader(tcp_client_->data());
   tcp_client_->clearData(frame.HeaderSize);
   auto len = frame.payloadSize();
   if (len) {
-    tcp_client_->waitForData(len);
+    EXPECT_TRUE(tcp_client_->waitForData(len));
     frame.setPayload(tcp_client_->data());
     tcp_client_->clearData(len);
   }

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -104,7 +104,8 @@ public:
   void close();
   void waitForData(const std::string& data, bool exact_match = true);
   // wait for at least `length` bytes to be received
-  void waitForData(size_t length);
+  ABSL_MUST_USE_RESULT AssertionResult
+  waitForData(size_t length, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
   void waitForDisconnect(bool ignore_spurious_events = false);
   void waitForHalfClose();
   void readDisable(bool disabled);

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -70,13 +70,13 @@ TEST_P(TcpProxyIntegrationTest, TcpProxyUpstreamWritesFirst) {
   tcp_client->waitForData("ello", false);
 
   // Make sure length based wait works for the data already received
-  tcp_client->waitForData(5);
-  tcp_client->waitForData(4);
+  ASSERT_TRUE(tcp_client->waitForData(5));
+  ASSERT_TRUE(tcp_client->waitForData(4));
 
   // Drain part of the received message
   tcp_client->clearData(2);
   tcp_client->waitForData("llo");
-  tcp_client->waitForData(3);
+  ASSERT_TRUE(tcp_client->waitForData(3));
 
   ASSERT_TRUE(tcp_client->write("hello"));
   ASSERT_TRUE(fake_upstream_connection->waitForData(5));

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -302,7 +302,7 @@ TEST_P(TcpTunnelingIntegrationTest, Basic) {
 
   // Send data from upstream to downstream.
   upstream_request_->encodeData(12, false);
-  tcp_client->waitForData(12);
+  ASSERT_TRUE(tcp_client->waitForData(12));
 
   // Now send more data and close the TCP client. This should be treated as half close, so the data
   // should go through.
@@ -370,7 +370,7 @@ TEST_P(TcpTunnelingIntegrationTest, CloseUpstreamFirst) {
   // Send data from upstream to downstream with an end stream and make sure the data is received
   // before the connection is half-closed.
   upstream_request_->encodeData(12, true);
-  tcp_client->waitForData(12);
+  ASSERT_TRUE(tcp_client->waitForData(12));
   tcp_client->waitForHalfClose();
 
   // Attempt to send data upstream.


### PR DESCRIPTION
Removing infinite timeouts from tcp client wait-for-n-bytes and tcp client wait for disconnect

Risk Level: n/a
Testing: tests pass
Hopefully helps debug #11801
