### PR TITLE
runtime: cleanup strict_authority_validation

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -223,8 +223,7 @@ void HeaderUtility::stripPortFromHost(RequestHeaderMap& headers, uint32_t listen
 absl::optional<std::reference_wrapper<const absl::string_view>>
 HeaderUtility::requestHeadersValid(const RequestHeaderMap& headers) {
   // Make sure the host is valid.
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.strict_authority_validation") &&
-      headers.Host() && !HeaderUtility::authorityIsValid(headers.Host()->value().getStringView())) {
+  if (headers.Host() && !HeaderUtility::authorityIsValid(headers.Host()->value().getStringView())) {
     return SharedResponseCodeDetails::get().InvalidAuthority;
   }
   return absl::nullopt;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -56,7 +56,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.http1_flood_protection",
     "envoy.reloadable_features.test_feature_true",
     "envoy.reloadable_features.connection_header_sanitization",
-    "envoy.reloadable_features.strict_authority_validation",
     // Begin alphabetically sorted section.
     "envoy.reloadable_features.activate_fds_next_event_loop",
     "envoy.deprecated_features.allow_deprecated_extension_names",


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/11934

Risk Level: Low
Testing: Apparently there were no tests for this flag. :(
Docs Changes: N/A (no docs)
Release Notes: N/A (skipped because no docs)
