### PR TITLE
aws-signing: add es and glacier for payloads special treatment

### DIFF
--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -24,8 +24,8 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 }
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
-  // S3 payloads require special treatment.
-  if (service_name_ == "s3") {
+  // S3, gracier, es payloads require special treatment.
+  if (service_name_ == "s3" || service_name_ == "gracier" || service_name_ == "es") {
     headers.setReference(SignatureHeaders::get().ContentSha256,
                          SignatureConstants::get().UnsignedPayload);
     sign(headers, SignatureConstants::get().UnsignedPayload);

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -25,9 +25,12 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
   // S3, gracier, es payloads require special treatment.
-  // s3: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
-  // es: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
-  // gracier: https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html
+  // s3:
+  // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+  // es:
+  // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
+  // gracier:
+  // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html
   if (service_name_ == "s3" || service_name_ == "gracier" || service_name_ == "es") {
     headers.setReference(SignatureHeaders::get().ContentSha256,
                          SignatureConstants::get().UnsignedPayload);

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -24,12 +24,12 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 }
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
-  // S3, gracier, es payloads require special treatment.
-  // s3:
+  // S3, Gracier, ES payloads require special treatment.
+  // S3:
   // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
-  // es:
+  // ES:
   // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
-  // gracier:
+  // Gracier:
   // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html
   if (service_name_ == "s3" || service_name_ == "gracier" || service_name_ == "es") {
     headers.setReference(SignatureHeaders::get().ContentSha256,

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -24,14 +24,14 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 }
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
-  // S3, Gracier, ES payloads require special treatment.
+  // S3, Glacier, ES payloads require special treatment.
   // S3:
-  // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+  // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
   // ES:
-  // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
-  // Gracier:
-  // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html
-  if (service_name_ == "s3" || service_name_ == "gracier" || service_name_ == "es") {
+  // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html.
+  // Glacier:
+  // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html.
+  if (service_name_ == "s3" || service_name_ == "glacier" || service_name_ == "es") {
     headers.setReference(SignatureHeaders::get().ContentSha256,
                          SignatureConstants::get().UnsignedPayload);
     sign(headers, SignatureConstants::get().UnsignedPayload);

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -24,14 +24,7 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 }
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
-  // S3, Glacier, ES payloads require special treatment.
-  // S3:
-  // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
-  // ES:
-  // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html.
-  // Glacier:
-  // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html.
-  if (service_name_ == "s3" || service_name_ == "glacier" || service_name_ == "es") {
+  if (require_content_hash_) {
     headers.setReference(SignatureHeaders::get().ContentSha256,
                          SignatureConstants::get().UnsignedPayload);
     sign(headers, SignatureConstants::get().UnsignedPayload);

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -25,6 +25,9 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
   // S3, gracier, es payloads require special treatment.
+  // s3: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
+  // es: https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
+  // gracier: https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html
   if (service_name_ == "s3" || service_name_ == "gracier" || service_name_ == "es") {
     headers.setReference(SignatureHeaders::get().ContentSha256,
                          SignatureConstants::get().UnsignedPayload);

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -74,6 +74,16 @@ private:
 
   const std::string service_name_;
   const std::string region_;
+
+  // S3, Glacier, ES payloads require special treatment.
+  // S3:
+  // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
+  // ES:
+  // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html.
+  // Glacier:
+  // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html.
+  const bool require_content_hash_{service_name_ == "s3" || service_name_ == "glacier" ||
+                                   service_name_ == "es"};
   CredentialsProviderSharedPtr credentials_provider_;
   TimeSource& time_source_;
   DateFormatter long_date_formatter_;

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -47,8 +47,19 @@ class SignerImpl : public Signer, public Logger::Loggable<Logger::Id::http> {
 public:
   SignerImpl(absl::string_view service_name, absl::string_view region,
              const CredentialsProviderSharedPtr& credentials_provider, TimeSource& time_source)
-      : service_name_(service_name), region_(region), credentials_provider_(credentials_provider),
-        time_source_(time_source), long_date_formatter_(SignatureConstants::get().LongDateFormat),
+      : service_name_(service_name), region_(region),
+
+        // S3, Glacier, ES payloads require special treatment.
+        // S3:
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
+        // ES:
+        // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html.
+        // Glacier:
+        // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html.
+        require_content_hash_{service_name_ == "s3" || service_name_ == "glacier" ||
+                              service_name_ == "es"},
+        credentials_provider_(credentials_provider), time_source_(time_source),
+        long_date_formatter_(SignatureConstants::get().LongDateFormat),
         short_date_formatter_(SignatureConstants::get().ShortDateFormat) {}
 
   void sign(Http::RequestMessage& message, bool sign_body = false) override;
@@ -75,15 +86,7 @@ private:
   const std::string service_name_;
   const std::string region_;
 
-  // S3, Glacier, ES payloads require special treatment.
-  // S3:
-  // https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html.
-  // ES:
-  // https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html.
-  // Glacier:
-  // https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html.
-  const bool require_content_hash_{service_name_ == "s3" || service_name_ == "glacier" ||
-                                   service_name_ == "es"};
+  const bool require_content_hash_;
   CredentialsProviderSharedPtr credentials_provider_;
   TimeSource& time_source_;
   DateFormatter long_date_formatter_;

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -226,7 +226,7 @@ TEST_F(SignerImplTest, SignHeadersES) {
 
   EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/es/aws4_request, "
             "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
-            "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
+            "Signature=0fd9c974bb2ad16c8d8a314dca4f6db151d32cbd04748d9c018afee2a685a02e",
             headers.get(Http::CustomHeaders::get().Authorization)->value().getStringView());
   EXPECT_EQ(SignatureConstants::get().UnsignedPayload,
             headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
@@ -247,7 +247,7 @@ TEST_F(SignerImplTest, SignHeadersGracier) {
 
   EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/gracier/aws4_request, "
             "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
-            "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
+            "Signature=06a594b2fa4cf2bfe43e8535dc4bd0a6d3b8ae3080f4fbdbc3c6d8b16b038941",
             headers.get(Http::CustomHeaders::get().Authorization)->value().getStringView());
   EXPECT_EQ(SignatureConstants::get().UnsignedPayload,
             headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -224,7 +224,7 @@ TEST_F(SignerImplTest, SignHeadersES) {
                     time_system_);
   signer.sign(headers);
 
-  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/s3/aws4_request, "
+  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/es/aws4_request, "
             "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
             "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
             headers.get(Http::CustomHeaders::get().Authorization)->value().getStringView());
@@ -241,11 +241,11 @@ TEST_F(SignerImplTest, SignHeadersGracier) {
   headers.setPath("/");
   headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
 
-  SignerImpl signer("es", "region", CredentialsProviderSharedPtr{credentials_provider},
+  SignerImpl signer("gracier", "region", CredentialsProviderSharedPtr{credentials_provider},
                     time_system_);
   signer.sign(headers);
 
-  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/s3/aws4_request, "
+  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/gracier/aws4_request, "
             "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
             "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
             headers.get(Http::CustomHeaders::get().Authorization)->value().getStringView());

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -190,7 +190,7 @@ TEST_F(SignerImplTest, SignHostHeader) {
       message_->headers().get(Http::CustomHeaders::get().Authorization)->value().getStringView());
 }
 
-// Verify signing headers for services
+// Verify signing headers for services.
 TEST_F(SignerImplTest, SignHeadersByService) {
   expectSignHeaders("s3", "d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
                     SignatureConstants::get().UnsignedPayload);
@@ -198,7 +198,7 @@ TEST_F(SignerImplTest, SignHeadersByService) {
                     SignatureConstants::get().HashedEmptyString);
   expectSignHeaders("es", "0fd9c974bb2ad16c8d8a314dca4f6db151d32cbd04748d9c018afee2a685a02e",
                     SignatureConstants::get().UnsignedPayload);
-  expectSignHeaders("gracier", "06a594b2fa4cf2bfe43e8535dc4bd0a6d3b8ae3080f4fbdbc3c6d8b16b038941",
+  expectSignHeaders("glacier", "8d1f241d77c64cda57b042cd312180f16e98dbd7a96e5545681430f8dbde45a0",
                     SignatureConstants::get().UnsignedPayload);
 }
 

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -232,7 +232,7 @@ TEST_F(SignerImplTest, SignHeadersES) {
             headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
 }
 
-// Verify signing headers for gracier
+// Verify signing headers for Gracier
 TEST_F(SignerImplTest, SignHeadersGracier) {
   auto* credentials_provider = new NiceMock<MockCredentialsProvider>();
   EXPECT_CALL(*credentials_provider, getCredentials()).WillOnce(Return(credentials_));

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -211,6 +211,48 @@ TEST_F(SignerImplTest, SignHeadersNonS3) {
             headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
 }
 
+// Verify signing headers for es
+TEST_F(SignerImplTest, SignHeadersES) {
+  auto* credentials_provider = new NiceMock<MockCredentialsProvider>();
+  EXPECT_CALL(*credentials_provider, getCredentials()).WillOnce(Return(credentials_));
+  Http::TestRequestHeaderMapImpl headers{};
+  headers.setMethod("GET");
+  headers.setPath("/");
+  headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
+
+  SignerImpl signer("es", "region", CredentialsProviderSharedPtr{credentials_provider},
+                    time_system_);
+  signer.sign(headers);
+
+  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/s3/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
+            headers.get(Http::CustomHeaders::get().Authorization)->value().getStringView());
+  EXPECT_EQ(SignatureConstants::get().UnsignedPayload,
+            headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
+}
+
+// Verify signing headers for gracier
+TEST_F(SignerImplTest, SignHeadersGracier) {
+  auto* credentials_provider = new NiceMock<MockCredentialsProvider>();
+  EXPECT_CALL(*credentials_provider, getCredentials()).WillOnce(Return(credentials_));
+  Http::TestRequestHeaderMapImpl headers{};
+  headers.setMethod("GET");
+  headers.setPath("/");
+  headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
+
+  SignerImpl signer("es", "region", CredentialsProviderSharedPtr{credentials_provider},
+                    time_system_);
+  signer.sign(headers);
+
+  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/s3/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
+            headers.get(Http::CustomHeaders::get().Authorization)->value().getStringView());
+  EXPECT_EQ(SignatureConstants::get().UnsignedPayload,
+            headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
+}
+
 } // namespace
 } // namespace Aws
 } // namespace Common

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -121,7 +121,6 @@ GCP
 GETting
 GLB
 GOAWAY
-Glacier
 GRPC
 GSS
 GTEST

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -121,7 +121,7 @@ GCP
 GETting
 GLB
 GOAWAY
-Gracier
+Glacier
 GRPC
 GSS
 GTEST

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -121,6 +121,7 @@ GCP
 GETting
 GLB
 GOAWAY
+Gracier
 GRPC
 GSS
 GTEST


### PR DESCRIPTION
Commit Message:  aws-signing: add elasticsearch and glacier for payloads special treatment
Additional Description:

I found aws_request_signing for elasticsearch service failed in POST.
ESS too needs x-amz-content-sha256 like s3, so I added service_name es ( and gracier too ).

https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.html
https://docs.aws.amazon.com/amazonglacier/latest/dev/amazon-glacier-signing-requests.html

Risk Level: Low
Testing:  yes
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: azihsoyn <azihsoyn@gmail.com>
