### PR TITLE
buffer: add method to extract front slice without copying

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -64,16 +64,7 @@ public:
   virtual ~SliceData() = default;
 
   /**
-   * @return true if the underlying slice data is mutable.
-   */
-  virtual bool isMutable() const PURE;
-  /**
-   * @return an immutable view of the slice data.
-   */
-  virtual absl::Span<const uint8_t> getData() const PURE;
-  /**
-   * Calling this method if isMutable() returns false will have undefined behavior.
-   * @return a mutable view of the slice data, but only if isMutable() returns true.
+   * @return a mutable view of the slice data.
    */
   virtual absl::Span<uint8_t> getMutableData() PURE;
 };
@@ -172,13 +163,7 @@ public:
   /**
    * Transfer ownership of the front slice to the caller. Must only be called if the
    * buffer is not empty otherwise the implementation will have undefined behavior.
-   * @return pointer to SliceData object that wraps the front slice
-   */
-  virtual SliceDataPtr extractFrontSlice() PURE;
-
-  /**
-   * Identical to extractFrontSlice() if the underlying slice is mutable. If the
-   * underlying slice is immutable then the implementation must create and return
+   * If the underlying slice is immutable then the implementation must create and return
    * a mutable slice that has a copy of the immutable data.
    * @return pointer to SliceData object that wraps the front slice
    */

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -56,6 +56,25 @@ public:
 };
 
 /**
+ * A wrapper class to facilitate extracting buffer slices from a buffer instance.
+ */
+class SliceData {
+public:
+  virtual ~SliceData() = default;
+  /**
+   * @return void* a pointer to the data.
+   */
+  virtual void* data() PURE;
+
+  /**
+   * @return size_t the size of the data.
+   */
+  virtual size_t size() const PURE;
+};
+
+using SliceDataPtr = std::unique_ptr<SliceData>;
+
+/**
  * A basic buffer abstraction.
  */
 class Instance {
@@ -143,6 +162,13 @@ public:
    */
   virtual RawSliceVector
   getRawSlices(absl::optional<uint64_t> max_slices = absl::nullopt) const PURE;
+
+  /**
+   * Transfer ownership of the front slice to the caller. Must only be called if the
+   * buffer is not empty otherwise the implementation will have undefined behavior.
+   * @return pointer to SliceData object that wraps the front slice
+   */
+  virtual SliceDataPtr extractFrontSlice() PURE;
 
   /**
    * @return uint64_t the total length of the buffer (not necessarily contiguous in memory).

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -16,6 +16,7 @@
 #include "absl/container/inlined_vector.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "absl/types/span.h"
 
 namespace Envoy {
 namespace Buffer {
@@ -56,20 +57,15 @@ public:
 };
 
 /**
- * A wrapper class to facilitate extracting buffer slices from a buffer instance.
+ * A class to facilitate extracting buffer slices from a buffer instance.
  */
 class SliceData {
 public:
   virtual ~SliceData() = default;
   /**
-   * @return void* a pointer to the data.
+   * @return absl::Span<uint8_t> a span of the slice data.
    */
-  virtual void* data() PURE;
-
-  /**
-   * @return size_t the size of the data.
-   */
-  virtual size_t size() const PURE;
+  virtual absl::Span<uint8_t> getData() PURE;
 };
 
 using SliceDataPtr = std::unique_ptr<SliceData>;

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -72,8 +72,8 @@ public:
    */
   virtual absl::Span<const uint8_t> getData() const PURE;
   /**
+   * Calling this method if isMutable() returns false will have undefined behavior.
    * @return a mutable view of the slice data, but only if isMutable() returns true.
-   * If isMutable() returns false then the mutable view will be {nullptr,0}.
    */
   virtual absl::Span<uint8_t> getMutableData() PURE;
 };
@@ -175,6 +175,13 @@ public:
    * @return pointer to SliceData object that wraps the front slice
    */
   virtual SliceDataPtr extractFrontSlice() PURE;
+
+  /**
+   * Identical to extractFrontSlice() if the underlying slice is mutable. If the
+   * underlying slice is immutable then the implementation must create and return
+   * a mutable slice that has a copy of the immutable data.
+   * @return pointer to SliceData object that wraps the front slice
+   */
   virtual SliceDataPtr extractMutableFrontSlice() PURE;
 
   /**

--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -62,10 +62,20 @@ public:
 class SliceData {
 public:
   virtual ~SliceData() = default;
+
   /**
-   * @return absl::Span<uint8_t> a span of the slice data.
+   * @return true if the underlying slice data is mutable.
    */
-  virtual absl::Span<uint8_t> getData() PURE;
+  virtual bool isMutable() const PURE;
+  /**
+   * @return an immutable view of the slice data.
+   */
+  virtual absl::Span<const uint8_t> getData() const PURE;
+  /**
+   * @return a mutable view of the slice data, but only if isMutable() returns true.
+   * If isMutable() returns false then the mutable view will be {nullptr,0}.
+   */
+  virtual absl::Span<uint8_t> getMutableData() PURE;
 };
 
 using SliceDataPtr = std::unique_ptr<SliceData>;
@@ -165,6 +175,7 @@ public:
    * @return pointer to SliceData object that wraps the front slice
    */
   virtual SliceDataPtr extractFrontSlice() PURE;
+  virtual SliceDataPtr extractMutableFrontSlice() PURE;
 
   /**
    * @return uint64_t the total length of the buffer (not necessarily contiguous in memory).

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -200,10 +200,16 @@ RawSliceVector OwnedImpl::getRawSlices(absl::optional<uint64_t> max_slices) cons
 }
 
 SliceDataPtr OwnedImpl::extractFrontSlice() {
+  RELEASE_ASSERT(length_ > 0, "Extract called on empty buffer");
+  // Remove zero byte fragments from the front of the queue to ensure
+  // that the extracted slice has data.
+  while (!slices_.empty() && slices_.front()->dataSize() == 0) {
+    slices_.pop_front();
+  }
   ASSERT(!slices_.empty());
   ASSERT(slices_.front());
   length_ -= slices_.front()->dataSize();
-  auto slice = std::make_unique<SliceDataImpl>(std::move(slices_.front()));
+  auto slice = std::move(slices_.front());
   slices_.pop_front();
   return slice;
 }

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -199,6 +199,15 @@ RawSliceVector OwnedImpl::getRawSlices(absl::optional<uint64_t> max_slices) cons
   return raw_slices;
 }
 
+std::unique_ptr<SliceData> OwnedImpl::extractFrontSlice() {
+  ASSERT(!slices_.empty());
+  ASSERT(slices_.front());
+  length_ -= slices_.front()->dataSize();
+  auto slice = std::make_unique<SliceDataImpl>(std::move(slices_.front()));
+  slices_.pop_front();
+  return slice;
+}
+
 uint64_t OwnedImpl::length() const {
 #ifndef NDEBUG
   // When running in debug mode, verify that the precomputed length matches the sum

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -199,7 +199,7 @@ RawSliceVector OwnedImpl::getRawSlices(absl::optional<uint64_t> max_slices) cons
   return raw_slices;
 }
 
-std::unique_ptr<SliceData> OwnedImpl::extractFrontSlice() {
+SliceDataPtr OwnedImpl::extractFrontSlice() {
   ASSERT(!slices_.empty());
   ASSERT(slices_.front());
   length_ -= slices_.front()->dataSize();

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -35,11 +35,7 @@ class Slice : public SliceData {
 public:
   using Reservation = RawSlice;
 
-  virtual ~Slice() {
-    for (const auto& drain_tracker : drain_trackers_) {
-      drain_tracker();
-    }
-  }
+  virtual ~Slice() { callAndClearDrainTrackers(); }
 
   // SliceData
   absl::Span<uint8_t> getMutableData() override {

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -35,7 +35,7 @@ class Slice : public SliceData {
 public:
   using Reservation = RawSlice;
 
-  virtual ~Slice() { callAndClearDrainTrackers(); }
+  ~Slice() override { callAndClearDrainTrackers(); }
 
   // SliceData
   absl::Span<uint8_t> getMutableData() override {

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -239,8 +239,8 @@ public:
     ASSERT(slice_);
     ASSERT(slice_->dataSize() > 0);
   }
-  void* data() { return slice_->data(); };
-  size_t size() const { return slice_->dataSize(); };
+  void* data() override { return slice_->data(); };
+  size_t size() const override { return slice_->dataSize(); };
 
 private:
   SlicePtr slice_;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -42,7 +42,14 @@ public:
   }
 
   // SliceData
-  absl::Span<uint8_t> getData() override { return {base_ + data_, reservable_ - data_}; }
+  bool isMutable() const override {
+    // Extracted slice data is immutable by default.
+    return false;
+  };
+  absl::Span<const uint8_t> getData() const override {
+    return {base_ + data_, reservable_ - data_};
+  };
+  absl::Span<uint8_t> getMutableData() override { return {nullptr, 0}; }
 
   /**
    * @return a pointer to the start of the usable content.
@@ -260,6 +267,10 @@ public:
     slice->reservable_ = size;
     return slice;
   }
+
+  // SliceData
+  bool isMutable() const override { return true; };
+  absl::Span<uint8_t> getMutableData() override { return {base_ + data_, reservable_ - data_}; }
 
 private:
   OwnedSlice(uint64_t size) : Slice(0, 0, size) { base_ = storage_; }
@@ -543,6 +554,7 @@ public:
   void drain(uint64_t size) override;
   RawSliceVector getRawSlices(absl::optional<uint64_t> max_slices = absl::nullopt) const override;
   SliceDataPtr extractFrontSlice() override;
+  SliceDataPtr extractMutableFrontSlice() override;
   uint64_t length() const override;
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -49,7 +49,10 @@ public:
   absl::Span<const uint8_t> getData() const override {
     return {base_ + data_, reservable_ - data_};
   };
-  absl::Span<uint8_t> getMutableData() override { return {nullptr, 0}; }
+  absl::Span<uint8_t> getMutableData() override {
+    RELEASE_ASSERT(isMutable(), "Not allowed to call getMutableData if slice is immutable");
+    return {base_ + data_, reservable_ - data_};
+  }
 
   /**
    * @return a pointer to the start of the usable content.
@@ -270,7 +273,6 @@ public:
 
   // SliceData
   bool isMutable() const override { return true; };
-  absl::Span<uint8_t> getMutableData() override { return {base_ + data_, reservable_ - data_}; }
 
 private:
   OwnedSlice(uint64_t size) : Slice(0, 0, size) { base_ = storage_; }

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -51,12 +51,6 @@ void WatermarkBuffer::move(Instance& rhs, uint64_t length) {
   checkHighAndOverflowWatermarks();
 }
 
-SliceDataPtr WatermarkBuffer::extractFrontSlice() {
-  auto result = OwnedImpl::extractFrontSlice();
-  checkLowWatermark();
-  return result;
-}
-
 SliceDataPtr WatermarkBuffer::extractMutableFrontSlice() {
   auto result = OwnedImpl::extractMutableFrontSlice();
   checkLowWatermark();

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -57,6 +57,12 @@ SliceDataPtr WatermarkBuffer::extractFrontSlice() {
   return result;
 }
 
+SliceDataPtr WatermarkBuffer::extractMutableFrontSlice() {
+  auto result = OwnedImpl::extractMutableFrontSlice();
+  checkLowWatermark();
+  return result;
+}
+
 Api::IoCallUint64Result WatermarkBuffer::read(Network::IoHandle& io_handle, uint64_t max_length) {
   Api::IoCallUint64Result result = OwnedImpl::read(io_handle, max_length);
   checkHighAndOverflowWatermarks();

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -51,6 +51,12 @@ void WatermarkBuffer::move(Instance& rhs, uint64_t length) {
   checkHighAndOverflowWatermarks();
 }
 
+SliceDataPtr WatermarkBuffer::extractFrontSlice() {
+  auto result = OwnedImpl::extractFrontSlice();
+  checkLowWatermark();
+  return result;
+}
+
 Api::IoCallUint64Result WatermarkBuffer::read(Network::IoHandle& io_handle, uint64_t max_length) {
   Api::IoCallUint64Result result = OwnedImpl::read(io_handle, max_length);
   checkHighAndOverflowWatermarks();
@@ -67,6 +73,15 @@ Api::IoCallUint64Result WatermarkBuffer::write(Network::IoHandle& io_handle) {
   Api::IoCallUint64Result result = OwnedImpl::write(io_handle);
   checkLowWatermark();
   return result;
+}
+
+void WatermarkBuffer::appendSliceForTest(const void* data, uint64_t size) {
+  OwnedImpl::appendSliceForTest(data, size);
+  checkHighAndOverflowWatermarks();
+}
+
+void WatermarkBuffer::appendSliceForTest(absl::string_view data) {
+  appendSliceForTest(data.data(), data.size());
 }
 
 void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_watermark) {

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -34,7 +34,6 @@ public:
   void drain(uint64_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
-  SliceDataPtr extractFrontSlice() override;
   SliceDataPtr extractMutableFrontSlice() override;
   Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -35,6 +35,7 @@ public:
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
   SliceDataPtr extractFrontSlice() override;
+  SliceDataPtr extractMutableFrontSlice() override;
   Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   Api::IoCallUint64Result write(Network::IoHandle& io_handle) override;

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -34,10 +34,13 @@ public:
   void drain(uint64_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
+  SliceDataPtr extractFrontSlice() override;
   Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   Api::IoCallUint64Result write(Network::IoHandle& io_handle) override;
   void postProcess() override { checkLowWatermark(); }
+  void appendSliceForTest(const void* data, uint64_t size) override;
+  void appendSliceForTest(absl::string_view data) override;
 
   void setWatermarks(uint32_t watermark) { setWatermarks(watermark / 2, watermark); }
   void setWatermarks(uint32_t low_watermark, uint32_t high_watermark);

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -133,8 +133,6 @@ public:
     return mutableStart();
   }
 
-  Buffer::SliceDataPtr extractFrontSlice() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
-
   Buffer::SliceDataPtr extractMutableFrontSlice() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -14,6 +14,7 @@
 
 #include "absl/container/fixed_array.h"
 #include "absl/strings/match.h"
+#include "absl/types/span.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -131,6 +132,26 @@ public:
   void* linearize(uint32_t /*size*/) override {
     // Sketchy, but probably will work for test purposes.
     return mutableStart();
+  }
+
+  class SliceDataImpl : public Buffer::SliceData {
+  public:
+    SliceDataImpl() = delete;
+    SliceDataImpl(absl::Span<uint8_t> slice) : slice_(slice) {}
+    void* data() override { return slice_.data(); }
+    size_t size() const override { return slice_.size(); }
+
+  private:
+    absl::Span<uint8_t> slice_;
+  };
+
+  std::unique_ptr<Buffer::SliceData> extractFrontSlice() override {
+    ASSERT(size_ > 0);
+    // assumption: test keeps buffer instance alive while using extracted slice
+    auto slice = std::make_unique<SliceDataImpl>(
+        absl::Span<uint8_t>{reinterpret_cast<uint8_t*>(data_.data() + start_), size_});
+    drain(size_);
+    return slice;
   }
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -134,24 +134,9 @@ public:
     return mutableStart();
   }
 
-  class SliceDataImpl : public Buffer::SliceData {
-  public:
-    SliceDataImpl() = delete;
-    SliceDataImpl(absl::Span<uint8_t> slice) : slice_(slice) {}
-    void* data() override { return slice_.data(); }
-    size_t size() const override { return slice_.size(); }
-
-  private:
-    absl::Span<uint8_t> slice_;
-  };
-
-  std::unique_ptr<Buffer::SliceData> extractFrontSlice() override {
-    ASSERT(size_ > 0);
-    // assumption: test keeps buffer instance alive while using extracted slice
-    auto slice = std::make_unique<SliceDataImpl>(
-        absl::Span<uint8_t>{reinterpret_cast<uint8_t*>(data_.data() + start_), size_});
-    drain(size_);
-    return slice;
+  Buffer::SliceDataPtr extractFrontSlice() override {
+    // not used
+    return Buffer::SliceDataPtr{};
   }
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -134,10 +134,9 @@ public:
     return mutableStart();
   }
 
-  Buffer::SliceDataPtr extractFrontSlice() override {
-    // not used
-    return Buffer::SliceDataPtr{};
-  }
+  Buffer::SliceDataPtr extractFrontSlice() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+
+  Buffer::SliceDataPtr extractMutableFrontSlice() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
   void move(Buffer::Instance& rhs) override { move(rhs, rhs.length()); }
 

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -14,7 +14,6 @@
 
 #include "absl/container/fixed_array.h"
 #include "absl/strings/match.h"
-#include "absl/types/span.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -482,11 +482,6 @@ TEST_F(OwnedImplTest, ExtractUnownedSlice) {
             absl::string_view(reinterpret_cast<const char*>(slice_data.data()), slice_data.size()));
   EXPECT_EQ(expected_length1, buffer.length());
 
-  // The immutable slice should not have mutable data.
-  auto slice_mutable_data = slice->getMutableData();
-  EXPECT_EQ(slice_mutable_data.data(), nullptr);
-  EXPECT_EQ(slice_mutable_data.size(), 0);
-
   // This test now has ownership of the unowned slice, which means that the
   // release callback will only be called once the slice is destroyed.
   EXPECT_FALSE(release_callback_called_);

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -386,7 +386,8 @@ TEST_F(OwnedImplTest, DrainThenExtractOwnedSlice) {
   ASSERT_TRUE(slice);
   ASSERT_NE(slice->data(), nullptr);
   EXPECT_EQ(slice->size(), expected_length0 - partial_drain_size);
-  EXPECT_TRUE(0 == memcmp(slice->data(), "abcde" + partial_drain_size,
+  EXPECT_TRUE(0 == memcmp(slice->data(),
+                          reinterpret_cast<const uint8_t*>("abcde") + partial_drain_size,
                           expected_length0 - partial_drain_size));
   EXPECT_EQ(buffer.toString(), "123");
 }

--- a/test/common/buffer/watermark_buffer_test.cc
+++ b/test/common/buffer/watermark_buffer_test.cc
@@ -155,10 +155,10 @@ TEST_F(WatermarkBufferTest, Drain) {
 }
 
 TEST_F(WatermarkBufferTest, DrainUsingExtract) {
-  // Similar to `Drain` test, but using extractFrontSlice() instead of drain()
+  // Similar to `Drain` test, but using extractMutableFrontSlice() instead of drain().
   buffer_.add(TEN_BYTES, 10);
   ASSERT_EQ(buffer_.length(), 10);
-  buffer_.extractFrontSlice();
+  buffer_.extractMutableFrontSlice();
   EXPECT_EQ(0, times_high_watermark_called_);
   EXPECT_EQ(0, times_low_watermark_called_);
 
@@ -168,20 +168,20 @@ TEST_F(WatermarkBufferTest, DrainUsingExtract) {
   buffer_.appendSliceForTest(TEN_BYTES, 5);
   EXPECT_EQ(1, times_high_watermark_called_);
   EXPECT_EQ(0, times_low_watermark_called_);
-  auto slice0 = buffer_.extractFrontSlice(); // essentially drain(5)
+  auto slice0 = buffer_.extractMutableFrontSlice(); // essentially drain(5)
   ASSERT_TRUE(slice0);
-  EXPECT_EQ(slice0->getData().size(), 5);
+  EXPECT_EQ(slice0->getMutableData().size(), 5);
   EXPECT_EQ(6, buffer_.length());
   EXPECT_EQ(0, times_low_watermark_called_);
 
   // Now drain below.
   auto slice1 = buffer_.extractMutableFrontSlice(); // essentially drain(1)
   ASSERT_TRUE(slice1);
-  EXPECT_EQ(slice1->getData().size(), 1);
+  EXPECT_EQ(slice1->getMutableData().size(), 1);
   EXPECT_EQ(1, times_high_watermark_called_);
   EXPECT_EQ(1, times_low_watermark_called_);
 
-  // Going back above should trigger the high again
+  // Going back above should trigger the high again.
   buffer_.add(TEN_BYTES, 10);
   EXPECT_EQ(2, times_high_watermark_called_);
 }

--- a/test/common/buffer/watermark_buffer_test.cc
+++ b/test/common/buffer/watermark_buffer_test.cc
@@ -142,6 +142,7 @@ TEST_F(WatermarkBufferTest, Drain) {
   buffer_.add(TEN_BYTES, 11);
   buffer_.drain(5);
   EXPECT_EQ(6, buffer_.length());
+  EXPECT_EQ(1, times_high_watermark_called_);
   EXPECT_EQ(0, times_low_watermark_called_);
 
   // Now drain below.
@@ -165,12 +166,19 @@ TEST_F(WatermarkBufferTest, DrainUsingExtract) {
   buffer_.appendSliceForTest(TEN_BYTES, 5);
   buffer_.appendSliceForTest(TEN_BYTES, 1);
   buffer_.appendSliceForTest(TEN_BYTES, 5);
-  buffer_.extractFrontSlice(); // essentially drain(5)
+  EXPECT_EQ(1, times_high_watermark_called_);
+  EXPECT_EQ(0, times_low_watermark_called_);
+  auto slice0 = buffer_.extractFrontSlice(); // essentially drain(5)
+  ASSERT_TRUE(slice0);
+  EXPECT_EQ(slice0->getData().size(), 5);
   EXPECT_EQ(6, buffer_.length());
   EXPECT_EQ(0, times_low_watermark_called_);
 
   // Now drain below.
-  buffer_.extractFrontSlice(); // essentially drain(1)
+  auto slice1 = buffer_.extractMutableFrontSlice(); // essentially drain(1)
+  ASSERT_TRUE(slice1);
+  EXPECT_EQ(slice1->getData().size(), 1);
+  EXPECT_EQ(1, times_high_watermark_called_);
   EXPECT_EQ(1, times_low_watermark_called_);
 
   // Going back above should trigger the high again


### PR DESCRIPTION
Add a method to Envoy::Buffer::Instance that may be used to extract the front slice of the implementation's queue (SliceDeque in the case of Buffer::OwnedImpl) without copying the actual payload.  A SliceData class is defined to facilitate the extraction process.

Risk Level: Low
Testing: Additional unit tests
Docs Changes: n/a
Release Notes: n/a
Fixes #12373
