### PR TITLE
aws_lambda: Increase code coverage in AWS Lambda filter

### DIFF
--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -25,12 +25,9 @@ getInvocationMode(const envoy::extensions::filters::http::aws_lambda::v3::Config
   switch (proto_config.invocation_mode()) {
   case Config_InvocationMode_ASYNCHRONOUS:
     return InvocationMode::Asynchronous;
-    break;
   case Config_InvocationMode_SYNCHRONOUS:
     return InvocationMode::Synchronous;
-    break;
-  default:
-    NOT_REACHED_GCOVR_EXCL_LINE;
+  default: NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -27,7 +27,8 @@ getInvocationMode(const envoy::extensions::filters::http::aws_lambda::v3::Config
     return InvocationMode::Asynchronous;
   case Config_InvocationMode_SYNCHRONOUS:
     return InvocationMode::Synchronous;
-  default: NOT_REACHED_GCOVR_EXCL_LINE;
+  default:
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -37,7 +37,6 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/http/cache/simple_http_cache:84.5"
 "source/extensions/filters/http/ip_tagging:91.2"
 "source/extensions/filters/http/grpc_json_transcoder:93.3"
-"source/extensions/filters/http/aws_lambda:96.4"
 "source/extensions/filters/listener:96.0"
 "source/extensions/filters/listener/tls_inspector:92.4"
 "source/extensions/filters/listener/http_inspector:93.3"


### PR DESCRIPTION
Signed-off-by: Nolan Varani <landesherr@users.noreply.github.com>


Commit Message: Increase code coverage in AWS Lambda filter
Additional Description: Removing unreachable/dead lines of code, remove aws_lambda from `per_file_coverage.sh`
Risk Level: Low
Testing: `bazel test //test/extensions/filters/http/aws_lambda/...`
Docs Changes: N/A
Release Notes: N/A
Fixes #11989
