### PR TITLE
docs: fix formatting for --ignore-unknown-dynamic-fields

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -309,9 +309,9 @@ following are the command line options that Envoy supports.
 .. option:: --ignore-unknown-dynamic-fields
 
   *(optional)* This flag disables validation of protobuf configuration for unknown fields in dynamic
-   configuration. Unlike setting --reject-unknown-dynamic-fields to false, it does not log warnings or
-   count occurrences of unknown fields, in the interest of configuration processing speed. If
-   --reject-unknown-dynamic-fields is set to true, this flag has no effect.
+  configuration. Unlike setting :option:`--reject-unknown-dynamic-fields` to false, it does not log warnings
+  or count occurrences of unknown fields, in the interest of configuration processing speed. If
+  :option:`--reject-unknown-dynamic-fields` is set to true, this flag has no effect.
 
 .. option:: --disable-extensions <extension list>
 


### PR DESCRIPTION
Commit Message: fix indentation in --ignore-unknown-dynamic-fields, and thus the generated formatting.
Additional Description: I'm not sure how to see the generated site from this, but it sure looks wrong on envoyproxy.io today.
Risk Level: Low
Testing: docs-only, non performed locally.
Docs Changes: Fixing indentation from #10982
Release Notes: N/A
