### PR TITLE
header-to-metadata: add support for cookie to metadata

### DIFF
--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -86,6 +86,7 @@ message Config {
   }
 
   // A Rule defines what metadata to apply when a header is present or missing.
+  // [#next-free-field: 6]
   message Rule {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.header_to_metadata.v2.Config.Rule";

--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -95,14 +95,14 @@ message Config {
     //
     // The header to be extracted.
     string header = 1 [
-       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
-       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
     ];
 
     // The cookie to be extracted.
     string cookie = 5 [
-       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
-       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
     ];
 
     // If the header or cookie is present, apply this metadata KeyValuePair.

--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -90,8 +90,7 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.header_to_metadata.v2.Config.Rule";
 
-    // Specifies that one of the header or cookie match will be performed on
-    // the value of the header or cookie.
+    // Specifies that a match will be performed on the value of a header or a cookie.
     //
     // The header to be extracted.
     string header = 1 [

--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -90,25 +90,37 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.header_to_metadata.v2.Config.Rule";
 
-    // The header that triggers this rule — required.
-    string header = 1
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    // Specifies that one of the header or cookie match will be performed on
+    // the value of the header or cookie.
+    //
+    // The header to be extracted.
+    string header = 1 [
+       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+    ];
 
-    // If the header is present, apply this metadata KeyValuePair.
+    // The cookie to be extracted.
+    string cookie = 5 [
+       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+    ];
+
+    // If the header or cookie is present, apply this metadata KeyValuePair.
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
-    // of the header value.
+    // of the header or cookie value.
     KeyValuePair on_header_present = 2;
 
-    // If the header is not present, apply this metadata KeyValuePair.
+    // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
-    // of the missing header value.
+    // of the missing header or cookie value.
     KeyValuePair on_header_missing = 3;
 
     // Whether or not to remove the header after a rule is applied.
     //
     // This prevents headers from leaking.
+    // This field is not supported in case of a cookie.
     bool remove = 4;
   }
 

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -90,25 +90,34 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.http.header_to_metadata.v3.Config.Rule";
 
-    // The header that triggers this rule — required.
-    string header = 1
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    // Specifies that one of the header or cookie match will be performed on
+    // the value of the header or cookie.
+    oneof header_cookie_specifier {
+      // The header to be extracted.
+      string header = 1
+          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
-    // If the header is present, apply this metadata KeyValuePair.
+      // The cookie to be extracted.
+      string cookie = 5
+          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    }
+
+    // If the header or cookie is present, apply this metadata KeyValuePair.
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
-    // of the header value.
+    // of the header or cookie value.
     KeyValuePair on_header_present = 2;
 
-    // If the header is not present, apply this metadata KeyValuePair.
+    // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
-    // of the missing header value.
+    // of the missing header or cookie value.
     KeyValuePair on_header_missing = 3;
 
     // Whether or not to remove the header after a rule is applied.
     //
     // This prevents headers from leaking.
+    // This field is not supported in case of a cookie.
     bool remove = 4;
   }
 

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -86,21 +86,21 @@ message Config {
   }
 
   // A Rule defines what metadata to apply when a header is present or missing.
+  // [#next-free-field: 6]
   message Rule {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.http.header_to_metadata.v3.Config.Rule";
 
-    // Specifies that a match will be performed on the value of a header or a cookie.
     oneof header_cookie_specifier {
+      // Specifies that a match will be performed on the value of a header or a cookie.
+      //
       // The header to be extracted.
-      string header = 1 [
-        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
-      ];
+      string header = 1
+          [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
 
       // The cookie to be extracted.
-      string cookie = 5 [
-        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
-      ];
+      string cookie = 5
+          [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
     }
 
     // If the header or cookie is present, apply this metadata KeyValuePair.

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -90,8 +90,7 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.http.header_to_metadata.v3.Config.Rule";
 
-    // Specifies that one of the header or cookie match will be performed on
-    // the value of the header or cookie.
+    // Specifies that a match will be performed on the value of a header or a cookie.
     oneof header_cookie_specifier {
       // The header to be extracted.
       string header = 1 [

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -94,12 +94,14 @@ message Config {
     // the value of the header or cookie.
     oneof header_cookie_specifier {
       // The header to be extracted.
-      string header = 1
-          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      string header = 1 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
 
       // The cookie to be extracted.
-      string cookie = 5
-          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      string cookie = 5 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
     }
 
     // If the header or cookie is present, apply this metadata KeyValuePair.

--- a/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
+++ b/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
@@ -7,8 +7,13 @@ Envoy Header-To-Metadata Filter
 
 This filter is configured with rules that will be matched against requests and responses.
 Each rule has either a cookie or a header and can be triggered either when the header
-is present or missing. When a rule is triggered, dynamic metadata will be added based
-on the configuration of the rule.
+or cookie is present or missing.
+
+When a rule is triggered, dynamic metadata will be added based on the configuration of the rule.
+If the header or cookie is present, it's value is extracted and used along with the specified
+key as metadata. If the header or cookie is missing, on missing case is triggered and the value
+specifed is used for adding metadata.
+
 The metadata can then be used for load balancing decisions, consumed from logs, etc.
 
 A typical use case for this filter is to dynamically match requests with load balancer
@@ -41,7 +46,8 @@ absence of a version header could be:
             remove: false
 
 As with headers, the value of the specified cookie will be extracted from the request
-and added as metdata with the key specified.
+and added as metadata with the key specified.
+`remove: true` is unsupported for cookie.
 
 .. code-block:: yaml
 

--- a/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
+++ b/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
@@ -6,8 +6,9 @@ Envoy Header-To-Metadata Filter
 * This filter should be configured with the name *envoy.filters.http.header_to_metadata*.
 
 This filter is configured with rules that will be matched against requests and responses.
-Each rule has a header and can be triggered either when the header is present or missing. When
-a rule is triggered, dynamic metadata will be added based on the configuration of the rule.
+Each rule has either a cookie or a header and can be triggered either when the header
+is present or missing. When a rule is triggered, dynamic metadata will be added based
+on the configuration of the rule.
 The metadata can then be used for load balancing decisions, consumed from logs, etc.
 
 A typical use case for this filter is to dynamically match requests with load balancer
@@ -28,6 +29,28 @@ absence of a version header could be:
         "@type": type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config
         request_rules:
           - header: x-version
+            on_header_present:
+              metadata_namespace: envoy.lb
+              key: version
+              type: STRING
+            on_header_missing:
+              metadata_namespace: envoy.lb
+              key: default
+              value: 'true'
+              type: STRING
+            remove: false
+
+As with headers, the value of the specified cookie will be extracted from the request
+and added as metdata with the key specified.
+
+.. code-block:: yaml
+
+  http_filters:
+    - name: envoy.filters.http.header_to_metadata
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config
+        request_rules:
+          - cookie: cookie
             on_header_present:
               metadata_namespace: envoy.lb
               key: version

--- a/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
+++ b/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
@@ -12,7 +12,7 @@ or cookie is present or missing.
 When a rule is triggered, dynamic metadata will be added based on the configuration of the rule.
 If the header or cookie is present, it's value is extracted and used along with the specified
 key as metadata. If the header or cookie is missing, on missing case is triggered and the value
-specifed is used for adding metadata.
+specified is used for adding metadata.
 
 The metadata can then be used for load balancing decisions, consumed from logs, etc.
 

--- a/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
+++ b/docs/root/configuration/http/http_filters/header_to_metadata_filter.rst
@@ -47,7 +47,7 @@ absence of a version header could be:
 
 As with headers, the value of the specified cookie will be extracted from the request
 and added as metadata with the key specified.
-`remove: true` is unsupported for cookie.
+Removing a cookie when a rule matches is unsupported.
 
 .. code-block:: yaml
 

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -86,6 +86,7 @@ message Config {
   }
 
   // A Rule defines what metadata to apply when a header is present or missing.
+  // [#next-free-field: 6]
   message Rule {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.header_to_metadata.v2.Config.Rule";

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -95,14 +95,14 @@ message Config {
     //
     // The header to be extracted.
     string header = 1 [
-       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
-       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
     ];
 
     // The cookie to be extracted.
     string cookie = 5 [
-       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
-       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+      (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+      (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
     ];
 
     // If the header or cookie is present, apply this metadata KeyValuePair.

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -90,8 +90,7 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.header_to_metadata.v2.Config.Rule";
 
-    // Specifies that one of the header or cookie match will be performed on
-    // the value of the header or cookie.
+    // Specifies that a match will be performed on the value of a header or a cookie.
     //
     // The header to be extracted.
     string header = 1 [

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -90,25 +90,37 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.http.header_to_metadata.v2.Config.Rule";
 
-    // The header that triggers this rule — required.
-    string header = 1
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    // Specifies that one of the header or cookie match will be performed on
+    // the value of the header or cookie.
+    //
+    // The header to be extracted.
+    string header = 1 [
+       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+    ];
 
-    // If the header is present, apply this metadata KeyValuePair.
+    // The cookie to be extracted.
+    string cookie = 5 [
+       (validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false},
+       (udpa.annotations.field_migrate).oneof_promotion = "header_cookie_specifier"
+    ];
+
+    // If the header or cookie is present, apply this metadata KeyValuePair.
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
-    // of the header value.
+    // of the header or cookie value.
     KeyValuePair on_header_present = 2;
 
-    // If the header is not present, apply this metadata KeyValuePair.
+    // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
-    // of the missing header value.
+    // of the missing header or cookie value.
     KeyValuePair on_header_missing = 3;
 
     // Whether or not to remove the header after a rule is applied.
     //
     // This prevents headers from leaking.
+    // This field is not supported in case of a cookie.
     bool remove = 4;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -90,25 +90,34 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.http.header_to_metadata.v3.Config.Rule";
 
-    // The header that triggers this rule — required.
-    string header = 1
-        [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    // Specifies that one of the header or cookie match will be performed on
+    // the value of the header or cookie.
+    oneof header_cookie_specifier {
+      // The header to be extracted.
+      string header = 1
+          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
-    // If the header is present, apply this metadata KeyValuePair.
+      // The cookie to be extracted.
+      string cookie = 5
+          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+    }
+
+    // If the header or cookie is present, apply this metadata KeyValuePair.
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
-    // of the header value.
+    // of the header or cookie value.
     KeyValuePair on_header_present = 2;
 
-    // If the header is not present, apply this metadata KeyValuePair.
+    // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
-    // of the missing header value.
+    // of the missing header or cookie value.
     KeyValuePair on_header_missing = 3;
 
     // Whether or not to remove the header after a rule is applied.
     //
     // This prevents headers from leaking.
+    // This field is not supported in case of a cookie.
     bool remove = 4;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -86,21 +86,21 @@ message Config {
   }
 
   // A Rule defines what metadata to apply when a header is present or missing.
+  // [#next-free-field: 6]
   message Rule {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.http.header_to_metadata.v3.Config.Rule";
 
-    // Specifies that a match will be performed on the value of a header or a cookie.
     oneof header_cookie_specifier {
+      // Specifies that a match will be performed on the value of a header or a cookie.
+      //
       // The header to be extracted.
-      string header = 1 [
-        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
-      ];
+      string header = 1
+          [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
 
       // The cookie to be extracted.
-      string cookie = 5 [
-        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
-      ];
+      string cookie = 5
+          [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
     }
 
     // If the header or cookie is present, apply this metadata KeyValuePair.

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -90,8 +90,7 @@ message Config {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.http.header_to_metadata.v3.Config.Rule";
 
-    // Specifies that one of the header or cookie match will be performed on
-    // the value of the header or cookie.
+    // Specifies that a match will be performed on the value of a header or a cookie.
     oneof header_cookie_specifier {
       // The header to be extracted.
       string header = 1 [

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -94,12 +94,14 @@ message Config {
     // the value of the header or cookie.
     oneof header_cookie_specifier {
       // The header to be extracted.
-      string header = 1
-          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      string header = 1 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
 
       // The cookie to be extracted.
-      string cookie = 5
-          [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      string cookie = 5 [
+        (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_NAME strict: false}
+      ];
     }
 
     // If the header or cookie is present, apply this metadata KeyValuePair.

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -50,7 +50,8 @@ Rule::Rule(const ProtoRule& rule) : rule_(rule) {
 
   // Initialize the shared pointer.
   if (!rule.header().empty()) {
-    selector_ = std::make_shared<HeaderValueSelector>(Http::LowerCaseString(rule.header()), rule.remove());
+    selector_ =
+        std::make_shared<HeaderValueSelector>(Http::LowerCaseString(rule.header()), rule.remove());
   } else if (!rule.cookie().empty()) {
     selector_ = std::make_shared<CookieValueSelector>(rule.cookie());
   } else {
@@ -111,7 +112,7 @@ bool Config::configToVector(const ProtobufRepeatedRule& proto_rules,
   }
 
   for (const auto& entry : proto_rules) {
-      vector.emplace_back(entry);
+    vector.emplace_back(entry);
   }
 
   return true;
@@ -151,8 +152,8 @@ void HeaderToMetadataFilter::setEncoderFilterCallbacks(
 }
 
 bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta_namespace,
-                                         const std::string& key, std::string value,
-                                         ValueType type, ValueEncode encode) const {
+                                         const std::string& key, std::string value, ValueType type,
+                                         ValueEncode encode) const {
   ProtobufWkt::Value val;
 
   ASSERT(!value.empty());
@@ -216,10 +217,8 @@ const std::string& HeaderToMetadataFilter::decideNamespace(const std::string& ns
 }
 
 // add metadata['key']= value depending on header present or missing case
-void HeaderToMetadataFilter::applyKeyValue(std::string value,
-                                           const Rule& rule,
-                                           const KeyValuePair& keyval,
-                                           StructMap& np) {
+void HeaderToMetadataFilter::applyKeyValue(std::string value, const Rule& rule,
+                                           const KeyValuePair& keyval, StructMap& np) {
   if (!keyval.value().empty()) {
     value = keyval.value();
   } else {
@@ -246,9 +245,11 @@ void HeaderToMetadataFilter::writeHeaderToMetadata(Http::HeaderMap& headers,
     absl::optional<std::string> value = rule.selector_->extract(headers);
 
     if (value && proto_rule.has_on_header_present()) {
-      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_present(), structs_by_namespace);
+      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_present(),
+                    structs_by_namespace);
     } else if (!value && proto_rule.has_on_header_missing()) {
-      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_missing(), structs_by_namespace);
+      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_missing(),
+                    structs_by_namespace);
     }
   }
   // Any matching rules?

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -36,7 +36,7 @@ absl::optional<std::string> HeaderValueSelector::extract(Http::HeaderMap& map) c
 absl::optional<std::string> CookieValueSelector::extract(Http::HeaderMap& map) const {
   std::string value = Envoy::Http::Utility::parseCookieValue(map, cookie_);
   if (!value.empty()) {
-    return absl::optional<std::string>(value);
+    return absl::optional<std::string>(std::move(value));
   }
   return absl::nullopt;
 }

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -18,7 +18,69 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderToMetadataFilter {
 
-Rule::Rule(const std::string& header, const ProtoRule& rule) : header_(header), rule_(rule) {
+// Extract the value of the header.
+absl::optional<std::string> HeaderValueSelector::extract(Http::HeaderMap& map) const {
+  const Http::HeaderEntry* header_entry = map.get(header_);
+  if (header_entry == nullptr) {
+    return absl::nullopt; // no value
+  }
+  // Catch the value in the header before removing.
+  absl::optional<std::string> value = std::string(header_entry->value().getStringView());
+  if (remove_) {
+    map.remove(header_); // remove the header
+  }
+  return value;
+}
+
+// Extract the value of the key from the cookie header.
+absl::optional<std::string> CookieValueSelector::extract(Http::HeaderMap& map) const {
+  std::string value = Envoy::Http::Utility::parseCookieValue(map, cookie_);
+  if (!value.empty()) {
+    return absl::optional<std::string>(value);
+  }
+  return absl::nullopt; // no value
+}
+
+Rule::Rule(const ProtoRule& rule) : rule_(rule) {
+  // Ensure only one of header and cookie is specified.
+  // TODO(radha13): remove this once we are on v4 and these fields are folded into a oneof.
+  if (!rule.cookie().empty() && !rule.header().empty()) {
+    throw EnvoyException("Cannot specify both header and cookie");
+  }
+
+  // Initialize the shared pointer.
+  if (!rule.header().empty()) {
+    selector_ = std::make_shared<HeaderValueSelector>(Http::LowerCaseString(rule.header()), rule.remove());
+  } else if (!rule.cookie().empty()) {
+    selector_ = std::make_shared<CookieValueSelector>(rule.cookie());
+  } else {
+    throw EnvoyException("One of Cookie or Header option needs to be specified");
+  }
+
+  // Rule must have at least one of the `on_header_*` fields set.
+  if (!rule.has_on_header_present() && !rule.has_on_header_missing()) {
+    const auto& error = fmt::format("header to metadata filter: rule for {} has neither "
+                                    "`on_header_present` nor `on_header_missing` set",
+                                    selector_->toString());
+    throw EnvoyException(error);
+  }
+
+  // Ensure value and regex_value_rewrite are not mixed.
+  // TODO(rgs1): remove this once we are on v4 and these fields are folded into a oneof.
+  if (!rule.on_header_present().value().empty() &&
+      rule.on_header_present().has_regex_value_rewrite()) {
+    throw EnvoyException("Cannot specify both value and regex_value_rewrite");
+  }
+
+  // Remove field is un-supported for cookie.
+  if (!rule.cookie().empty() && rule.remove()) {
+    throw EnvoyException("Cannot specify remove for cookie");
+  }
+
+  if (rule.has_on_header_missing() && rule.on_header_missing().value().empty()) {
+    throw EnvoyException("Cannot specify on_header_missing rule with an empty value");
+  }
+
   if (rule.on_header_present().has_regex_value_rewrite()) {
     const auto& rewrite_spec = rule.on_header_present().regex_value_rewrite();
     regex_rewrite_ = Regex::Utility::parseRegex(rewrite_spec.pattern());
@@ -49,26 +111,7 @@ bool Config::configToVector(const ProtobufRepeatedRule& proto_rules,
   }
 
   for (const auto& entry : proto_rules) {
-    // Rule must have at least one of the `on_header_*` fields set.
-    if (!entry.has_on_header_present() && !entry.has_on_header_missing()) {
-      const auto& error = fmt::format("header to metadata filter: rule for header '{}' has neither "
-                                      "`on_header_present` nor `on_header_missing` set",
-                                      entry.header());
-      throw EnvoyException(error);
-    }
-
-    // Ensure value and regex_value_rewrite are not mixed.
-    // TODO(rgs1): remove this once we are on v4 and these fields are folded into a oneof.
-    if (!entry.on_header_present().value().empty() &&
-        entry.on_header_present().has_regex_value_rewrite()) {
-      throw EnvoyException("Cannot specify both value and regex_value_rewrite");
-    }
-
-    if (entry.has_on_header_missing() && entry.on_header_missing().value().empty()) {
-      throw EnvoyException("Cannot specify on_header_missing rule with an empty value");
-    }
-
-    vector.emplace_back(entry.header(), entry);
+      vector.emplace_back(entry);
   }
 
   return true;
@@ -108,7 +151,7 @@ void HeaderToMetadataFilter::setEncoderFilterCallbacks(
 }
 
 bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta_namespace,
-                                         const std::string& key, absl::string_view value,
+                                         const std::string& key, std::string value,
                                          ValueType type, ValueEncode encode) const {
   ProtobufWkt::Value val;
 
@@ -120,7 +163,7 @@ bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta
     return false;
   }
 
-  std::string decodedValue = std::string(value);
+  std::string decodedValue = value;
   if (encode == envoy::extensions::filters::http::header_to_metadata::v3::Config::BASE64) {
     decodedValue = Base64::decodeWithoutPadding(value);
     if (decodedValue.empty()) {
@@ -172,56 +215,42 @@ const std::string& HeaderToMetadataFilter::decideNamespace(const std::string& ns
   return nspace.empty() ? HttpFilterNames::get().HeaderToMetadata : nspace;
 }
 
+// add metadata['key']= value depending on header present or missing case
+void HeaderToMetadataFilter::applyKeyValue(std::string value,
+                                           const Rule& rule,
+                                           const KeyValuePair& keyval,
+                                           StructMap& np) {
+  if (!keyval.value().empty()) {
+    value = keyval.value();
+  } else {
+    const auto& matcher = rule.regexRewrite();
+    if (matcher != nullptr) {
+      value = matcher->replaceAll(value, rule.regexSubstitution());
+    }
+  }
+  if (!value.empty()) {
+    const auto& nspace = decideNamespace(keyval.metadata_namespace());
+    addMetadata(np, nspace, keyval.key(), value, keyval.type(), keyval.encode());
+  } else {
+    ENVOY_LOG(debug, "value is empty, not adding metadata");
+  }
+}
+
 void HeaderToMetadataFilter::writeHeaderToMetadata(Http::HeaderMap& headers,
                                                    const HeaderToMetadataRules& rules,
                                                    Http::StreamFilterCallbacks& callbacks) {
   StructMap structs_by_namespace;
 
   for (const auto& rule : rules) {
-    const auto& header = rule.header();
     const auto& proto_rule = rule.rule();
-    const Http::HeaderEntry* header_entry = headers.get(header);
+    absl::optional<std::string> value = rule.selector_->extract(headers);
 
-    if (header_entry != nullptr && proto_rule.has_on_header_present()) {
-      const auto& keyval = proto_rule.on_header_present();
-      absl::string_view value = header_entry->value().getStringView();
-      // This is used to hold the rewritten header value, so that it can
-      // be bound to value without going out of scope.
-      std::string rewritten_value;
-
-      if (!keyval.value().empty()) {
-        value = absl::string_view(keyval.value());
-      } else {
-        const auto& matcher = rule.regexRewrite();
-        if (matcher != nullptr) {
-          rewritten_value = matcher->replaceAll(value, rule.regexSubstitution());
-          value = rewritten_value;
-        }
-      }
-
-      if (!value.empty()) {
-        const auto& nspace = decideNamespace(keyval.metadata_namespace());
-        addMetadata(structs_by_namespace, nspace, keyval.key(), value, keyval.type(),
-                    keyval.encode());
-      } else {
-        ENVOY_LOG(debug, "value is empty, not adding metadata");
-      }
-
-      if (proto_rule.remove()) {
-        headers.remove(header);
-      }
-    }
-    if (header_entry == nullptr && proto_rule.has_on_header_missing()) {
-      // Add metadata for the header missing case.
-      const auto& keyval = proto_rule.on_header_missing();
-
-      ASSERT(!keyval.value().empty());
-      const auto& nspace = decideNamespace(keyval.metadata_namespace());
-      addMetadata(structs_by_namespace, nspace, keyval.key(), keyval.value(), keyval.type(),
-                  keyval.encode());
+    if (value && proto_rule.has_on_header_present()) {
+      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_present(), structs_by_namespace);
+    } else if (!value && proto_rule.has_on_header_missing()) {
+      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_missing(), structs_by_namespace);
     }
   }
-
   // Any matching rules?
   if (!structs_by_namespace.empty()) {
     for (auto const& entry : structs_by_namespace) {

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -20,17 +20,63 @@ namespace HeaderToMetadataFilter {
 using ProtoRule = envoy::extensions::filters::http::header_to_metadata::v3::Config::Rule;
 using ValueType = envoy::extensions::filters::http::header_to_metadata::v3::Config::ValueType;
 using ValueEncode = envoy::extensions::filters::http::header_to_metadata::v3::Config::ValueEncode;
+using KeyValuePair = envoy::extensions::filters::http::header_to_metadata::v3::Config::KeyValuePair;
 
-class Rule {
+// Interface for getting values from a cookie or a header.
+class ValueSelector {
 public:
-  Rule(const std::string& header, const ProtoRule& rule);
-  const ProtoRule& rule() const { return rule_; }
-  const Regex::CompiledMatcherPtr& regexRewrite() const { return regex_rewrite_; }
-  const std::string& regexSubstitution() const { return regex_rewrite_substitution_; }
-  const Http::LowerCaseString& header() const { return header_; }
+  virtual ~ValueSelector() = default;
+
+  /**
+   * Called to extract the value of a given header or cookie.
+   * @param http header map.
+   */
+  virtual absl::optional<std::string> extract(Http::HeaderMap& map) const PURE;
+
+  /**
+   * @return a string representation of either a cookie or a header passed in the request.
+   */
+  virtual std::string toString() const PURE;
+};
+
+// Get value from a header.
+class HeaderValueSelector : public ValueSelector
+{
+public:
+  // Implements ValueSelector.
+  explicit HeaderValueSelector(Http::LowerCaseString header, bool remove) : header_(std::move(header)), remove_(std::move(remove)) {}
+  absl::optional<std::string> extract(Http::HeaderMap& map) const override;
+  std::string toString() const override { return fmt::format("header '{}'", header_.get()); }
+  ~HeaderValueSelector() override = default;
 
 private:
   const Http::LowerCaseString header_;
+  const bool remove_;
+};
+
+// Get value from a cookie.
+class CookieValueSelector : public ValueSelector
+{
+public:
+  // Implements ValueSelector.
+  explicit CookieValueSelector(std::string cookie) : cookie_(std::move(cookie)) {}
+  absl::optional<std::string> extract(Http::HeaderMap& map) const override;
+  std::string toString() const override { return fmt::format("cookie '{}'", cookie_); }
+  ~CookieValueSelector() override = default;
+
+private:
+  const std::string cookie_;
+};
+
+class Rule {
+public:
+  Rule(const ProtoRule& rule);
+  const ProtoRule& rule() const { return rule_; }
+  const Regex::CompiledMatcherPtr& regexRewrite() const { return regex_rewrite_; }
+  const std::string& regexSubstitution() const { return regex_rewrite_substitution_; }
+  std::shared_ptr<const ValueSelector> selector_;
+
+private:
   const ProtoRule rule_;
   Regex::CompiledMatcherPtr regex_rewrite_{};
   std::string regex_rewrite_substitution_{};
@@ -142,8 +188,9 @@ private:
    */
   void writeHeaderToMetadata(Http::HeaderMap& headers, const HeaderToMetadataRules& rules,
                              Http::StreamFilterCallbacks& callbacks);
-  bool addMetadata(StructMap&, const std::string&, const std::string&, absl::string_view, ValueType,
+  bool addMetadata(StructMap&, const std::string&, const std::string&, std::string, ValueType,
                    ValueEncode) const;
+  void applyKeyValue(std::string, const Rule&, const KeyValuePair&, StructMap&);
   const std::string& decideNamespace(const std::string& nspace) const;
   const Config* getConfig() const;
 };

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -30,6 +30,7 @@ public:
   /**
    * Called to extract the value of a given header or cookie.
    * @param http header map.
+   * @return absl::optional<std::string> the extracted header or cookie.
    */
   virtual absl::optional<std::string> extract(Http::HeaderMap& map) const PURE;
 

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -42,7 +42,7 @@ public:
 // Get value from a header.
 class HeaderValueSelector : public ValueSelector {
 public:
-  // Implements ValueSelector.
+  // ValueSelector.
   explicit HeaderValueSelector(Http::LowerCaseString header, bool remove)
       : header_(std::move(header)), remove_(std::move(remove)) {}
   absl::optional<std::string> extract(Http::HeaderMap& map) const override;
@@ -57,7 +57,7 @@ private:
 // Get value from a cookie.
 class CookieValueSelector : public ValueSelector {
 public:
-  // Implements ValueSelector.
+  // ValueSelector.
   explicit CookieValueSelector(std::string cookie) : cookie_(std::move(cookie)) {}
   absl::optional<std::string> extract(Http::HeaderMap& map) const override;
   std::string toString() const override { return fmt::format("cookie '{}'", cookie_); }

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -40,11 +40,11 @@ public:
 };
 
 // Get value from a header.
-class HeaderValueSelector : public ValueSelector
-{
+class HeaderValueSelector : public ValueSelector {
 public:
   // Implements ValueSelector.
-  explicit HeaderValueSelector(Http::LowerCaseString header, bool remove) : header_(std::move(header)), remove_(std::move(remove)) {}
+  explicit HeaderValueSelector(Http::LowerCaseString header, bool remove)
+      : header_(std::move(header)), remove_(std::move(remove)) {}
   absl::optional<std::string> extract(Http::HeaderMap& map) const override;
   std::string toString() const override { return fmt::format("header '{}'", header_.get()); }
   ~HeaderValueSelector() override = default;
@@ -55,8 +55,7 @@ private:
 };
 
 // Get value from a cookie.
-class CookieValueSelector : public ValueSelector
-{
+class CookieValueSelector : public ValueSelector {
 public:
   // Implements ValueSelector.
   explicit CookieValueSelector(std::string cookie) : cookie_(std::move(cookie)) {}

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -31,17 +31,6 @@ void testForbiddenConfig(const std::string& yaml) {
                EnvoyException);
 }
 
-// Tests that an empty header is rejected.
-TEST(HeaderToMetadataFilterConfigTest, InvalidEmptyHeader) {
-  const std::string yaml = R"EOF(
-request_rules:
-- header: ""
-  )EOF";
-
-  HeaderToMetadataProtoConfig proto_config;
-  EXPECT_THROW(TestUtility::loadFromYamlAndValidate(yaml, proto_config), ProtoValidationException);
-}
-
 // Tests that empty (metadata) keys are rejected.
 TEST(HeaderToMetadataFilterConfigTest, InvalidEmptyKey) {
   const std::string yaml = R"EOF(
@@ -57,7 +46,22 @@ request_rules:
   EXPECT_THROW(TestUtility::loadFromYamlAndValidate(yaml, proto_config), ProtoValidationException);
 }
 
-// Tests that a valid config is properly consumed.
+// Tests that empty (metadata) keys are rejected in case of cookie.
+TEST(HeaderToMetadataFilterConfigTest, InvalidEmptyCookieKey) {
+  const std::string yaml = R"EOF(
+request_rules:
+  - cookie: x-cookie
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: ""
+      type: STRING
+  )EOF";
+
+  HeaderToMetadataProtoConfig proto_config;
+  EXPECT_THROW(TestUtility::loadFromYamlAndValidate(yaml, proto_config), ProtoValidationException);
+}
+
+// Tests that a valid config with header is properly consumed.
 TEST(HeaderToMetadataFilterConfigTest, SimpleConfig) {
   const std::string yaml = R"EOF(
 request_rules:
@@ -65,6 +69,34 @@ request_rules:
     on_header_present:
       metadata_namespace: envoy.lb
       key: version
+      type: STRING
+    on_header_missing:
+      metadata_namespace: envoy.lb
+      key: default
+      value: 'true'
+      type: STRING
+  )EOF";
+
+  HeaderToMetadataProtoConfig proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  HeaderToMetadataConfig factory;
+
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamFilter(_));
+  cb(filter_callbacks);
+}
+
+// Tests that a valid config with cookie is properly consumed.
+TEST(HeaderToMetadataFilterConfigTest, SimpleCookieConfig) {
+  const std::string yaml = R"EOF(
+request_rules:
+  - cookie: x-cookie
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: version1
       type: STRING
     on_header_missing:
       metadata_namespace: envoy.lb
@@ -133,11 +165,44 @@ request_rules:
   testForbiddenConfig(yaml);
 }
 
+// Tests that cookie configuration does not allow value and regex_value_rewrite in the same rule.
+TEST(HeaderToMetadataFilterConfigTest, CookieValueAndRegex) {
+  const std::string yaml = R"EOF(
+request_rules:
+  - cookie: x-cookie
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: cluster
+      value: foo
+      regex_value_rewrite:
+        pattern:
+          google_re2: {}
+          regex: "^/(cluster[\\d\\w-]+)/?.*$"
+        substitution: "\\1"
+  )EOF";
+
+  testForbiddenConfig(yaml);
+}
+
 // Tests that on_header_missing rules don't allow an empty value.
 TEST(HeaderToMetadataFilterConfigTest, OnHeaderMissingEmptyValue) {
   const std::string yaml = R"EOF(
 request_rules:
   - header: x-version
+    on_header_missing:
+      metadata_namespace: envoy.lb
+      key: "foo"
+      type: STRING
+  )EOF";
+
+  testForbiddenConfig(yaml);
+}
+
+// Tests that on_header_missing rules don't allow an empty cookie value.
+TEST(HeaderToMetadataFilterConfigTest, CookieOnHeaderMissingEmptyValue) {
+  const std::string yaml = R"EOF(
+request_rules:
+  - cookie: x-cookie
     on_header_missing:
       metadata_namespace: envoy.lb
       key: "foo"

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -444,6 +444,38 @@ TEST_F(HeaderToMetadataTest, PerRouteEmtpyRules) {
 }
 
 /**
+ * Invalid empty header or cookie should be rejected.
+ */
+TEST_F(HeaderToMetadataTest, RejectEmptyHeader) {
+  const std::string config = R"EOF(
+request_rules:
+  - header: ""
+
+)EOF";
+  auto expected = "One of Cookie or Header option needs to be specified";
+  EXPECT_THROW_WITH_MESSAGE(initializeFilter(config), EnvoyException, expected);
+}
+
+/**
+ * Rules with both header and cookie fields should be rejected.
+ */
+TEST_F(HeaderToMetadataTest, RejectBothCookieHeader) {
+  const std::string config = R"EOF(
+request_rules:
+  - header: x-something
+    cookie: something-else
+    on_header_present:
+      key: something
+      value: else
+      type: STRING
+    remove: false
+
+)EOF";
+  auto expected = "Cannot specify both header and cookie";
+  EXPECT_THROW_WITH_MESSAGE(initializeFilter(config), EnvoyException, expected);
+}
+
+/**
  * Rules with remove field should be rejected in case of a cookie.
  */
 TEST_F(HeaderToMetadataTest, RejectRemoveForCookie) {
@@ -458,11 +490,6 @@ request_rules:
 )EOF";
   auto expected = "Cannot specify remove for cookie";
   EXPECT_THROW_WITH_MESSAGE(initializeFilter(config), EnvoyException, expected);
-}
-
-TEST_F(HeaderToMetadataTest, RejectRemoveCookieRules) {
-  envoy::extensions::filters::http::header_to_metadata::v3::Config config_proto;
-  EXPECT_THROW(std::make_shared<Config>(config_proto, true), EnvoyException);
 }
 
 /**

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -636,7 +636,6 @@ response_rules:
   EXPECT_CALL(req_info_,
               setDynamicMetadata(HttpFilterNames::get().HeaderToMetadata, MapEq(expected)));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(incoming_headers, false));
-
 }
 
 /**
@@ -721,7 +720,6 @@ request_rules:
     EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
   }
-
 }
 
 } // namespace HeaderToMetadataFilter

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -444,6 +444,28 @@ TEST_F(HeaderToMetadataTest, PerRouteEmtpyRules) {
 }
 
 /**
+ * Rules with remove field should be rejected in case of a cookie.
+ */
+TEST_F(HeaderToMetadataTest, RejectRemoveForCookie) {
+  const std::string config = R"EOF(
+request_rules:
+  - cookie: cookie
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: version
+      type: STRING
+    remove: true
+)EOF";
+  auto expected = "Cannot specify remove for cookie";
+  EXPECT_THROW_WITH_MESSAGE(initializeFilter(config), EnvoyException, expected);
+}
+
+TEST_F(HeaderToMetadataTest, RejectRemoveCookieRules) {
+  envoy::extensions::filters::http::header_to_metadata::v3::Config config_proto;
+  EXPECT_THROW(std::make_shared<Config>(config_proto, true), EnvoyException);
+}
+
+/**
  * Empty values not added to metadata.
  */
 TEST_F(HeaderToMetadataTest, NoEmptyValues) {
@@ -541,6 +563,165 @@ request_rules:
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
   EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+/**
+ * on header missing case with no header data
+ */
+
+TEST_F(HeaderToMetadataTest, OnMissingWhenHeaderIsPresent) {
+  const std::string config = R"EOF(
+request_rules:
+  - header: x-version
+    on_header_missing:
+      metadata_namespace: envoy.lb
+      key: version
+      value: some_value
+      type: STRING
+)EOF";
+  initializeFilter(config);
+  Http::TestRequestHeaderMapImpl headers{{"x-version", ""}};
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+/**
+ * on header present case, when the regex replacement turns the header into an empty string
+ */
+TEST_F(HeaderToMetadataTest, HeaderIsPresentButRegexEmptiesIt) {
+  const std::string config = R"EOF(
+request_rules:
+  - header: x-version
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: cluster
+      regex_value_rewrite:
+        pattern:
+          google_re2: {}
+          regex: "^foo"
+        substitution: ""
+    on_header_missing:
+      metadata_namespace: envoy.lb
+      key: version
+      value: some_value
+      type: STRING
+)EOF";
+  initializeFilter(config);
+  Http::TestRequestHeaderMapImpl headers{{"x-version", "foo"}};
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_, setDynamicMetadata(_, _)).Times(0);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+/**
+ * cookie value extracted and stored
+ */
+TEST_F(HeaderToMetadataTest, CookieValueUsed) {
+  const std::string response_config_yaml = R"EOF(
+response_rules:
+  - cookie: bar
+    on_header_present:
+      key: bar
+      type: STRING
+    remove: false
+)EOF";
+  initializeFilter(response_config_yaml);
+  Http::TestResponseHeaderMapImpl incoming_headers{{"cookie", "bar=foo"}};
+  std::map<std::string, std::string> expected = {{"bar", "foo"}};
+
+  EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_,
+              setDynamicMetadata(HttpFilterNames::get().HeaderToMetadata, MapEq(expected)));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(incoming_headers, false));
+
+}
+
+/**
+ * Ignore the cookie's value, use a given constant value.
+ */
+TEST_F(HeaderToMetadataTest, IgnoreCookieValueUseConstant) {
+  const std::string response_config_yaml = R"EOF(
+response_rules:
+  - cookie: meh
+    on_header_present:
+      key: meh
+      value: some_value
+      type: STRING
+    remove: false
+)EOF";
+  initializeFilter(response_config_yaml);
+  Http::TestResponseHeaderMapImpl incoming_headers{{"cookie", "meh=foo"}};
+  std::map<std::string, std::string> expected = {{"meh", "some_value"}};
+
+  EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_,
+              setDynamicMetadata(HttpFilterNames::get().HeaderToMetadata, MapEq(expected)));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(incoming_headers, false));
+}
+
+/**
+ * No cookie value, no metadata
+ */
+TEST_F(HeaderToMetadataTest, NoCookieValue) {
+  const std::string config = R"EOF(
+request_rules:
+  - cookie: foo
+    on_header_missing:
+      metadata_namespace: envoy.lb
+      key: foo
+      value: some_value
+      type: STRING
+)EOF";
+  initializeFilter(config);
+  Http::TestRequestHeaderMapImpl headers{{"cookie", ""}};
+  std::map<std::string, std::string> expected = {{"foo", "some_value"}};
+
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+  EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+/**
+ * Regex substitution on cookie value.
+ */
+TEST_F(HeaderToMetadataTest, CookieRegexSubstitution) {
+  const std::string config = R"EOF(
+request_rules:
+  - cookie: foo
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: cluster
+      regex_value_rewrite:
+        pattern:
+          google_re2: {}
+          regex: "^(cluster[\\d\\w-]+)$"
+        substitution: "\\1 matched"
+)EOF";
+  initializeFilter(config);
+
+  // match.
+  {
+    Http::TestRequestHeaderMapImpl headers{{"cookie", "foo=cluster-prod-001"}};
+    std::map<std::string, std::string> expected = {{"cluster", "cluster-prod-001 matched"}};
+
+    EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+    EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  }
+
+  // No match.
+  {
+    Http::TestRequestHeaderMapImpl headers{{"cookie", "foo=cluster"}};
+    std::map<std::string, std::string> expected = {{"cluster", "cluster"}};
+
+    EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
+    EXPECT_CALL(req_info_, setDynamicMetadata("envoy.lb", MapEq(expected)));
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  }
+
 }
 
 } // namespace HeaderToMetadataFilter


### PR DESCRIPTION
Commit Message:
header-to-metadata filter supports adding a header's value to a metadata key which is later used for subset load balancing.

This PR adds support for extracting a specific cookie value before it's added as metadata.

Usage:

- example request headers:
```
'cookie', some=cookie; someother=cookie; X-Devhostname=docs-dev-yellow-mon'

```

- example config:
```
      request_rules:
        - cookie: "X-Devhostname"
          on_header_present:
            metadata_namespace: envoy.lb 
            key: "dev-hostname"
            type: STRING
            remove: false
```

- adds - metadata['dev-hostname'] = "docs-dev-yellow-mon"

Additional Description:
- refactor code a little
- `remove` action is not supported
- regex substitution works as it does for headers.

Risk Level: Medium
Testing: Unit tests
Docs Changes: updated
Release Notes: TODO

Co-authored-by: Ariane van der Steldt  <avandersteldt@slack-corp.com>
Signed-off-by: Radha Kumari <rkumari@slack-corp.com>