### PR TITLE
tcp tunneling: fix integration test flake

### DIFF
--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -19,15 +19,12 @@ public:
   ApiListenerIntegrationTest() : BaseIntegrationTest(GetParam(), bootstrapConfig()) {
     use_lds_ = false;
     autonomous_upstream_ = true;
+    defer_listener_finalization_ = true;
   }
 
   void SetUp() override {
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      // currently ApiListener does not trigger this wait
-      // https://github.com/envoyproxy/envoy/blob/0b92c58d08d28ba7ef0ed5aaf44f90f0fccc5dce/test/integration/integration.cc#L454
-      // Thus, the ApiListener has to be added in addition to the already existing listener in the
-      // config.
-      bootstrap.mutable_static_resources()->add_listeners()->MergeFrom(
+      bootstrap.mutable_static_resources()->mutable_listeners(0)->MergeFrom(
           Server::parseListenerFromV2Yaml(apiListenerConfig()));
     });
   }

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -490,7 +490,9 @@ void BaseIntegrationTest::createGeneratedApiTestServer(
     const char* rejected = "listener_manager.lds.update_rejected";
     for (Stats::CounterSharedPtr success_counter = test_server_->counter(success),
                                  rejected_counter = test_server_->counter(rejected);
-         (success_counter == nullptr || success_counter->value() < concurrency_) &&
+         (success_counter == nullptr ||
+          success_counter->value() <
+              concurrency_ * config_helper_.bootstrap().static_resources().listeners_size()) &&
          (!allow_lds_rejection || rejected_counter == nullptr || rejected_counter->value() == 0);
          success_counter = test_server_->counter(success),
                                  rejected_counter = test_server_->counter(rejected)) {


### PR DESCRIPTION
We need to wait for all listeners to be up.

Fixes https://github.com/envoyproxy/envoy/issues/12253 (and maybe other flakes)

Risk Level: None
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
