### PR TITLE
zookeeper: convert ASSERT() into check

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -183,8 +183,11 @@ void DecoderImpl::decodeOnWrite(Buffer::Instance& data, uint64_t& offset) {
   OpCodes opcode;
 
   if (xid_code != XidCodes::WatchXid) {
-    // If this fails, it's a server-side bug.
-    ASSERT(it != requests_by_xid_.end());
+    // If this fails, it's either a server-side bug or a malformed packet.
+    if (it == requests_by_xid_.end()) {
+      throw EnvoyException("xid not found");
+    }
+
     latency = std::chrono::duration_cast<std::chrono::milliseconds>(time_source_.monotonicTime() -
                                                                     it->second.start_time);
     opcode = it->second.opcode;

--- a/source/extensions/filters/network/zookeeper_proxy/decoder.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/decoder.cc
@@ -176,13 +176,13 @@ void DecoderImpl::decodeOnWrite(Buffer::Instance& data, uint64_t& offset) {
   const auto xid = helper_.peekInt32(data, offset);
   const auto xid_code = static_cast<XidCodes>(xid);
 
-  // Find the corresponding request for this XID.
-  const auto it = requests_by_xid_.find(xid);
-
   std::chrono::milliseconds latency;
   OpCodes opcode;
 
   if (xid_code != XidCodes::WatchXid) {
+    // Find the corresponding request for this XID.
+    const auto it = requests_by_xid_.find(xid);
+
     // If this fails, it's either a server-side bug or a malformed packet.
     if (it == requests_by_xid_.end()) {
       throw EnvoyException("xid not found");

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -953,6 +953,18 @@ TEST_F(ZooKeeperFilterTest, WatchEvent) {
   EXPECT_EQ(0UL, config_->stats().decoder_error_.value());
 }
 
+TEST_F(ZooKeeperFilterTest, MissingXid) {
+  initialize();
+
+  const auto& stat = config_->stats().getdata_resp_;
+  Buffer::OwnedImpl data = encodeResponseHeader(1000, 2000, 0);
+
+  EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onWrite(data, false));
+  EXPECT_EQ(0UL, stat.value());
+  EXPECT_EQ(0UL, config_->stats().response_bytes_.value());
+  EXPECT_EQ(1UL, config_->stats().decoder_error_.value());
+}
+
 } // namespace ZooKeeperProxy
 } // namespace NetworkFilters
 } // namespace Extensions


### PR DESCRIPTION
A malformed packet or buggy server could trigger the ASSERT(),
so let's deal with it.

Fixes #12327.

Reported-by: @jianwen612

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
