### PR TITLE
logging: add metadata access log filter

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -245,6 +245,7 @@ proto_library(
         "//envoy/service/discovery/v3:pkg",
         "//envoy/service/endpoint/v3:pkg",
         "//envoy/service/event_reporting/v3:pkg",
+        "//envoy/service/extension/v3:pkg",
         "//envoy/service/health/v3:pkg",
         "//envoy/service/listener/v3:pkg",
         "//envoy/service/load_stats/v3:pkg",

--- a/api/BUILD
+++ b/api/BUILD
@@ -245,7 +245,6 @@ proto_library(
         "//envoy/service/discovery/v3:pkg",
         "//envoy/service/endpoint/v3:pkg",
         "//envoy/service/event_reporting/v3:pkg",
-        "//envoy/service/extension/v3:pkg",
         "//envoy/service/health/v3:pkg",
         "//envoy/service/listener/v3:pkg",
         "//envoy/service/load_stats/v3:pkg",

--- a/api/envoy/config/accesslog/v3/BUILD
+++ b/api/envoy/config/accesslog/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/accesslog/v2:pkg",
         "//envoy/config/route/v3:pkg",
+        "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -9,6 +9,7 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -287,16 +288,18 @@ message GrpcStatusFilter {
 }
 
 // Filters based on matching dynamic metadata.
+// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
+// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.MetadataFilter";
 
   // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint".
+  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
   type.matcher.v3.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
-  bool no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
+  google.protobuf.BoolValue no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -41,8 +41,8 @@ message AccessLog {
   // Filter which is used to determine if the access log needs to be written.
   AccessLogFilter filter = 2;
 
-  // Custom configuration that depends on the access log being instantiated. Built-in
-  // configurations include:
+  // Custom configuration that depends on the access log being instantiated.
+  // Built-in configurations include:
   //
   // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_extensions.access_loggers.file.v3.FileAccessLog>`
@@ -161,25 +161,30 @@ message RuntimeFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.RuntimeFilter";
 
-  // Runtime key to get an optional overridden numerator for use in the *percent_sampled* field.
-  // If found in runtime, this value will replace the default numerator.
+  // Runtime key to get an optional overridden numerator for use in the
+  // *percent_sampled* field. If found in runtime, this value will replace the
+  // default numerator.
   string runtime_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // The default sampling percentage. If not specified, defaults to 0% with denominator of 100.
+  // The default sampling percentage. If not specified, defaults to 0% with
+  // denominator of 100.
   type.v3.FractionalPercent percent_sampled = 2;
 
   // By default, sampling pivots on the header
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being present. If
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` is present, the filter will
-  // consistently sample across multiple hosts based on the runtime key value and the value
-  // extracted from :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
-  // missing, or *use_independent_randomness* is set to true, the filter will randomly sample based
-  // on the runtime key value alone. *use_independent_randomness* can be used for logging kill
-  // switches within complex nested :ref:`AndFilter
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being
+  // present. If :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`
+  // is present, the filter will consistently sample across multiple hosts based
+  // on the runtime key value and the value extracted from
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
+  // missing, or *use_independent_randomness* is set to true, the filter will
+  // randomly sample based on the runtime key value alone.
+  // *use_independent_randomness* can be used for logging kill switches within
+  // complex nested :ref:`AndFilter
   // <envoy_api_msg_config.accesslog.v3.AndFilter>` and :ref:`OrFilter
-  // <envoy_api_msg_config.accesslog.v3.OrFilter>` blocks that are easier to reason about
-  // from a probability perspective (i.e., setting to true will cause the filter to behave like
-  // an independent random variable when composed within logical operator filters).
+  // <envoy_api_msg_config.accesslog.v3.OrFilter>` blocks that are easier to
+  // reason about from a probability perspective (i.e., setting to true will
+  // cause the filter to behave like an independent random variable when
+  // composed within logical operator filters).
   bool use_independent_randomness = 3;
 }
 
@@ -208,21 +213,22 @@ message HeaderFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.HeaderFilter";
 
-  // Only requests with a header which matches the specified HeaderMatcher will pass the filter
-  // check.
+  // Only requests with a header which matches the specified HeaderMatcher will
+  // pass the filter check.
   route.v3.HeaderMatcher header = 1 [(validate.rules).message = {required: true}];
 }
 
 // Filters requests that received responses with an Envoy response flag set.
 // A list of the response flags can be found
-// in the access log formatter :ref:`documentation<config_access_log_format_response_flags>`.
+// in the access log formatter
+// :ref:`documentation<config_access_log_format_response_flags>`.
 message ResponseFlagFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.ResponseFlagFilter";
 
-  // Only responses with the any of the flags listed in this field will be logged.
-  // This field is optional. If it is not specified, then any response flag will pass
-  // the filter check.
+  // Only responses with the any of the flags listed in this field will be
+  // logged. This field is optional. If it is not specified, then any response
+  // flag will pass the filter check.
   repeated string flags = 1 [(validate.rules).repeated = {
     items {
       string {
@@ -253,8 +259,8 @@ message ResponseFlagFilter {
   }];
 }
 
-// Filters gRPC requests based on their response status. If a gRPC status is not provided, the
-// filter will infer the status from the HTTP status code.
+// Filters gRPC requests based on their response status. If a gRPC status is not
+// provided, the filter will infer the status from the HTTP status code.
 message GrpcStatusFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.GrpcStatusFilter";
@@ -282,24 +288,30 @@ message GrpcStatusFilter {
   // Logs only responses that have any one of the gRPC statuses in this field.
   repeated Status statuses = 1 [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 
-  // If included and set to true, the filter will instead block all responses with a gRPC status or
-  // inferred gRPC status enumerated in statuses, and allow all other responses.
+  // If included and set to true, the filter will instead block all responses
+  // with a gRPC status or inferred gRPC status enumerated in statuses, and
+  // allow all other responses.
   bool exclude = 2;
 }
 
 // Filters based on matching dynamic metadata.
-// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
-// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
+// If the matcher path and key correspond to an existing key in dynamic
+// metadata, the request is logged only if the matcher value is equal to the
+// metadata value. If the matcher path and key *do not* correspond to an
+// existing key in dynamic metadata, the request is logged only if
+// match_if_key_not_found is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.MetadataFilter";
 
-  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
+  // Matcher to check metadata for specified value. For example, to match on the
+  // access_log_hint metadata, set the filter to "envoy.common" and the path to
+  // "access_log_hint", and the value to "true".
   type.matcher.v3.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
-  google.protobuf.BoolValue no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or
+  // true, then log; if false, then don't log.
+  google.protobuf.BoolValue match_if_key_not_found = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -4,6 +4,7 @@ package envoy.config.accesslog.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
+import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
@@ -53,7 +54,7 @@ message AccessLog {
   }
 }
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message AccessLogFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.AccessLogFilter";
@@ -93,6 +94,9 @@ message AccessLogFilter {
 
     // Extension filter.
     ExtensionFilter extension_filter = 11;
+
+    // Metadata Filter
+    MetadataFilter metadata_filter = 12;
   }
 }
 
@@ -280,6 +284,19 @@ message GrpcStatusFilter {
   // If included and set to true, the filter will instead block all responses with a gRPC status or
   // inferred gRPC status enumerated in statuses, and allow all other responses.
   bool exclude = 2;
+}
+
+// Filters based on matching dynamic metadata.
+message MetadataFilter {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.accesslog.v2.MetadataFilter";
+
+  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
+  // set the filter to "envoy.common" and the path to "access_log_hint".
+  type.matcher.v3.MetadataMatcher matcher = 1;
+
+  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
+  bool no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/api/envoy/config/accesslog/v4alpha/BUILD
+++ b/api/envoy/config/accesslog/v4alpha/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/config/accesslog/v3:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
+        "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/api/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -41,8 +41,8 @@ message AccessLog {
   // Filter which is used to determine if the access log needs to be written.
   AccessLogFilter filter = 2;
 
-  // Custom configuration that depends on the access log being instantiated. Built-in
-  // configurations include:
+  // Custom configuration that depends on the access log being instantiated.
+  // Built-in configurations include:
   //
   // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_extensions.access_loggers.file.v4alpha.FileAccessLog>`
@@ -161,25 +161,30 @@ message RuntimeFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.RuntimeFilter";
 
-  // Runtime key to get an optional overridden numerator for use in the *percent_sampled* field.
-  // If found in runtime, this value will replace the default numerator.
+  // Runtime key to get an optional overridden numerator for use in the
+  // *percent_sampled* field. If found in runtime, this value will replace the
+  // default numerator.
   string runtime_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // The default sampling percentage. If not specified, defaults to 0% with denominator of 100.
+  // The default sampling percentage. If not specified, defaults to 0% with
+  // denominator of 100.
   type.v3.FractionalPercent percent_sampled = 2;
 
   // By default, sampling pivots on the header
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being present. If
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` is present, the filter will
-  // consistently sample across multiple hosts based on the runtime key value and the value
-  // extracted from :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
-  // missing, or *use_independent_randomness* is set to true, the filter will randomly sample based
-  // on the runtime key value alone. *use_independent_randomness* can be used for logging kill
-  // switches within complex nested :ref:`AndFilter
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being
+  // present. If :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`
+  // is present, the filter will consistently sample across multiple hosts based
+  // on the runtime key value and the value extracted from
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
+  // missing, or *use_independent_randomness* is set to true, the filter will
+  // randomly sample based on the runtime key value alone.
+  // *use_independent_randomness* can be used for logging kill switches within
+  // complex nested :ref:`AndFilter
   // <envoy_api_msg_config.accesslog.v4alpha.AndFilter>` and :ref:`OrFilter
-  // <envoy_api_msg_config.accesslog.v4alpha.OrFilter>` blocks that are easier to reason about
-  // from a probability perspective (i.e., setting to true will cause the filter to behave like
-  // an independent random variable when composed within logical operator filters).
+  // <envoy_api_msg_config.accesslog.v4alpha.OrFilter>` blocks that are easier to
+  // reason about from a probability perspective (i.e., setting to true will
+  // cause the filter to behave like an independent random variable when
+  // composed within logical operator filters).
   bool use_independent_randomness = 3;
 }
 
@@ -207,21 +212,22 @@ message HeaderFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.HeaderFilter";
 
-  // Only requests with a header which matches the specified HeaderMatcher will pass the filter
-  // check.
+  // Only requests with a header which matches the specified HeaderMatcher will
+  // pass the filter check.
   route.v4alpha.HeaderMatcher header = 1 [(validate.rules).message = {required: true}];
 }
 
 // Filters requests that received responses with an Envoy response flag set.
 // A list of the response flags can be found
-// in the access log formatter :ref:`documentation<config_access_log_format_response_flags>`.
+// in the access log formatter
+// :ref:`documentation<config_access_log_format_response_flags>`.
 message ResponseFlagFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.ResponseFlagFilter";
 
-  // Only responses with the any of the flags listed in this field will be logged.
-  // This field is optional. If it is not specified, then any response flag will pass
-  // the filter check.
+  // Only responses with the any of the flags listed in this field will be
+  // logged. This field is optional. If it is not specified, then any response
+  // flag will pass the filter check.
   repeated string flags = 1 [(validate.rules).repeated = {
     items {
       string {
@@ -252,8 +258,8 @@ message ResponseFlagFilter {
   }];
 }
 
-// Filters gRPC requests based on their response status. If a gRPC status is not provided, the
-// filter will infer the status from the HTTP status code.
+// Filters gRPC requests based on their response status. If a gRPC status is not
+// provided, the filter will infer the status from the HTTP status code.
 message GrpcStatusFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.GrpcStatusFilter";
@@ -281,24 +287,30 @@ message GrpcStatusFilter {
   // Logs only responses that have any one of the gRPC statuses in this field.
   repeated Status statuses = 1 [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 
-  // If included and set to true, the filter will instead block all responses with a gRPC status or
-  // inferred gRPC status enumerated in statuses, and allow all other responses.
+  // If included and set to true, the filter will instead block all responses
+  // with a gRPC status or inferred gRPC status enumerated in statuses, and
+  // allow all other responses.
   bool exclude = 2;
 }
 
 // Filters based on matching dynamic metadata.
-// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
-// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
+// If the matcher path and key correspond to an existing key in dynamic
+// metadata, the request is logged only if the matcher value is equal to the
+// metadata value. If the matcher path and key *do not* correspond to an
+// existing key in dynamic metadata, the request is logged only if
+// match_if_key_not_found is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.MetadataFilter";
 
-  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
+  // Matcher to check metadata for specified value. For example, to match on the
+  // access_log_hint metadata, set the filter to "envoy.common" and the path to
+  // "access_log_hint", and the value to "true".
   type.matcher.v4alpha.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
-  google.protobuf.BoolValue no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or
+  // true, then log; if false, then don't log.
+  google.protobuf.BoolValue match_if_key_not_found = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/api/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/api/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -4,6 +4,7 @@ package envoy.config.accesslog.v4alpha;
 
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
+import "envoy/type/matcher/v4alpha/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
@@ -53,7 +54,7 @@ message AccessLog {
   }
 }
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message AccessLogFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.AccessLogFilter";
@@ -93,6 +94,9 @@ message AccessLogFilter {
 
     // Extension filter.
     ExtensionFilter extension_filter = 11;
+
+    // Metadata Filter
+    MetadataFilter metadata_filter = 12;
   }
 }
 
@@ -279,6 +283,19 @@ message GrpcStatusFilter {
   // If included and set to true, the filter will instead block all responses with a gRPC status or
   // inferred gRPC status enumerated in statuses, and allow all other responses.
   bool exclude = 2;
+}
+
+// Filters based on matching dynamic metadata.
+message MetadataFilter {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.accesslog.v3.MetadataFilter";
+
+  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
+  // set the filter to "envoy.common" and the path to "access_log_hint".
+  type.matcher.v4alpha.MetadataMatcher matcher = 1;
+
+  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
+  bool no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/api/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/api/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -9,6 +9,7 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -286,16 +287,18 @@ message GrpcStatusFilter {
 }
 
 // Filters based on matching dynamic metadata.
+// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
+// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.MetadataFilter";
 
   // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint".
+  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
   type.matcher.v4alpha.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
-  bool no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
+  google.protobuf.BoolValue no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,7 +38,7 @@ Removed Config or Runtime
 
 New Features
 ------------
-
+* access log: added a :ref:`dynamic metadata filter<envoy_v3_api_msg_config.accesslog.v3.MetadataFilter>` for access logs, which filters whether to log based on matching dynamic metadata.
 * access log: added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_access_log_format_response_flags>` as a response flag.
 * dynamic_forward_proxy: added :ref:`use_tcp_for_dns_lookups<envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` option to use TCP for DNS lookups in order to match the DNS options for :ref:`Clusters<envoy_v3_api_msg_config.cluster.v3.Cluster>`.
 * ext_authz filter: added support for emitting dynamic metadata for both :ref:`HTTP <config_http_filters_ext_authz_dynamic_metadata>` and :ref:`network <config_network_filters_ext_authz_dynamic_metadata>` filters.

--- a/generated_api_shadow/envoy/config/accesslog/v3/BUILD
+++ b/generated_api_shadow/envoy/config/accesslog/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/accesslog/v2:pkg",
         "//envoy/config/route/v3:pkg",
+        "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
@@ -4,6 +4,7 @@ package envoy.config.accesslog.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
+import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
@@ -51,7 +52,7 @@ message AccessLog {
   }
 }
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message AccessLogFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.AccessLogFilter";
@@ -91,6 +92,9 @@ message AccessLogFilter {
 
     // Extension filter.
     ExtensionFilter extension_filter = 11;
+
+    // Metadata Filter
+    MetadataFilter metadata_filter = 12;
   }
 }
 
@@ -278,6 +282,19 @@ message GrpcStatusFilter {
   // If included and set to true, the filter will instead block all responses with a gRPC status or
   // inferred gRPC status enumerated in statuses, and allow all other responses.
   bool exclude = 2;
+}
+
+// Filters based on matching dynamic metadata.
+message MetadataFilter {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.filter.accesslog.v2.MetadataFilter";
+
+  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
+  // set the filter to "envoy.common" and the path to "access_log_hint".
+  type.matcher.v3.MetadataMatcher matcher = 1;
+
+  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
+  bool no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
@@ -9,6 +9,7 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -285,16 +286,18 @@ message GrpcStatusFilter {
 }
 
 // Filters based on matching dynamic metadata.
+// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
+// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.MetadataFilter";
 
   // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint".
+  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
   type.matcher.v3.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
-  bool no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
+  google.protobuf.BoolValue no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v3/accesslog.proto
@@ -37,8 +37,8 @@ message AccessLog {
   // Filter which is used to determine if the access log needs to be written.
   AccessLogFilter filter = 2;
 
-  // Custom configuration that depends on the access log being instantiated. Built-in
-  // configurations include:
+  // Custom configuration that depends on the access log being instantiated.
+  // Built-in configurations include:
   //
   // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_extensions.access_loggers.file.v3.FileAccessLog>`
@@ -159,25 +159,30 @@ message RuntimeFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.RuntimeFilter";
 
-  // Runtime key to get an optional overridden numerator for use in the *percent_sampled* field.
-  // If found in runtime, this value will replace the default numerator.
+  // Runtime key to get an optional overridden numerator for use in the
+  // *percent_sampled* field. If found in runtime, this value will replace the
+  // default numerator.
   string runtime_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // The default sampling percentage. If not specified, defaults to 0% with denominator of 100.
+  // The default sampling percentage. If not specified, defaults to 0% with
+  // denominator of 100.
   type.v3.FractionalPercent percent_sampled = 2;
 
   // By default, sampling pivots on the header
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being present. If
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` is present, the filter will
-  // consistently sample across multiple hosts based on the runtime key value and the value
-  // extracted from :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
-  // missing, or *use_independent_randomness* is set to true, the filter will randomly sample based
-  // on the runtime key value alone. *use_independent_randomness* can be used for logging kill
-  // switches within complex nested :ref:`AndFilter
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being
+  // present. If :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`
+  // is present, the filter will consistently sample across multiple hosts based
+  // on the runtime key value and the value extracted from
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
+  // missing, or *use_independent_randomness* is set to true, the filter will
+  // randomly sample based on the runtime key value alone.
+  // *use_independent_randomness* can be used for logging kill switches within
+  // complex nested :ref:`AndFilter
   // <envoy_api_msg_config.accesslog.v3.AndFilter>` and :ref:`OrFilter
-  // <envoy_api_msg_config.accesslog.v3.OrFilter>` blocks that are easier to reason about
-  // from a probability perspective (i.e., setting to true will cause the filter to behave like
-  // an independent random variable when composed within logical operator filters).
+  // <envoy_api_msg_config.accesslog.v3.OrFilter>` blocks that are easier to
+  // reason about from a probability perspective (i.e., setting to true will
+  // cause the filter to behave like an independent random variable when
+  // composed within logical operator filters).
   bool use_independent_randomness = 3;
 }
 
@@ -206,21 +211,22 @@ message HeaderFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.HeaderFilter";
 
-  // Only requests with a header which matches the specified HeaderMatcher will pass the filter
-  // check.
+  // Only requests with a header which matches the specified HeaderMatcher will
+  // pass the filter check.
   route.v3.HeaderMatcher header = 1 [(validate.rules).message = {required: true}];
 }
 
 // Filters requests that received responses with an Envoy response flag set.
 // A list of the response flags can be found
-// in the access log formatter :ref:`documentation<config_access_log_format_response_flags>`.
+// in the access log formatter
+// :ref:`documentation<config_access_log_format_response_flags>`.
 message ResponseFlagFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.ResponseFlagFilter";
 
-  // Only responses with the any of the flags listed in this field will be logged.
-  // This field is optional. If it is not specified, then any response flag will pass
-  // the filter check.
+  // Only responses with the any of the flags listed in this field will be
+  // logged. This field is optional. If it is not specified, then any response
+  // flag will pass the filter check.
   repeated string flags = 1 [(validate.rules).repeated = {
     items {
       string {
@@ -251,8 +257,8 @@ message ResponseFlagFilter {
   }];
 }
 
-// Filters gRPC requests based on their response status. If a gRPC status is not provided, the
-// filter will infer the status from the HTTP status code.
+// Filters gRPC requests based on their response status. If a gRPC status is not
+// provided, the filter will infer the status from the HTTP status code.
 message GrpcStatusFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.GrpcStatusFilter";
@@ -280,24 +286,30 @@ message GrpcStatusFilter {
   // Logs only responses that have any one of the gRPC statuses in this field.
   repeated Status statuses = 1 [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 
-  // If included and set to true, the filter will instead block all responses with a gRPC status or
-  // inferred gRPC status enumerated in statuses, and allow all other responses.
+  // If included and set to true, the filter will instead block all responses
+  // with a gRPC status or inferred gRPC status enumerated in statuses, and
+  // allow all other responses.
   bool exclude = 2;
 }
 
 // Filters based on matching dynamic metadata.
-// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
-// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
+// If the matcher path and key correspond to an existing key in dynamic
+// metadata, the request is logged only if the matcher value is equal to the
+// metadata value. If the matcher path and key *do not* correspond to an
+// existing key in dynamic metadata, the request is logged only if
+// match_if_key_not_found is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.accesslog.v2.MetadataFilter";
 
-  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
+  // Matcher to check metadata for specified value. For example, to match on the
+  // access_log_hint metadata, set the filter to "envoy.common" and the path to
+  // "access_log_hint", and the value to "true".
   type.matcher.v3.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
-  google.protobuf.BoolValue no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or
+  // true, then log; if false, then don't log.
+  google.protobuf.BoolValue match_if_key_not_found = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/generated_api_shadow/envoy/config/accesslog/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/accesslog/v4alpha/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/config/accesslog/v3:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
+        "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -41,8 +41,8 @@ message AccessLog {
   // Filter which is used to determine if the access log needs to be written.
   AccessLogFilter filter = 2;
 
-  // Custom configuration that depends on the access log being instantiated. Built-in
-  // configurations include:
+  // Custom configuration that depends on the access log being instantiated.
+  // Built-in configurations include:
   //
   // #. "envoy.access_loggers.file": :ref:`FileAccessLog
   //    <envoy_api_msg_extensions.access_loggers.file.v4alpha.FileAccessLog>`
@@ -161,25 +161,30 @@ message RuntimeFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.RuntimeFilter";
 
-  // Runtime key to get an optional overridden numerator for use in the *percent_sampled* field.
-  // If found in runtime, this value will replace the default numerator.
+  // Runtime key to get an optional overridden numerator for use in the
+  // *percent_sampled* field. If found in runtime, this value will replace the
+  // default numerator.
   string runtime_key = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // The default sampling percentage. If not specified, defaults to 0% with denominator of 100.
+  // The default sampling percentage. If not specified, defaults to 0% with
+  // denominator of 100.
   type.v3.FractionalPercent percent_sampled = 2;
 
   // By default, sampling pivots on the header
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being present. If
-  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` is present, the filter will
-  // consistently sample across multiple hosts based on the runtime key value and the value
-  // extracted from :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
-  // missing, or *use_independent_randomness* is set to true, the filter will randomly sample based
-  // on the runtime key value alone. *use_independent_randomness* can be used for logging kill
-  // switches within complex nested :ref:`AndFilter
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>` being
+  // present. If :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`
+  // is present, the filter will consistently sample across multiple hosts based
+  // on the runtime key value and the value extracted from
+  // :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
+  // missing, or *use_independent_randomness* is set to true, the filter will
+  // randomly sample based on the runtime key value alone.
+  // *use_independent_randomness* can be used for logging kill switches within
+  // complex nested :ref:`AndFilter
   // <envoy_api_msg_config.accesslog.v4alpha.AndFilter>` and :ref:`OrFilter
-  // <envoy_api_msg_config.accesslog.v4alpha.OrFilter>` blocks that are easier to reason about
-  // from a probability perspective (i.e., setting to true will cause the filter to behave like
-  // an independent random variable when composed within logical operator filters).
+  // <envoy_api_msg_config.accesslog.v4alpha.OrFilter>` blocks that are easier to
+  // reason about from a probability perspective (i.e., setting to true will
+  // cause the filter to behave like an independent random variable when
+  // composed within logical operator filters).
   bool use_independent_randomness = 3;
 }
 
@@ -207,21 +212,22 @@ message HeaderFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.HeaderFilter";
 
-  // Only requests with a header which matches the specified HeaderMatcher will pass the filter
-  // check.
+  // Only requests with a header which matches the specified HeaderMatcher will
+  // pass the filter check.
   route.v4alpha.HeaderMatcher header = 1 [(validate.rules).message = {required: true}];
 }
 
 // Filters requests that received responses with an Envoy response flag set.
 // A list of the response flags can be found
-// in the access log formatter :ref:`documentation<config_access_log_format_response_flags>`.
+// in the access log formatter
+// :ref:`documentation<config_access_log_format_response_flags>`.
 message ResponseFlagFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.ResponseFlagFilter";
 
-  // Only responses with the any of the flags listed in this field will be logged.
-  // This field is optional. If it is not specified, then any response flag will pass
-  // the filter check.
+  // Only responses with the any of the flags listed in this field will be
+  // logged. This field is optional. If it is not specified, then any response
+  // flag will pass the filter check.
   repeated string flags = 1 [(validate.rules).repeated = {
     items {
       string {
@@ -252,8 +258,8 @@ message ResponseFlagFilter {
   }];
 }
 
-// Filters gRPC requests based on their response status. If a gRPC status is not provided, the
-// filter will infer the status from the HTTP status code.
+// Filters gRPC requests based on their response status. If a gRPC status is not
+// provided, the filter will infer the status from the HTTP status code.
 message GrpcStatusFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.GrpcStatusFilter";
@@ -281,24 +287,30 @@ message GrpcStatusFilter {
   // Logs only responses that have any one of the gRPC statuses in this field.
   repeated Status statuses = 1 [(validate.rules).repeated = {items {enum {defined_only: true}}}];
 
-  // If included and set to true, the filter will instead block all responses with a gRPC status or
-  // inferred gRPC status enumerated in statuses, and allow all other responses.
+  // If included and set to true, the filter will instead block all responses
+  // with a gRPC status or inferred gRPC status enumerated in statuses, and
+  // allow all other responses.
   bool exclude = 2;
 }
 
 // Filters based on matching dynamic metadata.
-// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
-// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
+// If the matcher path and key correspond to an existing key in dynamic
+// metadata, the request is logged only if the matcher value is equal to the
+// metadata value. If the matcher path and key *do not* correspond to an
+// existing key in dynamic metadata, the request is logged only if
+// match_if_key_not_found is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.MetadataFilter";
 
-  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
+  // Matcher to check metadata for specified value. For example, to match on the
+  // access_log_hint metadata, set the filter to "envoy.common" and the path to
+  // "access_log_hint", and the value to "true".
   type.matcher.v4alpha.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
-  google.protobuf.BoolValue no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or
+  // true, then log; if false, then don't log.
+  google.protobuf.BoolValue match_if_key_not_found = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -4,6 +4,7 @@ package envoy.config.accesslog.v4alpha;
 
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
+import "envoy/type/matcher/v4alpha/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
@@ -53,7 +54,7 @@ message AccessLog {
   }
 }
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message AccessLogFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.AccessLogFilter";
@@ -93,6 +94,9 @@ message AccessLogFilter {
 
     // Extension filter.
     ExtensionFilter extension_filter = 11;
+
+    // Metadata Filter
+    MetadataFilter metadata_filter = 12;
   }
 }
 
@@ -279,6 +283,19 @@ message GrpcStatusFilter {
   // If included and set to true, the filter will instead block all responses with a gRPC status or
   // inferred gRPC status enumerated in statuses, and allow all other responses.
   bool exclude = 2;
+}
+
+// Filters based on matching dynamic metadata.
+message MetadataFilter {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.accesslog.v3.MetadataFilter";
+
+  // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
+  // set the filter to "envoy.common" and the path to "access_log_hint".
+  type.matcher.v4alpha.MetadataMatcher matcher = 1;
+
+  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
+  bool no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -9,6 +9,7 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -286,16 +287,18 @@ message GrpcStatusFilter {
 }
 
 // Filters based on matching dynamic metadata.
+// If the matcher path and key correspond to an existing key in dynamic metadata, the request is logged only if the matcher value is equal to the metadata value.
+// If the matcher path and key *do not* correspond to an existing key in dynamic metadata, the request is logged only if no_key_default is "true" or unset.
 message MetadataFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.accesslog.v3.MetadataFilter";
 
   // Matcher to check metadata for specified value. For example, to match on the access_log_hint metadata,
-  // set the filter to "envoy.common" and the path to "access_log_hint".
+  // set the filter to "envoy.common" and the path to "access_log_hint", and the value to "true".
   type.matcher.v4alpha.MetadataMatcher matcher = 1;
 
-  // Default result if the key does not exist in dynamic metadata: if true, then log; if false, then don't log.
-  bool no_key_default = 2;
+  // Default result if the key does not exist in dynamic metadata: if unset or true, then log; if false, then don't log.
+  google.protobuf.BoolValue no_key_default = 2;
 }
 
 // Extension filter is statically registered at runtime.

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -258,7 +258,12 @@ Grpc::Status::GrpcStatus GrpcStatusFilter::protoToGrpcStatus(
 }
 
 MetadataFilter::MetadataFilter(const envoy::config::accesslog::v3::MetadataFilter& filter_config)
-    : matcher_config_(filter_config.matcher()), default_res_(filter_config.no_key_default()) {}
+    : matcher_config_(filter_config.matcher()) {
+  default_res_ = true;
+  if (filter_config.has_no_key_default()) {
+    default_res_ = filter_config.no_key_default().value();
+  }
+}
 
 bool MetadataFilter::evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap&,
                               const Http::ResponseHeaderMap&,

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -13,8 +13,8 @@
 
 #include "common/common/assert.h"
 #include "common/common/utility.h"
-#include "common/config/utility.h"
 #include "common/config/metadata.h"
+#include "common/config/utility.h"
 #include "common/http/header_map_impl.h"
 #include "common/http/header_utility.h"
 #include "common/http/headers.h"

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -241,7 +241,12 @@ public:
                 const Http::ResponseTrailerMap& response_trailers) const override;
 
 private:
-  const envoy::type::matcher::v3::MetadataMatcher matcher_config_;
+  Matchers::ValueMatcherConstSharedPtr present_matcher_;
+  Matchers::ValueMatcherConstSharedPtr value_matcher_;
+
+  std::vector<std::string> path_;
+  std::string filter_;
+
   bool default_res_;
 };
 

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -245,9 +245,9 @@ private:
   Matchers::ValueMatcherConstSharedPtr value_matcher_;
 
   std::vector<std::string> path_;
-  std::string filter_;
 
-  bool default_res_;
+  const bool default_match_;
+  const std::string filter_;
 };
 
 /**

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -13,6 +13,7 @@
 #include "envoy/server/access_log_config.h"
 #include "envoy/type/v3/percent.pb.h"
 
+#include "common/common/matchers.h"
 #include "common/grpc/status.h"
 #include "common/http/header_utility.h"
 #include "common/protobuf/protobuf.h"
@@ -226,6 +227,22 @@ private:
    */
   Grpc::Status::GrpcStatus
   protoToGrpcStatus(envoy::config::accesslog::v3::GrpcStatusFilter::Status status) const;
+};
+
+/**
+ * Filters requests based on dynamic metadata
+ */
+class MetadataFilter : public Filter {
+public:
+  MetadataFilter(const envoy::config::accesslog::v3::MetadataFilter& filter_config);
+
+  bool evaluate(const StreamInfo::StreamInfo& info, const Http::RequestHeaderMap& request_headers,
+                const Http::ResponseHeaderMap& response_headers,
+                const Http::ResponseTrailerMap& response_trailers) const override;
+
+private:
+  const envoy::type::matcher::v3::MetadataMatcher matcher_config_;
+  bool default_res_;
 };
 
 /**

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1341,7 +1341,7 @@ filter:
         - key: "c"
       value:
         bool_match: true
-    no_key_default:
+    match_if_key_not_found:
       value: false
 
 typed_config:

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1269,6 +1269,108 @@ typed_config:
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info_);
 }
 
+TEST_F(AccessLogImplTest, MetadataFilter) {
+  const std::string yaml = R"EOF(
+name: accesslog
+filter:
+  metadata_filter:
+    matcher:
+      filter: "some.namespace"
+      path:
+        - key: "a"
+        - key: "b"
+        - key: "c"
+      value:
+        bool_match: true
+
+typed_config:
+  "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+  path: /dev/null
+  )EOF";
+
+  TestStreamInfo stream_info;
+  ProtobufWkt::Struct metadata_val;
+  auto& fields_a = *metadata_val.mutable_fields();
+  auto& struct_b = *fields_a["a"].mutable_struct_value();
+  auto& fields_b = *struct_b.mutable_fields();
+  auto& struct_c = *fields_b["b"].mutable_struct_value();
+  auto& fields_c = *struct_c.mutable_fields();
+  fields_c["c"].set_bool_value(true);
+
+  stream_info.setDynamicMetadata("some.namespace", metadata_val);
+
+  const InstanceSharedPtr log =
+      AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
+
+  EXPECT_CALL(*file_, write(_)).Times(1);
+
+  log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+  fields_c["c"].set_bool_value(false);
+
+  EXPECT_CALL(*file_, write(_)).Times(0);
+}
+
+TEST_F(AccessLogImplTest, MetadataFilterNoKey) {
+  const std::string default_true_yaml = R"EOF(
+name: accesslog
+filter:
+  metadata_filter:
+    matcher:
+      filter: "some.namespace"
+      path:
+        - key: "a"
+        - key: "b"
+        - key: "c"
+      value:
+        bool_match: true
+    no_key_default: true
+
+typed_config:
+  "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+  path: /dev/null
+  )EOF";
+
+  const std::string default_false_yaml = R"EOF(
+name: accesslog
+filter:
+  metadata_filter:
+    matcher:
+      filter: "some.namespace"
+      path:
+        - key: "a"
+        - key: "b"
+        - key: "c"
+      value:
+        bool_match: true
+    no_key_default: false
+
+typed_config:
+  "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+  path: /dev/null
+  )EOF";
+
+  TestStreamInfo stream_info;
+  ProtobufWkt::Struct metadata_val;
+  auto& fields_a = *metadata_val.mutable_fields();
+  auto& struct_b = *fields_a["a"].mutable_struct_value();
+  auto& fields_b = *struct_b.mutable_fields();
+  fields_b["b"].set_bool_value(true);
+
+  stream_info.setDynamicMetadata("some.namespace", metadata_val);
+
+  const InstanceSharedPtr default_false_log =
+      AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(default_false_yaml), context_);
+  EXPECT_CALL(*file_, write(_)).Times(0);
+
+  default_false_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+
+  const InstanceSharedPtr default_true_log =
+      AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(default_true_yaml), context_);
+  EXPECT_CALL(*file_, write(_)).Times(1);
+
+  default_true_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
+}
+
 class TestHeaderFilterFactory : public ExtensionFilterFactory {
 public:
   ~TestHeaderFilterFactory() override = default;

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1323,7 +1323,6 @@ filter:
         - key: "c"
       value:
         bool_match: true
-    no_key_default: true
 
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
@@ -1342,7 +1341,8 @@ filter:
         - key: "c"
       value:
         bool_match: true
-    no_key_default: false
+    no_key_default:
+      value: false
 
 typed_config:
   "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1318,9 +1318,7 @@ filter:
     matcher:
       filter: "some.namespace"
       path:
-        - key: "a"
-        - key: "b"
-        - key: "c"
+        - key: "x"
       value:
         bool_match: true
 
@@ -1336,9 +1334,7 @@ filter:
     matcher:
       filter: "some.namespace"
       path:
-        - key: "a"
-        - key: "b"
-        - key: "c"
+        - key: "y"
       value:
         bool_match: true
     match_if_key_not_found:


### PR DESCRIPTION
Signed-off-by: davidraskin <draskin@google.com>

Commit Message: add metadata access log filter
Additional Description: Adding a filter for access logs that will decide whether to log based on dynamic metadata
Risk Level: Low
Testing: Added tests to access log filter tests
Docs Changes: Documentation in Access Log Filter proto

Split off from #11705 
cc @mattklein123 @htuch @liminw 
