### PR TITLE
test: fixing a double close bug

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -318,6 +318,9 @@ FakeHttpConnection::FakeHttpConnection(
 }
 
 AssertionResult FakeConnectionBase::close(std::chrono::milliseconds timeout) {
+  if (!shared_connection_.connected()) {
+    return AssertionSuccess();
+  }
   return shared_connection_.executeOnDispatcher(
       [](Network::Connection& connection) {
         connection.close(Network::ConnectionCloseType::FlushWrite);


### PR DESCRIPTION
this test literally failed on fake_upstream_connection_->close(); because of an "unexpected close" 

Additional Description: n/a
Risk Level: n/a
Testing: n/a
Docs Changes:
Release Notes:
Fixes #12254

