### PR TITLE
config validation: ValidationAdmin should pretend that addHandler and removeHandler complete successfully

### DIFF
--- a/source/server/config_validation/admin.cc
+++ b/source/server/config_validation/admin.cc
@@ -3,11 +3,12 @@
 namespace Envoy {
 namespace Server {
 
+// Pretend that handler was added successfully.
 bool ValidationAdmin::addHandler(const std::string&, const std::string&, HandlerCb, bool, bool) {
-  return false;
+  return true;
 }
 
-bool ValidationAdmin::removeHandler(const std::string&) { return false; }
+bool ValidationAdmin::removeHandler(const std::string&) { return true; }
 
 const Network::Socket& ValidationAdmin::socket() { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 


### PR DESCRIPTION
Description:
When running in config validation mode logic is mostly preserved, but low level methods are usually overwritten and return success. This was not the case for ValidateAdmin::addHandler and ValidateAdmin::removeHandler. Both of those methods returned false, causing assertion failure in Tap::AdminHandler:

```
 const bool rc =admin_.addHandler("/tap", "tap filter control", MAKE_ADMIN_HANDLER(handler), true, true);
 RELEASE_ASSERT(rc, "/tap admin endpoint is taken");

```
Risk Level:
Low.

Testing:
Manual testing.

Docs Changes:
No.

Release Notes:
No.

Fixes #10154