### PR TITLE
protoxform: preserve work_in_progress file status annotations.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -245,7 +245,6 @@ proto_library(
         "//envoy/service/discovery/v3:pkg",
         "//envoy/service/endpoint/v3:pkg",
         "//envoy/service/event_reporting/v3:pkg",
-        "//envoy/service/extension/v3:pkg",
         "//envoy/service/health/v3:pkg",
         "//envoy/service/listener/v3:pkg",
         "//envoy/service/load_stats/v3:pkg",

--- a/tools/protoxform/protoprint.py
+++ b/tools/protoxform/protoprint.py
@@ -224,8 +224,7 @@ def FormatHeaderFromFile(source_code_info, file_proto, empty_file):
     options.Extensions[migrate_pb2.file_migrate].CopyFrom(
         file_proto.options.Extensions[migrate_pb2.file_migrate])
 
-  if file_proto.options.HasExtension(
-      status_pb2.file_status) and file_proto.package.endswith('alpha'):
+  if file_proto.options.HasExtension(status_pb2.file_status):
     options.Extensions[status_pb2.file_status].CopyFrom(
         file_proto.options.Extensions[status_pb2.file_status])
 

--- a/tools/testdata/protoxform/envoy/v2/sample.proto
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto
@@ -5,6 +5,7 @@ package envoy.v2;
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 
+option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 enum SomeEnum {

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.active_or_frozen.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.active_or_frozen.gold
@@ -8,6 +8,7 @@ import "udpa/annotations/status.proto";
 option java_package = "io.envoyproxy.envoy.v2";
 option java_outer_classname = "SampleProto";
 option java_multiple_files = true;
+option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 enum SomeEnum {

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.next_major_version_candidate.envoy_internal.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.next_major_version_candidate.envoy_internal.gold
@@ -8,6 +8,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.v3";
 option java_outer_classname = "SampleProto";
 option java_multiple_files = true;
+option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
 
 enum SomeEnum {

--- a/tools/testdata/protoxform/envoy/v2/sample.proto.next_major_version_candidate.gold
+++ b/tools/testdata/protoxform/envoy/v2/sample.proto.next_major_version_candidate.gold
@@ -8,6 +8,7 @@ import "udpa/annotations/versioning.proto";
 option java_package = "io.envoyproxy.envoy.v3";
 option java_outer_classname = "SampleProto";
 option java_multiple_files = true;
+option (udpa.annotations.file_status).work_in_progress = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
 
 enum SomeEnum {


### PR DESCRIPTION
For some reason they were restricted only to alpha files before.

Risk level: Low
Testing: Golden protoxform test added.

Addresses issue in
https://github.com/envoyproxy/envoy/pull/12159#issuecomment-662541179

Signed-off-by: Harvey Tuch <htuch@google.com>