### PR TITLE
Update filesystem_setup.sh

### DIFF
--- a/test/common/runtime/filesystem_setup.sh
+++ b/test/common/runtime/filesystem_setup.sh
@@ -9,10 +9,10 @@ cd "${TEST_SRCDIR}/envoy"
 rm -rf "${TEST_TMPDIR}/${TEST_DATA}"
 mkdir -p "${TEST_TMPDIR}/${TEST_DATA}"
 cp -RfL "${TEST_DATA}"/* "${TEST_TMPDIR}/${TEST_DATA}"
+chmod -R u+rwX "${TEST_TMPDIR}/${TEST_DATA}"
 # Verify text value is treated as a binary blob regardless of source line-ending settings
 printf "hello\nworld" > "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/file_lf"
 printf "hello\r\nworld" > "${TEST_TMPDIR}/${TEST_DATA}/root/envoy/file_crlf"
-chmod -R u+rwX "${TEST_TMPDIR}/${TEST_DATA}"
 
 # Deliberate symlink of doom.
 LOOP_PATH="${TEST_TMPDIR}/${TEST_DATA}/loop"


### PR DESCRIPTION
Move chmod permissions for writing to new directory *before* executing printfs to verify text value treatment in subdirectory.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Move chmod permissions for writing to new directory *before* executing printfs to verify text value treatment in subdirectory.
Additional Description:
Risk Level: low
Testing: test/common/runtime:runtime_impl_test
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
