### PR TITLE
compdb: use aspects generated header files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -260,11 +260,7 @@ build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
 
 # Compile database generation config
-# We don't care about built binaries so always strip and use fastbuild.
-build:compdb -c fastbuild
-build:compdb --strip=always
 build:compdb --build_tag_filters=-nocompdb
-build:compdb --define=ENVOY_CONFIG_COMPILATION_DATABASE=1
 
 # Windows build quirks
 build:windows --action_env=TMPDIR

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -125,11 +125,6 @@ config_setting(
 )
 
 config_setting(
-    name = "compdb_build",
-    values = {"define": "ENVOY_CONFIG_COMPILATION_DATABASE=1"},
-)
-
-config_setting(
     name = "clang_build",
     flag_values = {
         "@bazel_tools//tools/cpp:compiler": "clang",

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -735,7 +735,7 @@ For example, you can use [You Complete Me](https://valloric.github.io/YouComplet
 For example, use following command to prepare a compilation database:
 
 ```
-TEST_TMPDIR=/tmp tools/gen_compilation_database.py --run_bazel_build
+TEST_TMPDIR=/tmp tools/gen_compilation_database.py
 ```
 
 

--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -95,13 +95,6 @@ def envoy_cc_library(
     if tcmalloc_dep:
         deps += tcmalloc_external_deps(repository)
 
-    # Intended for compilation database generation. This generates an empty cc
-    # source file so Bazel generates virtual includes and recognize them as C++.
-    # Workaround for https://github.com/bazelbuild/bazel/issues/10845.
-    srcs += select({
-        "@envoy//bazel:compdb_build": ["@envoy//bazel/external:empty.cc"],
-        "//conditions:default": [],
-    })
     cc_library(
         name = name,
         srcs = srcs,

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -210,11 +210,6 @@ def envoy_cc_test_library(
         repository + "//test/test_common:printers_includes",
     ]
 
-    # Same as envoy_cc_library
-    srcs += select({
-        "@envoy//bazel:compdb_build": ["@envoy//bazel/external:empty.cc"],
-        "//conditions:default": [],
-    })
     _envoy_cc_test_infrastructure_library(
         name,
         srcs,

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -42,9 +42,10 @@ USE_CATEGORIES_WITH_CPE_OPTIONAL = ["build", "test", "other"]
 
 DEPENDENCY_REPOSITORIES = dict(
     bazel_compdb = dict(
-        sha256 = "87e376a685eacfb27bcc0d0cdf5ded1d0b99d868390ac50f452ba6ed781caffe",
-        strip_prefix = "bazel-compilation-database-0.4.2",
-        urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.4.2.tar.gz"],
+        sha256 = "943f1a57e01d030b9c649f9e41fdafd871e8b0e8a1431f93c6673c38b9c15b3b",
+        strip_prefix = "bazel-compilation-database-c37b909045eb72d29a47f77cc1e9b519dd5c10b6",
+        # 2020-07-31
+        urls = ["https://github.com/grailbio/bazel-compilation-database/archive/c37b909045eb72d29a47f77cc1e9b519dd5c10b6.tar.gz"],
         use_category = ["build"],
     ),
     bazel_gazelle = dict(

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -31,7 +31,7 @@ trap cleanup EXIT
 
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
-"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --run_bazel_build --include_headers
+"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers
 
 # Do not run clang-tidy against win32 impl
 # TODO(scw00): We should run clang-tidy against win32 impl once we have clang-cl support for Windows

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -224,11 +224,6 @@ envoy_cc_test_library(
     ],
 )
 
-envoy_cc_test_library(
-    name = "spdy_platform_test_impl_lib",
-    hdrs = ["spdy_test_impl.h"],
-)
-
 envoy_cc_test(
     name = "envoy_quic_clock_test",
     srcs = ["envoy_quic_clock_test.cc"],

--- a/tools/api_boost/api_boost.py
+++ b/tools/api_boost/api_boost.py
@@ -101,7 +101,7 @@ def ApiBoostTree(target_paths,
   # tool in place before we can start boosting.
   if generate_compilation_database:
     print('Building compilation database for %s' % dep_build_targets)
-    sp.run(['./tools/gen_compilation_database.py', '--run_bazel_build', '--include_headers'] +
+    sp.run(['./tools/gen_compilation_database.py', '--include_headers'] +
            dep_build_targets,
            check=True)
 

--- a/tools/api_boost/api_boost.py
+++ b/tools/api_boost/api_boost.py
@@ -101,8 +101,7 @@ def ApiBoostTree(target_paths,
   # tool in place before we can start boosting.
   if generate_compilation_database:
     print('Building compilation database for %s' % dep_build_targets)
-    sp.run(['./tools/gen_compilation_database.py', '--include_headers'] +
-           dep_build_targets,
+    sp.run(['./tools/gen_compilation_database.py', '--include_headers'] + dep_build_targets,
            check=True)
 
   if build_api_booster:

--- a/tools/clang_tools/README.md
+++ b/tools/clang_tools/README.md
@@ -36,7 +36,7 @@ generates this and also does setup of the Bazel cache paths to allow external
 dependencies to be located:
 
 ```console
-tools/gen_compilation_database.py --run_bazel_build --include_headers
+tools/gen_compilation_database.py --include_headers
 ```
 
 Finally, the tool can be run against source files in the Envoy tree:

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -10,19 +10,6 @@ import subprocess
 from pathlib import Path
 
 
-def runBazelBuildForCompilationDatabase(bazel_options, bazel_targets):
-  query_targets = ' union '.join(bazel_targets)
-  query = ' union '.join(
-      q.format(query_targets) for q in [
-          'attr(include_prefix, ".+", kind(cc_library, deps({})))',
-          'attr(strip_include_prefix, ".+", kind(cc_library, deps({})))',
-          'attr(generator_function, ".*proto_library", kind(cc_.*, deps({})))',
-      ])
-  build_targets = subprocess.check_output(["bazel", "query", "--notool_deps",
-                                           query]).decode().splitlines()
-  subprocess.check_call(["bazel", "build"] + bazel_options + build_targets)
-
-
 # This method is equivalent to https://github.com/grailbio/bazel-compilation-database/blob/master/generate.sh
 def generateCompilationDatabase(args):
   # We need to download all remote outputs for generated source code. This option lives here to override those
@@ -31,20 +18,10 @@ def generateCompilationDatabase(args):
       "--config=compdb",
       "--remote_download_outputs=all",
   ]
-  if args.keep_going:
-    bazel_options.append("-k")
-  if args.run_bazel_build:
-    try:
-      runBazelBuildForCompilationDatabase(bazel_options, args.bazel_targets)
-    except subprocess.CalledProcessError as e:
-      if not args.keep_going:
-        raise
-      else:
-        logging.warning("bazel build failed {}: {}".format(e.returncode, e.cmd))
 
   subprocess.check_call(["bazel", "build"] + bazel_options + [
       "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
-      "--output_groups=compdb_files"
+      "--output_groups=compdb_files,header_files"
   ] + args.bazel_targets)
 
   execroot = subprocess.check_output(["bazel", "info", "execution_root"] +
@@ -110,8 +87,6 @@ def fixCompilationDatabase(args, db):
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Generate JSON compilation database')
-  parser.add_argument('--run_bazel_build', action='store_true')
-  parser.add_argument('-k', '--keep_going', action='store_true')
   parser.add_argument('--include_external', action='store_true')
   parser.add_argument('--include_genfiles', action='store_true')
   parser.add_argument('--include_headers', action='store_true')

--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -3,7 +3,7 @@
 [[ -z "${SKIP_PROTO_FORMAT}" ]] && tools/proto_format/proto_format.sh fix
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --run_bazel_build -k
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py
 
 # Kill clangd to reload the compilation database
 killall -v /opt/llvm/bin/clangd


### PR DESCRIPTION
Clear tech debts solved by https://github.com/grailbio/bazel-compilation-database/pull/58, this should make compilation database generation much faster than before especially when cache doesn't exist.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
