### PR TITLE
Only do DNS lookups for routes to Dynamic Forward Proxy clusters

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -23,6 +23,7 @@ Bug Fixes
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
 * csrf: fixed issues with regards to origin and host header parsing.
+* dynamic_forward_proxy: only perform DNS lookups for routes to Dynamic Forward Proxy clusters since other cluster types handle DNS lookup themselves.
 * fault: fixed an issue with `active_faults` gauge not being decremented for when abort faults were injected.
 
 Removed Config or Runtime

--- a/source/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/source/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -16,9 +16,11 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:filter_interface",
         "//source/common/runtime:runtime_features_lib",
+        "//source/extensions/clusters:well_known_names",
         "//source/extensions/common/dynamic_forward_proxy:dns_cache_interface",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -17,6 +17,7 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.http.dynamic_forward_proxy",
     deps = [
         "//source/common/stats:isolated_store_lib",
+        "//source/extensions/clusters:well_known_names",
         "//source/extensions/common/dynamic_forward_proxy:dns_cache_impl",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/dynamic_forward_proxy:config",
@@ -24,6 +25,7 @@ envoy_extension_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:test_runtime_lib",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -16,7 +16,6 @@ using testing::AtLeast;
 using testing::Eq;
 using testing::InSequence;
 using testing::Return;
-using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -249,8 +249,6 @@ TEST_F(ProxyFilterTest, NoCluster) {
 
 // No cluster type leads to skipping DNS lookups.
 TEST_F(ProxyFilterTest, NoClusterType) {
-  CustomClusterType cluster_type;
-  cluster_type.set_name(Envoy::Extensions::Clusters::ClusterTypes::get().Static);
   cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = absl::nullopt;
 
   InSequence s;

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -1,5 +1,7 @@
+#include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
 
+#include "extensions/clusters/well_known_names.h"
 #include "extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
 #include "extensions/filters/http/dynamic_forward_proxy/proxy_filter.h"
 #include "extensions/filters/http/well_known_names.h"
@@ -14,12 +16,15 @@ using testing::AtLeast;
 using testing::Eq;
 using testing::InSequence;
 using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace DynamicForwardProxy {
 namespace {
+
+using CustomClusterType = envoy::config::cluster::v3::Cluster::CustomClusterType;
 
 using LoadDnsCacheEntryStatus = Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus;
 using MockLoadDnsCacheEntryResult =
@@ -43,6 +48,12 @@ public:
     // Allow for an otherwise strict mock.
     EXPECT_CALL(callbacks_, connection()).Times(AtLeast(0));
     EXPECT_CALL(callbacks_, streamId()).Times(AtLeast(0));
+
+    // Configure upstream cluster to be a Dynamic Forward Proxy since that's the
+    // kind we need to do DNS entries for.
+    CustomClusterType cluster_type;
+    cluster_type.set_name(Envoy::Extensions::Clusters::ClusterTypes::get().DynamicForwardProxy);
+    cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = cluster_type;
 
     // Configure max pending to 1 so we can test circuit breaking.
     cm_.thread_local_cluster_.cluster_.info_->resetResourceManager(0, 1, 0, 0, 0);
@@ -234,6 +245,32 @@ TEST_F(ProxyFilterTest, NoCluster) {
 
   EXPECT_CALL(callbacks_, route());
   EXPECT_CALL(cm_, get(_)).WillOnce(Return(nullptr));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+}
+
+// No cluster type leads to skipping DNS lookups.
+TEST_F(ProxyFilterTest, NoClusterType) {
+  CustomClusterType cluster_type;
+  cluster_type.set_name(Envoy::Extensions::Clusters::ClusterTypes::get().Static);
+  cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = absl::nullopt;
+
+  InSequence s;
+
+  EXPECT_CALL(callbacks_, route());
+  EXPECT_CALL(cm_, get(_));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+}
+
+// Cluster that isn't a dynamic forward proxy cluster
+TEST_F(ProxyFilterTest, NonDynamicForwardProxy) {
+  CustomClusterType cluster_type;
+  cluster_type.set_name(Envoy::Extensions::Clusters::ClusterTypes::get().Static);
+  cm_.thread_local_cluster_.cluster_.info_->cluster_type_ = cluster_type;
+
+  InSequence s;
+
+  EXPECT_CALL(callbacks_, route());
+  EXPECT_CALL(cm_, get(_));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
 }
 


### PR DESCRIPTION
We only need to do DNS lookups for routes to dynamic forward proxy
clusters because the other cluster types handle DNS lookup themselves.

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

Risk Level: Low
Testing: bazel test //test/extensions/filters/http/dynamic_forward_proxy:proxy_filter_integration_test //test/extensions/filters/http/dynamic_forward_proxy:proxy_filter_test
Docs Changes: N/A
Release Notes: N/A