### PR TITLE
Windows: Enable now-passing unit tests

### DIFF
--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -45,7 +45,6 @@ envoy_cc_test(
         "--runtime-feature-override-for-tests=envoy.reloadable_features.new_codec_behavior",
     ],
     shard_count = 5,
-    tags = ["fails_on_windows"],
     deps = CODEC_TEST_DEPS,
 )
 
@@ -57,7 +56,6 @@ envoy_cc_test(
         "--runtime-feature-disable-for-tests=envoy.reloadable_features.new_codec_behavior",
     ],
     shard_count = 5,
-    tags = ["fails_on_windows"],
     deps = CODEC_TEST_DEPS,
 )
 
@@ -128,7 +126,6 @@ envoy_cc_test(
         "response_header_corpus/simple_example_huffman",
         "response_header_corpus/simple_example_plain",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         ":frame_replay_lib",
         "//test/common/http/http2:codec_impl_test_util",

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -98,7 +98,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "dns_impl_test",
     srcs = ["dns_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:address_interface",
@@ -275,7 +274,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "addr_family_aware_socket_option_impl_test",
     srcs = ["addr_family_aware_socket_option_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":socket_option_test",
         "//source/common/network:addr_family_aware_socket_option_lib",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -289,7 +289,6 @@ envoy_cc_test(
     name = "router_upstream_log_test",
     srcs = ["router_upstream_log_test.cc"],
     external_deps = ["abseil_optional"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/network:utility_lib",

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -135,7 +135,6 @@ envoy_benchmark_test(
 envoy_cc_test(
     name = "health_checker_impl_test",
     srcs = ["health_checker_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         ":utility_lib",
         "//source/common/buffer:buffer_lib",
@@ -405,7 +404,6 @@ envoy_benchmark_test(
     name = "load_balancer_benchmark_test",
     timeout = "long",
     benchmark_binary = "load_balancer_benchmark",
-    tags = ["fails_on_windows"],
 )
 
 envoy_cc_test(

--- a/test/extensions/filters/network/rocketmq_proxy/BUILD
+++ b/test/extensions/filters/network/rocketmq_proxy/BUILD
@@ -47,7 +47,6 @@ envoy_extension_cc_test(
     name = "router_test",
     srcs = ["router_test.cc"],
     extension_name = "envoy.filters.network.rocketmq_proxy",
-    tags = ["fails_on_windows"],
     deps = [
         ":mocks_lib",
         ":utility_lib",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -353,7 +353,6 @@ envoy_cc_test(
         ":server_test_data",
         ":static_validation_test_data",
     ],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/version:version_lib",
         "//source/extensions/access_loggers/file:config",


### PR DESCRIPTION
Commit Message:
Windows: Enable now-passing unit tests

This pass only enables passing unit tests, integration tests have been flaky and are being worked on in a separate effort.

Enabled tests:
```
/test/common/http/http2:codec_impl_legacy_test
//test/common/http/http2:codec_impl_test
//test/common/http/http2:frame_replay_test
//test/common/network:addr_family_aware_socket_option_impl_test
//test/common/network:dns_impl_test
//test/common/router:router_upstream_log_test
//test/common/upstream:health_checker_impl_test
//test/common/upstream:load_balancer_benchmark_test
//test/extensions/filters/network/rocketmq_proxy:router_test
//test/server:server_test
```

Additional Description: N/A
Risk Level: Low
Testing: Validated tests passing locally and via RBE
Docs Changes: N/A
Release Notes: N/A