### PR TITLE
ASOPVII: init-manager-query-unready-targets

### DIFF
--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -265,8 +265,8 @@ using SnapshotConstSharedPtr = std::shared_ptr<const Snapshot>;
 class Loader {
 public:
   virtual ~Loader() = default;
-
-  using ReadyCallback = std::function<void()>;
+  // (ASOPVII: Pass target_name to watcher's callback)
+  using ReadyCallback = std::function<void(const std::string)>;
 
   /**
    * Post-construction initialization. Runtime will be generally available after

--- a/source/common/init/manager_impl.cc
+++ b/source/common/init/manager_impl.cc
@@ -5,9 +5,10 @@
 namespace Envoy {
 namespace Init {
 
+// (ASOPVII: update 2nd para of watcher_ to a func with 'const std::string' para)
 ManagerImpl::ManagerImpl(absl::string_view name)
     : name_(fmt::format("init manager {}", name)), state_(State::Uninitialized), count_(0),
-      watcher_(name_, [this]() { onTargetReady(); }) {}
+      watcher_(name_, [this](const std::string target_name) { onTargetReady(target_name); }) {}
 
 Manager::State ManagerImpl::state() const { return state_; }
 
@@ -18,6 +19,11 @@ void ManagerImpl::add(const Target& target) {
   case State::Uninitialized:
     // If the manager isn't initialized yet, save the target handle to be initialized later.
     ENVOY_LOG(debug, "added {} to {}", target.name(), name_);
+
+    // (ASOPVII)
+    target_names_.push_back(std::string(target.name()));
+    ++target_names_count_[std::string(target.name())];
+
     target_handles_.push_back(std::move(target_handle));
     return;
   case State::Initializing:
@@ -25,6 +31,10 @@ void ManagerImpl::add(const Target& target) {
     // it's important in this case that count_ was incremented above before calling the target,
     // because if the target calls the init manager back immediately, count_ will be decremented
     // here (see the definition of watcher_ above).
+
+    // (ASOPVII)
+    ++target_names_count_[std::string(target.name())];
+
     target_handle->initialize(watcher_);
     return;
   case State::Initialized:
@@ -51,17 +61,35 @@ void ManagerImpl::initialize(const Watcher& watcher) {
 
     // Attempt to initialize each target. If a target is unavailable, treat it as though it
     // completed immediately.
+    // (ASOPVII: pass const std::string para to 'onTargetReady')
+    uint32_t target_index = 0;
     for (const auto& target_handle : target_handles_) {
       if (!target_handle->initialize(watcher_)) {
-        onTargetReady();
+        onTargetReady(target_names_[target_index]);
       }
+      target_index++;
     }
   }
 }
 
-void ManagerImpl::onTargetReady() {
+// (ASOPVII: add 'checkUnreadyTargets' method for init manager to query unready targets)
+void ManagerImpl::checkUnreadyTargets() {
+  ENVOY_LOG(debug, "QUERY: List of unready targets..................");
+  for(auto unready_target : target_names_count_) {
+    ENVOY_LOG(debug, "{} x {}", unready_target.first, unready_target.second);
+  }
+  ENVOY_LOG(debug, "QUERY ENDS..................");
+}
+
+// (ASOPVII: add 'target_name' parameter to onTargetReady)
+void ManagerImpl::onTargetReady(const std::string target_name) {
   // If there are no remaining targets and one mysteriously calls us back, this manager is haunted.
   ASSERT(count_ != 0, fmt::format("{} called back by target after initialization complete"));
+
+  // decrease count of a target_name by 1
+  if(--target_names_count_[target_name] == 0) {
+    target_names_count_.erase(target_name);
+  }
 
   // If there are no uninitialized targets remaining when called back by a target, that means it was
   // the last. Signal `ready` to the handle we saved in `initialize`.

--- a/source/common/init/manager_impl.h
+++ b/source/common/init/manager_impl.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <list>
+#include <vector>
+#include <unordered_map>
 
 #include "envoy/init/manager.h"
 
@@ -35,8 +37,12 @@ public:
   void add(const Target& target) override;
   void initialize(const Watcher& watcher) override;
 
+  // (ASOPVII: For init manager to query unready targets)
+  void checkUnreadyTargets();
+
 private:
-  void onTargetReady();
+  // (ASOPVII: Update implementation of 'onTargetReady')
+  void onTargetReady(const std::string target_name);
   void ready();
 
   // Human-readable name for logging
@@ -56,6 +62,11 @@ private:
 
   // All registered targets
   std::list<TargetHandlePtr> target_handles_;
+
+  // (ASOPVII: Corresponding name of registered targets)
+  std::vector<std::string> target_names_;
+  // (ASOPVII: Count of target_name)
+  std::unordered_map<std::string, uint32_t> target_names_count_;
 };
 
 } // namespace Init

--- a/source/common/init/watcher_impl.cc
+++ b/source/common/init/watcher_impl.cc
@@ -12,7 +12,8 @@ bool WatcherHandleImpl::ready() const {
   if (locked_fn) {
     // If we can "lock" a shared pointer to the watcher's callback function, call it.
     ENVOY_LOG(debug, "{} initialized, notifying {}", handle_name_, name_);
-    (*locked_fn)();
+    // (ASOPVII: Pass target_name to watcher's callback)
+    (*locked_fn)(handle_name_);
     return true;
   } else {
     // If not, the watcher was already destroyed.

--- a/source/common/init/watcher_impl.h
+++ b/source/common/init/watcher_impl.h
@@ -13,7 +13,8 @@ namespace Init {
  * A watcher is just a glorified callback function, called by a target or a manager when
  * initialization completes.
  */
-using ReadyFn = std::function<void()>;
+// (ASOPVII: Add a target_name parameter to the callback funtion 'onTargetReady')
+using ReadyFn = std::function<void(const std::string)>;
 
 /**
  * A WatcherHandleImpl functions as a weak reference to a Watcher. It is how a TargetImpl safely

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -468,6 +468,7 @@ void ProtoLayer::walkProtoValue(const ProtobufWkt::Value& v, const std::string& 
   }
 }
 
+// (ASOPVII: Pass target_name to watcher's callback)
 LoaderImpl::LoaderImpl(Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator& tls,
                        const envoy::config::bootstrap::v3::LayeredRuntime& config,
                        const LocalInfo::LocalInfo& local_info, Stats::Store& store,
@@ -475,7 +476,7 @@ LoaderImpl::LoaderImpl(Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator
                        ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api)
     : generator_(generator), stats_(generateStats(store)), tls_(tls.allocateSlot()),
       config_(config), service_cluster_(local_info.clusterName()), api_(api),
-      init_watcher_("RDTS", [this]() { onRdtsReady(); }), store_(store) {
+      init_watcher_("RDTS", [this](const std::string target_name) { onRdtsReady(target_name); }), store_(store) {
   std::unordered_set<std::string> layer_names;
   for (const auto& layer : config_.layers()) {
     auto ret = layer_names.insert(layer.name());
@@ -526,9 +527,10 @@ void LoaderImpl::startRtdsSubscriptions(ReadyCallback on_done) {
   init_manager_.initialize(init_watcher_);
 }
 
-void LoaderImpl::onRdtsReady() {
+// (ASOPVII: Pass target_name to watcher's callback)
+void LoaderImpl::onRdtsReady(const std::string target_name) {
   ENVOY_LOG(info, "RTDS has finished initialization");
-  on_rtds_initialized_();
+  on_rtds_initialized_(target_name);
 }
 
 RtdsSubscription::RtdsSubscription(

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -262,7 +262,8 @@ private:
   // Load a new Snapshot into TLS
   void loadNewSnapshot();
   RuntimeStats generateStats(Stats::Store& store);
-  void onRdtsReady();
+  // (ASOPVII: Pass target_name to watcher's callback)
+  void onRdtsReady(const std::string);
 
   RandomGenerator& generator_;
   RuntimeStats stats_;

--- a/test/common/init/manager_impl_test.cc
+++ b/test/common/init/manager_impl_test.cc
@@ -22,9 +22,11 @@ TEST(InitManagerImplTest, AddImmediateTargetsWhenUninitialized) {
 
   ExpectableTargetImpl t1("t1");
   m.add(t1);
+  m.checkUnreadyTargets(); // (ASOPVII)
 
   ExpectableTargetImpl t2("t2");
   m.add(t2);
+  m.checkUnreadyTargets(); // (ASOPVII)
 
   ExpectableWatcherImpl w;
 
@@ -33,6 +35,7 @@ TEST(InitManagerImplTest, AddImmediateTargetsWhenUninitialized) {
   t2.expectInitializeWillCallReady();
   w.expectReady();
   m.initialize(w);
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitialized(m);
 }
 
@@ -44,9 +47,11 @@ TEST(InitManagerImplTest, AddAsyncTargetsWhenUninitialized) {
 
   ExpectableTargetImpl t1("t1");
   m.add(t1);
+  m.checkUnreadyTargets(); // (ASOPVII)
 
   ExpectableTargetImpl t2("t2");
   m.add(t2);
+  m.checkUnreadyTargets(); // (ASOPVII)
 
   ExpectableWatcherImpl w;
 
@@ -54,15 +59,18 @@ TEST(InitManagerImplTest, AddAsyncTargetsWhenUninitialized) {
   t1.expectInitialize();
   t2.expectInitialize();
   m.initialize(w);
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitializing(m);
 
   // should still be initializing after first target initializes
   t1.ready();
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitializing(m);
 
   // initialization should finish after second target initializes
   w.expectReady();
   t2.ready();
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitialized(m);
 }
 
@@ -77,18 +85,20 @@ TEST(InitManagerImplTest, AddMixedTargetsWhenUninitialized) {
 
   ExpectableTargetImpl t2("t2");
   m.add(t2);
-
+  m.checkUnreadyTargets(); // (ASOPVII)
   ExpectableWatcherImpl w;
 
   // initialization should begin, and first target will initialize immediately
   t1.expectInitializeWillCallReady();
   t2.expectInitialize();
   m.initialize(w);
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitializing(m);
 
   // initialization should finish after second target initializes
   w.expectReady();
   t2.ready();
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitialized(m);
 }
 
@@ -100,23 +110,27 @@ TEST(InitManagerImplTest, AddImmediateTargetWhenInitializing) {
 
   ExpectableTargetImpl t1("t1");
   m.add(t1);
-
+  m.checkUnreadyTargets(); // (ASOPVII)
+  
   ExpectableWatcherImpl w;
 
   // initialization should begin
   t1.expectInitialize();
   m.initialize(w);
   expectInitializing(m);
+  m.checkUnreadyTargets(); // (ASOPVII)
 
   // adding an immediate target shouldn't finish initialization
   ExpectableTargetImpl t2("t2");
   t2.expectInitializeWillCallReady();
   m.add(t2);
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitializing(m);
 
   // initialization should finish after original target initializes
   w.expectReady();
   t1.ready();
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitialized(m);
 }
 
@@ -130,6 +144,7 @@ TEST(InitManagerImplTest, UnavailableTarget) {
   {
     ExpectableTargetImpl t("t");
     m.add(t);
+    m.checkUnreadyTargets(); // (ASOPVII)
     t.expectInitialize().Times(0);
   }
 
@@ -138,6 +153,7 @@ TEST(InitManagerImplTest, UnavailableTarget) {
   // initialization should complete despite the destroyed target
   w.expectReady();
   m.initialize(w);
+  m.checkUnreadyTargets(); // (ASOPVII)
   expectInitialized(m);
 }
 
@@ -152,10 +168,12 @@ TEST(InitManagerImplTest, UnavailableManager) {
     expectUninitialized(m);
 
     m.add(t);
+    m.checkUnreadyTargets(); // (ASOPVII)
 
     // initialization should begin before destroying the manager
     t.expectInitialize();
     m.initialize(w);
+    m.checkUnreadyTargets(); // (ASOPVII)
     expectInitializing(m);
   }
 
@@ -172,6 +190,7 @@ TEST(InitManagerImplTest, UnavailableWatcher) {
 
   ExpectableTargetImpl t("t");
   m.add(t);
+  m.checkUnreadyTargets(); // (ASOPVII)
 
   {
     ExpectableWatcherImpl w;
@@ -179,13 +198,16 @@ TEST(InitManagerImplTest, UnavailableWatcher) {
     // initialization should begin before destroying the watcher
     t.expectInitialize();
     m.initialize(w);
+    m.checkUnreadyTargets(); // (ASOPVII)
     expectInitializing(m);
 
     w.expectReady().Times(0);
+    m.checkUnreadyTargets(); // (ASOPVII)
   }
 
   // initialization should finish without notifying the watcher
   t.ready();
+  m.checkUnreadyTargets(); // (ASOPVII)
 }
 
 } // namespace

--- a/test/mocks/init/mocks.cc
+++ b/test/mocks/init/mocks.cc
@@ -5,8 +5,9 @@ namespace Init {
 
 using ::testing::Invoke;
 
+// (ASOPVII: Pass target_name to watcher's callback)
 ExpectableWatcherImpl::ExpectableWatcherImpl(absl::string_view name)
-    : WatcherImpl(name, {[this]() { ready(); }}) {}
+    : WatcherImpl(name, {[this](const std::string) { ready(); }}) {}
 ::testing::internal::TypedExpectation<void()>& ExpectableWatcherImpl::expectReady() const {
   return EXPECT_CALL(*this, ready());
 }


### PR DESCRIPTION
Commit Message: "ASOPVII: init-manager-query-unready-targets"

Additional Description: Store the **unready_target_name:count** key-value pair in a hash table for manager to easily query which registered targets are not ready. 

Risk Level: Low

Testing: add 'manager.checkUnreadyTargets' in test/common/init/manager_impl_test.cc