### PR TITLE
buffer: Improve Buffer::OwnedImpl::linearize implementation

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -218,32 +218,28 @@ void* OwnedImpl::linearize(uint32_t size) {
   if (slices_.empty()) {
     return nullptr;
   }
-  uint64_t linearized_size = 0;
-  uint64_t num_slices_to_linearize = 0;
-  for (const auto& slice : slices_) {
-    num_slices_to_linearize++;
-    linearized_size += slice->dataSize();
-    if (linearized_size >= size) {
-      break;
-    }
-  }
-  if (num_slices_to_linearize > 1) {
-    auto new_slice = OwnedSlice::create(linearized_size);
+  if (slices_[0]->dataSize() < size) {
+    auto new_slice = OwnedSlice::create(size);
     uint64_t bytes_copied = 0;
-    Slice::Reservation reservation = new_slice->reserve(linearized_size);
+    Slice::Reservation reservation = new_slice->reserve(size);
     ASSERT(reservation.mem_ != nullptr);
-    ASSERT(reservation.len_ == linearized_size);
+    ASSERT(reservation.len_ == size);
     auto dest = static_cast<uint8_t*>(reservation.mem_);
     do {
       uint64_t data_size = slices_.front()->dataSize();
-      if (data_size > 0) {
-        memcpy(dest, slices_.front()->data(), data_size);
-        bytes_copied += data_size;
-        dest += data_size;
+      uint64_t copy_size = std::min(data_size, size - bytes_copied);
+      if (copy_size > 0) {
+        memcpy(dest, slices_.front()->data(), copy_size);
+        bytes_copied += copy_size;
+        dest += copy_size;
       }
-      slices_.pop_front();
-    } while (bytes_copied < linearized_size);
-    ASSERT(dest == static_cast<const uint8_t*>(reservation.mem_) + linearized_size);
+
+      slices_.front()->drain(copy_size);
+      if (slices_.front()->dataSize() == 0) {
+        slices_.pop_front();
+      }
+    } while (bytes_copied < size);
+    ASSERT(dest == static_cast<const uint8_t*>(reservation.mem_) + size);
     new_slice->commit(reservation);
     slices_.emplace_front(std::move(new_slice));
   }

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -582,6 +582,7 @@ private:
   bool isSameBufferImpl(const Instance& rhs) const;
 
   void addImpl(const void* data, uint64_t size);
+  void drainImpl(uint64_t size);
 
   /**
    * Moves contents of the `other_slice` by either taking its ownership or coalescing it

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -595,22 +595,22 @@ TEST_F(OwnedImplTest, LinearizeDrainTracking) {
   testing::MockFunction<void(int, int)> drain_tracker;
   testing::MockFunction<void()> done_tracker;
   EXPECT_CALL(tracker1, Call());
+  EXPECT_CALL(drain_tracker, Call(3 * LargeChunk + 108 * SmallChunk, 16384));
   EXPECT_CALL(release_callback_tracker, Call(_, _, _));
   EXPECT_CALL(tracker2, Call());
-  EXPECT_CALL(drain_tracker, Call(3 * LargeChunk + 108 * SmallChunk, 16384));
   EXPECT_CALL(release_callback_tracker2, Call(_, _, _));
   EXPECT_CALL(tracker3, Call());
-  EXPECT_CALL(tracker4, Call());
   EXPECT_CALL(drain_tracker, Call(2 * LargeChunk + 107 * SmallChunk, 16384));
   EXPECT_CALL(drain_tracker, Call(LargeChunk + 106 * SmallChunk, 16384));
+  EXPECT_CALL(tracker4, Call());
   EXPECT_CALL(drain_tracker, Call(105 * SmallChunk, 16384));
   EXPECT_CALL(tracker5, Call());
   EXPECT_CALL(drain_tracker, Call(4616, 4616));
   EXPECT_CALL(done_tracker, Call());
-  for (auto& expected_first_slice : std::vector<std::vector<int>>{{16584, 3832, 20416},
-                                                                  {32904, 3896, 36800},
-                                                                  {16520, 3896, 36800},
-                                                                  {20296, 120, 20416},
+  for (auto& expected_first_slice : std::vector<std::vector<int>>{{16384, 4032, 20416},
+                                                                  {16384, 4032, 20416},
+                                                                  {16520, 0, 32704},
+                                                                  {16384, 4032, 20416},
                                                                   {4616, 3512, 8128}}) {
     const uint32_t write_size = std::min<uint32_t>(LinearizeSize, buffer.length());
     buffer.linearize(write_size);


### PR DESCRIPTION
Commit Message: buffer: Change the Buffer::OwnedImpl::linearize implementation so it only moves the requested number of bytes to the a flat buffer slice at the beginning of the buffer.  Linearizing beyond the requested size can result in the excess bytes needing to be copied again as part of the next linearize call if the buffer ends up with more than 1 buffer slice when the linearize operation completes.  Typical usage of linearize involves flattening the first 16kb in a buffer in a loop to construct inputs appropriate to SSL_write; the original implementation ended up copying an extra 4032 bytes when linearizing a 16KB block.
Additional Description:
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a