### PR TITLE
api: Add CertificateProviderInstance to CommonTlsContext.

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -40,7 +40,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -227,6 +227,13 @@ message Bootstrap {
   // Optional overriding of default socket interface. The value must be the name of one of the
   // socket interface factories initialized through a bootstrap extension
   string default_socket_interface = 24;
+
+  // Global map of CertificateProvider instances. These instances are referred to by name in the
+  // :ref:`CommonTlsContext.CertificateProviderInstance.instance_name
+  // <envoy_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance.instance_name>`
+  // field.
+  // [#not-implemented-hide:]
+  map<string, core.v3.TypedExtensionConfig> certificate_provider_instances = 25;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -38,7 +38,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v3.Bootstrap";
@@ -218,6 +218,13 @@ message Bootstrap {
   // Optional overriding of default socket interface. The value must be the name of one of the
   // socket interface factories initialized through a bootstrap extension
   string default_socket_interface = 24;
+
+  // Global map of CertificateProvider instances. These instances are referred to by name in the
+  // :ref:`CommonTlsContext.CertificateProviderInstance.instance_name
+  // <envoy_api_field_extensions.transport_sockets.tls.v4alpha.CommonTlsContext.CertificateProviderInstance.instance_name>`
+  // field.
+  // [#not-implemented-hide:]
+  map<string, core.v4alpha.TypedExtensionConfig> certificate_provider_instances = 25;
 }
 
 // Administration interface :ref:`operations documentation

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -123,17 +123,23 @@ message CommonTlsContext {
     }
   }
 
-  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
-  // client side instead of being sent from the control plane.
+  // Similar to CertificateProvider above, but allows the provider instances to be configured on
+  // the client side instead of being sent from the control plane.
   message CertificateProviderInstance {
-    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
-    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // Provider instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
     // field that would be sent in the CertificateProvider message if the config was sent by the
     // control plane). If not present, defaults to "default".
-    string plugin_instance_name = 1;
+    //
+    // Instance names should generally be defined not in terms of the underlying provider
+    // implementation (e.g., "file_watcher") but rather in terms of the function of the
+    // certificates (e.g., "foo_deployment_identity").
+    string instance_name = 1;
 
     // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    // a root-certificate (validation context) or "example.com" to specify a certificate for a
+    // particular domain. Not all provider instances will actually use this field, so the value
+    // defaults to the empty string.
     string certificate_name = 2;
   }
 
@@ -147,20 +153,23 @@ message CommonTlsContext {
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    // Only to be used when validation_context_certificate_provider is not used.
+    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+    // or validation_context_certificate_provider_instance may be used.
     SdsSecretConfig validation_context_sds_secret_config = 2 [
       (validate.rules).message = {required: true},
       (udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"
     ];
 
-    // Certificate provider for fetching validation context - only to be used when
-    // validation_context_sds_secret_config is not used.
+    // Certificate provider for fetching validation context.
+    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+    // or validation_context_certificate_provider_instance may be used.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
         [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
 
-    // Certificate provider instance for fetching validation context - only to be used when
-    // validation_context_sds_secret_config is not used.
+    // Certificate provider instance for fetching validation context.
+    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+    // or validation_context_certificate_provider_instance may be used.
     // [#not-implemented-hide:]
     CertificateProviderInstance validation_context_certificate_provider_instance = 4
         [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -99,7 +99,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 11]
+// [#next-free-field: 13]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -123,6 +123,20 @@ message CommonTlsContext {
     }
   }
 
+  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
+  // client side instead of being sent from the control plane.
+  message CertificateProviderInstance {
+    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // field that would be sent in the CertificateProvider message if the config was sent by the
+    // control plane). If not present, defaults to "default".
+    string plugin_instance_name = 1;
+
+    // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    string certificate_name = 2;
+  }
+
   message CombinedCertificateValidationContext {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.auth.CommonTlsContext.CombinedCertificateValidationContext";
@@ -143,6 +157,12 @@ message CommonTlsContext {
     // validation_context_sds_secret_config is not used.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+
+    // Certificate provider instance for fetching validation context - only to be used when
+    // validation_context_sds_secret_config is not used.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 4
         [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
   }
 
@@ -168,6 +188,10 @@ message CommonTlsContext {
   // [#not-implemented-hide:]
   CertificateProvider tls_certificate_certificate_provider = 9;
 
+  // Certificate provider instance for fetching TLS certificates.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+
   oneof validation_context_type {
     // How to validate peer certificates.
     CertificateValidationContext validation_context = 3;
@@ -188,6 +212,10 @@ message CommonTlsContext {
     // Certificate provider for fetching validation context.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 10;
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
 
   // Supplies the list of ALPN protocols that the listener should expose. In

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -126,20 +126,26 @@ message CommonTlsContext {
     }
   }
 
-  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
-  // client side instead of being sent from the control plane.
+  // Similar to CertificateProvider above, but allows the provider instances to be configured on
+  // the client side instead of being sent from the control plane.
   message CertificateProviderInstance {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance";
 
-    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
-    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // Provider instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
     // field that would be sent in the CertificateProvider message if the config was sent by the
     // control plane). If not present, defaults to "default".
-    string plugin_instance_name = 1;
+    //
+    // Instance names should generally be defined not in terms of the underlying provider
+    // implementation (e.g., "file_watcher") but rather in terms of the function of the
+    // certificates (e.g., "foo_deployment_identity").
+    string instance_name = 1;
 
     // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    // a root-certificate (validation context) or "example.com" to specify a certificate for a
+    // particular domain. Not all provider instances will actually use this field, so the value
+    // defaults to the empty string.
     string certificate_name = 2;
   }
 
@@ -155,17 +161,20 @@ message CommonTlsContext {
     oneof dynamic_validation_context {
       // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
       // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-      // Only to be used when validation_context_certificate_provider is not used.
+      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+      // or validation_context_certificate_provider_instance may be used.
       SdsSecretConfig validation_context_sds_secret_config = 2
           [(validate.rules).message = {required: true}];
 
-      // Certificate provider for fetching validation context - only to be used when
-      // validation_context_sds_secret_config is not used.
+      // Certificate provider for fetching validation context.
+      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+      // or validation_context_certificate_provider_instance may be used.
       // [#not-implemented-hide:]
       CertificateProvider validation_context_certificate_provider = 3;
 
-      // Certificate provider instance for fetching validation context - only to be used when
-      // validation_context_sds_secret_config is not used.
+      // Certificate provider instance for fetching validation context.
+      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+      // or validation_context_certificate_provider_instance may be used.
       // [#not-implemented-hide:]
       CertificateProviderInstance validation_context_certificate_provider_instance = 4;
     }

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -98,7 +98,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 11]
+// [#next-free-field: 13]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext";
@@ -126,6 +126,23 @@ message CommonTlsContext {
     }
   }
 
+  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
+  // client side instead of being sent from the control plane.
+  message CertificateProviderInstance {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance";
+
+    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // field that would be sent in the CertificateProvider message if the config was sent by the
+    // control plane). If not present, defaults to "default".
+    string plugin_instance_name = 1;
+
+    // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    string certificate_name = 2;
+  }
+
   message CombinedCertificateValidationContext {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext."
@@ -146,6 +163,11 @@ message CommonTlsContext {
       // validation_context_sds_secret_config is not used.
       // [#not-implemented-hide:]
       CertificateProvider validation_context_certificate_provider = 3;
+
+      // Certificate provider instance for fetching validation context - only to be used when
+      // validation_context_sds_secret_config is not used.
+      // [#not-implemented-hide:]
+      CertificateProviderInstance validation_context_certificate_provider_instance = 4;
     }
   }
 
@@ -171,6 +193,10 @@ message CommonTlsContext {
   // [#not-implemented-hide:]
   CertificateProvider tls_certificate_certificate_provider = 9;
 
+  // Certificate provider instance for fetching TLS certificates.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+
   oneof validation_context_type {
     // How to validate peer certificates.
     CertificateValidationContext validation_context = 3;
@@ -191,6 +217,10 @@ message CommonTlsContext {
     // Certificate provider for fetching validation context.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 10;
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
 
   // Supplies the list of ALPN protocols that the listener should expose. In

--- a/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
@@ -40,7 +40,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -225,6 +225,13 @@ message Bootstrap {
   // Optional overriding of default socket interface. The value must be the name of one of the
   // socket interface factories initialized through a bootstrap extension
   string default_socket_interface = 24;
+
+  // Global map of CertificateProvider instances. These instances are referred to by name in the
+  // :ref:`CommonTlsContext.CertificateProviderInstance.instance_name
+  // <envoy_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance.instance_name>`
+  // field.
+  // [#not-implemented-hide:]
+  map<string, core.v3.TypedExtensionConfig> certificate_provider_instances = 25;
 
   Runtime hidden_envoy_deprecated_runtime = 11
       [deprecated = true, (envoy.annotations.disallowed_by_default) = true];

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -39,7 +39,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 25]
+// [#next-free-field: 26]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v3.Bootstrap";
@@ -226,6 +226,13 @@ message Bootstrap {
   // Optional overriding of default socket interface. The value must be the name of one of the
   // socket interface factories initialized through a bootstrap extension
   string default_socket_interface = 24;
+
+  // Global map of CertificateProvider instances. These instances are referred to by name in the
+  // :ref:`CommonTlsContext.CertificateProviderInstance.instance_name
+  // <envoy_api_field_extensions.transport_sockets.tls.v4alpha.CommonTlsContext.CertificateProviderInstance.instance_name>`
+  // field.
+  // [#not-implemented-hide:]
+  map<string, core.v4alpha.TypedExtensionConfig> certificate_provider_instances = 25;
 }
 
 // Administration interface :ref:`operations documentation

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -123,17 +123,23 @@ message CommonTlsContext {
     }
   }
 
-  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
-  // client side instead of being sent from the control plane.
+  // Similar to CertificateProvider above, but allows the provider instances to be configured on
+  // the client side instead of being sent from the control plane.
   message CertificateProviderInstance {
-    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
-    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // Provider instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
     // field that would be sent in the CertificateProvider message if the config was sent by the
     // control plane). If not present, defaults to "default".
-    string plugin_instance_name = 1;
+    //
+    // Instance names should generally be defined not in terms of the underlying provider
+    // implementation (e.g., "file_watcher") but rather in terms of the function of the
+    // certificates (e.g., "foo_deployment_identity").
+    string instance_name = 1;
 
     // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    // a root-certificate (validation context) or "example.com" to specify a certificate for a
+    // particular domain. Not all provider instances will actually use this field, so the value
+    // defaults to the empty string.
     string certificate_name = 2;
   }
 
@@ -147,20 +153,23 @@ message CommonTlsContext {
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    // Only to be used when validation_context_certificate_provider is not used.
+    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+    // or validation_context_certificate_provider_instance may be used.
     SdsSecretConfig validation_context_sds_secret_config = 2 [
       (validate.rules).message = {required: true},
       (udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"
     ];
 
-    // Certificate provider for fetching validation context - only to be used when
-    // validation_context_sds_secret_config is not used.
+    // Certificate provider for fetching validation context.
+    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+    // or validation_context_certificate_provider_instance may be used.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
         [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
 
-    // Certificate provider instance for fetching validation context - only to be used when
-    // validation_context_sds_secret_config is not used.
+    // Certificate provider instance for fetching validation context.
+    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+    // or validation_context_certificate_provider_instance may be used.
     // [#not-implemented-hide:]
     CertificateProviderInstance validation_context_certificate_provider_instance = 4
         [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -99,7 +99,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 11]
+// [#next-free-field: 13]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -123,6 +123,20 @@ message CommonTlsContext {
     }
   }
 
+  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
+  // client side instead of being sent from the control plane.
+  message CertificateProviderInstance {
+    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // field that would be sent in the CertificateProvider message if the config was sent by the
+    // control plane). If not present, defaults to "default".
+    string plugin_instance_name = 1;
+
+    // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    string certificate_name = 2;
+  }
+
   message CombinedCertificateValidationContext {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.auth.CommonTlsContext.CombinedCertificateValidationContext";
@@ -143,6 +157,12 @@ message CommonTlsContext {
     // validation_context_sds_secret_config is not used.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+
+    // Certificate provider instance for fetching validation context - only to be used when
+    // validation_context_sds_secret_config is not used.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 4
         [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
   }
 
@@ -168,6 +188,10 @@ message CommonTlsContext {
   // [#not-implemented-hide:]
   CertificateProvider tls_certificate_certificate_provider = 9;
 
+  // Certificate provider instance for fetching TLS certificates.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+
   oneof validation_context_type {
     // How to validate peer certificates.
     CertificateValidationContext validation_context = 3;
@@ -188,6 +212,10 @@ message CommonTlsContext {
     // Certificate provider for fetching validation context.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 10;
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
 
   // Supplies the list of ALPN protocols that the listener should expose. In

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -126,20 +126,26 @@ message CommonTlsContext {
     }
   }
 
-  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
-  // client side instead of being sent from the control plane.
+  // Similar to CertificateProvider above, but allows the provider instances to be configured on
+  // the client side instead of being sent from the control plane.
   message CertificateProviderInstance {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance";
 
-    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
-    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // Provider instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
     // field that would be sent in the CertificateProvider message if the config was sent by the
     // control plane). If not present, defaults to "default".
-    string plugin_instance_name = 1;
+    //
+    // Instance names should generally be defined not in terms of the underlying provider
+    // implementation (e.g., "file_watcher") but rather in terms of the function of the
+    // certificates (e.g., "foo_deployment_identity").
+    string instance_name = 1;
 
     // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    // a root-certificate (validation context) or "example.com" to specify a certificate for a
+    // particular domain. Not all provider instances will actually use this field, so the value
+    // defaults to the empty string.
     string certificate_name = 2;
   }
 
@@ -155,17 +161,20 @@ message CommonTlsContext {
     oneof dynamic_validation_context {
       // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
       // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-      // Only to be used when validation_context_certificate_provider is not used.
+      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+      // or validation_context_certificate_provider_instance may be used.
       SdsSecretConfig validation_context_sds_secret_config = 2
           [(validate.rules).message = {required: true}];
 
-      // Certificate provider for fetching validation context - only to be used when
-      // validation_context_sds_secret_config is not used.
+      // Certificate provider for fetching validation context.
+      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+      // or validation_context_certificate_provider_instance may be used.
       // [#not-implemented-hide:]
       CertificateProvider validation_context_certificate_provider = 3;
 
-      // Certificate provider instance for fetching validation context - only to be used when
-      // validation_context_sds_secret_config is not used.
+      // Certificate provider instance for fetching validation context.
+      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
+      // or validation_context_certificate_provider_instance may be used.
       // [#not-implemented-hide:]
       CertificateProviderInstance validation_context_certificate_provider_instance = 4;
     }

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -98,7 +98,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 11]
+// [#next-free-field: 13]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext";
@@ -126,6 +126,23 @@ message CommonTlsContext {
     }
   }
 
+  // Similar to CertificateProvider above, but allows the plugin instances to be configured on the
+  // client side instead of being sent from the control plane.
+  message CertificateProviderInstance {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance";
+
+    // Plugin instance name. This name must be defined in the client's configuration (e.g., a
+    // bootstrap file) to correspond to a plugin instance (i.e., the same data in the typed_config
+    // field that would be sent in the CertificateProvider message if the config was sent by the
+    // control plane). If not present, defaults to "default".
+    string plugin_instance_name = 1;
+
+    // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+    // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+    string certificate_name = 2;
+  }
+
   message CombinedCertificateValidationContext {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext."
@@ -146,6 +163,11 @@ message CommonTlsContext {
       // validation_context_sds_secret_config is not used.
       // [#not-implemented-hide:]
       CertificateProvider validation_context_certificate_provider = 3;
+
+      // Certificate provider instance for fetching validation context - only to be used when
+      // validation_context_sds_secret_config is not used.
+      // [#not-implemented-hide:]
+      CertificateProviderInstance validation_context_certificate_provider_instance = 4;
     }
   }
 
@@ -171,6 +193,10 @@ message CommonTlsContext {
   // [#not-implemented-hide:]
   CertificateProvider tls_certificate_certificate_provider = 9;
 
+  // Certificate provider instance for fetching TLS certificates.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+
   oneof validation_context_type {
     // How to validate peer certificates.
     CertificateValidationContext validation_context = 3;
@@ -191,6 +217,10 @@ message CommonTlsContext {
     // Certificate provider for fetching validation context.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 10;
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
 
   // Supplies the list of ALPN protocols that the listener should expose. In


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Add CertificateProviderInstance to CommonTlsContext.
Additional Description: This is similar to the CertificateProvider API added in #11061, but it allows the actual plugin instances to be configured on the client side.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A

CC @htuch 
@jiangtaoli2016 @yihuazhang
@jaychenatr @karthikbox 
@costinm @louiscryan 
@easwars @sanjaypujare @ejona86 @dfawley @yashykt @srini100