### PR TITLE
Fix a compilation error for com_lightstep_tracer_cpp

### DIFF
--- a/bazel/com_lightstep_tracer_cpp.patch
+++ b/bazel/com_lightstep_tracer_cpp.patch
@@ -1,0 +1,12 @@
+diff --git a/bazel/lightstep_build_system.bzl b/bazel/lightstep_build_system.bzl
+index cd896c8..bdbba6d 100644
+--- a/bazel/lightstep_build_system.bzl
++++ b/bazel/lightstep_build_system.bzl
+@@ -46,6 +46,7 @@ def lightstep_copts(is_3rd_party=False):
+       "-Wno-overloaded-virtual",
+       "-Wvla",
+       "-std=c++11",
++      "-fsigned-char",
+   ]
+ 
+ def lightstep_linkopts():

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -411,7 +411,14 @@ def _io_opentracing_cpp():
     )
 
 def _com_lightstep_tracer_cpp():
-    _repository_impl("com_lightstep_tracer_cpp")
+    _repository_impl(
+        name = "com_lightstep_tracer_cpp",
+        patch_args = ["-p1"],
+        # Workaround for GCC architecture specific optimization about 'char' type
+        # on different arches: arm64, ia64, ppc64, ...
+        # Ref: https://wiki.debian.org/ArchitectureSpecificsMemo
+        patches = ["@envoy//bazel:com_lightstep_tracer_cpp.patch"],
+    )
     native.bind(
         name = "lightstep",
         actual = "@com_lightstep_tracer_cpp//:manual_tracer_lib",


### PR DESCRIPTION
When compiling the external repo com_lightstep_tracer_cpp on arm64
by GCC, it would show the following error:

com_lightstep_tracer_cpp/src/common/BUILD:173:1: C++ compilation of rule
'@com_lightstep_tracer_cpp//src/common:utility_lib' failed (Exit 1) gcc
failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE
-fstack-protector -Wall -Wunused-but-set-parameter ...
external/com_lightstep_tracer_cpp/src/common/utility.cpp:76:20: error:
comparison is always true due to limited range of data type
[-Werror=type-limits]
         if ('\x00' <= c && c <= '\x1f') {
                 ~~~~~~~^~~~
cc1plus: all warnings being treated as errors
Target //source/exe:envoy-static failed to build

This warning is due to the explanation for 'char' type on arm64 is explained as
'unsigned char', but for x86_64, it's for 'signed char'.
More details about this warning could be found at:
https://stackoverflow.com/questions/757482/\
comparison-is-always-true-due-to-limited-range-of-data-type-warning-in-c

This patch fixes the above error by adding a forced 'signed-char' flag
to copts when building lightstep_tracer_cpp package which would force to
use the 'singed char' explanation to 'char' type.

Signed-off-by: Trevor Tao <trevor.tao@arm.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
