### PR TITLE
docs: Fix refs in Lua docs

### DIFF
--- a/api/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/api/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -27,7 +27,7 @@ message Lua {
   // strings so complex scripts can be easily expressed inline in the configuration.
   string inline_code = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // Map of named Lua source codes that can be referenced in :ref:` LuaPerRoute
+  // Map of named Lua source codes that can be referenced in :ref:`LuaPerRoute
   // <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>`. The Lua source codes can be
   // loaded from inline string or local files.
   //

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -59,7 +59,7 @@ Configuration
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.lua.v3.Lua>`
 * This filter should be configured with the name *envoy.filters.http.lua*.
 
-A simple example of configuring Lua HTTP filter that contains only :ref:`inline_code 
+A simple example of configuring Lua HTTP filter that contains only :ref:`inline_code
 <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>` is as follow:
 
 .. code-block:: yaml
@@ -77,14 +77,14 @@ A simple example of configuring Lua HTTP filter that contains only :ref:`inline_
         -- Do something.
       end
 
-By default, Lua script defined in ``inline_code`` will be treated as a ``GLOBAL`` script. Envoy will 
+By default, Lua script defined in ``inline_code`` will be treated as a ``GLOBAL`` script. Envoy will
 execute it for every HTTP request.
 
 Per-Route Configuration
 -----------------------
 
-The Lua HTTP filter also can be disabled or overridden on a per-route basis by providing a 
-:ref:`LuaPerRoute <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>` configuration 
+The Lua HTTP filter also can be disabled or overridden on a per-route basis by providing a
+:ref:`LuaPerRoute <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>` configuration
 on the virtual host, route, or weighted cluster.
 
 As a concrete example, given the following Lua filter configuration:
@@ -110,8 +110,9 @@ As a concrete example, given the following Lua filter configuration:
             response_handle:logInfo("Bye Bye.")
           end
 
-The HTTP Lua filter can be disabled on some virtual host, route, or weighted cluster by the 
-LuaPerRoute configuration as follow:
+The HTTP Lua filter can be disabled on some virtual host, route, or weighted cluster by the
+:ref:`LuaPerRoute <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>` configuration as
+follow:
 
 .. code-block:: yaml
 
@@ -119,7 +120,7 @@ LuaPerRoute configuration as follow:
     envoy.filters.http.lua:
       disabled: true
 
-We can also refer to a Lua script in the filter configuration by specifying a name in LuaPerRoute. 
+We can also refer to a Lua script in the filter configuration by specifying a name in LuaPerRoute.
 The ``GLOBAL`` Lua script will be overridden by the referenced script:
 
 .. code-block:: yaml
@@ -130,10 +131,10 @@ The ``GLOBAL`` Lua script will be overridden by the referenced script:
 
 .. attention::
 
-  The name ``GLOBAL`` is reserved for :ref:`Lua.inline_code 
-  <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>`. Therefore, do not use 
+  The name ``GLOBAL`` is reserved for :ref:`Lua.inline_code
+  <envoy_v3_api_field_extensions.filters.http.lua.v3.Lua.inline_code>`. Therefore, do not use
   ``GLOBAL`` as name for other Lua scripts.
-    
+
 
 Script examples
 ---------------

--- a/generated_api_shadow/envoy/extensions/filters/http/lua/v3/lua.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/lua/v3/lua.proto
@@ -27,7 +27,7 @@ message Lua {
   // strings so complex scripts can be easily expressed inline in the configuration.
   string inline_code = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // Map of named Lua source codes that can be referenced in :ref:` LuaPerRoute
+  // Map of named Lua source codes that can be referenced in :ref:`LuaPerRoute
   // <envoy_v3_api_msg_extensions.filters.http.lua.v3.LuaPerRoute>`. The Lua source codes can be
   // loaded from inline string or local files.
   //


### PR DESCRIPTION
Commit Message: 

This is a "docs" only change, mostly on how to refer to LuaPerRoute info (previously it was not rendered properly in the docs) and cleaning up some superfluous empty spaces.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

Risk Level: Low
Testing: N/A
Docs Changes: Docs only
Release Notes: N/A
