### PR TITLE
docs: fix link syntax in grpc json transcorder docs

### DIFF
--- a/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
@@ -85,7 +85,7 @@ as its output message type. The implementation needs to set
 Multiple `google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_
 can be send by the gRPC server in the server streaming case.
 In this case, HTTP response header `Content-Type` will use the `content-type` from the first
-`google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`.
+`google.api.HttpBody <https://github.com/googleapis/googleapis/blob/master/google/api/httpbody.proto>`_.
 
 Headers
 --------


### PR DESCRIPTION
Risk Level: low
