### PR TITLE
test: improve test coverage for extensions/resource_monitors/fixed_heap

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -44,7 +44,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/health_checkers/redis:95.9"
 "source/extensions/quic_listeners:84.8"
 "source/extensions/quic_listeners/quiche:84.8"
-"source/extensions/resource_monitors/fixed_heap:90.9"
 "source/extensions/retry:95.5"
 "source/extensions/retry/host:85.7"
 "source/extensions/retry/host/omit_canary_hosts:64.3"


### PR DESCRIPTION
Commit Message: add unit test to improve coverage of extensions/resource_monitors/fixed_heap
Risk Level: low
Testing: unit test
Fixes #12006 

Signed-off-by: Elisha Ziskind <eziskind@google.com>
