### PR TITLE
format: preventing new usage of absl::string_view / absl::optional 

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -647,6 +647,12 @@ def checkSourceLine(line, file_path, reportError):
     reportError("Don't use strptime; use absl::FormatTime instead")
   if tokenInLine("strerror", line):
     reportError("Don't use strerror; use Envoy::errorDetails instead")
+  # With envoy being built in C++17, absl::optional/string_view now uses std implementations
+  # by default. As a result, new code should directly call the standard library versions.
+  if tokenInLine("absl::optional", line):
+    reportError("Don't use absl::optional; use std::optional instead")
+  if tokenInLine("absl::string_view", line):
+    reportError("Don't use absl::string_view; use std::string_view instead")
   # Prefer using abseil hash maps/sets over std::unordered_map/set for performance optimizations and
   # non-deterministic iteration order that exposes faulty assertions.
   # See: https://abseil.io/docs/cpp/guides/container#hash-tables

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -238,6 +238,10 @@ def runChecks():
   errors += checkUnfixableError(
       "std_unordered_set.cc", "Don't use std::unordered_set; use absl::flat_hash_set instead " +
       "or absl::node_hash_set if pointer stability of keys/values is required")
+  errors += checkUnfixableError(
+      "absl_string_view.cc", "Don't use absl::string_view; use std::string_view instead")
+  errors += checkUnfixableError(
+      "absl_optional.cc", "Don't use absl::optional; use std::optional instead")
 
   # The following files have errors that can be automatically fixed.
   errors += checkAndFixError("over_enthusiastic_spaces.cc",

--- a/tools/testdata/check_format/absl_optional.cc
+++ b/tools/testdata/check_format/absl_optional.cc
@@ -1,0 +1,7 @@
+#include "absl/types/optional.h"
+
+namespace Envoy {
+
+    absl::optional<int> test_subject;
+    
+} // namespace Envoy

--- a/tools/testdata/check_format/absl_string_view.cc
+++ b/tools/testdata/check_format/absl_string_view.cc
@@ -1,0 +1,7 @@
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+
+    absl::string_view buffer;
+    
+} // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Yifan Yang <needyyang@google.com>

This adds additional code_format checks to prevent new cases of absl::string_view and absl::optional. Building with C++17 means that abseil symbols become aliases for standard library implementations. This issue was raised at https://github.com/envoyproxy/envoy/issues/12341.

Commit Message:
Additional Description:
Risk Level: Low. This should not bring any change in mechanics. But if the client uses abseil library internally and does not have ABSL_USES_STD_STRING_VIEW enabled, it can potentially cause a discrepancy in type. 
More specifically, this occurs when 
- Envoy returns a std::string_view from some method
- Internal code wants to pass that std::string_view as an argument to another internal method
- That internal method accepts an absl::string_view, which is now a different type 

Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
