### PR TITLE
 header-to-metadata: rename on_header_present and on_header_missing fields

### DIFF
--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -109,14 +109,13 @@ message Config {
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
     // of the header or cookie value.
-    KeyValuePair on_header_present = 2;
+    KeyValuePair on_header_present = 2 [(udpa.annotations.field_migrate).rename = "on_present"];
 
     // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
     // of the missing header or cookie value.
-    KeyValuePair on_header_missing = 3;
-
+    KeyValuePair on_header_missing = 3 [(udpa.annotations.field_migrate).rename = "on_missing"];
     // Whether or not to remove the header after a rule is applied.
     //
     // This prevents headers from leaking.

--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -116,6 +116,7 @@ message Config {
     // The value in the KeyValuePair must be set, since it'll be used in lieu
     // of the missing header or cookie value.
     KeyValuePair on_header_missing = 3 [(udpa.annotations.field_migrate).rename = "on_missing"];
+
     // Whether or not to remove the header after a rule is applied.
     //
     // This prevents headers from leaking.

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -107,13 +107,13 @@ message Config {
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
     // of the header or cookie value.
-    KeyValuePair on_header_present = 2;
+    KeyValuePair on_present = 2;
 
     // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
     // of the missing header or cookie value.
-    KeyValuePair on_header_missing = 3;
+    KeyValuePair on_missing = 3;
 
     // Whether or not to remove the header after a rule is applied.
     //

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -109,13 +109,13 @@ message Config {
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
     // of the header or cookie value.
-    KeyValuePair on_header_present = 2;
+    KeyValuePair on_header_present = 2 [(udpa.annotations.field_migrate).rename = "on_present"];
 
     // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
     // of the missing header or cookie value.
-    KeyValuePair on_header_missing = 3;
+    KeyValuePair on_header_missing = 3 [(udpa.annotations.field_migrate).rename = "on_missing"];
 
     // Whether or not to remove the header after a rule is applied.
     //

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -107,13 +107,13 @@ message Config {
     //
     // If the value in the KeyValuePair is non-empty, it'll be used instead
     // of the header or cookie value.
-    KeyValuePair on_header_present = 2;
+    KeyValuePair on_present = 2;
 
     // If the header or cookie is not present, apply this metadata KeyValuePair.
     //
     // The value in the KeyValuePair must be set, since it'll be used in lieu
     // of the missing header or cookie value.
-    KeyValuePair on_header_missing = 3;
+    KeyValuePair on_missing = 3;
 
     // Whether or not to remove the header after a rule is applied.
     //


### PR DESCRIPTION
Commit Message:
This is a follow up of https://github.com/envoyproxy/envoy/pull/12206.

This PR renames `on_header_present` and `on_header_missing` fields as now this filter deals with both
header and cookie and it doesn't make sense to have the `header` in the name field.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Radha Kumari <rkumari@slack-corp.com>