### PR TITLE
Fuzz: add fuzz test for functions in common/stats/utility.cc

### DIFF
--- a/test/common/stats/utility_fuzz_test.cc
+++ b/test/common/stats/utility_fuzz_test.cc
@@ -1,3 +1,8 @@
+#include <string>
+#include <vector>
+
+#include "common/stats/isolated_store_impl.h"
+#include "common/stats/symbol_table_creator.h"
 #include "common/stats/utility.h"
 
 #include "test/fuzz/fuzz_runner.h"
@@ -8,8 +13,63 @@ namespace Envoy {
 namespace Fuzz {
 
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
-  const absl::string_view string_buffer(reinterpret_cast<const char*>(buf), len);
-  Stats::Utility::sanitizeStatsName(string_buffer);
+
+  Stats::Utility::sanitizeStatsName(absl::string_view(reinterpret_cast<const char*>(buf), len));
+
+  if (len < 4) {
+    return;
+  }
+
+  // Create a greater scope vector to store the string to prevent the string memory from being free
+  std::list<std::string> string_list;
+  auto make_string = [&string_list](absl::string_view str) -> absl::string_view {
+    string_list.push_back(std::string(str));
+    return string_list.back();
+  };
+
+  // generate a random number as the maximum length of the stat name
+  const size_t max_len = *reinterpret_cast<const uint8_t*>(buf) % (len - 3);
+  FuzzedDataProvider provider(buf, len);
+
+  // model common/stats/utility_test.cc, initialize those objects to create random elements as
+  // input
+  Stats::SymbolTablePtr symbol_table;
+  if (provider.ConsumeBool()) {
+    symbol_table = std::make_unique<Stats::FakeSymbolTableImpl>();
+  } else {
+    symbol_table = std::make_unique<Stats::SymbolTableImpl>();
+  }
+  std::unique_ptr<Stats::IsolatedStoreImpl> store =
+      std::make_unique<Stats::IsolatedStoreImpl>(*symbol_table);
+  Stats::StatNamePool pool(*symbol_table);
+  Stats::ScopePtr scope = store->createScope(provider.ConsumeRandomLengthString(max_len));
+  Stats::ElementVec ele_vec;
+  Stats::StatNameVec sn_vec;
+  Stats::StatNameTagVector tags;
+  Stats::StatName key, val;
+
+  if (provider.remaining_bytes() == 0) {
+    Stats::Utility::counterFromStatNames(*scope, {});
+    Stats::Utility::counterFromElements(*scope, {});
+  } else {
+    // add random length string in each loop
+    while (provider.remaining_bytes() > 3) {
+      if (provider.ConsumeBool()) {
+        absl::string_view str = make_string(
+            provider.ConsumeRandomLengthString(std::min(max_len, provider.remaining_bytes())));
+        ele_vec.push_back(Stats::DynamicName(str));
+        sn_vec.push_back(pool.add(str));
+      } else {
+        key = pool.add(
+            provider.ConsumeRandomLengthString(std::min(max_len, provider.remaining_bytes() / 2)));
+        val = pool.add(
+            provider.ConsumeRandomLengthString(std::min(max_len, provider.remaining_bytes())));
+        tags.push_back({key, val});
+      }
+      Stats::Utility::counterFromStatNames(*scope, sn_vec, tags);
+      Stats::Utility::counterFromElements(*scope, ele_vec, tags);
+    }
+  }
 }
 
 } // namespace Fuzz


### PR DESCRIPTION
**Commit Message:**
Add fuzz test for counterFromElements() and counterFromStatNames() in common/stats/utility.cc
**Additional Description:**
The changes in this PR are copied from PR #11644 due to the DCO check failure
**Risk Level:**
Low
**Testing:**
Add fuzz test for counterFromElements() and counterFromStatNames()
**Docs Changes:** N/A
**Release Notes:** N/A

Signed-off-by: tengpeng <tengpeng.li2020@gmail.com>

	modified:   test/common/stats/utility_fuzz_test.cc

