### PR TITLE
build: remove the separate c++14 flag

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -221,7 +221,6 @@ elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
     --define path_normalization_by_default=true \
     --define deprecated_features=disabled \
     --define use_legacy_codecs_in_integration_tests=true \
-    --define --cxxopt=-std=c++14 \
   "
   ENVOY_STDLIB="${ENVOY_STDLIB:-libstdc++}"
   setup_clang_toolchain


### PR DESCRIPTION
Signed-off-by: Yifan Yang <needyyang@google.com>

This PR is the final step in porting envoy to C++17. After this change, all envoy builds including envoy-mobile will be built in C++17 mode. See this for the PR that make envoy-mobile built in C++17 https://github.com/lyft/envoy-mobile/pull/964. 

Commit Message:
Additional Description:
Risk Level: low, as the master has been running with c++17 mode for almost two weeks now and envoy mobile is also building with C++17
Testing: All existing tests have been passed.
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
