### PR TITLE
protobuf: optimize unpackTo() for message upgrades.

### DIFF
--- a/source/common/config/version_converter.h
+++ b/source/common/config/version_converter.h
@@ -92,6 +92,15 @@ public:
                                         envoy::config::core::v3::ApiVersion api_version);
 
   /**
+   * Annotate an upgraded message with original message type information.
+   *
+   * @param prev_descriptor descriptor for original type.
+   * @param upgraded_message upgraded message.
+   */
+  static void annotateWithOriginalType(const Protobuf::Descriptor& prev_descriptor,
+                                       Protobuf::Message& upgraded_message);
+
+  /**
    * For a message that may have been upgraded, recover the original message.
    * This is useful for config dump, debug output etc.
    *


### PR DESCRIPTION
While looking at eds_speed_test flamegraphs as part of #10875, it seemed
we were doing some redundant work, namely first unpacking to v2 message
and then upgrading from v2 to v3. Since v2 and v3 are wire compatible,
and upgrade is just a wirecast, we might as well just unpack to v2.

This improves eds_speed_test significantly, the penalty for v3 vs. v2
drops from 2.6x to 2x.

Part of #11362 #10875.

Risk level: Low
Testing: Coverage of behavior from existing tests.

Signed-off-by: Harvey Tuch <htuch@google.com>