### PR TITLE
fuzz: fix crash into filter fuzz test

### DIFF
--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5726031248621568
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-5726031248621568
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.tap"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap"
+    value: "\n\002\022\000"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/uber_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.cc
@@ -195,7 +195,7 @@ void UberFilterFuzzer::fuzz(
         Server::Configuration::NamedHttpFilterConfigFactory>(proto_config.name());
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         proto_config, factory_context_.messageValidationVisitor(), factory);
-    // Clean-up config with filter-specific logic.
+    // Clean-up config with filter-specific logic before it runs through validations.
     cleanFuzzedConfig(proto_config.name(), message.get());
     cb_ = factory.createFilterFactoryFromProto(*message, "stats", factory_context_);
     cb_(filter_callback_);

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -104,9 +104,15 @@ void cleanTapConfig(Protobuf::Message* message) {
         true);
   }
   // TODO(samflattery): remove once StreamingGrpcSink is implemented
+  // a static config filter is required to have one sink, but since validation isn't performed on
+  // the filter until after this function runs, we have to manually check that there are sinks
+  // before checking that they are not StreamingGrpc
   else if (config.common_config().config_type_case() ==
                envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::
                    kStaticConfig &&
+           config.common_config()
+                   .static_config()
+                   .output_config().sinks().size() > 0 &&
            config.common_config()
                    .static_config()
                    .output_config()
@@ -129,7 +135,7 @@ void UberFilterFuzzer::cleanFuzzedConfig(absl::string_view filter_name,
   } else if (name == HttpFilterNames::get().Squash) {
     cleanAttachmentTemplate(message);
   } else if (name == HttpFilterNames::get().Tap) {
-    // TapDS oneof field not implemented.
+    // TapDS oneof field and OutputSinkType StreamingGrpc not implemented
     cleanTapConfig(message);
   }
   if (filter_name == HttpFilterNames::get().JwtAuthn) {

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -110,7 +110,7 @@ void cleanTapConfig(Protobuf::Message* message) {
   else if (config.common_config().config_type_case() ==
                envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::
                    kStaticConfig &&
-           config.common_config().static_config().output_config().sinks().size() > 0 &&
+           !config.common_config().static_config().output_config().sinks().empty() &&
            config.common_config()
                    .static_config()
                    .output_config()

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -110,9 +110,7 @@ void cleanTapConfig(Protobuf::Message* message) {
   else if (config.common_config().config_type_case() ==
                envoy::extensions::common::tap::v3::CommonExtensionConfig::ConfigTypeCase::
                    kStaticConfig &&
-           config.common_config()
-                   .static_config()
-                   .output_config().sinks().size() > 0 &&
+           config.common_config().static_config().output_config().sinks().size() > 0 &&
            config.common_config()
                    .static_config()
                    .output_config()


### PR DESCRIPTION
Commit Message: Fix crash in filter fuzz test due to validation not running until after cleaning
Additional Description:

- since the input config message contains an `Any` field, validation is not run on it, so I added a check to make sure that there was at least one sink before trying to deference it
- test doesn't reproduce in gtest mode
- test does reproduce in libfuzzer mode with --config asan-fuzzer (with bazel build, then run binary with argument /full/path/to/failing/test)

Risk Level: Low
Testing: passes regression corpus
Docs Changes: N/A
Release Notes: N/A
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24301