### PR TITLE
lua: release assert state allocations

### DIFF
--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -51,7 +51,7 @@ ThreadLocalState::ThreadLocalState(const std::string& code, ThreadLocal::SlotAll
 
   // First verify that the supplied code can be parsed.
   CSmartPtr<lua_State, lua_close> state(lua_open());
-  ASSERT(state.get() != nullptr, "unable to create new lua state object");
+  RELEASE_ASSERT(state.get() != nullptr, "unable to create new Lua state object");
   luaL_openlibs(state.get());
 
   if (0 != luaL_dostring(state.get(), code.c_str())) {
@@ -92,7 +92,7 @@ CoroutinePtr ThreadLocalState::createCoroutine() {
 }
 
 ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : state_(lua_open()) {
-  ASSERT(state_.get() != nullptr, "unable to create new lua state object");
+  RELEASE_ASSERT(state_.get() != nullptr, "unable to create new Lua state object");
   luaL_openlibs(state_.get());
   int rc = luaL_dostring(state_.get(), code.c_str());
   ASSERT(rc == 0);


### PR DESCRIPTION
Since `lua_open` can fail on memory allocation, it should be checked with
`RELEASE_ASSERT` so that the NULL Lua state is never dereferenced.

Risk Level: Low
Testing: Unit tests
Docs Changes: None
Release Notes: None
Fixes: #11948
