### PR TITLE
Adds an env newLine helper function 

### DIFF
--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -69,7 +69,8 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
     EXPECT_THAT(request->headers(), IsSupersetOfHeaders(response_headers));
     EXPECT_EQ(request->headers().get(Http::Headers::get().Age), nullptr);
     EXPECT_EQ(request->body(), std::string(42, 'a'));
-    EXPECT_EQ(waitForAccessLog(access_log_name_), fmt::format("- via_upstream{}", TestEnvironment::newLine()));
+    EXPECT_EQ(waitForAccessLog(access_log_name_),
+              fmt::format("- via_upstream{}", TestEnvironment::newLine()));
   }
 
   // Advance time, to verify the original date header is preserved.
@@ -84,7 +85,8 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
   EXPECT_NE(request->headers().get(Http::Headers::get().Age), nullptr);
   // Advance time to force a log flush.
   simTime().advanceTimeWait(std::chrono::seconds(1));
-  EXPECT_EQ(waitForAccessLog(access_log_name_, 1), fmt::format("RFCF cache.response_from_cache_filter{}", TestEnvironment::newLine()));
+  EXPECT_EQ(waitForAccessLog(access_log_name_, 1),
+            fmt::format("RFCF cache.response_from_cache_filter{}", TestEnvironment::newLine()));
 }
 
 // Send the same GET request twice with body and trailers twice, then check that the response

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -69,7 +69,7 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
     EXPECT_THAT(request->headers(), IsSupersetOfHeaders(response_headers));
     EXPECT_EQ(request->headers().get(Http::Headers::get().Age), nullptr);
     EXPECT_EQ(request->body(), std::string(42, 'a'));
-    EXPECT_EQ(waitForAccessLog(access_log_name_), "- via_upstream\n");
+    EXPECT_EQ(waitForAccessLog(access_log_name_), fmt::format("- via_upstream{}", TestEnvironment::newLine()));
   }
 
   // Advance time, to verify the original date header is preserved.
@@ -84,7 +84,7 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
   EXPECT_NE(request->headers().get(Http::Headers::get().Age), nullptr);
   // Advance time to force a log flush.
   simTime().advanceTimeWait(std::chrono::seconds(1));
-  EXPECT_EQ(waitForAccessLog(access_log_name_, 1), "RFCF cache.response_from_cache_filter\n");
+  EXPECT_EQ(waitForAccessLog(access_log_name_, 1), fmt::format("RFCF cache.response_from_cache_filter{}", TestEnvironment::newLine()));
 }
 
 // Send the same GET request twice with body and trailers twice, then check that the response

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -70,7 +70,7 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
     EXPECT_EQ(request->headers().get(Http::Headers::get().Age), nullptr);
     EXPECT_EQ(request->body(), std::string(42, 'a'));
     EXPECT_EQ(waitForAccessLog(access_log_name_),
-              fmt::format("- via_upstream{}", TestEnvironment::newLine()));
+              fmt::format("- via_upstream{}", TestEnvironment::newLine));
   }
 
   // Advance time, to verify the original date header is preserved.
@@ -86,7 +86,7 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
   // Advance time to force a log flush.
   simTime().advanceTimeWait(std::chrono::seconds(1));
   EXPECT_EQ(waitForAccessLog(access_log_name_, 1),
-            fmt::format("RFCF cache.response_from_cache_filter{}", TestEnvironment::newLine()));
+            fmt::format("RFCF cache.response_from_cache_filter{}", TestEnvironment::newLine));
 }
 
 // Send the same GET request twice with body and trailers twice, then check that the response

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -273,6 +273,14 @@ const std::string& TestEnvironment::nullDevicePath() {
 #endif
 }
 
+const std::string& TestEnvironment::newLine() {
+#ifdef WIN32
+  CONSTRUCT_ON_FIRST_USE(std::string, "\r\n");
+#else
+  CONSTRUCT_ON_FIRST_USE(std::string, "\n");
+#endif
+}
+
 std::string TestEnvironment::runfilesDirectory(const std::string& workspace) {
   RELEASE_ASSERT(runfiles_ != nullptr, "");
   return runfiles_->Rlocation(workspace);

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -273,14 +273,6 @@ const std::string& TestEnvironment::nullDevicePath() {
 #endif
 }
 
-const std::string& TestEnvironment::newLine() {
-#ifdef WIN32
-  CONSTRUCT_ON_FIRST_USE(std::string, "\r\n");
-#else
-  CONSTRUCT_ON_FIRST_USE(std::string, "\n");
-#endif
-}
-
 std::string TestEnvironment::runfilesDirectory(const std::string& workspace) {
   RELEASE_ASSERT(runfiles_ != nullptr, "");
   return runfiles_->Rlocation(workspace);

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -95,7 +95,7 @@ public:
 
   /**
    * Obtain platform specific new line character(s)
-   * @return const std::string& platform specific new line character(s)
+   * @return absl::string_view platform specific new line character(s)
    */
   static constexpr absl::string_view newLine() {
 #ifdef WIN32

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -94,6 +94,12 @@ public:
   static const std::string& nullDevicePath();
 
   /**
+   * Obtain platform specific new line character(s)
+   * @return const std::string& platform specific new line character(s)
+   */
+  static const std::string& newLine();
+
+  /**
    * Obtain read-only test input data directory.
    * @param workspace the name of the Bazel workspace where the input data is.
    * @return const std::string& with the path to the read-only test input directory.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -97,13 +97,12 @@ public:
    * Obtain platform specific new line character(s)
    * @return absl::string_view platform specific new line character(s)
    */
-  static constexpr absl::string_view newLine() {
+  static constexpr absl::string_view newLine
 #ifdef WIN32
-    return {"\r\n", 2};
+    {"\r\n"};
 #else
-    return {"\n", 2};
+    {"\n"};
 #endif
-  }
 
   /**
    * Obtain read-only test input data directory.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -97,7 +97,13 @@ public:
    * Obtain platform specific new line character(s)
    * @return const std::string& platform specific new line character(s)
    */
-  static const std::string& newLine();
+  static constexpr absl::string_view newLine() {
+#ifdef WIN32
+    return {"\r\n", 2};
+#else
+    return {"\n", 2};
+#endif
+  }
 
   /**
    * Obtain read-only test input data directory.

--- a/test/test_common/environment.h
+++ b/test/test_common/environment.h
@@ -99,9 +99,9 @@ public:
    */
   static constexpr absl::string_view newLine
 #ifdef WIN32
-    {"\r\n"};
+      {"\r\n"};
 #else
-    {"\n"};
+      {"\n"};
 #endif
 
   /**


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Adds the helper function `const std::string& TestEnvironment::newLine()` in the test environment that can be used in test code for cross platform comparison of strings that contain new lines.

Additional Description:

Part of the effort to make envoy portable to Windows

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A