### PR TITLE
format: add api-shadow starlark files checker

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -904,9 +904,6 @@ def checkApiShadowStarlarkFiles(api_shadow_root, file_path, error_messages):
   api_shadow_starlark_path = api_shadow_root + re.sub(r"\./api/", '', file_path)
   command += api_shadow_starlark_path
 
-  if not os.path.exists(api_shadow_starlark_path):
-    return error_messages
-
   error_message = executeCommand(command, "invalid .bzl in generated_api_shadow", file_path)
   if operation_type == "check":
     error_messages += error_message

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -898,6 +898,24 @@ def checkOwners(dir_name, owned_directories, error_messages):
     error_messages.append("New directory %s appears to not have owners in CODEOWNERS" % dir_name)
 
 
+def checkApiShadowStarlarkFiles(api_shadow_root, file_path, error_messages):
+  command = "diff -u "
+  command += file_path + " "
+  api_shadow_starlark_path = api_shadow_root + re.sub(r"\./api/", '', file_path)
+  command += api_shadow_starlark_path
+
+  if not os.path.exists(api_shadow_starlark_path):
+    return error_messages
+
+  error_message = executeCommand(command, "invalid .bzl in generated_api_shadow", file_path)
+  if operation_type == "check":
+    error_messages += error_message
+  elif operation_type == "fix" and len(error_message) != 0:
+    shutil.copy(file_path, api_shadow_starlark_path)
+
+  return error_messages
+
+
 def checkFormatVisitor(arg, dir_name, names):
   """Run checkFormat in parallel for the given files.
 
@@ -914,7 +932,7 @@ def checkFormatVisitor(arg, dir_name, names):
   # python lists are passed as references, this is used to collect the list of
   # async results (futures) from running checkFormat and passing them back to
   # the caller.
-  pool, result_list, owned_directories, error_messages = arg
+  pool, result_list, owned_directories, api_shadow_root, error_messages = arg
 
   # Sanity check CODEOWNERS.  This doesn't need to be done in a multi-threaded
   # manner as it is a small and limited list.
@@ -927,6 +945,10 @@ def checkFormatVisitor(arg, dir_name, names):
     checkOwners(dir_name[len(source_prefix):], owned_directories, error_messages)
 
   for file_name in names:
+    if dir_name.startswith("./api") and isSkylarkFile(file_name):
+      result = pool.apply_async(checkApiShadowStarlarkFiles,
+                                args=(api_shadow_root, dir_name + "/" + file_name, error_messages))
+      result_list.append(result)
     result = pool.apply_async(checkFormatReturnTraceOnError, args=(dir_name + "/" + file_name,))
     result_list.append(result)
 
@@ -993,6 +1015,7 @@ if __name__ == "__main__":
 
   operation_type = args.operation_type
   target_path = args.target_path
+  api_shadow_root = args.api_shadow_prefix
   envoy_build_rule_check = not args.skip_envoy_build_rule_check
   namespace_check = args.namespace_check
   namespace_check_excluded_paths = args.namespace_check_excluded_paths + [
@@ -1058,8 +1081,8 @@ if __name__ == "__main__":
       # For each file in target_path, start a new task in the pool and collect the
       # results (results is passed by reference, and is used as an output).
       for root, _, files in os.walk(target_path):
-        checkFormatVisitor((pool, results, owned_directories, error_messages), root,
-                           [f for f in files if path_predicate(f)])
+        checkFormatVisitor((pool, results, owned_directories, api_shadow_root, error_messages),
+                           root, [f for f in files if path_predicate(f)])
 
       # Close the pool to new tasks, wait for all of the running tasks to finish,
       # then collect the error messages.


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: https://github.com/envoyproxy/envoy/pull/12129#pullrequestreview-449837894, to ensure the consistency between `api/bazel/*.bzl` and `generated_api_shadow/bazel/*.bzl`
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
