### PR TITLE
gzip filter: fix docs wrt runtime feature flag

### DIFF
--- a/docs/root/configuration/http/http_filters/gzip_filter.rst
+++ b/docs/root/configuration/http/http_filters/gzip_filter.rst
@@ -29,11 +29,9 @@ Configuration
 Runtime
 -------
 
-The Gzip filter supports the following runtime settings:
-
-gzip.filter_enabled
-    The % of requests for which the filter is enabled. Default is 100.
-
+The Gzip filter can be runtime feature flagged via the :ref:`runtime_enabled
+<envoy_v3_api_field_extensions.filters.http.gzip.v3.Gzip.compressor>`
+configuration field within the compressor field.
 
 How it works
 ------------


### PR DESCRIPTION
Although this filter is deprecated in favor of the compressor
filter, let's go ahead and fix the incorrect reference to the
now optional runtime feature flag.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
