### PR TITLE
[1.13] [http1] Preserve LWS from the middle of HTTP1 header values that requ…

### DIFF
--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -130,6 +130,12 @@ public:
   char* buffer() { return buffer_.dynamic_; }
 
   /**
+   * Trim trailing whitespaces from the HeaderString.
+   * v1.13 support all implementation.
+   */
+  void rtrim();
+
+  /**
    * Get an absl::string_view. It will NOT be NUL terminated!
    *
    * @return an absl::string_view.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -131,7 +131,7 @@ public:
 
   /**
    * Trim trailing whitespaces from the HeaderString.
-   * v1.13 support all implementation.
+   * v1.13 supports both Inline and Dynamic, but not Reference type.
    */
   void rtrim();
 

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -153,30 +153,10 @@ void HeaderString::append(const char* data, uint32_t size) {
 void HeaderString::rtrim() {
   switch (type_) {
   case Type::Reference: {
-    absl::string_view original = getStringView();
-    absl::string_view rtrimmed = StringUtil::rtrim(original);
-    const uint64_t new_size = rtrimmed.size();
-    // rtrim does nothing.
-    if (new_size == string_length_) {
-      break;
-    }
-    if (new_size > sizeof(inline_buffer_)) {
-      type_ = Type::Dynamic;
-      char* buf = static_cast<char*>(malloc(dynamic_capacity_));
-      RELEASE_ASSERT(buf != nullptr, "");
-      memcpy(buf, buffer_.ref_, new_size);
-      buffer_.dynamic_ = buf;
-      dynamic_capacity_ = new_size;
-      string_length_ = new_size;
-    } else {
-      type_ = Type::Inline;
-      memcpy(inline_buffer_, buffer_.ref_, new_size);
-      string_length_ = new_size;
-    }
-    break;
+    RELEASE_ASSERT(false, "rtrim does not support header string in reference type.");
   }
   case Type::Dynamic: {
-    // rtrim only manipulate length_. Share the same code with Inline.
+    // v1.13: rtrim manipulate length_. Share the same code with Inline.
     FALLTHRU;
   }
   case Type::Inline: {

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -151,22 +151,11 @@ void HeaderString::append(const char* data, uint32_t size) {
 }
 
 void HeaderString::rtrim() {
-  switch (type_) {
-  case Type::Reference: {
-    RELEASE_ASSERT(false, "rtrim does not support header string in reference type.");
-  }
-  case Type::Dynamic: {
-    // v1.13: rtrim manipulate length_. Share the same code with Inline.
-    FALLTHRU;
-  }
-  case Type::Inline: {
-    absl::string_view original = getStringView();
-    absl::string_view rtrimmed = StringUtil::rtrim(original);
-    if (original.size() != rtrimmed.size()) {
-      string_length_ = rtrimmed.size();
-    }
-    break;
-  }
+  ASSERT(type() == Type::Inline || type() == Type::Dynamic);
+  absl::string_view original = getStringView();
+  absl::string_view rtrimmed = StringUtil::rtrim(original);
+  if (original.size() != rtrimmed.size()) {
+    string_length_ = rtrimmed.size();
   }
 }
 

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -461,6 +461,10 @@ void ConnectionImpl::completeLastHeader() {
   checkHeaderNameForUnderscores();
   if (!current_header_field_.empty()) {
     toLowerTable().toLowerCase(current_header_field_.buffer(), current_header_field_.size());
+    // Strip trailing whitespace of the current header value if any. Leading whitespace was trimmed
+    // in ConnectionImpl::onHeaderValue. http_parser does not strip leading or trailing whitespace
+    // as the spec requires: https://tools.ietf.org/html/rfc7230#section-3.2.4
+    current_header_value_.rtrim();
     current_header_map_->addViaMove(std::move(current_header_field_),
                                     std::move(current_header_value_));
   }
@@ -584,9 +588,8 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
   if (!current_header_map_) {
     current_header_map_ = std::make_unique<HeaderMapImpl>();
   }
-  // Work around a bug in http_parser where trailing whitespace is not trimmed
-  // as the spec requires: https://tools.ietf.org/html/rfc7230#section-3.2.4
-  const absl::string_view header_value = StringUtil::trim(absl::string_view(data, length));
+
+  absl::string_view header_value{data, length};
 
   if (strict_header_validation_) {
     if (!Http::HeaderUtility::headerValueIsValid(header_value)) {
@@ -604,6 +607,13 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
   }
 
   header_parsing_state_ = HeaderParsingState::Value;
+  if (current_header_value_.empty()) {
+    // Strip leading whitespace if the current header value input contains the first bytes of the
+    // encoded header value. Trailing whitespace is stripped once the full header value is known in
+    // ConnectionImpl::completeLastHeader. http_parser does not strip leading or trailing whitespace
+    // as the spec requires: https://tools.ietf.org/html/rfc7230#section-3.2.4 .
+    header_value = StringUtil::ltrim(header_value);
+  }
   current_header_value_.append(header_value.data(), header_value.length());
 
   checkMaxHeadersSize();

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -115,6 +115,19 @@ TEST(HeaderStringTest, All) {
     EXPECT_EQ("HELLO", string.getStringView());
   }
 
+  // Inline rtrim removes trailing whitespace only.
+  {
+    const std::string data_with_leading_lws = " \t\f\v  data";
+    const std::string data_with_leading_and_trailing_lws = data_with_leading_lws + " \t\f\v";
+    HeaderString string;
+    string.append(data_with_leading_and_trailing_lws.data(),
+                  data_with_leading_and_trailing_lws.size());
+    EXPECT_EQ(data_with_leading_and_trailing_lws, string.getStringView());
+    string.rtrim();
+    EXPECT_NE(data_with_leading_and_trailing_lws, string.getStringView());
+    EXPECT_EQ(data_with_leading_lws, string.getStringView());
+  }
+
   // Static clear() does nothing.
   {
     std::string static_string("HELLO");

--- a/test/common/http/header_map_impl_test.cc
+++ b/test/common/http/header_map_impl_test.cc
@@ -117,15 +117,33 @@ TEST(HeaderStringTest, All) {
 
   // Inline rtrim removes trailing whitespace only.
   {
+    // This header string is short enough to fit into Inline type.
     const std::string data_with_leading_lws = " \t\f\v  data";
     const std::string data_with_leading_and_trailing_lws = data_with_leading_lws + " \t\f\v";
     HeaderString string;
     string.append(data_with_leading_and_trailing_lws.data(),
                   data_with_leading_and_trailing_lws.size());
     EXPECT_EQ(data_with_leading_and_trailing_lws, string.getStringView());
+    EXPECT_EQ(string.type(), HeaderString::Type::Inline);
     string.rtrim();
     EXPECT_NE(data_with_leading_and_trailing_lws, string.getStringView());
     EXPECT_EQ(data_with_leading_lws, string.getStringView());
+  }
+
+  // Dynamic rtrim removes trailing whitespace only.
+  {
+    // Making this string longer than Inline can fit.
+    const std::string padding_data_with_leading_lws = " \t\f\v  data" + std::string(128, 'a');
+    const std::string data_with_leading_and_trailing_lws =
+        padding_data_with_leading_lws + " \t\f\v";
+    HeaderString string;
+    string.append(data_with_leading_and_trailing_lws.data(),
+                  data_with_leading_and_trailing_lws.size());
+    EXPECT_EQ(data_with_leading_and_trailing_lws, string.getStringView());
+    EXPECT_EQ(string.type(), HeaderString::Type::Dynamic);
+    string.rtrim();
+    EXPECT_NE(data_with_leading_and_trailing_lws, string.getStringView());
+    EXPECT_EQ(padding_data_with_leading_lws, string.getStringView());
   }
 
   // Static clear() does nothing.

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -43,6 +43,16 @@ std::string createHeaderFragment(int num_headers) {
   }
   return headers;
 }
+
+Buffer::OwnedImpl createBufferWithNByteSlices(absl::string_view input, size_t max_slice_size) {
+  Buffer::OwnedImpl buffer;
+  for (size_t offset = 0; offset < input.size(); offset += max_slice_size) {
+    buffer.appendSliceForTest(input.substr(offset, max_slice_size));
+  }
+  // Verify that the buffer contains the right number of slices.
+  ASSERT(buffer.getRawSlices(nullptr, 0) == (input.size() + max_slice_size - 1) / max_slice_size);
+  return buffer;
+}
 } // namespace
 
 class Http1ServerConnectionImplTest : public testing::Test {
@@ -72,7 +82,13 @@ public:
   // Then send a response just to clean up.
   void sendAndValidateRequestAndSendResponse(absl::string_view raw_request,
                                              const TestHeaderMapImpl& expected_request_headers) {
-    NiceMock<Http::MockStreamDecoder> decoder;
+    Buffer::OwnedImpl buffer(raw_request);
+    sendAndValidateRequestAndSendResponse(buffer, expected_request_headers);
+  }
+
+  void sendAndValidateRequestAndSendResponse(Buffer::Instance& buffer,
+                                             const TestHeaderMapImpl& expected_request_headers) {
+    NiceMock<MockStreamDecoder> decoder;
     Http::StreamEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))
         .Times(1)
@@ -80,8 +96,7 @@ public:
           response_encoder = &encoder;
           return decoder;
         }));
-    EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_request_headers), true)).Times(1);
-    Buffer::OwnedImpl buffer(raw_request);
+    EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_request_headers), true));
     codec_->dispatch(buffer);
     EXPECT_EQ(0U, buffer.length());
     response_encoder->encodeHeaders(TestHeaderMapImpl{{":status", "200"}}, true);
@@ -351,6 +366,42 @@ TEST_F(Http1ServerConnectionImplTest, HostWithLWS) {
   // Regression test mixed spaces and tabs before and after the host header value.
   sendAndValidateRequestAndSendResponse(
       "GET / HTTP/1.1\r\nHost: 	 	  host		  	 \r\n\r\n", expected_headers);
+}
+
+// Regression test for https://github.com/envoyproxy/envoy/issues/10270. Linear whitespace at the
+// beginning and end of a header value should be stripped. Whitespace in the middle should be
+// preserved.
+TEST_F(Http1ServerConnectionImplTest, InnerLWSIsPreserved) {
+  initialize();
+
+  // Header with many spaces surrounded by non-whitespace characters to ensure that dispatching is
+  // split across multiple dispatch calls. The threshold used here comes from Envoy preferring 16KB
+  // reads, but the important part is that the header value is split such that the pieces have
+  // leading and trailing whitespace characters.
+  const std::string header_value_with_inner_lws = "v" + std::string(32 * 1024, ' ') + "v";
+  TestHeaderMapImpl expected_headers{{":authority", "host"},
+                                     {":path", "/"},
+                                     {":method", "GET"},
+                                     {"header_field", header_value_with_inner_lws}};
+
+  {
+    // Regression test spaces in the middle are preserved
+    Buffer::OwnedImpl header_buffer = createBufferWithNByteSlices(
+        "GET / HTTP/1.1\r\nHost: host\r\nheader_field: " + header_value_with_inner_lws + "\r\n\r\n",
+        16 * 1024);
+    EXPECT_EQ(3, header_buffer.getRawSlices(nullptr, 0));
+    sendAndValidateRequestAndSendResponse(header_buffer, expected_headers);
+  }
+
+  {
+    // Regression test spaces before and after are removed
+    Buffer::OwnedImpl header_buffer = createBufferWithNByteSlices(
+        "GET / HTTP/1.1\r\nHost: host\r\nheader_field:  " + header_value_with_inner_lws +
+            "  \r\n\r\n",
+        16 * 1024);
+    EXPECT_EQ(3, header_buffer.getRawSlices(nullptr, 0));
+    sendAndValidateRequestAndSendResponse(header_buffer, expected_headers);
+  }
 }
 
 TEST_F(Http1ServerConnectionImplTest, Http10) {


### PR DESCRIPTION
…ire multiple dispatch calls to process (#10886)

Correctly preserve linear whitespace in the middle of HTTP1 header values. The fix in 6a95a21 trimmed away both leading and trailing whitespace when accepting header value fragments which can result in inner LWS in header values being stripped away if the LWS lands at the beginning or end of a buffer slice.

Signed-off-by: Antonio Vicente <avd@google.com>
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

