### PR TITLE
ci: use run_under to test tap

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -y update \
   && groupmod -g 65515 pcap && chgrp pcap /usr/sbin/tcpdump \
   # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
   && groupadd --gid $USER_GID $USERNAME \
-  && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME -d /build \
+  && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME -G pcap -d /build \
   # [Optional] Add sudo support for non-root user
   && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,8 @@
   "runArgs": [
     "--user=vscode",
     "--cap-add=SYS_PTRACE",
+    "--cap-add=NET_RAW",
+    "--cap-add=NET_ADMIN",
     "--security-opt=seccomp=unconfined",
     "--volume=${env:HOME}:${env:HOME}",
     "--volume=envoy-build:/build",

--- a/bazel/test/BUILD
+++ b/bazel/test/BUILD
@@ -1,0 +1,3 @@
+licenses(["notice"])  # Apache 2
+
+exports_files(["verify_tap_test.sh"])

--- a/bazel/test/verify_tap_test.sh
+++ b/bazel/test/verify_tap_test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+# Clear existing tap directory if previous run wasn't in sandbox
+rm -rf tap
+
+mkdir -p tap
+TAP_TMP="$(realpath tap)"
+
+TAP_PATH="${TAP_TMP}/tap" "$@"
+
+# TODO(htuch): Check for pcap, now CI (with or without RBE) does have
+# enough capabilities.
+# Verify that some pb_text files have been created.
+ls -l "${TAP_TMP}"/tap_*.pb_text > /dev/null

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -169,17 +169,9 @@ elif [[ "$CI_TARGET" == "bazel.asan" ]]; then
   # works. This requires that we set TAP_PATH. We do this under bazel.asan to
   # ensure a debug build in CI.
   echo "Validating integration test traffic tapping..."
-  TAP_TMP=/tmp/tap/
-  rm -rf "${TAP_TMP}"
-  mkdir -p "${TAP_TMP}"
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} \
-    --strategy=TestRunner=local --test_env=TAP_PATH="${TAP_TMP}/tap" \
-    --test_env=PATH="/usr/sbin:${PATH}" \
+    --run_under=@envoy//bazel/test:verify_tap_test.sh \
     //test/extensions/transport_sockets/tls/integration:ssl_integration_test
-  # Verify that some pb_text files have been created. We can't check for pcap,
-  # since tcpdump is not available in general due to CircleCI lack of support
-  # for privileged Docker executors.
-  ls -l "${TAP_TMP}"/tap_*.pb_text > /dev/null
   exit 0
 elif [[ "$CI_TARGET" == "bazel.tsan" ]]; then
   setup_clang_toolchain


### PR DESCRIPTION
When ssl_integration_test are cached, no pb_text will be generated locally, testing it with `--run_under` makes it possible to be cached.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
