### PR TITLE
[runtime] Add runtime disabler for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ There are four suggested options for testing new runtime features:
    GetParam() as outlined in (1).
 3. Set up integration tests with custom runtime defaults as documented in the
    [integration test README](https://github.com/envoyproxy/envoy/blob/master/test/integration/README.md)
-4. Run a given unit test with the new runtime value explicitly set true as done
+4. Run a given unit test with the new runtime value explicitly set true or false as done
    for [runtime_flag_override_test](https://github.com/envoyproxy/envoy/blob/master/test/common/runtime/BUILD)
 
 Runtime code is held to the same standard as regular Envoy code, so both the old

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -86,10 +86,10 @@ constexpr const char* runtime_features[] = {
 // When features are added here, there should be a tracking bug assigned to the
 // code owner to flip the default after sufficient testing.
 constexpr const char* disabled_runtime_features[] = {
-    // Sentinel and test flag.
-    "envoy.reloadable_features.test_feature_false",
     // TODO(alyssawilk) flip true after the release.
     "envoy.reloadable_features.new_tcp_connection_pool",
+    // Sentinel and test flag.
+    "envoy.reloadable_features.test_feature_false",
 };
 
 RuntimeFeatures::RuntimeFeatures() {

--- a/test/common/runtime/BUILD
+++ b/test/common/runtime/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test(
     srcs = ["runtime_flag_override_test.cc"],
     args = [
         "--runtime-feature-override-for-tests=envoy.reloadable_features.test_feature_false",
+        "--runtime-feature-disable-for-tests=envoy.reloadable_features.test_feature_true",
     ],
     coverage = False,
     deps = [

--- a/test/common/runtime/BUILD
+++ b/test/common/runtime/BUILD
@@ -79,3 +79,16 @@ envoy_cc_test(
         "//source/common/runtime:runtime_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "runtime_flag_override_noop_test",
+    srcs = ["runtime_flag_override_noop_test.cc"],
+    args = [
+        "--runtime-feature-override-for-tests=envoy.reloadable_features.test_feature_true",
+        "--runtime-feature-disable-for-tests=envoy.reloadable_features.test_feature_false",
+    ],
+    coverage = False,
+    deps = [
+        "//source/common/runtime:runtime_lib",
+    ],
+)

--- a/test/common/runtime/runtime_flag_override_noop_test.cc
+++ b/test/common/runtime/runtime_flag_override_noop_test.cc
@@ -1,0 +1,24 @@
+#include "common/runtime/runtime_features.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Runtime {
+
+// Features not in runtime_features.cc are false by default (and this particular one is verified to
+// be false in runtime_impl_test.cc). However in in the envoy_cc_test declaration, the flag is set
+// "--runtime-feature-override-for-tests=envoy.reloadable_features.test_feature_false"
+// to override the return value of runtimeFeatureEnabled to true.
+TEST(RuntimeFlagOverrideNoopTest, OverridesNoop) {
+  EXPECT_FALSE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_false"));
+}
+
+// For features in runtime_features.cc that are true by default, this flag
+// "--runtime-feature-override-for-tests=envoy.reloadable_features.test_feature_false" is set in the
+// envoy_cc_test declaration to override the return value of runtimeFeatureEnabled to false.
+TEST(RuntimeFlagOverrideNoopTest, OverrideDisableFeatureNoop) {
+  EXPECT_TRUE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_true"));
+}
+
+} // namespace Runtime
+} // namespace Envoy

--- a/test/common/runtime/runtime_flag_override_test.cc
+++ b/test/common/runtime/runtime_flag_override_test.cc
@@ -13,5 +13,12 @@ TEST(RuntimeFlagOverrideTest, OverridesWork) {
   EXPECT_TRUE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_false"));
 }
 
+// For features in runtime_features.cc that are true by default, this flag
+// "--runtime-feature-override-for-tests=envoy.reloadable_features.test_feature_false" is set in the
+// envoy_cc_test declaration to override the return value of runtimeFeatureEnabled to false.
+TEST(RuntimeFlagOverrideTest, OverrideDisableFeatureWork) {
+  EXPECT_FALSE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_true"));
+}
+
 } // namespace Runtime
 } // namespace Envoy

--- a/test/common/runtime/utility.h
+++ b/test/common/runtime/utility.h
@@ -8,33 +8,21 @@ namespace Runtime {
 
 class RuntimeFeaturesPeer {
 public:
-  static bool addFeature(const std::string& feature, bool disable) {
-    if (disable) {
-      // Remove from enabled features and add to disabled features.
-      bool found = const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-                       ->enabledByDefault(feature);
-      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-          ->enabled_features_.erase(feature);
-      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-          ->disabled_features_.insert(feature);
-      return found;
-    } else {
-      return const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-          ->enabled_features_.insert(feature)
-          .second;
-    }
+  static bool enableFeature(const std::string& feature) {
+    // Remove from disabled features and add to enabled features.
+    const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+        ->disabled_features_.erase(feature);
+    return const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+        ->enabled_features_.insert(feature)
+        .second;
   }
-  static void removeFeature(const std::string& feature, bool disable) {
-    if (disable) {
-      // Remove from disabled features and add to enabled features as set originally.
-      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-          ->disabled_features_.erase(feature);
-      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-          ->enabled_features_.insert(feature);
-    } else {
-      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-          ->enabled_features_.erase(feature);
-    }
+  static bool disableFeature(const std::string& feature) {
+    // Remove from enabled features and add to disabled features.
+    const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+        ->enabled_features_.erase(feature);
+    return const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+        ->disabled_features_.insert(feature)
+        .second;
   }
 };
 

--- a/test/common/runtime/utility.h
+++ b/test/common/runtime/utility.h
@@ -8,14 +8,33 @@ namespace Runtime {
 
 class RuntimeFeaturesPeer {
 public:
-  static bool addFeature(const std::string& feature) {
-    return const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-        ->enabled_features_.insert(feature)
-        .second;
+  static bool addFeature(const std::string& feature, bool disable) {
+    if (disable) {
+      // Remove from enabled features and add to disabled features.
+      bool found = const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+                       ->enabledByDefault(feature);
+      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+          ->enabled_features_.erase(feature);
+      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+          ->disabled_features_.insert(feature);
+      return found;
+    } else {
+      return const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+          ->enabled_features_.insert(feature)
+          .second;
+    }
   }
-  static void removeFeature(const std::string& feature) {
-    const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
-        ->enabled_features_.erase(feature);
+  static void removeFeature(const std::string& feature, bool disable) {
+    if (disable) {
+      // Remove from disabled features and add to enabled features as set originally.
+      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+          ->disabled_features_.erase(feature);
+      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+          ->enabled_features_.insert(feature);
+    } else {
+      const_cast<Runtime::RuntimeFeatures*>(&Runtime::RuntimeFeaturesDefaults::get())
+          ->enabled_features_.erase(feature);
+    }
   }
 };
 

--- a/test/test_runner.cc
+++ b/test/test_runner.cc
@@ -117,7 +117,7 @@ int TestRunner::RunTests(int argc, char** argv) {
                         "Running with runtime feature override disable {}",
                         runtime_override_disable);
     // Set up a listener which will create a global runtime and set the feature
-    // to true for the duration of each test instance.
+    // to false for the duration of each test instance.
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new RuntimeManagingListener(runtime_override_disable, true));
   }

--- a/test/test_runner.cc
+++ b/test/test_runner.cc
@@ -44,12 +44,13 @@ std::string findAndRemove(const std::regex& pattern, int& argc, char**& argv) {
 // This class is created iff a test is run with the special runtime override flag.
 class RuntimeManagingListener : public ::testing::EmptyTestEventListener {
 public:
-  RuntimeManagingListener(std::string& runtime_override) : runtime_override_(runtime_override) {}
+  RuntimeManagingListener(std::string& runtime_override, bool disable = false)
+      : runtime_override_(runtime_override), disable_(disable) {}
 
   // On each test start, edit RuntimeFeaturesDefaults with our custom runtime defaults.
   void OnTestStart(const ::testing::TestInfo&) override {
     if (!runtime_override_.empty()) {
-      if (!Runtime::RuntimeFeaturesPeer::addFeature(runtime_override_)) {
+      if (!Runtime::RuntimeFeaturesPeer::addFeature(runtime_override_, disable_)) {
         // If the entry was already in the hash map, don't remove it OnTestEnd.
         runtime_override_.clear();
       }
@@ -59,10 +60,13 @@ public:
   // As each test ends, clean up the RuntimeFeaturesDefaults state.
   void OnTestEnd(const ::testing::TestInfo&) override {
     if (!runtime_override_.empty()) {
-      Runtime::RuntimeFeaturesPeer::removeFeature(runtime_override_);
+      Runtime::RuntimeFeaturesPeer::removeFeature(runtime_override_, disable_);
     }
   }
   std::string runtime_override_;
+  // This marks whether the runtime feature was enabled by default and needs to be overridden to
+  // false.
+  bool disable_;
 };
 
 } // namespace
@@ -94,15 +98,28 @@ int TestRunner::RunTests(int argc, char** argv) {
   // Before letting TestEnvironment latch argv and argc, remove any runtime override flag.
   // This allows doing test overrides of Envoy runtime features without adding
   // test flags to the Envoy production command line.
-  const std::regex PATTERN{"--runtime-feature-override-for-tests=(.*)", std::regex::optimize};
-  std::string runtime_override = findAndRemove(PATTERN, argc, argv);
-  if (!runtime_override.empty()) {
+  const std::regex ENABLE_PATTERN{"--runtime-feature-override-for-tests=(.*)",
+                                  std::regex::optimize};
+  std::string runtime_override_enable = findAndRemove(ENABLE_PATTERN, argc, argv);
+  if (!runtime_override_enable.empty()) {
     ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::testing), info,
-                        "Running with runtime feature override {}", runtime_override);
+                        "Running with runtime feature override enable {}", runtime_override_enable);
     // Set up a listener which will create a global runtime and set the feature
     // to true for the duration of each test instance.
     ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
-    listeners.Append(new RuntimeManagingListener(runtime_override));
+    listeners.Append(new RuntimeManagingListener(runtime_override_enable));
+  }
+  const std::regex DISABLE_PATTERN{"--runtime-feature-disable-for-tests=(.*)",
+                                   std::regex::optimize};
+  std::string runtime_override_disable = findAndRemove(DISABLE_PATTERN, argc, argv);
+  if (!runtime_override_disable.empty()) {
+    ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::testing), info,
+                        "Running with runtime feature override disable {}",
+                        runtime_override_disable);
+    // Set up a listener which will create a global runtime and set the feature
+    // to true for the duration of each test instance.
+    ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new RuntimeManagingListener(runtime_override_disable, true));
   }
 
 #ifdef ENVOY_CONFIG_COVERAGE

--- a/test/test_runner.cc
+++ b/test/test_runner.cc
@@ -50,7 +50,9 @@ public:
   // On each test start, edit RuntimeFeaturesDefaults with our custom runtime defaults.
   void OnTestStart(const ::testing::TestInfo&) override {
     if (!runtime_override_.empty()) {
-      if (!Runtime::RuntimeFeaturesPeer::addFeature(runtime_override_, disable_)) {
+      bool reset = disable_ ? Runtime::RuntimeFeaturesPeer::disableFeature(runtime_override_)
+                            : Runtime::RuntimeFeaturesPeer::enableFeature(runtime_override_);
+      if (!reset) {
         // If the entry was already in the hash map, don't remove it OnTestEnd.
         runtime_override_.clear();
       }
@@ -60,7 +62,8 @@ public:
   // As each test ends, clean up the RuntimeFeaturesDefaults state.
   void OnTestEnd(const ::testing::TestInfo&) override {
     if (!runtime_override_.empty()) {
-      Runtime::RuntimeFeaturesPeer::removeFeature(runtime_override_, disable_);
+      disable_ ? Runtime::RuntimeFeaturesPeer::enableFeature(runtime_override_)
+               : Runtime::RuntimeFeaturesPeer::disableFeature(runtime_override_);
     }
   }
   std::string runtime_override_;


### PR DESCRIPTION
Commit Message: Add a flag `--runtime-feature-disable-for-tests=envoy.reloadable_features.test_feature_true` for use in tests that flips an enabled by default flag to disabled for the duration of the test.
Risk Level: Low, test-only
Testing: Added a test in the referenced test in CONTRIBUTING.md
Docs Changes: Reference added

Also changed sentinel flag to actually be sentinel.

Signed-off-by: Asra Ali <asraa@google.com>


