### PR TITLE
Change HdsCluster::cluster_ to a value instead of reference

### DIFF
--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -175,10 +175,10 @@ void HdsDelegate::processMessage(
     ENVOY_LOG(debug, "New HdsCluster config {} ", cluster_config.DebugString());
 
     // Create HdsCluster
-    hds_clusters_.emplace_back(new HdsCluster(admin_, runtime_, cluster_config, bind_config,
-                                              store_stats_, ssl_context_manager_, false,
-                                              info_factory_, cm_, local_info_, dispatcher_, random_,
-                                              singleton_manager_, tls_, validation_visitor_, api_));
+    hds_clusters_.emplace_back(
+        new HdsCluster(admin_, runtime_, std::move(cluster_config), bind_config, store_stats_,
+                       ssl_context_manager_, false, info_factory_, cm_, local_info_, dispatcher_,
+                       random_, singleton_manager_, tls_, validation_visitor_, api_));
     hds_clusters_.back()->initialize([] {});
 
     hds_clusters_.back()->startHealthchecks(access_log_manager_, runtime_, random_, dispatcher_,
@@ -233,7 +233,7 @@ void HdsDelegate::onRemoteClose(Grpc::Status::GrpcStatus status, const std::stri
 }
 
 HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
-                       const envoy::config::cluster::v3::Cluster& cluster,
+                       envoy::config::cluster::v3::Cluster cluster,
                        const envoy::config::core::v3::BindConfig& bind_config, Stats::Store& stats,
                        Ssl::ContextManager& ssl_context_manager, bool added_via_api,
                        ClusterInfoFactory& info_factory, ClusterManager& cm,
@@ -241,7 +241,7 @@ HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
                        Random::RandomGenerator& random, Singleton::Manager& singleton_manager,
                        ThreadLocal::SlotAllocator& tls,
                        ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api)
-    : runtime_(runtime), cluster_(cluster), bind_config_(bind_config), stats_(stats),
+    : runtime_(runtime), cluster_(std::move(cluster)), bind_config_(bind_config), stats_(stats),
       ssl_context_manager_(ssl_context_manager), added_via_api_(added_via_api),
       initial_hosts_(new HostVector()), validation_visitor_(validation_visitor) {
   ENVOY_LOG(debug, "Creating an HdsCluster");
@@ -251,7 +251,7 @@ HdsCluster::HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
       {admin, runtime_, cluster_, bind_config_, stats_, ssl_context_manager_, added_via_api_, cm,
        local_info, dispatcher, random, singleton_manager, tls, validation_visitor, api});
 
-  for (const auto& host : cluster.load_assignment().endpoints(0).lb_endpoints()) {
+  for (const auto& host : cluster_.load_assignment().endpoints(0).lb_endpoints()) {
     initial_hosts_->emplace_back(
         new HostImpl(info_, "", Network::Address::resolveProtoAddress(host.endpoint().address()),
                      nullptr, 1, envoy::config::core::v3::Locality().default_instance(),

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -42,7 +42,7 @@ class HdsCluster : public Cluster, Logger::Loggable<Logger::Id::upstream> {
 public:
   static ClusterSharedPtr create();
   HdsCluster(Server::Admin& admin, Runtime::Loader& runtime,
-             const envoy::config::cluster::v3::Cluster& cluster,
+             envoy::config::cluster::v3::Cluster cluster,
              const envoy::config::core::v3::BindConfig& bind_config, Stats::Store& stats,
              Ssl::ContextManager& ssl_context_manager, bool added_via_api,
              ClusterInfoFactory& info_factory, ClusterManager& cm,
@@ -78,7 +78,7 @@ private:
   std::function<void()> initialization_complete_callback_;
 
   Runtime::Loader& runtime_;
-  const envoy::config::cluster::v3::Cluster& cluster_;
+  const envoy::config::cluster::v3::Cluster cluster_;
   const envoy::config::core::v3::BindConfig& bind_config_;
   Stats::Store& stats_;
   Ssl::ContextManager& ssl_context_manager_;


### PR DESCRIPTION
Commit Message:
Change HdsCluster to store Cluster config proto with unique_ptr

Additional Description:
Currently it's created locally and assigned to a const reference, may be better to use unique_ptr .

Risk Level: Low
Testing: Passed hds_test and hds_integration_test.
Docs Changes: N/A
Release Notes: N/A
