### PR TITLE
bugfix: check_format script, tokenInLine helper function

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -567,6 +567,10 @@ def tokenInLine(token, line):
   index = 0
   while True:
     index = line.find(token, index)
+    # the following check has been changed from index < 1 to index < 0 because 
+    # this function incorrectly returns false when the token in question is the 
+    # first one in a line. The following line returns false when the token is present:
+    #violating_symbol foo;
     if index < 0:
       break
     if index == 0 or not (line[index - 1].isalnum() or line[index - 1] == '_'):

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -567,8 +567,8 @@ def tokenInLine(token, line):
   index = 0
   while True:
     index = line.find(token, index)
-    # the following check has been changed from index < 1 to index < 0 because 
-    # this function incorrectly returns false when the token in question is the 
+    # the following check has been changed from index < 1 to index < 0 because
+    # this function incorrectly returns false when the token in question is the
     # first one in a line. The following line returns false when the token is present:
     # (no leading whitespace) violating_symbol foo;
     if index < 0:

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -567,7 +567,7 @@ def tokenInLine(token, line):
   index = 0
   while True:
     index = line.find(token, index)
-    if index < 1:
+    if index < 0:
       break
     if index == 0 or not (line[index - 1].isalnum() or line[index - 1] == '_'):
       if index + len(token) >= len(line) or not (line[index + len(token)].isalnum() or

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -570,7 +570,7 @@ def tokenInLine(token, line):
     # the following check has been changed from index < 1 to index < 0 because 
     # this function incorrectly returns false when the token in question is the 
     # first one in a line. The following line returns false when the token is present:
-    #violating_symbol foo;
+    # (no leading whitespace) violating_symbol foo;
     if index < 0:
       break
     if index == 0 or not (line[index - 1].isalnum() or line[index - 1] == '_'):


### PR DESCRIPTION
Signed-off-by: Yifan Yang <needyyang@google.com>
This looks like a bug to me. @sunjayBhatia do you mind confirming this? 
The effect of this is that this function incorrectly returns false when the token in question is the first one in a line. 

This was found during my attempt here https://github.com/envoyproxy/envoy/pull/12421. 
Commit Message:
Additional Description:
Risk Level: low, should correct an incorrect behavior. 
Testing: All existing tests have passed 
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
