### PR TITLE
android: update SUPPORTS_PTHREAD_GETNAME_NP conditional

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -253,11 +253,11 @@ struct mmsghdr {
 #endif
 
 // https://android.googlesource.com/platform/bionic/+/master/docs/status.md
-// ``pthread_getname_np`` is introduced in API 26
+// ``pthread_getname_np`` was introduced in API 26
 #ifdef __ANDROID_API__
-#if __ANDROID_API__ > 26
+#if __ANDROID_API__ >= 26
 #define SUPPORTS_PTHREAD_GETNAME_NP 1
-#endif // __ANDROID_API__ > 26
+#endif // __ANDROID_API__ >= 26
 #endif // ifdef __ANDROID_API__
 
 // Ensure `SUPPORTS_PTHREAD_GETNAME_NP` is set


### PR DESCRIPTION
This API was introduced in 26, so we should include that version as well.

Follow-up to https://github.com/envoyproxy/envoy/pull/12011.

Signed-off-by: Michael Rebello <me@michaelrebello.com>

Risk Level: Low
Testing: N/A
Docs Changes: None