### PR TITLE
ssl: add test for changed cipher suite support when boringssl version changes

### DIFF
--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -43,36 +43,37 @@ namespace TransportSockets {
 namespace Tls {
 
 namespace {
-const std::vector<std::string> KNOWN_CIPHER_SUITES{"ECDHE-ECDSA-AES128-GCM-SHA256",
-                                                   "ECDHE-RSA-AES128-GCM-SHA256",
-                                                   "ECDHE-ECDSA-AES256-GCM-SHA384",
-                                                   "ECDHE-RSA-AES256-GCM-SHA384",
-                                                   "ECDHE-ECDSA-CHACHA20-POLY1305",
-                                                   "ECDHE-RSA-CHACHA20-POLY1305",
-                                                   "ECDHE-PSK-CHACHA20-POLY1305",
-                                                   "ECDHE-ECDSA-AES128-SHA",
-                                                   "ECDHE-RSA-AES128-SHA",
-                                                   "ECDHE-PSK-AES128-CBC-SHA",
-                                                   "ECDHE-ECDSA-AES256-SHA",
-                                                   "ECDHE-RSA-AES256-SHA",
-                                                   "ECDHE-PSK-AES256-CBC-SHA",
-                                                   "AES128-GCM-SHA256",
-                                                   "AES256-GCM-SHA384",
-                                                   "AES128-SHA",
-                                                   "PSK-AES128-CBC-SHA",
-                                                   "AES256-SHA",
-                                                   "PSK-AES256-CBC-SHA",
-                                                   "DES-CBC3-SHA"};
-
+const std::vector<std::string>& knownCipherSuites() {
+  CONSTRUCT_ON_FIRST_USE(std::vector<std::string>, {"ECDHE-ECDSA-AES128-GCM-SHA256",
+                                                    "ECDHE-RSA-AES128-GCM-SHA256",
+                                                    "ECDHE-ECDSA-AES256-GCM-SHA384",
+                                                    "ECDHE-RSA-AES256-GCM-SHA384",
+                                                    "ECDHE-ECDSA-CHACHA20-POLY1305",
+                                                    "ECDHE-RSA-CHACHA20-POLY1305",
+                                                    "ECDHE-PSK-CHACHA20-POLY1305",
+                                                    "ECDHE-ECDSA-AES128-SHA",
+                                                    "ECDHE-RSA-AES128-SHA",
+                                                    "ECDHE-PSK-AES128-CBC-SHA",
+                                                    "ECDHE-ECDSA-AES256-SHA",
+                                                    "ECDHE-RSA-AES256-SHA",
+                                                    "ECDHE-PSK-AES256-CBC-SHA",
+                                                    "AES128-GCM-SHA256",
+                                                    "AES256-GCM-SHA384",
+                                                    "AES128-SHA",
+                                                    "PSK-AES128-CBC-SHA",
+                                                    "AES256-SHA",
+                                                    "PSK-AES256-CBC-SHA",
+                                                    "DES-CBC3-SHA"});
+}
 } // namespace
 
 class SslLibraryCipherSuiteSupport : public ::testing::TestWithParam<std::string> {};
 
 INSTANTIATE_TEST_SUITE_P(CipherSuites, SslLibraryCipherSuiteSupport,
-                         ::testing::ValuesIn(KNOWN_CIPHER_SUITES));
+                         ::testing::ValuesIn(knownCipherSuites()));
 
 // Tests for whether new cipher suites are added. When they are, they must be added to
-// KNOWN_CIPHER_SUITES so that this test can detect if they are removed in the future.
+// knownCipherSuites() so that this test can detect if they are removed in the future.
 TEST_F(SslLibraryCipherSuiteSupport, CipherSuitesNotAdded) {
   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
   EXPECT_NE(0, SSL_CTX_set_strict_cipher_list(ctx.get(), "ALL"));
@@ -81,7 +82,7 @@ TEST_F(SslLibraryCipherSuiteSupport, CipherSuitesNotAdded) {
   for (const SSL_CIPHER* cipher : SSL_CTX_get_ciphers(ctx.get())) {
     present_cipher_suites.push_back(SSL_CIPHER_get_name(cipher));
   }
-  EXPECT_THAT(present_cipher_suites, testing::IsSubsetOf(KNOWN_CIPHER_SUITES));
+  EXPECT_THAT(present_cipher_suites, testing::IsSubsetOf(knownCipherSuites()));
 }
 
 // Test that no previously supported cipher suites were removed from the SSL library. If a cipher

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -84,7 +84,7 @@ TEST_F(SslLibraryCipherSuiteSupport, CipherSuitesNotAdded) {
   EXPECT_THAT(present_cipher_suites, testing::IsSubsetOf(KNOWN_CIPHER_SUITES));
 }
 
-// Test that no previously supported cipher suites were removed from the SSL library.  If a cipher
+// Test that no previously supported cipher suites were removed from the SSL library. If a cipher
 // suite is removed, it must be added to the release notes as an incompatible change, because it can
 // cause previously loadable configurations to no longer load if they reference the cipher suite.
 TEST_P(SslLibraryCipherSuiteSupport, CipherSuitesNotRemoved) {

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -42,6 +42,56 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
+namespace {
+const std::vector<std::string> KNOWN_CIPHER_SUITES{"ECDHE-ECDSA-AES128-GCM-SHA256",
+                                                   "ECDHE-RSA-AES128-GCM-SHA256",
+                                                   "ECDHE-ECDSA-AES256-GCM-SHA384",
+                                                   "ECDHE-RSA-AES256-GCM-SHA384",
+                                                   "ECDHE-ECDSA-CHACHA20-POLY1305",
+                                                   "ECDHE-RSA-CHACHA20-POLY1305",
+                                                   "ECDHE-PSK-CHACHA20-POLY1305",
+                                                   "ECDHE-ECDSA-AES128-SHA",
+                                                   "ECDHE-RSA-AES128-SHA",
+                                                   "ECDHE-PSK-AES128-CBC-SHA",
+                                                   "ECDHE-ECDSA-AES256-SHA",
+                                                   "ECDHE-RSA-AES256-SHA",
+                                                   "ECDHE-PSK-AES256-CBC-SHA",
+                                                   "AES128-GCM-SHA256",
+                                                   "AES256-GCM-SHA384",
+                                                   "AES128-SHA",
+                                                   "PSK-AES128-CBC-SHA",
+                                                   "AES256-SHA",
+                                                   "PSK-AES256-CBC-SHA",
+                                                   "DES-CBC3-SHA"};
+
+} // namespace
+
+class SslLibraryCipherSuiteSupport : public ::testing::TestWithParam<std::string> {};
+
+INSTANTIATE_TEST_SUITE_P(CipherSuites, SslLibraryCipherSuiteSupport,
+                         ::testing::ValuesIn(KNOWN_CIPHER_SUITES));
+
+// Tests for whether new cipher suites are added. When they are, they must be added to
+// KNOWN_CIPHER_SUITES so that this test can detect if they are removed in the future.
+TEST_F(SslLibraryCipherSuiteSupport, CipherSuitesNotAdded) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  EXPECT_NE(0, SSL_CTX_set_strict_cipher_list(ctx.get(), "ALL"));
+
+  std::vector<std::string> present_cipher_suites;
+  for (const SSL_CIPHER* cipher : SSL_CTX_get_ciphers(ctx.get())) {
+    present_cipher_suites.push_back(SSL_CIPHER_get_name(cipher));
+  }
+  EXPECT_THAT(present_cipher_suites, testing::IsSubsetOf(KNOWN_CIPHER_SUITES));
+}
+
+// Test that no previously supported cipher suites were removed from the SSL library.  If a cipher
+// suite is removed, it must be added to the release notes as an incompatible change, because it can
+// cause previously loadable configurations to no longer load if they reference the cipher suite.
+TEST_P(SslLibraryCipherSuiteSupport, CipherSuitesNotRemoved) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  EXPECT_NE(0, SSL_CTX_set_strict_cipher_list(ctx.get(), GetParam().c_str()));
+}
+
 class SslContextImplTest : public SslCertsTest {
 protected:
   Event::SimulatedTimeSystem time_system_;


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

Output of a failure from a newly supported cipher suite (simulated by removing `PSK-AES256-CBC-SHA` from the known list): 
```
[==========] Running 94 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 1 test from SslLibraryCipherSuiteSupport
[ RUN      ] SslLibraryCipherSuiteSupport.CipherSuitesNotAdded
test/extensions/transport_sockets/tls/context_impl_test.cc:73: Failure
Value of: present_cipher_suites
Expected: an injection from elements to requirements exists such that:
 - an element is equal to "ECDHE-ECDSA-AES128-GCM-SHA256"
 - an element is equal to "ECDHE-RSA-AES128-GCM-SHA256"
 - an element is equal to "ECDHE-ECDSA-AES256-GCM-SHA384"
 - an element is equal to "ECDHE-RSA-AES256-GCM-SHA384"
 - an element is equal to "ECDHE-ECDSA-CHACHA20-POLY1305"
 - an element is equal to "ECDHE-RSA-CHACHA20-POLY1305"
 - an element is equal to "ECDHE-PSK-CHACHA20-POLY1305"
 - an element is equal to "ECDHE-ECDSA-AES128-SHA"
 - an element is equal to "ECDHE-RSA-AES128-SHA"
 - an element is equal to "ECDHE-PSK-AES128-CBC-SHA"
 - an element is equal to "ECDHE-ECDSA-AES256-SHA"
 - an element is equal to "ECDHE-RSA-AES256-SHA"
 - an element is equal to "ECDHE-PSK-AES256-CBC-SHA"
 - an element is equal to "AES128-GCM-SHA256"
 - an element is equal to "AES256-GCM-SHA384"
 - an element is equal to "AES128-SHA"
 - an element is equal to "PSK-AES128-CBC-SHA"
 - an element is equal to "AES256-SHA"
 - an element is equal to "DES-CBC3-SHA"
  Actual: { "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-CHACHA20-POLY1305", "ECDHE-RSA-CHACHA20-POLY1305", "ECDHE-PSK-CHACHA20-POLY1305", "ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES128-SHA", "ECDHE-PSK-AES128-CBC-SHA", "ECDHE-ECDSA-AES256-SHA", "ECDHE-RSA-AES256-SHA", "ECDHE-PSK-AES256-CBC-SHA", "AES128-GCM-SHA256", "AES256-GCM-SHA384", "AES128-SHA", "PSK-AES128-CBC-SHA", "AES256-SHA", "PSK-AES256-CBC-SHA", "DES-CBC3-SHA" }, where the following elements don't match any matchers:
element #18: "PSK-AES256-CBC-SHA"
Stack trace:
  0x14f268e: Envoy::Extensions::TransportSockets::Tls::SslLibraryCipherSuiteSupport_CipherSuitesNotAdded_Test::TestBody()
  0x3508944: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
  0x34f91ee: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x34e31f3: testing::Test::Run()
  0x34e3ddd: testing::TestInfo::Run()
... Google Test internal frames ...

[  FAILED  ] SslLibraryCipherSuiteSupport.CipherSuitesNotAdded (110 ms)
[----------] 1 test from SslLibraryCipherSuiteSupport (110 ms total)
```

Output from a cipher suite being removed (simulated by adding `doesnt-exist` to the list of known ciphers):
```
[----------] 21 tests from CipherSuites/SslLibraryCipherSuiteSupport
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/0
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/0 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/1
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/1 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/2
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/2 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/3
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/3 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/4
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/4 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/5
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/5 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/6
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/6 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/7
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/7 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/8
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/8 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/9
test/extensions/transport_sockets/tls/context_impl_test.cc:93: Failure
Expected: (0) != (SSL_CTX_set_strict_cipher_list(ctx.get(), GetParam().c_str())), actual: 0 vs 0
Stack trace:
  0x14f2873: Envoy::Extensions::TransportSockets::Tls::SslLibraryCipherSuiteSupport_CipherSuitesNotRemoved_Test::TestBody()
  0x3508a44: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
  0x34f92ee: testing::internal::HandleExceptionsInMethodIfSupported<>()
  0x34e32f3: testing::Test::Run()
  0x34e3edd: testing::TestInfo::Run()
... Google Test internal frames ...

[  FAILED  ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/9, where GetParam() = "doesnt-exist" (109 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/10
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/10 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/11
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/11 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/12
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/12 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/13
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/13 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/14
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/14 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/15
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/15 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/16
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/16 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/17
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/17 (1 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/18
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/18 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/19
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/19 (0 ms)
[ RUN      ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/20
[       OK ] CipherSuites/SslLibraryCipherSuiteSupport.CipherSuitesNotRemoved/20 (0 ms)
[----------] 21 tests from CipherSuites/SslLibraryCipherSuiteSupport (110 ms total)
```