### PR TITLE
Update jwt_verify_lib to 2020-07-09 with added PS alg support

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -278,10 +278,10 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     com_github_google_jwt_verify = dict(
-        sha256 = "d2e28897c297bd04429e43a1b485f7350acc23cbfee6365b8a3634c17840b2f6",
-        strip_prefix = "jwt_verify_lib-f44cf49d185ad0694b472da78071b4d67313fb86",
-        # 2020-06-03
-        urls = ["https://github.com/google/jwt_verify_lib/archive/f44cf49d185ad0694b472da78071b4d67313fb86.tar.gz"],
+        sha256 = "f1fde4f3ebb3b2d841332c7a02a4b50e0529a19709934c63bc6208d1bbe28fb1",
+        strip_prefix = "jwt_verify_lib-7276a339af8426724b744216f619c99152f8c141",
+        # 2020-07-09
+        urls = ["https://github.com/google/jwt_verify_lib/archive/7276a339af8426724b744216f619c99152f8c141.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -8,8 +8,17 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
 .. attention::
-   EdDSA, ES256, ES384, ES512, HS256, HS384, HS512, RS256, RS384 and RS512 are supported for the JWT alg.
+Supported JWT alg:
 
+.. code-block::
+
+   ES256, ES384, ES512,
+   HS256, HS384, HS512,
+   RS256, RS384, RS512,
+   PS256, PS384, PS512,
+   EdDSA
+
+   
 Configuration
 -------------
 

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -7,8 +7,7 @@ This HTTP filter can be used to verify JSON Web Token (JWT). It will verify its 
 
 JWKS is needed to verify JWT signatures. They can be specified in the filter config or can be fetched remotely from a JWKS server.
 
-.. attention::
-Supported JWT alg:
+Following are supported JWT alg:
 
 .. code-block::
 
@@ -18,7 +17,6 @@ Supported JWT alg:
    PS256, PS384, PS512,
    EdDSA
 
-   
 Configuration
 -------------
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

jwt_verify_lib has two changes
* added support RSA PSS 

Risk Level:  None
Testing:  None
Docs Changes: Yes
Release Notes: None

