### PR TITLE
thrift proxy: improve router code coverage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,7 +22,7 @@ extensions/filters/common/original_src @snowp @klarose
 # rocketmq_proxy extension
 /*/extensions/filters/network/rocketmq_proxy @aaron-ai @lizhanhui @lizan
 # thrift_proxy extension
-/*/extensions/filters/network/thrift_proxy @zuercher @brian-pane
+/*/extensions/filters/network/thrift_proxy @zuercher @rgs1
 # compressor used by http compression filters
 /*/extensions/filters/http/common/compressor @gsagula @rojkov @dio
 /*/extensions/filters/http/compressor @rojkov @dio

--- a/test/extensions/filters/network/thrift_proxy/filters/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/filters/BUILD
@@ -1,0 +1,18 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "pass_through_filter_test",
+    srcs = ["pass_through_filter_test.cc"],
+    deps = [
+        "//source/extensions/filters/network/thrift_proxy/filters:pass_through_filter_lib",
+        "//test/extensions/filters/network/thrift_proxy:mocks",
+    ],
+)

--- a/test/extensions/filters/network/thrift_proxy/filters/pass_through_filter_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/pass_through_filter_test.cc
@@ -1,0 +1,118 @@
+#include <memory>
+#include <string>
+
+#include "extensions/filters/network/thrift_proxy/filters/pass_through_filter.h"
+
+#include "test/extensions/filters/network/thrift_proxy/mocks.h"
+#include "test/test_common/printers.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ThriftProxy {
+namespace ThriftFilters {
+
+using namespace Envoy::Extensions::NetworkFilters;
+
+class ThriftPassThroughDecoderFilterTest : public testing::Test {
+public:
+  class Filter : public PassThroughDecoderFilter {
+  public:
+    DecoderFilterCallbacks* decoderFilterCallbacks() { return decoder_callbacks_; }
+  };
+
+  void initialize() {
+    filter_ = std::make_unique<Filter>();
+    filter_->setDecoderFilterCallbacks(filter_callbacks_);
+  }
+
+  std::unique_ptr<Filter> filter_;
+  NiceMock<MockDecoderFilterCallbacks> filter_callbacks_;
+  ThriftProxy::MessageMetadataSharedPtr request_metadata_;
+};
+
+// Tests that each method returns ThriftProxy::FilterStatus::Continue.
+TEST_F(ThriftPassThroughDecoderFilterTest, AllMethodsAreImplementedTrivially) {
+  initialize();
+
+  EXPECT_EQ(&filter_callbacks_, filter_->decoderFilterCallbacks());
+
+  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->transportBegin(request_metadata_));
+  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(request_metadata_));
+  {
+    std::string dummy_str = "dummy";
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->structBegin(dummy_str));
+  }
+  {
+    std::string dummy_str = "dummy";
+    ThriftProxy::FieldType dummy_ft{ThriftProxy::FieldType::I32};
+    int16_t dummy_id{1};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue,
+              filter_->fieldBegin(dummy_str, dummy_ft, dummy_id));
+  }
+  {
+    bool dummy_val{false};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->boolValue(dummy_val));
+  }
+  {
+    uint8_t dummy_val{0};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->byteValue(dummy_val));
+  }
+  {
+    int16_t dummy_val{0};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->int16Value(dummy_val));
+  }
+  {
+    int32_t dummy_val{0};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->int32Value(dummy_val));
+  }
+  {
+    int64_t dummy_val{0};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->int64Value(dummy_val));
+  }
+  {
+    double dummy_val{0.0};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->doubleValue(dummy_val));
+  }
+  {
+    std::string dummy_str = "dummy";
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->stringValue(dummy_str));
+  }
+  {
+    ThriftProxy::FieldType dummy_ft = ThriftProxy::FieldType::I32;
+    uint32_t dummy_size{1};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue,
+              filter_->mapBegin(dummy_ft, dummy_ft, dummy_size));
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->mapEnd());
+  }
+  {
+    ThriftProxy::FieldType dummy_ft = ThriftProxy::FieldType::I32;
+    uint32_t dummy_size{1};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->listBegin(dummy_ft, dummy_size));
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->listEnd());
+  }
+  {
+    ThriftProxy::FieldType dummy_ft = ThriftProxy::FieldType::I32;
+    uint32_t dummy_size{1};
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->setBegin(dummy_ft, dummy_size));
+    EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->setEnd());
+  }
+  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->structEnd());
+  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->fieldEnd());
+  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageEnd());
+  EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->transportEnd());
+
+  EXPECT_NO_THROW(filter_->onDestroy());
+}
+
+} // namespace ThriftFilters
+} // namespace ThriftProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
@@ -3,6 +3,8 @@
 #include "envoy/extensions/filters/network/thrift_proxy/v3/route.pb.h"
 #include "envoy/extensions/filters/network/thrift_proxy/v3/route.pb.validate.h"
 
+#include "common/config/metadata.h"
+
 #include "extensions/filters/network/thrift_proxy/router/config.h"
 #include "extensions/filters/network/thrift_proxy/router/router_impl.h"
 
@@ -887,6 +889,118 @@ routes:
     EXPECT_EQ("k2", mmc[1]->name());
     EXPECT_EQ(hv3, mmc[1]->value());
   }
+}
+
+// Test that the route entry has metadata match criteria when using a cluster header.
+TEST(ThriftRouteMatcherTest, ClusterHeaderMetadataMatch) {
+  envoy::extensions::filters::network::thrift_proxy::v3::RouteConfiguration config;
+  {
+    config.set_name("config");
+    auto* route = config.add_routes();
+    route->mutable_match()->set_method_name("method1");
+    auto* action = route->mutable_route();
+    action->set_cluster_header("header_name");
+    auto* metadata = action->mutable_metadata_match();
+    Envoy::Config::Metadata::mutableMetadataValue(*metadata, "envoy.lb", "k1")
+        .set_string_value("v1");
+    Envoy::Config::Metadata::mutableMetadataValue(*metadata, "envoy.lb", "k2")
+        .set_string_value("v2");
+
+    auto* route2 = config.add_routes();
+    route2->mutable_match()->set_method_name("method2");
+    auto* action2 = route2->mutable_route();
+    action2->set_cluster("cluster2");
+  }
+
+  RouteMatcher matcher(config);
+
+  // match with metadata
+  {
+    MessageMetadata metadata;
+    metadata.setMethodName("method1");
+    metadata.headers().addCopy(Http::LowerCaseString{"header_name"}, "cluster1");
+    RouteConstSharedPtr route = matcher.route(metadata, 0);
+    EXPECT_NE(nullptr, route);
+    EXPECT_NE(nullptr, route->routeEntry());
+
+    EXPECT_EQ(Http::LowerCaseString{"header_name"}, route->routeEntry()->clusterHeader());
+
+    const Envoy::Router::MetadataMatchCriteria* criteria =
+        route->routeEntry()->metadataMatchCriteria();
+    EXPECT_NE(nullptr, criteria);
+    const std::vector<Envoy::Router::MetadataMatchCriterionConstSharedPtr>& mmc =
+        criteria->metadataMatchCriteria();
+    EXPECT_EQ(2, mmc.size());
+
+    ProtobufWkt::Value v1, v2;
+    v1.set_string_value("v1");
+    v2.set_string_value("v2");
+    HashedValue hv1(v1), hv2(v2);
+
+    EXPECT_EQ("k1", mmc[0]->name());
+    EXPECT_EQ(hv1, mmc[0]->value());
+
+    EXPECT_EQ("k2", mmc[1]->name());
+    EXPECT_EQ(hv2, mmc[1]->value());
+  }
+
+  // match with no metadata
+  {
+    MessageMetadata metadata;
+    metadata.setMethodName("method2");
+    RouteConstSharedPtr route = matcher.route(metadata, 0);
+    EXPECT_NE(nullptr, route);
+    EXPECT_NE(nullptr, route->routeEntry());
+    EXPECT_EQ(nullptr, route->routeEntry()->metadataMatchCriteria());
+
+    EXPECT_EQ(Http::LowerCaseString{""}, route->routeEntry()->clusterHeader());
+  }
+}
+
+// Tests that weighted cluster route entries can be configured to strip the service name.
+TEST(RouteMatcherTest, WeightedClusterWithStripServiceEnabled) {
+  envoy::extensions::filters::network::thrift_proxy::v3::RouteConfiguration config;
+  {
+    config.set_name("config");
+    auto* route = config.add_routes();
+    route->mutable_match()->set_method_name("method1");
+    auto* action = route->mutable_route();
+    auto* cluster1 = action->mutable_weighted_clusters()->add_clusters();
+    cluster1->set_name("cluster1");
+    cluster1->mutable_weight()->set_value(50);
+    auto* cluster2 = action->mutable_weighted_clusters()->add_clusters();
+    cluster2->set_name("cluster2");
+    cluster2->mutable_weight()->set_value(50);
+    action->set_strip_service_name(true);
+  }
+
+  RouteMatcher matcher(config);
+
+  MessageMetadata metadata;
+  metadata.setMethodName("method1");
+
+  EXPECT_TRUE(matcher.route(metadata, 0)->routeEntry()->stripServiceName());
+}
+
+// Tests that dynamic route entries can be configured to strip the service name.
+TEST(RouteMatcherTest, ClusterHeaderWithStripServiceEnabled) {
+  envoy::extensions::filters::network::thrift_proxy::v3::RouteConfiguration config;
+  {
+    config.set_name("config");
+    auto* route = config.add_routes();
+    route->mutable_match()->set_method_name("method1");
+    auto* action = route->mutable_route();
+    action->set_cluster_header("header_name");
+    action->set_strip_service_name(true);
+  }
+
+  RouteMatcher matcher(config);
+
+  MessageMetadata metadata;
+  metadata.setMethodName("method1");
+  metadata.headers().addCopy(Http::LowerCaseString{"header_name"}, "cluster1");
+
+  EXPECT_TRUE(matcher.route(metadata, 0)->routeEntry()->stripServiceName());
 }
 
 } // namespace

--- a/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/route_matcher_test.cc
@@ -758,6 +758,8 @@ routes:
 
     EXPECT_EQ("k2", mmc[1]->name());
     EXPECT_EQ(hv2, mmc[1]->value());
+
+    EXPECT_EQ(Http::LowerCaseString{""}, route->routeEntry()->clusterHeader());
   }
 
   // match with weighted cluster with different metadata key

--- a/test/extensions/filters/network/thrift_proxy/router_ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_ratelimit_test.cc
@@ -34,6 +34,10 @@ public:
   void initialize(const std::string& yaml) {
     envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy config;
     TestUtility::loadFromYaml(yaml, config);
+    initialize(config);
+  }
+
+  void initialize(envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy& config) {
     config_ = std::make_unique<ThriftProxy::ConfigImpl>(config, factory_context_);
   }
 
@@ -167,6 +171,125 @@ route_config:
               testing::ContainerEq(descriptors));
 
   rate_limits = route->rateLimitPolicy().getApplicableRateLimit(10);
+  EXPECT_TRUE(rate_limits.empty());
+}
+
+// Test that rate limiter stages work with weighted cluster route entries.
+TEST_F(ThriftRateLimitConfigurationTest, WeightedClusterStages) {
+  envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy config;
+  {
+    auto* route_config = config.mutable_route_config();
+    route_config->set_name("config");
+    auto* route = route_config->add_routes();
+    route->mutable_match()->set_method_name("foo");
+    auto* action = route->mutable_route();
+    auto* cluster1 = action->mutable_weighted_clusters()->add_clusters();
+    cluster1->set_name("thrift");
+    cluster1->mutable_weight()->set_value(50);
+    auto* cluster2 = action->mutable_weighted_clusters()->add_clusters();
+    cluster2->set_name("thrift2");
+    cluster2->mutable_weight()->set_value(50);
+
+    auto* limit1 = action->add_rate_limits();
+    limit1->mutable_stage()->set_value(1);
+    limit1->add_actions()->mutable_remote_address();
+
+    action->add_rate_limits()->add_actions()->mutable_destination_cluster();
+
+    auto* limit3 = action->add_rate_limits();
+    limit3->add_actions()->mutable_destination_cluster();
+    limit3->add_actions()->mutable_source_cluster();
+  }
+  initialize(config);
+
+  auto route = config_->route(genMetadata("foo"), 0)->routeEntry();
+  std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
+      route->rateLimitPolicy().getApplicableRateLimit(0);
+  EXPECT_EQ(2U, rate_limits.size());
+
+  std::vector<Envoy::RateLimit::Descriptor> descriptors;
+  for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
+    rate_limit.populateDescriptors(*route, descriptors, "service_cluster", *metadata_,
+                                   default_remote_address_);
+  }
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
+                  {{{{"destination_cluster", "thrift"}}},
+                   {{{"destination_cluster", "thrift"}, {"source_cluster", "service_cluster"}}}}),
+              testing::ContainerEq(descriptors));
+
+  descriptors.clear();
+  rate_limits = route->rateLimitPolicy().getApplicableRateLimit(1);
+  EXPECT_EQ(1U, rate_limits.size());
+
+  for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
+    rate_limit.populateDescriptors(*route, descriptors, "service_cluster", *metadata_,
+                                   default_remote_address_);
+  }
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
+              testing::ContainerEq(descriptors));
+
+  rate_limits = route->rateLimitPolicy().getApplicableRateLimit(10);
+  EXPECT_TRUE(rate_limits.empty());
+}
+
+// Test that rate limiter stages work with dynamic route entries.
+TEST_F(ThriftRateLimitConfigurationTest, ClusterHeaderStages) {
+  envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy config;
+  {
+    auto* route_config = config.mutable_route_config();
+    route_config->set_name("config");
+    auto* route = route_config->add_routes();
+    route->mutable_match()->set_method_name("foo");
+    auto* action = route->mutable_route();
+    action->set_cluster_header("header_name");
+
+    auto* limit1 = action->add_rate_limits();
+    limit1->mutable_stage()->set_value(1);
+    limit1->add_actions()->mutable_remote_address();
+
+    action->add_rate_limits()->add_actions()->mutable_destination_cluster();
+
+    auto* limit3 = action->add_rate_limits();
+    limit3->add_actions()->mutable_destination_cluster();
+    limit3->add_actions()->mutable_source_cluster();
+  }
+  initialize(config);
+
+  auto& metadata = genMetadata("foo");
+  metadata.headers().addCopy(Http::LowerCaseString{"header_name"}, "thrift");
+
+  // Keep hold of route, it's a newly minted shared pointer.
+  auto route = config_->route(metadata, 0);
+  auto* route_entry = route->routeEntry();
+
+  std::vector<std::reference_wrapper<const RateLimitPolicyEntry>> rate_limits =
+      route_entry->rateLimitPolicy().getApplicableRateLimit(0);
+
+  EXPECT_EQ(2U, rate_limits.size());
+
+  std::vector<Envoy::RateLimit::Descriptor> descriptors;
+  for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
+    rate_limit.populateDescriptors(*route_entry, descriptors, "service_cluster", *metadata_,
+                                   default_remote_address_);
+  }
+
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>(
+                  {{{{"destination_cluster", "thrift"}}},
+                   {{{"destination_cluster", "thrift"}, {"source_cluster", "service_cluster"}}}}),
+              testing::ContainerEq(descriptors));
+
+  descriptors.clear();
+  rate_limits = route_entry->rateLimitPolicy().getApplicableRateLimit(1);
+  EXPECT_EQ(1U, rate_limits.size());
+
+  for (const RateLimitPolicyEntry& rate_limit : rate_limits) {
+    rate_limit.populateDescriptors(*route_entry, descriptors, "service_cluster", *metadata_,
+                                   default_remote_address_);
+  }
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"remote_address", "10.0.0.1"}}}}),
+              testing::ContainerEq(descriptors));
+
+  rate_limits = route_entry->rateLimitPolicy().getApplicableRateLimit(10);
   EXPECT_TRUE(rate_limits.empty());
 }
 

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -700,6 +700,75 @@ TEST_F(ThriftRouterTest, ProtocolUpgrade) {
   destroyRouter();
 }
 
+// Test the case where an upgrade will occur, but the conn pool
+// returns immediately with a valid, but never, used connection.
+TEST_F(ThriftRouterTest, ProtocolUpgradeOnExistingUnusedConnection) {
+  initializeRouter();
+
+  EXPECT_CALL(*context_.cluster_manager_.tcp_conn_pool_.connection_data_, addUpstreamCallbacks(_))
+      .WillOnce(Invoke(
+          [&](Tcp::ConnectionPool::UpstreamCallbacks& cb) -> void { upstream_callbacks_ = &cb; }));
+
+  conn_state_.reset();
+  EXPECT_CALL(*context_.cluster_manager_.tcp_conn_pool_.connection_data_, connectionState())
+      .WillRepeatedly(
+          Invoke([&]() -> Tcp::ConnectionPool::ConnectionState* { return conn_state_.get(); }));
+  EXPECT_CALL(*context_.cluster_manager_.tcp_conn_pool_.connection_data_, setConnectionState_(_))
+      .WillOnce(Invoke(
+          [&](Tcp::ConnectionPool::ConnectionStatePtr& cs) -> void { conn_state_.swap(cs); }));
+
+  MockThriftObject* upgrade_response = new NiceMock<MockThriftObject>();
+
+  EXPECT_CALL(upstream_connection_, write(_, false))
+      .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
+        EXPECT_EQ("upgrade request", buffer.toString());
+      }));
+
+  // Simulate an existing connection that's never been used.
+  EXPECT_CALL(context_.cluster_manager_.tcp_conn_pool_, newConnection(_))
+      .WillOnce(
+          Invoke([&](Tcp::ConnectionPool::Callbacks& cb) -> Tcp::ConnectionPool::Cancellable* {
+            context_.cluster_manager_.tcp_conn_pool_.newConnectionImpl(cb);
+
+            EXPECT_CALL(*protocol_, supportsUpgrade()).WillOnce(Return(true));
+
+            EXPECT_CALL(*protocol_, attemptUpgrade(_, _, _))
+                .WillOnce(Invoke([&](Transport&, ThriftConnectionState&,
+                                     Buffer::Instance& buffer) -> ThriftObjectPtr {
+                  buffer.add("upgrade request");
+                  return ThriftObjectPtr{upgrade_response};
+                }));
+
+            context_.cluster_manager_.tcp_conn_pool_.poolReady(upstream_connection_);
+            return nullptr;
+          }));
+
+  startRequest(MessageType::Call);
+
+  EXPECT_NE(nullptr, upstream_callbacks_);
+
+  Buffer::OwnedImpl buffer;
+  EXPECT_CALL(*upgrade_response, onData(Ref(buffer))).WillOnce(Return(false));
+  upstream_callbacks_->onUpstreamData(buffer, false);
+
+  EXPECT_CALL(*upgrade_response, onData(Ref(buffer))).WillOnce(Return(true));
+  EXPECT_CALL(*protocol_, completeUpgrade(_, Ref(*upgrade_response)));
+  EXPECT_CALL(callbacks_, continueDecoding());
+  EXPECT_CALL(*protocol_, writeMessageBegin(_, _))
+      .WillOnce(Invoke([&](Buffer::Instance&, const MessageMetadata& metadata) -> void {
+        EXPECT_EQ(metadata_->methodName(), metadata.methodName());
+        EXPECT_EQ(metadata_->messageType(), metadata.messageType());
+        EXPECT_EQ(metadata_->sequenceId(), metadata.sequenceId());
+      }));
+  upstream_callbacks_->onUpstreamData(buffer, false);
+
+  // Then the actual request...
+  sendTrivialStruct(FieldType::String);
+  completeRequest();
+  returnResponse();
+  destroyRouter();
+}
+
 TEST_F(ThriftRouterTest, ProtocolUpgradeSkippedOnExistingConnection) {
   initializeRouter();
   startRequest(MessageType::Call);

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -9,7 +9,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/common/wasm/v8:85.4"
 "source/extensions/common/wasm/null:77.8"
 "source/extensions/filters/network/sni_cluster:90.3"
-"source/extensions/filters/network/thrift_proxy/router:96.0"
 "source/extensions/filters/network/sni_dynamic_forward_proxy:90.9"
 "source/extensions/filters/network/dubbo_proxy:96.1"
 "source/extensions/filters/network/dubbo_proxy/router:95.1"


### PR DESCRIPTION
Adds some additional tests to cover untested lines in the Thrift router
filter. In addition, updates code ownership.

Risk Level: low
Testing: adds test cases
Docs Changes: n/a
Release Notes: n/a
Fixes: #12003
