### PR TITLE
xds: increment config_reload after workers receive TLS update

### DIFF
--- a/include/envoy/config/extension_config_provider.h
+++ b/include/envoy/config/extension_config_provider.h
@@ -49,7 +49,8 @@ public:
    * @param version_info is the version of the new extension configuration.
    * @param cb the continuation callback for a completed configuration application.
    */
-  virtual void onConfigUpdate(FactoryCallback config, const std::string& version_info, ConfigAppliedCb cb) PURE;
+  virtual void onConfigUpdate(FactoryCallback config, const std::string& version_info,
+                              ConfigAppliedCb cb) PURE;
 };
 
 } // namespace Config

--- a/include/envoy/config/extension_config_provider.h
+++ b/include/envoy/config/extension_config_provider.h
@@ -9,6 +9,8 @@
 namespace Envoy {
 namespace Config {
 
+using ConfigAppliedCb = std::function<void()>;
+
 /**
  * A provider for extension configurations obtained either statically or via
  * the extension configuration discovery service. Dynamically updated extension
@@ -45,8 +47,9 @@ public:
    * Update the provider with a new configuration.
    * @param config is an extension factory callback to replace the existing configuration.
    * @param version_info is the version of the new extension configuration.
+   * @param cb the continuation callback for a completed configuration application.
    */
-  virtual void onConfigUpdate(FactoryCallback config, const std::string& version_info) PURE;
+  virtual void onConfigUpdate(FactoryCallback config, const std::string& version_info, ConfigAppliedCb cb) PURE;
 };
 
 } // namespace Config

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -153,6 +153,11 @@ public:
    * @param handler the handler that will receive this Admin's listener.
    */
   virtual void addListenerToHandler(Network::ConnectionHandler* handler) PURE;
+
+  /**
+   * @return the number of worker threads to run in the server.
+   */
+  virtual uint32_t concurrency() const PURE;
 };
 
 } // namespace Server

--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -131,7 +131,7 @@ void FilterConfigSubscription::onConfigUpdate(
       factory.createFilterFactoryFromProto(*message, stat_prefix_, factory_context_);
   ENVOY_LOG(debug, "Updating filter config {}", filter_config_name_);
   const auto pending_update = std::make_shared<std::atomic<uint64_t>>(
-      factory_context_.admin().concurrency() * filter_config_providers_.size());
+      (factory_context_.admin().concurrency() + 1) * filter_config_providers_.size());
   for (auto* provider : filter_config_providers_) {
     provider->onConfigUpdate(factory_callback, version_info, [this, pending_update]() {
       if (--(*pending_update) == 0) {

--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -52,11 +52,14 @@ void DynamicFilterConfigProviderImpl::validateConfig(
 }
 
 void DynamicFilterConfigProviderImpl::onConfigUpdate(Envoy::Http::FilterFactoryCb config,
-                                                     const std::string&) {
-  tls_->runOnAllThreads([config](ThreadLocal::ThreadLocalObjectSharedPtr previous)
+                                                     const std::string&, Config::ConfigAppliedCb cb) {
+  tls_->runOnAllThreads([config, cb](ThreadLocal::ThreadLocalObjectSharedPtr previous)
                             -> ThreadLocal::ThreadLocalObjectSharedPtr {
     auto prev_config = std::dynamic_pointer_cast<ThreadLocalConfig>(previous);
     prev_config->config_ = config;
+    if (cb) {
+      cb();
+    }
     return previous;
   });
 }
@@ -126,10 +129,17 @@ void FilterConfigSubscription::onConfigUpdate(
   Envoy::Http::FilterFactoryCb factory_callback =
       factory.createFilterFactoryFromProto(*message, stat_prefix_, factory_context_);
   ENVOY_LOG(debug, "Updating filter config {}", filter_config_name_);
+  const auto pending_update =
+      std::make_shared<std::atomic<uint64_t>>(factory_context_.admin().concurrency() * filter_config_providers_.size());
   for (auto* provider : filter_config_providers_) {
-    provider->onConfigUpdate(factory_callback, version_info);
+    provider->onConfigUpdate(factory_callback, version_info, [this, version_info, pending_update]() {
+      std::cout << "UPDATING CONFIG " << version_info << std::endl;
+      if (--(*pending_update) == 0) {
+        std::cout << "STAT INCREMENT UPDATING CONFIG " << version_info << std::endl;
+        stats_.config_reload_.inc();
+      }
+    });
   }
-  stats_.config_reload_.inc();
   last_config_hash_ = new_hash;
 }
 

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -41,7 +41,8 @@ public:
   absl::optional<Envoy::Http::FilterFactoryCb> config() override;
   void validateConfig(const ProtobufWkt::Any& proto_config,
                       Server::Configuration::NamedHttpFilterConfigFactory&) override;
-  void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&, Config::ConfigAppliedCb cb) override;
+  void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&,
+                      Config::ConfigAppliedCb cb) override;
 
 private:
   struct ThreadLocalConfig : public ThreadLocal::ThreadLocalObject {
@@ -146,7 +147,8 @@ public:
                       Server::Configuration::NamedHttpFilterConfigFactory&) override {
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
-  void onConfigUpdate(Envoy::Http::FilterFactoryCb, const std::string&, Config::ConfigAppliedCb) override {
+  void onConfigUpdate(Envoy::Http::FilterFactoryCb, const std::string&,
+                      Config::ConfigAppliedCb) override {
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
 

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -41,7 +41,7 @@ public:
   absl::optional<Envoy::Http::FilterFactoryCb> config() override;
   void validateConfig(const ProtobufWkt::Any& proto_config,
                       Server::Configuration::NamedHttpFilterConfigFactory&) override;
-  void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&) override;
+  void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&, Config::ConfigAppliedCb cb) override;
 
 private:
   struct ThreadLocalConfig : public ThreadLocal::ThreadLocalObject {
@@ -146,7 +146,7 @@ public:
                       Server::Configuration::NamedHttpFilterConfigFactory&) override {
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
-  void onConfigUpdate(Envoy::Http::FilterFactoryCb, const std::string&) override {
+  void onConfigUpdate(Envoy::Http::FilterFactoryCb, const std::string&, Config::ConfigAppliedCb) override {
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -551,7 +551,7 @@ void HttpConnectionManagerConfig::processDynamicFilterConfig(
         config_discovery.default_config(), context_.messageValidationVisitor(), *default_factory);
     Http::FilterFactoryCb default_config =
         default_factory->createFilterFactoryFromProto(*message, stats_prefix_, context_);
-    filter_config_provider->onConfigUpdate(default_config, "");
+    filter_config_provider->onConfigUpdate(default_config, "", nullptr);
   }
   filter_factories.push_back(std::move(filter_config_provider));
 }

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -93,6 +93,9 @@ public:
                          Network::Address::InstanceConstSharedPtr address,
                          const Network::Socket::OptionsSharedPtr& socket_options,
                          Stats::ScopePtr&& listener_scope) override;
+  uint32_t concurrency() const override {
+    return server_.options().concurrency();
+  }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&) const override {

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -93,9 +93,7 @@ public:
                          Network::Address::InstanceConstSharedPtr address,
                          const Network::Socket::OptionsSharedPtr& socket_options,
                          Stats::ScopePtr&& listener_scope) override;
-  uint32_t concurrency() const override {
-    return server_.options().concurrency();
-  }
+  uint32_t concurrency() const override { return server_.options().concurrency(); }
 
   // Network::FilterChainManager
   const Network::FilterChain* findFilterChain(const Network::ConnectionSocket&) const override {

--- a/source/server/config_validation/admin.h
+++ b/source/server/config_validation/admin.h
@@ -27,7 +27,7 @@ public:
   Http::Code request(absl::string_view path_and_query, absl::string_view method,
                      Http::ResponseHeaderMap& response_headers, std::string& body) override;
   void addListenerToHandler(Network::ConnectionHandler* handler) override;
-  uint32_t concurrency() override { return 1; }
+  uint32_t concurrency() const override { return 1; }
 
 private:
   ConfigTrackerImpl config_tracker_;

--- a/source/server/config_validation/admin.h
+++ b/source/server/config_validation/admin.h
@@ -27,6 +27,7 @@ public:
   Http::Code request(absl::string_view path_and_query, absl::string_view method,
                      Http::ResponseHeaderMap& response_headers, std::string& body) override;
   void addListenerToHandler(Network::ConnectionHandler* handler) override;
+  uint32_t concurrency() override { return 1; }
 
 private:
   ConfigTrackerImpl config_tracker_;

--- a/test/common/filter/http/filter_config_discovery_impl_test.cc
+++ b/test/common/filter/http/filter_config_discovery_impl_test.cc
@@ -28,6 +28,7 @@
 using testing::_;
 using testing::InSequence;
 using testing::Invoke;
+using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -51,6 +52,7 @@ public:
     ON_CALL(init_manager_, initialize(_))
         .WillByDefault(Invoke(
             [this](const Init::Watcher& watcher) { init_target_handle_->initialize(watcher); }));
+    EXPECT_CALL(factory_context_.admin_, concurrency()).WillRepeatedly(Return(0));
   }
 
   Event::SimulatedTimeSystem& timeSystem() { return time_system_; }

--- a/test/common/filter/http/filter_config_discovery_impl_test.cc
+++ b/test/common/filter/http/filter_config_discovery_impl_test.cc
@@ -52,7 +52,8 @@ public:
     ON_CALL(init_manager_, initialize(_))
         .WillByDefault(Invoke(
             [this](const Init::Watcher& watcher) { init_target_handle_->initialize(watcher); }));
-    EXPECT_CALL(factory_context_.admin_, concurrency()).WillRepeatedly(Return(0));
+    // Thread local storage assumes a single (master) thread with no workers.
+    ON_CALL(factory_context_.admin_, concurrency()).WillByDefault(Return(0));
   }
 
   Event::SimulatedTimeSystem& timeSystem() { return time_system_; }

--- a/test/common/filter/http/filter_config_discovery_impl_test.cc
+++ b/test/common/filter/http/filter_config_discovery_impl_test.cc
@@ -52,7 +52,7 @@ public:
     ON_CALL(init_manager_, initialize(_))
         .WillByDefault(Invoke(
             [this](const Init::Watcher& watcher) { init_target_handle_->initialize(watcher); }));
-    // Thread local storage assumes a single (master) thread with no workers.
+    // Thread local storage assumes a single (main) thread with no workers.
     ON_CALL(factory_context_.admin_, concurrency()).WillByDefault(Return(0));
   }
 

--- a/test/mocks/server/admin.cc
+++ b/test/mocks/server/admin.cc
@@ -7,6 +7,7 @@ namespace Envoy {
 namespace Server {
 MockAdmin::MockAdmin() {
   ON_CALL(*this, getConfigTracker()).WillByDefault(testing::ReturnRef(config_tracker_));
+  ON_CALL(*this, concurrency()).WillByDefault(testing::Return(1));
 }
 
 MockAdmin::~MockAdmin() = default;

--- a/test/mocks/server/admin.cc
+++ b/test/mocks/server/admin.cc
@@ -7,7 +7,7 @@ namespace Envoy {
 namespace Server {
 MockAdmin::MockAdmin() {
   ON_CALL(*this, getConfigTracker()).WillByDefault(testing::ReturnRef(config_tracker_));
-  ON_CALL(*this, concurrency()).WillByDefault(testing::Return(2));
+  ON_CALL(*this, concurrency()).WillByDefault(testing::Return(1));
 }
 
 MockAdmin::~MockAdmin() = default;

--- a/test/mocks/server/admin.cc
+++ b/test/mocks/server/admin.cc
@@ -7,7 +7,7 @@ namespace Envoy {
 namespace Server {
 MockAdmin::MockAdmin() {
   ON_CALL(*this, getConfigTracker()).WillByDefault(testing::ReturnRef(config_tracker_));
-  ON_CALL(*this, concurrency()).WillByDefault(testing::Return(1));
+  ON_CALL(*this, concurrency()).WillByDefault(testing::Return(2));
 }
 
 MockAdmin::~MockAdmin() = default;

--- a/test/mocks/server/admin.h
+++ b/test/mocks/server/admin.h
@@ -31,6 +31,7 @@ public:
               (absl::string_view path_and_query, absl::string_view method,
                Http::ResponseHeaderMap& response_headers, std::string& body));
   MOCK_METHOD(void, addListenerToHandler, (Network::ConnectionHandler * handler));
+  MOCK_METHOD(uint32_t, concurrency, (), (const));
 
   ::testing::NiceMock<MockConfigTracker> config_tracker_;
 };


### PR DESCRIPTION
Commit Message: partial fix for #12326:
```
//test/integration:extension_discovery_integration_test                  FAILED in 2 out of 5000 in 15.1s
 ```
Risk Level: low
Testing: unit
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
