### PR TITLE
event: add a range timer interface

### DIFF
--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -61,8 +61,7 @@ public:
 using TimerPtr = std::unique_ptr<Timer>;
 
 /**
- * An abstract event timer that can be scheduled for a timeout within a range. The actual timeout
- * used is left up to individual implementations.
+ * An abstract event timer that can be scheduled for a timeout within a range.
  */
 class RangeTimer {
 public:
@@ -74,8 +73,9 @@ public:
   virtual void disableTimer() PURE;
 
   /**
-   * Enable a pending timeout within the given range. If a timeout is already pending, it will be
-   * reset to the new timeout.
+   * Enable a pending timeout within the given range. Unless disabled, the timer will fire exactly
+   * once, after min_ms has elapsed and before max_ms has elapsed. If a timeout is already pending,
+   * it will be reset to the new timeout.
    *
    * @param min_ms supplies the minimum duration of the alarm in milliseconds.
    * @param max_ms supplies the maximum duration of the alarm in milliseconds.

--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -60,6 +60,39 @@ public:
 
 using TimerPtr = std::unique_ptr<Timer>;
 
+/**
+ * An abstract event timer that can be scheduled for a timeout within a range. The actual timeout
+ * used is left up to individual implementations.
+ */
+class RangeTimer {
+public:
+  virtual ~RangeTimer() = default;
+
+  /**
+   * Disable a pending timeout without destroying the underlying timer.
+   */
+  virtual void disableTimer() PURE;
+
+  /**
+   * Enable a pending timeout within the given range. If a timeout is already pending, it will be
+   * reset to the new timeout.
+   *
+   * @param min_ms supplies the minimum duration of the alarm in milliseconds.
+   * @param max_ms supplies the maximum duration of the alarm in milliseconds.
+   * @param object supplies an optional scope for the duration of the alarm.
+   */
+  virtual void enableTimer(const std::chrono::milliseconds& min_ms,
+                           const std::chrono::milliseconds& max_ms,
+                           const ScopeTrackedObject* object = nullptr) PURE;
+
+  /**
+   * Return whether the timer is currently armed.
+   */
+  virtual bool enabled() PURE;
+};
+
+using RangeTimerPtr = std::unique_ptr<RangeTimer>;
+
 class Scheduler {
 public:
   virtual ~Scheduler() = default;

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -51,6 +51,19 @@ MockTimer::MockTimer(MockDispatcher* dispatcher) : MockTimer() {
 
 MockTimer::~MockTimer() = default;
 
+MockRangeTimer::MockRangeTimer() {
+  ON_CALL(*this, enableTimer(_, _, _))
+      .WillByDefault(Invoke([&](const std::chrono::milliseconds&, const std::chrono::milliseconds&,
+                                const ScopeTrackedObject* scope) {
+        enabled_ = true;
+        scope_ = scope;
+      }));
+  ON_CALL(*this, disableTimer()).WillByDefault(Assign(&enabled_, false));
+  ON_CALL(*this, enabled()).WillByDefault(ReturnPointee(&enabled_));
+}
+
+MockRangeTimer::~MockRangeTimer() = default;
+
 MockSchedulableCallback::~MockSchedulableCallback() = default;
 
 MockSchedulableCallback::MockSchedulableCallback(MockDispatcher* dispatcher)

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -174,6 +174,38 @@ private:
   Event::TimerCb callback_;
 };
 
+class MockRangeTimer : public RangeTimer {
+public:
+  MockRangeTimer();
+  ~MockRangeTimer() override;
+
+  void invokeCallback() {
+    EXPECT_TRUE(enabled_);
+    enabled_ = false;
+    if (scope_ == nullptr) {
+      callback_();
+      return;
+    }
+    ScopeTrackerScopeState scope(scope_, *dispatcher_);
+    scope_ = nullptr;
+    callback_();
+  }
+
+  // RangeTimer
+  MOCK_METHOD(void, disableTimer, ());
+  MOCK_METHOD(void, enableTimer,
+              (const std::chrono::milliseconds& min, const std::chrono::milliseconds& max,
+               const ScopeTrackedObject* scope));
+  MOCK_METHOD(bool, enabled, ());
+
+  MockDispatcher* dispatcher_{};
+  const ScopeTrackedObject* scope_{};
+  bool enabled_{};
+
+private:
+  Event::TimerCb callback_;
+};
+
 class MockSchedulableCallback : public SchedulableCallback {
 public:
   MockSchedulableCallback(MockDispatcher* dispatcher);


### PR DESCRIPTION
Commit Message: Add RangeTimer interface
Additional Description:
Add an interface for timers that can be enabled for some timeout within a range. The actual choice of when the timer should be triggered is not specified by the interface. Possible implementations of the interface include

 - timers that are triggered when a thread is not busy
 - timers that are triggered early/late in response to load

Risk Level: low
Testing: none (interface only)
Docs Changes: none
Release Notes: none

This supersedes #11806 
cc @antoniovicente 
