### PR TITLE
benchmark: Skip expensive setup and benchmarks to avoid filter_chain_benchmark_test_benchmark_test timeouts under tsan

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -227,9 +227,9 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     com_github_google_benchmark = dict(
-        sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",
-        strip_prefix = "benchmark-1.5.0",
-        urls = ["https://github.com/google/benchmark/archive/v1.5.0.tar.gz"],
+        sha256 = "23082937d1663a53b90cb5b61df4bcc312f6dee7018da78ba00dd6bd669dfef2",
+        strip_prefix = "benchmark-1.5.1",
+        urls = ["https://github.com/google/benchmark/archive/v1.5.1.tar.gz"],
         use_category = ["test"],
     ),
     com_github_libevent_libevent = dict(

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -11,6 +11,7 @@
 
 #include "extensions/transport_sockets/well_known_names.h"
 
+#include "test/benchmark/main.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/environment.h"
@@ -178,11 +179,9 @@ const char YamlSingleDstPortBottom[] = R"EOF(
             - filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ticket_key_a")EOF";
 } // namespace
 
-class FilterChainBenchmarkFixture : public benchmark::Fixture {
+class FilterChainBenchmarkFixture : public ::benchmark::Fixture {
 public:
-  using benchmark::Fixture::SetUp;
-
-  void SetUp(::benchmark::State& state) override {
+  void initialize(::benchmark::State& state) {
     int64_t input_size = state.range(0);
     std::vector<std::string> port_chains;
     port_chains.reserve(input_size);
@@ -195,6 +194,10 @@ public:
     TestUtility::loadFromYaml(listener_yaml_config_, listener_config_);
     filter_chains_ = listener_config_.filter_chains();
   }
+
+  Envoy::Thread::MutexBasicLockable lock_;
+  Logger::Context logging_state_{spdlog::level::warn, Logger::Logger::DEFAULT_LOG_FORMAT, lock_,
+                                 false};
   std::string listener_yaml_config_;
   envoy::config::listener::v3::Listener listener_config_;
   absl::Span<const envoy::config::listener::v3::FilterChain* const> filter_chains_;
@@ -205,6 +208,12 @@ public:
 // NOLINTNEXTLINE(readability-redundant-member-init)
 BENCHMARK_DEFINE_F(FilterChainBenchmarkFixture, FilterChainManagerBuildTest)
 (::benchmark::State& state) {
+  if (benchmark::skipExpensiveBenchmarks() && state.range(0) > 64) {
+    state.SkipWithError("Skipping expensive benchmark");
+    return;
+  }
+
+  initialize(state);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   for (auto _ : state) {
     FilterChainManagerImpl filter_chain_manager{
@@ -216,6 +225,12 @@ BENCHMARK_DEFINE_F(FilterChainBenchmarkFixture, FilterChainManagerBuildTest)
 
 BENCHMARK_DEFINE_F(FilterChainBenchmarkFixture, FilterChainFindTest)
 (::benchmark::State& state) {
+  if (benchmark::skipExpensiveBenchmarks() && state.range(0) > 64) {
+    state.SkipWithError("Skipping expensive benchmark");
+    return;
+  }
+
+  initialize(state);
   std::vector<MockConnectionSocket> sockets;
   sockets.reserve(state.range(0));
   for (int i = 0; i < state.range(0); i++) {
@@ -238,12 +253,14 @@ BENCHMARK_REGISTER_F(FilterChainBenchmarkFixture, FilterChainManagerBuildTest)
     ->Ranges({
         // scale of the chains
         {1, 4096},
-    });
+    })
+    ->Unit(::benchmark::kMillisecond);
 BENCHMARK_REGISTER_F(FilterChainBenchmarkFixture, FilterChainFindTest)
     ->Ranges({
         // scale of the chains
         {1, 4096},
-    });
+    })
+    ->Unit(::benchmark::kMillisecond);
 
 /*
 clang-format off


### PR DESCRIPTION
Commit Message:
benchmark: Skip expensive setup and benchmarks to avoid filter_chain_benchmark_test_benchmark_test timeouts under tsan.
Also, bump up the googlebenchmark version to pickup the fix to SkipWithError, https://github.com/google/benchmark/pull/938 .

Additional Description:
Risk Level: n/a test-only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #12242
