### PR TITLE
tcp: fixing a bug in the new connection pool due to too many shared pointers

### DIFF
--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -88,6 +88,7 @@ bool ConnPoolImplBase::tryCreateNewConnection() {
     ASSERT(client->state_ == ActiveClient::State::CONNECTING);
     ASSERT(std::numeric_limits<uint64_t>::max() - connecting_stream_capacity_ >=
            client->effectiveConcurrentRequestLimit());
+    ASSERT(client->real_host_description_);
     connecting_stream_capacity_ += client->effectiveConcurrentRequestLimit();
     client->moveIntoList(std::move(client), owningList(client->state_));
   }

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -109,7 +109,6 @@ public:
   void clearCallbacks();
 
   ConnPoolImpl& parent_;
-  Upstream::HostDescriptionConstSharedPtr real_host_description_;
   ConnectionPool::UpstreamCallbacks* callbacks_{};
   Network::ClientConnectionPtr connection_;
   ConnectionPool::ConnectionStatePtr connection_state_;

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -671,11 +671,13 @@ void ConfigHelper::finalize(const std::vector<uint32_t>& ports) {
         for (int k = 0; k < locality_lb->lb_endpoints_size(); ++k) {
           auto lb_endpoint = locality_lb->mutable_lb_endpoints(k);
           if (lb_endpoint->endpoint().address().has_socket_address()) {
-            RELEASE_ASSERT(ports.size() > port_idx, "");
-            lb_endpoint->mutable_endpoint()
-                ->mutable_address()
-                ->mutable_socket_address()
-                ->set_port_value(ports[port_idx++]);
+            if (lb_endpoint->endpoint().address().socket_address().port_value() == 0) {
+              RELEASE_ASSERT(ports.size() > port_idx, "");
+              lb_endpoint->mutable_endpoint()
+                  ->mutable_address()
+                  ->mutable_socket_address()
+                  ->set_port_value(ports[port_idx++]);
+            }
           }
         }
       }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -677,6 +677,9 @@ void ConfigHelper::finalize(const std::vector<uint32_t>& ports) {
                   ->mutable_address()
                   ->mutable_socket_address()
                   ->set_port_value(ports[port_idx++]);
+            } else {
+              ENVOY_LOG_MISC(debug, "Not overriding preset port",
+                             lb_endpoint->endpoint().address().socket_address().port_value());
             }
           }
         }

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -117,12 +117,12 @@ static_resources:
                 address:
                   socket_address:
                     address: 127.0.0.1
-                    port_value: 1
+                    port_value: 0
             - endpoint:
                 address:
                   socket_address:
                     address: 127.0.0.1
-                    port_value: 1
+                    port_value: 0
     - name: cluster_2
       type: STATIC
       lb_policy: RANDOM
@@ -134,12 +134,12 @@ static_resources:
                 address:
                   socket_address:
                     address: 127.0.0.1
-                    port_value: 2
+                    port_value: 0
             - endpoint:
                 address:
                   socket_address:
                     address: 127.0.0.1
-                    port_value: 2
+                    port_value: 0
   listeners:
     name: listener_0
     address:
@@ -235,7 +235,7 @@ static_resources:
                 address:
                   socket_address:
                     address: 127.0.0.1
-                    port_value: 1
+                    port_value: 0
     - name: cluster_2
       type: STATIC
       typed_extension_protocol_options:
@@ -251,7 +251,7 @@ static_resources:
                 address:
                   socket_address:
                     address: 127.0.0.1
-                    port_value: 2
+                    port_value: 0
   listeners:
     name: listener_0
     address:

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -184,7 +184,7 @@ public:
   virtual void createEnvoy();
   // Sets upstream_protocol_ and alters the upstream protocol in the config_helper_
   void setUpstreamProtocol(FakeHttpConnection::Type protocol);
-  // Sets fake_upstreams_count_ and alters the upstream protocol in the config_helper_
+  // Sets fake_upstreams_count_
   void setUpstreamCount(uint32_t count) { fake_upstreams_count_ = count; }
   // Skip validation that ensures that all upstream ports are referenced by the
   // configuration generated in ConfigHelper::finalize.

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -192,7 +192,6 @@ private:
           auto* socket_address = host->mutable_socket_address();
           socket_address->set_protocol(envoy::config::core::v3::SocketAddress::TCP);
           socket_address->set_address("0.0.0.0");
-          socket_address->set_port_value(80);
         }
       }
     });


### PR DESCRIPTION
The prior regression was due to variable shadowing.
ActiveTcpClient::ActiveTcpClient sets real_host_description_ in the constructor.  Here it set its own real_host_description_ where it was supposed to set the base class real_host_description_
When onPoollFailure was called, it was called with the base class real_host_description_ (nullptr)  So in the TCP filter 
read_callbacks_->upstreamHost(host); set a null pointer.
and in void Filter::onUpstreamEvent read_callbacks_->upstreamHost()->outlierDetector().putResult( would segfault.

Risk Level: n/a (flag disabled code)
Testing: new regression test of upstream failure, unit test assert
Docs Changes: n/a
Release Notes: n/a
