### PR TITLE
build: Use c++17 when compiling googleurl

### DIFF
--- a/bazel/external/googleurl.patch
+++ b/bazel/external/googleurl.patch
@@ -77,10 +77,10 @@ index d5fca65..fc0d7e5 100644
 -]
 +_default_copts = select({
 +    "@envoy//bazel:windows_x86_64": [
-+        "/std:c++14",
++        "/std:c++17",
 +    ],
 +    "//conditions:default": [
-+        "-std=c++14",
++        "-std=c++17",
 +        "-fno-strict-aliasing",
 +    ],
 +})
@@ -114,6 +114,6 @@ index 0126bdc..5d1a171 100644
          "//base",
          "//base/strings",
          "//polyfills",
-+         "@org_unicode_icuuc//:common",
++        "@org_unicode_icuuc//:common",
      ],
  )


### PR DESCRIPTION
Commit Message: Use `c++17` std flag when compiling `googleurl`.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

Additional Description:
Risk Level: Low
Testing: Existing
Docs Changes: N/A
Release Notes: N/A