### PR TITLE
tidy: fix main_common_test and signals_test

### DIFF
--- a/test/common/signal/signals_test.cc
+++ b/test/common/signal/signals_test.cc
@@ -30,8 +30,7 @@ TEST(SignalsDeathTest, InvalidAddressDeathTest) {
       []() -> void {
         // Oops!
         volatile int* nasty_ptr = reinterpret_cast<int*>(0x0);
-        // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
-        *(nasty_ptr) = 0;
+        *(nasty_ptr) = 0; // NOLINT(clang-analyzer-core.NullDereference)
       }(),
       "backtrace.*Segmentation fault");
 }
@@ -49,8 +48,7 @@ TEST(SignalsDeathTest, RegisteredHandlerTest) {
       []() -> void {
         // Oops!
         volatile int* nasty_ptr = reinterpret_cast<int*>(0x0);
-        // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
-        *(nasty_ptr) = 0;
+        *(nasty_ptr) = 0; // NOLINT(clang-analyzer-core.NullDereference)
       }(),
       "HERE");
   SignalAction::removeFatalErrorHandler(handler);

--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -151,7 +151,8 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, MainCommonDeathTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
-#if defined(__has_feature) && (__has_feature(thread_sanitizer) || __has_feature(address_sanitizer))
+#if defined(__clang_analyzer__) || (defined(__has_feature) && (__has_feature(thread_sanitizer) ||  \
+                                                               __has_feature(address_sanitizer)))
   ENVOY_LOG_MISC(critical,
                  "MainCommonTest::OutOfMemoryHandler not supported by this compiler configuration");
 #else
@@ -172,7 +173,6 @@ TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
              size *= 1000) {
           int* p = new int[size];
           // Use the pointer to prevent clang from optimizing the allocation away in opt mode.
-          // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
           ENVOY_LOG_MISC(debug, "p={}", reinterpret_cast<intptr_t>(p));
         }
       }(),


### PR DESCRIPTION
NOLINTNEXTLINE doesn't work well within macro expansion. Do it inline or disable with #if.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
