### PR TITLE
Added random jitter option to watchdog kill_timeout.

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -305,7 +305,7 @@ message ClusterManager {
 // Envoy process watchdog configuration. When configured, this monitors for
 // nonresponsive threads and kills the process after the configured thresholds.
 // See the :ref:`watchdog documentation <operations_performance_watchdog>` for more information.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Watchdog {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v2.Watchdog";
 
@@ -322,6 +322,12 @@ message Watchdog {
   // programming error and kill the entire Envoy process. Set to 0 to disable
   // kill behavior. If not specified the default is 0 (disabled).
   google.protobuf.Duration kill_timeout = 3;
+
+  // Defines the maximum jitter used to adjust the *kill_timeout* if *kill_timeout* is
+  // enabled. Enabling this feature would help to reduce risk of synchronized
+  // watchdog kill events across proxies due to external triggers. Set to 0 to
+  // disable. If not specified the default is 0 (disabled).
+  google.protobuf.Duration max_kill_timeout_jitter = 6 [(validate.rules).duration = {gte {}}];
 
   // If max(2, ceil(registered_threads * Fraction(*multikill_threshold*)))
   // threads have been nonresponsive for at least this duration kill the entire

--- a/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -296,7 +296,7 @@ message ClusterManager {
 // Envoy process watchdog configuration. When configured, this monitors for
 // nonresponsive threads and kills the process after the configured thresholds.
 // See the :ref:`watchdog documentation <operations_performance_watchdog>` for more information.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Watchdog {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v3.Watchdog";
 
@@ -313,6 +313,12 @@ message Watchdog {
   // programming error and kill the entire Envoy process. Set to 0 to disable
   // kill behavior. If not specified the default is 0 (disabled).
   google.protobuf.Duration kill_timeout = 3;
+
+  // Defines the maximum jitter used to adjust the *kill_timeout* if *kill_timeout* is
+  // enabled. Enabling this feature would help to reduce risk of synchronized
+  // watchdog kill events across proxies due to external triggers. Set to 0 to
+  // disable. If not specified the default is 0 (disabled).
+  google.protobuf.Duration max_kill_timeout_jitter = 6 [(validate.rules).duration = {gte {}}];
 
   // If max(2, ceil(registered_threads * Fraction(*multikill_threshold*)))
   // threads have been nonresponsive for at least this duration kill the entire

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -59,6 +59,7 @@ New Features
 * stats: allow configuring histogram buckets for stats sinks and admin endpoints that support it.
 * tap: added :ref:`generic body matcher<envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and responses for text or hex patterns.
 * tcp: switched the TCP connection pool to the new "shared" connection pool, sharing a common code base with HTTP and HTTP/2. Any unexpected behavioral changes can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
+* watchdog: support randomizing the watchdog's kill timeout to prevent synchronized kills via a maximium jitter parameter :ref:`max_kill_timeout_jitter<envoy_v3_api_field_config.bootstrap.v3.Watchdog.max_kill_timeout_jitter>`.
 * xds: added :ref:`extension config discovery<envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP filters.
 
 Deprecated

--- a/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
@@ -306,7 +306,7 @@ message ClusterManager {
 // Envoy process watchdog configuration. When configured, this monitors for
 // nonresponsive threads and kills the process after the configured thresholds.
 // See the :ref:`watchdog documentation <operations_performance_watchdog>` for more information.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Watchdog {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v2.Watchdog";
 
@@ -323,6 +323,12 @@ message Watchdog {
   // programming error and kill the entire Envoy process. Set to 0 to disable
   // kill behavior. If not specified the default is 0 (disabled).
   google.protobuf.Duration kill_timeout = 3;
+
+  // Defines the maximum jitter used to adjust the *kill_timeout* if *kill_timeout* is
+  // enabled. Enabling this feature would help to reduce risk of synchronized
+  // watchdog kill events across proxies due to external triggers. Set to 0 to
+  // disable. If not specified the default is 0 (disabled).
+  google.protobuf.Duration max_kill_timeout_jitter = 6 [(validate.rules).duration = {gte {}}];
 
   // If max(2, ceil(registered_threads * Fraction(*multikill_threshold*)))
   // threads have been nonresponsive for at least this duration kill the entire

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -304,7 +304,7 @@ message ClusterManager {
 // Envoy process watchdog configuration. When configured, this monitors for
 // nonresponsive threads and kills the process after the configured thresholds.
 // See the :ref:`watchdog documentation <operations_performance_watchdog>` for more information.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Watchdog {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.bootstrap.v3.Watchdog";
 
@@ -321,6 +321,12 @@ message Watchdog {
   // programming error and kill the entire Envoy process. Set to 0 to disable
   // kill behavior. If not specified the default is 0 (disabled).
   google.protobuf.Duration kill_timeout = 3;
+
+  // Defines the maximum jitter used to adjust the *kill_timeout* if *kill_timeout* is
+  // enabled. Enabling this feature would help to reduce risk of synchronized
+  // watchdog kill events across proxies due to external triggers. Set to 0 to
+  // disable. If not specified the default is 0 (disabled).
+  google.protobuf.Duration max_kill_timeout_jitter = 6 [(validate.rules).duration = {gte {}}];
 
   // If max(2, ceil(registered_threads * Fraction(*multikill_threshold*)))
   // threads have been nonresponsive for at least this duration kill the entire

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -90,8 +90,20 @@ void MainImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap& bootstr
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(watchdog, miss_timeout, 200));
   watchdog_megamiss_timeout_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(watchdog, megamiss_timeout, 1000));
-  watchdog_kill_timeout_ =
-      std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(watchdog, kill_timeout, 0));
+  uint64_t kill_timeout = PROTOBUF_GET_MS_OR_DEFAULT(watchdog, kill_timeout, 0);
+  const uint64_t max_kill_timeout_jitter =
+      PROTOBUF_GET_MS_OR_DEFAULT(watchdog, max_kill_timeout_jitter, 0);
+
+  // Adjust kill timeout if we have skew enabled.
+  if (kill_timeout > 0 && max_kill_timeout_jitter > 0) {
+    // Increments the kill timeout with a random value in (0, max_skew].
+    // We shouldn't have overflow issues due to the range of Duration.
+    // This won't be entirely uniform, depending on how large max_skew
+    // is relation to uint64.
+    kill_timeout += (server.random().random() % max_kill_timeout_jitter) + 1;
+  }
+
+  watchdog_kill_timeout_ = std::chrono::milliseconds(kill_timeout);
   watchdog_multikill_timeout_ =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(watchdog, multikill_timeout, 0));
   watchdog_multikill_threshold_ =


### PR DESCRIPTION
This is essentially https://github.com/envoyproxy/envoy/pull/12082 without DCO rebase issues.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

Commit Message: Added random skew option to watchdog kill_timeout.
Additional Description:
Risk Level: Low, backwards compatible by default
Testing: Implemented unit tests
Docs Changes: No
Release Notes: Included.
Optional Fixes: #11389 (Fixes part of that issue)
