### PR TITLE
fuzz: add unit tests to xDS verifier

### DIFF
--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -147,6 +147,7 @@ envoy_cc_test_library(
         ":xds_verifier_lib",
         "//test/integration:http_integration_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
+        "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -129,6 +129,15 @@ envoy_cc_test_library(
     ],
 )
 
+envoy_cc_test(
+    name = "xds_verifier_test",
+    srcs = ["xds_verifier_test.cc"],
+    deps = [
+        ":xds_verifier_lib",
+        "//test/config:utility_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "xds_fuzz_lib",
     srcs = ["xds_fuzz.cc"],
@@ -138,7 +147,6 @@ envoy_cc_test_library(
         ":xds_verifier_lib",
         "//test/integration:http_integration_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
-        "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -69,6 +69,9 @@ XdsFuzzTest::XdsFuzzTest(const test::server::config_validation::XdsTestCase& inp
   create_xds_upstream_ = true;
   tls_xds_upstream_ = false;
 
+  // avoid listeners draining during the test
+  drain_time_ = std::chrono::seconds(60);
+
   if (input.config().sotw_or_delta() == test::server::config_validation::Config::SOTW) {
     sotw_or_delta_ = Grpc::SotwOrDelta::Sotw;
   } else {
@@ -171,7 +174,7 @@ void XdsFuzzTest::addRoute(const std::string& route_name) {
 
   if (has_route) {
     // if the route was already in routes_, don't send a duplicate add in delta request
-    updateRoute(routes_, {}, {});
+    updateRoute(routes_, {route}, {});
     verifier_.routeUpdated(route);
   } else {
     updateRoute(routes_, {route}, {});

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -133,6 +133,7 @@ bool XdsFuzzTest::hasRoute(const std::string& route_name) {
  */
 void XdsFuzzTest::addListener(const std::string& listener_name, const std::string& route_name) {
   ENVOY_LOG_MISC(debug, "Adding {} with reference to {}", listener_name, route_name);
+  lds_update_success_++;
   bool removed = eraseListener(listener_name);
   auto listener = buildListener(listener_name, route_name);
   listeners_.push_back(listener);
@@ -157,6 +158,7 @@ void XdsFuzzTest::removeListener(const std::string& listener_name) {
   bool removed = eraseListener(listener_name);
 
   if (removed) {
+    lds_update_success_++;
     updateListener(listeners_, {}, {listener_name});
     EXPECT_TRUE(waitForAck(Config::TypeUrl::get().Listener, std::to_string(version_)));
     verifier_.listenerRemoved(listener_name);
@@ -280,6 +282,7 @@ void XdsFuzzTest::replay() {
       test_server_->waitForCounterEq("listener_manager.listener_modified", verifier_.numModified());
       test_server_->waitForCounterEq("listener_manager.listener_added", verifier_.numAdded());
       test_server_->waitForCounterEq("listener_manager.listener_removed", verifier_.numRemoved());
+      test_server_->waitForCounterEq("listener_manager.lds.update_success", lds_update_success_);
     }
     ENVOY_LOG_MISC(debug, "warming {} ({}), active {} ({}), draining {} ({})",
                    verifier_.numWarming(),

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -170,18 +170,14 @@ void XdsFuzzTest::removeListener(const std::string& listener_name) {
  */
 void XdsFuzzTest::addRoute(const std::string& route_name) {
   ENVOY_LOG_MISC(debug, "Adding {}", route_name);
-  bool has_route = hasRoute(route_name);
   auto route = buildRouteConfig(route_name);
-  routes_.push_back(route);
 
-  if (has_route) {
-    // if the route was already in routes_, don't send a duplicate add in delta request
-    updateRoute(routes_, {route}, {});
-    verifier_.routeUpdated(route);
-  } else {
-    updateRoute(routes_, {route}, {});
-    verifier_.routeAdded(route);
+  if (!hasRoute(route_name)) {
+    routes_.push_back(route);
   }
+
+  updateRoute(routes_, {route}, {});
+  verifier_.routeAdded(route);
 
   EXPECT_TRUE(waitForAck(Config::TypeUrl::get().RouteConfiguration, std::to_string(version_)));
 }

--- a/test/server/config_validation/xds_fuzz.h
+++ b/test/server/config_validation/xds_fuzz.h
@@ -63,7 +63,7 @@ private:
   std::vector<envoy::api::v2::RouteConfiguration> getRoutesConfigDump();
 
   bool eraseListener(const std::string& listener_name);
-  bool hasRoute(const std::string& route_num);
+  bool hasRoute(const std::string& route_name);
   AssertionResult waitForAck(const std::string& expected_type_url,
                              const std::string& expected_version);
 

--- a/test/server/config_validation/xds_fuzz.h
+++ b/test/server/config_validation/xds_fuzz.h
@@ -77,6 +77,8 @@ private:
   envoy::config::core::v3::ApiVersion api_version_;
 
   Network::Address::IpVersion ip_version_;
+
+  uint64_t lds_update_success_{0};
 };
 
 } // namespace Envoy

--- a/test/server/config_validation/xds_verifier.cc
+++ b/test/server/config_validation/xds_verifier.cc
@@ -160,7 +160,7 @@ void XdsVerifier::listenerAdded(const envoy::config::listener::v3::Listener& lis
 void XdsVerifier::listenerRemoved(const std::string& name) {
   bool found = false;
 
-  for (auto it = listeners_.begin(); it != listeners_.end(); ) {
+  for (auto it = listeners_.begin(); it != listeners_.end();) {
     auto& rep = *it;
     if (rep.listener.name() != name) {
       ++it;

--- a/test/server/config_validation/xds_verifier.cc
+++ b/test/server/config_validation/xds_verifier.cc
@@ -32,8 +32,18 @@ bool XdsVerifier::hasRoute(const envoy::config::listener::v3::Listener& listener
   return all_routes_.contains(getRoute(listener));
 }
 
+bool XdsVerifier::hasRoute(const std::string& name) { return all_routes_.contains(name); }
+
 bool XdsVerifier::hasActiveRoute(const envoy::config::listener::v3::Listener& listener) {
   return active_routes_.contains(getRoute(listener));
+}
+
+bool XdsVerifier::hasActiveRoute(const std::string& name) { return active_routes_.contains(name); }
+
+bool XdsVerifier::hasListener(const std::string& name, ListenerState state) {
+  return std::any_of(listeners_.begin(), listeners_.end(), [&](const auto& rep) {
+    return rep.listener.name() == name && state == rep.state;
+  });
 }
 
 /**

--- a/test/server/config_validation/xds_verifier.h
+++ b/test/server/config_validation/xds_verifier.h
@@ -49,12 +49,16 @@ public:
 
   void dumpState();
 
+  bool hasListener(const std::string& name, ListenerState state);
+  bool hasRoute(const envoy::config::listener::v3::Listener& listener);
+  bool hasRoute(const std::string& name);
+  bool hasActiveRoute(const envoy::config::listener::v3::Listener& listener);
+  bool hasActiveRoute(const std::string& name);
+
 private:
   enum SotwOrDelta { SOTW, DELTA };
 
   std::string getRoute(const envoy::config::listener::v3::Listener& listener);
-  bool hasRoute(const envoy::config::listener::v3::Listener& listener);
-  bool hasActiveRoute(const envoy::config::listener::v3::Listener& listener);
   void updateSotwListeners();
   void updateDeltaListeners(const envoy::config::route::v3::RouteConfiguration& route);
   void markForRemoval(ListenerRepresentation& rep);

--- a/test/server/config_validation/xds_verifier_test.cc
+++ b/test/server/config_validation/xds_verifier_test.cc
@@ -1,0 +1,227 @@
+#include "test/config/utility.h"
+#include "test/server/config_validation/xds_verifier.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+
+envoy::config::listener::v3::Listener buildListener(const std::string& listener_name,
+                                                    const std::string& route_name) {
+  return ConfigHelper::buildListener(listener_name, route_name, "", "ads_test",
+                                     envoy::config::core::v3::ApiVersion::V3);
+}
+
+envoy::config::route::v3::RouteConfiguration buildRoute(const std::string& route_name) {
+  return ConfigHelper::buildRouteConfig(route_name, "cluster_0",
+                                        envoy::config::core::v3::ApiVersion::V3);
+}
+
+// add, warm, drain and remove a listener
+TEST(XdsVerifier, Basic) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+  EXPECT_EQ(verifier.numAdded(), 1);
+  EXPECT_EQ(verifier.numWarming(), 1);
+
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_TRUE(verifier.hasRoute("route_config_0") && verifier.hasActiveRoute("route_config_0"));
+  EXPECT_EQ(verifier.numAdded(), 1);
+  EXPECT_EQ(verifier.numWarming(), 0);
+  EXPECT_EQ(verifier.numActive(), 1);
+
+  verifier.listenerRemoved("listener_0");
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.DRAINING));
+  EXPECT_EQ(verifier.numDraining(), 1);
+  EXPECT_EQ(verifier.numRemoved(), 1);
+  EXPECT_EQ(verifier.numActive(), 0);
+
+  verifier.drainedListener("listener_0");
+  EXPECT_FALSE(verifier.hasListener("listener_0", verifier.DRAINING));
+  EXPECT_EQ(verifier.numRemoved(), 1);
+}
+
+TEST(XdsVerifier, RouteBeforeListenerSOTW) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+  // send a route first, so envoy will not accept it
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasRoute("route_config_0"));
+  EXPECT_FALSE(verifier.hasActiveRoute("route_config_0"));
+
+  // envoy still doesn't know about the route, so this will warm
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+  EXPECT_EQ(verifier.numAdded(), 1);
+  EXPECT_EQ(verifier.numWarming(), 1);
+
+  // send a new route, which will include route_config_0 since SOTW, so route_config_0 will become
+  // active
+  verifier.routeAdded(buildRoute("route_config_1"));
+  EXPECT_TRUE(verifier.hasRoute("route_config_1"));
+  EXPECT_FALSE(verifier.hasActiveRoute("route_config_1"));
+  EXPECT_TRUE(verifier.hasActiveRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_EQ(verifier.numActive(), 1);
+}
+
+TEST(XdsVerifier, RouteBeforeListenerDelta) {
+  XdsVerifier verifier(test::server::config_validation::Config::DELTA);
+  // send a route first, so envoy will not accept it
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_FALSE(verifier.hasActiveRoute("route_config_0"));
+
+  // envoy still doesn't know about the route, so this will warm
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+  EXPECT_EQ(verifier.numAdded(), 1);
+  EXPECT_EQ(verifier.numWarming(), 1);
+
+  // send a new route, which will not include route_config_0 since SOTW, so route_config_0 will not
+  // become active
+  verifier.routeAdded(buildRoute("route_config_1"));
+  EXPECT_FALSE(verifier.hasActiveRoute("route_config_1"));
+  EXPECT_FALSE(verifier.hasActiveRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+  EXPECT_EQ(verifier.numWarming(), 1);
+}
+
+TEST(XdsVerifier, UpdateWarmingListener) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  verifier.listenerUpdated(buildListener("listener_0", "route_config_1"));
+  // the new listener should just silently delete the old since it's warming
+  EXPECT_EQ(verifier.numModified(), 0);
+  EXPECT_EQ(verifier.numAdded(), 1);
+
+  // send the route for the old listener, which should have been replaced with the update
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_FALSE(verifier.hasListener("listener_0", verifier.ACTIVE));
+
+  // now the new should become active
+  verifier.routeAdded(buildRoute("route_config_1"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+}
+
+TEST(XdsVerifier, UpdateActiveListener) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+
+  // add an active listener
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+
+  // send an update, which should keep the old listener active until the new warms
+  verifier.listenerUpdated(buildListener("listener_0", "route_config_1"));
+  EXPECT_EQ(verifier.numModified(), 1);
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+
+  // warm the new listener, which should remove the old
+  verifier.routeAdded(buildRoute("route_config_1"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_FALSE(verifier.hasListener("listener_0", verifier.DRAINING));
+  EXPECT_FALSE(verifier.hasListener("listener_0", verifier.WARMING));
+
+  EXPECT_EQ(verifier.numActive(), 1);
+}
+
+TEST(XdsVerifier, UpdateActiveToActive) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+
+  // add two active listeners to different routes
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+
+  // add an active listener
+  verifier.listenerAdded(buildListener("listener_1", "route_config_1"));
+  verifier.routeAdded(buildRoute("route_config_1"));
+  EXPECT_TRUE(verifier.hasListener("listener_1", verifier.ACTIVE));
+  EXPECT_EQ(verifier.numAdded(), 2);
+
+  // send an update, which should make the new listener active straight away and remove the old
+  // since its route is already active
+  verifier.listenerUpdated(buildListener("listener_0", "route_config_1"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_FALSE(verifier.hasListener("listener_0", verifier.WARMING));
+  EXPECT_EQ(verifier.numActive(), 2);
+}
+
+TEST(XdsVerifier, WarmMultipleListenersSOTW) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+
+  // add two warming listener to the same route
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  verifier.listenerAdded(buildListener("listener_1", "route_config_0"));
+
+  // send the route, make sure both are active
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_TRUE(verifier.hasListener("listener_1", verifier.ACTIVE));
+  EXPECT_EQ(verifier.numActive(), 2);
+}
+
+TEST(XdsVerifier, WarmMultipleListenersDelta) {
+  XdsVerifier verifier(test::server::config_validation::Config::DELTA);
+
+  // add two warming listener to the same route
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  verifier.listenerAdded(buildListener("listener_1", "route_config_0"));
+
+  // send the route, make sure both are active
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+  EXPECT_TRUE(verifier.hasListener("listener_1", verifier.ACTIVE));
+  EXPECT_EQ(verifier.numActive(), 2);
+}
+
+TEST(XdsVerifier, ResendRouteSOTW) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+
+  // send a route that will be ignored
+  verifier.routeAdded(buildRoute("route_config_0"));
+
+  // add a warming listener that refers to this route
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+
+  // send the same route again, make sure listener becomes active
+  verifier.routeUpdated(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+}
+
+TEST(XdsVerifier, ResendRouteDelta) {
+  XdsVerifier verifier(test::server::config_validation::Config::DELTA);
+
+  // send a route that will be ignored
+  verifier.routeAdded(buildRoute("route_config_0"));
+
+  // add a warming listener that refers to this route
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.WARMING));
+
+  // send the same route again, make sure listener becomes active
+  verifier.routeUpdated(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+}
+
+TEST(XdsVerifier, RemoveThenAddListener) {
+  XdsVerifier verifier(test::server::config_validation::Config::SOTW);
+
+  // add an active listener
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  verifier.routeAdded(buildRoute("route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+
+  // remove it
+  verifier.listenerRemoved("listener_0");
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.DRAINING));
+
+  // and add it back, it should now be draining and active
+  verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.DRAINING));
+  EXPECT_TRUE(verifier.hasListener("listener_0", verifier.ACTIVE));
+}
+
+} // namespace Envoy

--- a/test/server/config_validation/xds_verifier_test.cc
+++ b/test/server/config_validation/xds_verifier_test.cc
@@ -90,8 +90,8 @@ TEST(XdsVerifier, UpdateWarmingListener) {
   XdsVerifier verifier(test::server::config_validation::Config::SOTW);
   verifier.listenerAdded(buildListener("listener_0", "route_config_0"));
   verifier.listenerUpdated(buildListener("listener_0", "route_config_1"));
-  // the new listener should just silently delete the old since it's warming
-  EXPECT_EQ(verifier.numModified(), 0);
+  // the new listener should directly replace the old listener since it's warming
+  EXPECT_EQ(verifier.numModified(), 1);
   EXPECT_EQ(verifier.numAdded(), 1);
 
   // send the route for the old listener, which should have been replaced with the update


### PR DESCRIPTION
Commit Message: Add unit tests to xDS verifier
Additional Description:

- add new file `xds_verifier_test.cc` with unit tests
- add tests for main paths through verifier

Risk Level: Low
Testing: all tests pass with current verifier
Docs Changes: N/A
Release Notes: N/A
