### PR TITLE
jwt_authn: If a request has multiple JWT tokens, all must be valid.

### DIFF
--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -49,9 +49,11 @@ If *from_headers* and *from_params* is empty,  the default location to extract J
 
   Authorization: Bearer <token>
 
-If fails to extract a JWT from above header, then check query parameter key *access_token* as in this example::
+and query parameter key *access_token* as::
 
   /path?access_token=<JWT>
+
+If a request has two tokens, one from the header and the other from the query parameter, all of them must be valid.
 
 In the :ref:`filter config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.JwtAuthentication>`, *providers* is a map, to map *provider_name* to a :ref:`JwtProvider <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.JwtProvider>`. The *provider_name* must be unique, it is referred in the `JwtRequirement <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.JwtRequirement>` in its *provider_name* field.
 

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -268,8 +268,8 @@ void AuthenticatorImpl::doneWithStatus(const Status& status) {
 
   // If a request has multiple tokens, all of them must be valid. Otherwise it may have
   // following security hole: a request has a good token and a bad one, it will pass
-  // verification, forwarded to the backend, and the backend will use the bad token
-  // for authorization.
+  // verification, forwarded to the backend, and the backend may mistakenly use the bad
+  // token as the good one that passed the verification.
 
   // Unless allowing failed or missing, all tokens must be verified successfully.
   if ((Status::Ok != status && !is_allow_failed_ && !is_allow_missing_) || tokens_.empty()) {

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -130,6 +130,13 @@ void AuthenticatorImpl::verify(Http::HeaderMap& headers, Tracing::Span& parent_s
     return;
   }
 
+  // For a valid provider without allow_failed, multiple tokens exist, reject it.
+  if (tokens_.size() > 1 && provider_ && !is_allow_failed_) {
+    tokens_.clear();
+    doneWithStatus(Status::JwtMissed);
+    return;
+  }
+
   startVerify();
 }
 

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -268,9 +268,10 @@ void AuthenticatorImpl::doneWithStatus(const Status& status) {
 
   // If a request has multiple tokens, all of them must be valid. Otherwise it may have
   // following security hole: a request has a good token and a bad one, it will pass
-  // verifification, forwarded to the backend, and the backend will use the bad
-  // token for authorization.
-  // Unless allowing failed or missing, all tokens must be varified successfully.
+  // verification, forwarded to the backend, and the backend will use the bad token
+  // for authorization.
+
+  // Unless allowing failed or missing, all tokens must be verified successfully.
   if ((Status::Ok != status && !is_allow_failed_ && !is_allow_missing_) || tokens_.empty()) {
     tokens_.clear();
     if (is_allow_failed_) {

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -185,18 +185,17 @@ TEST_F(AuthenticatorTest, TestMissedJWT) {
   expectVerifyStatus(Status::JwtMissed, headers);
 }
 
-// This test verifies if there are multiple tokens, request is rejected.
+// This test verifies a request with multiple tokens is rejected.
 TEST_F(AuthenticatorTest, TestMultipleJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
   // headers with multiple tokens
-  auto headers =
-      Http::TestRequestHeaderMapImpl{
-    {"Authorization", "Bearer " + std::string(NonExistKidToken)},
-    {":path", "/foo?access_token=invalid-token"},
+  auto headers = Http::TestRequestHeaderMapImpl{
+      {"Authorization", "Bearer " + std::string(NonExistKidToken)},
+      {":path", "/foo?access_token=invalid-token"},
   };
 
-  expectVerifyStatus(Status::JwtMissed, headers);
+  expectVerifyStatus(Status::JwtMultipleTokens, headers);
 }
 
 // This test verifies if Jwt is invalid, JwtBadFormat status is returned.

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -187,14 +187,27 @@ TEST_F(AuthenticatorTest, TestMissedJWT) {
   expectVerifyStatus(Status::JwtMissed, headers);
 }
 
-// Test multiple tokens; one of them is bad, verification is ok.
-TEST_F(AuthenticatorTest, TestMultipleJWTOneBad) {
+// Test multiple tokens; the one from query parameter is bad, verification should fail.
+TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromQuery) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
 
   // headers with multiple tokens: one good, one bad
   auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {":path", "/foo?access_token=" + std::string(NonExistKidToken)},
+  };
+
+  expectVerifyStatus(Status::JwtVerificationFail, headers);
+}
+
+// Test multiple tokens; the one from header is bad, verification should fail.
+TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromHeader) {
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
+
+  // headers with multiple tokens: one good, one bad
+  auto headers = Http::TestRequestHeaderMapImpl{
+      {"Authorization", "Bearer " + std::string(NonExistKidToken)},
+      {":path", "/foo?access_token=" + std::string(GoodToken)},
   };
 
   expectVerifyStatus(Status::JwtVerificationFail, headers);

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -185,6 +185,20 @@ TEST_F(AuthenticatorTest, TestMissedJWT) {
   expectVerifyStatus(Status::JwtMissed, headers);
 }
 
+// This test verifies if there are multiple tokens, request is rejected.
+TEST_F(AuthenticatorTest, TestMultipleJWT) {
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
+
+  // headers with multiple tokens
+  auto headers =
+      Http::TestRequestHeaderMapImpl{
+    {"Authorization", "Bearer " + std::string(NonExistKidToken)},
+    {":path", "/foo?access_token=invalid-token"},
+  };
+
+  expectVerifyStatus(Status::JwtMissed, headers);
+}
+
 // This test verifies if Jwt is invalid, JwtBadFormat status is returned.
 TEST_F(AuthenticatorTest, TestInvalidJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -101,8 +101,7 @@ TEST_F(AuthenticatorTest, TestOkJWTandCache) {
 
   // Test OK pubkey and its cache
   for (int i = 0; i < 10; i++) {
-    auto headers =
-        Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+    Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
 
     expectVerifyStatus(Status::Ok, headers);
 
@@ -124,8 +123,7 @@ TEST_F(AuthenticatorTest, TestForwardJwt) {
       }));
 
   // Test OK pubkey and its cache
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
 
   expectVerifyStatus(Status::Ok, headers);
 
@@ -149,8 +147,7 @@ TEST_F(AuthenticatorTest, TestSetPayload) {
       }));
 
   // Test OK pubkey and its cache
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
 
   expectVerifyStatus(Status::Ok, headers);
 
@@ -171,8 +168,8 @@ TEST_F(AuthenticatorTest, TestJwtWithNonExistKid) {
       }));
 
   // Test OK pubkey and its cache
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(NonExistKidToken)}};
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(NonExistKidToken)}};
 
   expectVerifyStatus(Status::JwtVerificationFail, headers);
 }
@@ -182,7 +179,7 @@ TEST_F(AuthenticatorTest, TestMissedJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
   // Empty headers.
-  auto headers = Http::TestRequestHeaderMapImpl{};
+  Http::TestRequestHeaderMapImpl headers{};
 
   expectVerifyStatus(Status::JwtMissed, headers);
 }
@@ -192,7 +189,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromQuery) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
 
   // headers with multiple tokens: one good, one bad
-  auto headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {":path", "/foo?access_token=" + std::string(NonExistKidToken)},
   };
@@ -205,7 +202,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromHeader) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
 
   // headers with multiple tokens: one good, one bad
-  auto headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers{
       {"Authorization", "Bearer " + std::string(NonExistKidToken)},
       {":path", "/foo?access_token=" + std::string(GoodToken)},
   };
@@ -218,7 +215,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTAllGood) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
 
   // headers with multiple tokens: all are good
-  auto headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {":path", "/foo?access_token=" + std::string(GoodToken)},
   };
@@ -233,7 +230,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTOneBadAllowFails) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
 
   // headers with multiple tokens: one good, one bad
-  auto headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {":path", "/foo?access_token=" + std::string(NonExistKidToken)},
   };
@@ -248,7 +245,7 @@ TEST_F(AuthenticatorTest, TestAllowMissingWithEmptyHeader) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
   // Empty headers
-  auto headers = Http::TestRequestHeaderMapImpl{};
+  Http::TestRequestHeaderMapImpl headers{};
 
   expectVerifyStatus(Status::Ok, headers);
 }
@@ -258,7 +255,7 @@ TEST_F(AuthenticatorTest, TestInvalidJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
   std::string token = "invalidToken";
-  auto headers = Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + token}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + token}};
   expectVerifyStatus(Status::JwtBadFormat, headers);
 }
 
@@ -266,7 +263,7 @@ TEST_F(AuthenticatorTest, TestInvalidJWT) {
 TEST_F(AuthenticatorTest, TestInvalidPrefix) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
-  auto headers = Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer-invalid"}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer-invalid"}};
   expectVerifyStatus(Status::JwtMissed, headers);
 }
 
@@ -275,8 +272,8 @@ TEST_F(AuthenticatorTest, TestInvalidPrefix) {
 TEST_F(AuthenticatorTest, TestNonExpiringJWT) {
   EXPECT_CALL(mock_factory_ctx_.cluster_manager_, httpAsyncClientForCluster(_)).Times(0);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(NonExpiringToken)}};
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(NonExpiringToken)}};
   expectVerifyStatus(Status::JwtAudienceNotAllowed, headers);
 }
 
@@ -284,8 +281,7 @@ TEST_F(AuthenticatorTest, TestNonExpiringJWT) {
 TEST_F(AuthenticatorTest, TestExpiredJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(ExpiredToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(ExpiredToken)}};
   expectVerifyStatus(Status::JwtExpired, headers);
 }
 
@@ -293,8 +289,8 @@ TEST_F(AuthenticatorTest, TestExpiredJWT) {
 TEST_F(AuthenticatorTest, TestNotYetValidJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(NotYetValidToken)}};
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(NotYetValidToken)}};
   expectVerifyStatus(Status::JwtNotYetValid, headers);
 }
 
@@ -307,8 +303,7 @@ TEST_F(AuthenticatorTest, TestInvalidLocalJwks) {
 
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::JwksNoValidKeys, headers);
 }
 
@@ -316,8 +311,8 @@ TEST_F(AuthenticatorTest, TestInvalidLocalJwks) {
 TEST_F(AuthenticatorTest, TestNonMatchAudJWT) {
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(InvalidAudToken)}};
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(InvalidAudToken)}};
   expectVerifyStatus(Status::JwtAudienceNotAllowed, headers);
 }
 
@@ -329,8 +324,7 @@ TEST_F(AuthenticatorTest, TestIssuerNotFound) {
 
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::JwtUnknownIssuer, headers);
 }
 
@@ -342,8 +336,7 @@ TEST_F(AuthenticatorTest, TestPubkeyFetchFail) {
         receiver.onJwksError(JwksFetcher::JwksReceiver::Failure::InvalidJwks);
       }));
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::JwksFetchFail, headers);
 
   Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
@@ -359,8 +352,7 @@ TEST_F(AuthenticatorTest, TestOnDestroy) {
   // Cancel is called once.
   EXPECT_CALL(*raw_fetcher_, cancel()).Times(1);
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   initTokenExtractor();
   auto tokens = extractor_->extract(headers);
   // callback should not be called.
@@ -383,8 +375,7 @@ TEST_F(AuthenticatorTest, TestNoForwardPayloadHeader) {
         receiver.onJwksSuccess(std::move(jwks_));
       }));
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::Ok, headers);
 
   // Test when forward_payload_header is not set, the output should NOT
@@ -409,29 +400,29 @@ TEST_F(AuthenticatorTest, TestAllowFailedMultipleTokens) {
         receiver.onJwksSuccess(std::move(jwks_));
       }));
 
-  auto headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers1{
       {"a", "Bearer " + std::string(ExpiredToken)},
       {"b", "Bearer " + std::string(GoodToken)},
       {"c", "Bearer " + std::string(InvalidAudToken)},
       {":path", "/"},
   };
-  expectVerifyStatus(Status::Ok, headers);
+  expectVerifyStatus(Status::Ok, headers1);
 
-  EXPECT_TRUE(headers.has("a"));
-  EXPECT_FALSE(headers.has("b"));
-  EXPECT_TRUE(headers.has("c"));
+  EXPECT_TRUE(headers1.has("a"));
+  EXPECT_FALSE(headers1.has("b"));
+  EXPECT_TRUE(headers1.has("c"));
 
-  headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers2{
       {"a", "Bearer " + std::string(GoodToken)},
       {"b", "Bearer " + std::string(GoodToken)},
       {"c", "Bearer " + std::string(GoodToken)},
       {":path", "/"},
   };
-  expectVerifyStatus(Status::Ok, headers);
+  expectVerifyStatus(Status::Ok, headers2);
 
-  EXPECT_FALSE(headers.has("a"));
-  EXPECT_FALSE(headers.has("b"));
-  EXPECT_FALSE(headers.has("c"));
+  EXPECT_FALSE(headers2.has("a"));
+  EXPECT_FALSE(headers2.has("b"));
+  EXPECT_FALSE(headers2.has("c"));
 }
 
 // This test verifies that allow failed authenticator will verify all tokens.
@@ -459,7 +450,7 @@ TEST_F(AuthenticatorTest, TestAllowFailedMultipleIssuers) {
         receiver.onJwksSuccess(std::move(jwks));
       }));
 
-  auto headers = Http::TestRequestHeaderMapImpl{
+  Http::TestRequestHeaderMapImpl headers{
       {"Authorization", "Bearer " + std::string(GoodToken)},
       {"expired-auth", "Bearer " + std::string(ExpiredToken)},
       {"other-auth", "Bearer " + std::string(OtherGoodToken)},
@@ -483,12 +474,12 @@ TEST_F(AuthenticatorTest, TestCustomCheckAudience) {
         receiver.onJwksSuccess(std::move(jwks_));
       }));
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(InvalidAudToken)}};
-  expectVerifyStatus(Status::Ok, headers);
+  Http::TestRequestHeaderMapImpl headers1{
+      {"Authorization", "Bearer " + std::string(InvalidAudToken)}};
+  expectVerifyStatus(Status::Ok, headers1);
 
-  headers = Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
-  expectVerifyStatus(Status::JwtAudienceNotAllowed, headers);
+  Http::TestRequestHeaderMapImpl headers2{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  expectVerifyStatus(Status::JwtAudienceNotAllowed, headers2);
 }
 
 // This test verifies that when invalid JWKS is fetched, an JWKS error status is returned.
@@ -500,8 +491,7 @@ TEST_F(AuthenticatorTest, TestInvalidPubkeyKey) {
         receiver.onJwksSuccess(std::move(jwks));
       }));
 
-  auto headers =
-      Http::TestRequestHeaderMapImpl{{"Authorization", "Bearer " + std::string(GoodToken)}};
+  Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   expectVerifyStatus(Status::JwksPemBadBase64, headers);
 }
 


### PR DESCRIPTION
By default, jwt_authn filter extracts JWT token from `Authorization` header and
 `access_token` query parameter. A request may have multiple JWT tokens, and will be
forwarded to the backend if one of the tokens is good. 

It poses a security risk: a hacker can put a good token in the query parameter and an invalid one in
the Authorization header. Envoy will forward the request to the backend,
and the backend will use the bad token in Authorization header.

This PR try to patch such security hole: all tokens in a request should be valid. 

Risk Level: Low.  This change only impacts the requests with multiple JWT tokens. In production traffic,
  it will be very rare that a request have multiple JWT tokens. 
Testing: Unit-test
Docs Changes: None
Release Notes: None
