### PR TITLE
Use TestEnvironment::nullDevicePath instead of /dev/null/

### DIFF
--- a/test/extensions/clusters/aggregate/cluster_integration_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_integration_test.cc
@@ -29,9 +29,9 @@ const int FirstUpstreamIndex = 2;
 const int SecondUpstreamIndex = 3;
 
 const std::string& config() {
-  CONSTRUCT_ON_FIRST_USE(std::string, R"EOF(
+  CONSTRUCT_ON_FIRST_USE(std::string, fmt::format(R"EOF(
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: 127.0.0.1
@@ -47,7 +47,7 @@ dynamic_resources:
 static_resources:
   clusters:
   - name: my_cds_cluster
-    http2_protocol_options: {}
+    http2_protocol_options: {{}}
     load_assignment:
       cluster_name: my_cds_cluster
       endpoints:
@@ -108,7 +108,8 @@ static_resources:
                 match:
                   prefix: "/aggregatecluster"
               domains: "*"
-)EOF");
+)EOF",
+                                                  TestEnvironment::nullDevicePath()));
 }
 
 class AggregateIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,

--- a/test/extensions/clusters/redis/redis_cluster_integration_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_integration_test.cc
@@ -18,9 +18,9 @@ namespace {
 // in the cluster. The load balancing policy must be set
 // to random for proper test operation.
 const std::string& listenerConfig() {
-  CONSTRUCT_ON_FIRST_USE(std::string, R"EOF(
+  CONSTRUCT_ON_FIRST_USE(std::string, fmt::format(R"EOF(
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: 127.0.0.1
@@ -44,7 +44,8 @@ static_resources:
           settings:
             op_timeout: 5s
             enable_redirection: true
-)EOF");
+)EOF",
+                                                  TestEnvironment::nullDevicePath()));
 }
 
 const std::string& clusterConfig() {

--- a/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_integration_test.cc
@@ -27,6 +27,7 @@ class MySQLIntegrationTest : public testing::TestWithParam<Network::Address::IpV
   std::string mysqlConfig() {
     return fmt::format(TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
                            "test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml")),
+                       TestEnvironment::nullDevicePath(),
                        Network::Test::getLoopbackAddressString(GetParam()),
                        Network::Test::getLoopbackAddressString(GetParam()),
                        Network::Test::getAnyAddressString(GetParam()));

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_config.yaml
@@ -1,5 +1,5 @@
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: "{}"

--- a/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
@@ -19,8 +19,7 @@ class PostgresIntegrationTest : public testing::TestWithParam<Network::Address::
     return fmt::format(
         TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
             "test/extensions/filters/network/postgres_proxy/postgres_test_config.yaml")),
-        TestEnvironment::nullDevicePath(),
-        Network::Test::getLoopbackAddressString(GetParam()),
+        TestEnvironment::nullDevicePath(), Network::Test::getLoopbackAddressString(GetParam()),
         Network::Test::getLoopbackAddressString(GetParam()),
         Network::Test::getAnyAddressString(GetParam()));
   }

--- a/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_integration_test.cc
@@ -19,6 +19,7 @@ class PostgresIntegrationTest : public testing::TestWithParam<Network::Address::
     return fmt::format(
         TestEnvironment::readFileToStringForTest(TestEnvironment::runfilesPath(
             "test/extensions/filters/network/postgres_proxy/postgres_test_config.yaml")),
+        TestEnvironment::nullDevicePath(),
         Network::Test::getLoopbackAddressString(GetParam()),
         Network::Test::getLoopbackAddressString(GetParam()),
         Network::Test::getAnyAddressString(GetParam()));

--- a/test/extensions/filters/network/postgres_proxy/postgres_test_config.yaml
+++ b/test/extensions/filters/network/postgres_proxy/postgres_test_config.yaml
@@ -1,5 +1,5 @@
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: "{}"

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -63,7 +63,7 @@ static_resources:
           settings:
             op_timeout: 5s
 )EOF",
-                                                 TestEnvironment::nullDevicePath());
+                                       TestEnvironment::nullDevicePath());
 
 // This is a configuration with command stats enabled.
 const std::string CONFIG_WITH_COMMAND_STATS = CONFIG + R"EOF(
@@ -156,7 +156,7 @@ static_resources:
           settings:
             op_timeout: 5s
 )EOF",
-                                                 TestEnvironment::nullDevicePath());
+                                       TestEnvironment::nullDevicePath());
 
 const std::string CONFIG_WITH_ROUTES = CONFIG_WITH_ROUTES_BASE + R"EOF(
           prefix_routes:
@@ -277,7 +277,7 @@ static_resources:
             - prefix: "baz:"
               cluster: cluster_2
 )EOF",
-                                                 TestEnvironment::nullDevicePath());
+                                       TestEnvironment::nullDevicePath());
 
 // This is a configuration with fault injection enabled.
 const std::string CONFIG_WITH_FAULT_INJECTION = CONFIG + R"EOF(

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -156,7 +156,7 @@ static_resources:
           settings:
             op_timeout: 5s
 )EOF",
-                                       TestEnvironment::nullDevicePath());
+                                                        TestEnvironment::nullDevicePath());
 
 const std::string CONFIG_WITH_ROUTES = CONFIG_WITH_ROUTES_BASE + R"EOF(
           prefix_routes:

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -197,7 +197,8 @@ const std::string CONFIG_WITH_DOWNSTREAM_AUTH_PASSWORD_SET = CONFIG + R"EOF(
           downstream_auth_password: { inline_string: somepassword }
 )EOF";
 
-const std::string CONFIG_WITH_ROUTES_AND_AUTH_PASSWORDS = fmt::format(R"EOF(
+const std::string CONFIG_WITH_ROUTES_AND_AUTH_PASSWORDS =
+    fmt::format(R"EOF(
 admin:
   access_log_path: {}
   address:

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -212,7 +212,7 @@ static_resources:
       typed_extension_protocol_options:
         envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
-          auth_password: { inline_string: cluster_0_password }
+          auth_password: {{ inline_string: cluster_0_password }}
       lb_policy: RANDOM
       load_assignment:
         cluster_name: cluster_0
@@ -229,7 +229,7 @@ static_resources:
       typed_extension_protocol_options:
         envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
-          auth_password: { inline_string: cluster_1_password }
+          auth_password: {{ inline_string: cluster_1_password }}
       load_assignment:
         cluster_name: cluster_1
         endpoints:
@@ -244,7 +244,7 @@ static_resources:
       typed_extension_protocol_options:
         envoy.filters.network.redis_proxy:
           "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProtocolOptions
-          auth_password: { inline_string: cluster_2_password }
+          auth_password: {{ inline_string: cluster_2_password }}
       lb_policy: RANDOM
       load_assignment:
         cluster_name: cluster_2

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -63,7 +63,7 @@ static_resources:
           settings:
             op_timeout: 5s
 )EOF",
-                                       TestEnvironment::nullDevicePath());
+                                                        TestEnvironment::nullDevicePath());
 
 // This is a configuration with command stats enabled.
 const std::string CONFIG_WITH_COMMAND_STATS = CONFIG + R"EOF(
@@ -277,7 +277,7 @@ static_resources:
             - prefix: "baz:"
               cluster: cluster_2
 )EOF",
-                                       TestEnvironment::nullDevicePath());
+                TestEnvironment::nullDevicePath());
 
 // This is a configuration with fault injection enabled.
 const std::string CONFIG_WITH_FAULT_INJECTION = CONFIG + R"EOF(

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -63,7 +63,7 @@ static_resources:
           settings:
             op_timeout: 5s
 )EOF",
-                                                        TestEnvironment::nullDevicePath());
+                                       TestEnvironment::nullDevicePath());
 
 // This is a configuration with command stats enabled.
 const std::string CONFIG_WITH_COMMAND_STATS = CONFIG + R"EOF(
@@ -156,7 +156,7 @@ static_resources:
           settings:
             op_timeout: 5s
 )EOF",
-                                                        TestEnvironment::nullDevicePath());
+                                       TestEnvironment::nullDevicePath());
 
 const std::string CONFIG_WITH_ROUTES = CONFIG_WITH_ROUTES_BASE + R"EOF(
           prefix_routes:

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -19,9 +19,9 @@ namespace {
 // in the cluster. The load balancing policy must be set
 // to random for proper test operation.
 
-const std::string CONFIG = R"EOF(
+const std::string CONFIG = fmt::format(R"EOF(
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: 127.0.0.1
@@ -62,7 +62,8 @@ static_resources:
               cluster: cluster_0
           settings:
             op_timeout: 5s
-)EOF";
+)EOF",
+                                                 TestEnvironment::nullDevicePath());
 
 // This is a configuration with command stats enabled.
 const std::string CONFIG_WITH_COMMAND_STATS = CONFIG + R"EOF(
@@ -80,9 +81,9 @@ const std::string CONFIG_WITH_BATCHING = CONFIG + R"EOF(
             buffer_flush_timeout: 0.003s 
 )EOF";
 
-const std::string CONFIG_WITH_ROUTES_BASE = R"EOF(
+const std::string CONFIG_WITH_ROUTES_BASE = fmt::format(R"EOF(
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: 127.0.0.1
@@ -154,7 +155,8 @@ static_resources:
           stat_prefix: redis_stats
           settings:
             op_timeout: 5s
-)EOF";
+)EOF",
+                                                 TestEnvironment::nullDevicePath());
 
 const std::string CONFIG_WITH_ROUTES = CONFIG_WITH_ROUTES_BASE + R"EOF(
           prefix_routes:
@@ -195,9 +197,9 @@ const std::string CONFIG_WITH_DOWNSTREAM_AUTH_PASSWORD_SET = CONFIG + R"EOF(
           downstream_auth_password: { inline_string: somepassword }
 )EOF";
 
-const std::string CONFIG_WITH_ROUTES_AND_AUTH_PASSWORDS = R"EOF(
+const std::string CONFIG_WITH_ROUTES_AND_AUTH_PASSWORDS = fmt::format(R"EOF(
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: 127.0.0.1
@@ -274,7 +276,8 @@ static_resources:
               cluster: cluster_1
             - prefix: "baz:"
               cluster: cluster_2
-)EOF";
+)EOF",
+                                                 TestEnvironment::nullDevicePath());
 
 // This is a configuration with fault injection enabled.
 const std::string CONFIG_WITH_FAULT_INJECTION = CONFIG + R"EOF(

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -1,7 +1,7 @@
 #include "envoy/service/runtime/v3/rtds.pb.h"
-
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -55,13 +55,13 @@ layered_runtime:
   - name: some_admin_layer
     admin_layer: {{}}
 admin:
-  access_log_path: /dev/null
+  access_log_path: {}
   address:
     socket_address:
       address: 127.0.0.1
       port_value: 0
 )EOF",
-                     api_type);
+                     api_type, TestEnvironment::nullDevicePath());
 }
 
 class RtdsIntegrationTest : public Grpc::DeltaSotwIntegrationParamTest, public HttpIntegrationTest {

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -1,4 +1,5 @@
 #include "envoy/service/runtime/v3/rtds.pb.h"
+
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/integration/http_integration.h"
 #include "test/test_common/utility.h"


### PR DESCRIPTION
Signed-off-by: davinci26 <sotirisnan@gmail.com>
Changes the config file to use the cross-platform `TestEnvironment::nullDevicePath()` instead of /dev/null in:

1. `rtds_integration_test.cc`
2. `cluster_integration_test.cc`
3. `redis_cluster_integration_test.cc`
4.  `mysql_integration_test.cc `
5. `postgres_integration_test.cc`
6. `rtds_integration_test.cc`

Additional Description:

The test list is flaky on Windows. I think it is related to #11793 and it will be less flaky when this change gets merged.

Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
