### PR TITLE
docs: Display the code block correctly

### DIFF
--- a/docs/root/start/sandboxes/grpc_bridge.rst
+++ b/docs/root/start/sandboxes/grpc_bridge.rst
@@ -32,7 +32,7 @@ Docker compose
 ~~~~~~~~~~~~~~
 
 To run the docker compose file, and set up both the Python and the gRPC containers
-run:
+run::
 
   $ pwd
   envoy/examples/grpc-bridge


### PR DESCRIPTION
I found that the code block in `grpc_bridge.rst` hasn't been displayed well.
So I fixed it.

Signed-off-by: zawawahoge <zawawahoge@gmail.com>

## Risk Level
Low

## Testing
No test is added

## Docs Changes
Yes

![image](https://user-images.githubusercontent.com/13769670/88420548-fd788c80-ce21-11ea-9a11-3c519276a434.png)
