### PR TITLE
v2 to v3 changes for function constructConfigFromV2Yaml

### DIFF
--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -60,10 +60,11 @@ Config constructConfigFromYaml(const std::string& yaml,
   return Config(tcp_proxy, context);
 }
 
-Config constructConfigFromV2Yaml(const std::string& yaml,
-                                 Server::Configuration::FactoryContext& context) {
+Config constructConfigFromV3Yaml(const std::string& yaml,
+                                 Server::Configuration::FactoryContext& context,
+                                 bool avoid_boosting = true) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy tcp_proxy;
-  TestUtility::loadFromYamlAndValidate(yaml, tcp_proxy);
+  TestUtility::loadFromYamlAndValidate(yaml, tcp_proxy, false, avoid_boosting);
   return Config(tcp_proxy, context);
 }
 
@@ -76,7 +77,7 @@ cluster: foo
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
   EXPECT_EQ(std::chrono::hours(1), config_obj.sharedConfig()->idleTimeout().value());
 }
 
@@ -88,7 +89,7 @@ idle_timeout: 0s
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
   EXPECT_FALSE(config_obj.sharedConfig()->idleTimeout().has_value());
 }
 
@@ -100,7 +101,7 @@ idle_timeout: 1s
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
   EXPECT_EQ(std::chrono::seconds(1), config_obj.sharedConfig()->idleTimeout().value());
 }
 
@@ -403,7 +404,7 @@ TEST(ConfigTest, WeightedClusterWithZeroWeightConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  EXPECT_THROW(constructConfigFromV2Yaml(yaml, factory_context), EnvoyException);
+  EXPECT_THROW(constructConfigFromV3Yaml(yaml, factory_context), EnvoyException);
 }
 
 // Tests that it is possible to define a list of weighted clusters.
@@ -419,7 +420,7 @@ TEST(ConfigTest, WeightedClustersConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   NiceMock<Network::MockConnection> connection;
   EXPECT_CALL(factory_context.random_, random()).WillOnce(Return(0));
@@ -453,7 +454,7 @@ TEST(ConfigTest, WeightedClustersWithMetadataMatchConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   {
     ProtobufWkt::Value v1, v2;
@@ -540,7 +541,7 @@ TEST(ConfigTest, WeightedClustersWithMetadataMatchAndTopLevelMetadataMatchConfig
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   ProtobufWkt::Value v00, v01, v04;
   v00.set_string_value("v00");
@@ -631,7 +632,7 @@ TEST(ConfigTest, WeightedClustersWithTopLevelMetadataMatchConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   ProtobufWkt::Value v1, v2;
   v1.set_string_value("v1");
@@ -670,7 +671,7 @@ TEST(ConfigTest, TopLevelMetadataMatchConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   ProtobufWkt::Value v1, v2;
   v1.set_string_value("v1");
@@ -703,7 +704,7 @@ TEST(ConfigTest, ClusterWithTopLevelMetadataMatchConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   ProtobufWkt::Value v1, v2;
   v1.set_string_value("v1");
@@ -742,7 +743,7 @@ TEST(ConfigTest, PerConnectionClusterWithTopLevelMetadataMatchConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
 
   ProtobufWkt::Value v1, v2;
   v1.set_string_value("v1");
@@ -781,7 +782,7 @@ TEST(ConfigTest, HashWithSourceIpConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
   EXPECT_NE(nullptr, config_obj.hashPolicy());
 }
 
@@ -792,7 +793,7 @@ TEST(ConfigTest, HashWithSourceIpDefaultConfig) {
 )EOF";
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  Config config_obj(constructConfigFromV2Yaml(yaml, factory_context));
+  Config config_obj(constructConfigFromV3Yaml(yaml, factory_context));
   EXPECT_EQ(nullptr, config_obj.hashPolicy());
 }
 


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: v2 to v3 changes for function constructConfigFromV2Yaml under file "test/common/tcp_proxy/tcp_proxy_test.cc"
Additional Description: This PR is duplicate of PR https://github.com/envoyproxy/envoy/pull/11923.  
Risk Level: NA
Testing: Unit and Format
Docs Changes: NA
Release Notes:
[Optional Runtime guard:]
Optional Fixes #10843 
[Optional Deprecated:]
