### PR TITLE
cleanup: clang tidy naming

### DIFF
--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -187,7 +187,7 @@ public:
    * Gets the current map of vendor specific factory versions.
    */
   static absl::flat_hash_map<std::string, envoy::config::core::v3::BuildVersion>&
-  versioned_factories() {
+  versionedFactories() {
     using VersionedFactoryMap =
         absl::flat_hash_map<std::string, envoy::config::core::v3::BuildVersion>;
     MUTABLE_CONSTRUCT_ON_FIRST_USE(VersionedFactoryMap);
@@ -236,7 +236,7 @@ public:
     if (!result.second) {
       throw EnvoyException(fmt::format("Double registration for name: '{}'", factory.name()));
     }
-    versioned_factories().emplace(std::make_pair(name, version));
+    versionedFactories().emplace(std::make_pair(name, version));
     if (!instead_value.empty()) {
       deprecatedFactoryNames().emplace(std::make_pair(name, instead_value));
     }
@@ -328,8 +328,8 @@ public:
    */
   static absl::optional<envoy::config::core::v3::BuildVersion>
   getFactoryVersion(absl::string_view name) {
-    auto it = versioned_factories().find(name);
-    if (it == versioned_factories().end()) {
+    auto it = versionedFactories().find(name);
+    if (it == versionedFactories().end()) {
       return absl::nullopt;
     }
     return it->second;

--- a/source/common/common/hash.cc
+++ b/source/common/common/hash.cc
@@ -8,7 +8,7 @@ namespace Envoy {
 // platforms are needed.
 // from
 // (https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=libstdc%2b%2b-v3/libsupc%2b%2b/hash_bytes.cc)
-uint64_t MurmurHash::murmurHash2_64(absl::string_view key, uint64_t seed) {
+uint64_t MurmurHash::murmurHash2(absl::string_view key, uint64_t seed) {
   static const uint64_t mul = 0xc6a4a7935bd1e995UL;
   const char* const buf = static_cast<const char*>(key.data());
   uint64_t len = key.size();

--- a/source/common/common/hash.cc
+++ b/source/common/common/hash.cc
@@ -19,13 +19,13 @@ uint64_t MurmurHash::murmurHash2_64(absl::string_view key, uint64_t seed) {
   const char* const end = buf + len_aligned;
   uint64_t hash = seed ^ (len * mul);
   for (const char* p = buf; p != end; p += 8) {
-    const uint64_t data = shiftMix(unaligned_load(p) * mul) * mul;
+    const uint64_t data = shiftMix(unalignedLoad(p) * mul) * mul;
     hash ^= data;
     hash *= mul;
   }
 
   if ((len & 0x7) != 0) {
-    const uint64_t data = load_bytes(end, len & 0x7);
+    const uint64_t data = loadBytes(end, len & 0x7);
     hash ^= data;
     hash *= mul;
   }

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -58,14 +58,14 @@ public:
   static uint64_t murmurHash2_64(absl::string_view key, uint64_t seed = STD_HASH_SEED);
 
 private:
-  static inline uint64_t unaligned_load(const char* p) {
+  static inline uint64_t unalignedLoad(const char* p) {
     uint64_t result;
     memcpy(&result, p, sizeof(result));
     return result;
   }
 
   // Loads n bytes, where 1 <= n < 8.
-  static inline uint64_t load_bytes(const char* p, int n) {
+  static inline uint64_t loadBytes(const char* p, int n) {
     uint64_t result = 0;
     --n;
     do {

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -55,7 +55,7 @@ public:
    * @param seed the seed to use for the hash
    * @return 64-bit hash representation of the supplied string view
    */
-  static uint64_t murmurHash2_64(absl::string_view key, uint64_t seed = STD_HASH_SEED);
+  static uint64_t murmurHash2(absl::string_view key, uint64_t seed = STD_HASH_SEED);
 
 private:
   static inline uint64_t unalignedLoad(const char* p) {

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -105,7 +105,7 @@ Context::~Context() {
 
 void Context::activate() {
   Registry::getSink()->setLock(lock_);
-  Registry::getSink()->set_should_escape(should_escape_);
+  Registry::getSink()->setShouldEscape(should_escape_);
   Registry::setLogLevel(log_level_);
   Registry::setLogFormat(log_format_);
 }

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -104,7 +104,7 @@ public:
   virtual void flush() PURE;
 
 protected:
-  SinkDelegate* previous_delegate() { return previous_delegate_; }
+  SinkDelegate* previousDelegate() { return previous_delegate_; }
 
 private:
   SinkDelegate* previous_delegate_;
@@ -146,7 +146,7 @@ public:
     set_formatter(spdlog::details::make_unique<spdlog::pattern_formatter>(pattern));
   }
   void set_formatter(std::unique_ptr<spdlog::formatter> formatter) override;
-  void set_should_escape(bool should_escape) { should_escape_ = should_escape; }
+  void setShouldEscape(bool should_escape) { should_escape_ = should_escape; }
 
   /**
    * @return bool whether a lock has been established.

--- a/source/common/protobuf/message_validator_impl.h
+++ b/source/common/protobuf/message_validator_impl.h
@@ -85,11 +85,11 @@ public:
                                          : dynamic_warning_validation_visitor_)
                                   : ProtobufMessage::getStrictValidationVisitor()) {}
 
-  ProtobufMessage::WarningValidationVisitorImpl& static_warning_validation_visitor() {
+  ProtobufMessage::WarningValidationVisitorImpl& staticWarningValidationVisitor() {
     return static_warning_validation_visitor_;
   }
 
-  ProtobufMessage::WarningValidationVisitorImpl& dynamic_warning_validation_visitor() {
+  ProtobufMessage::WarningValidationVisitorImpl& dynamicWarningValidationVisitor() {
     return dynamic_warning_validation_visitor_;
   }
 

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -406,7 +406,7 @@ ConfigProviderPtr ScopedRoutesConfigProviderManager::createXdsConfigProvider(
                 typed_optarg.scope_key_builder_, factory_context, stat_prefix,
                 typed_optarg.rds_config_source_,
                 static_cast<ScopedRoutesConfigProviderManager&>(config_provider_manager)
-                    .route_config_provider_manager(),
+                    .routeConfigProviderPanager(),
                 static_cast<ScopedRoutesConfigProviderManager&>(config_provider_manager));
           });
 

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -234,7 +234,7 @@ public:
       Server::Configuration::ServerFactoryContext& factory_context,
       const Envoy::Config::ConfigProviderManager::OptionalArg& optarg) override;
 
-  RouteConfigProviderManager& route_config_provider_manager() {
+  RouteConfigProviderManager& routeConfigProviderPanager() {
     return route_config_provider_manager_;
   }
 

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -168,7 +168,7 @@ RingHashLoadBalancer::Ring::Ring(const NormalizedHostWeightVector& normalized_ho
 
       const uint64_t hash =
           (hash_function == HashFunction::Cluster_RingHashLbConfig_HashFunction_MURMUR_HASH_2)
-              ? MurmurHash::murmurHash2_64(hash_key, MurmurHash::STD_HASH_SEED)
+              ? MurmurHash::murmurHash2(hash_key, MurmurHash::STD_HASH_SEED)
               : HashUtil::xxHash64(hash_key);
 
       ENVOY_LOG(trace, "ring hash: hash_key={} hash={}", hash_key.data(), hash);

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -185,7 +185,7 @@ RedisLoadBalancerContextImpl::RedisLoadBalancerContextImpl(
     const NetworkFilters::Common::Redis::RespValue& request,
     NetworkFilters::Common::Redis::Client::ReadPolicy read_policy)
     : hash_key_(is_redis_cluster ? Crc16::crc16(hashtag(key, true))
-                                 : MurmurHash::murmurHash2_64(hashtag(key, enabled_hashtagging))),
+                                 : MurmurHash::murmurHash2(hashtag(key, enabled_hashtagging))),
       is_read_(isReadRequest(request)), read_policy_(read_policy) {}
 
 // Inspired by the redis-cluster hashtagging algorithm

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -214,7 +214,7 @@ public:
   // The insertion is streamed into the cache in chunks whose size is determined
   // by the client, but with a pace determined by the cache. To avoid streaming
   // data into cache too fast for the cache to handle, clients should wait for
-  // the cache to call ready_for_next_chunk() before streaming the next chunk.
+  // the cache to call readyForNextChunk() before streaming the next chunk.
   //
   // The client can abort the streaming insertion by dropping the
   // InsertContextPtr. A cache can abort the insertion by passing 'false' into

--- a/source/extensions/filters/network/dubbo_proxy/active_message.h
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.h
@@ -44,7 +44,7 @@ public:
   StreamHandler& newStream() override { return *this; }
   void onHeartbeat(MessageMetadataSharedPtr) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
-  uint64_t requestId() const { return metadata_ ? metadata_->request_id() : 0; }
+  uint64_t requestId() const { return metadata_ ? metadata_->requestId() : 0; }
 
 private:
   FilterStatus applyMessageEncodedFilters(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx);
@@ -185,7 +185,7 @@ public:
   void onError(const std::string& what);
   MessageMetadataSharedPtr metadata() const { return metadata_; }
   ContextSharedPtr context() const { return context_; }
-  bool pending_stream_decoded() const { return pending_stream_decoded_; }
+  bool pendingStreamDecoded() const { return pending_stream_decoded_; }
 
 private:
   void addDecoderFilterWorker(DubboFilters::DecoderFilterSharedPtr filter, bool dual_filter);

--- a/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/dubbo_proxy/conn_manager.cc
@@ -38,7 +38,7 @@ Network::FilterStatus ConnectionManager::onData(Buffer::Instance& data, bool end
     if (stopped_) {
       ASSERT(!active_message_list_.empty());
       auto metadata = (*active_message_list_.begin())->metadata();
-      if (metadata && metadata->message_type() == MessageType::Oneway) {
+      if (metadata && metadata->messageType() == MessageType::Oneway) {
         ENVOY_CONN_LOG(trace, "waiting for one-way completion", read_callbacks_->connection());
         half_closed_ = true;
         return Network::FilterStatus::StopIteration;

--- a/source/extensions/filters/network/dubbo_proxy/decoder.cc
+++ b/source/extensions/filters/network/dubbo_proxy/decoder.cc
@@ -19,22 +19,22 @@ DecoderStateMachine::onDecodeStreamHeader(Buffer::Instance& buffer) {
   }
 
   auto context = ret.first;
-  if (metadata->message_type() == MessageType::HeartbeatRequest ||
-      metadata->message_type() == MessageType::HeartbeatResponse) {
-    if (buffer.length() < (context->header_size() + context->body_size())) {
+  if (metadata->messageType() == MessageType::HeartbeatRequest ||
+      metadata->messageType() == MessageType::HeartbeatResponse) {
+    if (buffer.length() < (context->headerSize() + context->bodySize())) {
       ENVOY_LOG(debug, "dubbo decoder: need more data for {} protocol heartbeat", protocol_.name());
       return {ProtocolState::WaitForData};
     }
 
     ENVOY_LOG(debug, "dubbo decoder: this is the {} heartbeat message", protocol_.name());
-    buffer.drain(context->header_size() + context->body_size());
+    buffer.drain(context->headerSize() + context->bodySize());
     delegate_.onHeartbeat(metadata);
     return {ProtocolState::Done};
   }
 
   active_stream_ = delegate_.newStream(metadata, context);
   ASSERT(active_stream_);
-  context->message_origin_data().move(buffer, context->header_size());
+  context->messageOriginData().move(buffer, context->headerSize());
 
   return {ProtocolState::OnDecodeStreamData};
 }
@@ -49,8 +49,7 @@ DecoderStateMachine::onDecodeStreamData(Buffer::Instance& buffer) {
     return {ProtocolState::WaitForData};
   }
 
-  active_stream_->context_->message_origin_data().move(buffer,
-                                                       active_stream_->context_->body_size());
+  active_stream_->context_->messageOriginData().move(buffer, active_stream_->context_->bodySize());
   active_stream_->onStreamDecoded();
   active_stream_ = nullptr;
 

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
@@ -29,9 +29,9 @@ DubboHessian2SerializerImpl::deserializeRpcInvocation(Buffer::Instance& buffer,
   std::string method_name = HessianUtils::peekString(buffer, &size, total_size);
   total_size += size;
 
-  if (static_cast<uint64_t>(context->body_size()) < total_size) {
+  if (static_cast<uint64_t>(context->bodySize()) < total_size) {
     throw EnvoyException(fmt::format("RpcInvocation size({}) large than body size({})", total_size,
-                                     context->body_size()));
+                                     context->bodySize()));
   }
 
   auto invo = std::make_shared<RpcInvocationImpl>();
@@ -45,7 +45,7 @@ DubboHessian2SerializerImpl::deserializeRpcInvocation(Buffer::Instance& buffer,
 std::pair<RpcResultSharedPtr, bool>
 DubboHessian2SerializerImpl::deserializeRpcResult(Buffer::Instance& buffer,
                                                   ContextSharedPtr context) {
-  ASSERT(buffer.length() >= context->body_size());
+  ASSERT(buffer.length() >= context->bodySize());
   size_t total_size = 0;
   bool has_value = true;
 
@@ -69,15 +69,15 @@ DubboHessian2SerializerImpl::deserializeRpcResult(Buffer::Instance& buffer,
     throw EnvoyException(fmt::format("not supported return type {}", static_cast<uint8_t>(type)));
   }
 
-  if (context->body_size() < total_size) {
+  if (context->bodySize() < total_size) {
     throw EnvoyException(fmt::format("RpcResult size({}) large than body size({})", total_size,
-                                     context->body_size()));
+                                     context->bodySize()));
   }
 
-  if (!has_value && context->body_size() != total_size) {
+  if (!has_value && context->bodySize() != total_size) {
     throw EnvoyException(
         fmt::format("RpcResult is no value, but the rest of the body size({}) not equal 0",
-                    (context->body_size() - total_size)));
+                    (context->bodySize() - total_size)));
   }
 
   return std::pair<RpcResultSharedPtr, bool>(result, true);

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -66,7 +66,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, MessageMetadataSharedPtr
                      static_cast<std::underlying_type<SerializationType>::type>(type)));
   }
 
-  if (!is_two_way && metadata->message_type() != MessageType::HeartbeatRequest) {
+  if (!is_two_way && metadata->messageType() != MessageType::HeartbeatRequest) {
     metadata->setMessageType(MessageType::Oneway);
   }
 
@@ -129,9 +129,9 @@ DubboProtocolImpl::decodeHeader(Buffer::Instance& buffer, MessageMetadataSharedP
   }
 
   auto context = std::make_shared<ContextImpl>();
-  context->set_header_size(DubboProtocolImpl::MessageSize);
-  context->set_body_size(body_size);
-  context->set_heartbeat(is_event);
+  context->setHeaderSize(DubboProtocolImpl::MessageSize);
+  context->setBodySize(body_size);
+  context->setHeartbeat(is_event);
 
   return std::pair<ContextSharedPtr, bool>(context, true);
 }
@@ -140,11 +140,11 @@ bool DubboProtocolImpl::decodeData(Buffer::Instance& buffer, ContextSharedPtr co
                                    MessageMetadataSharedPtr metadata) {
   ASSERT(serializer_);
 
-  if ((buffer.length()) < static_cast<uint64_t>(context->body_size())) {
+  if ((buffer.length()) < static_cast<uint64_t>(context->bodySize())) {
     return false;
   }
 
-  switch (metadata->message_type()) {
+  switch (metadata->messageType()) {
   case MessageType::Oneway:
   case MessageType::Request: {
     auto ret = serializer_->deserializeRpcInvocation(buffer, context);
@@ -175,16 +175,16 @@ bool DubboProtocolImpl::encode(Buffer::Instance& buffer, const MessageMetadata& 
                                const std::string& content, RpcResponseType type) {
   ASSERT(serializer_);
 
-  switch (metadata.message_type()) {
+  switch (metadata.messageType()) {
   case MessageType::HeartbeatResponse: {
     ASSERT(metadata.hasResponseStatus());
     ASSERT(content.empty());
     buffer.writeBEInt<uint16_t>(MagicNumber);
-    uint8_t flag = static_cast<uint8_t>(metadata.serialization_type());
+    uint8_t flag = static_cast<uint8_t>(metadata.serializationType());
     flag = flag ^ EventMask;
     buffer.writeByte(flag);
-    buffer.writeByte(static_cast<uint8_t>(metadata.response_status()));
-    buffer.writeBEInt<uint64_t>(metadata.request_id());
+    buffer.writeByte(static_cast<uint8_t>(metadata.responseStatus()));
+    buffer.writeBEInt<uint64_t>(metadata.requestId());
     buffer.writeBEInt<uint32_t>(0);
     return true;
   }
@@ -195,9 +195,9 @@ bool DubboProtocolImpl::encode(Buffer::Instance& buffer, const MessageMetadata& 
     size_t serialized_body_size = serializer_->serializeRpcResult(body_buffer, content, type);
 
     buffer.writeBEInt<uint16_t>(MagicNumber);
-    buffer.writeByte(static_cast<uint8_t>(metadata.serialization_type()));
-    buffer.writeByte(static_cast<uint8_t>(metadata.response_status()));
-    buffer.writeBEInt<uint64_t>(metadata.request_id());
+    buffer.writeByte(static_cast<uint8_t>(metadata.serializationType()));
+    buffer.writeByte(static_cast<uint8_t>(metadata.responseStatus()));
+    buffer.writeBEInt<uint64_t>(metadata.requestId());
     buffer.writeBEInt<uint32_t>(serialized_body_size);
 
     buffer.move(body_buffer, serialized_body_size);

--- a/source/extensions/filters/network/dubbo_proxy/heartbeat_response.cc
+++ b/source/extensions/filters/network/dubbo_proxy/heartbeat_response.cc
@@ -8,8 +8,8 @@ namespace DubboProxy {
 DubboFilters::DirectResponse::ResponseType
 HeartbeatResponse::encode(MessageMetadata& metadata, DubboProxy::Protocol& protocol,
                           Buffer::Instance& buffer) const {
-  ASSERT(metadata.response_status() == ResponseStatus::Ok);
-  ASSERT(metadata.message_type() == MessageType::HeartbeatResponse);
+  ASSERT(metadata.responseStatus() == ResponseStatus::Ok);
+  ASSERT(metadata.messageType() == MessageType::HeartbeatResponse);
 
   if (!protocol.encode(buffer, metadata, "")) {
     throw EnvoyException("failed to encode heartbeat message");

--- a/source/extensions/filters/network/dubbo_proxy/message.h
+++ b/source/extensions/filters/network/dubbo_proxy/message.h
@@ -93,11 +93,11 @@ public:
   bool hasAttachments() const { return !attachments_.empty(); }
   const AttachmentMap& attachments() const { return attachments_; }
 
-  Buffer::Instance& message_origin_data() { return message_origin_buffer_; }
-  size_t message_size() const { return header_size() + body_size(); }
+  Buffer::Instance& messageOriginData() { return message_origin_buffer_; }
+  size_t messageSize() const { return headerSize() + bodySize(); }
 
-  virtual size_t body_size() const PURE;
-  virtual size_t header_size() const PURE;
+  virtual size_t bodySize() const PURE;
+  virtual size_t headerSize() const PURE;
 
 protected:
   Context() = default;
@@ -118,10 +118,10 @@ class RpcInvocation {
 public:
   virtual ~RpcInvocation() = default;
 
-  virtual const std::string& service_name() const PURE;
-  virtual const std::string& method_name() const PURE;
-  virtual const absl::optional<std::string>& service_version() const PURE;
-  virtual const absl::optional<std::string>& service_group() const PURE;
+  virtual const std::string& serviceName() const PURE;
+  virtual const std::string& methodName() const PURE;
+  virtual const absl::optional<std::string>& serviceVersion() const PURE;
+  virtual const absl::optional<std::string>& serviceGroup() const PURE;
 };
 
 using RpcInvocationSharedPtr = std::shared_ptr<RpcInvocation>;

--- a/source/extensions/filters/network/dubbo_proxy/message_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/message_impl.h
@@ -13,11 +13,11 @@ public:
   ~ContextBase() override = default;
 
   // Override from Context
-  size_t body_size() const override { return body_size_; }
-  size_t header_size() const override { return header_size_; }
+  size_t bodySize() const override { return body_size_; }
+  size_t headerSize() const override { return header_size_; }
 
-  void set_body_size(size_t size) { body_size_ = size; }
-  void set_header_size(size_t size) { header_size_ = size; }
+  void setBodySize(size_t size) { body_size_ = size; }
+  void setHeaderSize(size_t size) { header_size_ = size; }
 
 protected:
   size_t body_size_{0};
@@ -29,8 +29,8 @@ public:
   ContextImpl() = default;
   ~ContextImpl() override = default;
 
-  bool is_heartbeat() const { return is_heartbeat_; }
-  void set_heartbeat(bool is_heartbeat) { is_heartbeat_ = is_heartbeat; }
+  bool isHeartbeat() const { return is_heartbeat_; }
+  void setHeartbeat(bool is_heartbeat) { is_heartbeat_ = is_heartbeat; }
 
 private:
   bool is_heartbeat_{false};
@@ -41,16 +41,16 @@ public:
   ~RpcInvocationBase() override = default;
 
   void setServiceName(const std::string& name) { service_name_ = name; }
-  const std::string& service_name() const override { return service_name_; }
+  const std::string& serviceName() const override { return service_name_; }
 
   void setMethodName(const std::string& name) { method_name_ = name; }
-  const std::string& method_name() const override { return method_name_; }
+  const std::string& methodName() const override { return method_name_; }
 
   void setServiceVersion(const std::string& version) { service_version_ = version; }
-  const absl::optional<std::string>& service_version() const override { return service_version_; }
+  const absl::optional<std::string>& serviceVersion() const override { return service_version_; }
 
   void setServiceGroup(const std::string& group) { group_ = group; }
-  const absl::optional<std::string>& service_group() const override { return group_; }
+  const absl::optional<std::string>& serviceGroup() const override { return group_; }
 
 protected:
   std::string service_name_;

--- a/source/extensions/filters/network/dubbo_proxy/metadata.h
+++ b/source/extensions/filters/network/dubbo_proxy/metadata.h
@@ -23,31 +23,31 @@ public:
     invocation_info_ = invocation_info;
   }
   bool hasInvocationInfo() const { return invocation_info_ != nullptr; }
-  const RpcInvocation& invocation_info() const { return *invocation_info_; }
+  const RpcInvocation& invocationInfo() const { return *invocation_info_; }
 
   void setProtocolType(ProtocolType type) { proto_type_ = type; }
-  ProtocolType protocol_type() const { return proto_type_; }
+  ProtocolType protocolType() const { return proto_type_; }
 
   void setProtocolVersion(uint8_t version) { protocol_version_ = version; }
-  uint8_t protocol_version() const { return protocol_version_; }
+  uint8_t protocolVersion() const { return protocol_version_; }
 
   void setMessageType(MessageType type) { message_type_ = type; }
-  MessageType message_type() const { return message_type_; }
+  MessageType messageType() const { return message_type_; }
 
   void setRequestId(int64_t id) { request_id_ = id; }
-  int64_t request_id() const { return request_id_; }
+  int64_t requestId() const { return request_id_; }
 
   void setTimeout(uint32_t timeout) { timeout_ = timeout; }
   absl::optional<uint32_t> timeout() const { return timeout_; }
 
   void setTwoWayFlag(bool two_way) { is_two_way_ = two_way; }
-  bool is_two_way() const { return is_two_way_; }
+  bool isTwoWay() const { return is_two_way_; }
 
   template <typename T = SerializationType> void setSerializationType(T type) {
     ASSERT((std::is_same<uint8_t, typename std::underlying_type<T>::type>::value));
     serialization_type_ = static_cast<uint8_t>(type);
   }
-  template <typename T = SerializationType> T serialization_type() const {
+  template <typename T = SerializationType> T serializationType() const {
     ASSERT((std::is_same<uint8_t, typename std::underlying_type<T>::type>::value));
     return static_cast<T>(serialization_type_);
   }
@@ -56,7 +56,7 @@ public:
     ASSERT((std::is_same<uint8_t, typename std::underlying_type<T>::type>::value));
     response_status_ = static_cast<uint8_t>(status);
   }
-  template <typename T = ResponseStatus> T response_status() const {
+  template <typename T = ResponseStatus> T responseStatus() const {
     ASSERT((std::is_same<uint8_t, typename std::underlying_type<T>::type>::value));
     return static_cast<T>(response_status_.value());
   }

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
@@ -82,7 +82,7 @@ bool ParameterRouteEntryImpl::matchParameter(absl::string_view request_data,
 RouteConstSharedPtr ParameterRouteEntryImpl::matches(const MessageMetadata& metadata,
                                                      uint64_t random_value) const {
   ASSERT(metadata.hasInvocationInfo());
-  const auto invocation = dynamic_cast<const RpcInvocationImpl*>(&metadata.invocation_info());
+  const auto invocation = dynamic_cast<const RpcInvocationImpl*>(&metadata.invocationInfo());
   ASSERT(invocation);
   if (!invocation->hasParameters()) {
     return nullptr;
@@ -141,7 +141,7 @@ MethodRouteEntryImpl::~MethodRouteEntryImpl() = default;
 RouteConstSharedPtr MethodRouteEntryImpl::matches(const MessageMetadata& metadata,
                                                   uint64_t random_value) const {
   ASSERT(metadata.hasInvocationInfo());
-  const auto invocation = dynamic_cast<const RpcInvocationImpl*>(&metadata.invocation_info());
+  const auto invocation = dynamic_cast<const RpcInvocationImpl*>(&metadata.invocationInfo());
   ASSERT(invocation);
 
   if (invocation->hasHeaders() && !RouteEntryImplBase::headersMatch(invocation->headers())) {
@@ -149,14 +149,14 @@ RouteConstSharedPtr MethodRouteEntryImpl::matches(const MessageMetadata& metadat
     return nullptr;
   }
 
-  if (invocation->method_name().empty()) {
+  if (invocation->methodName().empty()) {
     ENVOY_LOG(error, "dubbo route matcher: there is no method name in the metadata");
     return nullptr;
   }
 
-  if (!method_name_.match(invocation->method_name())) {
+  if (!method_name_.match(invocation->methodName())) {
     ENVOY_LOG(debug, "dubbo route matcher: method matching failed, input method '{}'",
-              invocation->method_name());
+              invocation->methodName());
     return nullptr;
   }
 
@@ -182,13 +182,13 @@ SingleRouteMatcherImpl::SingleRouteMatcherImpl(const RouteConfig& config,
 RouteConstSharedPtr SingleRouteMatcherImpl::route(const MessageMetadata& metadata,
                                                   uint64_t random_value) const {
   ASSERT(metadata.hasInvocationInfo());
-  const auto& invocation = metadata.invocation_info();
+  const auto& invocation = metadata.invocationInfo();
 
-  if (service_name_ == invocation.service_name() &&
+  if (service_name_ == invocation.serviceName() &&
       (group_.value().empty() ||
-       (invocation.service_group().has_value() && invocation.service_group().value() == group_)) &&
-      (version_.value().empty() || (invocation.service_version().has_value() &&
-                                    invocation.service_version().value() == version_))) {
+       (invocation.serviceGroup().has_value() && invocation.serviceGroup().value() == group_)) &&
+      (version_.value().empty() || (invocation.serviceVersion().has_value() &&
+                                    invocation.serviceVersion().value() == version_))) {
     for (const auto& route : routes_) {
       RouteConstSharedPtr route_entry = route->matches(metadata, random_value);
       if (nullptr != route_entry) {

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
@@ -24,15 +24,15 @@ void Router::setDecoderFilterCallbacks(DubboFilters::DecoderFilterCallbacks& cal
 
 FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) {
   ASSERT(metadata->hasInvocationInfo());
-  const auto& invocation = metadata->invocation_info();
+  const auto& invocation = metadata->invocationInfo();
 
   route_ = callbacks_->route();
   if (!route_) {
     ENVOY_STREAM_LOG(debug, "dubbo router: no cluster match for interface '{}'", *callbacks_,
-                     invocation.service_name());
+                     invocation.serviceName());
     callbacks_->sendLocalReply(AppException(ResponseStatus::ServiceNotFound,
                                             fmt::format("dubbo router: no route for interface '{}'",
-                                                        invocation.service_name())),
+                                                        invocation.serviceName())),
                                false);
     return FilterStatus::StopIteration;
   }
@@ -52,7 +52,7 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
 
   cluster_ = cluster->info();
   ENVOY_STREAM_LOG(debug, "dubbo router: cluster '{}' match for interface '{}'", *callbacks_,
-                   route_entry_->clusterName(), invocation.service_name());
+                   route_entry_->clusterName(), invocation.serviceName());
 
   if (cluster_->maintenanceMode()) {
     callbacks_->sendLocalReply(
@@ -75,7 +75,7 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
   }
 
   ENVOY_STREAM_LOG(debug, "dubbo router: decoding request", *callbacks_);
-  upstream_request_buffer_.move(ctx->message_origin_data(), ctx->message_size());
+  upstream_request_buffer_.move(ctx->messageOriginData(), ctx->messageSize());
 
   upstream_request_ = std::make_unique<UpstreamRequest>(
       *this, *conn_pool, metadata, callbacks_->serializationType(), callbacks_->protocolType());
@@ -262,7 +262,7 @@ void Router::UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionCo
 }
 
 void Router::UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason reason) {
-  if (metadata_->message_type() == MessageType::Oneway) {
+  if (metadata_->messageType() == MessageType::Oneway) {
     // For oneway requests, we should not attempt a response. Reset the downstream to signal
     // an error.
     ENVOY_LOG(debug, "dubbo upstream request: the request is oneway, reset downstream stream");

--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -166,7 +166,7 @@ void ProxyFilter::decodeQuery(QueryMessagePtr&& message) {
     }
 
     // Global stats.
-    if (active_query->query_info_.max_time() < 1) {
+    if (active_query->query_info_.maxTime() < 1) {
       stats_.op_query_no_max_time_.inc();
     }
     if (query_type == QueryMessageInfo::QueryType::ScatterGet) {

--- a/source/extensions/filters/network/mongo_proxy/utility.h
+++ b/source/extensions/filters/network/mongo_proxy/utility.h
@@ -40,7 +40,7 @@ public:
   /**
    * @return the value of maxTimeMS or 0 if not given.
    */
-  int32_t max_time() { return max_time_; }
+  int32_t maxTime() { return max_time_; }
 
   /**
    * @return the type of a query message.

--- a/source/extensions/filters/network/thrift_proxy/metadata.h
+++ b/source/extensions/filters/network/thrift_proxy/metadata.h
@@ -65,7 +65,7 @@ public:
   /**
    * @return SpanList& a reference to a mutable list of Spans
    */
-  SpanList& mutable_spans() { return spans_; }
+  SpanList& mutableSpans() { return spans_; }
 
   bool hasAppException() const { return app_ex_type_.has_value(); }
   void setAppException(AppExceptionType app_ex_type, const std::string& message) {

--- a/source/extensions/filters/network/thrift_proxy/twitter_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/twitter_protocol_impl.cc
@@ -1054,7 +1054,7 @@ void TwitterProtocolImpl::updateMetadataWithResponseHeader(const ThriftObject& h
   }
 
   SpanList& spans = resp_header.spans();
-  std::copy(spans.begin(), spans.end(), std::back_inserter(metadata.mutable_spans()));
+  std::copy(spans.begin(), spans.end(), std::back_inserter(metadata.mutableSpans()));
 }
 
 void TwitterProtocolImpl::writeResponseHeader(Buffer::Instance& buffer,

--- a/source/extensions/tracers/zipkin/span_context.h
+++ b/source/extensions/tracers/zipkin/span_context.h
@@ -52,17 +52,17 @@ public:
   /**
    * @return the span's parent id as an integer.
    */
-  uint64_t parent_id() const { return parent_id_; }
+  uint64_t parentId() const { return parent_id_; }
 
   /**
    * @return the high 64 bits of the trace id as an integer.
    */
-  uint64_t trace_id_high() const { return trace_id_high_; }
+  uint64_t traceIdHigh() const { return trace_id_high_; }
 
   /**
    * @return the low 64 bits of the trace id as an integer.
    */
-  uint64_t trace_id() const { return trace_id_; }
+  uint64_t traceId() const { return trace_id_; }
 
   /**
    * @return whether using 128 bit trace id.

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -86,8 +86,8 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
 
     // Initialize the shared context for the new span
     span_ptr->setId(previous_context.id());
-    if (previous_context.parent_id()) {
-      span_ptr->setParentId(previous_context.parent_id());
+    if (previous_context.parentId()) {
+      span_ptr->setParentId(previous_context.parentId());
     }
 
     // Set the SR annotation value
@@ -105,9 +105,9 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
   span_ptr->addAnnotation(std::move(annotation));
 
   // Keep the same trace id
-  span_ptr->setTraceId(previous_context.trace_id());
+  span_ptr->setTraceId(previous_context.traceId());
   if (previous_context.is128BitTraceId()) {
-    span_ptr->setTraceIdHigh(previous_context.trace_id_high());
+    span_ptr->setTraceIdHigh(previous_context.traceIdHigh());
   }
 
   // Keep the same sampled flag

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -78,7 +78,7 @@ public:
                          Http::ResponseHeaderMap& response_headers, Buffer::Instance& response,
                          AdminStream& admin_stream);
   const Network::Socket& socket() override { return *socket_; }
-  Network::Socket& mutable_socket() { return *socket_; }
+  Network::Socket& mutableSocket() { return *socket_; }
 
   // Server::Admin
   // TODO(jsedgwick) These can be managed with a generic version of ConfigTracker.

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -330,9 +330,9 @@ void InstanceImpl::initialize(const Options& options,
       ServerStats{ALL_SERVER_STATS(POOL_COUNTER_PREFIX(stats_store_, server_stats_prefix),
                                    POOL_GAUGE_PREFIX(stats_store_, server_stats_prefix),
                                    POOL_HISTOGRAM_PREFIX(stats_store_, server_stats_prefix))});
-  validation_context_.static_warning_validation_visitor().setUnknownCounter(
+  validation_context_.staticWarningValidationVisitor().setUnknownCounter(
       server_stats_->static_unknown_fields_);
-  validation_context_.dynamic_warning_validation_visitor().setUnknownCounter(
+  validation_context_.dynamicWarningValidationVisitor().setUnknownCounter(
       server_stats_->dynamic_unknown_fields_);
 
   initialization_timer_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(

--- a/test/common/common/hash_fuzz_test.cc
+++ b/test/common/common/hash_fuzz_test.cc
@@ -12,7 +12,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   const std::string input(reinterpret_cast<const char*>(buf), len);
   { HashUtil::xxHash64(input); }
   { HashUtil::djb2CaseInsensitiveHash(input); }
-  { MurmurHash::murmurHash2_64(input); }
+  { MurmurHash::murmurHash2(input); }
   if (len > 0) {
     // Split the input string into two parts to make a key-value pair.
     const size_t split_point = *reinterpret_cast<const uint8_t*>(buf) % len;

--- a/test/common/common/hash_test.cc
+++ b/test/common/common/hash_test.cc
@@ -19,22 +19,21 @@ TEST(Hash, djb2CaseInsensitiveHash) {
   EXPECT_EQ(5381U, HashUtil::djb2CaseInsensitiveHash(""));
 }
 
-TEST(Hash, murmurHash2_64) {
-  EXPECT_EQ(9631199822919835226U, MurmurHash::murmurHash2_64("foo"));
-  EXPECT_EQ(11474628671133349555U, MurmurHash::murmurHash2_64("bar"));
-  EXPECT_EQ(16306510975912980159U, MurmurHash::murmurHash2_64("foo\nbar"));
-  EXPECT_EQ(12847078931730529320U, MurmurHash::murmurHash2_64("lyft"));
-  EXPECT_EQ(6142509188972423790U, MurmurHash::murmurHash2_64(""));
+TEST(Hash, murmurHash2) {
+  EXPECT_EQ(9631199822919835226U, MurmurHash::murmurHash2("foo"));
+  EXPECT_EQ(11474628671133349555U, MurmurHash::murmurHash2("bar"));
+  EXPECT_EQ(16306510975912980159U, MurmurHash::murmurHash2("foo\nbar"));
+  EXPECT_EQ(12847078931730529320U, MurmurHash::murmurHash2("lyft"));
+  EXPECT_EQ(6142509188972423790U, MurmurHash::murmurHash2(""));
 }
 
 #if __GLIBCXX__ >= 20130411 && __GLIBCXX__ <= 20180726
 TEST(Hash, stdhash) {
-  EXPECT_EQ(std::hash<std::string>()(std::string("foo")), MurmurHash::murmurHash2_64("foo"));
-  EXPECT_EQ(std::hash<std::string>()(std::string("bar")), MurmurHash::murmurHash2_64("bar"));
-  EXPECT_EQ(std::hash<std::string>()(std::string("foo\nbar")),
-            MurmurHash::murmurHash2_64("foo\nbar"));
-  EXPECT_EQ(std::hash<std::string>()(std::string("lyft")), MurmurHash::murmurHash2_64("lyft"));
-  EXPECT_EQ(std::hash<std::string>()(std::string("")), MurmurHash::murmurHash2_64(""));
+  EXPECT_EQ(std::hash<std::string>()(std::string("foo")), MurmurHash::murmurHash2("foo"));
+  EXPECT_EQ(std::hash<std::string>()(std::string("bar")), MurmurHash::murmurHash2("bar"));
+  EXPECT_EQ(std::hash<std::string>()(std::string("foo\nbar")), MurmurHash::murmurHash2("foo\nbar"));
+  EXPECT_EQ(std::hash<std::string>()(std::string("lyft")), MurmurHash::murmurHash2("lyft"));
+  EXPECT_EQ(std::hash<std::string>()(std::string("")), MurmurHash::murmurHash2(""));
 }
 #endif
 

--- a/test/extensions/filters/network/dubbo_proxy/app_exception_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/app_exception_test.cc
@@ -49,9 +49,9 @@ TEST_F(AppExceptionTest, Encode) {
   EXPECT_TRUE(result.second);
 
   const ContextImpl* context = static_cast<const ContextImpl*>(result.first.get());
-  EXPECT_EQ(expect_body_size, context->body_size());
-  EXPECT_EQ(metadata->message_type(), MessageType::Response);
-  buffer.drain(context->header_size());
+  EXPECT_EQ(expect_body_size, context->bodySize());
+  EXPECT_EQ(metadata->messageType(), MessageType::Response);
+  buffer.drain(context->headerSize());
 
   // Verify the response type and content.
   size_t hessian_int_size;

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -366,13 +366,13 @@ TEST_F(ConnectionManagerTest, OnDataHandlesHeartbeatEvent) {
         auto result = protocol->decodeHeader(buffer, metadata);
         EXPECT_TRUE(result.second);
         const DubboProxy::ContextImpl& ctx = *static_cast<const ContextImpl*>(result.first.get());
-        EXPECT_TRUE(ctx.is_heartbeat());
+        EXPECT_TRUE(ctx.isHeartbeat());
         EXPECT_TRUE(metadata->hasResponseStatus());
-        EXPECT_FALSE(metadata->is_two_way());
-        EXPECT_EQ(ProtocolType::Dubbo, metadata->protocol_type());
-        EXPECT_EQ(metadata->response_status(), ResponseStatus::Ok);
-        EXPECT_EQ(metadata->message_type(), MessageType::HeartbeatResponse);
-        buffer.drain(ctx.header_size());
+        EXPECT_FALSE(metadata->isTwoWay());
+        EXPECT_EQ(ProtocolType::Dubbo, metadata->protocolType());
+        EXPECT_EQ(metadata->responseStatus(), ResponseStatus::Ok);
+        EXPECT_EQ(metadata->messageType(), MessageType::HeartbeatResponse);
+        buffer.drain(ctx.headerSize());
       }));
 
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
@@ -1187,7 +1187,7 @@ route_config:
       .WillOnce(Invoke([&](DubboFilters::DecoderFilterCallbacks& cb) -> void { callbacks = &cb; }));
   EXPECT_CALL(*decoder_filter, onMessageDecoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr metadata, ContextSharedPtr) -> FilterStatus {
-        auto invo = static_cast<const RpcInvocationBase*>(&metadata->invocation_info());
+        auto invo = static_cast<const RpcInvocationBase*>(&metadata->invocationInfo());
         auto data = const_cast<RpcInvocationBase*>(invo);
         data->setServiceName("org.apache.dubbo.demo.DemoService");
         data->setMethodName("test");
@@ -1248,7 +1248,7 @@ TEST_F(ConnectionManagerTest, MessageDecodedReturnStopIteration) {
   size_t buf_size = buffer_.length();
   EXPECT_CALL(*decoder_filter, onMessageDecoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr, ContextSharedPtr ctx) -> FilterStatus {
-        EXPECT_EQ(ctx->message_size(), buf_size);
+        EXPECT_EQ(ctx->messageSize(), buf_size);
         return FilterStatus::StopIteration;
       }));
 
@@ -1336,8 +1336,8 @@ TEST_F(ConnectionManagerTest, HandleResponseWithEncoderFilter) {
   EXPECT_CALL(*encoder_filter, onMessageEncoded(_, _))
       .WillOnce(
           Invoke([&](MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) -> FilterStatus {
-            EXPECT_EQ(metadata->request_id(), request_id);
-            EXPECT_EQ(ctx->message_size(), expect_response_length);
+            EXPECT_EQ(metadata->requestId(), request_id);
+            EXPECT_EQ(ctx->messageSize(), expect_response_length);
             return FilterStatus::Continue;
           }));
 
@@ -1364,7 +1364,7 @@ TEST_F(ConnectionManagerTest, HandleResponseWithCodecFilter) {
       .WillOnce(Invoke([&](DubboFilters::DecoderFilterCallbacks& cb) -> void { callbacks = &cb; }));
   EXPECT_CALL(*mock_codec_filter, onMessageDecoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr metadata, ContextSharedPtr) -> FilterStatus {
-        EXPECT_EQ(metadata->request_id(), request_id);
+        EXPECT_EQ(metadata->requestId(), request_id);
         return FilterStatus::Continue;
       }));
 
@@ -1386,8 +1386,8 @@ TEST_F(ConnectionManagerTest, HandleResponseWithCodecFilter) {
   EXPECT_CALL(*mock_codec_filter, onMessageEncoded(_, _))
       .WillOnce(
           Invoke([&](MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) -> FilterStatus {
-            EXPECT_EQ(metadata->request_id(), request_id);
-            EXPECT_EQ(ctx->message_size(), expect_response_length);
+            EXPECT_EQ(metadata->requestId(), request_id);
+            EXPECT_EQ(ctx->messageSize(), expect_response_length);
             return FilterStatus::Continue;
           }));
 
@@ -1410,7 +1410,7 @@ TEST_F(ConnectionManagerTest, AddDataWithStopAndContinue) {
 
   EXPECT_CALL(*config_->decoder_filters_[0], onMessageDecoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr metadata, ContextSharedPtr) -> FilterStatus {
-        EXPECT_EQ(metadata->request_id(), request_id);
+        EXPECT_EQ(metadata->requestId(), request_id);
         return FilterStatus::Continue;
       }));
   EXPECT_CALL(*config_->decoder_filters_[1], onMessageDecoded(_, _))
@@ -1425,7 +1425,7 @@ TEST_F(ConnectionManagerTest, AddDataWithStopAndContinue) {
   // For encode direction
   EXPECT_CALL(*config_->encoder_filters_[0], onMessageEncoded(_, _))
       .WillOnce(Invoke([&](MessageMetadataSharedPtr metadata, ContextSharedPtr) -> FilterStatus {
-        EXPECT_EQ(metadata->request_id(), request_id);
+        EXPECT_EQ(metadata->requestId(), request_id);
         return FilterStatus::Continue;
       }));
   EXPECT_CALL(*config_->encoder_filters_[1], onMessageEncoded(_, _))

--- a/test/extensions/filters/network/dubbo_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/decoder_test.cc
@@ -38,8 +38,8 @@ public:
             Invoke([=](Buffer::Instance&,
                        MessageMetadataSharedPtr metadata) -> std::pair<ContextSharedPtr, bool> {
               auto context = std::make_shared<ContextImpl>();
-              context->set_header_size(16);
-              context->set_body_size(body_size);
+              context->setHeaderSize(16);
+              context->setBodySize(body_size);
               metadata->setMessageType(type);
 
               return std::pair<ContextSharedPtr, bool>(context, true);
@@ -99,7 +99,7 @@ TEST_F(DubboDecoderStateMachineTest, RequestMessageCallbacks) {
   Buffer::OwnedImpl buffer;
   EXPECT_EQ(dsm.run(buffer), ProtocolState::Done);
 
-  EXPECT_EQ(active_stream_->metadata_->message_type(), MessageType::Request);
+  EXPECT_EQ(active_stream_->metadata_->messageType(), MessageType::Request);
 }
 
 TEST_F(DubboDecoderStateMachineTest, ResponseMessageCallbacks) {
@@ -114,7 +114,7 @@ TEST_F(DubboDecoderStateMachineTest, ResponseMessageCallbacks) {
   Buffer::OwnedImpl buffer;
   EXPECT_EQ(dsm.run(buffer), ProtocolState::Done);
 
-  EXPECT_EQ(active_stream_->metadata_->message_type(), MessageType::Response);
+  EXPECT_EQ(active_stream_->metadata_->messageType(), MessageType::Response);
 }
 
 TEST_F(DubboDecoderStateMachineTest, SerializeRpcInvocationException) {
@@ -194,8 +194,8 @@ TEST_F(DubboDecoderTest, NeedMoreDataForProtocolBody) {
                           MessageMetadataSharedPtr metadate) -> std::pair<ContextSharedPtr, bool> {
         metadate->setMessageType(MessageType::Response);
         auto context = std::make_shared<ContextImpl>();
-        context->set_header_size(16);
-        context->set_body_size(10);
+        context->setHeaderSize(16);
+        context->setBodySize(10);
         return std::pair<ContextSharedPtr, bool>(context, true);
       }));
   EXPECT_CALL(protocol_, decodeData(_, _, _))
@@ -228,8 +228,8 @@ TEST_F(DubboDecoderTest, DecodeResponseMessage) {
                           MessageMetadataSharedPtr metadate) -> std::pair<ContextSharedPtr, bool> {
         metadate->setMessageType(MessageType::Response);
         auto context = std::make_shared<ContextImpl>();
-        context->set_header_size(16);
-        context->set_body_size(10);
+        context->setHeaderSize(16);
+        context->setBodySize(10);
         return std::pair<ContextSharedPtr, bool>(context, true);
       }));
   EXPECT_CALL(protocol_, decodeData(_, _, _)).WillOnce(Return(true));
@@ -251,8 +251,8 @@ TEST_F(DubboDecoderTest, DecodeResponseMessage) {
                           MessageMetadataSharedPtr metadate) -> std::pair<ContextSharedPtr, bool> {
         metadate->setMessageType(MessageType::Response);
         auto context = std::make_shared<ContextImpl>();
-        context->set_header_size(16);
-        context->set_body_size(10);
+        context->setHeaderSize(16);
+        context->setBodySize(10);
         return std::pair<ContextSharedPtr, bool>(context, true);
       }));
   EXPECT_CALL(protocol_, decodeData(_, _, _)).WillOnce(Return(true));

--- a/test/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl_test.cc
@@ -32,14 +32,14 @@ TEST(HessianProtocolTest, deserializeRpcInvocation) {
         0x04, 't', 'e', 's', 't',      // method name
     }));
     std::shared_ptr<ContextImpl> context = std::make_shared<ContextImpl>();
-    context->set_body_size(buffer.length());
+    context->setBodySize(buffer.length());
     auto result = serializer.deserializeRpcInvocation(buffer, context);
     EXPECT_TRUE(result.second);
 
     auto invo = result.first;
-    EXPECT_STREQ("test", invo->method_name().c_str());
-    EXPECT_STREQ("test", invo->service_name().c_str());
-    EXPECT_STREQ("0.0.0", invo->service_version().value().c_str());
+    EXPECT_STREQ("test", invo->methodName().c_str());
+    EXPECT_STREQ("test", invo->serviceName().c_str());
+    EXPECT_STREQ("0.0.0", invo->serviceVersion().value().c_str());
   }
 
   // incorrect body size
@@ -54,7 +54,7 @@ TEST(HessianProtocolTest, deserializeRpcInvocation) {
     std::string exception_string = fmt::format("RpcInvocation size({}) large than body size({})",
                                                buffer.length(), buffer.length() - 1);
     std::shared_ptr<ContextImpl> context = std::make_shared<ContextImpl>();
-    context->set_body_size(buffer.length() - 1);
+    context->setBodySize(buffer.length() - 1);
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcInvocation(buffer, context), EnvoyException,
                               exception_string);
   }
@@ -70,7 +70,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x94',                   // return type
         0x04, 't', 'e', 's', 't', // return body
     }));
-    context->set_body_size(4);
+    context->setBodySize(4);
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
     EXPECT_FALSE(result.first->hasException());
@@ -82,7 +82,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x93',                   // return type
         0x04, 't', 'e', 's', 't', // return body
     }));
-    context->set_body_size(4);
+    context->setBodySize(4);
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
     EXPECT_TRUE(result.first->hasException());
@@ -94,7 +94,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x90',                   // return type
         0x04, 't', 'e', 's', 't', // return body
     }));
-    context->set_body_size(4);
+    context->setBodySize(4);
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
     EXPECT_TRUE(result.first->hasException());
@@ -106,7 +106,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x91',                   // return type
         0x04, 't', 'e', 's', 't', // return body
     }));
-    context->set_body_size(4);
+    context->setBodySize(4);
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
     EXPECT_TRUE(result.first->hasException());
@@ -119,7 +119,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x94',                   // return type
         0x05, 't', 'e', 's', 't', // return body
     }));
-    context->set_body_size(0);
+    context->setBodySize(0);
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcResult(buffer, context), EnvoyException,
                               "RpcResult size(1) large than body size(0)");
   }
@@ -131,7 +131,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
         '\x96',                   // incorrect return type
         0x05, 't', 'e', 's', 't', // return body
     }));
-    context->set_body_size(buffer.length());
+    context->setBodySize(buffer.length());
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcResult(buffer, context), EnvoyException,
                               "not supported return type 6");
   }
@@ -146,7 +146,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
     std::string exception_string =
         fmt::format("RpcResult is no value, but the rest of the body size({}) not equal 0",
                     buffer.length() - 1);
-    context->set_body_size(buffer.length());
+    context->setBodySize(buffer.length());
     EXPECT_THROW_WITH_MESSAGE(serializer.deserializeRpcResult(buffer, context), EnvoyException,
                               exception_string);
   }
@@ -180,7 +180,7 @@ TEST(HessianProtocolTest, serializeRpcResult) {
 
   size_t body_size = mock_response.size() + sizeof(mock_response_type);
   std::shared_ptr<ContextImpl> context = std::make_shared<ContextImpl>();
-  context->set_body_size(body_size);
+  context->setBodySize(body_size);
   auto result = serializer.deserializeRpcResult(buffer, context);
   EXPECT_TRUE(result.first->hasException());
 }

--- a/test/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl_test.cc
@@ -44,9 +44,9 @@ TEST(DubboProtocolImplTest, Normal) {
     auto result = dubbo_protocol.decodeHeader(buffer, metadata);
     auto context = result.first;
     EXPECT_TRUE(result.second);
-    EXPECT_EQ(1, metadata->request_id());
-    EXPECT_EQ(1, context->body_size());
-    EXPECT_EQ(MessageType::Request, metadata->message_type());
+    EXPECT_EQ(1, metadata->requestId());
+    EXPECT_EQ(1, context->bodySize());
+    EXPECT_EQ(MessageType::Request, metadata->messageType());
   }
 
   // Normal dubbo response message
@@ -59,9 +59,9 @@ TEST(DubboProtocolImplTest, Normal) {
     auto result = dubbo_protocol.decodeHeader(buffer, metadata);
     auto context = result.first;
     EXPECT_TRUE(result.second);
-    EXPECT_EQ(1, metadata->request_id());
-    EXPECT_EQ(1, context->body_size());
-    EXPECT_EQ(MessageType::Response, metadata->message_type());
+    EXPECT_EQ(1, metadata->requestId());
+    EXPECT_EQ(1, context->bodySize());
+    EXPECT_EQ(MessageType::Response, metadata->messageType());
   }
 }
 
@@ -136,20 +136,20 @@ TEST(DubboProtocolImplTest, encode) {
   auto result = dubbo_protocol.decodeHeader(buffer, output_metadata);
   EXPECT_TRUE(result.second);
 
-  EXPECT_EQ(metadata.message_type(), output_metadata->message_type());
-  EXPECT_EQ(metadata.response_status(), output_metadata->response_status());
-  EXPECT_EQ(metadata.serialization_type(), output_metadata->serialization_type());
-  EXPECT_EQ(metadata.request_id(), output_metadata->request_id());
+  EXPECT_EQ(metadata.messageType(), output_metadata->messageType());
+  EXPECT_EQ(metadata.responseStatus(), output_metadata->responseStatus());
+  EXPECT_EQ(metadata.serializationType(), output_metadata->serializationType());
+  EXPECT_EQ(metadata.requestId(), output_metadata->requestId());
 
   Buffer::OwnedImpl body_buffer;
   size_t serialized_body_size = dubbo_protocol.serializer()->serializeRpcResult(
       body_buffer, content, RpcResponseType::ResponseWithValue);
   auto context = result.first;
-  EXPECT_EQ(context->body_size(), serialized_body_size);
+  EXPECT_EQ(context->bodySize(), serialized_body_size);
   EXPECT_EQ(false, context->hasAttachments());
   EXPECT_EQ(0, context->attachments().size());
 
-  buffer.drain(context->header_size());
+  buffer.drain(context->headerSize());
   EXPECT_TRUE(dubbo_protocol.decodeData(buffer, context, output_metadata));
 }
 
@@ -216,10 +216,10 @@ TEST(DubboProtocolImplTest, decode) {
     auto result = dubbo_protocol.decodeHeader(buffer, metadata);
     EXPECT_TRUE(result.second);
     auto context = result.first;
-    EXPECT_EQ(1, context->body_size());
-    EXPECT_EQ(MessageType::Request, metadata->message_type());
-    EXPECT_EQ(1, metadata->request_id());
-    EXPECT_EQ(SerializationType::Hessian2, metadata->serialization_type());
+    EXPECT_EQ(1, context->bodySize());
+    EXPECT_EQ(MessageType::Request, metadata->messageType());
+    EXPECT_EQ(1, metadata->requestId());
+    EXPECT_EQ(SerializationType::Hessian2, metadata->serializationType());
     buffer.drain(buffer.length());
   }
 
@@ -231,10 +231,10 @@ TEST(DubboProtocolImplTest, decode) {
     auto result = dubbo_protocol.decodeHeader(buffer, metadata);
     EXPECT_TRUE(result.second);
     auto context = result.first;
-    EXPECT_EQ(1, context->body_size());
-    EXPECT_EQ(MessageType::Oneway, metadata->message_type());
-    EXPECT_EQ(1, metadata->request_id());
-    EXPECT_EQ(SerializationType::Hessian2, metadata->serialization_type());
+    EXPECT_EQ(1, context->bodySize());
+    EXPECT_EQ(MessageType::Oneway, metadata->messageType());
+    EXPECT_EQ(1, metadata->requestId());
+    EXPECT_EQ(SerializationType::Hessian2, metadata->serializationType());
   }
 }
 

--- a/test/extensions/filters/network/dubbo_proxy/metadata_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/metadata_test.cc
@@ -22,19 +22,19 @@ TEST(MessageMetadataTest, Fields) {
   EXPECT_TRUE(metadata.timeout().has_value());
 
   invo->setMethodName("method");
-  EXPECT_EQ("method", invo->method_name());
+  EXPECT_EQ("method", invo->methodName());
 
-  EXPECT_FALSE(invo->service_version().has_value());
-  EXPECT_THROW(invo->service_version().value(), absl::bad_optional_access);
+  EXPECT_FALSE(invo->serviceVersion().has_value());
+  EXPECT_THROW(invo->serviceVersion().value(), absl::bad_optional_access);
   invo->setServiceVersion("1.0.0");
-  EXPECT_TRUE(invo->service_version().has_value());
-  EXPECT_EQ("1.0.0", invo->service_version().value());
+  EXPECT_TRUE(invo->serviceVersion().has_value());
+  EXPECT_EQ("1.0.0", invo->serviceVersion().value());
 
-  EXPECT_FALSE(invo->service_group().has_value());
-  EXPECT_THROW(invo->service_group().value(), absl::bad_optional_access);
+  EXPECT_FALSE(invo->serviceGroup().has_value());
+  EXPECT_THROW(invo->serviceGroup().value(), absl::bad_optional_access);
   invo->setServiceGroup("group");
-  EXPECT_TRUE(invo->service_group().has_value());
-  EXPECT_EQ("group", invo->service_group().value());
+  EXPECT_TRUE(invo->serviceGroup().has_value());
+  EXPECT_EQ("group", invo->serviceGroup().value());
 }
 
 TEST(MessageMetadataTest, Headers) {

--- a/test/extensions/filters/network/dubbo_proxy/router_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/router_test.cc
@@ -380,7 +380,7 @@ TEST_F(DubboRouterTest, UnexpectedRouterDestroy) {
   buffer.add("test");                                  // Body
 
   auto ctx = static_cast<ContextImpl*>(message_context_.get());
-  ctx->message_origin_data().move(buffer, buffer.length());
+  ctx->messageOriginData().move(buffer, buffer.length());
   startRequest(MessageType::Request);
   connectUpstream();
   destroyRouter();

--- a/test/extensions/filters/network/mongo_proxy/utility_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/utility_test.cc
@@ -137,7 +137,7 @@ TEST(QueryMessageInfoTest, MaxTime) {
     q.fullCollectionName("db.foo");
     q.query(Bson::DocumentImpl::create());
     QueryMessageInfo info(q);
-    EXPECT_EQ(0, info.max_time());
+    EXPECT_EQ(0, info.maxTime());
   }
 
   {
@@ -145,7 +145,7 @@ TEST(QueryMessageInfoTest, MaxTime) {
     q.fullCollectionName("db.foo");
     q.query(Bson::DocumentImpl::create()->addInt32("$maxTimeMS", 1212));
     QueryMessageInfo info(q);
-    EXPECT_EQ(1212, info.max_time());
+    EXPECT_EQ(1212, info.maxTime());
   }
 
   {
@@ -153,7 +153,7 @@ TEST(QueryMessageInfoTest, MaxTime) {
     q.fullCollectionName("db.foo");
     q.query(Bson::DocumentImpl::create()->addInt64("$maxTimeMS", 1212));
     QueryMessageInfo info(q);
-    EXPECT_EQ(1212, info.max_time());
+    EXPECT_EQ(1212, info.maxTime());
   }
 
   {
@@ -161,7 +161,7 @@ TEST(QueryMessageInfoTest, MaxTime) {
     q.fullCollectionName("db.foo");
     q.query(Bson::DocumentImpl::create()->addInt64("maxTimeMS", 2400));
     QueryMessageInfo info(q);
-    EXPECT_EQ(2400, info.max_time());
+    EXPECT_EQ(2400, info.maxTime());
   }
 }
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -134,7 +134,7 @@ public:
     EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
         .WillOnce(
             Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-              EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64("hash_key"));
+              EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
               EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
               EXPECT_EQ(context->downstreamConnection(), nullptr);
               return this->cm_.thread_local_cluster_.lb_.host_;
@@ -230,7 +230,7 @@ public:
     EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
         .WillOnce(
             Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-              EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64("hash_key"));
+              EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
               EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
               EXPECT_EQ(context->downstreamConnection(), nullptr);
               auto redis_context =
@@ -306,7 +306,7 @@ TEST_F(RedisConnPoolImplTest, Basic) {
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
       .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64("hash_key"));
+        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
         return cm_.thread_local_cluster_.lb_.host_;
@@ -337,7 +337,7 @@ TEST_F(RedisConnPoolImplTest, BasicRespVariant) {
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
       .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64("hash_key"));
+        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
         return cm_.thread_local_cluster_.lb_.host_;
@@ -367,7 +367,7 @@ TEST_F(RedisConnPoolImplTest, ClientRequestFailed) {
 
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
       .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64("hash_key"));
+        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
         return cm_.thread_local_cluster_.lb_.host_;
@@ -410,7 +410,7 @@ TEST_F(RedisConnPoolImplTest, Hashtagging) {
 
   auto expectHashKey = [](const std::string& s) {
     return [s](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-      EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64(s));
+      EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2(s));
       return nullptr;
     };
   };
@@ -441,7 +441,7 @@ TEST_F(RedisConnPoolImplTest, HashtaggingNotEnabled) {
 
   auto expectHashKey = [](const std::string& s) {
     return [s](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-      EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64(s));
+      EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2(s));
       return nullptr;
     };
   };
@@ -1186,7 +1186,7 @@ TEST_F(RedisConnPoolImplTest, MakeRequestAndRedirectFollowedByDelete) {
   MockPoolCallbacks callbacks;
   EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_))
       .WillOnce(Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
-        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2_64("hash_key"));
+        EXPECT_EQ(context->computeHashKey().value(), MurmurHash::murmurHash2("hash_key"));
         EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
         EXPECT_EQ(context->downstreamConnection(), nullptr);
         return this->cm_.thread_local_cluster_.lb_.host_;

--- a/test/extensions/filters/network/thrift_proxy/twitter_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/twitter_protocol_impl_test.cc
@@ -99,8 +99,8 @@ public:
 
     TestTwitterProtocolImpl proto;
 
-    metadata_->mutable_spans().emplace_back(trace_id, "", span_id, absl::optional<int64_t>(),
-                                            AnnotationList(), BinaryAnnotationList(), false);
+    metadata_->mutableSpans().emplace_back(trace_id, "", span_id, absl::optional<int64_t>(),
+                                           AnnotationList(), BinaryAnnotationList(), false);
     metadata_->headers().addCopy(Http::LowerCaseString("test-header"), "test-header-value");
 
     proto.writeResponseHeaderForTest(buffer, *metadata_);
@@ -724,7 +724,7 @@ TEST_F(TwitterProtocolTest, WriteResponseHeader) {
   headers.addCopy(Http::LowerCaseString("key1"), "value1");
   headers.addCopy(Http::LowerCaseString("key2"), "value2");
 
-  SpanList& spans = metadata_->mutable_spans();
+  SpanList& spans = metadata_->mutableSpans();
   spans.emplace_back(1, "s1", 100, absl::optional<int64_t>(10),
                      AnnotationList({
                          Annotation(100000, "a1", {Endpoint(0xC0A80001, 0, "")}),
@@ -924,8 +924,8 @@ TEST_F(TwitterProtocolTest, TestUpgradedWriteMessageBegin) {
   metadata_->setMethodName("message");
   metadata_->setSequenceId(1);
   metadata_->setTraceId(1);
-  metadata_->mutable_spans().emplace_back(100, "", 100, absl::optional<int64_t>(), AnnotationList(),
-                                          BinaryAnnotationList(), false);
+  metadata_->mutableSpans().emplace_back(100, "", 100, absl::optional<int64_t>(), AnnotationList(),
+                                         BinaryAnnotationList(), false);
 
   {
     // Call

--- a/test/extensions/tracers/zipkin/span_context_extractor_test.cc
+++ b/test/extensions/tracers/zipkin/span_context_extractor_test.cc
@@ -27,10 +27,10 @@ TEST(ZipkinSpanContextExtractorTest, Largest) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(2, context.first.parent_id());
+  EXPECT_EQ(2, context.first.parentId());
   EXPECT_TRUE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(9, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(9, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -42,10 +42,10 @@ TEST(ZipkinSpanContextExtractorTest, WithoutParentDebug) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_TRUE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(9, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(9, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -73,10 +73,10 @@ TEST(ZipkinSpanContextExtractorTest, DebugOnly) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_FALSE(context.second);
   EXPECT_EQ(0, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(0, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(0, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_FALSE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -87,10 +87,10 @@ TEST(ZipkinSpanContextExtractorTest, Sampled) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_FALSE(context.second);
   EXPECT_EQ(0, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(0, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(0, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_FALSE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -101,10 +101,10 @@ TEST(ZipkinSpanContextExtractorTest, SampledFalse) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_FALSE(context.second);
   EXPECT_EQ(0, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(0, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(0, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_FALSE(context.first.sampled());
   EXPECT_FALSE(extractor.extractSampled({Tracing::Reason::Sampling, true}));
 }
@@ -116,10 +116,10 @@ TEST(ZipkinSpanContextExtractorTest, IdNotYetSampled128) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_TRUE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(9, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(9, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_FALSE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -130,10 +130,10 @@ TEST(ZipkinSpanContextExtractorTest, IdsUnsampled) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_FALSE(extractor.extractSampled({Tracing::Reason::Sampling, true}));
 }
@@ -145,10 +145,10 @@ TEST(ZipkinSpanContextExtractorTest, ParentUnsampled) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(2, context.first.parent_id());
+  EXPECT_EQ(2, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_FALSE(extractor.extractSampled({Tracing::Reason::Sampling, true}));
 }
@@ -160,10 +160,10 @@ TEST(ZipkinSpanContextExtractorTest, ParentDebug) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(2, context.first.parent_id());
+  EXPECT_EQ(2, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -174,10 +174,10 @@ TEST(ZipkinSpanContextExtractorTest, IdsWithDebug) {
   auto context = extractor.extractSpanContext(true);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_TRUE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, false}));
 }
@@ -188,10 +188,10 @@ TEST(ZipkinSpanContextExtractorTest, WithoutSampled) {
   auto context = extractor.extractSpanContext(false);
   EXPECT_TRUE(context.second);
   EXPECT_EQ(3, context.first.id());
-  EXPECT_EQ(0, context.first.parent_id());
+  EXPECT_EQ(0, context.first.parentId());
   EXPECT_FALSE(context.first.is128BitTraceId());
-  EXPECT_EQ(1, context.first.trace_id());
-  EXPECT_EQ(0, context.first.trace_id_high());
+  EXPECT_EQ(1, context.first.traceId());
+  EXPECT_EQ(0, context.first.traceIdHigh());
   EXPECT_FALSE(context.first.sampled());
   EXPECT_TRUE(extractor.extractSampled({Tracing::Reason::Sampling, true}));
 }

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -185,8 +185,8 @@ TEST_F(ZipkinTracerTest, SpanCreation) {
   ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Ingress));
   TestRandomGenerator generator;
   const uint64_t generated_parent_id = generator.random();
-  SpanContext modified_root_span_context(root_span_context.trace_id_high(),
-                                         root_span_context.trace_id(), root_span_context.id(),
+  SpanContext modified_root_span_context(root_span_context.traceIdHigh(),
+                                         root_span_context.traceId(), root_span_context.id(),
                                          generated_parent_id, root_span_context.sampled());
   SpanPtr new_shared_context_span =
       tracer.startSpan(config, "new_shared_context_span", timestamp, modified_root_span_context);
@@ -202,7 +202,7 @@ TEST_F(ZipkinTracerTest, SpanCreation) {
 
   // The parent should be the same as in the CS side
   EXPECT_TRUE(new_shared_context_span->isSetParentId());
-  EXPECT_EQ(modified_root_span_context.parent_id(), new_shared_context_span->parentId());
+  EXPECT_EQ(modified_root_span_context.parentId(), new_shared_context_span->parentId());
 
   // span timestamp should not be set (it was set in the CS side)
   EXPECT_FALSE(new_shared_context_span->isSetTimestamp());

--- a/test/test_common/logging.cc
+++ b/test/test_common/logging.cc
@@ -28,12 +28,12 @@ LogRecordingSink::LogRecordingSink(Logger::DelegatingLogSinkSharedPtr log_sink)
 LogRecordingSink::~LogRecordingSink() = default;
 
 void LogRecordingSink::log(absl::string_view msg) {
-  previous_delegate()->log(msg);
+  previousDelegate()->log(msg);
 
   absl::MutexLock ml(&mtx_);
   messages_.push_back(std::string(msg));
 }
 
-void LogRecordingSink::flush() { previous_delegate()->flush(); }
+void LogRecordingSink::flush() { previousDelegate()->flush(); }
 
 } // namespace Envoy

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -94,7 +94,7 @@ using ExpectedLogMessages = std::vector<StringPair>;
     ASSERT_FALSE(expected_messages.empty()) << "Expected messages cannot be empty.";               \
     Envoy::LogLevelSetter save_levels(spdlog::level::trace);                                       \
     Envoy::Logger::DelegatingLogSinkSharedPtr sink_ptr = Envoy::Logger::Registry::getSink();       \
-    sink_ptr->set_should_escape(escaped);                                                          \
+    sink_ptr->setShouldEscape(escaped);                                                            \
     Envoy::LogRecordingSink log_recorder(sink_ptr);                                                \
     stmt;                                                                                          \
     if (log_recorder.messages().empty()) {                                                         \


### PR DESCRIPTION
got bit by clang tidy "rename this thing you didn't write" one too many time...

Risk Level: low (function renames)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
