### PR TITLE
test: attempting to fix raw buffer config coverage

### DIFF
--- a/source/extensions/transport_sockets/raw_buffer/config.h
+++ b/source/extensions/transport_sockets/raw_buffer/config.h
@@ -16,7 +16,6 @@ namespace RawBuffer {
  */
 class RawBufferSocketFactory : public virtual Server::Configuration::TransportSocketConfigFactory {
 public:
-  ~RawBufferSocketFactory() override = default;
   std::string name() const override { return TransportSocketNames::get().RawBuffer; }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 };

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -54,7 +54,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/tracers/opencensus:90.1"
 "source/extensions/tracers/xray:95.3"
 "source/extensions/transport_sockets:94.8"
-"source/extensions/transport_sockets/raw_buffer:90.9"
 "source/extensions/transport_sockets/tap:95.6"
 "source/extensions/transport_sockets/tls:94.2"
 "source/extensions/transport_sockets/tls/private_key:76.9"


### PR DESCRIPTION
Removing an unnecessary destructor declaration.
(https://storage.googleapis.com/envoy-postsubmit/master/coverage/source/extensions/transport_sockets/raw_buffer/config.h.gcov.html)

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #11979
