### PR TITLE
caching: add parsing of range requests to CacheFilter

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -517,6 +517,33 @@ std::string StringUtil::removeCharacters(const absl::string_view& str,
   return absl::StrJoin(pieces, "");
 }
 
+absl::optional<uint64_t> StringUtil::readAndRemoveLeadingDigits(absl::string_view& str) {
+  const char* ptr = str.data();
+  const char* limit = ptr + str.size();
+  uint64_t val = 0;
+
+  while (ptr < limit) {
+    const char cur = *ptr;
+    if (cur < '0' || cur > '9') {
+      break;
+    }
+    uint64_t new_val = (val * 10) + (cur - '0');
+    if (new_val / 8 < val) {
+      // Overflow occurred
+      return absl::nullopt;
+    }
+    val = new_val;
+    ptr++;
+  }
+
+  if (ptr > str.data()) {
+    // Consume some digits
+    str.remove_prefix(ptr - str.data());
+    return val;
+  }
+  return absl::nullopt;
+}
+
 bool Primes::isPrime(uint32_t x) {
   if (x < 4) {
     return true; // eliminates special-casing 2.

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -380,6 +380,13 @@ public:
    */
   static std::string removeCharacters(const absl::string_view& str,
                                       const IntervalSet<size_t>& remove_characters);
+
+  /**
+   * Read a leading positive decimal integer value and advance "*s" past the
+   * digits read. If overflow occurs, or no digits exist, return
+   * absl::nullopt without advancing "*s".
+   */
+  static absl::optional<uint64_t> readAndRemoveLeadingDigits(absl::string_view& str);
 };
 
 /**

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -191,6 +191,7 @@ public:
   const LowerCaseString Path{":path"};
   const LowerCaseString Protocol{":protocol"};
   const LowerCaseString ProxyConnection{"proxy-connection"};
+  const LowerCaseString Range{"range"};
   const LowerCaseString RequestId{"x-request-id"};
   const LowerCaseString Scheme{":scheme"};
   const LowerCaseString Server{"server"};

--- a/source/extensions/filters/http/cache/BUILD
+++ b/source/extensions/filters/http/cache/BUILD
@@ -56,6 +56,8 @@ envoy_cc_library(
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:header_map_interface",
         "//source/common/common:assert_lib",
+        "//source/common/common:utility_lib",
+        "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/cache/v3alpha:pkg_cc_proto",

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -82,8 +82,8 @@ void CacheFilter::onHeaders(LookupResult&& result) {
   switch (result.cache_entry_status_) {
   case CacheEntryStatus::RequiresValidation:
   case CacheEntryStatus::FoundNotModified:
-  case CacheEntryStatus::UnsatisfiableRange:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE; // We don't yet return or support these codes.
+  case CacheEntryStatus::NotSatisfiableRange: // TODO(#10132): create 416 response.
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;          // We don't yet return or support these codes.
   case CacheEntryStatus::Unusable:
     if (state_ == GetHeadersState::FinishedGetHeadersCall) {
       // decodeHeader returned Http::FilterHeadersStatus::StopAllIterationAndWatermark--restart it
@@ -93,6 +93,8 @@ void CacheFilter::onHeaders(LookupResult&& result) {
       state_ = GetHeadersState::GetHeadersResultUnusable;
     }
     return;
+  case CacheEntryStatus::SatisfiableRange: // TODO(#10132): break response content to the ranges
+                                           // requested.
   case CacheEntryStatus::Ok:
     response_has_trailers_ = result.has_trailers_;
     const bool end_stream = (result.content_length_ == 0 && !response_has_trailers_);

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -11,6 +11,7 @@
 #include "envoy/http/header_map.h"
 
 #include "common/common/assert.h"
+#include "common/common/logger.h"
 
 #include "source/extensions/filters/http/cache/key.pb.h"
 
@@ -32,8 +33,10 @@ enum class CacheEntryStatus {
   // This entry is fresh, and an appropriate basis for a 304 Not Modified
   // response.
   FoundNotModified,
-  // This entry is fresh, but can't satisfy the requested range(s).
-  UnsatisfiableRange,
+  // This entry is fresh, but cannot satisfy the requested range(s).
+  NotSatisfiableRange,
+  // This entry is fresh, and can satisfy the requested range(s).
+  SatisfiableRange,
 };
 
 std::ostream& operator<<(std::ostream& os, CacheEntryStatus status);
@@ -67,6 +70,13 @@ public:
 private:
   const uint64_t first_byte_pos_;
   const uint64_t last_byte_pos_;
+};
+
+class RangeRequests : Logger::Loggable<Logger::Id::cache_filter> {
+public:
+  // Parses the ranges from the request headers into a vector<RawByteRange>.
+  static std::vector<RawByteRange> parseRanges(const Http::RequestHeaderMap& request_headers,
+                                               int byte_range_parse_limit);
 };
 
 // Byte range from an HTTP request, adjusted for a known response body size, and converted from an

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -420,6 +420,111 @@ TEST(StringUtil, removeCharacters) {
   EXPECT_EQ("1256x", StringUtil::removeCharacters("0123456789x", removals));
 }
 
+void TestReadAndRemoveLeadingDigits(absl::string_view s, int64_t expected,
+                                    absl::string_view remaining) {
+  absl::string_view input(s);
+  auto output = StringUtil::readAndRemoveLeadingDigits(input);
+  if (output) {
+    EXPECT_EQ(output, static_cast<uint64_t>(expected));
+    EXPECT_EQ(input, remaining);
+  } else {
+    EXPECT_LT(expected, 0);
+    EXPECT_EQ(input, remaining);
+  }
+}
+
+TEST(StringUtil, ReadAndRemoveLeadingDigits) {
+  TestReadAndRemoveLeadingDigits("123", 123, "");
+  TestReadAndRemoveLeadingDigits("a123", -1, "a123");
+  TestReadAndRemoveLeadingDigits("9_", 9, "_");
+  TestReadAndRemoveLeadingDigits("11111111111xyz", 11111111111ll, "xyz");
+
+  // Overflow case
+  TestReadAndRemoveLeadingDigits("1111111111111111111111111111111xyz", -1,
+                                 "1111111111111111111111111111111xyz");
+
+  // 2^64
+  TestReadAndRemoveLeadingDigits("18446744073709551616xyz", -1, "18446744073709551616xyz");
+  // 2^64-1
+  TestReadAndRemoveLeadingDigits("18446744073709551615xyz", 18446744073709551615ull, "xyz");
+  // (2^64-1)*10+9
+  TestReadAndRemoveLeadingDigits("184467440737095516159yz", -1, "184467440737095516159yz");
+}
+
+TEST(StringUtil, ReadAndRemoveLeadingDigitsExhaustive) {
+  // Pseudo-exhaustive test.
+  // We run through every possible 16-20 digit number, where the middle
+  // 14 digits consist of the same 2 digits repeated 7 times, as well as
+  // every 16-digit number where the middle 14 digits are 67440737095516,
+  // which is the middle digits of 2^64. And we run them twice, once as
+  // just the number, and again with a trailing "X".
+  // The "same 2 digits" are all combos 00-99 for low and high values of
+  // leading 4 digits, and all combos divisible by 3 when the first 4
+  // numbers are 1000-8999.
+  bool saw_264 = false, saw_264_minus_1 = false;
+  for (int hi4 = 0; hi4 <= 9999; ++hi4) {
+    for (int mid2 = 0; mid2 <= 100; ++mid2) {
+      char buf[32];
+      if (mid2 < 100) {
+        snprintf(buf, sizeof(buf), "%d%02d%02d%02d%02d%02d%02d%02d", hi4, mid2, mid2, mid2, mid2,
+                 mid2, mid2, mid2);
+      } else {
+        snprintf(buf, sizeof(buf), "%d67440737095516", hi4);
+      }
+      uint64_t expected = hi4 * 100000000000000 + mid2 * 1010101010101;
+      if (mid2 == 100)
+        expected = hi4 * 100000000000000 + 67440737095516;
+
+      absl::string_view input(buf);
+      absl::optional<uint64_t> output = StringUtil::readAndRemoveLeadingDigits(input);
+      EXPECT_TRUE(output) << " given " << buf;
+      EXPECT_EQ(expected, output);
+      EXPECT_EQ(0, input.size());
+
+      // To save time, use the leading digits over and over again, hand-placing
+      // the final digits at the end of buf.
+      char* write = &buf[strlen(buf)];
+      int lo2_inc = 1;
+      if (hi4 > 999 && hi4 < 9000 && hi4 != 1844) {
+        // To save time, only do 1/3rd of the possibilities for the last
+        // digits, when the first four digits are between 1000 and 9000.
+        // This doubles the speed while still still doing a lot of testing.
+        lo2_inc += 2;
+      }
+      for (int lo2 = 0; lo2 <= 99; lo2 += lo2_inc) {
+        write[0] = '0' + lo2 / 10;
+        write[1] = '0' + lo2 % 10;
+        write[2] = '\0';
+        absl::string_view big_input(buf);
+        uint64_t big_expected = expected * 100 + lo2;
+        if (big_input == "18446744073709551616")
+          saw_264 = true;
+        if (big_input == "18446744073709551615")
+          saw_264_minus_1 = true;
+        absl::optional<uint64_t> big_output;
+        if (big_expected / 100 != expected) { // overflow
+          big_output = StringUtil::readAndRemoveLeadingDigits(big_input);
+          EXPECT_FALSE(big_output) << " given overflowing " << buf;
+        } else {
+          big_output = StringUtil::readAndRemoveLeadingDigits(big_input);
+          EXPECT_TRUE(big_output) << " given " << buf;
+          EXPECT_EQ(big_expected, big_output) << " given " << buf;
+          EXPECT_EQ(0, big_input.size());
+          write[2] = 'X';
+          write[3] = '\0';
+          big_input = buf;
+          big_output = StringUtil::readAndRemoveLeadingDigits(big_input);
+          EXPECT_TRUE(big_output) << " given " << buf;
+          EXPECT_EQ(big_expected, big_output) << " given " << buf;
+          EXPECT_EQ(1, big_input.size());
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(saw_264);
+  EXPECT_TRUE(saw_264_minus_1);
+}
+
 TEST(AccessLogDateTimeFormatter, fromTime) {
   SystemTime time1(std::chrono::seconds(1522796769));
   EXPECT_EQ("2018-04-03T23:06:09.000Z", AccessLogDateTimeFormatter::fromTime(time1));

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -170,9 +170,14 @@ TEST_F(LookupRequestTest, NotExpiredViaFallbackheader) {
   EXPECT_EQ(CacheEntryStatus::Ok, lookup_response.cache_entry_status_);
 }
 
-TEST_F(LookupRequestTest, FullRange) {
-  request_headers_.addCopy("Range", "0-99");
+TEST_F(LookupRequestTest, SatisfiableRange) {
+  // add method (GET) and range to headers
+  request_headers_.addCopy(Http::Headers::get().Method.get(),
+                           Http::Headers::get().MethodValues.Get);
+  request_headers_.addCopy(Http::Headers::get().Range.get(), "bytes=1-99,3-,-2");
+
   const LookupRequest lookup_request(request_headers_, current_time_);
+
   const Http::TestResponseHeaderMapImpl response_headers(
       {{"date", formatter_.fromTime(current_time_)},
        {"cache-control", "public, max-age=3600"},
@@ -180,11 +185,51 @@ TEST_F(LookupRequestTest, FullRange) {
   const uint64_t content_length = 4;
   const LookupResult lookup_response =
       makeLookupResult(lookup_request, response_headers, content_length);
-  ASSERT_EQ(CacheEntryStatus::Ok, lookup_response.cache_entry_status_);
+  ASSERT_EQ(CacheEntryStatus::SatisfiableRange, lookup_response.cache_entry_status_);
+
   ASSERT_TRUE(lookup_response.headers_);
   EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
   EXPECT_EQ(lookup_response.content_length_, 4);
-  EXPECT_TRUE(lookup_response.response_ranges_.empty());
+
+  // checks that the ranges have been adjusted to the content's length
+  EXPECT_EQ(lookup_response.response_ranges_.size(), 3);
+
+  EXPECT_EQ(lookup_response.response_ranges_[0].begin(), 1);
+  EXPECT_EQ(lookup_response.response_ranges_[0].end(), 4);
+  EXPECT_EQ(lookup_response.response_ranges_[0].length(), 3);
+
+  EXPECT_EQ(lookup_response.response_ranges_[1].begin(), 3);
+  EXPECT_EQ(lookup_response.response_ranges_[1].end(), 4);
+  EXPECT_EQ(lookup_response.response_ranges_[1].length(), 1);
+
+  EXPECT_EQ(lookup_response.response_ranges_[2].begin(), 2);
+  EXPECT_EQ(lookup_response.response_ranges_[2].end(), 4);
+  EXPECT_EQ(lookup_response.response_ranges_[2].length(), 2);
+
+  EXPECT_FALSE(lookup_response.has_trailers_);
+}
+
+TEST_F(LookupRequestTest, NotSatisfiableRange) {
+  // add method (GET) and range headers
+  request_headers_.addCopy(Http::Headers::get().Method.get(),
+                           Http::Headers::get().MethodValues.Get);
+  request_headers_.addCopy(Http::Headers::get().Range.get(), "bytes=5-99,100-");
+
+  const LookupRequest lookup_request(request_headers_, current_time_);
+
+  const Http::TestResponseHeaderMapImpl response_headers(
+      {{"date", formatter_.fromTime(current_time_)},
+       {"cache-control", "public, max-age=3600"},
+       {"content-length", "4"}});
+  const uint64_t content_length = 4;
+  const LookupResult lookup_response =
+      makeLookupResult(lookup_request, response_headers, content_length);
+  ASSERT_EQ(CacheEntryStatus::NotSatisfiableRange, lookup_response.cache_entry_status_);
+
+  ASSERT_TRUE(lookup_response.headers_);
+  EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
+  EXPECT_EQ(lookup_response.content_length_, 4);
+  ASSERT_TRUE(lookup_response.response_ranges_.empty());
   EXPECT_FALSE(lookup_response.has_trailers_);
 }
 
@@ -251,6 +296,138 @@ TEST(AdjustByteRange, NoRangeRequest) {
   std::vector<AdjustedByteRange> result;
   ASSERT_TRUE(adjustByteRangeSet(result, {}, 8));
   EXPECT_THAT(result, ContainerEq(std::vector<AdjustedByteRange>{}));
+}
+
+namespace {
+Http::TestRequestHeaderMapImpl makeTestHeaderMap(std::string rangeValue) {
+  return Http::TestRequestHeaderMapImpl{{":method", "GET"}, {"range", rangeValue}};
+}
+} // namespace
+
+TEST(ParseRangesTest, InvalidUnit) {
+  auto headers = makeTestHeaderMap("bits=3-4");
+  auto result_vector = RangeRequests::parseRanges(headers, 5);
+
+  ASSERT_EQ(0, result_vector.size());
+}
+
+TEST(ParseRangesTest, SingleRange) {
+  auto headers = makeTestHeaderMap("bytes=3-4");
+  auto result_vector = RangeRequests::parseRanges(headers, 5);
+
+  ASSERT_EQ(1, result_vector.size());
+
+  ASSERT_EQ(3, result_vector[0].firstBytePos());
+  ASSERT_EQ(4, result_vector[0].lastBytePos());
+}
+
+TEST(ParseRangesTest, MissingFirstBytePos) {
+  auto headers = makeTestHeaderMap("bytes=-5");
+  auto result_vector = RangeRequests::parseRanges(headers, 5);
+
+  ASSERT_EQ(1, result_vector.size());
+
+  ASSERT_TRUE(result_vector[0].isSuffix());
+  ASSERT_EQ(5, result_vector[0].suffixLength());
+}
+
+TEST(ParseRangesTest, MissingLastBytePos) {
+  auto headers = makeTestHeaderMap("bytes=6-");
+  auto result_vector = RangeRequests::parseRanges(headers, 5);
+
+  ASSERT_EQ(1, result_vector.size());
+
+  ASSERT_EQ(6, result_vector[0].firstBytePos());
+  ASSERT_EQ(UINT64_MAX, result_vector[0].lastBytePos());
+}
+
+TEST(ParseRangesTest, MultipleRanges) {
+  auto headers = makeTestHeaderMap("bytes=345-456,-567,6789-");
+  auto result_vector = RangeRequests::parseRanges(headers, 5);
+
+  ASSERT_EQ(3, result_vector.size());
+
+  ASSERT_EQ(345, result_vector[0].firstBytePos());
+  ASSERT_EQ(456, result_vector[0].lastBytePos());
+
+  ASSERT_TRUE(result_vector[1].isSuffix());
+  ASSERT_EQ(567, result_vector[1].suffixLength());
+
+  ASSERT_EQ(6789, result_vector[2].firstBytePos());
+  ASSERT_EQ(UINT64_MAX, result_vector[2].lastBytePos());
+}
+
+TEST(ParseRangesTest, LongRangeHeaderValue) {
+  auto headers = makeTestHeaderMap("bytes=1000-1000,1001-1001,1002-1002,1003-1003,1004-1004,1005-"
+                                   "1005,1006-1006,1007-1007,1008-1008,100-");
+  auto result_vector = RangeRequests::parseRanges(headers, 10);
+
+  ASSERT_EQ(10, result_vector.size());
+}
+
+TEST(ParseRangesTest, ZeroRangeLimit) {
+  auto headers = makeTestHeaderMap("bytes=1000-1000");
+  auto result_vector = RangeRequests::parseRanges(headers, 0);
+
+  ASSERT_EQ(0, result_vector.size());
+}
+
+TEST(ParseRangesTest, OverRangeLimit) {
+  auto headers = makeTestHeaderMap("bytes=1000-1000,1001-1001");
+  auto result_vector = RangeRequests::parseRanges(headers, 1);
+
+  ASSERT_EQ(0, result_vector.size());
+}
+
+class ParseInvalidRangeHeaderTest : public testing::Test,
+                                    public testing::WithParamInterface<std::string> {
+protected:
+  auto range() { return makeTestHeaderMap(GetParam()); }
+};
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(
+    Default, ParseInvalidRangeHeaderTest,
+    testing::Values("-",
+                    "1-2",
+                    "12",
+                    "a",
+                    "a1",
+                    "bytes=-",
+                    "bytes1-2",
+                    "bytes=12",
+                    "bytes=1-2-3",
+                    "bytes=1-2-",
+                    "bytes=1--3",
+                    "bytes=--2",
+                    "bytes=2--",
+                    "bytes=-2-",
+                    "bytes=-1-2",
+                    "bytes=a-2",
+                    "bytes=2-a",
+                    "bytes=-a",
+                    "bytes=a-",
+                    "bytes=a1-2",
+                    "bytes=1-a2",
+                    "bytes=1a-2",
+                    "bytes=1-2a",
+                    "bytes=1-2,3-a",
+                    "bytes=1-a,3-4",
+                    "bytes=1-2,3a-4",
+                    "bytes=1-2,3-4a",
+                    "bytes=1-2,3-4-5",
+                    "bytes=1-2,3-4,a",
+                    // too many byte ranges (test sets the limit as 5)
+                    "bytes=0-1,1-2,2-3,3-4,4-5,5-6",
+                    // UINT64_MAX-UINT64_MAX+1
+                    "bytes=18446744073709551615-18446744073709551616",
+                    // UINT64_MAX+1-UINT64_MAX+2
+                    "bytes=18446744073709551616-18446744073709551617"));
+// clang-format on
+
+TEST_P(ParseInvalidRangeHeaderTest, InvalidRangeReturnsEmpty) {
+  auto result_vector = RangeRequests::parseRanges(range(), 5);
+  ASSERT_EQ(0, result_vector.size());
 }
 
 } // namespace Cache


### PR DESCRIPTION
Commit Message: caching: add parsing of range requests to CacheFilter

Additional Description:
Tackles the first part of issue #10132 (parsing range requests). Added a function getRequestRanges to parse ranges from requests' headers into LookupRequest. This allows the creation of appropriate ranges for the LookupResult object, which will have the corresponding bytes for the content of the response. In turn, this will allow the extension of the function CacheFilter::onHeaders to provide only the requested range(s) of content.


Co-authored-by: Josiah Kiehl <josiah@capoferro.net>

Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A