### PR TITLE
http: restore previous HeaderMap::remove() behavior

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -508,10 +508,17 @@ size_t HeaderMapImpl::removeIf(const HeaderMap::HeaderMatchPredicate& predicate)
 }
 
 size_t HeaderMapImpl::remove(const LowerCaseString& key) {
-  // TODO(mattklein123): When the lazy map is implemented we can stop using removeIf() here.
-  return HeaderMapImpl::removeIf([&key](const HeaderEntry& entry) -> bool {
-    return key.get() == entry.key().getStringView();
-  });
+  auto lookup = staticLookup(key.get());
+  if (lookup.has_value()) {
+    const size_t old_size = headers_.size();
+    removeInline(lookup.value().entry_);
+    return old_size - headers_.size();
+  } else {
+    // TODO(mattklein123): When the lazy map is implemented we can stop using removeIf() here.
+    return HeaderMapImpl::removeIf([&key](const HeaderEntry& entry) -> bool {
+      return key.get() == entry.key().getStringView();
+    });
+  }
 }
 
 size_t HeaderMapImpl::removePrefix(const LowerCaseString& prefix) {

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -520,6 +520,20 @@ TEST(HeaderMapImplTest, Remove) {
   EXPECT_EQ(0UL, headers.remove(Headers::get().ContentLength));
 }
 
+TEST(HeaderMapImplTest, RemoveHost) {
+  TestRequestHeaderMapImpl headers;
+  headers.setHost("foo");
+  EXPECT_EQ("foo", headers.get_("host"));
+  EXPECT_EQ("foo", headers.get_(":authority"));
+  // Make sure that when we remove by "host" without using the inline functions, the mapping to
+  // ":authority" still takes place.
+  // https://github.com/envoyproxy/envoy/pull/12160
+  EXPECT_EQ(1UL, headers.remove("host"));
+  EXPECT_EQ("", headers.get_("host"));
+  EXPECT_EQ("", headers.get_(":authority"));
+  EXPECT_EQ(nullptr, headers.Host());
+}
+
 TEST(HeaderMapImplTest, RemoveIf) {
   LowerCaseString key1 = LowerCaseString("X-postfix-foo");
   LowerCaseString key2 = LowerCaseString("X-postfix-");


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/12160 changed
the behavior of remove() to not first look in the inline
header map for a header. This is a subtle change in
behavior that specifically breaks attempting to remove
":authority" via the "host" mapping. This restores that
behavior and is thus a bug fix and low risk.

Risk Level: Low
Testing: New UT
Docs Changes: N/A
Release Notes: N/A
