### PR TITLE
http: more and more granular response code details.

### DIFF
--- a/docs/root/faq/debugging/why_is_envoy_sending_http2_resets.rst
+++ b/docs/root/faq/debugging/why_is_envoy_sending_http2_resets.rst
@@ -17,4 +17,8 @@ from the file "source/common/http/http2/codec_impl.cc" of the form
 for example:
 `invalid http2: Invalid HTTP header field was received: frame type: 1, stream: 1, name: [content-length], value: [3]`
 
+You can also check :ref:`HTTP/2 stats`<config_http_conn_man_stats_per_codec>`: in many cases where
+Envoy resets streams, for example if there are more headers than allowed by configuration or flood
+detection kicks in, http2 counters will be incremented as the streams are reset.
+
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -39,6 +39,7 @@ struct Http1ResponseCodeDetailValues {
   const absl::string_view BodyDisallowed = "http1.body_disallowed";
   const absl::string_view TransferEncodingNotAllowed = "http1.transfer_encoding_not_allowed";
   const absl::string_view ContentLengthNotAllowed = "http1.content_length_not_allowed";
+  const absl::string_view InvalidUnderscore = "http1.unexpected_underscore";
 };
 
 struct Http1HeaderTypesValues {
@@ -1045,7 +1046,7 @@ void ServerConnectionImpl::checkHeaderNameForUnderscores() {
       ENVOY_CONN_LOG(debug, "Rejecting request due to header name with underscores: {}",
                      connection_, current_header_field_.getStringView());
       error_code_ = Http::Code::BadRequest;
-      sendProtocolError(Http1ResponseCodeDetails::get().InvalidCharacters);
+      sendProtocolError(Http1ResponseCodeDetails::get().InvalidUnderscore);
       stats_.requests_rejected_with_underscores_in_headers_.inc();
       throw CodecProtocolException("http/1.1 protocol error: header name contains underscores");
     }

--- a/source/common/http/http1/codec_impl_legacy.cc
+++ b/source/common/http/http1/codec_impl_legacy.cc
@@ -40,6 +40,7 @@ struct Http1ResponseCodeDetailValues {
   const absl::string_view BodyDisallowed = "http1.body_disallowed";
   const absl::string_view TransferEncodingNotAllowed = "http1.transfer_encoding_not_allowed";
   const absl::string_view ContentLengthNotAllowed = "http1.content_length_not_allowed";
+  const absl::string_view InvalidUnderscore = "http1.unexpected_underscore";
 };
 
 struct Http1HeaderTypesValues {
@@ -1050,7 +1051,7 @@ void ServerConnectionImpl::checkHeaderNameForUnderscores() {
       ENVOY_CONN_LOG(debug, "Rejecting request due to header name with underscores: {}",
                      connection_, current_header_field_.getStringView());
       error_code_ = Http::Code::BadRequest;
-      sendProtocolError(Http1ResponseCodeDetails::get().InvalidCharacters);
+      sendProtocolError(Http1ResponseCodeDetails::get().InvalidUnderscore);
       stats_.requests_rejected_with_underscores_in_headers_.inc();
       throw CodecProtocolException("http/1.1 protocol error: header name contains underscores");
     }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -42,7 +42,7 @@ public:
   const absl::string_view outbound_frame_flood = "http2.outbound_frames_flood";
   // Envoy detected an inbound HTTP/2 frame flood.
   const absl::string_view inbound_empty_frame_flood = "http2.inbound_empty_frames_flood";
-  // Envoy was configured to drop requests with header keys begining with underscores.
+  // Envoy was configured to drop requests with header keys beginning with underscores.
   const absl::string_view invalid_underscore = "http2.unexpected_underscore";
 
   const absl::string_view errorDetails(int error_code) const {

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -506,7 +506,7 @@ private:
   virtual void checkOutboundQueueLimits() PURE;
   void incrementOutboundFrameCount(bool is_outbound_flood_monitored_control_frame);
   virtual bool trackInboundFrames(const nghttp2_frame_hd* hd, uint32_t padding_length) PURE;
-  virtual bool checkInboundFrameLimits() PURE;
+  virtual bool checkInboundFrameLimits(int32_t stream_id) PURE;
   void releaseOutboundFrame();
   void releaseOutboundControlFrame();
 
@@ -546,7 +546,7 @@ private:
   // TODO(yanavlasov): add flood mitigation for upstream connections as well.
   void checkOutboundQueueLimits() override {}
   bool trackInboundFrames(const nghttp2_frame_hd*, uint32_t) override { return true; }
-  bool checkInboundFrameLimits() override { return true; }
+  bool checkInboundFrameLimits(int32_t) override { return true; }
 
   Http::ConnectionCallbacks& callbacks_;
 };
@@ -571,7 +571,7 @@ private:
   int onHeader(const nghttp2_frame* frame, HeaderString&& name, HeaderString&& value) override;
   void checkOutboundQueueLimits() override;
   bool trackInboundFrames(const nghttp2_frame_hd* hd, uint32_t padding_length) override;
-  bool checkInboundFrameLimits() override;
+  bool checkInboundFrameLimits(int32_t stream_id) override;
   absl::optional<int> checkHeaderNameForUnderscores(absl::string_view header_name) override;
 
   // Http::Connection

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1129,7 +1129,7 @@ TEST_P(Http1ServerConnectionImplTest, HeaderNameWithUnderscoreCauseRequestReject
   auto status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
   EXPECT_EQ(status.message(), "http/1.1 protocol error: header name contains underscores");
-  EXPECT_EQ("http1.invalid_characters", response_encoder->getStream().responseDetails());
+  EXPECT_EQ("http1.unexpected_underscore", response_encoder->getStream().responseDetails());
   EXPECT_EQ(1, store_.counter("http1.requests_rejected_with_underscores_in_headers").value());
 }
 

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1730,6 +1730,7 @@ TEST_P(Http2FloodMitigationTest, EmptyHeaders) {
 }
 
 TEST_P(Http2FloodMitigationTest, EmptyHeadersContinuation) {
+  useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   beginSession();
 
   uint32_t request_idx = 0;
@@ -1743,12 +1744,14 @@ TEST_P(Http2FloodMitigationTest, EmptyHeadersContinuation) {
 
   tcp_client_->waitForDisconnect();
 
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.inbound_empty_frames_flood"));
   EXPECT_EQ(1, test_server_->counter("http2.inbound_empty_frames_flood")->value());
   EXPECT_EQ(1,
             test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());
 }
 
 TEST_P(Http2FloodMitigationTest, EmptyData) {
+  useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   beginSession();
   fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
@@ -1763,6 +1766,7 @@ TEST_P(Http2FloodMitigationTest, EmptyData) {
 
   tcp_client_->waitForDisconnect();
 
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.inbound_empty_frames_flood"));
   EXPECT_EQ(1, test_server_->counter("http2.inbound_empty_frames_flood")->value());
   EXPECT_EQ(1,
             test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -37,10 +37,10 @@
 #include "absl/time/time.h"
 #include "gtest/gtest.h"
 
-using testing::HasSubstr;
-
 namespace Envoy {
 namespace {
+
+using testing::HasSubstr;
 
 envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::CodecType
 typeToCodecType(Http::CodecClient::Type type) {
@@ -344,16 +344,15 @@ void HttpIntegrationTest::verifyResponse(IntegrationStreamDecoderPtr response,
                                          const std::string& expected_body) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ(response_code, response->headers().getStatusValue());
-  expected_headers.iterate(
-      [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-        auto response_headers = static_cast<Http::ResponseHeaderMap*>(context);
-        const Http::HeaderEntry* entry =
-            response_headers->get(Http::LowerCaseString{std::string(header.key().getStringView())});
-        EXPECT_NE(entry, nullptr);
-        EXPECT_EQ(header.value().getStringView(), entry->value().getStringView());
-        return Http::HeaderMap::Iterate::Continue;
-      },
-      const_cast<void*>(static_cast<const void*>(&response->headers())));
+  expected_headers.iterate([response_headers = &response->headers()](
+                               const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+    const Http::HeaderEntry* entry =
+        response_headers->get(Http::LowerCaseString{std::string(header.key().getStringView())});
+    EXPECT_NE(entry, nullptr);
+    EXPECT_EQ(header.value().getStringView(), entry->value().getStringView());
+    return Http::HeaderMap::Iterate::Continue;
+  });
+
   EXPECT_EQ(response->body(), expected_body);
 }
 
@@ -1044,18 +1043,13 @@ void HttpIntegrationTest::testLargeRequestHeaders(uint32_t size, uint32_t count,
       response->waitForReset();
       codec_client_->close();
     }
-    if (count > max_count) {
-      if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
-        EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http1.too_many_headers"));
-      } else {
-        EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.too_many_headers"));
-      }
-    }
-
   } else {
     auto response = sendRequestAndWaitForResponse(big_headers, 0, default_response_headers_, 0);
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().getStatusValue());
+  }
+  if (count > max_count) {
+    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("too_many_headers"));
   }
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -942,6 +942,7 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresRemainByDefault) {
 
 // Verify that request with headers containing underscores is rejected when configured.
 TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestRejectedByDefault) {
+  useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   config_helper_.addConfigModifier(
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void {
@@ -967,6 +968,7 @@ TEST_P(ProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestRejectedByDefa
     ASSERT_TRUE(response->reset());
     EXPECT_EQ(Http::StreamResetReason::RemoteReset, response->reset_reason());
   }
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("unexpected_underscore"));
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {


### PR DESCRIPTION
Adding rc details to a bunch of cases where Envoy does its own HTTP/2 validity checks

Risk Level: low/medium (changes to H2 codec)
Testing: extended integration tests
Docs Changes: better debug docs
Release Notes: n/a
Fixes https://github.com/envoyproxy/envoy/issues/11774
