### PR TITLE
Guard check that event_base_new initializes correctly

### DIFF
--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -16,7 +16,7 @@ void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
 } // namespace
 
 LibeventScheduler::LibeventScheduler() {
-  auto eventBase = event_base_new();
+  event_base* eventBase = event_base_new();
   RELEASE_ASSERT(eventBase != nullptr, "Failed to initialize libevent event_base");
   libevent_ = Libevent::BasePtr(eventBase);
 

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -17,7 +17,7 @@ void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
 
 LibeventScheduler::LibeventScheduler() {
   event_base* event_base = event_base_new();
-  RELEASE_ASSERT(eventBase != nullptr, "Failed to initialize libevent event_base");
+  RELEASE_ASSERT(event_base != nullptr, "Failed to initialize libevent event_base");
   libevent_ = Libevent::BasePtr(event_base);
 
   // The dispatcher won't work as expected if libevent hasn't been configured to use threads.

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -16,9 +16,9 @@ void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
 } // namespace
 
 LibeventScheduler::LibeventScheduler() {
-  event_base* eventBase = event_base_new();
+  event_base* event_base = event_base_new();
   RELEASE_ASSERT(eventBase != nullptr, "Failed to initialize libevent event_base");
-  libevent_ = Libevent::BasePtr(eventBase);
+  libevent_ = Libevent::BasePtr(event_base);
 
   // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
   RELEASE_ASSERT(Libevent::Global::initialized(), "");

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -15,7 +15,11 @@ void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
 }
 } // namespace
 
-LibeventScheduler::LibeventScheduler() : libevent_(event_base_new()) {
+LibeventScheduler::LibeventScheduler(){
+  auto eventBase = event_base_new();
+  RELEASE_ASSERT(eventBase != nullptr, "Failed to initialize libevent event_base");
+  libevent_ = Libevent::BasePtr(eventBase);
+
   // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
   RELEASE_ASSERT(Libevent::Global::initialized(), "");
 }

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -15,7 +15,7 @@ void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
 }
 } // namespace
 
-LibeventScheduler::LibeventScheduler(){
+LibeventScheduler::LibeventScheduler() {
   auto eventBase = event_base_new();
   RELEASE_ASSERT(eventBase != nullptr, "Failed to initialize libevent event_base");
   libevent_ = Libevent::BasePtr(eventBase);


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos sonanopo@microsoft.com

Add a release assert to the libevent `event_base_new()` to make sure that the initialization is correct and make envoy fail fast if it fails.

Additional Description: 

This scenario crashes with an Access Violation at later stages. With this change we just make sure that we crash closer to where we actually failed. 


Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A