### PR TITLE
[fix]thrift_proxy:Fixed potential assert failure when input contains invalid characters

### DIFF
--- a/api/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
@@ -103,7 +103,9 @@ message RouteAction {
     // header is not found or the referenced cluster does not exist Envoy will
     // respond with an unknown method exception or an internal error exception,
     // respectively.
-    string cluster_header = 6 [(validate.rules).string = {min_bytes: 1}];
+    string cluster_header = 6 [
+      (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE strict: false}
+    ];
   }
 
   // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in

--- a/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
@@ -103,7 +103,9 @@ message RouteAction {
     // header is not found or the referenced cluster does not exist Envoy will
     // respond with an unknown method exception or an internal error exception,
     // respectively.
-    string cluster_header = 6 [(validate.rules).string = {min_bytes: 1}];
+    string cluster_header = 6 [
+      (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE strict: false}
+    ];
   }
 
   // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -20,6 +20,7 @@ Minor Behavior Changes
   in the environment.
 * router: added transport failure reason to response body when upstream reset happens. After this change, the response body will be of the form `upstream connect error or disconnect/reset before headers. reset reason:{}, transport failure reason:{}`.This behavior may be reverted by setting runtime feature `envoy.reloadable_features.http_transport_failure_reason_in_body` to false.
 * router: now consumes all retry related headers to prevent them from being propagated to the upstream. This behavior may be reverted by setting runtime feature `envoy.reloadable_features.consume_all_retry_headers` to false.
+* thrift_proxy: special characters {'\0', '\r', '\n'} will be stripped from thrift headers.
 
 Bug Fixes
 ---------

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
@@ -103,7 +103,9 @@ message RouteAction {
     // header is not found or the referenced cluster does not exist Envoy will
     // respond with an unknown method exception or an internal error exception,
     // respectively.
-    string cluster_header = 6 [(validate.rules).string = {min_bytes: 1}];
+    string cluster_header = 6 [
+      (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE strict: false}
+    ];
   }
 
   // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
@@ -103,7 +103,9 @@ message RouteAction {
     // header is not found or the referenced cluster does not exist Envoy will
     // respond with an unknown method exception or an internal error exception,
     // respectively.
-    string cluster_header = 6 [(validate.rules).string = {min_bytes: 1}];
+    string cluster_header = 6 [
+      (validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE strict: false}
+    ];
   }
 
   // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in

--- a/source/extensions/filters/network/thrift_proxy/header_transport_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/header_transport_impl.cc
@@ -8,6 +8,8 @@
 
 #include "extensions/filters/network/thrift_proxy/buffer_helper.h"
 
+#include "absl/strings/str_replace.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -143,8 +145,11 @@ bool HeaderTransportImpl::decodeFrameStart(Buffer::Instance& buffer, MessageMeta
     }
 
     while (num_headers-- > 0) {
-      const Http::LowerCaseString key =
-          Http::LowerCaseString(drainVarString(buffer, header_size, "header key"));
+      std::string key_string = drainVarString(buffer, header_size, "header key");
+      // LowerCaseString doesn't allow '\0', '\n', and '\r'.
+      key_string =
+          absl::StrReplaceAll(key_string, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
+      const Http::LowerCaseString key = Http::LowerCaseString(key_string);
       const std::string value = drainVarString(buffer, header_size, "header value");
       metadata.headers().addCopy(key, value);
     }

--- a/source/extensions/filters/network/thrift_proxy/twitter_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/twitter_protocol_impl.cc
@@ -1025,7 +1025,7 @@ void TwitterProtocolImpl::updateMetadataWithRequestHeader(const ThriftObject& he
   }
   for (const auto& context : *req_header.contexts()) {
     // LowerCaseString doesn't allow '\0', '\n', and '\r'.
-    std::string key =
+    const std::string key =
         absl::StrReplaceAll(context.key_, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
     headers.addCopy(Http::LowerCaseString{key}, context.value_);
   }
@@ -1035,9 +1035,10 @@ void TwitterProtocolImpl::updateMetadataWithRequestHeader(const ThriftObject& he
   // TODO(zuercher): Delegations are stored as headers for now. Consider passing them as simple
   // objects
   for (const auto& delegation : *req_header.delegations()) {
-    std::string key = fmt::format(":d:{}", delegation.src_);
     // LowerCaseString doesn't allow '\0', '\n', and '\r'.
-    key = absl::StrReplaceAll(key, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
+    const std::string src =
+        absl::StrReplaceAll(delegation.src_, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
+    const std::string key = fmt::format(":d:{}", src);
     headers.addCopy(Http::LowerCaseString{key}, delegation.dst_);
   }
   if (req_header.traceIdHigh()) {
@@ -1058,7 +1059,7 @@ void TwitterProtocolImpl::updateMetadataWithResponseHeader(const ThriftObject& h
   Http::HeaderMap& headers = metadata.headers();
   for (const auto& context : resp_header.contexts()) {
     // LowerCaseString doesn't allow '\0', '\n', and '\r'.
-    std::string key =
+    const std::string key =
         absl::StrReplaceAll(context.key_, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
     headers.addCopy(Http::LowerCaseString(key), context.value_);
   }

--- a/source/extensions/filters/network/thrift_proxy/twitter_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/twitter_protocol_impl.cc
@@ -8,6 +8,8 @@
 #include "extensions/filters/network/thrift_proxy/thrift_object_impl.h"
 #include "extensions/filters/network/thrift_proxy/unframed_transport_impl.h"
 
+#include "absl/strings/str_replace.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -1022,7 +1024,10 @@ void TwitterProtocolImpl::updateMetadataWithRequestHeader(const ThriftObject& he
     metadata.setFlags(*req_header.flags());
   }
   for (const auto& context : *req_header.contexts()) {
-    headers.addCopy(Http::LowerCaseString{context.key_}, context.value_);
+    // LowerCaseString doesn't allow '\0', '\n', and '\r'.
+    std::string key =
+        absl::StrReplaceAll(context.key_, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
+    headers.addCopy(Http::LowerCaseString{key}, context.value_);
   }
   if (req_header.dest()) {
     headers.addReferenceKey(Headers::get().Dest, *req_header.dest());
@@ -1031,6 +1036,8 @@ void TwitterProtocolImpl::updateMetadataWithRequestHeader(const ThriftObject& he
   // objects
   for (const auto& delegation : *req_header.delegations()) {
     std::string key = fmt::format(":d:{}", delegation.src_);
+    // LowerCaseString doesn't allow '\0', '\n', and '\r'.
+    key = absl::StrReplaceAll(key, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
     headers.addCopy(Http::LowerCaseString{key}, delegation.dst_);
   }
   if (req_header.traceIdHigh()) {
@@ -1050,7 +1057,10 @@ void TwitterProtocolImpl::updateMetadataWithResponseHeader(const ThriftObject& h
 
   Http::HeaderMap& headers = metadata.headers();
   for (const auto& context : resp_header.contexts()) {
-    headers.addCopy(Http::LowerCaseString(context.key_), context.value_);
+    // LowerCaseString doesn't allow '\0', '\n', and '\r'.
+    std::string key =
+        absl::StrReplaceAll(context.key_, {{std::string(1, '\0'), ""}, {"\n", ""}, {"\r", ""}});
+    headers.addCopy(Http::LowerCaseString(key), context.value_);
   }
 
   SpanList& spans = resp_header.spans();

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -140,7 +140,7 @@ thrift_filters:
   envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy config =
       parseThriftProxyFromV2Yaml(yaml);
   std::string header = "A";
-  header.push_back('\000'); // Add an invalid charater for http header.
+  header.push_back('\000'); // Add an invalid character for http header.
   config.mutable_route_config()->mutable_routes()->at(0).mutable_route()->set_cluster_header(
       header);
   EXPECT_THROW(factory_.createFilterFactoryFromProto(config, context_), ProtoValidationException);

--- a/test/extensions/filters/network/thrift_proxy/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/config_test.cc
@@ -122,7 +122,7 @@ TEST_F(ThriftFilterConfigTest, ThriftProxyWithEmptyProto) {
   testConfig(config);
 }
 
-// Test config with an explicitly defined router filter.
+// Test config with an invalid cluster_header.
 TEST_F(ThriftFilterConfigTest, RouterConfigWithInvalidClusterHeader) {
   const std::string yaml = R"EOF(
 stat_prefix: thrift
@@ -140,7 +140,7 @@ thrift_filters:
   envoy::extensions::filters::network::thrift_proxy::v3::ThriftProxy config =
       parseThriftProxyFromV2Yaml(yaml);
   std::string header = "A";
-  header.push_back('\000');
+  header.push_back('\000'); // Add an invalid charater for http header.
   config.mutable_route_config()->mutable_routes()->at(0).mutable_route()->set_cluster_header(
       header);
   EXPECT_THROW(factory_.createFilterFactoryFromProto(config, context_), ProtoValidationException);


### PR DESCRIPTION
The assert failure will occur when `config.route_config.route.cluster_header` contains invalid characters for the HTTP header. Added the validation for this field to avoid assert failure and regression a test case in the unit test.

```
[assert] [bazel-out/k8-fastbuild/bin/include/envoy/http/_virtual_includes/header_map_interface/envoy/http/header_map.h:54] assert failure: valid().
```

Risk Level: Low
Testing: Added a regression test case
Fixes #12361

/cc @asraa 
/cc @samkerner
