### PR TITLE
HCM: finalize header after upstream is selected

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -560,8 +560,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   // Inject the active span's tracing context into the request headers.
   callbacks_->activeSpan().injectContext(headers);
 
-  route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
-                                       !config_.suppress_envoy_headers_);
   FilterUtility::setUpstreamScheme(headers,
                                    host->transportSocketFactory().implementsSecureTransport());
 
@@ -580,8 +578,6 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
       active_shadow_policies_.push_back(std::cref(policy_ref));
     }
   }
-
-  ENVOY_STREAM_LOG(debug, "router decoding headers:\n{}", *callbacks_, headers);
 
   // Hang onto the modify_headers function for later use in handling upstream responses.
   modify_headers_ = modify_headers;

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -374,12 +374,14 @@ void UpstreamRequest::onPoolReady(
 
   calling_encode_headers_ = true;
   auto* headers = parent_.downstreamHeaders();
+  parent_.routeEntry()->finalizeRequestHeaders(*headers, parent_.callbacks()->streamInfo(),
+                                               !parent_.config().suppress_envoy_headers_);
   if (parent_.routeEntry()->autoHostRewrite() && !host->hostname().empty()) {
-    parent_.downstreamHeaders()->setHost(host->hostname());
+    headers->setHost(host->hostname());
   }
 
   if (span_ != nullptr) {
-    span_->injectContext(*parent_.downstreamHeaders());
+    span_->injectContext(*headers);
   }
 
   upstream_timing_.onFirstUpstreamTxByteSent(parent_.callbacks()->dispatcher().timeSource());
@@ -401,7 +403,7 @@ void UpstreamRequest::onPoolReady(
     }
   }
 
-  upstream_->encodeHeaders(*parent_.downstreamHeaders(), shouldSendEndStream());
+  upstream_->encodeHeaders(*headers, shouldSendEndStream());
 
   calling_encode_headers_ = false;
 


### PR DESCRIPTION
Commit Message:
Bring back "UPSTREAM_METADATA" evaluation in `request_headers_to_add`
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
Risk Level:
Testing: 
Docs Changes:
Release Notes:
Fixes: #12236
