### PR TITLE
Initialising variable which may be used in an uninitialised fashion.

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -379,7 +379,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(Socket& sock) {
   }
 
   sockaddr_storage orig_addr;
-  memset(&orig_addr, 0, sizeof(orig_addr); 
+  memset(&orig_addr, 0, sizeof(orig_addr)); 
   socklen_t addr_len = sizeof(sockaddr_storage);
   int status;
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -379,6 +379,7 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(Socket& sock) {
   }
 
   sockaddr_storage orig_addr;
+  memset(&orig_addr, 0, sizeof(orig_addr); 
   socklen_t addr_len = sizeof(sockaddr_storage);
   int status;
 


### PR DESCRIPTION
Commit Message:
    Initializing variable which may be used in an uninitialized fashion as reported by the test case included in issue TBD.

    Using uninitialized memory can be a security issue, such as potentially leaking previous stack contents. By zero-initializing, 
    we avoid such potential leaks.

    Running with the specific input case after this PR is applied no longer results in any error findings (credits: the input case 
    was found using google/clusterfuzz).

    Note that this PR only avoids the uninitialized memory use identified in that bug, and is unaware of the functionality or 
    semantics of the rest of the code. The project owners are welcome to suggest alternate fixes on this PR or address other 
    behavioral concerns in a separate PR.

   (For the record: I am currently a Visiting Researcher at Google NYC and this fix is the result of an internal project).
Additional Description: 
   Use of uninitialized variable found, which can be reproduced using the test case below:
```
Running: /tmp/testcase-5757259834195968
Uninitialized bytes in __interceptor_inet_ntop at offset 0 inside [0x709000005548, 16)
==1732493==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x561ff76c967e in Envoy::Network::Address::Ipv6Instance::Ipv6Helper::makeFriendlyAddress() const third_party/envoy/src/source/common/network/address_impl.cc:179:21
    #1 0x561ff76c9bc2 in Envoy::Network::Address::Ipv6Instance::Ipv6Instance(sockaddr_in6 const&, bool) third_party/envoy/src/source/common/network/address_impl.cc:186:37
    #2 0x561ff76cf214 in std::__msan::__compressed_pair_elem<Envoy::Network::Address::Ipv6Instance, 1, false>::__compressed_pair_elem<sockaddr_in6 const&, bool&, 0ul, 1ul>(std::__msan::piecewise_construct_t, std::__msan::tuple<sockaddr_in6 const&, bool&>, std::__msan::__tuple_indices<0ul, 1ul>) third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/memory:2119:9
    #3 0x561ff76cec93 in std::__msan::__compressed_pair<std::__msan::allocator<Envoy::Network::Address::Ipv6Instance>, Envoy::Network::Address::Ipv6Instance>::__compressed_pair<std::__msan::allocator<Envoy::Network::Address::Ipv6Instance>&, sockaddr_in6 const&, bool&>(std::__msan::piecewise_construct_t, std::__msan::tuple<std::__msan::allocator<Envoy::Network::Address::Ipv6Instance>&>, std::__msan::tuple<sockaddr_in6 const&, bool&>) third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/memory:2203:9
    #4 0x561ff76ce851 in std::__msan::__shared_ptr_emplace<Envoy::Network::Address::Ipv6Instance, std::__msan::allocator<Envoy::Network::Address::Ipv6Instance> >::__shared_ptr_emplace<sockaddr_in6 const&, bool&>(std::__msan::allocator<Envoy::Network::Address::Ipv6Instance>, sockaddr_in6 const&, bool&) third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/memory:3499:16
    #5 0x561ff76c58e4 in std::__msan::enable_if<!(is_array<Envoy::Network::Address::Ipv6Instance>::value), std::__msan::shared_ptr<Envoy::Network::Address::Ipv6Instance> >::type std::__msan::make_shared<Envoy::Network::Address::Ipv6Instance, sockaddr_in6 const&, bool&>(sockaddr_in6 const&, bool&) third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/memory:4349:26
    #6 0x561ff76c411b in Envoy::Network::Address::addressFromSockAddr(sockaddr_storage const&, unsigned int, bool) third_party/envoy/src/source/common/network/address_impl.cc:77:14
    #7 0x561ff7698600 in Envoy::Network::Utility::getOriginalDst(Envoy::Network::Socket&) third_party/envoy/src/source/common/network/utility.cc:373:10
    #8 0x561ff438a84b in Envoy::Extensions::ListenerFilters::OriginalDst::OriginalDstFilter::getOriginalDst(Envoy::Network::Socket&) third_party/envoy/src/source/extensions/filters/listener/original_dst/original_dst.cc:14:10
    #9 0x561ff438ad13 in Envoy::Extensions::ListenerFilters::OriginalDst::OriginalDstFilter::onAccept(Envoy::Network::ListenerFilterCallbacks&) third_party/envoy/src/source/extensions/filters/listener/original_dst/original_dst.cc:22:71
    #10 0x561ff4346433 in Envoy::Extensions::ListenerFilters::OriginalDst::TestOneProtoInput(envoy::extensions::filters::listener::original_dst::v3::OriginalDstTestCase const&) third_party/envoy/src/test/extensions/filters/listener/original_dst/original_dst_fuzz_test.cc:79:11
    #11 0x561ff4345d66 in LLVMFuzzerTestOneInput third_party/envoy/src/test/extensions/filters/listener/original_dst/original_dst_fuzz_test.cc:55:1
    #12 0x561ffa109de4 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:559:15
    #13 0x561ffa0aae0d in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:301:6
    #14 0x561ffa0c0f38 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:801:9
    #15 0x561ffa089f50 in main third_party/llvm/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #16 0x7f7a67653bbc in __libc_start_main (/usr/grte/v4/lib64/libc.so.6+0x38bbc)
    #17 0x561ff42ca448 in _start /usr/grte/v4/debug-src/src/csu/../sysdeps/x86_64/start.S:108
```

Risk Level: Medium
Testing: This has been tested using [Google's ClusterFuzz](https://github.com/google/clusterfuzz) engine, that yielded the following test case:
[testcase-5757259834195968-b501d73a79daea20d5ef.zip](https://github.com/envoyproxy/envoy/files/4963245/testcase-5757259834195968-b501d73a79daea20d5ef.zip)

Docs Changes: N/A.
Release Notes: N/A.