### PR TITLE
docs: remove incorrect statement about max_retries

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -51,8 +51,6 @@ A few notes on how Envoy does retries:
   upstream.base_retry_backoff_ms runtime parameter. The back-off intervals can also be modified
   by configuring the retry policy's
   :ref:`retry back-off <envoy_v3_api_field_config.route.v3.RetryPolicy.retry_back_off>`.
-* If max retries is set both by header as well as in the route configuration, the maximum value is
-  taken when determining the max retries to use for the request.
 
 .. _config_http_filters_router_x-envoy-retry-on:
 


### PR DESCRIPTION
This sentence is incorrect:

> If max retries is set both by header as well as in the route configuration, the maximum value is taken when determining the max retries to use for the request.

It contradicts an earlier sentence in this section:

> If this header is used, its value takes precedence over the number of retries set in either retry policy.

I verified this behavior experimentally.

Signed-off-by: Martin Matusiak <numerodix@gmail.com>

Risk Level: low
Testing: manual
Docs Changes: updated