### PR TITLE
tap: factor out the TAP filter matcher for later reuse in other filters

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -80,6 +80,8 @@ extensions/filters/common/original_src @snowp @klarose
 /*/extensions/filters/common/expr @kyessenov @yangminzhu @lizan
 # webassembly common extension
 /*/extensions/common/wasm @jplevyak @PiotrSikora @lizan
+# common matcher
+/*/extensions/common/matcher @mattklein123 @yangminzhu
 # common crypto extension
 /*/extensions/common/crypto @lizan @PiotrSikora @bdecoste
 /*/extensions/common/proxy_protocol @alyssawilk @wez470

--- a/api/BUILD
+++ b/api/BUILD
@@ -130,6 +130,7 @@ proto_library(
         "//envoy/config/accesslog/v3:pkg",
         "//envoy/config/bootstrap/v3:pkg",
         "//envoy/config/cluster/v3:pkg",
+        "//envoy/config/common/matcher/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/config/filter/thrift/router/v2alpha1:pkg",

--- a/api/envoy/config/common/matcher/v3/BUILD
+++ b/api/envoy/config/common/matcher/v3/BUILD
@@ -6,10 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/config/common/matcher/v3:pkg",
-        "//envoy/config/core/v3:pkg",
         "//envoy/config/route/v3:pkg",
-        "//envoy/service/tap/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/config/common/matcher/v3/matcher.proto
+++ b/api/envoy/config/common/matcher/v3/matcher.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package envoy.config.common.matcher.v3;
+
+import "envoy/config/route/v3/route_components.proto";
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.common.matcher.v3";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Unified Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 11]
+message MatchPredicate {
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP request headers match configuration.
+    HttpHeadersMatch http_request_headers_match = 5;
+
+    // HTTP request trailers match configuration.
+    HttpHeadersMatch http_request_trailers_match = 6;
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_response_headers_match = 7;
+
+    // HTTP response trailers match configuration.
+    HttpHeadersMatch http_response_trailers_match = 8;
+
+    // HTTP request generic body match configuration.
+    HttpGenericBodyMatch http_request_generic_body_match = 9;
+
+    // HTTP response generic body match configuration.
+    HttpGenericBodyMatch http_response_generic_body_match = 10;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  // HTTP headers to match.
+  repeated route.v3.HeaderMatcher headers = 1;
+}
+
+// HTTP generic body match configuration.
+// List of text strings and hex strings to be located in HTTP body.
+// All specified strings must be found in the HTTP body for positive match.
+// The search may be limited to specified number of bytes from the body start.
+//
+// .. attention::
+//
+//   Searching for patterns in HTTP body is potentially cpu intensive. For each specified pattern, http body is scanned byte by byte to find a match.
+//   If multiple patterns are specified, the process is repeated for each pattern. If location of a pattern is known, ``bytes_limit`` should be specified
+//   to scan only part of the http body.
+message HttpGenericBodyMatch {
+  message GenericTextMatch {
+    oneof rule {
+      option (validate.required) = true;
+
+      // Text string to be located in HTTP body.
+      string string_match = 1;
+
+      // Sequence of bytes to be located in HTTP body.
+      bytes binary_match = 2;
+    }
+  }
+
+  // Limits search to specified number of bytes - default zero (no limit - match entire captured buffer).
+  uint32 bytes_limit = 1;
+
+  // List of patterns to match.
+  repeated GenericTextMatch patterns = 2 [(validate.rules).repeated = {min_items: 1}];
+}

--- a/api/envoy/config/common/matcher/v4alpha/BUILD
+++ b/api/envoy/config/common/matcher/v4alpha/BUILD
@@ -7,9 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/common/matcher/v3:pkg",
-        "//envoy/config/core/v3:pkg",
-        "//envoy/config/route/v3:pkg",
-        "//envoy/service/tap/v2alpha:pkg",
+        "//envoy/config/route/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/config/common/matcher/v4alpha/matcher.proto
+++ b/api/envoy/config/common/matcher/v4alpha/matcher.proto
@@ -1,0 +1,114 @@
+syntax = "proto3";
+
+package envoy.config.common.matcher.v4alpha;
+
+import "envoy/config/route/v4alpha/route_components.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.common.matcher.v4alpha";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Unified Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 11]
+message MatchPredicate {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.common.matcher.v3.MatchPredicate";
+
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.common.matcher.v3.MatchPredicate.MatchSet";
+
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP request headers match configuration.
+    HttpHeadersMatch http_request_headers_match = 5;
+
+    // HTTP request trailers match configuration.
+    HttpHeadersMatch http_request_trailers_match = 6;
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_response_headers_match = 7;
+
+    // HTTP response trailers match configuration.
+    HttpHeadersMatch http_response_trailers_match = 8;
+
+    // HTTP request generic body match configuration.
+    HttpGenericBodyMatch http_request_generic_body_match = 9;
+
+    // HTTP response generic body match configuration.
+    HttpGenericBodyMatch http_response_generic_body_match = 10;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.common.matcher.v3.HttpHeadersMatch";
+
+  // HTTP headers to match.
+  repeated route.v4alpha.HeaderMatcher headers = 1;
+}
+
+// HTTP generic body match configuration.
+// List of text strings and hex strings to be located in HTTP body.
+// All specified strings must be found in the HTTP body for positive match.
+// The search may be limited to specified number of bytes from the body start.
+//
+// .. attention::
+//
+//   Searching for patterns in HTTP body is potentially cpu intensive. For each specified pattern, http body is scanned byte by byte to find a match.
+//   If multiple patterns are specified, the process is repeated for each pattern. If location of a pattern is known, ``bytes_limit`` should be specified
+//   to scan only part of the http body.
+message HttpGenericBodyMatch {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.common.matcher.v3.HttpGenericBodyMatch";
+
+  message GenericTextMatch {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.common.matcher.v3.HttpGenericBodyMatch.GenericTextMatch";
+
+    oneof rule {
+      option (validate.required) = true;
+
+      // Text string to be located in HTTP body.
+      string string_match = 1;
+
+      // Sequence of bytes to be located in HTTP body.
+      bytes binary_match = 2;
+    }
+  }
+
+  // Limits search to specified number of bytes - default zero (no limit - match entire captured buffer).
+  uint32 bytes_limit = 1;
+
+  // List of patterns to match.
+  repeated GenericTextMatch patterns = 2 [(validate.rules).repeated = {min_items: 1}];
+}

--- a/api/envoy/config/tap/v3/common.proto
+++ b/api/envoy/config/tap/v3/common.proto
@@ -29,11 +29,16 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  // Ignored if :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` is set.
-  MatchPredicate match_config = 1 [deprecated = true, (validate.rules).message = {required: true}];
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v3.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` will be used.
+  MatchPredicate match_config = 1 [deprecated = true];
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v3.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` will be used.
   common.matcher.v3.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,

--- a/api/envoy/config/tap/v3/common.proto
+++ b/api/envoy/config/tap/v3/common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.tap.v3;
 
+import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/route/v3/route_components.proto";
@@ -28,7 +29,12 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  MatchPredicate match_config = 1 [(validate.rules).message = {required: true}];
+  // Ignored if :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` is set.
+  MatchPredicate match_config = 1 [deprecated = true, (validate.rules).message = {required: true}];
+
+  // The match configuration. If the configuration matches the data source being tapped, a tap will
+  // occur, with the result written to the configured output.
+  common.matcher.v3.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,
   // a tap will occur and the data will be written to the configured output.

--- a/api/envoy/config/tap/v4alpha/BUILD
+++ b/api/envoy/config/tap/v4alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/common/matcher/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
         "//envoy/config/tap/v3:pkg",

--- a/api/envoy/config/tap/v4alpha/common.proto
+++ b/api/envoy/config/tap/v4alpha/common.proto
@@ -32,6 +32,9 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v4alpha.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` will be used.
   common.matcher.v4alpha.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,

--- a/api/envoy/config/tap/v4alpha/common.proto
+++ b/api/envoy/config/tap/v4alpha/common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.tap.v4alpha;
 
+import "envoy/config/common/matcher/v4alpha/matcher.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/grpc_service.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
@@ -25,9 +26,13 @@ message TapConfig {
 
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.tap.v3.TapConfig";
 
+  reserved 1;
+
+  reserved "match_config";
+
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  MatchPredicate match_config = 1 [(validate.rules).message = {required: true}];
+  common.matcher.v4alpha.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,
   // a tap will occur and the data will be written to the configured output.

--- a/api/versioning/BUILD
+++ b/api/versioning/BUILD
@@ -13,6 +13,7 @@ proto_library(
         "//envoy/config/accesslog/v3:pkg",
         "//envoy/config/bootstrap/v3:pkg",
         "//envoy/config/cluster/v3:pkg",
+        "//envoy/config/common/matcher/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/config/filter/thrift/router/v2alpha1:pkg",

--- a/docs/root/api-v3/config/common/common.rst
+++ b/docs/root/api-v3/config/common/common.rst
@@ -5,5 +5,6 @@ Common
   :glob:
   :maxdepth: 2
 
+  matcher/v3/*
   ../../extensions/common/dynamic_forward_proxy/v3/*
   ../../extensions/common/tap/v3/*

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -69,5 +69,5 @@ Deprecated
 ----------
 * The :ref:`track_timeout_budgets <envoy_v3_api_field_config.cluster.v3.Cluster.track_timeout_budgets>`
   field has been deprecated in favor of `timeout_budgets` part of an :ref:`Optional Configuration <envoy_v3_api_field_config.cluster.v3.Cluster.track_cluster_stats>`.
-* tap: the :ref:`match_config <envoy_api_field_config.tap.v3.TapConfig.match_config>` field has been deprecated in favor of
-  :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` field.
+* tap: the :ref:`match_config <envoy_v3_api_field_config.tap.v3.TapConfig.match_config>` field has been deprecated in favor of
+  :ref:`match <envoy_v3_api_field_config.tap.v3.TapConfig.match>` field.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -69,3 +69,5 @@ Deprecated
 ----------
 * The :ref:`track_timeout_budgets <envoy_v3_api_field_config.cluster.v3.Cluster.track_timeout_budgets>`
   field has been deprecated in favor of `timeout_budgets` part of an :ref:`Optional Configuration <envoy_v3_api_field_config.cluster.v3.Cluster.track_cluster_stats>`.
+* tap: the :ref:`match_config <envoy_api_field_config.tap.v3.TapConfig.match_config>` field has been deprecated in favor of
+  :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` field.

--- a/generated_api_shadow/envoy/config/common/matcher/v3/BUILD
+++ b/generated_api_shadow/envoy/config/common/matcher/v3/BUILD
@@ -6,10 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/config/common/matcher/v3:pkg",
-        "//envoy/config/core/v3:pkg",
         "//envoy/config/route/v3:pkg",
-        "//envoy/service/tap/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package envoy.config.common.matcher.v3;
+
+import "envoy/config/route/v3/route_components.proto";
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.common.matcher.v3";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Unified Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 11]
+message MatchPredicate {
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP request headers match configuration.
+    HttpHeadersMatch http_request_headers_match = 5;
+
+    // HTTP request trailers match configuration.
+    HttpHeadersMatch http_request_trailers_match = 6;
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_response_headers_match = 7;
+
+    // HTTP response trailers match configuration.
+    HttpHeadersMatch http_response_trailers_match = 8;
+
+    // HTTP request generic body match configuration.
+    HttpGenericBodyMatch http_request_generic_body_match = 9;
+
+    // HTTP response generic body match configuration.
+    HttpGenericBodyMatch http_response_generic_body_match = 10;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  // HTTP headers to match.
+  repeated route.v3.HeaderMatcher headers = 1;
+}
+
+// HTTP generic body match configuration.
+// List of text strings and hex strings to be located in HTTP body.
+// All specified strings must be found in the HTTP body for positive match.
+// The search may be limited to specified number of bytes from the body start.
+//
+// .. attention::
+//
+//   Searching for patterns in HTTP body is potentially cpu intensive. For each specified pattern, http body is scanned byte by byte to find a match.
+//   If multiple patterns are specified, the process is repeated for each pattern. If location of a pattern is known, ``bytes_limit`` should be specified
+//   to scan only part of the http body.
+message HttpGenericBodyMatch {
+  message GenericTextMatch {
+    oneof rule {
+      option (validate.required) = true;
+
+      // Text string to be located in HTTP body.
+      string string_match = 1;
+
+      // Sequence of bytes to be located in HTTP body.
+      bytes binary_match = 2;
+    }
+  }
+
+  // Limits search to specified number of bytes - default zero (no limit - match entire captured buffer).
+  uint32 bytes_limit = 1;
+
+  // List of patterns to match.
+  repeated GenericTextMatch patterns = 2 [(validate.rules).repeated = {min_items: 1}];
+}

--- a/generated_api_shadow/envoy/config/common/matcher/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/common/matcher/v4alpha/BUILD
@@ -7,9 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/common/matcher/v3:pkg",
-        "//envoy/config/core/v3:pkg",
-        "//envoy/config/route/v3:pkg",
-        "//envoy/service/tap/v2alpha:pkg",
+        "//envoy/config/route/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/common/matcher/v4alpha/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v4alpha/matcher.proto
@@ -1,0 +1,114 @@
+syntax = "proto3";
+
+package envoy.config.common.matcher.v4alpha;
+
+import "envoy/config/route/v4alpha/route_components.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.common.matcher.v4alpha";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Unified Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 11]
+message MatchPredicate {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.common.matcher.v3.MatchPredicate";
+
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.common.matcher.v3.MatchPredicate.MatchSet";
+
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP request headers match configuration.
+    HttpHeadersMatch http_request_headers_match = 5;
+
+    // HTTP request trailers match configuration.
+    HttpHeadersMatch http_request_trailers_match = 6;
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_response_headers_match = 7;
+
+    // HTTP response trailers match configuration.
+    HttpHeadersMatch http_response_trailers_match = 8;
+
+    // HTTP request generic body match configuration.
+    HttpGenericBodyMatch http_request_generic_body_match = 9;
+
+    // HTTP response generic body match configuration.
+    HttpGenericBodyMatch http_response_generic_body_match = 10;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.common.matcher.v3.HttpHeadersMatch";
+
+  // HTTP headers to match.
+  repeated route.v4alpha.HeaderMatcher headers = 1;
+}
+
+// HTTP generic body match configuration.
+// List of text strings and hex strings to be located in HTTP body.
+// All specified strings must be found in the HTTP body for positive match.
+// The search may be limited to specified number of bytes from the body start.
+//
+// .. attention::
+//
+//   Searching for patterns in HTTP body is potentially cpu intensive. For each specified pattern, http body is scanned byte by byte to find a match.
+//   If multiple patterns are specified, the process is repeated for each pattern. If location of a pattern is known, ``bytes_limit`` should be specified
+//   to scan only part of the http body.
+message HttpGenericBodyMatch {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.common.matcher.v3.HttpGenericBodyMatch";
+
+  message GenericTextMatch {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.common.matcher.v3.HttpGenericBodyMatch.GenericTextMatch";
+
+    oneof rule {
+      option (validate.required) = true;
+
+      // Text string to be located in HTTP body.
+      string string_match = 1;
+
+      // Sequence of bytes to be located in HTTP body.
+      bytes binary_match = 2;
+    }
+  }
+
+  // Limits search to specified number of bytes - default zero (no limit - match entire captured buffer).
+  uint32 bytes_limit = 1;
+
+  // List of patterns to match.
+  repeated GenericTextMatch patterns = 2 [(validate.rules).repeated = {min_items: 1}];
+}

--- a/generated_api_shadow/envoy/config/tap/v3/BUILD
+++ b/generated_api_shadow/envoy/config/tap/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/common/matcher/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/service/tap/v2alpha:pkg",

--- a/generated_api_shadow/envoy/config/tap/v3/common.proto
+++ b/generated_api_shadow/envoy/config/tap/v3/common.proto
@@ -29,11 +29,16 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  // Ignored if :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` is set.
-  MatchPredicate match_config = 1 [deprecated = true, (validate.rules).message = {required: true}];
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v3.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` will be used.
+  MatchPredicate match_config = 1 [deprecated = true];
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v3.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` will be used.
   common.matcher.v3.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,

--- a/generated_api_shadow/envoy/config/tap/v3/common.proto
+++ b/generated_api_shadow/envoy/config/tap/v3/common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.tap.v3;
 
+import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/route/v3/route_components.proto";
@@ -28,7 +29,12 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  MatchPredicate match_config = 1 [(validate.rules).message = {required: true}];
+  // Ignored if :ref:`match <envoy_api_field_config.tap.v3.TapConfig.match>` is set.
+  MatchPredicate match_config = 1 [deprecated = true, (validate.rules).message = {required: true}];
+
+  // The match configuration. If the configuration matches the data source being tapped, a tap will
+  // occur, with the result written to the configured output.
+  common.matcher.v3.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,
   // a tap will occur and the data will be written to the configured output.

--- a/generated_api_shadow/envoy/config/tap/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/tap/v4alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/common/matcher/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
         "//envoy/config/tap/v3:pkg",

--- a/generated_api_shadow/envoy/config/tap/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/config/tap/v4alpha/common.proto
@@ -28,12 +28,16 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  // Ignored if :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` is set.
-  MatchPredicate hidden_envoy_deprecated_match_config = 1
-      [deprecated = true, (validate.rules).message = {required: true}];
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v4alpha.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` will be used.
+  MatchPredicate hidden_envoy_deprecated_match_config = 1 [deprecated = true];
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
+  // Exactly one of :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` and
+  // :ref:`match_config <envoy_api_field_config.tap.v4alpha.TapConfig.match_config>` must be set. If both
+  // are set, the :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` will be used.
   common.matcher.v4alpha.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,

--- a/generated_api_shadow/envoy/config/tap/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/config/tap/v4alpha/common.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.tap.v4alpha;
 
+import "envoy/config/common/matcher/v4alpha/matcher.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/grpc_service.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
@@ -27,7 +28,13 @@ message TapConfig {
 
   // The match configuration. If the configuration matches the data source being tapped, a tap will
   // occur, with the result written to the configured output.
-  MatchPredicate match_config = 1 [(validate.rules).message = {required: true}];
+  // Ignored if :ref:`match <envoy_api_field_config.tap.v4alpha.TapConfig.match>` is set.
+  MatchPredicate hidden_envoy_deprecated_match_config = 1
+      [deprecated = true, (validate.rules).message = {required: true}];
+
+  // The match configuration. If the configuration matches the data source being tapped, a tap will
+  // occur, with the result written to the configured output.
+  common.matcher.v4alpha.MatchPredicate match = 4;
 
   // The tap output configuration. If a match configuration matches a data source being tapped,
   // a tap will occur and the data will be written to the configured output.

--- a/source/extensions/common/matcher/BUILD
+++ b/source/extensions/common/matcher/BUILD
@@ -1,0 +1,21 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "matcher_lib",
+    srcs = ["matcher.cc"],
+    hdrs = ["matcher.h"],
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/http:header_utility_lib",
+        "@envoy_api//envoy/config/common/matcher/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/common/tap/BUILD
+++ b/source/extensions/common/tap/BUILD
@@ -12,8 +12,8 @@ envoy_cc_library(
     name = "tap_interface",
     hdrs = ["tap.h"],
     deps = [
-        ":tap_matcher",
         "//include/envoy/http:header_map_interface",
+        "//source/extensions/common/matcher:matcher_lib",
         "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
         "@envoy_api//envoy/data/tap/v3:pkg_cc_proto",
     ],
@@ -25,23 +25,11 @@ envoy_cc_library(
     hdrs = ["tap_config_base.h"],
     deps = [
         ":tap_interface",
-        ":tap_matcher",
         "//source/common/common:assert_lib",
         "//source/common/common:hex_lib",
+        "//source/extensions/common/matcher:matcher_lib",
         "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
         "@envoy_api//envoy/data/tap/v3:pkg_cc_proto",
-    ],
-)
-
-envoy_cc_library(
-    name = "tap_matcher",
-    srcs = ["tap_matcher.cc"],
-    hdrs = ["tap_matcher.h"],
-    deps = [
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:matchers_lib",
-        "//source/common/http:header_utility_lib",
-        "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/common/tap/admin.h
+++ b/source/extensions/common/tap/admin.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "envoy/config/tap/v3/common.pb.h"
 #include "envoy/server/admin.h"
 #include "envoy/singleton/manager.h"
 

--- a/source/extensions/common/tap/tap.h
+++ b/source/extensions/common/tap/tap.h
@@ -5,7 +5,7 @@
 #include "envoy/data/tap/v3/wrapper.pb.h"
 #include "envoy/http/header_map.h"
 
-#include "extensions/common/tap/tap_matcher.h"
+#include "extensions/common/matcher/matcher.h"
 
 #include "absl/strings/string_view.h"
 
@@ -13,6 +13,8 @@ namespace Envoy {
 namespace Extensions {
 namespace Common {
 namespace Tap {
+
+using Matcher = Envoy::Extensions::Common::Matcher::Matcher;
 
 using TraceWrapperPtr = std::unique_ptr<envoy::data::tap::v3::TraceWrapper>;
 inline TraceWrapperPtr makeTraceWrapper() {

--- a/source/extensions/common/tap/tap_config_base.h
+++ b/source/extensions/common/tap/tap_config_base.h
@@ -7,13 +7,16 @@
 #include "envoy/data/tap/v3/common.pb.h"
 #include "envoy/data/tap/v3/wrapper.pb.h"
 
+#include "extensions/common/matcher/matcher.h"
 #include "extensions/common/tap/tap.h"
-#include "extensions/common/tap/tap_matcher.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace Common {
 namespace Tap {
+
+using Matcher = Envoy::Extensions::Common::Matcher::Matcher;
+using MatcherPtr = Envoy::Extensions::Common::Matcher::MatcherPtr;
 
 /**
  * Common utilities for tapping.

--- a/test/extensions/common/matcher/BUILD
+++ b/test/extensions/common/matcher/BUILD
@@ -1,0 +1,19 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "matcher_test",
+    srcs = ["matcher_test.cc"],
+    deps = [
+        "//source/extensions/common/matcher:matcher_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/common/matcher/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/common/matcher/matcher_test.cc
+++ b/test/extensions/common/matcher/matcher_test.cc
@@ -1,8 +1,8 @@
-#include "envoy/config/tap/v3/common.pb.h"
+#include "envoy/config/common/matcher/v3/matcher.pb.h"
 
 #include "common/protobuf/utility.h"
 
-#include "extensions/common/tap/tap_matcher.h"
+#include "extensions/common/matcher/matcher.h"
 
 #include "test/test_common/utility.h"
 
@@ -11,19 +11,19 @@
 namespace Envoy {
 namespace Extensions {
 namespace Common {
-namespace Tap {
+namespace Matcher {
 namespace {
 
-class TapMatcherTestBase {
+class MatcherTestBase {
 public:
   std::vector<MatcherPtr> matchers_;
   Matcher::MatchStatusVector statuses_;
-  envoy::config::tap::v3::MatchPredicate config_;
+  envoy::config::common::matcher::v3::MatchPredicate config_;
 
   enum class Direction { Request, Response };
 };
 
-class TapMatcherTest : public TapMatcherTestBase, public testing::Test {
+class TapMatcherTest : public MatcherTestBase, public testing::Test {
 public:
   Http::TestRequestHeaderMapImpl request_headers_;
   Http::TestRequestTrailerMapImpl request_trailers_;
@@ -31,12 +31,12 @@ public:
   Http::TestResponseTrailerMapImpl response_trailers_;
 };
 
-class TapMatcherGenericBodyConfigTest : public TapMatcherTestBase, public ::testing::Test {};
+class TapMatcherGenericBodyConfigTest : public MatcherTestBase, public ::testing::Test {};
 
 class TapMatcherGenericBodyTest
-    : public TapMatcherTestBase,
+    : public MatcherTestBase,
       public ::testing::TestWithParam<
-          std::tuple<TapMatcherTestBase::Direction,
+          std::tuple<MatcherTestBase::Direction,
                      std::tuple<std::vector<std::string>, std::list<std::list<uint32_t>>,
                                 std::pair<bool, bool>>>> {
 public:
@@ -242,8 +242,8 @@ TEST_P(TapMatcherGenericBodyTest, GenericBodyTest) {
 INSTANTIATE_TEST_SUITE_P(
     TapMatcherGenericBodyTestSuite, TapMatcherGenericBodyTest,
     ::testing::Combine(
-        ::testing::Values(TapMatcherTestBase::Direction::Request,
-                          TapMatcherTestBase::Direction::Response),
+        ::testing::Values(MatcherTestBase::Direction::Request,
+                          MatcherTestBase::Direction::Response),
         ::testing::Values(
             // SEARCHING FOR SINGLE PATTERN - no limit
             // Should match - there is a single body chunk and envoy is in the body
@@ -500,7 +500,7 @@ http_request_generic_body_match:
   }
 }
 } // namespace
-} // namespace Tap
+} // namespace Matcher
 } // namespace Common
 } // namespace Extensions
 } // namespace Envoy

--- a/test/extensions/common/tap/BUILD
+++ b/test/extensions/common/tap/BUILD
@@ -32,16 +32,6 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-    name = "tap_matcher_test",
-    srcs = ["tap_matcher_test.cc"],
-    deps = [
-        "//source/extensions/common/tap:tap_matcher",
-        "//test/test_common:utility_lib",
-        "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
-    ],
-)
-
-envoy_cc_test(
     name = "tap_config_base_test",
     srcs = ["tap_config_base_test.cc"],
     deps = [

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -49,7 +49,7 @@ public:
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     any_match: true
   output_config:
     sinks:

--- a/test/extensions/filters/http/tap/BUILD
+++ b/test/extensions/filters/http/tap/BUILD
@@ -56,6 +56,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/tap:config",
         "//test/integration:http_integration_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/data/tap/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -216,7 +216,7 @@ TEST_P(TapIntegrationTest, AdminBasicFlow) {
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     or_match:
       rules:
         - http_request_headers_match:
@@ -279,7 +279,7 @@ tap_config:
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     and_match:
       rules:
         - http_request_headers_match:
@@ -323,7 +323,7 @@ TEST_P(TapIntegrationTest, AdminTrailers) {
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     and_match:
       rules:
         - http_request_trailers_match:
@@ -364,7 +364,7 @@ TEST_P(TapIntegrationTest, AdminBodyAsBytes) {
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     any_match: true
   output_config:
     sinks:
@@ -395,7 +395,7 @@ TEST_P(TapIntegrationTest, AdminBodyAsString) {
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     any_match: true
   output_config:
     sinks:
@@ -427,7 +427,7 @@ TEST_P(TapIntegrationTest, AdminBodyAsBytesTruncated) {
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     any_match: true
   output_config:
     max_buffered_rx_bytes: 3
@@ -550,7 +550,7 @@ TEST_P(TapIntegrationTest, AdminBodyMatching) {
       R"EOF(
 config_id: test_config_id
 tap_config:
-  match_config:
+  match:
     and_match:
       rules:
         - http_request_generic_body_match:

--- a/test/extensions/filters/http/tap/tap_filter_integration_test.cc
+++ b/test/extensions/filters/http/tap/tap_filter_integration_test.cc
@@ -168,10 +168,14 @@ TEST_P(TapIntegrationTest, StaticFilePerTap) {
       R"EOF(
 name: tap
 typed_config:
-  "@type": type.googleapis.com/envoy.config.filter.http.tap.v2alpha.Tap
+  "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
   common_config:
     static_config:
+      # match_config should be ignored by the match field.
       match_config:
+        not_match:
+          any_match: true
+      match:
         any_match: true
       output_config:
         sinks:

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -396,10 +396,8 @@ public:
   envoy::extensions::transport_sockets::tap::v3::Tap
   createTapConfig(const envoy::config::core::v3::TransportSocket& inner_transport) {
     envoy::extensions::transport_sockets::tap::v3::Tap tap_config;
-    tap_config.mutable_common_config()
-        ->mutable_static_config()
-        ->mutable_match_config()
-        ->set_any_match(true);
+    tap_config.mutable_common_config()->mutable_static_config()->mutable_match()->set_any_match(
+        true);
     auto* output_config =
         tap_config.mutable_common_config()->mutable_static_config()->mutable_output_config();
     if (max_rx_bytes_.has_value()) {


### PR DESCRIPTION
This is the 1st PR for #11832 that factors out the TAP filter matcher to prepare for reuse in other filters.

Signed-off-by: Yangmin Zhu <ymzhu@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level: Low
Testing: Covered by existing tests
Docs Changes: N/A
Release Notes: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
