### PR TITLE
nghttp2: don't log unless ENVOY_NGHTTP2_TRACE is set.

### DIFF
--- a/bazel/EXTERNAL_DEPS.md
+++ b/bazel/EXTERNAL_DEPS.md
@@ -110,6 +110,8 @@ dependencies:
   in the `event` target in `bazel/foreign_cc/BUILD` for verbose tracing of
   libevent processing.
 
+* `nghttp2`: set `ENVOY_NGHTTP2_TRACE` in the environment and run at `-l trace`.
+
 # Distdir - prefetching dependencies
 
 Usually Bazel downloads all dependencies during build time. But there is a

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -523,6 +523,14 @@ bazel test -c dbg --config=macos-asan //test/...
 
 Log verbosity is controlled at runtime in all builds.
 
+To obtain `nghttp2` traces, you can set `ENVOY_NGHTTP2_TRACE` in the environment for enhanced
+logging at `-l trace`. For example, in tests:
+
+```
+bazel test //test/integration:protocol_integration_test --test_output=streamed \
+  --test_arg="-l trace" --test_env="ENVOY_NGHTTP2_TRACE="
+```
+
 ## Disabling optional features
 
 The following optional features can be disabled on the Bazel build command-line:

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -11,6 +11,8 @@ Minor Behavior Changes
 
 * http: the per-stream FilterState maintained by the HTTP connection manager will now provide read/write access to the downstream connection FilterState. As such, code that relies on interacting with this might
   see a change in behavior.
+* logging: nghttp2 log messages no longer appear at trace level unless `ENVOY_NGHTTP2_TRACE` is set
+  in the environment.
 * router: now consumes all retry related headers to prevent them from being propagated to the upstream. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.consume_all_retry_headers` to false.
 
 Bug Fixes

--- a/source/common/http/http2/nghttp2.cc
+++ b/source/common/http/http2/nghttp2.cc
@@ -15,14 +15,16 @@ namespace Http2 {
 
 void initializeNghttp2Logging() {
   nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
-    char buf[2048];
-    const int n = ::vsnprintf(buf, sizeof(buf), format, args);
-    // nghttp2 inserts new lines, but we also insert a new line in the ENVOY_LOG
-    // below, so avoid double \n.
-    if (n >= 1 && static_cast<size_t>(n) < sizeof(buf) && buf[n - 1] == '\n') {
-      buf[n - 1] = '\0';
+    if (std::getenv("ENVOY_NGHTTP2_TRACE") != nullptr) {
+      char buf[2048];
+      const int n = ::vsnprintf(buf, sizeof(buf), format, args);
+      // nghttp2 inserts new lines, but we also insert a new line in the ENVOY_LOG
+      // below, so avoid double \n.
+      if (n >= 1 && static_cast<size_t>(n) < sizeof(buf) && buf[n - 1] == '\n') {
+        buf[n - 1] = '\0';
+      }
+      ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::http2), trace, "nghttp2: {}", buf);
     }
-    ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::http2), trace, "nghttp2: {}", buf);
   });
 }
 

--- a/source/common/http/http2/nghttp2.cc
+++ b/source/common/http/http2/nghttp2.cc
@@ -14,6 +14,8 @@ namespace Http {
 namespace Http2 {
 
 void initializeNghttp2Logging() {
+  // Event when ENVOY_NGHTTP2_TRACE is not set, we install a debug logger, to prevent nghttp2
+  // logging directly to stdout at -l trace.
   nghttp2_set_debug_vprintf_callback([](const char* format, va_list args) {
     if (std::getenv("ENVOY_NGHTTP2_TRACE") != nullptr) {
       char buf[2048];


### PR DESCRIPTION
Avoid nghttp2 debug logs by default is good for two reasons:

1. In regular developer integration test debugging at trace level, it's
   a pain to filter the very spammy nghttp2 traces.

2. Coverage runs -l trace, it's hard to debug test output without generating
   O(100k) log lines, which results in massive CI log files.

Risk level: Low
Testing: No new tests, happy to add if it makes sense for this tweak.

Signed-off-by: Harvey Tuch <htuch@google.com>