### PR TITLE
Add histogram for maximum concurrent requests per connection

### DIFF
--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -419,6 +419,7 @@ protected:
   const uint32_t max_headers_kb_;
   const uint32_t max_headers_count_;
   uint32_t per_stream_buffer_limit_;
+  uint32_t max_concurrent_streams_;
   bool allow_metadata_;
   const bool stream_error_on_invalid_http_messaging_;
   bool flood_detected_;

--- a/source/common/http/http2/codec_stats.h
+++ b/source/common/http/http2/codec_stats.h
@@ -12,7 +12,7 @@ namespace Http2 {
 /**
  * All stats for the HTTP/2 codec. @see stats_macros.h
  */
-#define ALL_HTTP2_CODEC_STATS(COUNTER, GAUGE)                                                      \
+#define ALL_HTTP2_CODEC_STATS(COUNTER, GAUGE, HISTOGRAM)                                           \
   COUNTER(dropped_headers_with_underscores)                                                        \
   COUNTER(header_overflow)                                                                         \
   COUNTER(headers_cb_no_stream)                                                                    \
@@ -29,7 +29,8 @@ namespace Http2 {
   COUNTER(tx_flush_timeout)                                                                        \
   COUNTER(tx_reset)                                                                                \
   GAUGE(streams_active, Accumulate)                                                                \
-  GAUGE(pending_send_bytes, Accumulate)
+  GAUGE(pending_send_bytes, Accumulate)                                                            \
+  HISTOGRAM(cx_max_concurrent_streams, Unspecified)
 
 /**
  * Wrapper struct for the HTTP/2 codec stats. @see stats_macros.h
@@ -40,11 +41,12 @@ struct CodecStats {
   static CodecStats& atomicGet(AtomicPtr& ptr, Stats::Scope& scope) {
     return *ptr.get([&scope]() -> CodecStats* {
       return new CodecStats{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(scope, "http2."),
-                                                  POOL_GAUGE_PREFIX(scope, "http2."))};
+                                                  POOL_GAUGE_PREFIX(scope, "http2."),
+                                                  POOL_HISTOGRAM_PREFIX(scope, "http2."))};
     });
   }
 
-  ALL_HTTP2_CODEC_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+  ALL_HTTP2_CODEC_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 } // namespace Http2


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

Commit Message: This gives visibility into concurrent connections, and can help in setting an appropriate value for `http2_protocol_options.max_concurrent_streams`.
Additional Description:
Risk Level: low
Testing: TODO
Docs Changes: TODO
Release Notes: TODO
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
