### PR TITLE
Make Sphinx build with multiple cores

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -134,4 +134,4 @@ rsync -av "${SCRIPT_DIR}"/root/ "${SCRIPT_DIR}"/conf.py "${SCRIPT_DIR}"/_ext "${
 # To speed up validate_fragment invocations in validating_code_block 
 bazel build ${BAZEL_BUILD_OPTIONS} //tools/config_validation:validate_fragment
 
-sphinx-build -W --keep-going -b html "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"
+sphinx-build -W --keep-going -b html -j auto "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"


### PR DESCRIPTION
Commit Message:
Run Sphinx on all cores available when generating documentation.

Additional Description:
Sphinx won't read in parallel but it will write output files concurrently, which decreases overall running time.
See https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j

Risk Level: low
Testing: generated docs
Docs Changes: none
Release Notes: none