### PR TITLE
docker: run in front-envoy container as root

### DIFF
--- a/examples/front-proxy/docker-compose.yaml
+++ b/examples/front-proxy/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.3"
 services:
 
   front-envoy:
@@ -17,6 +17,8 @@ services:
       - "8080:8080"
       - "8443:8443"
       - "8001:8001"
+    environment:
+      - ENVOY_UID=0
 
   service1:
     build:


### PR DESCRIPTION
If run as the 'envoy' user, the proxy can't read the config yaml file and fails to start up. The not-starting-up appears to be a side-effect of #11323.

Also change the docker-compose version to 3.3 because none of the newer features are being used.

Signed-off-by: Alex Konradi <akonradi@google.com>

Commit Message: Run proxy as root in front-envoy container
Additional Description:
If run as the 'envoy' user, the proxy can't read the config yaml file and fails to start up.

Risk Level: low
Testing: ran `docker-compose up` and saw proxy and services were running
Docs Changes: none
Release Notes: none

@yosrym93