### PR TITLE
hcm: split out filter management into seperate class

### DIFF
--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -260,6 +260,11 @@ public:
   virtual void protocol(Http::Protocol protocol) PURE;
 
   /**
+   * @param code the response code.
+   */
+  virtual void setResponseCode(uint32_t code) PURE;
+
+  /**
    * @return the response code.
    */
   virtual absl::optional<uint32_t> responseCode() const PURE;
@@ -471,6 +476,11 @@ public:
    * connection does not use SSL.
    */
   virtual Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const PURE;
+
+  /**
+   * @param route_entry the updated route entry.
+   */
+  virtual void routeEntry(const Router::RouteEntry* route_entry) PURE;
 
   /**
    * @return const Router::RouteEntry* Get the route entry selected for this request. Note: this

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -9,6 +9,19 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
+    name = "filter_manager_lib",
+    srcs = ["filter_manager.cc"],
+    hdrs = ["filter_manager.h"],
+    deps = [
+        "//include/envoy/http:filter_interface",
+        "//source/common/buffer:watermark_buffer_lib",
+        "//source/common/common:linked_object",
+        "//source/common/local_reply:local_reply_lib",
+        "//source/common/stream_info:stream_info_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "async_client_lib",
     srcs = ["async_client_impl.cc"],
     hdrs = ["async_client_impl.h"],
@@ -166,6 +179,7 @@ envoy_cc_library(
         ":codes_lib",
         ":conn_manager_config_interface",
         ":exception_lib",
+        ":filter_manager_lib",
         ":header_map_lib",
         ":header_utility_lib",
         ":headers_lib",

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -584,7 +584,7 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
   }
 }
 
-void ConnectionManagerImpl::ActiveStream::finalize100ContinueHeaders(ResponseHeaderMap& headers) {
+void ConnectionManagerImpl::ActiveStream::encode100ContinueHeaders(ResponseHeaderMap& headers) {
   // Strip the T-E headers etc. Defer other header additions as well as drain-close logic to the
   // continuation headers.
   ConnectionManagerUtility::mutateResponseHeaders(headers, filter_manager_.request_headers_.get(),
@@ -592,6 +592,9 @@ void ConnectionManagerImpl::ActiveStream::finalize100ContinueHeaders(ResponseHea
 
   // Count both the 1xx and follow-up response code in stats.
   chargeStats(headers);
+
+  ENVOY_STREAM_LOG(debug, "encoding 100 continue headers via codec:\n{}", *this, headers);
+  response_encoder_->encode100ContinueHeaders(headers);
 }
 
 void ConnectionManagerImpl::ActiveStream::resetIdleTimer() {
@@ -1102,8 +1105,8 @@ uint32_t ConnectionManagerImpl::ActiveStream::maxPathTagLength() const {
   return connection_manager_.config_.tracingConfig()->max_path_tag_length_;
 }
 
-void ConnectionManagerImpl::ActiveStream::finalizeHeaders(ResponseHeaderMap& headers,
-                                                          bool end_stream) {
+void ConnectionManagerImpl::ActiveStream::encodeHeaders(ResponseHeaderMap& headers,
+                                                        bool end_stream) {
   // Base headers.
 
   // By default, always preserve the upstream date response header if present. If we choose to

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -49,37 +49,6 @@
 namespace Envoy {
 namespace Http {
 
-namespace {
-
-template <class T> using FilterList = std::list<std::unique_ptr<T>>;
-
-// Shared helper for recording the latest filter used.
-template <class T>
-void recordLatestDataFilter(const typename FilterList<T>::iterator current_filter,
-                            T*& latest_filter, const FilterList<T>& filters) {
-  // If this is the first time we're calling onData, just record the current filter.
-  if (latest_filter == nullptr) {
-    latest_filter = current_filter->get();
-    return;
-  }
-
-  // We want to keep this pointing at the latest filter in the filter list that has received the
-  // onData callback. To do so, we compare the current latest with the *previous* filter. If they
-  // match, then we must be processing a new filter for the first time. We omit this check if we're
-  // the first filter, since the above check handles that case.
-  //
-  // We compare against the previous filter to avoid multiple filter iterations from resetting the
-  // pointer: If we just set latest to current, then the first onData filter iteration would
-  // correctly iterate over the filters and set latest, but on subsequent onData iterations
-  // we'd start from the beginning again, potentially allowing filter N to modify the buffer even
-  // though filter M > N was the filter that inserted data into the buffer.
-  if (current_filter != filters.begin() && latest_filter == std::prev(current_filter)->get()) {
-    latest_filter = current_filter->get();
-  }
-}
-
-} // namespace
-
 ConnectionManagerStats ConnectionManagerImpl::generateStats(const std::string& prefix,
                                                             Stats::Scope& scope) {
   return ConnectionManagerStats(
@@ -110,9 +79,8 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
       conn_length_(new Stats::HistogramCompletableTimespanImpl(
           stats_.named_.downstream_cx_length_ms_, time_source)),
       drain_close_(drain_close), user_agent_(http_context.userAgentContext()),
-      random_generator_(random_generator), http_context_(http_context), runtime_(runtime),
-      local_info_(local_info), cluster_manager_(cluster_manager),
-      listener_stats_(config_.listenerStats()),
+      random_generator_(random_generator), runtime_(runtime), local_info_(local_info),
+      cluster_manager_(cluster_manager), listener_stats_(config_.listenerStats()),
       overload_stop_accepting_requests_ref_(overload_manager.getThreadLocalOverloadState().getState(
           Server::OverloadActionNames::get().StopAcceptingRequests)),
       overload_disable_keepalive_ref_(overload_manager.getThreadLocalOverloadState().getState(
@@ -191,22 +159,12 @@ void ConnectionManagerImpl::doEndStream(ActiveStream& stream) {
   // we move it to the deferred deletion list here. Then, we potentially close the connection. This
   // must be done after deleting the stream since the stream refers to the connection and must be
   // deleted first.
-  bool reset_stream = false;
-  // If the response encoder is still associated with the stream, reset the stream. The exception
-  // here is when Envoy "ends" the stream by calling recreateStream at which point recreateStream
-  // explicitly nulls out response_encoder to avoid the downstream being notified of the
-  // Envoy-internal stream instance being ended.
-  if (stream.response_encoder_ != nullptr &&
-      (!stream.state_.remote_complete_ || !stream.state_.codec_saw_local_complete_)) {
-    // Indicate local is complete at this point so that if we reset during a continuation, we don't
-    // raise further data or trailers.
-    ENVOY_STREAM_LOG(debug, "doEndStream() resetting stream", stream);
-    stream.state_.local_complete_ = true;
-    stream.state_.codec_saw_local_complete_ = true;
-    stream.response_encoder_->getStream().resetStream(StreamResetReason::LocalReset);
-    reset_stream = true;
-  }
 
+  const bool reset_stream = stream.filter_manager_.maybeEndStream();
+  if (reset_stream) {
+    ENVOY_STREAM_LOG(debug, "doEndStream() resetting stream", stream);
+    stream.response_encoder_->getStream().resetStream(StreamResetReason::LocalReset);
+  }
   if (!reset_stream) {
     doDeferredStreamDestroy(stream);
   }
@@ -227,19 +185,8 @@ void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
     stream.stream_idle_timer_->disableTimer();
     stream.stream_idle_timer_ = nullptr;
   }
-  stream.disarmRequestTimeout();
 
-  stream.state_.destroyed_ = true;
-  for (auto& filter : stream.decoder_filters_) {
-    filter->handle_->onDestroy();
-  }
-
-  for (auto& filter : stream.encoder_filters_) {
-    // Do not call on destroy twice for dual registered filters.
-    if (!filter->dual_filter_) {
-      filter->handle_->onDestroy();
-    }
-  }
+  stream.filter_manager_.doDeferredStreamDestroy();
 
   read_callbacks_->connection().dispatcher().deferredDelete(stream.removeFromList(streams_));
 
@@ -257,14 +204,15 @@ RequestDecoder& ConnectionManagerImpl::newStream(ResponseEncoder& response_encod
   ENVOY_CONN_LOG(debug, "new stream", read_callbacks_->connection());
   ActiveStreamPtr new_stream(new ActiveStream(*this));
   new_stream->state_.is_internally_created_ = is_internally_created;
+  new_stream->filter_manager_.setResponseEncoder(&response_encoder);
   new_stream->response_encoder_ = &response_encoder;
-  new_stream->response_encoder_->getStream().addCallbacks(*new_stream);
-  new_stream->response_encoder_->getStream().setFlushTimeout(new_stream->idle_timeout_ms_);
-  new_stream->buffer_limit_ = new_stream->response_encoder_->getStream().bufferLimit();
+  response_encoder.getStream().addCallbacks(*new_stream);
+  response_encoder.getStream().setFlushTimeout(new_stream->idle_timeout_ms_);
+
   // If the network connection is backed up, the stream should be made aware of it on creation.
   // Both HTTP/1.x and HTTP/2 codecs handle this in StreamCallbackHelper::addCallbacksHelper.
   ASSERT(read_callbacks_->connection().aboveHighWatermark() == false ||
-         new_stream->high_watermark_count_ > 0);
+         new_stream->filter_manager_.high_watermark_count_ > 0);
   new_stream->moveIntoList(std::move(new_stream), streams_);
   return **streams_.begin();
 }
@@ -386,9 +334,9 @@ void ConnectionManagerImpl::resetAllStreams(
       // of the form: if parameter is nonempty, use that; else if the
       // codec details are nonempty, use those. This hack does not
       // seem better than the code duplication, so punt for now.
-      stream.stream_info_.setResponseFlag(response_flag.value());
+      stream.filter_manager_.streamInfo().setResponseFlag(response_flag.value());
       if (*response_flag == StreamInfo::ResponseFlag::DownstreamProtocolError) {
-        stream.stream_info_.setResponseCodeDetails(
+        stream.filter_manager_.streamInfo().setResponseCodeDetails(
             stream.response_encoder_->getStream().responseDetails());
       }
     }
@@ -527,12 +475,15 @@ void ConnectionManagerImpl::RdsRouteConfigUpdateRequester::requestRouteConfigUpd
 ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connection_manager)
     : connection_manager_(connection_manager),
       stream_id_(connection_manager.random_generator_.random()),
+      filter_manager_(
+          stream_id_, connection_manager_.codec_->protocol(), connection_manager.timeSource(),
+          connection_manager_.read_callbacks_->connection().streamInfo().filterState(), *this,
+          connection_manager.config_.localReply(), connection_manager.config_.filterFactory(),
+          connection_manager.read_callbacks_->connection().dispatcher(),
+          connection_manager_.config_.proxy100Continue()),
       request_response_timespan_(new Stats::HistogramCompletableTimespanImpl(
-          connection_manager_.stats_.named_.downstream_rq_time_, connection_manager_.timeSource())),
-      stream_info_(connection_manager_.codec_->protocol(), connection_manager_.timeSource(),
-                   connection_manager_.read_callbacks_->connection().streamInfo().filterState(),
-                   StreamInfo::FilterState::LifeSpan::Connection),
-      upstream_options_(std::make_shared<Network::Socket::Options>()) {
+          connection_manager_.stats_.named_.downstream_rq_time_,
+          connection_manager_.timeSource())) {
   ASSERT(!connection_manager.config_.isRoutable() ||
              ((connection_manager.config_.routeConfigProvider() == nullptr &&
                connection_manager.config_.scopedRouteConfigProvider() != nullptr) ||
@@ -541,7 +492,12 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
          "Either routeConfigProvider or scopedRouteConfigProvider should be set in "
          "ConnectionManagerImpl.");
 
-  stream_info_.setRequestIDExtension(connection_manager.config_.requestIDExtension());
+  for (const AccessLog::InstanceSharedPtr& access_log : connection_manager_.config_.accessLogs()) {
+    filter_manager_.addAccessLogHandler(access_log);
+  }
+
+  filter_manager_.streamInfo().setRequestIDExtension(
+      connection_manager.config_.requestIDExtension());
 
   if (connection_manager_.config_.isRoutable() &&
       connection_manager.config_.routeConfigProvider() != nullptr) {
@@ -553,7 +509,7 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
     route_config_update_requester_ =
         std::make_unique<ConnectionManagerImpl::NullRouteConfigUpdateRequester>();
   }
-  ScopeTrackerScopeState scope(this,
+  ScopeTrackerScopeState scope(&filter_manager_,
                                connection_manager_.read_callbacks_->connection().dispatcher());
 
   connection_manager_.stats_.named_.downstream_rq_total_.inc();
@@ -565,18 +521,19 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
   } else {
     connection_manager_.stats_.named_.downstream_rq_http1_total_.inc();
   }
-  stream_info_.setDownstreamLocalAddress(
+  filter_manager_.streamInfo().setDownstreamLocalAddress(
       connection_manager_.read_callbacks_->connection().localAddress());
-  stream_info_.setDownstreamDirectRemoteAddress(
+  filter_manager_.streamInfo().setDownstreamDirectRemoteAddress(
       connection_manager_.read_callbacks_->connection().directRemoteAddress());
   // Initially, the downstream remote address is the source address of the
   // downstream connection. That can change later in the request's lifecycle,
   // based on XFF processing, but setting the downstream remote address here
   // prevents surprises for logging code in edge cases.
-  stream_info_.setDownstreamRemoteAddress(
+  filter_manager_.streamInfo().setDownstreamRemoteAddress(
       connection_manager_.read_callbacks_->connection().remoteAddress());
 
-  stream_info_.setDownstreamSslConnection(connection_manager_.read_callbacks_->connection().ssl());
+  filter_manager_.streamInfo().setDownstreamSslConnection(
+      connection_manager_.read_callbacks_->connection().ssl());
 
   if (connection_manager_.config_.streamIdleTimeout().count()) {
     idle_timeout_ms_ = connection_manager_.config_.streamIdleTimeout();
@@ -587,9 +544,10 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
 
   if (connection_manager_.config_.requestTimeout().count()) {
     std::chrono::milliseconds request_timeout_ms_ = connection_manager_.config_.requestTimeout();
-    request_timer_ = connection_manager.read_callbacks_->connection().dispatcher().createTimer(
-        [this]() -> void { onRequestTimeout(); });
-    request_timer_->enableTimer(request_timeout_ms_, this);
+    filter_manager_.request_timer_ =
+        connection_manager.read_callbacks_->connection().dispatcher().createTimer(
+            [this]() -> void { onRequestTimeout(); });
+    filter_manager_.request_timer_->enableTimer(request_timeout_ms_, &filter_manager_);
   }
 
   const auto max_stream_duration = connection_manager_.config_.maxStreamDuration();
@@ -598,46 +556,42 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
         connection_manager.read_callbacks_->connection().dispatcher().createTimer(
             [this]() -> void { onStreamMaxDurationReached(); });
     max_stream_duration_timer_->enableTimer(connection_manager_.config_.maxStreamDuration().value(),
-                                            this);
+                                            &filter_manager_);
   }
 
-  stream_info_.setRequestedServerName(
+  filter_manager_.streamInfo().setRequestedServerName(
       connection_manager_.read_callbacks_->connection().requestedServerName());
 }
 
 ConnectionManagerImpl::ActiveStream::~ActiveStream() {
-  stream_info_.onRequestComplete();
+  filter_manager_.streamInfo().onRequestComplete();
 
   // A downstream disconnect can be identified for HTTP requests when the upstream returns with a 0
   // response code and when no other response flags are set.
-  if (!stream_info_.hasAnyResponseFlag() && !stream_info_.responseCode()) {
-    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamConnectionTermination);
+  if (!filter_manager_.streamInfo().hasAnyResponseFlag() &&
+      !filter_manager_.streamInfo().responseCode()) {
+    filter_manager_.streamInfo().setResponseFlag(
+        StreamInfo::ResponseFlag::DownstreamConnectionTermination);
   }
 
   connection_manager_.stats_.named_.downstream_rq_active_.dec();
-  for (const AccessLog::InstanceSharedPtr& access_log : connection_manager_.config_.accessLogs()) {
-    access_log->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
-                    stream_info_);
-  }
-  for (const auto& log_handler : access_log_handlers_) {
-    log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
-                     stream_info_);
-  }
-
-  if (stream_info_.healthCheck()) {
+  if (filter_manager_.streamInfo().healthCheck()) {
     connection_manager_.config_.tracingStats().health_check_.inc();
   }
 
-  if (active_span_) {
-    Tracing::HttpTracerUtility::finalizeDownstreamSpan(
-        *active_span_, request_headers_.get(), response_headers_.get(), response_trailers_.get(),
-        stream_info_, *this);
-  }
-  if (state_.successful_upgrade_) {
+  if (filter_manager_.state_.successful_upgrade_) {
     connection_manager_.stats_.named_.downstream_cx_upgrades_active_.dec();
   }
+}
 
-  ASSERT(state_.filter_call_state_ == 0);
+void ConnectionManagerImpl::ActiveStream::finalize100ContinueHeaders(ResponseHeaderMap& headers) {
+  // Strip the T-E headers etc. Defer other header additions as well as drain-close logic to the
+  // continuation headers.
+  ConnectionManagerUtility::mutateResponseHeaders(headers, filter_manager_.request_headers_.get(),
+                                                  connection_manager_.config_, EMPTY_STRING);
+
+  // Count both the 1xx and follow-up response code in stats.
+  chargeStats(headers);
 }
 
 void ConnectionManagerImpl::ActiveStream::resetIdleTimer() {
@@ -652,25 +606,27 @@ void ConnectionManagerImpl::ActiveStream::resetIdleTimer() {
 void ConnectionManagerImpl::ActiveStream::onIdleTimeout() {
   connection_manager_.stats_.named_.downstream_rq_idle_timeout_.inc();
   // If headers have not been sent to the user, send a 408.
-  if (response_headers_ != nullptr) {
+  if (filter_manager_.response_headers_ != nullptr) {
     // TODO(htuch): We could send trailers here with an x-envoy timeout header
     // or gRPC status code, and/or set H2 RST_STREAM error.
     connection_manager_.doEndStream(*this);
   } else {
-    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout);
-    sendLocalReply(request_headers_ != nullptr &&
-                       Grpc::Common::isGrpcRequestHeaders(*request_headers_),
-                   Http::Code::RequestTimeout, "stream timeout", nullptr, state_.is_head_request_,
-                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().StreamIdleTimeout);
+    filter_manager_.streamInfo().setResponseFlag(StreamInfo::ResponseFlag::StreamIdleTimeout);
+    sendLocalReply(filter_manager_.request_headers_ != nullptr &&
+                       Grpc::Common::isGrpcRequestHeaders(*filter_manager_.request_headers_),
+                   Http::Code::RequestTimeout, "stream timeout", nullptr,
+                   filter_manager_.state_.is_head_request_, absl::nullopt,
+                   StreamInfo::ResponseCodeDetails::get().StreamIdleTimeout);
   }
 }
 
 void ConnectionManagerImpl::ActiveStream::onRequestTimeout() {
   connection_manager_.stats_.named_.downstream_rq_timeout_.inc();
-  sendLocalReply(request_headers_ != nullptr &&
-                     Grpc::Common::isGrpcRequestHeaders(*request_headers_),
-                 Http::Code::RequestTimeout, "request timeout", nullptr, state_.is_head_request_,
-                 absl::nullopt, StreamInfo::ResponseCodeDetails::get().RequestOverallTimeout);
+  sendLocalReply(filter_manager_.request_headers_ != nullptr &&
+                     Grpc::Common::isGrpcRequestHeaders(*filter_manager_.request_headers_),
+                 Http::Code::RequestTimeout, "request timeout", nullptr,
+                 filter_manager_.state_.is_head_request_, absl::nullopt,
+                 StreamInfo::ResponseCodeDetails::get().RequestOverallTimeout);
 }
 
 void ConnectionManagerImpl::ActiveStream::onStreamMaxDurationReached() {
@@ -679,46 +635,11 @@ void ConnectionManagerImpl::ActiveStream::onStreamMaxDurationReached() {
   connection_manager_.doEndStream(*this);
 }
 
-void ConnectionManagerImpl::ActiveStream::addStreamDecoderFilterWorker(
-    StreamDecoderFilterSharedPtr filter, bool dual_filter) {
-  ActiveStreamDecoderFilterPtr wrapper(new ActiveStreamDecoderFilter(*this, filter, dual_filter));
-  filter->setDecoderFilterCallbacks(*wrapper);
-  // Note: configured decoder filters are appended to decoder_filters_.
-  // This means that if filters are configured in the following order (assume all three filters are
-  // both decoder/encoder filters):
-  //   http_filters:
-  //     - A
-  //     - B
-  //     - C
-  // The decoder filter chain will iterate through filters A, B, C.
-  wrapper->moveIntoListBack(std::move(wrapper), decoder_filters_);
-}
-
-void ConnectionManagerImpl::ActiveStream::addStreamEncoderFilterWorker(
-    StreamEncoderFilterSharedPtr filter, bool dual_filter) {
-  ActiveStreamEncoderFilterPtr wrapper(new ActiveStreamEncoderFilter(*this, filter, dual_filter));
-  filter->setEncoderFilterCallbacks(*wrapper);
-  // Note: configured encoder filters are prepended to encoder_filters_.
-  // This means that if filters are configured in the following order (assume all three filters are
-  // both decoder/encoder filters):
-  //   http_filters:
-  //     - A
-  //     - B
-  //     - C
-  // The encoder filter chain will iterate through filters C, B, A.
-  wrapper->moveIntoList(std::move(wrapper), encoder_filters_);
-}
-
-void ConnectionManagerImpl::ActiveStream::addAccessLogHandler(
-    AccessLog::InstanceSharedPtr handler) {
-  access_log_handlers_.push_back(handler);
-}
-
 void ConnectionManagerImpl::ActiveStream::chargeStats(const ResponseHeaderMap& headers) {
   uint64_t response_code = Utility::getResponseStatus(headers);
-  stream_info_.response_code_ = response_code;
+  filter_manager_.streamInfo().setResponseCode(response_code);
 
-  if (stream_info_.health_check_request_) {
+  if (filter_manager_.streamInfo().healthCheck()) {
     return;
   }
 
@@ -742,7 +663,7 @@ void ConnectionManagerImpl::ActiveStream::chargeStats(const ResponseHeaderMap& h
   }
 }
 
-const Network::Connection* ConnectionManagerImpl::ActiveStream::connection() {
+const Network::Connection* ConnectionManagerImpl::ActiveStream::connection() const {
   return &connection_manager_.read_callbacks_->connection();
 }
 
@@ -766,9 +687,11 @@ uint32_t ConnectionManagerImpl::ActiveStream::localPort() {
 // modifications which may themselves affect route selection.
 void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& headers,
                                                         bool end_stream) {
-  ScopeTrackerScopeState scope(this,
+  ScopeTrackerScopeState scope(&filter_manager_,
                                connection_manager_.read_callbacks_->connection().dispatcher());
-  request_headers_ = std::move(headers);
+  // We hand over the headers to the FilterManager early in case they are
+  // necessary to send a local reply.
+  filter_manager_.request_headers_ = std::move(headers);
 
   // Both saw_connection_close_ and is_head_request_ affect local replies: set
   // them as early as possible.
@@ -777,15 +700,17 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.fixed_connection_close");
   if (fixed_connection_close) {
     state_.saw_connection_close_ =
-        HeaderUtility::shouldCloseConnection(protocol, *request_headers_);
+        HeaderUtility::shouldCloseConnection(protocol, *filter_manager_.request_headers_);
   }
-  if (Http::Headers::get().MethodValues.Head == request_headers_->getMethodValue()) {
-    state_.is_head_request_ = true;
+  if (Http::Headers::get().MethodValues.Head ==
+      filter_manager_.request_headers_->getMethodValue()) {
+    filter_manager_.state_.is_head_request_ = true;
   }
 
-  if (HeaderUtility::isConnect(*request_headers_) && !request_headers_->Path() &&
+  if (HeaderUtility::isConnect(*filter_manager_.request_headers_) &&
+      !filter_manager_.request_headers_->Path() &&
       !Runtime::runtimeFeatureEnabled("envoy.reloadable_features.stop_faking_paths")) {
-    request_headers_->setPath("/");
+    filter_manager_.request_headers_->setPath("/");
   }
 
   // We need to snap snapped_route_config_ here as it's used in mutateRequestHeaders later.
@@ -802,38 +727,40 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   }
 
   ENVOY_STREAM_LOG(debug, "request headers complete (end_stream={}):\n{}", *this, end_stream,
-                   *request_headers_);
+                   *filter_manager_.request_headers_);
 
   // We end the decode here only if the request is header only. If we convert the request to a
   // header only, the stream will be marked as done once a subsequent decodeData/decodeTrailers is
   // called with end_stream=true.
-  maybeEndDecode(end_stream);
+  filter_manager_.maybeEndDecode(end_stream);
 
   // Drop new requests when overloaded as soon as we have decoded the headers.
   if (connection_manager_.overload_stop_accepting_requests_ref_ ==
       Server::OverloadActionState::Active) {
     // In this one special case, do not create the filter chain. If there is a risk of memory
     // overload it is more important to avoid unnecessary allocation than to create the filters.
-    state_.created_filter_chain_ = true;
+    filter_manager_.state_.created_filter_chain_ = true;
     connection_manager_.stats_.named_.downstream_rq_overload_close_.inc();
-    sendLocalReply(Grpc::Common::isGrpcRequestHeaders(*request_headers_),
+    sendLocalReply(Grpc::Common::isGrpcRequestHeaders(*filter_manager_.request_headers_),
                    Http::Code::ServiceUnavailable, "envoy overloaded", nullptr,
-                   state_.is_head_request_, absl::nullopt,
+                   filter_manager_.state_.is_head_request_, absl::nullopt,
                    StreamInfo::ResponseCodeDetails::get().Overload);
     return;
   }
 
-  if (!connection_manager_.config_.proxy100Continue() && request_headers_->Expect() &&
-      request_headers_->Expect()->value() == Headers::get().ExpectValues._100Continue.c_str()) {
+  if (!connection_manager_.config_.proxy100Continue() &&
+      filter_manager_.request_headers_->Expect() &&
+      filter_manager_.request_headers_->Expect()->value() ==
+          Headers::get().ExpectValues._100Continue.c_str()) {
     // Note in the case Envoy is handling 100-Continue complexity, it skips the filter chain
     // and sends the 100-Continue directly to the encoder.
     chargeStats(continueHeader());
     response_encoder_->encode100ContinueHeaders(continueHeader());
     // Remove the Expect header so it won't be handled again upstream.
-    request_headers_->removeExpect();
+    filter_manager_.request_headers_->removeExpect();
   }
 
-  connection_manager_.user_agent_.initializeFromHeaders(*request_headers_,
+  connection_manager_.user_agent_.initializeFromHeaders(*filter_manager_.request_headers_,
                                                         connection_manager_.stats_.prefixStatName(),
                                                         connection_manager_.stats_.scope_);
 
@@ -844,75 +771,79 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
     // HTTP/1.1.
     //
     // The protocol may have shifted in the HTTP/1.0 case so reset it.
-    stream_info_.protocol(protocol);
+    filter_manager_.streamInfo().protocol(protocol);
     if (!connection_manager_.config_.http1Settings().accept_http_10_) {
       // Send "Upgrade Required" if HTTP/1.0 support is not explicitly configured on.
-      sendLocalReply(false, Code::UpgradeRequired, "", nullptr, state_.is_head_request_,
-                     absl::nullopt, StreamInfo::ResponseCodeDetails::get().LowVersion);
+      sendLocalReply(false, Code::UpgradeRequired, "", nullptr,
+                     filter_manager_.state_.is_head_request_, absl::nullopt,
+                     StreamInfo::ResponseCodeDetails::get().LowVersion);
       return;
     } else if (!fixed_connection_close) {
       // HTTP/1.0 defaults to single-use connections. Make sure the connection
       // will be closed unless Keep-Alive is present.
       state_.saw_connection_close_ = true;
-      if (absl::EqualsIgnoreCase(request_headers_->getConnectionValue(),
+      if (absl::EqualsIgnoreCase(filter_manager_.request_headers_->getConnectionValue(),
                                  Http::Headers::get().ConnectionValues.KeepAlive)) {
         state_.saw_connection_close_ = false;
       }
     }
-    if (!request_headers_->Host() &&
+    if (!filter_manager_.request_headers_->Host() &&
         !connection_manager_.config_.http1Settings().default_host_for_http_10_.empty()) {
       // Add a default host if configured to do so.
-      request_headers_->setHost(
+      filter_manager_.request_headers_->setHost(
           connection_manager_.config_.http1Settings().default_host_for_http_10_);
     }
   }
 
-  if (!request_headers_->Host()) {
+  if (!filter_manager_.request_headers_->Host()) {
     // Require host header. For HTTP/1.1 Host has already been translated to :authority.
-    sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::BadRequest, "",
-                   nullptr, state_.is_head_request_, absl::nullopt,
-                   StreamInfo::ResponseCodeDetails::get().MissingHost);
+    sendLocalReply(Grpc::Common::hasGrpcContentType(*filter_manager_.request_headers_),
+                   Code::BadRequest, "", nullptr, filter_manager_.state_.is_head_request_,
+                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().MissingHost);
     return;
   }
 
   // Verify header sanity checks which should have been performed by the codec.
-  ASSERT(HeaderUtility::requestHeadersValid(*request_headers_).has_value() == false);
+  ASSERT(HeaderUtility::requestHeadersValid(*filter_manager_.request_headers_).has_value() ==
+         false);
 
   // Check for the existence of the :path header for non-CONNECT requests, or present-but-empty
   // :path header for CONNECT requests. We expect the codec to have broken the path into pieces if
   // applicable. NOTE: Currently the HTTP/1.1 codec only does this when the allow_absolute_url flag
   // is enabled on the HCM.
-  if ((!HeaderUtility::isConnect(*request_headers_) || request_headers_->Path()) &&
-      request_headers_->getPathValue().empty()) {
-    sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::NotFound, "", nullptr,
-                   state_.is_head_request_, absl::nullopt,
-                   StreamInfo::ResponseCodeDetails::get().MissingPath);
+  if ((!HeaderUtility::isConnect(*filter_manager_.request_headers_) ||
+       filter_manager_.request_headers_->Path()) &&
+      filter_manager_.request_headers_->getPathValue().empty()) {
+    sendLocalReply(Grpc::Common::hasGrpcContentType(*filter_manager_.request_headers_),
+                   Code::NotFound, "", nullptr, filter_manager_.state_.is_head_request_,
+                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().MissingPath);
     return;
   }
 
   // Currently we only support relative paths at the application layer.
-  if (!request_headers_->getPathValue().empty() && request_headers_->getPathValue()[0] != '/') {
+  if (!filter_manager_.request_headers_->getPathValue().empty() &&
+      filter_manager_.request_headers_->getPathValue()[0] != '/') {
     connection_manager_.stats_.named_.downstream_rq_non_relative_path_.inc();
-    sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::NotFound, "", nullptr,
-                   state_.is_head_request_, absl::nullopt,
-                   StreamInfo::ResponseCodeDetails::get().AbsolutePath);
+    sendLocalReply(Grpc::Common::hasGrpcContentType(*filter_manager_.request_headers_),
+                   Code::NotFound, "", nullptr, filter_manager_.state_.is_head_request_,
+                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().AbsolutePath);
     return;
   }
 
   // Path sanitization should happen before any path access other than the above sanity check.
-  if (!ConnectionManagerUtility::maybeNormalizePath(*request_headers_,
+  if (!ConnectionManagerUtility::maybeNormalizePath(*filter_manager_.request_headers_,
                                                     connection_manager_.config_)) {
-    sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::BadRequest, "",
-                   nullptr, state_.is_head_request_, absl::nullopt,
-                   StreamInfo::ResponseCodeDetails::get().PathNormalizationFailed);
+    sendLocalReply(Grpc::Common::hasGrpcContentType(*filter_manager_.request_headers_),
+                   Code::BadRequest, "", nullptr, filter_manager_.state_.is_head_request_,
+                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().PathNormalizationFailed);
     return;
   }
 
-  ConnectionManagerUtility::maybeNormalizeHost(*request_headers_, connection_manager_.config_,
-                                               localPort());
+  ConnectionManagerUtility::maybeNormalizeHost(*filter_manager_.request_headers_,
+                                               connection_manager_.config_, localPort());
 
   if (!fixed_connection_close && protocol == Protocol::Http11 &&
-      absl::EqualsIgnoreCase(request_headers_->getConnectionValue(),
+      absl::EqualsIgnoreCase(filter_manager_.request_headers_->getConnectionValue(),
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
@@ -920,31 +851,32 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
   // since it is supported by http-parser the underlying parser for http
   // requests.
   if (!fixed_connection_close && protocol < Protocol::Http2 && !state_.saw_connection_close_ &&
-      absl::EqualsIgnoreCase(request_headers_->getProxyConnectionValue(),
+      absl::EqualsIgnoreCase(filter_manager_.request_headers_->getProxyConnectionValue(),
                              Http::Headers::get().ConnectionValues.Close)) {
     state_.saw_connection_close_ = true;
   }
 
   if (!state_.is_internally_created_) { // Only sanitize headers on first pass.
     // Modify the downstream remote address depending on configuration and headers.
-    stream_info_.setDownstreamRemoteAddress(ConnectionManagerUtility::mutateRequestHeaders(
-        *request_headers_, connection_manager_.read_callbacks_->connection(),
-        connection_manager_.config_, *snapped_route_config_, connection_manager_.local_info_));
+    filter_manager_.streamInfo().setDownstreamRemoteAddress(
+        ConnectionManagerUtility::mutateRequestHeaders(
+            *filter_manager_.request_headers_, connection_manager_.read_callbacks_->connection(),
+            connection_manager_.config_, *snapped_route_config_, connection_manager_.local_info_));
   }
-  ASSERT(stream_info_.downstreamRemoteAddress() != nullptr);
+  ASSERT(filter_manager_.streamInfo().downstreamRemoteAddress() != nullptr);
 
   ASSERT(!cached_route_);
   refreshCachedRoute();
 
   if (!state_.is_internally_created_) { // Only mutate tracing headers on first pass.
     ConnectionManagerUtility::mutateTracingRequestHeader(
-        *request_headers_, connection_manager_.runtime_, connection_manager_.config_,
-        cached_route_.value().get());
+        *filter_manager_.request_headers_, connection_manager_.runtime_,
+        connection_manager_.config_, cached_route_.value().get());
   }
 
-  stream_info_.setRequestHeaders(*request_headers_);
+  filter_manager_.streamInfo().setRequestHeaders(*filter_manager_.request_headers_);
 
-  const bool upgrade_rejected = createFilterChain() == false;
+  const bool upgrade_rejected = filter_manager_.createFilterChain() == false;
 
   // TODO if there are no filters when starting a filter iteration, the connection manager
   // should return 404. The current returns no response if there is no router filter.
@@ -957,9 +889,9 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
       // contains a smuggled HTTP request.
       state_.saw_connection_close_ = true;
       connection_manager_.stats_.named_.downstream_rq_ws_on_non_ws_route_.inc();
-      sendLocalReply(Grpc::Common::hasGrpcContentType(*request_headers_), Code::Forbidden, "",
-                     nullptr, state_.is_head_request_, absl::nullopt,
-                     StreamInfo::ResponseCodeDetails::get().UpgradeFailed);
+      sendLocalReply(Grpc::Common::hasGrpcContentType(*filter_manager_.request_headers_),
+                     Code::Forbidden, "", nullptr, filter_manager_.state_.is_head_request_,
+                     absl::nullopt, StreamInfo::ResponseCodeDetails::get().UpgradeFailed);
       return;
     }
     // Allow non websocket requests to go through websocket enabled routes.
@@ -993,345 +925,32 @@ void ConnectionManagerImpl::ActiveStream::decodeHeaders(RequestHeaderMapPtr&& he
     traceRequest();
   }
 
-  decodeHeaders(nullptr, *request_headers_, end_stream);
+  filter_manager_.decodeHeaders(end_stream);
 
   // Reset it here for both global and overridden cases.
   resetIdleTimer();
 }
 
 void ConnectionManagerImpl::ActiveStream::traceRequest() {
-  Tracing::Decision tracing_decision =
-      Tracing::HttpTracerUtility::isTracing(stream_info_, *request_headers_);
+  Tracing::Decision tracing_decision = Tracing::HttpTracerUtility::isTracing(
+      filter_manager_.streamInfo(), *filter_manager_.request_headers_);
   ConnectionManagerImpl::chargeTracingStats(tracing_decision.reason,
                                             connection_manager_.config_.tracingStats());
 
-  active_span_ = connection_manager_.tracer().startSpan(*this, *request_headers_, stream_info_,
-                                                        tracing_decision);
-
-  if (!active_span_) {
-    return;
-  }
-
-  // TODO: Need to investigate the following code based on the cached route, as may
-  // be broken in the case a filter changes the route.
-
-  // If a decorator has been defined, apply it to the active span.
-  if (hasCachedRoute() && cached_route_.value()->decorator()) {
-    const Router::Decorator* decorator = cached_route_.value()->decorator();
-
-    decorator->apply(*active_span_);
-
-    state_.decorated_propagate_ = decorator->propagate();
-
-    // Cache decorated operation.
-    if (!decorator->getOperation().empty()) {
-      decorated_operation_ = &decorator->getOperation();
-    }
-  }
-
-  if (connection_manager_.config_.tracingConfig()->operation_name_ ==
-      Tracing::OperationName::Egress) {
-    // For egress (outbound) requests, pass the decorator's operation name (if defined and
-    // propagation enabled) as a request header to enable the receiving service to use it in its
-    // server span.
-    if (decorated_operation_ && state_.decorated_propagate_) {
-      request_headers_->setEnvoyDecoratorOperation(*decorated_operation_);
-    }
-  } else {
-    const HeaderEntry* req_operation_override = request_headers_->EnvoyDecoratorOperation();
-
-    // For ingress (inbound) requests, if a decorator operation name has been provided, it
-    // should be used to override the active span's operation.
-    if (req_operation_override) {
-      if (!req_operation_override->value().empty()) {
-        active_span_->setOperation(req_operation_override->value().getStringView());
-
-        // Clear the decorated operation so won't be used in the response header, as
-        // it has been overridden by the inbound decorator operation request header.
-        decorated_operation_ = nullptr;
-      }
-      // Remove header so not propagated to service
-      request_headers_->removeEnvoyDecoratorOperation();
-    }
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::maybeContinueDecoding(
-    const std::list<ActiveStreamDecoderFilterPtr>::iterator& continue_data_entry) {
-  if (continue_data_entry != decoder_filters_.end()) {
-    // We use the continueDecoding() code since it will correctly handle not calling
-    // decodeHeaders() again. Fake setting StopSingleIteration since the continueDecoding() code
-    // expects it.
-    ASSERT(buffered_request_data_);
-    (*continue_data_entry)->iteration_state_ =
-        ActiveStreamFilterBase::IterationState::StopSingleIteration;
-    (*continue_data_entry)->continueDecoding();
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::decodeHeaders(ActiveStreamDecoderFilter* filter,
-                                                        RequestHeaderMap& headers,
-                                                        bool end_stream) {
-  // Headers filter iteration should always start with the next filter if available.
-  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
-      commonDecodePrefix(filter, FilterIterationStartState::AlwaysStartFromNext);
-  std::list<ActiveStreamDecoderFilterPtr>::iterator continue_data_entry = decoder_filters_.end();
-
-  for (; entry != decoder_filters_.end(); entry++) {
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeHeaders));
-    state_.filter_call_state_ |= FilterCallState::DecodeHeaders;
-    (*entry)->end_stream_ = state_.decoding_headers_only_ ||
-                            (end_stream && continue_data_entry == decoder_filters_.end());
-    FilterHeadersStatus status = (*entry)->decodeHeaders(headers, (*entry)->end_stream_);
-
-    ASSERT(!(status == FilterHeadersStatus::ContinueAndEndStream && (*entry)->end_stream_));
-    state_.filter_call_state_ &= ~FilterCallState::DecodeHeaders;
-    ENVOY_STREAM_LOG(trace, "decode headers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-
-    const bool new_metadata_added = processNewlyAddedMetadata();
-    // If end_stream is set in headers, and a filter adds new metadata, we need to delay end_stream
-    // in headers by inserting an empty data frame with end_stream set. The empty data frame is sent
-    // after the new metadata.
-    if ((*entry)->end_stream_ && new_metadata_added && !buffered_request_data_) {
-      Buffer::OwnedImpl empty_data("");
-      ENVOY_STREAM_LOG(
-          trace, "inserting an empty data frame for end_stream due metadata being added.", *this);
-      // Metadata frame doesn't carry end of stream bit. We need an empty data frame to end the
-      // stream.
-      addDecodedData(*((*entry).get()), empty_data, true);
-    }
-
-    (*entry)->decode_headers_called_ = true;
-    if (!(*entry)->commonHandleAfterHeadersCallback(status, state_.decoding_headers_only_) &&
-        std::next(entry) != decoder_filters_.end()) {
-      // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
-      // processing since we need to handle the case where a terminal filter wants to buffer, but
-      // a previous filter has added body.
-      maybeContinueDecoding(continue_data_entry);
-      return;
-    }
-
-    // Here we handle the case where we have a header only request, but a filter adds a body
-    // to it. We need to not raise end_stream = true to further filters during inline iteration.
-    if (end_stream && buffered_request_data_ && continue_data_entry == decoder_filters_.end()) {
-      continue_data_entry = entry;
-    }
-  }
-
-  maybeContinueDecoding(continue_data_entry);
-
-  if (end_stream) {
-    disarmRequestTimeout();
-  }
+  auto active_span = connection_manager_.tracer().startSpan(
+      *this, *filter_manager_.request_headers_, filter_manager_.streamInfo(), tracing_decision);
+  filter_manager_.traceRequest(std::move(active_span),
+                               connection_manager_.config_.tracingConfig()->operation_name_,
+                               cached_route_);
 }
 
 void ConnectionManagerImpl::ActiveStream::decodeData(Buffer::Instance& data, bool end_stream) {
-  ScopeTrackerScopeState scope(this,
+  ScopeTrackerScopeState scope(&filter_manager_,
                                connection_manager_.read_callbacks_->connection().dispatcher());
-  maybeEndDecode(end_stream);
-  stream_info_.addBytesReceived(data.length());
+  filter_manager_.maybeEndDecode(end_stream);
+  filter_manager_.streamInfo().addBytesReceived(data.length());
 
-  decodeData(nullptr, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
-}
-
-void ConnectionManagerImpl::ActiveStream::decodeData(
-    ActiveStreamDecoderFilter* filter, Buffer::Instance& data, bool end_stream,
-    FilterIterationStartState filter_iteration_start_state) {
-  ScopeTrackerScopeState scope(this,
-                               connection_manager_.read_callbacks_->connection().dispatcher());
-  resetIdleTimer();
-
-  // If we previously decided to decode only the headers, do nothing here.
-  if (state_.decoding_headers_only_) {
-    return;
-  }
-
-  // If a response is complete or a reset has been sent, filters do not care about further body
-  // data. Just drop it.
-  if (state_.local_complete_) {
-    return;
-  }
-
-  auto trailers_added_entry = decoder_filters_.end();
-  const bool trailers_exists_at_start = request_trailers_ != nullptr;
-  // Filter iteration may start at the current filter.
-  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
-      commonDecodePrefix(filter, filter_iteration_start_state);
-
-  for (; entry != decoder_filters_.end(); entry++) {
-    // If the filter pointed by entry has stopped for all frame types, return now.
-    if (handleDataIfStopAll(**entry, data, state_.decoder_filters_streaming_)) {
-      return;
-    }
-    // If end_stream_ is marked for a filter, the data is not for this filter and filters after.
-    //
-    // In following case, ActiveStreamFilterBase::commonContinue() could be called recursively and
-    // its doData() is called with wrong data.
-    //
-    //  There are 3 decode filters and "wrapper" refers to ActiveStreamFilter object.
-    //
-    //  filter0->decodeHeaders(_, true)
-    //    return STOP
-    //  filter0->continueDecoding()
-    //    wrapper0->commonContinue()
-    //      wrapper0->decodeHeaders(_, _, true)
-    //        filter1->decodeHeaders(_, true)
-    //          filter1->addDecodeData()
-    //          return CONTINUE
-    //        filter2->decodeHeaders(_, false)
-    //          return CONTINUE
-    //        wrapper1->commonContinue() // Detects data is added.
-    //          wrapper1->doData()
-    //            wrapper1->decodeData()
-    //              filter2->decodeData(_, true)
-    //                 return CONTINUE
-    //      wrapper0->doData() // This should not be called
-    //        wrapper0->decodeData()
-    //          filter1->decodeData(_, true)  // It will cause assertions.
-    //
-    // One way to solve this problem is to mark end_stream_ for each filter.
-    // If a filter is already marked as end_stream_ when decodeData() is called, bails out the
-    // whole function. If just skip the filter, the codes after the loop will be called with
-    // wrong data. For encodeData, the response_encoder->encode() will be called.
-    if ((*entry)->end_stream_) {
-      return;
-    }
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeData));
-
-    // We check the request_trailers_ pointer here in case addDecodedTrailers
-    // is called in decodeData during a previous filter invocation, at which point we communicate to
-    // the current and future filters that the stream has not yet ended.
-    if (end_stream) {
-      state_.filter_call_state_ |= FilterCallState::LastDataFrame;
-    }
-
-    recordLatestDataFilter(entry, state_.latest_data_decoding_filter_, decoder_filters_);
-
-    state_.filter_call_state_ |= FilterCallState::DecodeData;
-    (*entry)->end_stream_ = end_stream && !request_trailers_;
-    FilterDataStatus status = (*entry)->handle_->decodeData(data, (*entry)->end_stream_);
-    if ((*entry)->end_stream_) {
-      (*entry)->handle_->decodeComplete();
-    }
-    state_.filter_call_state_ &= ~FilterCallState::DecodeData;
-    if (end_stream) {
-      state_.filter_call_state_ &= ~FilterCallState::LastDataFrame;
-    }
-    ENVOY_STREAM_LOG(trace, "decode data called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-
-    processNewlyAddedMetadata();
-
-    if (!trailers_exists_at_start && request_trailers_ &&
-        trailers_added_entry == decoder_filters_.end()) {
-      trailers_added_entry = entry;
-    }
-
-    if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.decoder_filters_streaming_) &&
-        std::next(entry) != decoder_filters_.end()) {
-      // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
-      // processing since we need to handle the case where a terminal filter wants to buffer, but
-      // a previous filter has added trailers.
-      return;
-    }
-  }
-
-  // If trailers were adding during decodeData we need to trigger decodeTrailers in order
-  // to allow filters to process the trailers.
-  if (trailers_added_entry != decoder_filters_.end()) {
-    decodeTrailers(trailers_added_entry->get(), *request_trailers_);
-  }
-
-  if (end_stream) {
-    disarmRequestTimeout();
-  }
-}
-
-RequestTrailerMap& ConnectionManagerImpl::ActiveStream::addDecodedTrailers() {
-  // Trailers can only be added during the last data frame (i.e. end_stream = true).
-  ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
-
-  // Trailers can only be added once.
-  ASSERT(!request_trailers_);
-
-  request_trailers_ = RequestTrailerMapImpl::create();
-  return *request_trailers_;
-}
-
-void ConnectionManagerImpl::ActiveStream::addDecodedData(ActiveStreamDecoderFilter& filter,
-                                                         Buffer::Instance& data, bool streaming) {
-  if (state_.filter_call_state_ == 0 ||
-      (state_.filter_call_state_ & FilterCallState::DecodeHeaders) ||
-      (state_.filter_call_state_ & FilterCallState::DecodeData) ||
-      ((state_.filter_call_state_ & FilterCallState::DecodeTrailers) && !filter.canIterate())) {
-    // Make sure if this triggers watermarks, the correct action is taken.
-    state_.decoder_filters_streaming_ = streaming;
-    // If no call is happening or we are in the decode headers/data callback, buffer the data.
-    // Inline processing happens in the decodeHeaders() callback if necessary.
-    filter.commonHandleBufferData(data);
-  } else if (state_.filter_call_state_ & FilterCallState::DecodeTrailers) {
-    // In this case we need to inline dispatch the data to further filters. If those filters
-    // choose to buffer/stop iteration that's fine.
-    decodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
-  } else {
-    // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
-    // throw an exception here.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-}
-
-MetadataMapVector& ConnectionManagerImpl::ActiveStream::addDecodedMetadata() {
-  return *getRequestMetadataMapVector();
-}
-
-void ConnectionManagerImpl::ActiveStream::decodeTrailers(RequestTrailerMapPtr&& trailers) {
-  ScopeTrackerScopeState scope(this,
-                               connection_manager_.read_callbacks_->connection().dispatcher());
-  resetIdleTimer();
-  maybeEndDecode(true);
-  request_trailers_ = std::move(trailers);
-  decodeTrailers(nullptr, *request_trailers_);
-}
-
-void ConnectionManagerImpl::ActiveStream::decodeTrailers(ActiveStreamDecoderFilter* filter,
-                                                         RequestTrailerMap& trailers) {
-  // If we previously decided to decode only the headers, do nothing here.
-  if (state_.decoding_headers_only_) {
-    return;
-  }
-
-  // See decodeData() above for why we check local_complete_ here.
-  if (state_.local_complete_) {
-    return;
-  }
-
-  // Filter iteration may start at the current filter.
-  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
-      commonDecodePrefix(filter, FilterIterationStartState::CanStartFromCurrent);
-
-  for (; entry != decoder_filters_.end(); entry++) {
-    // If the filter pointed by entry has stopped for all frame type, return now.
-    if ((*entry)->stoppedAll()) {
-      return;
-    }
-
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeTrailers));
-    state_.filter_call_state_ |= FilterCallState::DecodeTrailers;
-    FilterTrailersStatus status = (*entry)->handle_->decodeTrailers(trailers);
-    (*entry)->handle_->decodeComplete();
-    (*entry)->end_stream_ = true;
-    state_.filter_call_state_ &= ~FilterCallState::DecodeTrailers;
-    ENVOY_STREAM_LOG(trace, "decode trailers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-
-    processNewlyAddedMetadata();
-
-    if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
-      return;
-    }
-  }
-  disarmRequestTimeout();
+  filter_manager_.decodeData(data, end_stream);
 }
 
 void ConnectionManagerImpl::ActiveStream::decodeMetadata(MetadataMapPtr&& metadata_map) {
@@ -1339,82 +958,16 @@ void ConnectionManagerImpl::ActiveStream::decodeMetadata(MetadataMapPtr&& metada
   // After going through filters, the ownership of metadata_map will be passed to terminal filter.
   // The terminal filter may encode metadata_map to the next hop immediately or store metadata_map
   // and encode later when connection pool is ready.
-  decodeMetadata(nullptr, *metadata_map);
+  filter_manager_.decodeMetadata(*metadata_map);
 }
 
-void ConnectionManagerImpl::ActiveStream::decodeMetadata(ActiveStreamDecoderFilter* filter,
-                                                         MetadataMap& metadata_map) {
-  // Filter iteration may start at the current filter.
-  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
-      commonDecodePrefix(filter, FilterIterationStartState::CanStartFromCurrent);
-
-  for (; entry != decoder_filters_.end(); entry++) {
-    // If the filter pointed by entry has stopped for all frame type, stores metadata and returns.
-    // If the filter pointed by entry hasn't returned from decodeHeaders, stores newly added
-    // metadata in case decodeHeaders returns StopAllIteration. The latter can happen when headers
-    // callbacks generate new metadata.
-    if (!(*entry)->decode_headers_called_ || (*entry)->stoppedAll()) {
-      Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
-      (*entry)->getSavedRequestMetadata()->emplace_back(std::move(metadata_map_ptr));
-      return;
-    }
-
-    FilterMetadataStatus status = (*entry)->handle_->decodeMetadata(metadata_map);
-    ENVOY_STREAM_LOG(trace, "decode metadata called: filter={} status={}, metadata: {}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status),
-                     metadata_map);
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::maybeEndDecode(bool end_stream) {
-  ASSERT(!state_.remote_complete_);
-  state_.remote_complete_ = end_stream;
-  if (end_stream) {
-    stream_info_.onLastDownstreamRxByteReceived();
-    ENVOY_STREAM_LOG(debug, "request end stream", *this);
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::disarmRequestTimeout() {
-  if (request_timer_) {
-    request_timer_->disableTimer();
-  }
-}
-
-std::list<ConnectionManagerImpl::ActiveStreamEncoderFilterPtr>::iterator
-ConnectionManagerImpl::ActiveStream::commonEncodePrefix(
-    ActiveStreamEncoderFilter* filter, bool end_stream,
-    FilterIterationStartState filter_iteration_start_state) {
-  // Only do base state setting on the initial call. Subsequent calls for filtering do not touch
-  // the base state.
-  if (filter == nullptr) {
-    ASSERT(!state_.local_complete_);
-    state_.local_complete_ = end_stream;
-    return encoder_filters_.begin();
-  }
-
-  if (filter_iteration_start_state == FilterIterationStartState::CanStartFromCurrent &&
-      (*(filter->entry()))->iterate_from_current_filter_) {
-    // The filter iteration has been stopped for all frame types, and now the iteration continues.
-    // The current filter's encoding callback has not be called. Call it now.
-    return filter->entry();
-  }
-  return std::next(filter->entry());
-}
-
-std::list<ConnectionManagerImpl::ActiveStreamDecoderFilterPtr>::iterator
-ConnectionManagerImpl::ActiveStream::commonDecodePrefix(
-    ActiveStreamDecoderFilter* filter, FilterIterationStartState filter_iteration_start_state) {
-  if (!filter) {
-    return decoder_filters_.begin();
-  }
-  if (filter_iteration_start_state == FilterIterationStartState::CanStartFromCurrent &&
-      (*(filter->entry()))->iterate_from_current_filter_) {
-    // The filter iteration has been stopped for all frame types, and now the iteration continues.
-    // The current filter's callback function has not been called. Call it now.
-    return filter->entry();
-  }
-  return std::next(filter->entry());
+void ConnectionManagerImpl::ActiveStream::decodeTrailers(RequestTrailerMapPtr&& trailers) {
+  ScopeTrackerScopeState scope(&filter_manager_,
+                               connection_manager_.read_callbacks_->connection().dispatcher());
+  resetIdleTimer();
+  filter_manager_.maybeEndDecode(true);
+  filter_manager_.request_trailers_ = std::move(trailers);
+  filter_manager_.decodeTrailers();
 }
 
 void ConnectionManagerImpl::startDrainSequence() {
@@ -1427,12 +980,13 @@ void ConnectionManagerImpl::startDrainSequence() {
 }
 
 void ConnectionManagerImpl::ActiveStream::snapScopedRouteConfig() {
-  ASSERT(request_headers_ != nullptr,
+  ASSERT(filter_manager_.request_headers_ != nullptr,
          "Try to snap scoped route config when there is no request headers.");
 
   // NOTE: if a RDS subscription hasn't got a RouteConfiguration back, a Router::NullConfigImpl is
   // returned, in that case we let it pass.
-  snapped_route_config_ = snapped_scoped_routes_config_->getRouteConfig(*request_headers_);
+  snapped_route_config_ =
+      snapped_scoped_routes_config_->getRouteConfig(*filter_manager_.request_headers_);
   if (snapped_route_config_ == nullptr) {
     ENVOY_STREAM_LOG(trace, "can't find SRDS scope.", *this);
     // TODO(stevenzzzz): Consider to pass an error message to router filter, so that it can
@@ -1445,27 +999,28 @@ void ConnectionManagerImpl::ActiveStream::refreshCachedRoute() { refreshCachedRo
 
 void ConnectionManagerImpl::ActiveStream::refreshCachedRoute(const Router::RouteCallback& cb) {
   Router::RouteConstSharedPtr route;
-  if (request_headers_ != nullptr) {
+  if (filter_manager_.request_headers_ != nullptr) {
     if (connection_manager_.config_.isRoutable() &&
         connection_manager_.config_.scopedRouteConfigProvider() != nullptr) {
       // NOTE: re-select scope as well in case the scope key header has been changed by a filter.
       snapScopedRouteConfig();
     }
     if (snapped_route_config_ != nullptr) {
-      route = snapped_route_config_->route(cb, *request_headers_, stream_info_, stream_id_);
+      route = snapped_route_config_->route(cb, *filter_manager_.request_headers_,
+                                           filter_manager_.streamInfo(), stream_id_);
     }
   }
-  stream_info_.route_entry_ = route ? route->routeEntry() : nullptr;
+  filter_manager_.streamInfo().routeEntry(route ? route->routeEntry() : nullptr);
   cached_route_ = std::move(route);
-  if (nullptr == stream_info_.route_entry_) {
+  if (filter_manager_.streamInfo().routeEntry() == nullptr) {
     cached_cluster_info_ = nullptr;
   } else {
-    Upstream::ThreadLocalCluster* local_cluster =
-        connection_manager_.cluster_manager_.get(stream_info_.route_entry_->clusterName());
+    Upstream::ThreadLocalCluster* local_cluster = connection_manager_.cluster_manager_.get(
+        filter_manager_.streamInfo().routeEntry()->clusterName());
     cached_cluster_info_ = (nullptr == local_cluster) ? nullptr : local_cluster->info();
   }
 
-  stream_info_.setUpstreamClusterInfo(cached_cluster_info_.value());
+  filter_manager_.streamInfo().setUpstreamClusterInfo(cached_cluster_info_.value());
   refreshCachedTracingCustomTags();
 }
 
@@ -1496,8 +1051,8 @@ void ConnectionManagerImpl::ActiveStream::refreshCachedTracingCustomTags() {
 void ConnectionManagerImpl::ActiveStream::requestRouteConfigUpdate(
     Event::Dispatcher& thread_local_dispatcher,
     Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) {
-  ASSERT(!request_headers_->Host()->value().empty());
-  const auto& host_header = absl::AsciiStrToLower(request_headers_->getHostValue());
+  ASSERT(!filter_manager_.request_headers_->Host()->value().empty());
+  const auto& host_header = absl::AsciiStrToLower(filter_manager_.request_headers_->getHostValue());
   route_config_update_requester_->requestRouteConfigUpdate(host_header, thread_local_dispatcher,
                                                            std::move(route_config_updated_cb));
 }
@@ -1510,155 +1065,53 @@ absl::optional<Router::ConfigConstSharedPtr> ConnectionManagerImpl::ActiveStream
       connection_manager_.config_.routeConfigProvider()->config());
 }
 
-void ConnectionManagerImpl::ActiveStream::sendLocalReply(
-    bool is_grpc_request, Code code, absl::string_view body,
-    const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
-    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
-  ENVOY_STREAM_LOG(debug, "Sending local reply with details {}", *this, details);
-  ASSERT(response_headers_ == nullptr);
-  // For early error handling, do a best-effort attempt to create a filter chain
-  // to ensure access logging. If the filter chain already exists this will be
-  // a no-op.
-  createFilterChain();
+void ConnectionManagerImpl::ActiveStream::onResetStream(StreamResetReason, absl::string_view) {
+  // NOTE: This function gets called in all of the following cases:
+  //       1) We TX an app level reset
+  //       2) The codec TX a codec level reset
+  //       3) The codec RX a reset
+  //       If we need to differentiate we need to do it inside the codec. Can start with this.
+  ENVOY_STREAM_LOG(debug, "stream reset", *this);
+  connection_manager_.stats_.named_.downstream_rq_rx_reset_.inc();
+  connection_manager_.doDeferredStreamDestroy(*this);
 
-  stream_info_.setResponseCodeDetails(details);
-  Utility::sendLocalReply(
-      state_.destroyed_,
-      Utility::EncodeFunctions{
-          [this](ResponseHeaderMap& response_headers, Code& code, std::string& body,
-                 absl::string_view& content_type) -> void {
-            connection_manager_.config_.localReply().rewrite(
-                request_headers_.get(), response_headers, stream_info_, code, body, content_type);
-          },
-          [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
-            if (modify_headers != nullptr) {
-              modify_headers(*headers);
-            }
-            response_headers_ = std::move(headers);
-            // TODO: Start encoding from the last decoder filter that saw the
-            // request instead.
-            encodeHeaders(nullptr, *response_headers_, end_stream);
-          },
-          [this](Buffer::Instance& data, bool end_stream) -> void {
-            // TODO: Start encoding from the last decoder filter that saw the
-            // request instead.
-            encodeData(nullptr, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
-          }},
-      Utility::LocalReplyData{is_grpc_request, code, body, grpc_status, is_head_request});
-}
-
-void ConnectionManagerImpl::ActiveStream::encode100ContinueHeaders(
-    ActiveStreamEncoderFilter* filter, ResponseHeaderMap& headers) {
-  resetIdleTimer();
-  ASSERT(connection_manager_.config_.proxy100Continue());
-  // Make sure commonContinue continues encode100ContinueHeaders.
-  state_.has_continue_headers_ = true;
-
-  // Similar to the block in encodeHeaders, run encode100ContinueHeaders on each
-  // filter. This is simpler than that case because 100 continue implies no
-  // end-stream, and because there are normal headers coming there's no need for
-  // complex continuation logic.
-  // 100-continue filter iteration should always start with the next filter if available.
-  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
-      commonEncodePrefix(filter, false, FilterIterationStartState::AlwaysStartFromNext);
-  for (; entry != encoder_filters_.end(); entry++) {
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::Encode100ContinueHeaders));
-    state_.filter_call_state_ |= FilterCallState::Encode100ContinueHeaders;
-    FilterHeadersStatus status = (*entry)->handle_->encode100ContinueHeaders(headers);
-    state_.filter_call_state_ &= ~FilterCallState::Encode100ContinueHeaders;
-    ENVOY_STREAM_LOG(trace, "encode 100 continue headers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-    if (!(*entry)->commonHandleAfter100ContinueHeadersCallback(status)) {
-      return;
-    }
-  }
-
-  // Strip the T-E headers etc. Defer other header additions as well as drain-close logic to the
-  // continuation headers.
-  ConnectionManagerUtility::mutateResponseHeaders(headers, request_headers_.get(),
-                                                  connection_manager_.config_, EMPTY_STRING);
-
-  // Count both the 1xx and follow-up response code in stats.
-  chargeStats(headers);
-
-  ENVOY_STREAM_LOG(debug, "encoding 100 continue headers via codec:\n{}", *this, headers);
-
-  // Now actually encode via the codec.
-  response_encoder_->encode100ContinueHeaders(headers);
-}
-
-void ConnectionManagerImpl::ActiveStream::maybeContinueEncoding(
-    const std::list<ActiveStreamEncoderFilterPtr>::iterator& continue_data_entry) {
-  if (continue_data_entry != encoder_filters_.end()) {
-    // We use the continueEncoding() code since it will correctly handle not calling
-    // encodeHeaders() again. Fake setting StopSingleIteration since the continueEncoding() code
-    // expects it.
-    ASSERT(buffered_response_data_);
-    (*continue_data_entry)->iteration_state_ =
-        ActiveStreamFilterBase::IterationState::StopSingleIteration;
-    (*continue_data_entry)->continueEncoding();
+  // If the codec sets its responseDetails(), impute a
+  // DownstreamProtocolError and propagate the details upwards.
+  const absl::string_view encoder_details = response_encoder_->getStream().responseDetails();
+  if (!encoder_details.empty()) {
+    filter_manager_.streamInfo().setResponseFlag(StreamInfo::ResponseFlag::DownstreamProtocolError);
+    filter_manager_.streamInfo().setResponseCodeDetails(encoder_details);
   }
 }
 
-void ConnectionManagerImpl::ActiveStream::encodeHeaders(ActiveStreamEncoderFilter* filter,
-                                                        ResponseHeaderMap& headers,
-                                                        bool end_stream) {
-  resetIdleTimer();
-  disarmRequestTimeout();
-
-  // Headers filter iteration should always start with the next filter if available.
-  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
-      commonEncodePrefix(filter, end_stream, FilterIterationStartState::AlwaysStartFromNext);
-  std::list<ActiveStreamEncoderFilterPtr>::iterator continue_data_entry = encoder_filters_.end();
-
-  for (; entry != encoder_filters_.end(); entry++) {
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeHeaders));
-    state_.filter_call_state_ |= FilterCallState::EncodeHeaders;
-    (*entry)->end_stream_ = state_.encoding_headers_only_ ||
-                            (end_stream && continue_data_entry == encoder_filters_.end());
-    FilterHeadersStatus status = (*entry)->handle_->encodeHeaders(headers, (*entry)->end_stream_);
-    if ((*entry)->end_stream_) {
-      (*entry)->handle_->encodeComplete();
-    }
-    state_.filter_call_state_ &= ~FilterCallState::EncodeHeaders;
-    ENVOY_STREAM_LOG(trace, "encode headers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-
-    (*entry)->encode_headers_called_ = true;
-    const auto continue_iteration =
-        (*entry)->commonHandleAfterHeadersCallback(status, state_.encoding_headers_only_);
-
-    // If we're encoding a headers only response, then mark the local as complete. This ensures
-    // that we don't attempt to reset the downstream request in doEndStream.
-    if (state_.encoding_headers_only_) {
-      state_.local_complete_ = true;
-    }
-
-    if (!continue_iteration) {
-      if (!(*entry)->end_stream_) {
-        maybeContinueEncoding(continue_data_entry);
-      }
-      return;
-    }
-
-    // Here we handle the case where we have a header only response, but a filter adds a body
-    // to it. We need to not raise end_stream = true to further filters during inline iteration.
-    if (end_stream && buffered_response_data_ && continue_data_entry == encoder_filters_.end()) {
-      continue_data_entry = entry;
-    }
-  }
-
-  const bool modified_end_stream = state_.encoding_headers_only_ ||
-                                   (end_stream && continue_data_entry == encoder_filters_.end());
-  encodeHeadersInternal(headers, modified_end_stream);
-
-  if (!modified_end_stream) {
-    maybeContinueEncoding(continue_data_entry);
-  }
+void ConnectionManagerImpl::ActiveStream::onAboveWriteBufferHighWatermark() {
+  ENVOY_STREAM_LOG(debug, "Disabling upstream stream due to downstream stream watermark.", *this);
+  filter_manager_.callHighWatermarkCallbacks();
 }
 
-void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMap& headers,
-                                                                bool end_stream) {
+void ConnectionManagerImpl::ActiveStream::onBelowWriteBufferLowWatermark() {
+  ENVOY_STREAM_LOG(debug, "Enabling upstream stream due to downstream stream watermark.", *this);
+  filter_manager_.callLowWatermarkCallbacks();
+}
+
+Tracing::OperationName ConnectionManagerImpl::ActiveStream::operationName() const {
+  return connection_manager_.config_.tracingConfig()->operation_name_;
+}
+
+const Tracing::CustomTagMap* ConnectionManagerImpl::ActiveStream::customTags() const {
+  return tracing_custom_tags_.get();
+}
+
+bool ConnectionManagerImpl::ActiveStream::verbose() const {
+  return connection_manager_.config_.tracingConfig()->verbose_;
+}
+
+uint32_t ConnectionManagerImpl::ActiveStream::maxPathTagLength() const {
+  return connection_manager_.config_.tracingConfig()->max_path_tag_length_;
+}
+
+void ConnectionManagerImpl::ActiveStream::finalizeHeaders(ResponseHeaderMap& headers,
+                                                          bool end_stream) {
   // Base headers.
 
   // By default, always preserve the upstream date response header if present. If we choose to
@@ -1666,7 +1119,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
   // is not from cache
   const bool should_preserve_upstream_date =
       Runtime::runtimeFeatureEnabled("envoy.reloadable_features.preserve_upstream_date") ||
-      stream_info_.hasResponseFlag(StreamInfo::ResponseFlag::ResponseFromCacheFilter);
+      filter_manager_.streamInfo().hasResponseFlag(
+          StreamInfo::ResponseFlag::ResponseFromCacheFilter);
   if (!should_preserve_upstream_date || !headers.Date()) {
     connection_manager_.config_.dateProvider().setDateHeader(headers);
   }
@@ -1678,7 +1132,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
        headers.Server() == nullptr)) {
     headers.setReferenceServer(connection_manager_.config_.serverName());
   }
-  ConnectionManagerUtility::mutateResponseHeaders(headers, request_headers_.get(),
+  ConnectionManagerUtility::mutateResponseHeaders(headers, filter_manager_.request_headers_.get(),
                                                   connection_manager_.config_,
                                                   connection_manager_.config_.via());
 
@@ -1723,7 +1177,7 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
   // If we are destroying a stream before remote is complete and the connection does not support
   // multiplexing, we should disconnect since we don't want to wait around for the request to
   // finish.
-  if (!state_.remote_complete_) {
+  if (!filter_manager_.state_.remote_complete_) {
     if (connection_manager_.codec_->protocol() < Protocol::Http2) {
       connection_manager_.drain_state_ = DrainState::Closing;
     }
@@ -1737,7 +1191,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
     // Do not do this for H2 (which drains via GOAWAY) or Upgrade or CONNECT (as the
     // payload is no longer HTTP/1.1)
     if (!Utility::isUpgrade(headers) &&
-        !HeaderUtility::isConnectResponse(request_headers_, *response_headers_)) {
+        !HeaderUtility::isConnectResponse(filter_manager_.request_headers_,
+                                          *filter_manager_.response_headers_)) {
       headers.setReferenceConnection(Headers::get().ConnectionValues.Close);
     }
   }
@@ -1749,8 +1204,8 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
       // decorator operation (override), and the decorated operation should be
       // propagated, then pass the decorator's operation name (if defined)
       // as a response header to enable the client service to use it in its client span.
-      if (decorated_operation_ && state_.decorated_propagate_) {
-        headers.setEnvoyDecoratorOperation(*decorated_operation_);
+      if (filter_manager_.decorated_operation_ && filter_manager_.state_.decorated_propagate_) {
+        headers.setEnvoyDecoratorOperation(*filter_manager_.decorated_operation_);
       }
     } else if (connection_manager_.config_.tracingConfig()->operation_name_ ==
                Tracing::OperationName::Egress) {
@@ -1759,8 +1214,9 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
       // For Egress (outbound) response, if a decorator operation name has been provided, it
       // should be used to override the active span's operation.
       if (resp_operation_override) {
-        if (!resp_operation_override->value().empty() && active_span_) {
-          active_span_->setOperation(resp_operation_override->value().getStringView());
+        if (!resp_operation_override->value().empty() && filter_manager_.active_span_) {
+          filter_manager_.active_span_->setOperation(
+              resp_operation_override->value().getStringView());
         }
         // Remove header so not propagated to service.
         headers.removeEnvoyDecoratorOperation();
@@ -1774,841 +1230,9 @@ void ConnectionManagerImpl::ActiveStream::encodeHeadersInternal(ResponseHeaderMa
                    headers);
 
   // Now actually encode via the codec.
-  stream_info_.onFirstDownstreamTxByteSent();
+  filter_manager_.streamInfo().onFirstDownstreamTxByteSent();
   response_encoder_->encodeHeaders(headers, end_stream);
-  maybeEndEncode(end_stream);
+  filter_manager_.maybeEndEncode(end_stream);
 }
-
-void ConnectionManagerImpl::ActiveStream::encodeMetadata(ActiveStreamEncoderFilter* filter,
-                                                         MetadataMapPtr&& metadata_map_ptr) {
-  resetIdleTimer();
-
-  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
-      commonEncodePrefix(filter, false, FilterIterationStartState::CanStartFromCurrent);
-
-  for (; entry != encoder_filters_.end(); entry++) {
-    // If the filter pointed by entry has stopped for all frame type, stores metadata and returns.
-    // If the filter pointed by entry hasn't returned from encodeHeaders, stores newly added
-    // metadata in case encodeHeaders returns StopAllIteration. The latter can happen when headers
-    // callbacks generate new metadata.
-    if (!(*entry)->encode_headers_called_ || (*entry)->stoppedAll()) {
-      (*entry)->getSavedResponseMetadata()->emplace_back(std::move(metadata_map_ptr));
-      return;
-    }
-
-    FilterMetadataStatus status = (*entry)->handle_->encodeMetadata(*metadata_map_ptr);
-    ENVOY_STREAM_LOG(trace, "encode metadata called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-  }
-  // TODO(soya3129): update stats with metadata.
-
-  // Now encode metadata via the codec.
-  if (!metadata_map_ptr->empty()) {
-    ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", *this, *metadata_map_ptr);
-    MetadataMapVector metadata_map_vector;
-    metadata_map_vector.emplace_back(std::move(metadata_map_ptr));
-    response_encoder_->encodeMetadata(metadata_map_vector);
-  }
-}
-
-ResponseTrailerMap& ConnectionManagerImpl::ActiveStream::addEncodedTrailers() {
-  // Trailers can only be added during the last data frame (i.e. end_stream = true).
-  ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
-
-  // Trailers can only be added once.
-  ASSERT(!response_trailers_);
-
-  response_trailers_ = ResponseTrailerMapImpl::create();
-  return *response_trailers_;
-}
-
-void ConnectionManagerImpl::ActiveStream::addEncodedData(ActiveStreamEncoderFilter& filter,
-                                                         Buffer::Instance& data, bool streaming) {
-  if (state_.filter_call_state_ == 0 ||
-      (state_.filter_call_state_ & FilterCallState::EncodeHeaders) ||
-      (state_.filter_call_state_ & FilterCallState::EncodeData) ||
-      ((state_.filter_call_state_ & FilterCallState::EncodeTrailers) && !filter.canIterate())) {
-    // Make sure if this triggers watermarks, the correct action is taken.
-    state_.encoder_filters_streaming_ = streaming;
-    // If no call is happening or we are in the decode headers/data callback, buffer the data.
-    // Inline processing happens in the decodeHeaders() callback if necessary.
-    filter.commonHandleBufferData(data);
-  } else if (state_.filter_call_state_ & FilterCallState::EncodeTrailers) {
-    // In this case we need to inline dispatch the data to further filters. If those filters
-    // choose to buffer/stop iteration that's fine.
-    encodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
-  } else {
-    // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
-    // throw an exception here.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::encodeData(
-    ActiveStreamEncoderFilter* filter, Buffer::Instance& data, bool end_stream,
-    FilterIterationStartState filter_iteration_start_state) {
-  resetIdleTimer();
-
-  // If we previously decided to encode only the headers, do nothing here.
-  if (state_.encoding_headers_only_) {
-    return;
-  }
-
-  // Filter iteration may start at the current filter.
-  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
-      commonEncodePrefix(filter, end_stream, filter_iteration_start_state);
-  auto trailers_added_entry = encoder_filters_.end();
-
-  const bool trailers_exists_at_start = response_trailers_ != nullptr;
-  for (; entry != encoder_filters_.end(); entry++) {
-    // If the filter pointed by entry has stopped for all frame type, return now.
-    if (handleDataIfStopAll(**entry, data, state_.encoder_filters_streaming_)) {
-      return;
-    }
-    // If end_stream_ is marked for a filter, the data is not for this filter and filters after.
-    // For details, please see the comment in the ActiveStream::decodeData() function.
-    if ((*entry)->end_stream_) {
-      return;
-    }
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeData));
-
-    // We check the response_trailers_ pointer here in case addEncodedTrailers
-    // is called in encodeData during a previous filter invocation, at which point we communicate to
-    // the current and future filters that the stream has not yet ended.
-    state_.filter_call_state_ |= FilterCallState::EncodeData;
-    if (end_stream) {
-      state_.filter_call_state_ |= FilterCallState::LastDataFrame;
-    }
-
-    recordLatestDataFilter(entry, state_.latest_data_encoding_filter_, encoder_filters_);
-
-    (*entry)->end_stream_ = end_stream && !response_trailers_;
-    FilterDataStatus status = (*entry)->handle_->encodeData(data, (*entry)->end_stream_);
-    if ((*entry)->end_stream_) {
-      (*entry)->handle_->encodeComplete();
-    }
-    state_.filter_call_state_ &= ~FilterCallState::EncodeData;
-    if (end_stream) {
-      state_.filter_call_state_ &= ~FilterCallState::LastDataFrame;
-    }
-    ENVOY_STREAM_LOG(trace, "encode data called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-
-    if (!trailers_exists_at_start && response_trailers_ &&
-        trailers_added_entry == encoder_filters_.end()) {
-      trailers_added_entry = entry;
-    }
-
-    if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.encoder_filters_streaming_)) {
-      return;
-    }
-  }
-
-  const bool modified_end_stream = end_stream && trailers_added_entry == encoder_filters_.end();
-  encodeDataInternal(data, modified_end_stream);
-
-  // If trailers were adding during encodeData we need to trigger decodeTrailers in order
-  // to allow filters to process the trailers.
-  if (trailers_added_entry != encoder_filters_.end()) {
-    encodeTrailers(trailers_added_entry->get(), *response_trailers_);
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::encodeDataInternal(Buffer::Instance& data,
-                                                             bool end_stream) {
-  ASSERT(!state_.encoding_headers_only_);
-  ENVOY_STREAM_LOG(trace, "encoding data via codec (size={} end_stream={})", *this, data.length(),
-                   end_stream);
-
-  stream_info_.addBytesSent(data.length());
-  response_encoder_->encodeData(data, end_stream);
-  maybeEndEncode(end_stream);
-}
-
-void ConnectionManagerImpl::ActiveStream::encodeTrailers(ActiveStreamEncoderFilter* filter,
-                                                         ResponseTrailerMap& trailers) {
-  resetIdleTimer();
-
-  // If we previously decided to encode only the headers, do nothing here.
-  if (state_.encoding_headers_only_) {
-    return;
-  }
-
-  // Filter iteration may start at the current filter.
-  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
-      commonEncodePrefix(filter, true, FilterIterationStartState::CanStartFromCurrent);
-  for (; entry != encoder_filters_.end(); entry++) {
-    // If the filter pointed by entry has stopped for all frame type, return now.
-    if ((*entry)->stoppedAll()) {
-      return;
-    }
-    ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeTrailers));
-    state_.filter_call_state_ |= FilterCallState::EncodeTrailers;
-    FilterTrailersStatus status = (*entry)->handle_->encodeTrailers(trailers);
-    (*entry)->handle_->encodeComplete();
-    (*entry)->end_stream_ = true;
-    state_.filter_call_state_ &= ~FilterCallState::EncodeTrailers;
-    ENVOY_STREAM_LOG(trace, "encode trailers called: filter={} status={}", *this,
-                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
-    if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
-      return;
-    }
-  }
-
-  ENVOY_STREAM_LOG(debug, "encoding trailers via codec:\n{}", *this, trailers);
-
-  response_encoder_->encodeTrailers(trailers);
-  maybeEndEncode(true);
-}
-
-void ConnectionManagerImpl::ActiveStream::maybeEndEncode(bool end_stream) {
-  if (end_stream) {
-    ASSERT(!state_.codec_saw_local_complete_);
-    state_.codec_saw_local_complete_ = true;
-    stream_info_.onLastDownstreamTxByteSent();
-    request_response_timespan_->complete();
-    connection_manager_.doEndStream(*this);
-  }
-}
-
-bool ConnectionManagerImpl::ActiveStream::processNewlyAddedMetadata() {
-  if (request_metadata_map_vector_ == nullptr) {
-    return false;
-  }
-  for (const auto& metadata_map : *getRequestMetadataMapVector()) {
-    decodeMetadata(nullptr, *metadata_map);
-  }
-  getRequestMetadataMapVector()->clear();
-  return true;
-}
-
-bool ConnectionManagerImpl::ActiveStream::handleDataIfStopAll(ActiveStreamFilterBase& filter,
-                                                              Buffer::Instance& data,
-                                                              bool& filter_streaming) {
-  if (filter.stoppedAll()) {
-    ASSERT(!filter.canIterate());
-    filter_streaming =
-        filter.iteration_state_ == ActiveStreamFilterBase::IterationState::StopAllWatermark;
-    filter.commonHandleBufferData(data);
-    return true;
-  }
-  return false;
-}
-
-void ConnectionManagerImpl::ActiveStream::onResetStream(StreamResetReason, absl::string_view) {
-  // NOTE: This function gets called in all of the following cases:
-  //       1) We TX an app level reset
-  //       2) The codec TX a codec level reset
-  //       3) The codec RX a reset
-  //       If we need to differentiate we need to do it inside the codec. Can start with this.
-  ENVOY_STREAM_LOG(debug, "stream reset", *this);
-  connection_manager_.stats_.named_.downstream_rq_rx_reset_.inc();
-  connection_manager_.doDeferredStreamDestroy(*this);
-
-  // If the codec sets its responseDetails(), impute a
-  // DownstreamProtocolError and propagate the details upwards.
-  const absl::string_view encoder_details = response_encoder_->getStream().responseDetails();
-  if (!encoder_details.empty()) {
-    stream_info_.setResponseFlag(StreamInfo::ResponseFlag::DownstreamProtocolError);
-    stream_info_.setResponseCodeDetails(encoder_details);
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::onAboveWriteBufferHighWatermark() {
-  ENVOY_STREAM_LOG(debug, "Disabling upstream stream due to downstream stream watermark.", *this);
-  callHighWatermarkCallbacks();
-}
-
-void ConnectionManagerImpl::ActiveStream::onBelowWriteBufferLowWatermark() {
-  ENVOY_STREAM_LOG(debug, "Enabling upstream stream due to downstream stream watermark.", *this);
-  callLowWatermarkCallbacks();
-}
-
-Tracing::OperationName ConnectionManagerImpl::ActiveStream::operationName() const {
-  return connection_manager_.config_.tracingConfig()->operation_name_;
-}
-
-const Tracing::CustomTagMap* ConnectionManagerImpl::ActiveStream::customTags() const {
-  return tracing_custom_tags_.get();
-}
-
-bool ConnectionManagerImpl::ActiveStream::verbose() const {
-  return connection_manager_.config_.tracingConfig()->verbose_;
-}
-
-uint32_t ConnectionManagerImpl::ActiveStream::maxPathTagLength() const {
-  return connection_manager_.config_.tracingConfig()->max_path_tag_length_;
-}
-
-void ConnectionManagerImpl::ActiveStream::callHighWatermarkCallbacks() {
-  ++high_watermark_count_;
-  for (auto watermark_callbacks : watermark_callbacks_) {
-    watermark_callbacks->onAboveWriteBufferHighWatermark();
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::callLowWatermarkCallbacks() {
-  ASSERT(high_watermark_count_ > 0);
-  --high_watermark_count_;
-  for (auto watermark_callbacks : watermark_callbacks_) {
-    watermark_callbacks->onBelowWriteBufferLowWatermark();
-  }
-}
-
-void ConnectionManagerImpl::ActiveStream::setBufferLimit(uint32_t new_limit) {
-  ENVOY_STREAM_LOG(debug, "setting buffer limit to {}", *this, new_limit);
-  buffer_limit_ = new_limit;
-  if (buffered_request_data_) {
-    buffered_request_data_->setWatermarks(buffer_limit_);
-  }
-  if (buffered_response_data_) {
-    buffered_response_data_->setWatermarks(buffer_limit_);
-  }
-}
-
-bool ConnectionManagerImpl::ActiveStream::createFilterChain() {
-  if (state_.created_filter_chain_) {
-    return false;
-  }
-  bool upgrade_rejected = false;
-  const Envoy::Http::HeaderEntry* upgrade =
-      request_headers_ ? request_headers_->Upgrade() : nullptr;
-  // Treat CONNECT requests as a special upgrade case.
-  if (!upgrade && request_headers_ && HeaderUtility::isConnect(*request_headers_)) {
-    upgrade = request_headers_->Method();
-  }
-  state_.created_filter_chain_ = true;
-  if (upgrade != nullptr) {
-    const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
-
-    // We must check if the 'cached_route_' optional is populated since this function can be called
-    // early via sendLocalReply(), before the cached route is populated.
-    if (hasCachedRoute() && cached_route_.value()->routeEntry()) {
-      upgrade_map = &cached_route_.value()->routeEntry()->upgradeMap();
-    }
-
-    if (connection_manager_.config_.filterFactory().createUpgradeFilterChain(
-            upgrade->value().getStringView(), upgrade_map, *this)) {
-      state_.successful_upgrade_ = true;
-      connection_manager_.stats_.named_.downstream_cx_upgrades_total_.inc();
-      connection_manager_.stats_.named_.downstream_cx_upgrades_active_.inc();
-      return true;
-    } else {
-      upgrade_rejected = true;
-      // Fall through to the default filter chain. The function calling this
-      // will send a local reply indicating that the upgrade failed.
-    }
-  }
-
-  connection_manager_.config_.filterFactory().createFilterChain(*this);
-  return !upgrade_rejected;
-}
-
-void ConnectionManagerImpl::ActiveStreamFilterBase::commonContinue() {
-  // TODO(mattklein123): Raise an error if this is called during a callback.
-  if (!canContinue()) {
-    ENVOY_STREAM_LOG(trace, "cannot continue filter chain: filter={}", parent_,
-                     static_cast<const void*>(this));
-    return;
-  }
-
-  ENVOY_STREAM_LOG(trace, "continuing filter chain: filter={}", parent_,
-                   static_cast<const void*>(this));
-  ASSERT(!canIterate());
-  // If iteration has stopped for all frame types, set iterate_from_current_filter_ to true so the
-  // filter iteration starts with the current filter instead of the next one.
-  if (stoppedAll()) {
-    iterate_from_current_filter_ = true;
-  }
-  allowIteration();
-
-  // Only resume with do100ContinueHeaders() if we've actually seen a 100-Continue.
-  if (has100Continueheaders()) {
-    continue_headers_continued_ = true;
-    do100ContinueHeaders();
-    // If the response headers have not yet come in, don't continue on with
-    // headers and body. doHeaders expects request headers to exist.
-    if (!parent_.response_headers_.get()) {
-      return;
-    }
-  }
-
-  // Make sure that we handle the zero byte data frame case. We make no effort to optimize this
-  // case in terms of merging it into a header only request/response. This could be done in the
-  // future.
-  if (!headers_continued_) {
-    headers_continued_ = true;
-    doHeaders(complete() && !bufferedData() && !hasTrailers());
-  }
-
-  doMetadata();
-
-  if (bufferedData()) {
-    doData(complete() && !hasTrailers());
-  }
-
-  if (hasTrailers()) {
-    doTrailers();
-  }
-
-  iterate_from_current_filter_ = false;
-}
-
-bool ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleAfter100ContinueHeadersCallback(
-    FilterHeadersStatus status) {
-  ASSERT(parent_.state_.has_continue_headers_);
-  ASSERT(!continue_headers_continued_);
-  ASSERT(canIterate());
-
-  if (status == FilterHeadersStatus::StopIteration) {
-    iteration_state_ = IterationState::StopSingleIteration;
-    return false;
-  } else {
-    ASSERT(status == FilterHeadersStatus::Continue);
-    continue_headers_continued_ = true;
-    return true;
-  }
-}
-
-bool ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleAfterHeadersCallback(
-    FilterHeadersStatus status, bool& headers_only) {
-  ASSERT(!headers_continued_);
-  ASSERT(canIterate());
-
-  if (status == FilterHeadersStatus::StopIteration) {
-    iteration_state_ = IterationState::StopSingleIteration;
-  } else if (status == FilterHeadersStatus::StopAllIterationAndBuffer) {
-    iteration_state_ = IterationState::StopAllBuffer;
-  } else if (status == FilterHeadersStatus::StopAllIterationAndWatermark) {
-    iteration_state_ = IterationState::StopAllWatermark;
-  } else if (status == FilterHeadersStatus::ContinueAndEndStream) {
-    // Set headers_only to true so we know to end early if necessary,
-    // but continue filter iteration so we actually write the headers/run the cleanup code.
-    headers_only = true;
-    ENVOY_STREAM_LOG(debug, "converting to headers only", parent_);
-  } else {
-    ASSERT(status == FilterHeadersStatus::Continue);
-    headers_continued_ = true;
-  }
-
-  handleMetadataAfterHeadersCallback();
-
-  if (stoppedAll() || status == FilterHeadersStatus::StopIteration) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
-void ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleBufferData(
-    Buffer::Instance& provided_data) {
-
-  // The way we do buffering is a little complicated which is why we have this common function
-  // which is used for both encoding and decoding. When data first comes into our filter pipeline,
-  // we send it through. Any filter can choose to stop iteration and buffer or not. If we then
-  // continue iteration in the future, we use the buffered data. A future filter can stop and
-  // buffer again. In this case, since we are already operating on buffered data, we don't
-  // rebuffer, because we assume the filter has modified the buffer as it wishes in place.
-  if (bufferedData().get() != &provided_data) {
-    if (!bufferedData()) {
-      bufferedData() = createBuffer();
-    }
-    bufferedData()->move(provided_data);
-  }
-}
-
-bool ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleAfterDataCallback(
-    FilterDataStatus status, Buffer::Instance& provided_data, bool& buffer_was_streaming) {
-
-  if (status == FilterDataStatus::Continue) {
-    if (iteration_state_ == IterationState::StopSingleIteration) {
-      commonHandleBufferData(provided_data);
-      commonContinue();
-      return false;
-    } else {
-      ASSERT(headers_continued_);
-    }
-  } else {
-    iteration_state_ = IterationState::StopSingleIteration;
-    if (status == FilterDataStatus::StopIterationAndBuffer ||
-        status == FilterDataStatus::StopIterationAndWatermark) {
-      buffer_was_streaming = status == FilterDataStatus::StopIterationAndWatermark;
-      commonHandleBufferData(provided_data);
-    } else if (complete() && !hasTrailers() && !bufferedData()) {
-      // If this filter is doing StopIterationNoBuffer and this stream is terminated with a zero
-      // byte data frame, we need to create an empty buffer to make sure that when commonContinue
-      // is called, the pipeline resumes with an empty data frame with end_stream = true
-      ASSERT(end_stream_);
-      bufferedData() = createBuffer();
-    }
-
-    return false;
-  }
-
-  return true;
-}
-
-bool ConnectionManagerImpl::ActiveStreamFilterBase::commonHandleAfterTrailersCallback(
-    FilterTrailersStatus status) {
-
-  if (status == FilterTrailersStatus::Continue) {
-    if (iteration_state_ == IterationState::StopSingleIteration) {
-      commonContinue();
-      return false;
-    } else {
-      ASSERT(headers_continued_);
-    }
-  } else {
-    return false;
-  }
-
-  return true;
-}
-
-const Network::Connection* ConnectionManagerImpl::ActiveStreamFilterBase::connection() {
-  return parent_.connection();
-}
-
-Event::Dispatcher& ConnectionManagerImpl::ActiveStreamFilterBase::dispatcher() {
-  return parent_.connection_manager_.read_callbacks_->connection().dispatcher();
-}
-
-StreamInfo::StreamInfo& ConnectionManagerImpl::ActiveStreamFilterBase::streamInfo() {
-  return parent_.stream_info_;
-}
-
-Tracing::Span& ConnectionManagerImpl::ActiveStreamFilterBase::activeSpan() {
-  if (parent_.active_span_) {
-    return *parent_.active_span_;
-  } else {
-    return Tracing::NullSpan::instance();
-  }
-}
-
-Tracing::Config& ConnectionManagerImpl::ActiveStreamFilterBase::tracingConfig() { return parent_; }
-
-Upstream::ClusterInfoConstSharedPtr ConnectionManagerImpl::ActiveStreamFilterBase::clusterInfo() {
-  // NOTE: Refreshing route caches clusterInfo as well.
-  if (!parent_.cached_route_.has_value()) {
-    parent_.refreshCachedRoute();
-  }
-
-  return parent_.cached_cluster_info_.value();
-}
-
-Router::RouteConstSharedPtr ConnectionManagerImpl::ActiveStreamFilterBase::route() {
-  return route(nullptr);
-}
-
-Router::RouteConstSharedPtr
-ConnectionManagerImpl::ActiveStreamFilterBase::route(const Router::RouteCallback& cb) {
-  if (parent_.cached_route_.has_value()) {
-    return parent_.cached_route_.value();
-  }
-  parent_.refreshCachedRoute(cb);
-  return parent_.cached_route_.value();
-}
-
-void ConnectionManagerImpl::ActiveStreamFilterBase::clearRouteCache() {
-  parent_.cached_route_ = absl::optional<Router::RouteConstSharedPtr>();
-  parent_.cached_cluster_info_ = absl::optional<Upstream::ClusterInfoConstSharedPtr>();
-  if (parent_.tracing_custom_tags_) {
-    parent_.tracing_custom_tags_->clear();
-  }
-}
-
-Buffer::WatermarkBufferPtr ConnectionManagerImpl::ActiveStreamDecoderFilter::createBuffer() {
-  auto buffer = std::make_unique<Buffer::WatermarkBuffer>(
-      [this]() -> void { this->requestDataDrained(); },
-      [this]() -> void { this->requestDataTooLarge(); },
-      []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });
-  buffer->setWatermarks(parent_.buffer_limit_);
-  return buffer;
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::handleMetadataAfterHeadersCallback() {
-  // If we drain accumulated metadata, the iteration must start with the current filter.
-  const bool saved_state = iterate_from_current_filter_;
-  iterate_from_current_filter_ = true;
-  // If decodeHeaders() returns StopAllIteration, we should skip draining metadata, and wait
-  // for doMetadata() to drain the metadata after iteration continues.
-  if (!stoppedAll() && saved_request_metadata_ != nullptr && !getSavedRequestMetadata()->empty()) {
-    drainSavedRequestMetadata();
-  }
-  // Restores the original value of iterate_from_current_filter_.
-  iterate_from_current_filter_ = saved_state;
-}
-
-RequestTrailerMap& ConnectionManagerImpl::ActiveStreamDecoderFilter::addDecodedTrailers() {
-  return parent_.addDecodedTrailers();
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::addDecodedData(Buffer::Instance& data,
-                                                                      bool streaming) {
-  parent_.addDecodedData(*this, data, streaming);
-}
-
-MetadataMapVector& ConnectionManagerImpl::ActiveStreamDecoderFilter::addDecodedMetadata() {
-  return parent_.addDecodedMetadata();
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::injectDecodedDataToFilterChain(
-    Buffer::Instance& data, bool end_stream) {
-  parent_.decodeData(this, data, end_stream,
-                     ActiveStream::FilterIterationStartState::CanStartFromCurrent);
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::continueDecoding() { commonContinue(); }
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::encode100ContinueHeaders(
-    ResponseHeaderMapPtr&& headers) {
-  // If Envoy is not configured to proxy 100-Continue responses, swallow the 100 Continue
-  // here. This avoids the potential situation where Envoy strips Expect: 100-Continue and sends a
-  // 100-Continue, then proxies a duplicate 100 Continue from upstream.
-  if (parent_.connection_manager_.config_.proxy100Continue()) {
-    parent_.continue_headers_ = std::move(headers);
-    parent_.encode100ContinueHeaders(nullptr, *parent_.continue_headers_);
-  }
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeHeaders(ResponseHeaderMapPtr&& headers,
-                                                                     bool end_stream) {
-  parent_.response_headers_ = std::move(headers);
-  parent_.encodeHeaders(nullptr, *parent_.response_headers_, end_stream);
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeData(Buffer::Instance& data,
-                                                                  bool end_stream) {
-  parent_.encodeData(nullptr, data, end_stream,
-                     ActiveStream::FilterIterationStartState::CanStartFromCurrent);
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeTrailers(
-    ResponseTrailerMapPtr&& trailers) {
-  parent_.response_trailers_ = std::move(trailers);
-  parent_.encodeTrailers(nullptr, *parent_.response_trailers_);
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::encodeMetadata(
-    MetadataMapPtr&& metadata_map_ptr) {
-  parent_.encodeMetadata(nullptr, std::move(metadata_map_ptr));
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::
-    onDecoderFilterAboveWriteBufferHighWatermark() {
-  ENVOY_STREAM_LOG(debug, "Read-disabling downstream stream due to filter callbacks.", parent_);
-  parent_.response_encoder_->getStream().readDisable(true);
-  parent_.connection_manager_.stats_.named_.downstream_flow_control_paused_reading_total_.inc();
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::requestDataTooLarge() {
-  ENVOY_STREAM_LOG(debug, "request data too large watermark exceeded", parent_);
-  if (parent_.state_.decoder_filters_streaming_) {
-    onDecoderFilterAboveWriteBufferHighWatermark();
-  } else {
-    parent_.connection_manager_.stats_.named_.downstream_rq_too_large_.inc();
-    sendLocalReply(Code::PayloadTooLarge, CodeUtility::toString(Code::PayloadTooLarge), nullptr,
-                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().RequestPayloadTooLarge);
-  }
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::requestDataDrained() {
-  // If this is called it means the call to requestDataTooLarge() was a
-  // streaming call, or a 413 would have been sent.
-  onDecoderFilterBelowWriteBufferLowWatermark();
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::
-    onDecoderFilterBelowWriteBufferLowWatermark() {
-  ENVOY_STREAM_LOG(debug, "Read-enabling downstream stream due to filter callbacks.", parent_);
-  // If the state is destroyed, the codec's stream is already torn down. On
-  // teardown the codec will unwind any remaining read disable calls.
-  if (!parent_.state_.destroyed_) {
-    parent_.response_encoder_->getStream().readDisable(false);
-  }
-  parent_.connection_manager_.stats_.named_.downstream_flow_control_resumed_reading_total_.inc();
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::addDownstreamWatermarkCallbacks(
-    DownstreamWatermarkCallbacks& watermark_callbacks) {
-  // This is called exactly once per upstream-stream, by the router filter. Therefore, we
-  // expect the same callbacks to not be registered twice.
-  ASSERT(std::find(parent_.watermark_callbacks_.begin(), parent_.watermark_callbacks_.end(),
-                   &watermark_callbacks) == parent_.watermark_callbacks_.end());
-  parent_.watermark_callbacks_.emplace(parent_.watermark_callbacks_.end(), &watermark_callbacks);
-  for (uint32_t i = 0; i < parent_.high_watermark_count_; ++i) {
-    watermark_callbacks.onAboveWriteBufferHighWatermark();
-  }
-}
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::removeDownstreamWatermarkCallbacks(
-    DownstreamWatermarkCallbacks& watermark_callbacks) {
-  ASSERT(std::find(parent_.watermark_callbacks_.begin(), parent_.watermark_callbacks_.end(),
-                   &watermark_callbacks) != parent_.watermark_callbacks_.end());
-  parent_.watermark_callbacks_.remove(&watermark_callbacks);
-}
-
-bool ConnectionManagerImpl::ActiveStreamDecoderFilter::recreateStream() {
-  // Because the filter's and the HCM view of if the stream has a body and if
-  // the stream is complete may differ, re-check bytesReceived() to make sure
-  // there was no body from the HCM's point of view.
-  if (!complete() || parent_.stream_info_.bytesReceived() != 0) {
-    return false;
-  }
-  // n.b. we do not currently change the codecs to point at the new stream
-  // decoder because the decoder callbacks are complete. It would be good to
-  // null out that pointer but should not be necessary.
-  RequestHeaderMapPtr request_headers(std::move(parent_.request_headers_));
-  ResponseEncoder* response_encoder = parent_.response_encoder_;
-  parent_.response_encoder_ = nullptr;
-  response_encoder->getStream().removeCallbacks(parent_);
-  // This functionally deletes the stream (via deferred delete) so do not
-  // reference anything beyond this point.
-  parent_.connection_manager_.doEndStream(this->parent_);
-
-  RequestDecoder& new_stream = parent_.connection_manager_.newStream(*response_encoder, true);
-  // We don't need to copy over the old parent FilterState from the old StreamInfo if it did not
-  // store any objects with a LifeSpan at or above DownstreamRequest. This is to avoid unnecessary
-  // heap allocation.
-  // TODO(snowp): In the case where connection level filter state has been set on the connection
-  // FilterState that we inherit, we'll end up copying this every time even though we could get
-  // away with just resetting it to the HCM filter_state_.
-  if (parent_.stream_info_.filter_state_->hasDataAtOrAboveLifeSpan(
-          StreamInfo::FilterState::LifeSpan::Request)) {
-    (*parent_.connection_manager_.streams_.begin())->stream_info_.filter_state_ =
-        std::make_shared<StreamInfo::FilterStateImpl>(
-            parent_.stream_info_.filter_state_->parent(),
-            StreamInfo::FilterState::LifeSpan::FilterChain);
-  }
-
-  new_stream.decodeHeaders(std::move(request_headers), true);
-  return true;
-}
-
-void ConnectionManagerImpl::ActiveStreamDecoderFilter::requestRouteConfigUpdate(
-    Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) {
-  parent_.requestRouteConfigUpdate(dispatcher(), std::move(route_config_updated_cb));
-}
-
-absl::optional<Router::ConfigConstSharedPtr>
-ConnectionManagerImpl::ActiveStreamDecoderFilter::routeConfig() {
-  return parent_.routeConfig();
-}
-
-Buffer::WatermarkBufferPtr ConnectionManagerImpl::ActiveStreamEncoderFilter::createBuffer() {
-  auto buffer = new Buffer::WatermarkBuffer(
-      [this]() -> void { this->responseDataDrained(); },
-      [this]() -> void { this->responseDataTooLarge(); },
-      []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });
-  buffer->setWatermarks(parent_.buffer_limit_);
-  return Buffer::WatermarkBufferPtr{buffer};
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::handleMetadataAfterHeadersCallback() {
-  // If we drain accumulated metadata, the iteration must start with the current filter.
-  const bool saved_state = iterate_from_current_filter_;
-  iterate_from_current_filter_ = true;
-  // If encodeHeaders() returns StopAllIteration, we should skip draining metadata, and wait
-  // for doMetadata() to drain the metadata after iteration continues.
-  if (!stoppedAll() && saved_response_metadata_ != nullptr &&
-      !getSavedResponseMetadata()->empty()) {
-    drainSavedResponseMetadata();
-  }
-  // Restores the original value of iterate_from_current_filter_.
-  iterate_from_current_filter_ = saved_state;
-}
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::addEncodedData(Buffer::Instance& data,
-                                                                      bool streaming) {
-  return parent_.addEncodedData(*this, data, streaming);
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::injectEncodedDataToFilterChain(
-    Buffer::Instance& data, bool end_stream) {
-  parent_.encodeData(this, data, end_stream,
-                     ActiveStream::FilterIterationStartState::CanStartFromCurrent);
-}
-
-ResponseTrailerMap& ConnectionManagerImpl::ActiveStreamEncoderFilter::addEncodedTrailers() {
-  return parent_.addEncodedTrailers();
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::addEncodedMetadata(
-    MetadataMapPtr&& metadata_map_ptr) {
-  return parent_.encodeMetadata(this, std::move(metadata_map_ptr));
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::
-    onEncoderFilterAboveWriteBufferHighWatermark() {
-  ENVOY_STREAM_LOG(debug, "Disabling upstream stream due to filter callbacks.", parent_);
-  parent_.callHighWatermarkCallbacks();
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::
-    onEncoderFilterBelowWriteBufferLowWatermark() {
-  ENVOY_STREAM_LOG(debug, "Enabling upstream stream due to filter callbacks.", parent_);
-  parent_.callLowWatermarkCallbacks();
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::continueEncoding() { commonContinue(); }
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::responseDataTooLarge() {
-  if (parent_.state_.encoder_filters_streaming_) {
-    onEncoderFilterAboveWriteBufferHighWatermark();
-  } else {
-    parent_.connection_manager_.stats_.named_.rs_too_large_.inc();
-
-    // If headers have not been sent to the user, send a 500.
-    if (!headers_continued_) {
-      // Make sure we won't end up with nested watermark calls from the body buffer.
-      parent_.state_.encoder_filters_streaming_ = true;
-      allowIteration();
-      parent_.stream_info_.setResponseCodeDetails(
-          StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
-      // This does not call the standard sendLocalReply because if there is already response data
-      // we do not want to pass a second set of response headers through the filter chain.
-      // Instead, call the encodeHeadersInternal / encodeDataInternal helpers
-      // directly, which maximizes shared code with the normal response path.
-      Http::Utility::sendLocalReply(
-          parent_.state_.destroyed_,
-          Utility::EncodeFunctions{
-              [&](ResponseHeaderMap& response_headers, Code& code, std::string& body,
-                  absl::string_view& content_type) -> void {
-                parent_.connection_manager_.config_.localReply().rewrite(
-                    parent_.request_headers_.get(), response_headers, parent_.stream_info_, code,
-                    body, content_type);
-              },
-              [&](ResponseHeaderMapPtr&& response_headers, bool end_stream) -> void {
-                parent_.response_headers_ = std::move(response_headers);
-                parent_.encodeHeadersInternal(*parent_.response_headers_, end_stream);
-              },
-              [&](Buffer::Instance& data, bool end_stream) -> void {
-                parent_.encodeDataInternal(data, end_stream);
-              }},
-          Utility::LocalReplyData{Grpc::Common::hasGrpcContentType(*parent_.request_headers_),
-                                  Http::Code::InternalServerError,
-                                  CodeUtility::toString(Http::Code::InternalServerError),
-                                  absl::nullopt, parent_.state_.is_head_request_});
-      parent_.maybeEndEncode(parent_.state_.local_complete_);
-    } else {
-      ENVOY_STREAM_LOG(
-          debug, "Resetting stream. Response data too large and headers have already been sent",
-          *this);
-      resetStream();
-    }
-  }
-}
-
-void ConnectionManagerImpl::ActiveStreamEncoderFilter::responseDataDrained() {
-  onEncoderFilterBelowWriteBufferLowWatermark();
-}
-
-void ConnectionManagerImpl::ActiveStreamFilterBase::resetStream() {
-  parent_.connection_manager_.stats_.named_.downstream_rq_tx_reset_.inc();
-  parent_.connection_manager_.doEndStream(this->parent_);
-}
-
-uint64_t ConnectionManagerImpl::ActiveStreamFilterBase::streamId() const {
-  return parent_.stream_id_;
-}
-
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -237,6 +237,16 @@ private:
 
     absl::optional<Router::ConfigConstSharedPtr> routeConfig() override;
 
+    void onResponseDataTooLarge() override {
+      connection_manager_.stats_.named_.rs_too_large_.inc();
+    }
+    void onStreamReset() override {
+      connection_manager_.stats_.named_.downstream_rq_tx_reset_.inc();
+    }
+    void onDownstreamRequestTooLarge() override {
+      connection_manager_.stats_.named_.downstream_rq_too_large_.inc();
+    }
+
     void chargeStats(const ResponseHeaderMap& headers);
 
     // Http::StreamCallbacks

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -305,6 +305,7 @@ private:
     Router::ConfigConstSharedPtr snapped_route_config_;
     Router::ScopedConfigConstSharedPtr snapped_scoped_routes_config_;
     const uint64_t stream_id_;
+    std::unique_ptr<Tracing::CustomTagMap> tracing_custom_tags_{nullptr};
     FilterManager filter_manager_;
     Stats::TimespanPtr request_response_timespan_;
     // Per-stream idle timeout.
@@ -317,7 +318,6 @@ private:
     absl::optional<Upstream::ClusterInfoConstSharedPtr> cached_cluster_info_;
     ResponseEncoder* response_encoder_;
     std::unique_ptr<RouteConfigUpdateRequester> route_config_update_requester_;
-    std::unique_ptr<Tracing::CustomTagMap> tracing_custom_tags_{nullptr};
   };
 
   using ActiveStreamPtr = std::unique_ptr<ActiveStream>;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -222,12 +222,11 @@ private:
       // away with just resetting it to the HCM filter_state_.
       if (filter_manager_.streamInfo().filterState()->hasDataAtOrAboveLifeSpan(
               StreamInfo::FilterState::LifeSpan::Request)) {
-        // TODO something needs to be done here so we can reset the FilterState
-        // (*connection_manager_.streams_.begin())->filter_manager_.streamInfo().stream_info_.filter_state_
-        // =
-        //     std::make_shared<StreamInfo::FilterStateImpl>(
-        //         parent_.stream_info_.filter_state_->parent(),
-        //         StreamInfo::FilterState::LifeSpan::FilterChain);
+        // TODO(snowp): Remove direct access to stream info?
+        (*connection_manager_.streams_.begin())->filter_manager_.stream_info_.filter_state_ =
+            std::make_shared<StreamInfo::FilterStateImpl>(
+                filter_manager_.stream_info_.filter_state_->parent(),
+                StreamInfo::FilterState::LifeSpan::FilterChain);
       }
 
       new_stream.decodeHeaders(std::move(request_headers), true);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -222,7 +222,7 @@ private:
       // away with just resetting it to the HCM filter_state_.
       if (filter_manager_.streamInfo().filterState()->hasDataAtOrAboveLifeSpan(
               StreamInfo::FilterState::LifeSpan::Request)) {
-        // TODO something needs to be done here so we can reset the FS
+        // TODO something needs to be done here so we can reset the FilterState
         // (*connection_manager_.streams_.begin())->filter_manager_.streamInfo().stream_info_.filter_state_
         // =
         //     std::make_shared<StreamInfo::FilterStateImpl>(

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -17,10 +17,12 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/context.h"
 #include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/router/rds.h"
+#include "envoy/router/router.h"
 #include "envoy/router/scopes.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/overload_manager.h"
@@ -35,6 +37,7 @@
 #include "common/common/linked_object.h"
 #include "common/grpc/common.h"
 #include "common/http/conn_manager_config.h"
+#include "common/http/filter_manager.h"
 #include "common/http/user_agent.h"
 #include "common/http/utility.h"
 #include "common/stream_info/stream_info_impl.h"
@@ -106,311 +109,6 @@ public:
 private:
   struct ActiveStream;
 
-  /**
-   * Base class wrapper for both stream encoder and decoder filters.
-   */
-  struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks {
-    ActiveStreamFilterBase(ActiveStream& parent, bool dual_filter)
-        : parent_(parent), iteration_state_(IterationState::Continue),
-          iterate_from_current_filter_(false), headers_continued_(false),
-          continue_headers_continued_(false), end_stream_(false), dual_filter_(dual_filter),
-          decode_headers_called_(false), encode_headers_called_(false) {}
-
-    // Functions in the following block are called after the filter finishes processing
-    // corresponding data. Those functions handle state updates and data storage (if needed)
-    // according to the status returned by filter's callback functions.
-    bool commonHandleAfter100ContinueHeadersCallback(FilterHeadersStatus status);
-    bool commonHandleAfterHeadersCallback(FilterHeadersStatus status, bool& headers_only);
-    bool commonHandleAfterDataCallback(FilterDataStatus status, Buffer::Instance& provided_data,
-                                       bool& buffer_was_streaming);
-    bool commonHandleAfterTrailersCallback(FilterTrailersStatus status);
-
-    // Buffers provided_data.
-    void commonHandleBufferData(Buffer::Instance& provided_data);
-
-    // If iteration has stopped for all frame types, calls this function to buffer the data before
-    // the filter processes data. The function also updates streaming state.
-    void commonBufferDataIfStopAll(Buffer::Instance& provided_data, bool& buffer_was_streaming);
-
-    void commonContinue();
-    virtual bool canContinue() PURE;
-    virtual Buffer::WatermarkBufferPtr createBuffer() PURE;
-    virtual Buffer::WatermarkBufferPtr& bufferedData() PURE;
-    virtual bool complete() PURE;
-    virtual bool has100Continueheaders() PURE;
-    virtual void do100ContinueHeaders() PURE;
-    virtual void doHeaders(bool end_stream) PURE;
-    virtual void doData(bool end_stream) PURE;
-    virtual void doTrailers() PURE;
-    virtual bool hasTrailers() PURE;
-    virtual void doMetadata() PURE;
-    // TODO(soya3129): make this pure when adding impl to encoder filter.
-    virtual void handleMetadataAfterHeadersCallback() PURE;
-
-    // Http::StreamFilterCallbacks
-    const Network::Connection* connection() override;
-    Event::Dispatcher& dispatcher() override;
-    void resetStream() override;
-    Router::RouteConstSharedPtr route() override;
-    Router::RouteConstSharedPtr route(const Router::RouteCallback& cb) override;
-    Upstream::ClusterInfoConstSharedPtr clusterInfo() override;
-    void clearRouteCache() override;
-    uint64_t streamId() const override;
-    StreamInfo::StreamInfo& streamInfo() override;
-    Tracing::Span& activeSpan() override;
-    Tracing::Config& tracingConfig() override;
-    const ScopeTrackedObject& scope() override { return parent_; }
-
-    // Functions to set or get iteration state.
-    bool canIterate() { return iteration_state_ == IterationState::Continue; }
-    bool stoppedAll() {
-      return iteration_state_ == IterationState::StopAllBuffer ||
-             iteration_state_ == IterationState::StopAllWatermark;
-    }
-    void allowIteration() {
-      ASSERT(iteration_state_ != IterationState::Continue);
-      iteration_state_ = IterationState::Continue;
-    }
-    MetadataMapVector* getSavedRequestMetadata() {
-      if (saved_request_metadata_ == nullptr) {
-        saved_request_metadata_ = std::make_unique<MetadataMapVector>();
-      }
-      return saved_request_metadata_.get();
-    }
-    MetadataMapVector* getSavedResponseMetadata() {
-      if (saved_response_metadata_ == nullptr) {
-        saved_response_metadata_ = std::make_unique<MetadataMapVector>();
-      }
-      return saved_response_metadata_.get();
-    }
-
-    // A vector to save metadata when the current filter's [de|en]codeMetadata() can not be called,
-    // either because [de|en]codeHeaders() of the current filter returns StopAllIteration or because
-    // [de|en]codeHeaders() adds new metadata to [de|en]code, but we don't know
-    // [de|en]codeHeaders()'s return value yet. The storage is created on demand.
-    std::unique_ptr<MetadataMapVector> saved_request_metadata_{nullptr};
-    std::unique_ptr<MetadataMapVector> saved_response_metadata_{nullptr};
-    // The state of iteration.
-    enum class IterationState {
-      Continue,            // Iteration has not stopped for any frame type.
-      StopSingleIteration, // Iteration has stopped for headers, 100-continue, or data.
-      StopAllBuffer,       // Iteration has stopped for all frame types, and following data should
-                           // be buffered.
-      StopAllWatermark,    // Iteration has stopped for all frame types, and following data should
-                           // be buffered until high watermark is reached.
-    };
-    ActiveStream& parent_;
-    IterationState iteration_state_;
-    // If the filter resumes iteration from a StopAllBuffer/Watermark state, the current filter
-    // hasn't parsed data and trailers. As a result, the filter iteration should start with the
-    // current filter instead of the next one. If true, filter iteration starts with the current
-    // filter. Otherwise, starts with the next filter in the chain.
-    bool iterate_from_current_filter_ : 1;
-    bool headers_continued_ : 1;
-    bool continue_headers_continued_ : 1;
-    // If true, end_stream is called for this filter.
-    bool end_stream_ : 1;
-    const bool dual_filter_ : 1;
-    bool decode_headers_called_ : 1;
-    bool encode_headers_called_ : 1;
-  };
-
-  /**
-   * Wrapper for a stream decoder filter.
-   */
-  struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
-                                     public StreamDecoderFilterCallbacks,
-                                     LinkedObject<ActiveStreamDecoderFilter> {
-    ActiveStreamDecoderFilter(ActiveStream& parent, StreamDecoderFilterSharedPtr filter,
-                              bool dual_filter)
-        : ActiveStreamFilterBase(parent, dual_filter), handle_(filter) {}
-
-    // ActiveStreamFilterBase
-    bool canContinue() override {
-      // It is possible for the connection manager to respond directly to a request even while
-      // a filter is trying to continue. If a response has already happened, we should not
-      // continue to further filters. A concrete example of this is a filter buffering data, the
-      // last data frame comes in and the filter continues, but the final buffering takes the stream
-      // over the high watermark such that a 413 is returned.
-      return !parent_.state_.local_complete_;
-    }
-    Buffer::WatermarkBufferPtr createBuffer() override;
-    Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_request_data_; }
-    bool complete() override { return parent_.state_.remote_complete_; }
-    bool has100Continueheaders() override { return false; }
-    void do100ContinueHeaders() override { NOT_REACHED_GCOVR_EXCL_LINE; }
-    void doHeaders(bool end_stream) override {
-      parent_.decodeHeaders(this, *parent_.request_headers_, end_stream);
-    }
-    void doData(bool end_stream) override {
-      parent_.decodeData(this, *parent_.buffered_request_data_, end_stream,
-                         ActiveStream::FilterIterationStartState::CanStartFromCurrent);
-    }
-    void doMetadata() override {
-      if (saved_request_metadata_ != nullptr) {
-        drainSavedRequestMetadata();
-      }
-    }
-    void doTrailers() override { parent_.decodeTrailers(this, *parent_.request_trailers_); }
-    bool hasTrailers() override { return parent_.request_trailers_ != nullptr; }
-
-    void drainSavedRequestMetadata() {
-      ASSERT(saved_request_metadata_ != nullptr);
-      for (auto& metadata_map : *getSavedRequestMetadata()) {
-        parent_.decodeMetadata(this, *metadata_map);
-      }
-      getSavedRequestMetadata()->clear();
-    }
-    // This function is called after the filter calls decodeHeaders() to drain accumulated metadata.
-    void handleMetadataAfterHeadersCallback() override;
-
-    // Http::StreamDecoderFilterCallbacks
-    void addDecodedData(Buffer::Instance& data, bool streaming) override;
-    void injectDecodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
-    RequestTrailerMap& addDecodedTrailers() override;
-    MetadataMapVector& addDecodedMetadata() override;
-    void continueDecoding() override;
-    const Buffer::Instance* decodingBuffer() override {
-      return parent_.buffered_request_data_.get();
-    }
-
-    void modifyDecodingBuffer(std::function<void(Buffer::Instance&)> callback) override {
-      ASSERT(parent_.state_.latest_data_decoding_filter_ == this);
-      callback(*parent_.buffered_request_data_.get());
-    }
-
-    void sendLocalReply(Code code, absl::string_view body,
-                        std::function<void(ResponseHeaderMap& headers)> modify_headers,
-                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
-                        absl::string_view details) override {
-      parent_.stream_info_.setResponseCodeDetails(details);
-      parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers,
-                             parent_.state_.is_head_request_, grpc_status, details);
-    }
-    void encode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override;
-    void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
-    void encodeData(Buffer::Instance& data, bool end_stream) override;
-    void encodeTrailers(ResponseTrailerMapPtr&& trailers) override;
-    void encodeMetadata(MetadataMapPtr&& metadata_map_ptr) override;
-    void onDecoderFilterAboveWriteBufferHighWatermark() override;
-    void onDecoderFilterBelowWriteBufferLowWatermark() override;
-    void
-    addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
-    void
-    removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
-    void setDecoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
-    uint32_t decoderBufferLimit() override { return parent_.buffer_limit_; }
-    bool recreateStream() override;
-
-    void addUpstreamSocketOptions(const Network::Socket::OptionsSharedPtr& options) override {
-      Network::Socket::appendOptions(parent_.upstream_options_, options);
-    }
-
-    Network::Socket::OptionsSharedPtr getUpstreamSocketOptions() const override {
-      return parent_.upstream_options_;
-    }
-
-    // Each decoder filter instance checks if the request passed to the filter is gRPC
-    // so that we can issue gRPC local responses to gRPC requests. Filter's decodeHeaders()
-    // called here may change the content type, so we must check it before the call.
-    FilterHeadersStatus decodeHeaders(RequestHeaderMap& headers, bool end_stream) {
-      is_grpc_request_ = Grpc::Common::isGrpcRequestHeaders(headers);
-      FilterHeadersStatus status = handle_->decodeHeaders(headers, end_stream);
-      if (end_stream) {
-        handle_->decodeComplete();
-      }
-      return status;
-    }
-
-    void requestDataTooLarge();
-    void requestDataDrained();
-
-    void requestRouteConfigUpdate(
-        Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) override;
-    absl::optional<Router::ConfigConstSharedPtr> routeConfig() override;
-
-    StreamDecoderFilterSharedPtr handle_;
-    bool is_grpc_request_{};
-  };
-
-  using ActiveStreamDecoderFilterPtr = std::unique_ptr<ActiveStreamDecoderFilter>;
-
-  /**
-   * Wrapper for a stream encoder filter.
-   */
-  struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
-                                     public StreamEncoderFilterCallbacks,
-                                     LinkedObject<ActiveStreamEncoderFilter> {
-    ActiveStreamEncoderFilter(ActiveStream& parent, StreamEncoderFilterSharedPtr filter,
-                              bool dual_filter)
-        : ActiveStreamFilterBase(parent, dual_filter), handle_(filter) {}
-
-    // ActiveStreamFilterBase
-    bool canContinue() override { return true; }
-    Buffer::WatermarkBufferPtr createBuffer() override;
-    Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_response_data_; }
-    bool complete() override { return parent_.state_.local_complete_; }
-    bool has100Continueheaders() override {
-      return parent_.state_.has_continue_headers_ && !continue_headers_continued_;
-    }
-    void do100ContinueHeaders() override {
-      parent_.encode100ContinueHeaders(this, *parent_.continue_headers_);
-    }
-    void doHeaders(bool end_stream) override {
-      parent_.encodeHeaders(this, *parent_.response_headers_, end_stream);
-    }
-    void doData(bool end_stream) override {
-      parent_.encodeData(this, *parent_.buffered_response_data_, end_stream,
-                         ActiveStream::FilterIterationStartState::CanStartFromCurrent);
-    }
-    void drainSavedResponseMetadata() {
-      ASSERT(saved_response_metadata_ != nullptr);
-      for (auto& metadata_map : *getSavedResponseMetadata()) {
-        parent_.encodeMetadata(this, std::move(metadata_map));
-      }
-      getSavedResponseMetadata()->clear();
-    }
-    void handleMetadataAfterHeadersCallback() override;
-
-    void doMetadata() override {
-      if (saved_response_metadata_ != nullptr) {
-        drainSavedResponseMetadata();
-      }
-    }
-    void doTrailers() override { parent_.encodeTrailers(this, *parent_.response_trailers_); }
-    bool hasTrailers() override { return parent_.response_trailers_ != nullptr; }
-
-    // Http::StreamEncoderFilterCallbacks
-    void addEncodedData(Buffer::Instance& data, bool streaming) override;
-    void injectEncodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
-    ResponseTrailerMap& addEncodedTrailers() override;
-    void addEncodedMetadata(MetadataMapPtr&& metadata_map) override;
-    void onEncoderFilterAboveWriteBufferHighWatermark() override;
-    void onEncoderFilterBelowWriteBufferLowWatermark() override;
-    void setEncoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
-    uint32_t encoderBufferLimit() override { return parent_.buffer_limit_; }
-    void continueEncoding() override;
-    const Buffer::Instance* encodingBuffer() override {
-      return parent_.buffered_response_data_.get();
-    }
-    void modifyEncodingBuffer(std::function<void(Buffer::Instance&)> callback) override {
-      ASSERT(parent_.state_.latest_data_encoding_filter_ == this);
-      callback(*parent_.buffered_response_data_.get());
-    }
-    Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
-      // TODO(mattklein123): At some point we might want to actually wrap this interface but for now
-      // we give the filter direct access to the encoder options.
-      return parent_.response_encoder_->http1StreamEncoderOptions();
-    }
-
-    void responseDataTooLarge();
-    void responseDataDrained();
-
-    StreamEncoderFilterSharedPtr handle_;
-  };
-
-  using ActiveStreamEncoderFilterPtr = std::unique_ptr<ActiveStreamEncoderFilter>;
-
   // Used to abstract making of RouteConfig update request.
   // RdsRouteConfigUpdateRequester is used when an RdsRouteConfigProvider is configured,
   // NullRouteConfigUpdateRequester is used in all other cases (specifically when
@@ -449,85 +147,84 @@ private:
                         public Event::DeferredDeletable,
                         public StreamCallbacks,
                         public RequestDecoder,
-                        public FilterChainFactoryCallbacks,
-                        public Tracing::Config,
-                        public ScopeTrackedObject {
+                        public FilterManagerCallbacks,
+                        public Tracing::Config {
     ActiveStream(ConnectionManagerImpl& connection_manager);
     ~ActiveStream() override;
 
-    // Indicates which filter to start the iteration with.
-    enum class FilterIterationStartState { AlwaysStartFromNext, CanStartFromCurrent };
+    // FilterManagerCallbacks
+    void onSpanFinalized(Tracing::Span& span, Http::RequestHeaderMap* request_headers,
+                         Http::ResponseHeaderMap* response_headers,
+                         Http::ResponseTrailerMap* response_trailers) override {
+      Tracing::HttpTracerUtility::finalizeDownstreamSpan(span, request_headers, response_headers,
+                                                         response_trailers,
+                                                         filter_manager_.streamInfo(), *this);
+    }
+    const Network::Connection* connection() const override;
+    uint64_t streamId() const override { return stream_id_; }
+    void refreshIdleTimeout() override { resetIdleTimer(); }
+    void finalizeHeaders(ResponseHeaderMap& response_headers, bool end_stream) override;
+    absl::optional<Router::RouteConstSharedPtr> cachedRoute() override { return cached_route_; }
+    void upgradeFilterChainCreated() override {
+      connection_manager_.stats_.named_.downstream_cx_upgrades_total_.inc();
+      connection_manager_.stats_.named_.downstream_cx_upgrades_active_.inc();
+    }
+    void endStream() override {
+      request_response_timespan_->complete();
+      connection_manager_.doEndStream(*this);
+    }
+    void finalize100ContinueHeaders(ResponseHeaderMap& headers) override;
+    Tracing::Config& tracingConfig() override { return *this; }
 
-    void addStreamDecoderFilterWorker(StreamDecoderFilterSharedPtr filter, bool dual_filter);
-    void addStreamEncoderFilterWorker(StreamEncoderFilterSharedPtr filter, bool dual_filter);
+    virtual absl::optional<Upstream::ClusterInfoConstSharedPtr> cachedClusterInfo() override {
+      return cached_cluster_info_;
+    }
+    void clearRouteCache() override {
+      cached_route_ = absl::optional<Router::RouteConstSharedPtr>();
+      cached_cluster_info_ = absl::optional<Upstream::ClusterInfoConstSharedPtr>();
+      if (tracing_custom_tags_) {
+        tracing_custom_tags_->clear();
+      }
+    }
+    void refreshCachedRoute() override;
+    void refreshCachedRoute(const Router::RouteCallback& cb) override;
+    void recreateStream(RequestHeaderMapPtr request_headers) override {
+      // n.b. we do not currently change the codecs to point at the new stream
+      // decoder because the decoder callbacks are complete. It would be good to
+      // null out that pointer but should not be necessary.
+      ResponseEncoder* response_encoder = response_encoder_;
+      response_encoder_ = nullptr;
+      response_encoder->getStream().removeCallbacks(*this);
+      // This functionally deletes the stream (via deferred delete) so do not
+      // reference anything beyond this point.
+      connection_manager_.doEndStream(*this);
+
+      RequestDecoder& new_stream = connection_manager_.newStream(*response_encoder, true);
+      // We don't need to copy over the old parent FilterState from the old StreamInfo if it did not
+      // store any objects with a LifeSpan at or above DownstreamRequest. This is to avoid
+      // unnecessary heap allocation.
+      // TODO(snowp): In the case where connection level filter state has been set on the connection
+      // FilterState that we inherit, we'll end up copying this every time even though we could get
+      // away with just resetting it to the HCM filter_state_.
+      if (filter_manager_.streamInfo().filterState()->hasDataAtOrAboveLifeSpan(
+              StreamInfo::FilterState::LifeSpan::Request)) {
+        // TODO something needs to be done here so we can reset the FS
+        // (*connection_manager_.streams_.begin())->filter_manager_.streamInfo().stream_info_.filter_state_
+        // =
+        //     std::make_shared<StreamInfo::FilterStateImpl>(
+        //         parent_.stream_info_.filter_state_->parent(),
+        //         StreamInfo::FilterState::LifeSpan::FilterChain);
+      }
+
+      new_stream.decodeHeaders(std::move(request_headers), true);
+    }
+    void requestRouteConfigUpdate(
+        Event::Dispatcher& thread_local_dispatcher,
+        Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) override;
+
+    absl::optional<Router::ConfigConstSharedPtr> routeConfig() override;
+
     void chargeStats(const ResponseHeaderMap& headers);
-    // Returns the encoder filter to start iteration with.
-    std::list<ActiveStreamEncoderFilterPtr>::iterator
-    commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_stream,
-                       FilterIterationStartState filter_iteration_start_state);
-    // Returns the decoder filter to start iteration with.
-    std::list<ActiveStreamDecoderFilterPtr>::iterator
-    commonDecodePrefix(ActiveStreamDecoderFilter* filter,
-                       FilterIterationStartState filter_iteration_start_state);
-    const Network::Connection* connection();
-    void addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::Instance& data, bool streaming);
-    RequestTrailerMap& addDecodedTrailers();
-    MetadataMapVector& addDecodedMetadata();
-    // Helper function for the case where we have a header only request, but a filter adds a body
-    // to it.
-    void maybeContinueDecoding(
-        const std::list<ActiveStreamDecoderFilterPtr>::iterator& maybe_continue_data_entry);
-    void decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHeaderMap& headers,
-                       bool end_stream);
-    // Sends data through decoding filter chains. filter_iteration_start_state indicates which
-    // filter to start the iteration with.
-    void decodeData(ActiveStreamDecoderFilter* filter, Buffer::Instance& data, bool end_stream,
-                    FilterIterationStartState filter_iteration_start_state);
-    void decodeTrailers(ActiveStreamDecoderFilter* filter, RequestTrailerMap& trailers);
-    void decodeMetadata(ActiveStreamDecoderFilter* filter, MetadataMap& metadata_map);
-    void disarmRequestTimeout();
-    void maybeEndDecode(bool end_stream);
-    void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
-    ResponseTrailerMap& addEncodedTrailers();
-    void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
-                        const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                        bool is_head_request,
-                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
-                        absl::string_view details) override;
-    void encode100ContinueHeaders(ActiveStreamEncoderFilter* filter, ResponseHeaderMap& headers);
-    // As with most of the encode functions, this runs encodeHeaders on various
-    // filters before calling encodeHeadersInternal which does final header munging and passes the
-    // headers to the encoder.
-    void maybeContinueEncoding(
-        const std::list<ActiveStreamEncoderFilterPtr>::iterator& maybe_continue_data_entry);
-    void encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHeaderMap& headers,
-                       bool end_stream);
-    // Sends data through encoding filter chains. filter_iteration_start_state indicates which
-    // filter to start the iteration with, and finally calls encodeDataInternal
-    // to update stats, do end stream bookkeeping, and send the data to encoder.
-    void encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instance& data, bool end_stream,
-                    FilterIterationStartState filter_iteration_start_state);
-    void encodeTrailers(ActiveStreamEncoderFilter* filter, ResponseTrailerMap& trailers);
-    void encodeMetadata(ActiveStreamEncoderFilter* filter, MetadataMapPtr&& metadata_map_ptr);
-
-    // This is a helper function for encodeHeaders and responseDataTooLarge which allows for shared
-    // code for the two headers encoding paths. It does header munging, updates timing stats, and
-    // sends the headers to the encoder.
-    void encodeHeadersInternal(ResponseHeaderMap& headers, bool end_stream);
-    // This is a helper function for encodeData and responseDataTooLarge which allows for shared
-    // code for the two data encoding paths. It does stats updates and tracks potential end of
-    // stream.
-    void encodeDataInternal(Buffer::Instance& data, bool end_stream);
-
-    void maybeEndEncode(bool end_stream);
-    // Returns true if new metadata is decoded. Otherwise, returns false.
-    bool processNewlyAddedMetadata();
-    uint64_t streamId() { return stream_id_; }
-    // Returns true if filter has stopped iteration for all frame types. Otherwise, returns false.
-    // filter_streaming is the variable to indicate if stream is streaming, and its value may be
-    // changed by the function.
-    bool handleDataIfStopAll(ActiveStreamFilterBase& filter, Buffer::Instance& data,
-                             bool& filter_streaming);
 
     // Http::StreamCallbacks
     void onResetStream(StreamResetReason reason,
@@ -542,19 +239,14 @@ private:
     // Http::RequestDecoder
     void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override;
     void decodeTrailers(RequestTrailerMapPtr&& trailers) override;
-
-    // Http::FilterChainFactoryCallbacks
-    void addStreamDecoderFilter(StreamDecoderFilterSharedPtr filter) override {
-      addStreamDecoderFilterWorker(filter, false);
+    void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
+                        const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
+                        bool is_head_request,
+                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                        absl::string_view details) override {
+      filter_manager_.sendLocalReply(is_grpc_request, code, body, modify_headers, is_head_request,
+                                     grpc_status, details);
     }
-    void addStreamEncoderFilter(StreamEncoderFilterSharedPtr filter) override {
-      addStreamEncoderFilterWorker(filter, false);
-    }
-    void addStreamFilter(StreamFilterSharedPtr filter) override {
-      addStreamDecoderFilterWorker(filter, true);
-      addStreamEncoderFilterWorker(filter, true);
-    }
-    void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) override;
 
     // Tracing::TracingConfig
     Tracing::OperationName operationName() const override;
@@ -562,113 +254,28 @@ private:
     bool verbose() const override;
     uint32_t maxPathTagLength() const override;
 
-    // ScopeTrackedObject
-    void dumpState(std::ostream& os, int indent_level = 0) const override {
-      const char* spaces = spacesForLevel(indent_level);
-      os << spaces << "ActiveStream " << this << DUMP_MEMBER(stream_id_)
-         << DUMP_MEMBER(state_.has_continue_headers_) << DUMP_MEMBER(state_.is_head_request_)
-         << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_)
-         << "\n";
-
-      DUMP_DETAILS(request_headers_);
-      DUMP_DETAILS(request_trailers_);
-      DUMP_DETAILS(response_headers_);
-      DUMP_DETAILS(response_trailers_);
-      DUMP_DETAILS(&stream_info_);
-    }
-
     void traceRequest();
 
     // Updates the snapped_route_config_ (by reselecting scoped route configuration), if a scope is
     // not found, snapped_route_config_ is set to Router::NullConfigImpl.
     void snapScopedRouteConfig();
 
-    void refreshCachedRoute();
-    void refreshCachedRoute(const Router::RouteCallback& cb);
-    void
-    requestRouteConfigUpdate(Event::Dispatcher& thread_local_dispatcher,
-                             Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb);
-    absl::optional<Router::ConfigConstSharedPtr> routeConfig();
-
     void refreshCachedTracingCustomTags();
-
-    // Pass on watermark callbacks to watermark subscribers. This boils down to passing watermark
-    // events for this stream and the downstream connection to the router filter.
-    void callHighWatermarkCallbacks();
-    void callLowWatermarkCallbacks();
-
-    /**
-     * Flags that keep track of which filter calls are currently in progress.
-     */
-    // clang-format off
-    struct FilterCallState {
-      static constexpr uint32_t DecodeHeaders   = 0x01;
-      static constexpr uint32_t DecodeData      = 0x02;
-      static constexpr uint32_t DecodeTrailers  = 0x04;
-      static constexpr uint32_t EncodeHeaders   = 0x08;
-      static constexpr uint32_t EncodeData      = 0x10;
-      static constexpr uint32_t EncodeTrailers  = 0x20;
-      // Encode100ContinueHeaders is a bit of a special state as 100 continue
-      // headers may be sent during request processing. This state is only used
-      // to verify we do not encode100Continue headers more than once per
-      // filter.
-      static constexpr uint32_t Encode100ContinueHeaders  = 0x40;
-      // Used to indicate that we're processing the final [En|De]codeData frame,
-      // i.e. end_stream = true
-      static constexpr uint32_t LastDataFrame = 0x80;
-    };
-    // clang-format on
 
     // All state for the stream. Put here for readability.
     struct State {
-      State()
-          : remote_complete_(false), local_complete_(false), codec_saw_local_complete_(false),
-            saw_connection_close_(false), successful_upgrade_(false), created_filter_chain_(false),
-            is_internally_created_(false), decorated_propagate_(true), has_continue_headers_(false),
-            is_head_request_(false) {}
+      State() : saw_connection_close_(false) {}
 
-      uint32_t filter_call_state_{0};
       // The following 3 members are booleans rather than part of the space-saving bitfield as they
       // are passed as arguments to functions expecting bools. Extend State using the bitfield
       // where possible.
-      bool encoder_filters_streaming_{true};
-      bool decoder_filters_streaming_{true};
-      bool destroyed_{false};
-      bool remote_complete_ : 1;
-      bool local_complete_ : 1; // This indicates that local is complete prior to filter processing.
-                                // A filter can still stop the stream from being complete as seen
-                                // by the codec.
-      bool codec_saw_local_complete_ : 1; // This indicates that local is complete as written all
-                                          // the way through to the codec.
       bool saw_connection_close_ : 1;
-      bool successful_upgrade_ : 1;
-      bool created_filter_chain_ : 1;
 
       // True if this stream is internally created. Currently only used for
       // internal redirects or other streams created via recreateStream().
       bool is_internally_created_ : 1;
-
-      bool decorated_propagate_ : 1;
-      // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
-      // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
-      bool has_continue_headers_ : 1;
-      bool is_head_request_ : 1;
-      // Whether a filter has indicated that the request should be treated as a headers only
-      // request.
-      bool decoding_headers_only_{false};
-      // Whether a filter has indicated that the response should be treated as a headers only
-      // response.
-      bool encoding_headers_only_{false};
-
-      // Used to track which filter is the latest filter that has received data.
-      ActiveStreamEncoderFilter* latest_data_encoding_filter_{};
-      ActiveStreamDecoderFilter* latest_data_decoding_filter_{};
     };
 
-    // Possibly increases buffer_limit_ to the value of limit.
-    void setBufferLimit(uint32_t limit);
-    // Set up the Encoder/Decoder filter chain.
-    bool createFilterChain();
     // Per-stream idle timeout callback.
     void onIdleTimeout();
     // Reset per-stream idle timer.
@@ -683,15 +290,8 @@ private:
     uint32_t localPort();
 
     friend std::ostream& operator<<(std::ostream& os, const ActiveStream& s) {
-      s.dumpState(os);
+      s.filter_manager_.dumpState(os);
       return os;
-    }
-
-    MetadataMapVector* getRequestMetadataMapVector() {
-      if (request_metadata_map_vector_ == nullptr) {
-        request_metadata_map_vector_ = std::make_unique<MetadataMapVector>();
-      }
-      return request_metadata_map_vector_.get();
     }
 
     Tracing::CustomTagMap& getOrMakeTracingCustomTagMap() {
@@ -704,40 +304,18 @@ private:
     ConnectionManagerImpl& connection_manager_;
     Router::ConfigConstSharedPtr snapped_route_config_;
     Router::ScopedConfigConstSharedPtr snapped_scoped_routes_config_;
-    Tracing::SpanPtr active_span_;
     const uint64_t stream_id_;
-    ResponseEncoder* response_encoder_{};
-    ResponseHeaderMapPtr continue_headers_;
-    ResponseHeaderMapPtr response_headers_;
-    Buffer::WatermarkBufferPtr buffered_response_data_;
-    ResponseTrailerMapPtr response_trailers_{};
-    RequestHeaderMapPtr request_headers_;
-    Buffer::WatermarkBufferPtr buffered_request_data_;
-    RequestTrailerMapPtr request_trailers_;
-    std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
-    std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
-    std::list<AccessLog::InstanceSharedPtr> access_log_handlers_;
+    FilterManager filter_manager_;
     Stats::TimespanPtr request_response_timespan_;
     // Per-stream idle timeout.
     Event::TimerPtr stream_idle_timer_;
-    // Per-stream request timeout.
-    Event::TimerPtr request_timer_;
     // Per-stream alive duration.
     Event::TimerPtr max_stream_duration_timer_;
     std::chrono::milliseconds idle_timeout_ms_{};
     State state_;
-    StreamInfo::StreamInfoImpl stream_info_;
     absl::optional<Router::RouteConstSharedPtr> cached_route_;
     absl::optional<Upstream::ClusterInfoConstSharedPtr> cached_cluster_info_;
-    std::list<DownstreamWatermarkCallbacks*> watermark_callbacks_{};
-    // Stores metadata added in the decoding filter that is being processed. Will be cleared before
-    // processing the next filter. The storage is created on demand. We need to store metadata
-    // temporarily in the filter in case the filter has stopped all while processing headers.
-    std::unique_ptr<MetadataMapVector> request_metadata_map_vector_{nullptr};
-    uint32_t buffer_limit_{0};
-    uint32_t high_watermark_count_{0};
-    const std::string* decorated_operation_{nullptr};
-    Network::Socket::OptionsSharedPtr upstream_options_;
+    ResponseEncoder* response_encoder_;
     std::unique_ptr<RouteConfigUpdateRequester> route_config_update_requester_;
     std::unique_ptr<Tracing::CustomTagMap> tracing_custom_tags_{nullptr};
   };
@@ -790,7 +368,6 @@ private:
   Event::TimerPtr connection_duration_timer_;
   Event::TimerPtr drain_timer_;
   Random::RandomGenerator& random_generator_;
-  Http::Context& http_context_;
   Runtime::Loader& runtime_;
   const LocalInfo::LocalInfo& local_info_;
   Upstream::ClusterManager& cluster_manager_;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -648,13 +648,6 @@ void FilterManager::encode100ContinueHeaders(ActiveStreamEncoderFilter* filter,
   }
 
   callbacks_.finalize100ContinueHeaders(headers);
-  // TOODOOOO
-  //   // Strip the T-E headers etc. Defer other header additions as well as drain-close logic to
-  //   the
-  //   // continuation headers.
-  //   ConnectionManagerUtility::mutateResponseHeaders(headers, request_headers_.get(),
-  //                                                   connection_manager_.config_, EMPTY_STRING);
-
   ENVOY_STREAM_LOG(debug, "encoding 100 continue headers via codec:\n{}", callbacks_, headers);
 
   // Now actually encode via the codec.

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1108,10 +1108,7 @@ void FilterManager::ActiveStreamDecoderFilter::encodeMetadata(MetadataMapPtr&& m
 }
 
 void FilterManager::ActiveStreamDecoderFilter::onDecoderFilterAboveWriteBufferHighWatermark() {
-  ENVOY_STREAM_LOG(debug, "Read-disabling downstream stream due to filter callbacks.",
-                   parent_.callbacks_);
-  parent_.response_encoder_->getStream().readDisable(true);
-  //   parent_.connection_manager_.stats_.named_.downstream_flow_control_paused_reading_total_.inc();
+  parent_.callbacks_.onFilterAboveWriteBufferHighWatermark();
 }
 
 void FilterManager::ActiveStreamDecoderFilter::requestDataTooLarge() {
@@ -1132,14 +1129,7 @@ void FilterManager::ActiveStreamDecoderFilter::requestDataDrained() {
 }
 
 void FilterManager::ActiveStreamDecoderFilter::onDecoderFilterBelowWriteBufferLowWatermark() {
-  ENVOY_STREAM_LOG(debug, "Read-enabling downstream stream due to filter callbacks.",
-                   parent_.callbacks_);
-  // If the state is destroyed, the codec's stream is already torn down. On
-  // teardown the codec will unwind any remaining read disable calls.
-  if (!parent_.state_.destroyed_) {
-    parent_.response_encoder_->getStream().readDisable(false);
-  }
-  //   parent_.connection_manager_.stats_.named_.downstream_flow_control_resumed_reading_total_.inc();
+  parent_.callbacks_.onFilterBelowWriteBufferLowWatermark();
 }
 
 void FilterManager::ActiveStreamDecoderFilter::addDownstreamWatermarkCallbacks(

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1,0 +1,1296 @@
+#include "common/http/filter_manager.h"
+
+#include "common/http/codes.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/header_utility.h"
+#include "common/http/utility.h"
+#include "common/runtime/runtime_features.h"
+#include "common/tracing/http_tracer_impl.h"
+
+namespace Envoy {
+namespace Http {
+
+namespace {
+
+template <class T> using FilterList = std::list<std::unique_ptr<T>>;
+
+// Shared helper for recording the latest filter used.
+template <class T>
+void recordLatestDataFilter(const typename FilterList<T>::iterator current_filter,
+                            T*& latest_filter, const FilterList<T>& filters) {
+  // If this is the first time we're calling onData, just record the current filter.
+  if (latest_filter == nullptr) {
+    latest_filter = current_filter->get();
+    return;
+  }
+
+  // We want to keep this pointing at the latest filter in the filter list that has received the
+  // onData callback. To do so, we compare the current latest with the *previous* filter. If they
+  // match, then we must be processing a new filter for the first time. We omit this check if we're
+  // the first filter, since the above check handles that case.
+  //
+  // We compare against the previous filter to avoid multiple filter iterations from resetting the
+  // pointer: If we just set latest to current, then the first onData filter iteration would
+  // correctly iterate over the filters and set latest, but on subsequent onData iterations
+  // we'd start from the beginning again, potentially allowing filter N to modify the buffer even
+  // though filter M > N was the filter that inserted data into the buffer.
+  if (current_filter != filters.begin() && latest_filter == std::prev(current_filter)->get()) {
+    latest_filter = current_filter->get();
+  }
+}
+
+} // namespace
+void FilterManager::addStreamDecoderFilterWorker(StreamDecoderFilterSharedPtr filter,
+                                                 bool dual_filter) {
+  ActiveStreamDecoderFilterPtr wrapper(new ActiveStreamDecoderFilter(*this, filter, dual_filter));
+  filter->setDecoderFilterCallbacks(*wrapper);
+  // Note: configured decoder filters are appended to decoder_filters_.
+  // This means that if filters are configured in the following order (assume all three filters are
+  // both decoder/encoder filters):
+  //   http_filters:
+  //     - A
+  //     - B
+  //     - C
+  // The decoder filter chain will iterate through filters A, B, C.
+  wrapper->moveIntoListBack(std::move(wrapper), decoder_filters_);
+}
+
+void FilterManager::addStreamEncoderFilterWorker(StreamEncoderFilterSharedPtr filter,
+                                                 bool dual_filter) {
+  ActiveStreamEncoderFilterPtr wrapper(new ActiveStreamEncoderFilter(*this, filter, dual_filter));
+  filter->setEncoderFilterCallbacks(*wrapper);
+  // Note: configured encoder filters are prepended to encoder_filters_.
+  // This means that if filters are configured in the following order (assume all three filters are
+  // both decoder/encoder filters):
+  //   http_filters:
+  //     - A
+  //     - B
+  //     - C
+  // The encoder filter chain will iterate through filters C, B, A.
+  wrapper->moveIntoList(std::move(wrapper), encoder_filters_);
+}
+
+void FilterManager::addAccessLogHandler(AccessLog::InstanceSharedPtr handler) {
+  access_log_handlers_.push_back(handler);
+}
+
+void FilterManager::maybeContinueDecoding(
+    const std::list<ActiveStreamDecoderFilterPtr>::iterator& continue_data_entry) {
+  if (continue_data_entry != decoder_filters_.end()) {
+    // We use the continueDecoding() code since it will correctly handle not calling
+    // decodeHeaders() again. Fake setting StopSingleIteration since the continueDecoding() code
+    // expects it.
+    ASSERT(buffered_request_data_);
+    (*continue_data_entry)->iteration_state_ =
+        ActiveStreamFilterBase::IterationState::StopSingleIteration;
+    (*continue_data_entry)->continueDecoding();
+  }
+}
+
+void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHeaderMap& headers,
+                                  bool end_stream) {
+  // Headers filter iteration should always start with the next filter if available.
+  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
+      commonDecodePrefix(filter, FilterIterationStartState::AlwaysStartFromNext);
+  std::list<ActiveStreamDecoderFilterPtr>::iterator continue_data_entry = decoder_filters_.end();
+
+  for (; entry != decoder_filters_.end(); entry++) {
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeHeaders));
+    state_.filter_call_state_ |= FilterCallState::DecodeHeaders;
+    (*entry)->end_stream_ = state_.decoding_headers_only_ ||
+                            (end_stream && continue_data_entry == decoder_filters_.end());
+    FilterHeadersStatus status = (*entry)->decodeHeaders(headers, (*entry)->end_stream_);
+
+    ASSERT(!(status == FilterHeadersStatus::ContinueAndEndStream && (*entry)->end_stream_));
+    state_.filter_call_state_ &= ~FilterCallState::DecodeHeaders;
+    ENVOY_STREAM_LOG(trace, "decode headers called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+
+    const bool new_metadata_added = processNewlyAddedMetadata();
+    // If end_stream is set in headers, and a filter adds new metadata, we need to delay end_stream
+    // in headers by inserting an empty data frame with end_stream set. The empty data frame is sent
+    // after the new metadata.
+    if ((*entry)->end_stream_ && new_metadata_added && !buffered_request_data_) {
+      Buffer::OwnedImpl empty_data("");
+      ENVOY_STREAM_LOG(trace,
+                       "inserting an empty data frame for end_stream due metadata being added.",
+                       callbacks_);
+      // Metadata frame doesn't carry end of stream bit. We need an empty data frame to end the
+      // stream.
+      addDecodedData(*((*entry).get()), empty_data, true);
+    }
+
+    (*entry)->decode_headers_called_ = true;
+    if (!(*entry)->commonHandleAfterHeadersCallback(status, state_.decoding_headers_only_) &&
+        std::next(entry) != decoder_filters_.end()) {
+      // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
+      // processing since we need to handle the case where a terminal filter wants to buffer, but
+      // a previous filter has added body.
+      maybeContinueDecoding(continue_data_entry);
+      return;
+    }
+
+    // Here we handle the case where we have a header only request, but a filter adds a body
+    // to it. We need to not raise end_stream = true to further filters during inline iteration.
+    if (end_stream && buffered_request_data_ && continue_data_entry == decoder_filters_.end()) {
+      continue_data_entry = entry;
+    }
+  }
+
+  maybeContinueDecoding(continue_data_entry);
+
+  if (end_stream) {
+    disarmRequestTimeout();
+  }
+}
+
+void FilterManager::decodeTrailers(ActiveStreamDecoderFilter* filter, RequestTrailerMap& trailers) {
+  // If we previously decided to decode only the headers, do nothing here.
+  if (state_.decoding_headers_only_) {
+    return;
+  }
+
+  // See decodeData() above for why we check local_complete_ here.
+  if (state_.local_complete_) {
+    return;
+  }
+
+  // Filter iteration may start at the current filter.
+  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
+      commonDecodePrefix(filter, FilterIterationStartState::CanStartFromCurrent);
+
+  for (; entry != decoder_filters_.end(); entry++) {
+    // If the filter pointed by entry has stopped for all frame type, return now.
+    if ((*entry)->stoppedAll()) {
+      return;
+    }
+
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeTrailers));
+    state_.filter_call_state_ |= FilterCallState::DecodeTrailers;
+    FilterTrailersStatus status = (*entry)->handle_->decodeTrailers(trailers);
+    (*entry)->handle_->decodeComplete();
+    (*entry)->end_stream_ = true;
+    state_.filter_call_state_ &= ~FilterCallState::DecodeTrailers;
+    ENVOY_STREAM_LOG(trace, "decode trailers called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+
+    processNewlyAddedMetadata();
+
+    if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
+      return;
+    }
+  }
+  disarmRequestTimeout();
+}
+
+void FilterManager::disarmRequestTimeout() {
+  if (request_timer_) {
+    request_timer_->disableTimer();
+  }
+}
+
+void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHeaderMap& headers,
+                                  bool end_stream) {
+  callbacks_.refreshIdleTimeout();
+  disarmRequestTimeout();
+
+  // Headers filter iteration should always start with the next filter if available.
+  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
+      commonEncodePrefix(filter, end_stream, FilterIterationStartState::AlwaysStartFromNext);
+  std::list<ActiveStreamEncoderFilterPtr>::iterator continue_data_entry = encoder_filters_.end();
+
+  for (; entry != encoder_filters_.end(); entry++) {
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeHeaders));
+    state_.filter_call_state_ |= FilterCallState::EncodeHeaders;
+    (*entry)->end_stream_ = state_.encoding_headers_only_ ||
+                            (end_stream && continue_data_entry == encoder_filters_.end());
+    FilterHeadersStatus status = (*entry)->handle_->encodeHeaders(headers, (*entry)->end_stream_);
+    if ((*entry)->end_stream_) {
+      (*entry)->handle_->encodeComplete();
+    }
+    state_.filter_call_state_ &= ~FilterCallState::EncodeHeaders;
+    ENVOY_STREAM_LOG(trace, "encode headers called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+
+    (*entry)->encode_headers_called_ = true;
+    const auto continue_iteration =
+        (*entry)->commonHandleAfterHeadersCallback(status, state_.encoding_headers_only_);
+
+    // If we're encoding a headers only response, then mark the local as complete. This ensures
+    // that we don't attempt to reset the downstream request in doEndStream.
+    if (state_.encoding_headers_only_) {
+      state_.local_complete_ = true;
+    }
+
+    if (!continue_iteration) {
+      if (!(*entry)->end_stream_) {
+        maybeContinueEncoding(continue_data_entry);
+      }
+      return;
+    }
+
+    // Here we handle the case where we have a header only response, but a filter adds a body
+    // to it. We need to not raise end_stream = true to further filters during inline iteration.
+    if (end_stream && buffered_response_data_ && continue_data_entry == encoder_filters_.end()) {
+      continue_data_entry = entry;
+    }
+  }
+
+  const bool modified_end_stream = state_.encoding_headers_only_ ||
+                                   (end_stream && continue_data_entry == encoder_filters_.end());
+  callbacks_.finalizeHeaders(headers, modified_end_stream);
+
+  if (!modified_end_stream) {
+    maybeContinueEncoding(continue_data_entry);
+  }
+}
+
+RequestTrailerMap& FilterManager::addDecodedTrailers() {
+  // Trailers can only be added during the last data frame (i.e. end_stream = true).
+  ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
+
+  // Trailers can only be added once.
+  ASSERT(!request_trailers_);
+
+  request_trailers_ = RequestTrailerMapImpl::create();
+  return *request_trailers_;
+}
+
+void FilterManager::addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::Instance& data,
+                                   bool streaming) {
+  if (state_.filter_call_state_ == 0 ||
+      (state_.filter_call_state_ & FilterCallState::DecodeHeaders) ||
+      (state_.filter_call_state_ & FilterCallState::DecodeData) ||
+      ((state_.filter_call_state_ & FilterCallState::DecodeTrailers) && !filter.canIterate())) {
+    // Make sure if this triggers watermarks, the correct action is taken.
+    state_.decoder_filters_streaming_ = streaming;
+    // If no call is happening or we are in the decode headers/data callback, buffer the data.
+    // Inline processing happens in the decodeHeaders() callback if necessary.
+    filter.commonHandleBufferData(data);
+  } else if (state_.filter_call_state_ & FilterCallState::DecodeTrailers) {
+    // In this case we need to inline dispatch the data to further filters. If those filters
+    // choose to buffer/stop iteration that's fine.
+    decodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
+  } else {
+    // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
+    // throw an exception here.
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+}
+
+MetadataMapVector& FilterManager::addDecodedMetadata() { return *getRequestMetadataMapVector(); }
+
+void FilterManager::decodeMetadata(ActiveStreamDecoderFilter* filter, MetadataMap& metadata_map) {
+  // Filter iteration may start at the current filter.
+  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
+      commonDecodePrefix(filter, FilterIterationStartState::CanStartFromCurrent);
+
+  for (; entry != decoder_filters_.end(); entry++) {
+    // If the filter pointed by entry has stopped for all frame type, stores metadata and returns.
+    // If the filter pointed by entry hasn't returned from decodeHeaders, stores newly added
+    // metadata in case decodeHeaders returns StopAllIteration. The latter can happen when headers
+    // callbacks generate new metadata.
+    if (!(*entry)->decode_headers_called_ || (*entry)->stoppedAll()) {
+      Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
+      (*entry)->getSavedRequestMetadata()->emplace_back(std::move(metadata_map_ptr));
+      return;
+    }
+
+    FilterMetadataStatus status = (*entry)->handle_->decodeMetadata(metadata_map);
+    ENVOY_STREAM_LOG(trace, "decode metadata called: filter={} status={}, metadata: {}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status),
+                     metadata_map);
+  }
+}
+
+void FilterManager::maybeEndDecode(bool end_stream) {
+  ASSERT(!state_.remote_complete_);
+  state_.remote_complete_ = end_stream;
+  if (end_stream) {
+    stream_info_.onLastDownstreamRxByteReceived();
+    ENVOY_STREAM_LOG(debug, "request end stream", callbacks_);
+  }
+}
+
+std::list<FilterManager::ActiveStreamEncoderFilterPtr>::iterator
+FilterManager::commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_stream,
+                                  FilterIterationStartState filter_iteration_start_state) {
+  // Only do base state setting on the initial call. Subsequent calls for filtering do not touch
+  // the base state.
+  if (filter == nullptr) {
+    ASSERT(!state_.local_complete_);
+    state_.local_complete_ = end_stream;
+    return encoder_filters_.begin();
+  }
+
+  if (filter_iteration_start_state == FilterIterationStartState::CanStartFromCurrent &&
+      (*(filter->entry()))->iterate_from_current_filter_) {
+    // The filter iteration has been stopped for all frame types, and now the iteration continues.
+    // The current filter's encoding callback has not be called. Call it now.
+    return filter->entry();
+  }
+  return std::next(filter->entry());
+}
+
+std::list<FilterManager::ActiveStreamDecoderFilterPtr>::iterator
+FilterManager::commonDecodePrefix(ActiveStreamDecoderFilter* filter,
+                                  FilterIterationStartState filter_iteration_start_state) {
+  if (!filter) {
+    return decoder_filters_.begin();
+  }
+  if (filter_iteration_start_state == FilterIterationStartState::CanStartFromCurrent &&
+      (*(filter->entry()))->iterate_from_current_filter_) {
+    // The filter iteration has been stopped for all frame types, and now the iteration continues.
+    // The current filter's callback function has not been called. Call it now.
+    return filter->entry();
+  }
+  return std::next(filter->entry());
+}
+
+void FilterManager::decodeData(ActiveStreamDecoderFilter* filter, Buffer::Instance& data,
+                               bool end_stream,
+                               FilterIterationStartState filter_iteration_start_state) {
+  callbacks_.refreshIdleTimeout();
+
+  // If we previously decided to decode only the headers, do nothing here.
+  if (state_.decoding_headers_only_) {
+    return;
+  }
+
+  // If a response is complete or a reset has been sent, filters do not care about further body
+  // data. Just drop it.
+  if (state_.local_complete_) {
+    return;
+  }
+
+  auto trailers_added_entry = decoder_filters_.end();
+  const bool trailers_exists_at_start = request_trailers_ != nullptr;
+  // Filter iteration may start at the current filter.
+  std::list<ActiveStreamDecoderFilterPtr>::iterator entry =
+      commonDecodePrefix(filter, filter_iteration_start_state);
+
+  for (; entry != decoder_filters_.end(); entry++) {
+    // If the filter pointed by entry has stopped for all frame types, return now.
+    if (handleDataIfStopAll(**entry, data, state_.decoder_filters_streaming_)) {
+      return;
+    }
+    // If end_stream_ is marked for a filter, the data is not for this filter and filters after.
+    //
+    // In following case, ActiveStreamFilterBase::commonContinue() could be called recursively and
+    // its doData() is called with wrong data.
+    //
+    //  There are 3 decode filters and "wrapper" refers to ActiveStreamFilter object.
+    //
+    //  filter0->decodeHeaders(_, true)
+    //    return STOP
+    //  filter0->continueDecoding()
+    //    wrapper0->commonContinue()
+    //      wrapper0->decodeHeaders(_, _, true)
+    //        filter1->decodeHeaders(_, true)
+    //          filter1->addDecodeData()
+    //          return CONTINUE
+    //        filter2->decodeHeaders(_, false)
+    //          return CONTINUE
+    //        wrapper1->commonContinue() // Detects data is added.
+    //          wrapper1->doData()
+    //            wrapper1->decodeData()
+    //              filter2->decodeData(_, true)
+    //                 return CONTINUE
+    //      wrapper0->doData() // This should not be called
+    //        wrapper0->decodeData()
+    //          filter1->decodeData(_, true)  // It will cause assertions.
+    //
+    // One way to solve this problem is to mark end_stream_ for each filter.
+    // If a filter is already marked as end_stream_ when decodeData() is called, bails out the
+    // whole function. If just skip the filter, the codes after the loop will be called with
+    // wrong data. For encodeData, the response_encoder->encode() will be called.
+    if ((*entry)->end_stream_) {
+      return;
+    }
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeData));
+
+    // We check the request_trailers_ pointer here in case addDecodedTrailers
+    // is called in decodeData during a previous filter invocation, at which point we communicate to
+    // the current and future filters that the stream has not yet ended.
+    if (end_stream) {
+      state_.filter_call_state_ |= FilterCallState::LastDataFrame;
+    }
+
+    recordLatestDataFilter(entry, state_.latest_data_decoding_filter_, decoder_filters_);
+
+    state_.filter_call_state_ |= FilterCallState::DecodeData;
+    (*entry)->end_stream_ = end_stream && !request_trailers_;
+    FilterDataStatus status = (*entry)->handle_->decodeData(data, (*entry)->end_stream_);
+    if ((*entry)->end_stream_) {
+      (*entry)->handle_->decodeComplete();
+    }
+    state_.filter_call_state_ &= ~FilterCallState::DecodeData;
+    if (end_stream) {
+      state_.filter_call_state_ &= ~FilterCallState::LastDataFrame;
+    }
+    ENVOY_STREAM_LOG(trace, "decode data called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+
+    processNewlyAddedMetadata();
+
+    if (!trailers_exists_at_start && request_trailers_ &&
+        trailers_added_entry == decoder_filters_.end()) {
+      trailers_added_entry = entry;
+    }
+
+    if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.decoder_filters_streaming_) &&
+        std::next(entry) != decoder_filters_.end()) {
+      // Stop iteration IFF this is not the last filter. If it is the last filter, continue with
+      // processing since we need to handle the case where a terminal filter wants to buffer, but
+      // a previous filter has added trailers.
+      return;
+    }
+  }
+
+  // If trailers were adding during decodeData we need to trigger decodeTrailers in order
+  // to allow filters to process the trailers.
+  if (trailers_added_entry != decoder_filters_.end()) {
+    decodeTrailers(trailers_added_entry->get(), *request_trailers_);
+  }
+
+  if (end_stream) {
+    disarmRequestTimeout();
+  }
+}
+
+void FilterManager::sendLocalReply(
+    bool is_grpc_request, Code code, absl::string_view body,
+    const std::function<void(ResponseHeaderMap& headers)>& modify_headers, bool is_head_request,
+    const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
+  ENVOY_STREAM_LOG(debug, "Sending local reply with details {}", callbacks_, details);
+  ASSERT(response_headers_ == nullptr);
+  // For early error handling, do a best-effort attempt to create a filter chain
+  // to ensure access logging. If the filter chain already exists this will be
+  // a no-op.
+  createFilterChain();
+
+  stream_info_.setResponseCodeDetails(details);
+  Utility::sendLocalReply(
+      state_.destroyed_,
+      Utility::EncodeFunctions{
+          [this](ResponseHeaderMap& response_headers, Code& code, std::string& body,
+                 absl::string_view& content_type) -> void {
+            local_reply_.rewrite(request_headers_.get(), response_headers, stream_info_, code, body,
+                                 content_type);
+          },
+          [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
+            if (modify_headers != nullptr) {
+              modify_headers(*headers);
+            }
+            response_headers_ = std::move(headers);
+            // TODO: Start encoding from the last decoder filter that saw the
+            // request instead.
+            encodeHeaders(nullptr, *response_headers_, end_stream);
+          },
+          [this](Buffer::Instance& data, bool end_stream) -> void {
+            // TODO: Start encoding from the last decoder filter that saw the
+            // request instead.
+            encodeData(nullptr, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
+          }},
+      Utility::LocalReplyData{is_grpc_request, code, body, grpc_status, is_head_request});
+}
+
+void FilterManager::encodeDataInternal(Buffer::Instance& data, bool end_stream) {
+  ASSERT(!state_.encoding_headers_only_);
+  ENVOY_STREAM_LOG(trace, "encoding data via codec (size={} end_stream={})", callbacks_,
+                   data.length(), end_stream);
+
+  stream_info_.addBytesSent(data.length());
+  response_encoder_->encodeData(data, end_stream);
+  maybeEndEncode(end_stream);
+}
+
+void FilterManager::setBufferLimit(uint32_t new_limit) {
+  ENVOY_STREAM_LOG(debug, "setting buffer limit to {}", callbacks_, new_limit);
+  buffer_limit_ = new_limit;
+  if (buffered_request_data_) {
+    buffered_request_data_->setWatermarks(buffer_limit_);
+  }
+  if (buffered_response_data_) {
+    buffered_response_data_->setWatermarks(buffer_limit_);
+  }
+}
+
+bool FilterManager::createFilterChain() {
+  if (state_.created_filter_chain_) {
+    return false;
+  }
+  bool upgrade_rejected = false;
+  const Envoy::Http::HeaderEntry* upgrade =
+      request_headers_ ? request_headers_->Upgrade() : nullptr;
+  // Treat CONNECT requests as a special upgrade case.
+  if (!upgrade && request_headers_ && HeaderUtility::isConnect(*request_headers_)) {
+    upgrade = request_headers_->Method();
+  }
+  state_.created_filter_chain_ = true;
+  if (upgrade != nullptr) {
+    const Router::RouteEntry::UpgradeMap* upgrade_map = nullptr;
+
+    // We must check if the 'cached_route_' optional is populated since this function can be called
+    // early via sendLocalReply(), before the cached route is populated.
+    if (callbacks_.cachedRoute().has_value() && callbacks_.cachedRoute().value() != nullptr &&
+        callbacks_.cachedRoute().value()->routeEntry()) {
+      upgrade_map = &callbacks_.cachedRoute().value()->routeEntry()->upgradeMap();
+    }
+
+    if (filter_chain_factory_.createUpgradeFilterChain(upgrade->value().getStringView(),
+                                                       upgrade_map, *this)) {
+      state_.successful_upgrade_ = true;
+      callbacks_.upgradeFilterChainCreated();
+      return true;
+    } else {
+      upgrade_rejected = true;
+      // Fall through to the default filter chain. The function calling this
+      // will send a local reply indicating that the upgrade failed.
+    }
+  }
+
+  filter_chain_factory_.createFilterChain(*this);
+  return !upgrade_rejected;
+}
+
+void FilterManager::encodeTrailers(ActiveStreamEncoderFilter* filter,
+                                   ResponseTrailerMap& trailers) {
+  callbacks_.refreshIdleTimeout();
+
+  // If we previously decided to encode only the headers, do nothing here.
+  if (state_.encoding_headers_only_) {
+    return;
+  }
+
+  // Filter iteration may start at the current filter.
+  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
+      commonEncodePrefix(filter, true, FilterIterationStartState::CanStartFromCurrent);
+  for (; entry != encoder_filters_.end(); entry++) {
+    // If the filter pointed by entry has stopped for all frame type, return now.
+    if ((*entry)->stoppedAll()) {
+      return;
+    }
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeTrailers));
+    state_.filter_call_state_ |= FilterCallState::EncodeTrailers;
+    FilterTrailersStatus status = (*entry)->handle_->encodeTrailers(trailers);
+    (*entry)->handle_->encodeComplete();
+    (*entry)->end_stream_ = true;
+    state_.filter_call_state_ &= ~FilterCallState::EncodeTrailers;
+    ENVOY_STREAM_LOG(trace, "encode trailers called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    if (!(*entry)->commonHandleAfterTrailersCallback(status)) {
+      return;
+    }
+  }
+
+  ENVOY_STREAM_LOG(debug, "encoding trailers via codec:\n{}", callbacks_, trailers);
+
+  response_encoder_->encodeTrailers(trailers);
+  maybeEndEncode(true);
+}
+
+void FilterManager::maybeEndEncode(bool end_stream) {
+  if (end_stream) {
+    ASSERT(!state_.codec_saw_local_complete_);
+    state_.codec_saw_local_complete_ = true;
+    stream_info_.onLastDownstreamTxByteSent();
+    callbacks_.endStream();
+  }
+}
+
+bool FilterManager::processNewlyAddedMetadata() {
+  if (request_metadata_map_vector_ == nullptr) {
+    return false;
+  }
+  for (const auto& metadata_map : *getRequestMetadataMapVector()) {
+    decodeMetadata(nullptr, *metadata_map);
+  }
+  getRequestMetadataMapVector()->clear();
+  return true;
+}
+
+bool FilterManager::handleDataIfStopAll(ActiveStreamFilterBase& filter, Buffer::Instance& data,
+                                        bool& filter_streaming) {
+  if (filter.stoppedAll()) {
+    ASSERT(!filter.canIterate());
+    filter_streaming =
+        filter.iteration_state_ == ActiveStreamFilterBase::IterationState::StopAllWatermark;
+    filter.commonHandleBufferData(data);
+    return true;
+  }
+  return false;
+}
+
+void FilterManager::encode100ContinueHeaders(ActiveStreamEncoderFilter* filter,
+                                             ResponseHeaderMap& headers) {
+  callbacks_.refreshIdleTimeout();
+  // Make sure commonContinue continues encode100ContinueHeaders.
+  state_.has_continue_headers_ = true;
+
+  // Similar to the block in encodeHeaders, run encode100ContinueHeaders on each
+  // filter. This is simpler than that case because 100 continue implies no
+  // end-stream, and because there are normal headers coming there's no need for
+  // complex continuation logic.
+  // 100-continue filter iteration should always start with the next filter if available.
+  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
+      commonEncodePrefix(filter, false, FilterIterationStartState::AlwaysStartFromNext);
+  for (; entry != encoder_filters_.end(); entry++) {
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::Encode100ContinueHeaders));
+    state_.filter_call_state_ |= FilterCallState::Encode100ContinueHeaders;
+    FilterHeadersStatus status = (*entry)->handle_->encode100ContinueHeaders(headers);
+    state_.filter_call_state_ &= ~FilterCallState::Encode100ContinueHeaders;
+    ENVOY_STREAM_LOG(trace, "encode 100 continue headers called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+    if (!(*entry)->commonHandleAfter100ContinueHeadersCallback(status)) {
+      return;
+    }
+  }
+
+  callbacks_.finalize100ContinueHeaders(headers);
+  // TOODOOOO
+  //   // Strip the T-E headers etc. Defer other header additions as well as drain-close logic to
+  //   the
+  //   // continuation headers.
+  //   ConnectionManagerUtility::mutateResponseHeaders(headers, request_headers_.get(),
+  //                                                   connection_manager_.config_, EMPTY_STRING);
+
+  ENVOY_STREAM_LOG(debug, "encoding 100 continue headers via codec:\n{}", callbacks_, headers);
+
+  // Now actually encode via the codec.
+  response_encoder_->encode100ContinueHeaders(headers);
+}
+
+void FilterManager::maybeContinueEncoding(
+    const std::list<ActiveStreamEncoderFilterPtr>::iterator& continue_data_entry) {
+  if (continue_data_entry != encoder_filters_.end()) {
+    // We use the continueEncoding() code since it will correctly handle not calling
+    // encodeHeaders() again. Fake setting StopSingleIteration since the continueEncoding() code
+    // expects it.
+    ASSERT(buffered_response_data_);
+    (*continue_data_entry)->iteration_state_ =
+        ActiveStreamFilterBase::IterationState::StopSingleIteration;
+    (*continue_data_entry)->continueEncoding();
+  }
+}
+ResponseTrailerMap& FilterManager::addEncodedTrailers() {
+  // Trailers can only be added during the last data frame (i.e. end_stream = true).
+  ASSERT(state_.filter_call_state_ & FilterCallState::LastDataFrame);
+
+  // Trailers can only be added once.
+  ASSERT(!response_trailers_);
+
+  response_trailers_ = ResponseTrailerMapImpl::create();
+  return *response_trailers_;
+}
+
+void FilterManager::addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data,
+                                   bool streaming) {
+  if (state_.filter_call_state_ == 0 ||
+      (state_.filter_call_state_ & FilterCallState::EncodeHeaders) ||
+      (state_.filter_call_state_ & FilterCallState::EncodeData) ||
+      ((state_.filter_call_state_ & FilterCallState::EncodeTrailers) && !filter.canIterate())) {
+    // Make sure if this triggers watermarks, the correct action is taken.
+    state_.encoder_filters_streaming_ = streaming;
+    // If no call is happening or we are in the decode headers/data callback, buffer the data.
+    // Inline processing happens in the decodeHeaders() callback if necessary.
+    filter.commonHandleBufferData(data);
+  } else if (state_.filter_call_state_ & FilterCallState::EncodeTrailers) {
+    // In this case we need to inline dispatch the data to further filters. If those filters
+    // choose to buffer/stop iteration that's fine.
+    encodeData(&filter, data, false, FilterIterationStartState::AlwaysStartFromNext);
+  } else {
+    // TODO(mattklein123): Formalize error handling for filters and add tests. Should probably
+    // throw an exception here.
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+}
+
+void FilterManager::encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instance& data,
+                               bool end_stream,
+                               FilterIterationStartState filter_iteration_start_state) {
+  callbacks_.refreshIdleTimeout();
+
+  // If we previously decided to encode only the headers, do nothing here.
+  if (state_.encoding_headers_only_) {
+    return;
+  }
+
+  // Filter iteration may start at the current filter.
+  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
+      commonEncodePrefix(filter, end_stream, filter_iteration_start_state);
+  auto trailers_added_entry = encoder_filters_.end();
+
+  const bool trailers_exists_at_start = response_trailers_ != nullptr;
+  for (; entry != encoder_filters_.end(); entry++) {
+    // If the filter pointed by entry has stopped for all frame type, return now.
+    if (handleDataIfStopAll(**entry, data, state_.encoder_filters_streaming_)) {
+      return;
+    }
+    // If end_stream_ is marked for a filter, the data is not for this filter and filters after.
+    // For details, please see the comment in the ActiveStream::decodeData() function.
+    if ((*entry)->end_stream_) {
+      return;
+    }
+    ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeData));
+
+    // We check the response_trailers_ pointer here in case addEncodedTrailers
+    // is called in encodeData during a previous filter invocation, at which point we communicate to
+    // the current and future filters that the stream has not yet ended.
+    state_.filter_call_state_ |= FilterCallState::EncodeData;
+    if (end_stream) {
+      state_.filter_call_state_ |= FilterCallState::LastDataFrame;
+    }
+
+    recordLatestDataFilter(entry, state_.latest_data_encoding_filter_, encoder_filters_);
+
+    (*entry)->end_stream_ = end_stream && !response_trailers_;
+    FilterDataStatus status = (*entry)->handle_->encodeData(data, (*entry)->end_stream_);
+    if ((*entry)->end_stream_) {
+      (*entry)->handle_->encodeComplete();
+    }
+    state_.filter_call_state_ &= ~FilterCallState::EncodeData;
+    if (end_stream) {
+      state_.filter_call_state_ &= ~FilterCallState::LastDataFrame;
+    }
+    ENVOY_STREAM_LOG(trace, "encode data called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+
+    if (!trailers_exists_at_start && response_trailers_ &&
+        trailers_added_entry == encoder_filters_.end()) {
+      trailers_added_entry = entry;
+    }
+
+    if (!(*entry)->commonHandleAfterDataCallback(status, data, state_.encoder_filters_streaming_)) {
+      return;
+    }
+  }
+
+  const bool modified_end_stream = end_stream && trailers_added_entry == encoder_filters_.end();
+  encodeDataInternal(data, modified_end_stream);
+
+  // If trailers were adding during encodeData we need to trigger decodeTrailers in order
+  // to allow filters to process the trailers.
+  if (trailers_added_entry != encoder_filters_.end()) {
+    encodeTrailers(trailers_added_entry->get(), *response_trailers_);
+  }
+}
+
+void FilterManager::encodeMetadata(ActiveStreamEncoderFilter* filter,
+                                   MetadataMapPtr&& metadata_map_ptr) {
+  callbacks_.refreshIdleTimeout();
+
+  std::list<ActiveStreamEncoderFilterPtr>::iterator entry =
+      commonEncodePrefix(filter, false, FilterIterationStartState::CanStartFromCurrent);
+
+  for (; entry != encoder_filters_.end(); entry++) {
+    // If the filter pointed by entry has stopped for all frame type, stores metadata and returns.
+    // If the filter pointed by entry hasn't returned from encodeHeaders, stores newly added
+    // metadata in case encodeHeaders returns StopAllIteration. The latter can happen when headers
+    // callbacks generate new metadata.
+    if (!(*entry)->encode_headers_called_ || (*entry)->stoppedAll()) {
+      (*entry)->getSavedResponseMetadata()->emplace_back(std::move(metadata_map_ptr));
+      return;
+    }
+
+    FilterMetadataStatus status = (*entry)->handle_->encodeMetadata(*metadata_map_ptr);
+    ENVOY_STREAM_LOG(trace, "encode metadata called: filter={} status={}", callbacks_,
+                     static_cast<const void*>((*entry).get()), static_cast<uint64_t>(status));
+  }
+  // TODO(soya3129): update stats with metadata.
+
+  // Now encode metadata via the codec.
+  if (!metadata_map_ptr->empty()) {
+    ENVOY_STREAM_LOG(debug, "encoding metadata via codec:\n{}", callbacks_, *metadata_map_ptr);
+    MetadataMapVector metadata_map_vector;
+    metadata_map_vector.emplace_back(std::move(metadata_map_ptr));
+    response_encoder_->encodeMetadata(metadata_map_vector);
+  }
+}
+
+void FilterManager::callHighWatermarkCallbacks() {
+  ++high_watermark_count_;
+  for (auto watermark_callbacks : watermark_callbacks_) {
+    watermark_callbacks->onAboveWriteBufferHighWatermark();
+  }
+}
+
+void FilterManager::callLowWatermarkCallbacks() {
+  ASSERT(high_watermark_count_ > 0);
+  --high_watermark_count_;
+  for (auto watermark_callbacks : watermark_callbacks_) {
+    watermark_callbacks->onBelowWriteBufferLowWatermark();
+  }
+}
+
+void FilterManager::ActiveStreamFilterBase::commonContinue() {
+  // TODO(mattklein123): Raise an error if this is called during a callback.
+  if (!canContinue()) {
+    ENVOY_STREAM_LOG(trace, "cannot continue filter chain: filter={}", parent_.callbacks_,
+                     static_cast<const void*>(this));
+    return;
+  }
+
+  ENVOY_STREAM_LOG(trace, "continuing filter chain: filter={}", parent_.callbacks_,
+                   static_cast<const void*>(this));
+  ASSERT(!canIterate());
+  // If iteration has stopped for all frame types, set iterate_from_current_filter_ to true so the
+  // filter iteration starts with the current filter instead of the next one.
+  if (stoppedAll()) {
+    iterate_from_current_filter_ = true;
+  }
+  allowIteration();
+
+  // Only resume with do100ContinueHeaders() if we've actually seen a 100-Continue.
+  if (has100Continueheaders()) {
+    continue_headers_continued_ = true;
+    do100ContinueHeaders();
+    // If the response headers have not yet come in, don't continue on with
+    // headers and body. doHeaders expects request headers to exist.
+    if (!parent_.response_headers_.get()) {
+      return;
+    }
+  }
+
+  // Make sure that we handle the zero byte data frame case. We make no effort to optimize this
+  // case in terms of merging it into a header only request/response. This could be done in the
+  // future.
+  if (!headers_continued_) {
+    headers_continued_ = true;
+    doHeaders(complete() && !bufferedData() && !hasTrailers());
+  }
+
+  doMetadata();
+
+  if (bufferedData()) {
+    doData(complete() && !hasTrailers());
+  }
+
+  if (hasTrailers()) {
+    doTrailers();
+  }
+
+  iterate_from_current_filter_ = false;
+}
+
+bool FilterManager::ActiveStreamFilterBase::commonHandleAfter100ContinueHeadersCallback(
+    FilterHeadersStatus status) {
+  ASSERT(parent_.state_.has_continue_headers_);
+  ASSERT(!continue_headers_continued_);
+  ASSERT(canIterate());
+
+  if (status == FilterHeadersStatus::StopIteration) {
+    iteration_state_ = IterationState::StopSingleIteration;
+    return false;
+  } else {
+    ASSERT(status == FilterHeadersStatus::Continue);
+    continue_headers_continued_ = true;
+    return true;
+  }
+}
+
+bool FilterManager::ActiveStreamFilterBase::commonHandleAfterHeadersCallback(
+    FilterHeadersStatus status, bool& headers_only) {
+  ASSERT(!headers_continued_);
+  ASSERT(canIterate());
+
+  if (status == FilterHeadersStatus::StopIteration) {
+    iteration_state_ = IterationState::StopSingleIteration;
+  } else if (status == FilterHeadersStatus::StopAllIterationAndBuffer) {
+    iteration_state_ = IterationState::StopAllBuffer;
+  } else if (status == FilterHeadersStatus::StopAllIterationAndWatermark) {
+    iteration_state_ = IterationState::StopAllWatermark;
+  } else if (status == FilterHeadersStatus::ContinueAndEndStream) {
+    // Set headers_only to true so we know to end early if necessary,
+    // but continue filter iteration so we actually write the headers/run the cleanup code.
+    headers_only = true;
+    ENVOY_STREAM_LOG(debug, "converting to headers only", parent_.callbacks_);
+  } else {
+    ASSERT(status == FilterHeadersStatus::Continue);
+    headers_continued_ = true;
+  }
+
+  handleMetadataAfterHeadersCallback();
+
+  if (stoppedAll() || status == FilterHeadersStatus::StopIteration) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+void FilterManager::ActiveStreamFilterBase::commonHandleBufferData(
+    Buffer::Instance& provided_data) {
+
+  // The way we do buffering is a little complicated which is why we have this common function
+  // which is used for both encoding and decoding. When data first comes into our filter pipeline,
+  // we send it through. Any filter can choose to stop iteration and buffer or not. If we then
+  // continue iteration in the future, we use the buffered data. A future filter can stop and
+  // buffer again. In this case, since we are already operating on buffered data, we don't
+  // rebuffer, because we assume the filter has modified the buffer as it wishes in place.
+  if (bufferedData().get() != &provided_data) {
+    if (!bufferedData()) {
+      bufferedData() = createBuffer();
+    }
+    bufferedData()->move(provided_data);
+  }
+}
+
+bool FilterManager::ActiveStreamFilterBase::commonHandleAfterDataCallback(
+    FilterDataStatus status, Buffer::Instance& provided_data, bool& buffer_was_streaming) {
+
+  if (status == FilterDataStatus::Continue) {
+    if (iteration_state_ == IterationState::StopSingleIteration) {
+      commonHandleBufferData(provided_data);
+      commonContinue();
+      return false;
+    } else {
+      ASSERT(headers_continued_);
+    }
+  } else {
+    iteration_state_ = IterationState::StopSingleIteration;
+    if (status == FilterDataStatus::StopIterationAndBuffer ||
+        status == FilterDataStatus::StopIterationAndWatermark) {
+      buffer_was_streaming = status == FilterDataStatus::StopIterationAndWatermark;
+      commonHandleBufferData(provided_data);
+    } else if (complete() && !hasTrailers() && !bufferedData()) {
+      // If this filter is doing StopIterationNoBuffer and this stream is terminated with a zero
+      // byte data frame, we need to create an empty buffer to make sure that when commonContinue
+      // is called, the pipeline resumes with an empty data frame with end_stream = true
+      ASSERT(end_stream_);
+      bufferedData() = createBuffer();
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+bool FilterManager::ActiveStreamFilterBase::commonHandleAfterTrailersCallback(
+    FilterTrailersStatus status) {
+
+  if (status == FilterTrailersStatus::Continue) {
+    if (iteration_state_ == IterationState::StopSingleIteration) {
+      commonContinue();
+      return false;
+    } else {
+      ASSERT(headers_continued_);
+    }
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+const Network::Connection* FilterManager::ActiveStreamFilterBase::connection() {
+  return parent_.callbacks_.connection();
+}
+
+Event::Dispatcher& FilterManager::ActiveStreamFilterBase::dispatcher() {
+  return parent_.dispatcher_;
+}
+
+StreamInfo::StreamInfo& FilterManager::ActiveStreamFilterBase::streamInfo() {
+  return parent_.stream_info_;
+}
+
+Tracing::Span& FilterManager::ActiveStreamFilterBase::activeSpan() {
+  if (parent_.active_span_) {
+    return *parent_.active_span_;
+  } else {
+    return Tracing::NullSpan::instance();
+  }
+}
+
+Tracing::Config& FilterManager::ActiveStreamFilterBase::tracingConfig() {
+  return parent_.callbacks_.tracingConfig();
+}
+
+Upstream::ClusterInfoConstSharedPtr FilterManager::ActiveStreamFilterBase::clusterInfo() {
+  // NOTE: Refreshing route caches clusterInfo as well.
+  if (!parent_.callbacks_.cachedRoute().has_value()) {
+    parent_.callbacks_.refreshCachedRoute();
+  }
+
+  return parent_.callbacks_.cachedClusterInfo().value();
+}
+
+Router::RouteConstSharedPtr FilterManager::ActiveStreamFilterBase::route() {
+  return route(nullptr);
+}
+
+Router::RouteConstSharedPtr
+FilterManager::ActiveStreamFilterBase::route(const Router::RouteCallback& cb) {
+  if (parent_.callbacks_.cachedRoute().has_value()) {
+    return parent_.callbacks_.cachedRoute().value();
+  }
+
+  parent_.callbacks_.refreshCachedRoute(cb);
+  return parent_.callbacks_.cachedRoute().value();
+}
+
+void FilterManager::ActiveStreamFilterBase::clearRouteCache() {
+  parent_.callbacks_.clearRouteCache();
+}
+
+Buffer::WatermarkBufferPtr FilterManager::ActiveStreamDecoderFilter::createBuffer() {
+  auto buffer = std::make_unique<Buffer::WatermarkBuffer>(
+      [this]() -> void { this->requestDataDrained(); },
+      [this]() -> void { this->requestDataTooLarge(); },
+      []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });
+  buffer->setWatermarks(parent_.buffer_limit_);
+  return buffer;
+}
+
+void FilterManager::ActiveStreamDecoderFilter::handleMetadataAfterHeadersCallback() {
+  // If we drain accumulated metadata, the iteration must start with the current filter.
+  const bool saved_state = iterate_from_current_filter_;
+  iterate_from_current_filter_ = true;
+  // If decodeHeaders() returns StopAllIteration, we should skip draining metadata, and wait
+  // for doMetadata() to drain the metadata after iteration continues.
+  if (!stoppedAll() && saved_request_metadata_ != nullptr && !getSavedRequestMetadata()->empty()) {
+    drainSavedRequestMetadata();
+  }
+  // Restores the original value of iterate_from_current_filter_.
+  iterate_from_current_filter_ = saved_state;
+}
+
+RequestTrailerMap& FilterManager::ActiveStreamDecoderFilter::addDecodedTrailers() {
+  return parent_.addDecodedTrailers();
+}
+
+void FilterManager::ActiveStreamDecoderFilter::addDecodedData(Buffer::Instance& data,
+                                                              bool streaming) {
+  parent_.addDecodedData(*this, data, streaming);
+}
+
+MetadataMapVector& FilterManager::ActiveStreamDecoderFilter::addDecodedMetadata() {
+  return parent_.addDecodedMetadata();
+}
+
+void FilterManager::ActiveStreamDecoderFilter::injectDecodedDataToFilterChain(
+    Buffer::Instance& data, bool end_stream) {
+  parent_.decodeData(this, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
+}
+
+void FilterManager::ActiveStreamDecoderFilter::continueDecoding() { commonContinue(); }
+
+void FilterManager::ActiveStreamDecoderFilter::encode100ContinueHeaders(
+    ResponseHeaderMapPtr&& headers) {
+  // If Envoy is not configured to proxy 100-Continue responses, swallow the 100 Continue
+  // here. This avoids the potential situation where Envoy strips Expect: 100-Continue and sends a
+  // 100-Continue, then proxies a duplicate 100 Continue from upstream.
+  if (parent_.proxy_100_continue_) {
+    parent_.continue_headers_ = std::move(headers);
+    parent_.encode100ContinueHeaders(nullptr, *parent_.continue_headers_);
+  }
+}
+
+void FilterManager::ActiveStreamDecoderFilter::encodeHeaders(ResponseHeaderMapPtr&& headers,
+                                                             bool end_stream) {
+  parent_.response_headers_ = std::move(headers);
+  parent_.encodeHeaders(nullptr, *parent_.response_headers_, end_stream);
+}
+
+void FilterManager::ActiveStreamDecoderFilter::encodeData(Buffer::Instance& data, bool end_stream) {
+  parent_.encodeData(nullptr, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
+}
+
+void FilterManager::ActiveStreamDecoderFilter::encodeTrailers(ResponseTrailerMapPtr&& trailers) {
+  parent_.response_trailers_ = std::move(trailers);
+  parent_.encodeTrailers(nullptr, *parent_.response_trailers_);
+}
+
+void FilterManager::ActiveStreamDecoderFilter::encodeMetadata(MetadataMapPtr&& metadata_map_ptr) {
+  parent_.encodeMetadata(nullptr, std::move(metadata_map_ptr));
+}
+
+void FilterManager::ActiveStreamDecoderFilter::onDecoderFilterAboveWriteBufferHighWatermark() {
+  ENVOY_STREAM_LOG(debug, "Read-disabling downstream stream due to filter callbacks.",
+                   parent_.callbacks_);
+  parent_.response_encoder_->getStream().readDisable(true);
+  //   parent_.connection_manager_.stats_.named_.downstream_flow_control_paused_reading_total_.inc();
+}
+
+void FilterManager::ActiveStreamDecoderFilter::requestDataTooLarge() {
+  ENVOY_STREAM_LOG(debug, "request data too large watermark exceeded", parent_.callbacks_);
+  if (parent_.state_.decoder_filters_streaming_) {
+    onDecoderFilterAboveWriteBufferHighWatermark();
+  } else {
+    // parent_.connection_manager_.stats_.named_.downstream_rq_too_large_.inc();
+    sendLocalReply(Code::PayloadTooLarge, CodeUtility::toString(Code::PayloadTooLarge), nullptr,
+                   absl::nullopt, StreamInfo::ResponseCodeDetails::get().RequestPayloadTooLarge);
+  }
+}
+
+void FilterManager::ActiveStreamDecoderFilter::requestDataDrained() {
+  // If this is called it means the call to requestDataTooLarge() was a
+  // streaming call, or a 413 would have been sent.
+  onDecoderFilterBelowWriteBufferLowWatermark();
+}
+
+void FilterManager::ActiveStreamDecoderFilter::onDecoderFilterBelowWriteBufferLowWatermark() {
+  ENVOY_STREAM_LOG(debug, "Read-enabling downstream stream due to filter callbacks.",
+                   parent_.callbacks_);
+  // If the state is destroyed, the codec's stream is already torn down. On
+  // teardown the codec will unwind any remaining read disable calls.
+  if (!parent_.state_.destroyed_) {
+    parent_.response_encoder_->getStream().readDisable(false);
+  }
+  //   parent_.connection_manager_.stats_.named_.downstream_flow_control_resumed_reading_total_.inc();
+}
+
+void FilterManager::ActiveStreamDecoderFilter::addDownstreamWatermarkCallbacks(
+    DownstreamWatermarkCallbacks& watermark_callbacks) {
+  // This is called exactly once per upstream-stream, by the router filter. Therefore, we
+  // expect the same callbacks to not be registered twice.
+  ASSERT(std::find(parent_.watermark_callbacks_.begin(), parent_.watermark_callbacks_.end(),
+                   &watermark_callbacks) == parent_.watermark_callbacks_.end());
+  parent_.watermark_callbacks_.emplace(parent_.watermark_callbacks_.end(), &watermark_callbacks);
+  for (uint32_t i = 0; i < parent_.high_watermark_count_; ++i) {
+    watermark_callbacks.onAboveWriteBufferHighWatermark();
+  }
+}
+void FilterManager::ActiveStreamDecoderFilter::removeDownstreamWatermarkCallbacks(
+    DownstreamWatermarkCallbacks& watermark_callbacks) {
+  ASSERT(std::find(parent_.watermark_callbacks_.begin(), parent_.watermark_callbacks_.end(),
+                   &watermark_callbacks) != parent_.watermark_callbacks_.end());
+  parent_.watermark_callbacks_.remove(&watermark_callbacks);
+}
+
+bool FilterManager::ActiveStreamDecoderFilter::recreateStream() {
+  // Because the filter's and the HCM view of if the stream has a body and if
+  // the stream is complete may differ, re-check bytesReceived() to make sure
+  // there was no body from the HCM's point of view.
+  if (!complete() || parent_.stream_info_.bytesReceived() != 0) {
+    return false;
+  }
+
+  parent_.response_encoder_ = nullptr;
+  parent_.callbacks_.recreateStream(std::move(parent_.request_headers_));
+  return true;
+}
+
+void FilterManager::ActiveStreamDecoderFilter::requestRouteConfigUpdate(
+    Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) {
+  parent_.callbacks_.requestRouteConfigUpdate(dispatcher(), std::move(route_config_updated_cb));
+}
+
+absl::optional<Router::ConfigConstSharedPtr>
+FilterManager::ActiveStreamDecoderFilter::routeConfig() {
+  return parent_.callbacks_.routeConfig();
+}
+
+Buffer::WatermarkBufferPtr FilterManager::ActiveStreamEncoderFilter::createBuffer() {
+  auto buffer = new Buffer::WatermarkBuffer(
+      [this]() -> void { this->responseDataDrained(); },
+      [this]() -> void { this->responseDataTooLarge(); },
+      []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });
+  buffer->setWatermarks(parent_.buffer_limit_);
+  return Buffer::WatermarkBufferPtr{buffer};
+}
+
+void FilterManager::ActiveStreamEncoderFilter::handleMetadataAfterHeadersCallback() {
+  // If we drain accumulated metadata, the iteration must start with the current filter.
+  const bool saved_state = iterate_from_current_filter_;
+  iterate_from_current_filter_ = true;
+  // If encodeHeaders() returns StopAllIteration, we should skip draining metadata, and wait
+  // for doMetadata() to drain the metadata after iteration continues.
+  if (!stoppedAll() && saved_response_metadata_ != nullptr &&
+      !getSavedResponseMetadata()->empty()) {
+    drainSavedResponseMetadata();
+  }
+  // Restores the original value of iterate_from_current_filter_.
+  iterate_from_current_filter_ = saved_state;
+}
+void FilterManager::ActiveStreamEncoderFilter::addEncodedData(Buffer::Instance& data,
+                                                              bool streaming) {
+  return parent_.addEncodedData(*this, data, streaming);
+}
+
+void FilterManager::ActiveStreamEncoderFilter::injectEncodedDataToFilterChain(
+    Buffer::Instance& data, bool end_stream) {
+  parent_.encodeData(this, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
+}
+
+ResponseTrailerMap& FilterManager::ActiveStreamEncoderFilter::addEncodedTrailers() {
+  return parent_.addEncodedTrailers();
+}
+
+void FilterManager::ActiveStreamEncoderFilter::addEncodedMetadata(
+    MetadataMapPtr&& metadata_map_ptr) {
+  return parent_.encodeMetadata(this, std::move(metadata_map_ptr));
+}
+
+void FilterManager::ActiveStreamEncoderFilter::onEncoderFilterAboveWriteBufferHighWatermark() {
+  ENVOY_STREAM_LOG(debug, "Disabling upstream stream due to filter callbacks.", parent_.callbacks_);
+  parent_.callHighWatermarkCallbacks();
+}
+
+void FilterManager::ActiveStreamEncoderFilter::onEncoderFilterBelowWriteBufferLowWatermark() {
+  ENVOY_STREAM_LOG(debug, "Enabling upstream stream due to filter callbacks.", parent_.callbacks_);
+  parent_.callLowWatermarkCallbacks();
+}
+
+void FilterManager::ActiveStreamEncoderFilter::continueEncoding() { commonContinue(); }
+
+void FilterManager::ActiveStreamEncoderFilter::responseDataTooLarge() {
+  if (parent_.state_.encoder_filters_streaming_) {
+    onEncoderFilterAboveWriteBufferHighWatermark();
+  } else {
+    // parent_.connection_manager_.stats_.named_.rs_too_large_.inc();
+
+    // If headers have not been sent to the user, send a 500.
+    if (!headers_continued_) {
+      // Make sure we won't end up with nested watermark calls from the body buffer.
+      parent_.state_.encoder_filters_streaming_ = true;
+      allowIteration();
+      parent_.stream_info_.setResponseCodeDetails(
+          StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
+      // This does not call the standard sendLocalReply because if there is already response data
+      // we do not want to pass a second set of response headers through the filter chain.
+      // Instead, call the encodeHeadersInternal / encodeDataInternal helpers
+      // directly, which maximizes shared code with the normal response path.
+      Http::Utility::sendLocalReply(
+          parent_.state_.destroyed_,
+          Utility::EncodeFunctions{
+              [&](ResponseHeaderMap& response_headers, Code& code, std::string& body,
+                  absl::string_view& content_type) -> void {
+                parent_.local_reply_.rewrite(parent_.request_headers_.get(), response_headers,
+                                             parent_.stream_info_, code, body, content_type);
+              },
+              [&](ResponseHeaderMapPtr&& response_headers, bool end_stream) -> void {
+                parent_.response_headers_ = std::move(response_headers);
+                parent_.callbacks_.finalizeHeaders(*parent_.response_headers_, end_stream);
+              },
+              [&](Buffer::Instance& data, bool end_stream) -> void {
+                parent_.encodeDataInternal(data, end_stream);
+              }},
+          Utility::LocalReplyData{Grpc::Common::hasGrpcContentType(*parent_.request_headers_),
+                                  Http::Code::InternalServerError,
+                                  CodeUtility::toString(Http::Code::InternalServerError),
+                                  absl::nullopt, parent_.state_.is_head_request_});
+      parent_.maybeEndEncode(parent_.state_.local_complete_);
+    } else {
+      ENVOY_STREAM_LOG(
+          debug, "Resetting stream. Response data too large and headers have already been sent",
+          parent_.callbacks_);
+      resetStream();
+    }
+  }
+}
+
+void FilterManager::ActiveStreamEncoderFilter::responseDataDrained() {
+  onEncoderFilterBelowWriteBufferLowWatermark();
+}
+
+void FilterManager::ActiveStreamFilterBase::resetStream() {
+  //   parent_.connection_manager_.stats_.named_.downstream_rq_tx_reset_.inc();
+  parent_.callbacks_.endStream();
+}
+
+uint64_t FilterManager::ActiveStreamFilterBase::streamId() const { return parent_.stream_id_; }
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -40,6 +40,7 @@ void recordLatestDataFilter(const typename FilterList<T>::iterator current_filte
 }
 
 } // namespace
+
 void FilterManager::addStreamDecoderFilterWorker(StreamDecoderFilterSharedPtr filter,
                                                  bool dual_filter) {
   ActiveStreamDecoderFilterPtr wrapper(new ActiveStreamDecoderFilter(*this, filter, dual_filter));
@@ -1109,7 +1110,7 @@ void FilterManager::ActiveStreamDecoderFilter::requestDataTooLarge() {
   if (parent_.state_.decoder_filters_streaming_) {
     onDecoderFilterAboveWriteBufferHighWatermark();
   } else {
-    // parent_.connection_manager_.stats_.named_.downstream_rq_too_large_.inc();
+    parent_.callbacks_.onDownstreamRequestTooLarge();
     sendLocalReply(Code::PayloadTooLarge, CodeUtility::toString(Code::PayloadTooLarge), nullptr,
                    absl::nullopt, StreamInfo::ResponseCodeDetails::get().RequestPayloadTooLarge);
   }
@@ -1223,7 +1224,7 @@ void FilterManager::ActiveStreamEncoderFilter::responseDataTooLarge() {
   if (parent_.state_.encoder_filters_streaming_) {
     onEncoderFilterAboveWriteBufferHighWatermark();
   } else {
-    // parent_.connection_manager_.stats_.named_.rs_too_large_.inc();
+    parent_.callbacks_.onResponseDataTooLarge();
 
     // If headers have not been sent to the user, send a 500.
     if (!headers_continued_) {
@@ -1270,7 +1271,7 @@ void FilterManager::ActiveStreamEncoderFilter::responseDataDrained() {
 }
 
 void FilterManager::ActiveStreamFilterBase::resetStream() {
-  //   parent_.connection_manager_.stats_.named_.downstream_rq_tx_reset_.inc();
+  parent_.callbacks_.onStreamReset();
   parent_.callbacks_.endStream();
 }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -51,6 +51,9 @@ public:
   virtual absl::optional<Router::ConfigConstSharedPtr> routeConfig() PURE;
   virtual void onFilterAboveWriteBufferHighWatermark() PURE;
   virtual void onFilterBelowWriteBufferLowWatermark() PURE;
+  virtual void onResponseDataTooLarge() PURE;
+  virtual void onStreamReset() PURE;
+  virtual void onDownstreamRequestTooLarge() PURE;
 };
 
 // Manages an iteration of a set of HTTP decoder/encoder filters.

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -51,6 +51,8 @@ public:
                            Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) PURE;
 
   virtual absl::optional<Router::ConfigConstSharedPtr> routeConfig() PURE;
+  virtual void onFilterAboveWriteBufferHighWatermark() PURE;
+  virtual void onFilterBelowWriteBufferLowWatermark() PURE;
 };
 
 // Manages an iteration of a set of HTTP decoder/encoder filters.

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -4,15 +4,6 @@
 
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/scope_tracker.h"
-#include "envoy/http/filter.h"
-
-#include "common/buffer/watermark_buffer.h"
-#include "common/common/dump_state_utils.h"
-#include "common/common/linked_object.h"
-#include "common/grpc/common.h"
-#include "common/local_reply/local_reply.h"
-#include "common/stream_info/stream_info_impl.h"
-
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/codec.h"
@@ -20,6 +11,13 @@
 #include "envoy/http/header_map.h"
 #include "envoy/stream_info/filter_state.h"
 #include "envoy/stream_info/stream_info.h"
+
+#include "common/buffer/watermark_buffer.h"
+#include "common/common/dump_state_utils.h"
+#include "common/common/linked_object.h"
+#include "common/grpc/common.h"
+#include "common/local_reply/local_reply.h"
+#include "common/stream_info/stream_info_impl.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -70,12 +70,6 @@ public:
         proxy_100_continue_(proxy_100_continue) {}
 
   ~FilterManager() {
-    // TODO(snowp): Add all these access loggers to access_log_handlers_
-    // for (const AccessLog::InstanceSharedPtr& access_log :
-    //      connection_manager_.config_.accessLogs()) {
-    //   access_log->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
-    //                   stream_info_);
-    // }
     for (const auto& log_handler : access_log_handlers_) {
       log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
                        stream_info_);
@@ -721,8 +715,9 @@ private:
 public:
   const std::string* decorated_operation_{nullptr};
 
-private:
   StreamInfo::StreamInfoImpl stream_info_;
+
+private:
   FilterManagerCallbacks& callbacks_;
 
 public:

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -1,0 +1,744 @@
+#pragma once
+
+#include <cstdint>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/scope_tracker.h"
+#include "envoy/http/filter.h"
+
+#include "common/buffer/watermark_buffer.h"
+#include "common/common/dump_state_utils.h"
+#include "common/common/linked_object.h"
+#include "common/grpc/common.h"
+#include "common/local_reply/local_reply.h"
+#include "common/stream_info/stream_info_impl.h"
+
+#include "envoy/common/time.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/http/codec.h"
+#include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
+#include "envoy/stream_info/filter_state.h"
+#include "envoy/stream_info/stream_info.h"
+
+namespace Envoy {
+namespace Http {
+
+class FilterManagerCallbacks {
+public:
+  virtual ~FilterManagerCallbacks() = default;
+
+  virtual void onSpanFinalized(Tracing::Span& span, Http::RequestHeaderMap* request_headers,
+                               Http::ResponseHeaderMap* response_headers,
+                               Http::ResponseTrailerMap* response_trailers) PURE;
+
+  virtual const Network::Connection* connection() const PURE;
+  virtual uint64_t streamId() const PURE;
+  virtual void refreshIdleTimeout() PURE;
+  virtual void finalizeHeaders(Http::ResponseHeaderMap& response_headers, bool end_stream) PURE;
+  virtual void finalize100ContinueHeaders(Http::ResponseHeaderMap& response_headers) PURE;
+  virtual absl::optional<Router::RouteConstSharedPtr> cachedRoute() PURE;
+  virtual void upgradeFilterChainCreated() PURE;
+  virtual void endStream() PURE;
+  virtual Tracing::Config& tracingConfig() PURE;
+  virtual absl::optional<Upstream::ClusterInfoConstSharedPtr> cachedClusterInfo() PURE;
+  virtual void refreshCachedRoute() PURE;
+  virtual void refreshCachedRoute(const Router::RouteCallback& cb) PURE;
+  virtual void clearRouteCache() PURE;
+  virtual void recreateStream(RequestHeaderMapPtr request_headers) PURE;
+  virtual void
+  requestRouteConfigUpdate(Event::Dispatcher& dispatcher,
+                           Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) PURE;
+
+  virtual absl::optional<Router::ConfigConstSharedPtr> routeConfig() PURE;
+};
+
+// Manages an iteration of a set of HTTP decoder/encoder filters.
+class FilterManager : public FilterChainFactoryCallbacks,
+                      public ScopeTrackedObject,
+                      Logger::Loggable<Logger::Id::http> {
+public:
+  FilterManager(uint64_t stream_id, Http::Protocol protocol, TimeSource& time_source,
+                StreamInfo::FilterStateSharedPtr parent_filter_state,
+                FilterManagerCallbacks& callbacks, const LocalReply::LocalReply& local_reply,
+                FilterChainFactory& filter_chain_factory, Event::Dispatcher& dispatcher,
+                bool proxy_100_continue)
+      : stream_id_(stream_id), stream_info_(protocol, time_source, parent_filter_state,
+                                            StreamInfo::FilterState::LifeSpan::Connection),
+        callbacks_(callbacks), local_reply_(local_reply),
+        filter_chain_factory_(filter_chain_factory), dispatcher_(dispatcher),
+        proxy_100_continue_(proxy_100_continue) {}
+
+  ~FilterManager() {
+    // TODO(snowp): Add all these access loggers to access_log_handlers_
+    // for (const AccessLog::InstanceSharedPtr& access_log :
+    //      connection_manager_.config_.accessLogs()) {
+    //   access_log->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
+    //                   stream_info_);
+    // }
+    for (const auto& log_handler : access_log_handlers_) {
+      log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
+                       stream_info_);
+    }
+
+    if (active_span_) {
+      callbacks_.onSpanFinalized(*active_span_, request_headers_.get(), response_headers_.get(),
+                                 response_trailers_.get());
+    }
+
+    ASSERT(state_.filter_call_state_ == 0);
+  }
+
+  void setResponseEncoder(ResponseEncoder* response_encoder) {
+    response_encoder_ = response_encoder;
+    buffer_limit_ = response_encoder->getStream().bufferLimit();
+  }
+
+  StreamInfo::StreamInfo& streamInfo() { return stream_info_; }
+
+  void traceRequest(Tracing::SpanPtr span, Tracing::OperationName operation_name,
+                    absl::optional<Router::RouteConstSharedPtr> route) {
+    active_span_ = std::move(span);
+    if (!active_span_) {
+      return;
+    }
+
+    // TODO: Need to investigate the following code based on the cached route, as may
+    // be broken in the case a filter changes the route.
+
+    // If a decorator has been defined, apply it to the active span.
+    if (route.has_value() && route.value()->decorator()) {
+      const Router::Decorator* decorator = route.value()->decorator();
+
+      decorator->apply(*active_span_);
+
+      state_.decorated_propagate_ = decorator->propagate();
+
+      // Cache decorated operation.
+      if (!decorator->getOperation().empty()) {
+        decorated_operation_ = &decorator->getOperation();
+      }
+    }
+
+    if (operation_name == Tracing::OperationName::Egress) {
+      // For egress (outbound) requests, pass the decorator's operation name (if defined and
+      // propagation enabled) as a request header to enable the receiving service to use it in its
+      // server span.
+      if (decorated_operation_ && state_.decorated_propagate_) {
+        request_headers_->setEnvoyDecoratorOperation(*decorated_operation_);
+      }
+    } else {
+      const HeaderEntry* req_operation_override = request_headers_->EnvoyDecoratorOperation();
+
+      // For ingress (inbound) requests, if a decorator operation name has been provided, it
+      // should be used to override the active span's operation.
+      if (req_operation_override) {
+        if (!req_operation_override->value().empty()) {
+          active_span_->setOperation(req_operation_override->value().getStringView());
+
+          // Clear the decorated operation so won't be used in the response header, as
+          // it has been overridden by the inbound decorator operation request header.
+          decorated_operation_ = nullptr;
+        }
+        // Remove header so not propagated to service
+        request_headers_->removeEnvoyDecoratorOperation();
+      }
+    }
+  }
+
+  bool maybeEndStream() {
+    bool reset_stream = false;
+    // If the response encoder is still associated with the stream, reset the stream. The exception
+    // here is when Envoy "ends" the stream by calling recreateStream at which point recreateStream
+    // explicitly nulls out response_encoder to avoid the downstream being notified of the
+    // Envoy-internal stream instance being ended.
+    if (response_encoder_ != nullptr &&
+        (!state_.remote_complete_ || !state_.codec_saw_local_complete_)) {
+      // Indicate local is complete at this point so that if we reset during a continuation, we
+      // don't raise further data or trailers.
+      state_.local_complete_ = true;
+      state_.codec_saw_local_complete_ = true;
+      reset_stream = true;
+    }
+
+    return reset_stream;
+  }
+
+  void doDeferredStreamDestroy() {
+    state_.destroyed_ = true;
+
+    for (auto& filter : decoder_filters_) {
+      filter->handle_->onDestroy();
+    }
+
+    for (auto& filter : encoder_filters_) {
+      // Do not call on destroy twice for dual registered filters.
+      if (!filter->dual_filter_) {
+        filter->handle_->onDestroy();
+      }
+    }
+
+    disarmRequestTimeout();
+  }
+
+  void addStreamDecoderFilterWorker(StreamDecoderFilterSharedPtr filter, bool dual_filter);
+  void addStreamEncoderFilterWorker(StreamEncoderFilterSharedPtr filter, bool dual_filter);
+
+  // Http::FilterChainFactoryCallbacks
+  void addStreamDecoderFilter(StreamDecoderFilterSharedPtr filter) override {
+    addStreamDecoderFilterWorker(filter, false);
+  }
+  void addStreamEncoderFilter(StreamEncoderFilterSharedPtr filter) override {
+    addStreamEncoderFilterWorker(filter, false);
+  }
+  void addStreamFilter(StreamFilterSharedPtr filter) override {
+    addStreamDecoderFilterWorker(filter, true);
+    addStreamEncoderFilterWorker(filter, true);
+  }
+  void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) override;
+
+  // ScopeTrackedObject
+  void dumpState(std::ostream& os, int indent_level = 0) const override {
+    const char* spaces = spacesForLevel(indent_level);
+    os << spaces << "ActiveStream " << this << DUMP_MEMBER(stream_id_)
+       << DUMP_MEMBER(state_.has_continue_headers_) << DUMP_MEMBER(state_.is_head_request_)
+       << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_)
+       << "\n";
+
+    DUMP_DETAILS(request_headers_);
+    DUMP_DETAILS(request_trailers_);
+    DUMP_DETAILS(response_headers_);
+    DUMP_DETAILS(response_trailers_);
+    DUMP_DETAILS(&stream_info_);
+  }
+
+  void decodeHeaders(bool end_stream) { decodeHeaders(nullptr, *request_headers_, end_stream); }
+  void decodeData(Buffer::Instance& data, bool end_stream) {
+    decodeData(nullptr, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
+  }
+  void decodeMetadata(MetadataMap& metadata_map) { decodeMetadata(nullptr, metadata_map); }
+  void decodeTrailers() { decodeTrailers(nullptr, *request_trailers_); }
+
+  // Pass on watermark callbacks to watermark subscribers. This boils down to passing watermark
+  // events for this stream and the downstream connection to the router filter.
+  void callHighWatermarkCallbacks();
+  void callLowWatermarkCallbacks();
+
+private:
+  /**
+   * Base class wrapper for both stream encoder and decoder filters.
+   */
+  struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks {
+    ActiveStreamFilterBase(FilterManager& parent, bool dual_filter)
+        : parent_(parent), iteration_state_(IterationState::Continue),
+          iterate_from_current_filter_(false), headers_continued_(false),
+          continue_headers_continued_(false), end_stream_(false), dual_filter_(dual_filter),
+          decode_headers_called_(false), encode_headers_called_(false) {}
+
+    // Functions in the following block are called after the filter finishes processing
+    // corresponding data. Those functions handle state updates and data storage (if needed)
+    // according to the status returned by filter's callback functions.
+    bool commonHandleAfter100ContinueHeadersCallback(FilterHeadersStatus status);
+    bool commonHandleAfterHeadersCallback(FilterHeadersStatus status, bool& headers_only);
+    bool commonHandleAfterDataCallback(FilterDataStatus status, Buffer::Instance& provided_data,
+                                       bool& buffer_was_streaming);
+    bool commonHandleAfterTrailersCallback(FilterTrailersStatus status);
+
+    // Buffers provided_data.
+    void commonHandleBufferData(Buffer::Instance& provided_data);
+
+    // If iteration has stopped for all frame types, calls this function to buffer the data before
+    // the filter processes data. The function also updates streaming state.
+    void commonBufferDataIfStopAll(Buffer::Instance& provided_data, bool& buffer_was_streaming);
+
+    void commonContinue();
+    virtual bool canContinue() PURE;
+    virtual Buffer::WatermarkBufferPtr createBuffer() PURE;
+    virtual Buffer::WatermarkBufferPtr& bufferedData() PURE;
+    virtual bool complete() PURE;
+    virtual bool has100Continueheaders() PURE;
+    virtual void do100ContinueHeaders() PURE;
+    virtual void doHeaders(bool end_stream) PURE;
+    virtual void doData(bool end_stream) PURE;
+    virtual void doTrailers() PURE;
+    virtual bool hasTrailers() PURE;
+    virtual void doMetadata() PURE;
+    // TODO(soya3129): make this pure when adding impl to encoder filter.
+    virtual void handleMetadataAfterHeadersCallback() PURE;
+
+    // Http::StreamFilterCallbacks
+    const Network::Connection* connection() override;
+    Event::Dispatcher& dispatcher() override;
+    void resetStream() override;
+    Router::RouteConstSharedPtr route() override;
+    Router::RouteConstSharedPtr route(const Router::RouteCallback& cb) override;
+    Upstream::ClusterInfoConstSharedPtr clusterInfo() override;
+    void clearRouteCache() override;
+    uint64_t streamId() const override;
+    StreamInfo::StreamInfo& streamInfo() override;
+    Tracing::Span& activeSpan() override;
+    Tracing::Config& tracingConfig() override;
+    const ScopeTrackedObject& scope() override { return parent_; }
+
+    // Functions to set or get iteration state.
+    bool canIterate() { return iteration_state_ == IterationState::Continue; }
+    bool stoppedAll() {
+      return iteration_state_ == IterationState::StopAllBuffer ||
+             iteration_state_ == IterationState::StopAllWatermark;
+    }
+    void allowIteration() {
+      ASSERT(iteration_state_ != IterationState::Continue);
+      iteration_state_ = IterationState::Continue;
+    }
+    MetadataMapVector* getSavedRequestMetadata() {
+      if (saved_request_metadata_ == nullptr) {
+        saved_request_metadata_ = std::make_unique<MetadataMapVector>();
+      }
+      return saved_request_metadata_.get();
+    }
+    MetadataMapVector* getSavedResponseMetadata() {
+      if (saved_response_metadata_ == nullptr) {
+        saved_response_metadata_ = std::make_unique<MetadataMapVector>();
+      }
+      return saved_response_metadata_.get();
+    }
+
+    // A vector to save metadata when the current filter's [de|en]codeMetadata() can not be called,
+    // either because [de|en]codeHeaders() of the current filter returns StopAllIteration or because
+    // [de|en]codeHeaders() adds new metadata to [de|en]code, but we don't know
+    // [de|en]codeHeaders()'s return value yet. The storage is created on demand.
+    std::unique_ptr<MetadataMapVector> saved_request_metadata_{nullptr};
+    std::unique_ptr<MetadataMapVector> saved_response_metadata_{nullptr};
+    // The state of iteration.
+    enum class IterationState {
+      Continue,            // Iteration has not stopped for any frame type.
+      StopSingleIteration, // Iteration has stopped for headers, 100-continue, or data.
+      StopAllBuffer,       // Iteration has stopped for all frame types, and following data should
+                           // be buffered.
+      StopAllWatermark,    // Iteration has stopped for all frame types, and following data should
+                           // be buffered until high watermark is reached.
+    };
+    FilterManager& parent_;
+    IterationState iteration_state_;
+    // If the filter resumes iteration from a StopAllBuffer/Watermark state, the current filter
+    // hasn't parsed data and trailers. As a result, the filter iteration should start with the
+    // current filter instead of the next one. If true, filter iteration starts with the current
+    // filter. Otherwise, starts with the next filter in the chain.
+    bool iterate_from_current_filter_ : 1;
+    bool headers_continued_ : 1;
+    bool continue_headers_continued_ : 1;
+    // If true, end_stream is called for this filter.
+    bool end_stream_ : 1;
+    const bool dual_filter_ : 1;
+    bool decode_headers_called_ : 1;
+    bool encode_headers_called_ : 1;
+  };
+
+  // Indicates which filter to start the iteration with.
+  enum class FilterIterationStartState { AlwaysStartFromNext, CanStartFromCurrent };
+
+  /**
+   * Wrapper for a stream decoder filter.
+   */
+  struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
+                                     public StreamDecoderFilterCallbacks,
+                                     LinkedObject<ActiveStreamDecoderFilter> {
+    ActiveStreamDecoderFilter(FilterManager& parent, StreamDecoderFilterSharedPtr filter,
+                              bool dual_filter)
+        : ActiveStreamFilterBase(parent, dual_filter), handle_(filter) {}
+
+    // ActiveStreamFilterBase
+    bool canContinue() override {
+      // It is possible for the connection manager to respond directly to a request even while
+      // a filter is trying to continue. If a response has already happened, we should not
+      // continue to further filters. A concrete example of this is a filter buffering data, the
+      // last data frame comes in and the filter continues, but the final buffering takes the stream
+      // over the high watermark such that a 413 is returned.
+      return !parent_.state_.local_complete_;
+    }
+    Buffer::WatermarkBufferPtr createBuffer() override;
+    Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_request_data_; }
+    bool complete() override { return parent_.state_.remote_complete_; }
+    bool has100Continueheaders() override { return false; }
+    void do100ContinueHeaders() override { NOT_REACHED_GCOVR_EXCL_LINE; }
+    void doHeaders(bool end_stream) override {
+      parent_.decodeHeaders(this, *parent_.request_headers_, end_stream);
+    }
+    void doData(bool end_stream) override {
+      parent_.decodeData(this, *parent_.buffered_request_data_, end_stream,
+                         FilterIterationStartState::CanStartFromCurrent);
+    }
+    void doMetadata() override {
+      if (saved_request_metadata_ != nullptr) {
+        drainSavedRequestMetadata();
+      }
+    }
+    void doTrailers() override { parent_.decodeTrailers(this, *parent_.request_trailers_); }
+    bool hasTrailers() override { return parent_.request_trailers_ != nullptr; }
+
+    void drainSavedRequestMetadata() {
+      ASSERT(saved_request_metadata_ != nullptr);
+      for (auto& metadata_map : *getSavedRequestMetadata()) {
+        parent_.decodeMetadata(this, *metadata_map);
+      }
+      getSavedRequestMetadata()->clear();
+    }
+    // This function is called after the filter calls decodeHeaders() to drain accumulated metadata.
+    void handleMetadataAfterHeadersCallback() override;
+
+    // Http::StreamDecoderFilterCallbacks
+    void addDecodedData(Buffer::Instance& data, bool streaming) override;
+    void injectDecodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
+    RequestTrailerMap& addDecodedTrailers() override;
+    MetadataMapVector& addDecodedMetadata() override;
+    void continueDecoding() override;
+    const Buffer::Instance* decodingBuffer() override {
+      return parent_.buffered_request_data_.get();
+    }
+
+    void modifyDecodingBuffer(std::function<void(Buffer::Instance&)> callback) override {
+      ASSERT(parent_.state_.latest_data_decoding_filter_ == this);
+      callback(*parent_.buffered_request_data_.get());
+    }
+
+    void sendLocalReply(Code code, absl::string_view body,
+                        std::function<void(ResponseHeaderMap& headers)> modify_headers,
+                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                        absl::string_view details) override {
+      parent_.stream_info_.setResponseCodeDetails(details);
+      parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers,
+                             parent_.state_.is_head_request_, grpc_status, details);
+    }
+    void encode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override;
+    void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
+    void encodeData(Buffer::Instance& data, bool end_stream) override;
+    void encodeTrailers(ResponseTrailerMapPtr&& trailers) override;
+    void encodeMetadata(MetadataMapPtr&& metadata_map_ptr) override;
+    void onDecoderFilterAboveWriteBufferHighWatermark() override;
+    void onDecoderFilterBelowWriteBufferLowWatermark() override;
+    void
+    addDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
+    void
+    removeDownstreamWatermarkCallbacks(DownstreamWatermarkCallbacks& watermark_callbacks) override;
+    void setDecoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
+    uint32_t decoderBufferLimit() override { return parent_.buffer_limit_; }
+    bool recreateStream() override;
+
+    void addUpstreamSocketOptions(const Network::Socket::OptionsSharedPtr& options) override {
+      Network::Socket::appendOptions(parent_.upstream_options_, options);
+    }
+
+    Network::Socket::OptionsSharedPtr getUpstreamSocketOptions() const override {
+      return parent_.upstream_options_;
+    }
+
+    // Each decoder filter instance checks if the request passed to the filter is gRPC
+    // so that we can issue gRPC local responses to gRPC requests. Filter's decodeHeaders()
+    // called here may change the content type, so we must check it before the call.
+    FilterHeadersStatus decodeHeaders(RequestHeaderMap& headers, bool end_stream) {
+      is_grpc_request_ = Grpc::Common::isGrpcRequestHeaders(headers);
+      FilterHeadersStatus status = handle_->decodeHeaders(headers, end_stream);
+      if (end_stream) {
+        handle_->decodeComplete();
+      }
+      return status;
+    }
+
+    void requestDataTooLarge();
+    void requestDataDrained();
+
+    void requestRouteConfigUpdate(
+        Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) override;
+    absl::optional<Router::ConfigConstSharedPtr> routeConfig() override;
+
+    StreamDecoderFilterSharedPtr handle_;
+    bool is_grpc_request_{};
+  };
+
+  using ActiveStreamDecoderFilterPtr = std::unique_ptr<ActiveStreamDecoderFilter>;
+
+  /**
+   * Wrapper for a stream encoder filter.
+   */
+  struct ActiveStreamEncoderFilter : public ActiveStreamFilterBase,
+                                     public StreamEncoderFilterCallbacks,
+                                     LinkedObject<ActiveStreamEncoderFilter> {
+    ActiveStreamEncoderFilter(FilterManager& parent, StreamEncoderFilterSharedPtr filter,
+                              bool dual_filter)
+        : ActiveStreamFilterBase(parent, dual_filter), handle_(filter) {}
+
+    // ActiveStreamFilterBase
+    bool canContinue() override { return true; }
+    Buffer::WatermarkBufferPtr createBuffer() override;
+    Buffer::WatermarkBufferPtr& bufferedData() override { return parent_.buffered_response_data_; }
+    bool complete() override { return parent_.state_.local_complete_; }
+    bool has100Continueheaders() override {
+      return parent_.state_.has_continue_headers_ && !continue_headers_continued_;
+    }
+    void do100ContinueHeaders() override {
+      parent_.encode100ContinueHeaders(this, *parent_.continue_headers_);
+    }
+    void doHeaders(bool end_stream) override {
+      parent_.encodeHeaders(this, *parent_.response_headers_, end_stream);
+    }
+    void doData(bool end_stream) override {
+      parent_.encodeData(this, *parent_.buffered_response_data_, end_stream,
+                         FilterIterationStartState::CanStartFromCurrent);
+    }
+    void drainSavedResponseMetadata() {
+      ASSERT(saved_response_metadata_ != nullptr);
+      for (auto& metadata_map : *getSavedResponseMetadata()) {
+        parent_.encodeMetadata(this, std::move(metadata_map));
+      }
+      getSavedResponseMetadata()->clear();
+    }
+    void handleMetadataAfterHeadersCallback() override;
+
+    void doMetadata() override {
+      if (saved_response_metadata_ != nullptr) {
+        drainSavedResponseMetadata();
+      }
+    }
+    void doTrailers() override { parent_.encodeTrailers(this, *parent_.response_trailers_); }
+    bool hasTrailers() override { return parent_.response_trailers_ != nullptr; }
+
+    // Http::StreamEncoderFilterCallbacks
+    void addEncodedData(Buffer::Instance& data, bool streaming) override;
+    void injectEncodedDataToFilterChain(Buffer::Instance& data, bool end_stream) override;
+    ResponseTrailerMap& addEncodedTrailers() override;
+    void addEncodedMetadata(MetadataMapPtr&& metadata_map) override;
+    void onEncoderFilterAboveWriteBufferHighWatermark() override;
+    void onEncoderFilterBelowWriteBufferLowWatermark() override;
+    void setEncoderBufferLimit(uint32_t limit) override { parent_.setBufferLimit(limit); }
+    uint32_t encoderBufferLimit() override { return parent_.buffer_limit_; }
+    void continueEncoding() override;
+    const Buffer::Instance* encodingBuffer() override {
+      return parent_.buffered_response_data_.get();
+    }
+    void modifyEncodingBuffer(std::function<void(Buffer::Instance&)> callback) override {
+      ASSERT(parent_.state_.latest_data_encoding_filter_ == this);
+      callback(*parent_.buffered_response_data_.get());
+    }
+    Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override {
+      // TODO(mattklein123): At some point we might want to actually wrap this interface but for now
+      // we give the filter direct access to the encoder options.
+      return parent_.response_encoder_->http1StreamEncoderOptions();
+    }
+
+    void responseDataTooLarge();
+    void responseDataDrained();
+
+    StreamEncoderFilterSharedPtr handle_;
+  };
+
+  using ActiveStreamEncoderFilterPtr = std::unique_ptr<ActiveStreamEncoderFilter>;
+
+  // Helper function for the case where we have a header only request, but a filter adds a body
+  // to it.
+  void maybeContinueDecoding(
+      const std::list<ActiveStreamDecoderFilterPtr>::iterator& maybe_continue_data_entry);
+  void decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHeaderMap& headers, bool end_stream);
+  // Sends data through decoding filter chains. filter_iteration_start_state indicates which
+  // filter to start the iteration with.
+  void decodeData(ActiveStreamDecoderFilter* filter, Buffer::Instance& data, bool end_stream,
+                  FilterIterationStartState filter_iteration_start_state);
+  void decodeTrailers(ActiveStreamDecoderFilter* filter, RequestTrailerMap& trailers);
+  void decodeMetadata(ActiveStreamDecoderFilter* filter, MetadataMap& metadata_map);
+
+public:
+  void maybeEndDecode(bool end_stream);
+
+private:
+  void addEncodedData(ActiveStreamEncoderFilter& filter, Buffer::Instance& data, bool streaming);
+  ResponseTrailerMap& addEncodedTrailers();
+
+  void encode100ContinueHeaders(ActiveStreamEncoderFilter* filter, ResponseHeaderMap& headers);
+  // As with most of the encode functions, this runs encodeHeaders on various
+  // filters before calling encodeHeadersInternal which does final header munging and passes the
+  // headers to the encoder.
+  void maybeContinueEncoding(
+      const std::list<ActiveStreamEncoderFilterPtr>::iterator& maybe_continue_data_entry);
+  void encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHeaderMap& headers,
+                     bool end_stream);
+  // Sends data through encoding filter chains. filter_iteration_start_state indicates which
+  // filter to start the iteration with, and finally calls encodeDataInternal
+  // to update stats, do end stream bookkeeping, and send the data to encoder.
+  void encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instance& data, bool end_stream,
+                  FilterIterationStartState filter_iteration_start_state);
+  void encodeTrailers(ActiveStreamEncoderFilter* filter, ResponseTrailerMap& trailers);
+  void encodeMetadata(ActiveStreamEncoderFilter* filter, MetadataMapPtr&& metadata_map_ptr);
+
+  // This is a helper function for encodeData and responseDataTooLarge which allows for shared
+  // code for the two data encoding paths. It does stats updates and tracks potential end of
+  // stream.
+  void encodeDataInternal(Buffer::Instance& data, bool end_stream);
+
+public:
+  void maybeEndEncode(bool end_stream);
+
+  void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
+                      const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
+                      bool is_head_request,
+                      const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                      absl::string_view details);
+
+private:
+  void addDecodedData(ActiveStreamDecoderFilter& filter, Buffer::Instance& data, bool streaming);
+  RequestTrailerMap& addDecodedTrailers();
+  MetadataMapVector& addDecodedMetadata();
+
+  // Returns true if filter has stopped iteration for all frame types. Otherwise, returns false.
+  // filter_streaming is the variable to indicate if stream is streaming, and its value may be
+  // changed by the function.
+  bool handleDataIfStopAll(ActiveStreamFilterBase& filter, Buffer::Instance& data,
+                           bool& filter_streaming);
+
+  // Returns the encoder filter to start iteration with.
+  std::list<ActiveStreamEncoderFilterPtr>::iterator
+  commonEncodePrefix(ActiveStreamEncoderFilter* filter, bool end_stream,
+                     FilterIterationStartState filter_iteration_start_state);
+  // Returns the decoder filter to start iteration with.
+  std::list<ActiveStreamDecoderFilterPtr>::iterator
+  commonDecodePrefix(ActiveStreamDecoderFilter* filter,
+                     FilterIterationStartState filter_iteration_start_state);
+  // Possibly increases buffer_limit_ to the value of limit.
+  void setBufferLimit(uint32_t limit);
+
+public:
+  // Set up the Encoder/Decoder filter chain.
+  bool createFilterChain();
+
+private:
+  MetadataMapVector* getRequestMetadataMapVector() {
+    if (request_metadata_map_vector_ == nullptr) {
+      request_metadata_map_vector_ = std::make_unique<MetadataMapVector>();
+    }
+    return request_metadata_map_vector_.get();
+  }
+
+  // Returns true if new metadata is decoded. Otherwise, returns false.
+  bool processNewlyAddedMetadata();
+
+  void disarmRequestTimeout();
+
+  /**
+   * Flags that keep track of which filter calls are currently in progress.
+   */
+  // clang-format off
+    struct FilterCallState {
+      static constexpr uint32_t DecodeHeaders   = 0x01;
+      static constexpr uint32_t DecodeData      = 0x02;
+      static constexpr uint32_t DecodeTrailers  = 0x04;
+      static constexpr uint32_t EncodeHeaders   = 0x08;
+      static constexpr uint32_t EncodeData      = 0x10;
+      static constexpr uint32_t EncodeTrailers  = 0x20;
+      // Encode100ContinueHeaders is a bit of a special state as 100 continue
+      // headers may be sent during request processing. This state is only used
+      // to verify we do not encode100Continue headers more than once per
+      // filter.
+      static constexpr uint32_t Encode100ContinueHeaders  = 0x40;
+      // Used to indicate that we're processing the final [En|De]codeData frame,
+      // i.e. end_stream = true
+      static constexpr uint32_t LastDataFrame = 0x80;
+    };
+  // clang-format on
+
+  // All state for the filter iteration. Put here for readability.
+  struct State {
+    State()
+        : created_filter_chain_(false), successful_upgrade_(false), is_head_request_(false),
+          has_continue_headers_(false), codec_saw_local_complete_(false), remote_complete_(false),
+          local_complete_(false), decorated_propagate_(false) {}
+
+    uint32_t filter_call_state_{0};
+    bool created_filter_chain_ : 1;
+    bool successful_upgrade_ : 1;
+    bool is_head_request_ : 1;
+    // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
+    // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
+    bool has_continue_headers_ : 1;
+    // Whether a filter has indicated that the request should be treated as a headers only
+    // request.
+    bool decoding_headers_only_{false};
+    // Whether a filter has indicated that the response should be treated as a headers only
+    // response.
+    bool encoding_headers_only_{false};
+
+    bool codec_saw_local_complete_ : 1; // This indicates that local is complete as written all
+                                        // the way through to the codec.
+    bool remote_complete_ : 1;
+    bool local_complete_ : 1; // This indicates that local is complete prior to filter processing.
+                              // A filter can still stop the stream from being complete as seen
+                              // by the codec.
+
+    bool decorated_propagate_ : 1;
+    bool encoder_filters_streaming_{true};
+    bool decoder_filters_streaming_{true};
+    bool destroyed_{false};
+
+    // Used to track which filter is the latest filter that has received data.
+    ActiveStreamEncoderFilter* latest_data_encoding_filter_{};
+    ActiveStreamDecoderFilter* latest_data_decoding_filter_{};
+  };
+
+  // Stores metadata added in the decoding filter that is being processed. Will be cleared before
+  // processing the next filter. The storage is created on demand. We need to store metadata
+  // temporarily in the filter in case the filter has stopped all while processing headers.
+  std::unique_ptr<MetadataMapVector> request_metadata_map_vector_{nullptr};
+  uint32_t buffer_limit_{0};
+  Network::Socket::OptionsSharedPtr upstream_options_;
+  ResponseEncoder* response_encoder_{};
+
+public:
+  State state_{};
+
+private:
+  const uint_fast64_t stream_id_;
+  ResponseHeaderMapPtr continue_headers_;
+
+public:
+  ResponseHeaderMapPtr response_headers_;
+
+private:
+  Buffer::WatermarkBufferPtr buffered_response_data_;
+  ResponseTrailerMapPtr response_trailers_{};
+
+public:
+  RequestHeaderMapPtr request_headers_;
+
+private:
+  Buffer::WatermarkBufferPtr buffered_request_data_;
+
+public:
+  RequestTrailerMapPtr request_trailers_;
+  Tracing::SpanPtr active_span_;
+
+private:
+  std::list<ActiveStreamDecoderFilterPtr> decoder_filters_;
+  std::list<ActiveStreamEncoderFilterPtr> encoder_filters_;
+  std::list<AccessLog::InstanceSharedPtr> access_log_handlers_;
+
+public:
+  const std::string* decorated_operation_{nullptr};
+
+private:
+  StreamInfo::StreamInfoImpl stream_info_;
+  FilterManagerCallbacks& callbacks_;
+
+public:
+  // Per-stream request timeout.
+  Event::TimerPtr request_timer_;
+  const LocalReply::LocalReply& local_reply_;
+  FilterChainFactory& filter_chain_factory_;
+  Event::Dispatcher& dispatcher_;
+
+public:
+  uint32_t high_watermark_count_{0};
+
+private:
+  std::list<DownstreamWatermarkCallbacks*> watermark_callbacks_{};
+  const bool proxy_100_continue_;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bits/stdint-uintn.h>
+
 #include <chrono>
 #include <cstdint>
 
@@ -7,6 +9,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/http/header_map.h"
 #include "envoy/http/request_id_extension.h"
+#include "envoy/router/router.h"
 #include "envoy/stream_info/stream_info.h"
 
 #include "common/common/assert.h"
@@ -111,6 +114,7 @@ struct StreamInfoImpl : public StreamInfo {
 
   void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
 
+  void setResponseCode(uint32_t code) override { response_code_ = code; }
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
 
   const absl::optional<std::string>& responseCodeDetails() const override {
@@ -205,6 +209,8 @@ struct StreamInfoImpl : public StreamInfo {
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
     return upstream_ssl_info_;
   }
+
+  void routeEntry(const Router::RouteEntry* route_entry) override { route_entry_ = route_entry; }
 
   const Router::RouteEntry* routeEntry() const override { return route_entry_; }
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <bits/stdint-uintn.h>
-
 #include <chrono>
 #include <cstdint>
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -192,11 +192,11 @@ public:
 
   void setUpBufferLimits() {
     ON_CALL(response_encoder_, getStream()).WillByDefault(ReturnRef(stream_));
+    EXPECT_CALL(stream_, bufferLimit()).WillOnce(Return(initial_buffer_limit_));
     EXPECT_CALL(stream_, addCallbacks(_))
         .WillOnce(Invoke(
             [&](Http::StreamCallbacks& callbacks) -> void { stream_callbacks_ = &callbacks; }));
     EXPECT_CALL(stream_, setFlushTimeout(_));
-    EXPECT_CALL(stream_, bufferLimit()).WillOnce(Return(initial_buffer_limit_));
   }
 
   // If request_with_data_and_trailers is true, includes data and trailers in the request. If

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -34,6 +34,7 @@ public:
   uint64_t bytesReceived() const override { return 1; }
   absl::optional<Http::Protocol> protocol() const override { return protocol_; }
   void protocol(Http::Protocol protocol) override { protocol_ = protocol; }
+  void setResponseCode(uint32_t response_code) override { response_code_ = response_code; }
   absl::optional<uint32_t> responseCode() const override { return response_code_; }
   const absl::optional<std::string>& responseCodeDetails() const override {
     return response_code_details_;
@@ -111,6 +112,7 @@ public:
   }
   const std::string& getRouteName() const override { return route_name_; }
 
+  void routeEntry(const Router::RouteEntry* route_entry) override { route_entry_ = route_entry; }
   const Router::RouteEntry* routeEntry() const override { return route_entry_; }
 
   absl::optional<std::chrono::nanoseconds>

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -49,6 +49,7 @@ public:
   MOCK_METHOD(const std::string&, getRouteName, (), (const));
   MOCK_METHOD(absl::optional<Http::Protocol>, protocol, (), (const));
   MOCK_METHOD(void, protocol, (Http::Protocol protocol));
+  MOCK_METHOD(void, setResponseCode, (uint32_t));
   MOCK_METHOD(absl::optional<uint32_t>, responseCode, (), (const));
   MOCK_METHOD(const absl::optional<std::string>&, responseCodeDetails, (), (const));
   MOCK_METHOD(void, addBytesSent, (uint64_t));
@@ -75,6 +76,7 @@ public:
   MOCK_METHOD(void, setUpstreamSslConnection, (const Ssl::ConnectionInfoConstSharedPtr&));
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, upstreamSslConnection, (), (const));
   MOCK_METHOD(const Router::RouteEntry*, routeEntry, (), (const));
+  MOCK_METHOD(void, routeEntry, (const Router::RouteEntry*), ());
   MOCK_METHOD(envoy::config::core::v3::Metadata&, dynamicMetadata, ());
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, dynamicMetadata, (), (const));
   MOCK_METHOD(void, setDynamicMetadata, (const std::string&, const ProtobufWkt::Struct&));


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <kpettersen@netflix.com>

Commit Message: Introduces a FilterManager class that manages the encoder/decoder filter iteration, making it possible to reuse the HTTP filter logic outside of the HCM.
Additional Description:
Risk Level: HIGH
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
Part of #10455