### PR TITLE
stats: Add additional constraints to histogram bucket configuration

### DIFF
--- a/api/envoy/config/metrics/v3/stats.proto
+++ b/api/envoy/config/metrics/v3/stats.proto
@@ -294,8 +294,13 @@ message HistogramBucketSettings {
   // before tag-extraction, for example `cluster.exampleclustername.upstream_cx_length_ms`.
   type.matcher.v3.StringMatcher match = 1 [(validate.rules).message = {required: true}];
 
-  // Each value is the upper bound of a successive bucket.
-  repeated double buckets = 2 [(validate.rules).repeated = {min_items: 1}];
+  // Each value is the upper bound of a bucket. Each bucket must be greater than 0 and unique.
+  // The order of the buckets does not matter.
+  repeated double buckets = 2 [(validate.rules).repeated = {
+    min_items: 1
+    unique: true
+    items {double {gt: 0.0}}
+  }];
 }
 
 // Stats configuration proto schema for built-in *envoy.stat_sinks.statsd* sink. This sink does not support

--- a/api/envoy/config/metrics/v4alpha/stats.proto
+++ b/api/envoy/config/metrics/v4alpha/stats.proto
@@ -297,8 +297,13 @@ message HistogramBucketSettings {
   // before tag-extraction, for example `cluster.exampleclustername.upstream_cx_length_ms`.
   type.matcher.v4alpha.StringMatcher match = 1 [(validate.rules).message = {required: true}];
 
-  // Each value is the upper bound of a successive bucket.
-  repeated double buckets = 2 [(validate.rules).repeated = {min_items: 1}];
+  // Each value is the upper bound of a bucket. Each bucket must be greater than 0 and unique.
+  // The order of the buckets does not matter.
+  repeated double buckets = 2 [(validate.rules).repeated = {
+    min_items: 1
+    unique: true
+    items {double {gt: 0.0}}
+  }];
 }
 
 // Stats configuration proto schema for built-in *envoy.stat_sinks.statsd* sink. This sink does not support

--- a/generated_api_shadow/envoy/config/metrics/v3/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v3/stats.proto
@@ -292,8 +292,13 @@ message HistogramBucketSettings {
   // before tag-extraction, for example `cluster.exampleclustername.upstream_cx_length_ms`.
   type.matcher.v3.StringMatcher match = 1 [(validate.rules).message = {required: true}];
 
-  // Each value is the upper bound of a successive bucket.
-  repeated double buckets = 2 [(validate.rules).repeated = {min_items: 1}];
+  // Each value is the upper bound of a bucket. Each bucket must be greater than 0 and unique.
+  // The order of the buckets does not matter.
+  repeated double buckets = 2 [(validate.rules).repeated = {
+    min_items: 1
+    unique: true
+    items {double {gt: 0.0}}
+  }];
 }
 
 // Stats configuration proto schema for built-in *envoy.stat_sinks.statsd* sink. This sink does not support

--- a/generated_api_shadow/envoy/config/metrics/v4alpha/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v4alpha/stats.proto
@@ -297,8 +297,13 @@ message HistogramBucketSettings {
   // before tag-extraction, for example `cluster.exampleclustername.upstream_cx_length_ms`.
   type.matcher.v4alpha.StringMatcher match = 1 [(validate.rules).message = {required: true}];
 
-  // Each value is the upper bound of a successive bucket.
-  repeated double buckets = 2 [(validate.rules).repeated = {min_items: 1}];
+  // Each value is the upper bound of a bucket. Each bucket must be greater than 0 and unique.
+  // The order of the buckets does not matter.
+  repeated double buckets = 2 [(validate.rules).repeated = {
+    min_items: 1
+    unique: true
+    items {double {gt: 0.0}}
+  }];
 }
 
 // Stats configuration proto schema for built-in *envoy.stat_sinks.statsd* sink. This sink does not support

--- a/source/common/stats/histogram_impl.cc
+++ b/source/common/stats/histogram_impl.cc
@@ -85,8 +85,9 @@ HistogramSettingsImpl::HistogramSettingsImpl(const envoy::config::metrics::v3::S
     : configs_([&config]() {
         std::vector<Config> configs;
         for (const auto& matcher : config.histogram_bucket_settings()) {
-          configs.emplace_back(matcher.match(), ConstSupportedBuckets{matcher.buckets().begin(),
-                                                                      matcher.buckets().end()});
+          std::vector<double> buckets{matcher.buckets().begin(), matcher.buckets().end()};
+          std::sort(buckets.begin(), buckets.end());
+          configs.emplace_back(matcher.match(), std::move(buckets));
         }
 
         return configs;

--- a/test/common/stats/histogram_impl_test.cc
+++ b/test/common/stats/histogram_impl_test.cc
@@ -38,6 +38,19 @@ TEST_F(HistogramSettingsImplTest, Basic) {
   EXPECT_EQ(settings_->buckets("abcd"), ConstSupportedBuckets({0.1, 2}));
 }
 
+// Test that buckets are correctly sorted.
+TEST_F(HistogramSettingsImplTest, Sorted) {
+  envoy::config::metrics::v3::HistogramBucketSettings setting;
+  setting.mutable_match()->set_exact("a");
+  setting.mutable_buckets()->Add(0.1);
+  setting.mutable_buckets()->Add(2);
+  setting.mutable_buckets()->Add(1); // Out-of-order
+  buckets_configs_.push_back(setting);
+
+  initialize();
+  EXPECT_EQ(settings_->buckets("a"), ConstSupportedBuckets({0.1, 1, 2}));
+}
+
 // Test that only matching configurations are applied.
 TEST_F(HistogramSettingsImplTest, Matching) {
   {


### PR DESCRIPTION
This ensures that the configuration is valid.

Signed-off-by: Greg Greenway <ggreenway@apple.com>

This is a follow-up to #12034, which was merged only 5 days ago, so I think it's ok to tighten the
config constraints, even though it technically breaks compatibility.

Risk Level: Low
Testing: Added UT
Docs Changes:
Release Notes: Not needed; original change was 5 days ago