### PR TITLE
Add further info on file permissions to Docker docs

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -179,6 +179,20 @@ You can then configure ``envoy`` to log to files in ``/var/log``
 
 The default ``envoy`` ``uid`` and ``gid`` are ``101``.
 
+The ``envoy`` user also needs to have permission to access any required configuration files mounted
+into the container.
+
+If you are running in an environment with a strict ``umask`` setting, you may need to provide envoy with
+access either by setting the ``uid`` or ``gid`` of the file, or by making the configuration file readable
+by the envoy user.
+
+One method of doing this without changing any file permissions or running as root inside the container
+is to start the container with the host user's ``uid``, for example:
+
+.. substitution-code-block:: none
+
+  $ docker run -d --name envoy -e ENVOY_UID=`id -u` -p 9901:9901 -p 10000:10000 envoy:v1
+
 
 Sandboxes
 ---------


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Add further info on file permissions to Docker docs
Additional Description: Address an issue that has arisen around configuration file permissions
Risk Level: very low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue] Touch #12112
[Optional Deprecated:]
