### PR TITLE
[WIP][ci] Enable binary size/building speed tracking for CI

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,70 @@
+name: perf
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  sizecurrent:
+    name: size_current
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: 'Build test binary'
+        run: |
+          export PATH=/usr/lib/llvm-8/bin:$PATH
+          export CC=clang
+          export CXX=clang++
+          bazelisk build //test/performance:test_binary_size --config=sizeopt
+      - uses: actions/upload-artifact@v1
+        with:
+          name: sizecurrent
+          path: bazel-bin/test/performance/test_binary_size
+  sizemaster:
+    name: size_master
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - name: 'Build test binary'
+        run: |
+          git checkout master && git pull origin master && git submodule update
+          export PATH=/usr/lib/llvm-8/bin:$PATH
+          export CC=clang
+          export CXX=clang++
+          bazelisk build //test/performance:test_binary_size --config=sizeopt
+      - uses: actions/upload-artifact@v1
+        with:
+          name: sizemaster
+          path: bazel-bin/test/performance/test_binary_size
+  sizecompare:
+    name: size_compare
+    needs: [sizecurrent, sizemaster]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/download-artifact@v1
+        with:
+          name: sizecurrent
+          path: dist/sizecurrent
+      - uses: actions/download-artifact@v1
+        with:
+          name: sizemaster
+          path: dist/sizemaster
+      - name: 'Strip and Zip binary'
+        run: |
+          ls -lh dist/
+          strip -s -o dist/master.stripped dist/sizemaster/test_binary_size
+          strip -s -o dist/current.stripped dist/sizecurrent/test_binary_size
+          zip -9 dist/master.zip dist/master.stripped
+          zip -9 dist/current.zip dist/current.stripped
+      - name: 'Test size regression'
+        run: ./ci/test_size_regression.sh dist/master.zip dist/current.zip

--- a/ci/test_size_regression.sh
+++ b/ci/test_size_regression.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Checks the absolute size and the relative size increase of a file.
+
+MAX_SIZE=5700000 # 5.7MB
+MAX_PERC=1
+
+if [ `uname` == "Darwin" ]
+then
+    SIZE1=$(stat -f "%z" "$1")
+    SIZE2=$(stat -f "%z" "$2")
+else
+    SIZE1=$(stat -c "%s" "$1")
+    SIZE2=$(stat -c "%s" "$2")
+fi
+PERC=$(bc <<< "scale=2; ($SIZE2 - $SIZE1)/$SIZE1 * 100")
+
+echo "The new binary is $PERC % different in size compared to main."
+echo "The new binary is $SIZE2 bytes."
+
+if [ $SIZE2 -gt $MAX_SIZE ]
+then
+    echo "The current size ($SIZE2) is larger than the maximum size ($MAX_SIZE)."
+    exit 1
+fi
+
+if [ $(bc <<< "scale=2; $PERC >= $MAX_PERC") -eq 1 ]
+then
+    echo "The percentage increase ($PERC) is larger then the maximum percentage increase ($MAX_PERC)."
+    exit 1
+fi

--- a/envoy.bloaty
+++ b/envoy.bloaty
@@ -1,0 +1,22 @@
+custom_data_source: {
+  name: "bloaty_package"
+  base_data_source: "compileunits"
+
+  #envoy source code.
+  rewrite: {
+    pattern: "^(external/envoy/source/)(\\w+/)(\\w+)"
+    replacement: "envoy \\2"
+  }
+
+  #envoy third party libraries.
+  rewrite: {
+      pattern: "^(external/)(\\w+/)"
+      replacement: "\\2"
+  }
+
+  #all compiled protos.
+  rewrite: {
+      pattern: "([.pb.cc | .pb.validate.cc])$"
+      replacement: "compiled protos"
+  }
+}

--- a/test/performance/BUILD
+++ b/test/performance/BUILD
@@ -1,0 +1,28 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_binary(
+    name = "test_binary_size",
+    stamped = "True",
+    deps = [":test_binary_size_lib"],
+)
+envoy_cc_library(
+    name = "test_binary_size_lib",
+    srcs = ["test_binary_size.cc"],
+    external_deps = [
+        "abseil_symbolize",
+    ],
+    deps = [
+        "//source/exe:envoy_main_common_lib",
+        "//source/exe:platform_impl_lib",
+    ],
+)
+

--- a/test/performance/test_binary_size.cc
+++ b/test/performance/test_binary_size.cc
@@ -1,0 +1,15 @@
+#include "exe/main_common.h"
+
+// NOLINT(namespace-envoy)
+
+// This binary is used to perform stripped down binary size investigations of the Envoy codebase.
+// TODO: add instruction for how to using it for investigation.
+
+/**
+ * Basic Site-Specific main()
+ *
+ * This should be used to do setup tasks specific to a particular site's
+ * deployment such as initializing signal handling. It calls main_common
+ * after setting up command line options.
+ */
+int main(int argc, char** argv) { return Envoy::MainCommon::main(argc, argv); }


### PR DESCRIPTION
Commit Message: Enable binary size/building speed tracking for CI
Additional Description: I am working on reduce compilation resource consumption. Some pull request will increase the binary size/compilation time, so it's necessary to track them by CI jobs.
This PR enables binary size investigation (now) and will add CI jobs to add size regression analysis on every PR.
CI should fail if the PR introduces a regression beyond the agreed upon thresholds.
Risk Level: Low
Testing: Work in progress
Docs Changes: N/A
Release Notes: No
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
