### PR TITLE
android: fix pthread compiler conditionals

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -250,13 +250,13 @@ struct mmsghdr {
 
 // https://android.googlesource.com/platform/bionic/+/master/docs/status.md
 // ``pthread_getname_np`` is introduced in API 26
-#define SUPPORTS_PTHREAD_GETNAME_NP 0
+#define SUPPORTS_PTHREAD_NAMING 0
 #if defined(__ANDROID_API__)
 #if __ANDROID_API__ >= 26
-#undef SUPPORTS_PTHREAD_GETNAME_NP
-#define SUPPORTS_PTHREAD_GETNAME_NP 1
+#undef SUPPORTS_PTHREAD_NAMING
+#define SUPPORTS_PTHREAD_NAMING 1
 #endif // __ANDROID_API__ >= 26
 #elif defined(__linux__)
-#undef SUPPORTS_PTHREAD_GETNAME_NP
-#define SUPPORTS_PTHREAD_GETNAME_NP 1
+#undef SUPPORTS_PTHREAD_NAMING
+#define SUPPORTS_PTHREAD_NAMING 1
 #endif // defined(__ANDROID_API__)

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -248,19 +248,12 @@ struct mmsghdr {
 #endif // __ANDROID_API__ < 24
 #endif // ifdef __ANDROID_API__
 
-#ifdef __linux__
-#define SUPPORTS_PTHREAD_GETNAME_NP 1
-#endif
-
 // https://android.googlesource.com/platform/bionic/+/master/docs/status.md
 // ``pthread_getname_np`` is introduced in API 26
-#ifdef __ANDROID_API__
-#if __ANDROID_API__ > 26
-#define SUPPORTS_PTHREAD_GETNAME_NP 1
-#endif // __ANDROID_API__ > 26
-#endif // ifdef __ANDROID_API__
-
-// Ensure `SUPPORTS_PTHREAD_GETNAME_NP` is set
-#ifndef SUPPORTS_PTHREAD_GETNAME_NP
-#define SUPPORTS_PTHREAD_GETNAME_NP 0
-#endif
+#if defined(__ANDROID_API__)
+#if __ANDROID_API__ >= 26
+#define SUPPORTS_PTHREAD_GETNAME_NP
+#endif // __ANDROID_API__ >= 26
+#elif defined(__linux__)
+#define SUPPORTS_PTHREAD_GETNAME_NP
+#endif // defined(__ANDROID_API__)

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -250,10 +250,13 @@ struct mmsghdr {
 
 // https://android.googlesource.com/platform/bionic/+/master/docs/status.md
 // ``pthread_getname_np`` is introduced in API 26
+#define SUPPORTS_PTHREAD_GETNAME_NP 0
 #if defined(__ANDROID_API__)
 #if __ANDROID_API__ >= 26
-#define SUPPORTS_PTHREAD_GETNAME_NP
+#undef SUPPORTS_PTHREAD_GETNAME_NP
+#define SUPPORTS_PTHREAD_GETNAME_NP 1
 #endif // __ANDROID_API__ >= 26
 #elif defined(__linux__)
-#define SUPPORTS_PTHREAD_GETNAME_NP
+#undef SUPPORTS_PTHREAD_GETNAME_NP
+#define SUPPORTS_PTHREAD_GETNAME_NP 1
 #endif // defined(__ANDROID_API__)

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -52,7 +52,7 @@ public:
         this);
     RELEASE_ASSERT(rc == 0, "");
 
-#if SUPPORTS_PTHREAD_GETNAME_NP
+#if SUPPORTS_PTHREAD_NAMING
     // If the name was not specified, get it from the OS. If the name was
     // specified, write it into the thread, and assert that the OS sees it the
     // same way.
@@ -93,7 +93,7 @@ public:
   }
 
 private:
-#if SUPPORTS_PTHREAD_GETNAME_NP
+#if SUPPORTS_PTHREAD_NAMING
   // Attempts to get the name from the operating system, returning true and
   // updating 'name' if successful. Note that during normal operation this
   // may fail, if the thread exits prior to the system call.

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -52,7 +52,7 @@ public:
         this);
     RELEASE_ASSERT(rc == 0, "");
 
-#ifdef SUPPORTS_PTHREAD_GETNAME_NP
+#if SUPPORTS_PTHREAD_GETNAME_NP
     // If the name was not specified, get it from the OS. If the name was
     // specified, write it into the thread, and assert that the OS sees it the
     // same way.
@@ -93,7 +93,7 @@ public:
   }
 
 private:
-#ifdef SUPPORTS_PTHREAD_GETNAME_NP
+#if SUPPORTS_PTHREAD_GETNAME_NP
   // Attempts to get the name from the operating system, returning true and
   // updating 'name' if successful. Note that during normal operation this
   // may fail, if the thread exits prior to the system call.

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -52,7 +52,7 @@ public:
         this);
     RELEASE_ASSERT(rc == 0, "");
 
-#if SUPPORTS_PTHREAD_GETNAME_NP
+#ifdef SUPPORTS_PTHREAD_GETNAME_NP
     // If the name was not specified, get it from the OS. If the name was
     // specified, write it into the thread, and assert that the OS sees it the
     // same way.
@@ -93,7 +93,7 @@ public:
   }
 
 private:
-#if SUPPORTS_PTHREAD_GETNAME_NP
+#ifdef SUPPORTS_PTHREAD_GETNAME_NP
   // Attempts to get the name from the operating system, returning true and
   // updating 'name' if successful. Note that during normal operation this
   // may fail, if the thread exits prior to the system call.


### PR DESCRIPTION
This is a follow-up to https://github.com/envoyproxy/envoy/pull/12011. The original fix didn't solve the Envoy Mobile issues because Envoy Mobile's Android builds are done on Linux CI, so `SUPPORTS_PTHREAD_GETNAME_NP` was still being defined as `1`.

The changes in this PR ensure that Android API availability supersedes the Linux conditional when defining `SUPPORTS_PTHREAD_GETNAME_NP`. It also updates us to filter on API version 26 **inclusive**, since that is the API where this became available.

Signed-off-by: Michael Rebello <me@michaelrebello.com>

Risk Level: Low
Testing: Local builds / CI in Envoy Mobile
Docs Changes: None