### PR TITLE
Revert "tcp: switching to the new pool (#12180)"

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -42,7 +42,6 @@ New Features
 * load balancer: added a :ref:`configuration<envoy_v3_api_msg_config.cluster.v3.Cluster.LeastRequestLbConfig>` option to specify the active request bias used by the least request load balancer.
 * redis: added fault injection support :ref:`fault injection for redis proxy <envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.faults>`, described further in :ref:`configuration documentation <config_network_filters_redis_proxy>`.
 * tap: added :ref:`generic body matcher<envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and responses for text or hex patterns.
-* tcp: switched the TCP connection pool to the new "shared" connection pool, sharing a common code base with HTTP and HTTP/2. Any unexpected behavioral changes can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
 
 Deprecated
 ----------

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -71,7 +71,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.http_default_alpn",
     "envoy.reloadable_features.listener_in_place_filterchain_update",
     "envoy.reloadable_features.new_codec_behavior",
-    "envoy.reloadable_features.new_tcp_connection_pool",
     "envoy.reloadable_features.preserve_query_string_in_path_redirects",
     "envoy.reloadable_features.preserve_upstream_date",
     "envoy.reloadable_features.stop_faking_paths",
@@ -88,6 +87,8 @@ constexpr const char* runtime_features[] = {
 // When features are added here, there should be a tracking bug assigned to the
 // code owner to flip the default after sufficient testing.
 constexpr const char* disabled_runtime_features[] = {
+    // TODO(alyssawilk) flip true after the release.
+    "envoy.reloadable_features.new_tcp_connection_pool",
     // Sentinel and test flag.
     "envoy.reloadable_features.test_feature_false",
 };


### PR DESCRIPTION
This reverts commit f50fba14928c0fa08d02447db8fade9d56e9164a.

Confirmed that switching the runtime override listed in that commit fixes the crash, so reverting as per advice in #12180.

```
[2020-07-20 16:12:49.616][19388][info][main] [source/server/server.cc:664] starting main dispatch loop
[2020-07-20 16:12:57.451][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:104] Caught Segmentation fault, suspect faulting address 0x0
[2020-07-20 16:12:57.451][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:91] Backtrace (use tools/stack_decode.py to get line numbers):
[2020-07-20 16:12:57.451][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:92] Envoy version: de43823f3956bede6c077a7da2783cc46bf1b50c/1.16.0-dev/Modified/DEBUG/BoringSSL
[2020-07-20 16:12:57.522][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #0: Envoy::SignalAction::sigHandler() [0x5630cd2d0bac]
[2020-07-20 16:12:57.522][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #1: __restore_rt [0x7f7d0fcf0390]
[2020-07-20 16:12:57.582][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #2: Envoy::TcpProxy::Filter::UpstreamCallbacks::onEvent() [0x5630cbf9f722]
[2020-07-20 16:12:57.641][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #3: Envoy::TcpProxy::Filter::onPoolFailure() [0x5630cbfa2228]
[2020-07-20 16:12:57.700][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #4: Envoy::Tcp::ConnPoolImpl::onPoolFailure() [0x5630cc8412f1]
[2020-07-20 16:12:57.749][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #5: Envoy::ConnectionPool::ConnPoolImplBase::purgePendingRequests() [0x5630ccab4f36]
[2020-07-20 16:12:57.795][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #6: Envoy::ConnectionPool::ConnPoolImplBase::onConnectionEvent() [0x5630ccab49ac]
[2020-07-20 16:12:57.841][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #7: Envoy::ConnectionPool::ActiveClient::onEvent() [0x5630ccab60fb]
[2020-07-20 16:12:57.888][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #8: Envoy::Tcp::ActiveTcpClient::onEvent() [0x5630ccaa1e75]
[2020-07-20 16:12:57.933][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #9: Envoy::Network::ConnectionImplBase::raiseConnectionEvent() [0x5630cc744141]
[2020-07-20 16:12:57.981][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #10: Envoy::Network::ConnectionImpl::raiseEvent() [0x5630cc736205]
[2020-07-20 16:12:58.026][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #11: Envoy::Network::ConnectionImpl::closeSocket() [0x5630cc736007]
[2020-07-20 16:12:58.074][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #12: Envoy::Network::ConnectionImpl::onWriteReady() [0x5630cc7399c0]
[2020-07-20 16:12:58.119][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #13: Envoy::Network::ConnectionImpl::onFileEvent() [0x5630cc73933e]
[2020-07-20 16:12:58.165][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #14: Envoy::Network::ConnectionImpl::ConnectionImpl()::$_6::operator()() [0x5630cc73db2e]
[2020-07-20 16:12:58.212][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #15: std::_Function_handler<>::_M_invoke() [0x5630cc73d9f1]
[2020-07-20 16:12:58.257][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #16: std::function<>::operator()() [0x5630cc72ce9a]
[2020-07-20 16:12:58.305][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #17: Envoy::Event::FileEventImpl::mergeInjectedEventsAndRunCb() [0x5630cc72beeb]
[2020-07-20 16:12:58.351][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #18: Envoy::Event::FileEventImpl::assignEvents()::$_1::operator()() [0x5630cc72c24a]
[2020-07-20 16:12:58.398][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #19: Envoy::Event::FileEventImpl::assignEvents()::$_1::__invoke() [0x5630cc72bff6]
[2020-07-20 16:12:58.444][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #20: event_persist_closure [0x5630cd1fa0ae]
[2020-07-20 16:12:58.491][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #21: event_process_active_single_queue [0x5630cd1f96d8]
[2020-07-20 16:12:58.536][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #22: event_process_active [0x5630cd1f3e9a]
[2020-07-20 16:12:58.583][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #23: event_base_loop [0x5630cd1f2d4c]
[2020-07-20 16:12:58.629][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #24: Envoy::Event::LibeventScheduler::run() [0x5630cc7572b8]
[2020-07-20 16:12:58.675][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #25: Envoy::Event::DispatcherImpl::run() [0x5630cc7230da]
[2020-07-20 16:12:58.722][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #26: Envoy::Server::WorkerImpl::threadRoutine() [0x5630cc6ff27d]
[2020-07-20 16:12:58.767][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #27: Envoy::Server::WorkerImpl::start()::$_4::operator()() [0x5630cc7009dc]
[2020-07-20 16:12:58.815][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #28: std::_Function_handler<>::_M_invoke() [0x5630cc70089d]
[2020-07-20 16:12:58.860][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #29: std::function<>::operator()() [0x5630cae7d0ce]
[2020-07-20 16:12:58.907][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #30: Envoy::Thread::ThreadImplPosix::ThreadImplPosix()::{lambda()#1}::operator()() [0x5630cd332ac2]
[2020-07-20 16:12:58.953][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #31: Envoy::Thread::ThreadImplPosix::ThreadImplPosix()::{lambda()#1}::__invoke() [0x5630cd332a95]
[2020-07-20 16:12:58.953][19417][critical][backtrace] [bazel-out/k8-fastbuild/bin/source/server/_virtual_includes/backtrace_lib/server/backtrace.h:96] #32: start_thread [0x7f7d0fce66ba]
Segmentation fault (core dumped)
```