### PR TITLE
Add upstream_local_address and upstream_transport_failure_reason fields in cel filter extension

### DIFF
--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -108,6 +108,8 @@ The following attributes are exposed to the language runtime:
    upstream.dns_san_peer_certificate, string, The first DNS entry in the SAN field of the peer certificate in the upstream TLS connection
    upstream.uri_san_local_certificate, string, The first URI entry in the SAN field of the local certificate in the upstream TLS connection
    upstream.uri_san_peer_certificate, string, The first URI entry in the SAN field of the peer certificate in the upstream TLS connection
+   upstream.local_address, string, The local address of the upstream connection
+   upstream.transport_failure_reason, string, The upstream transport failure reason e.g. certificate validation failed
 
 
 Most attributes are optional and provide the default value based on the type of the attribute.

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -190,6 +190,13 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
         upstream_host->address()->ip() != nullptr) {
       return CelValue::CreateInt64(upstream_host->address()->ip()->port());
     }
+  } else if (value == UpstreamLocalAddress) {
+    auto upstream_local_address = info_.upstreamLocalAddress();
+    if (upstream_local_address != nullptr) {
+      return CelValue::CreateStringView(upstream_local_address->asStringView());
+    }
+  } else if (value == UpstreamTransportFailureReason) {
+    return CelValue::CreateStringView(info_.upstreamTransportFailureReason());
   }
 
   auto ssl_info = info_.upstreamSslConnection();

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -66,6 +66,8 @@ constexpr absl::string_view Destination = "destination";
 
 // Upstream properties
 constexpr absl::string_view Upstream = "upstream";
+constexpr absl::string_view UpstreamLocalAddress = "upstream_local_address";
+constexpr absl::string_view UpstreamTransportFailureReason = "upstream_transport_failure_reason";
 
 class RequestWrapper;
 

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -66,8 +66,8 @@ constexpr absl::string_view Destination = "destination";
 
 // Upstream properties
 constexpr absl::string_view Upstream = "upstream";
-constexpr absl::string_view UpstreamLocalAddress = "upstream_local_address";
-constexpr absl::string_view UpstreamTransportFailureReason = "upstream_transport_failure_reason";
+constexpr absl::string_view UpstreamLocalAddress = "local_address";
+constexpr absl::string_view UpstreamTransportFailureReason = "transport_failure_reason";
 
 class RequestWrapper;
 


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Add upstream_local_address and upstream_transport_failure_reason fields in cel filter extension
Additional Description:
Risk Level: Low
Testing: Added unit test
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
