### PR TITLE
Update yaml-cpp with Windows build fixes

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -213,7 +213,9 @@ envoy_cmake_external(
     cache_entries = {
         "YAML_CPP_BUILD_TESTS": "off",
         "YAML_CPP_BUILD_TOOLS": "off",
+        "YAML_BUILD_SHARED_LIBS": "off",
         "CMAKE_CXX_COMPILER_FORCED": "on",
+        "YAML_MSVC_SHARED_RT": "off",
     },
     lib_source = "@com_github_jbeder_yaml_cpp//:all",
     static_libraries = select({

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -260,10 +260,10 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "cpe:2.3:a:gnu:zlib:*",
     ),
     com_github_jbeder_yaml_cpp = dict(
-        sha256 = "2292aa54311290c8767a0690fb58f808834ffe5d32513d502d63e6cea730a998",
-        strip_prefix = "yaml-cpp-fix-windows-eol",
+        sha256 = "79ab7069ef1c7c3632e7ffe095f7185d4c77b64d8035db3c085c239d4fe96d5f",
+        strip_prefix = "yaml-cpp-98acc5a8874faab28b82c28936f4b400b389f5d6",
         # 2020-07-28
-        urls = ["https://github.com/greenhouse-org/yaml-cpp/archive/fix-windows-eol.tar.gz"],
+        urls = ["https://github.com/greenhouse-org/yaml-cpp/archive/98acc5a8874faab28b82c28936f4b400b389f5d6.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -260,10 +260,10 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "cpe:2.3:a:gnu:zlib:*",
     ),
     com_github_jbeder_yaml_cpp = dict(
-        sha256 = "17ffa6320c33de65beec33921c9334dee65751c8a4b797ba5517e844062b98f1",
-        strip_prefix = "yaml-cpp-6701275f1910bf63631528dfd9df9c3ac787365b",
-        # 2020-05-25
-        urls = ["https://github.com/jbeder/yaml-cpp/archive/6701275f1910bf63631528dfd9df9c3ac787365b.tar.gz"],
+        sha256 = "2292aa54311290c8767a0690fb58f808834ffe5d32513d502d63e6cea730a998",
+        strip_prefix = "yaml-cpp-fix-windows-eol",
+        # 2020-07-28
+        urls = ["https://github.com/greenhouse-org/yaml-cpp/archive/fix-windows-eol.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),


### PR DESCRIPTION
Commit Message: Update yaml-cpp with Windows build fixes

Additional Description:
- Newest yaml-cpp CMake introduces new global defines on Windows
  which break the envoy-static build, toggle corresponding flags.

Co-authored-by: Sunjay Bhatia <sunjayb@vmware.com>
Co-authored-by: William A Rowe Jr <wrowe@vmware.com>
Signed-off-by: Sunjay Bhatia <sunjayb@vmware.com>
Signed-off-by: William A Rowe Jr <wrowe@vmware.com>

Risk Level: Low
Testing: Local on Windows
Docs Changes: n/a
Release Notes: n/a
