### PR TITLE
arm: enable hotrestart

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -83,7 +83,7 @@ export BAZEL_BUILD_OPTIONS=" ${BAZEL_OPTIONS} --verbose_failures --show_task_fin
   --test_output=errors --repository_cache=${BUILD_DIR}/repository_cache --experimental_repository_cache_hardlinks \
   ${BAZEL_BUILD_EXTRA_OPTIONS} ${BAZEL_EXTRA_TEST_OPTIONS}"
 
-[[ "$(uname -m)" == "aarch64" ]] && BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --define=hot_restart=disabled --test_env=HEAPCHECK="
+[[ "$(uname -m)" == "aarch64" ]] && BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HEAPCHECK="
 
 [[ "${BAZEL_EXPUNGE}" == "1" ]] && bazel clean --expunge
 

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -73,6 +73,10 @@ cat "${TEST_SRCDIR}/envoy"/test/config/integration/server.yaml |
   cat > "${HOT_RESTART_JSON_REUSE_PORT}"
 JSON_TEST_ARRAY+=("${HOT_RESTART_JSON_REUSE_PORT}")
 
+# Shared memory size varies by architecture
+SHARED_MEMORY_SIZE="104"
+[[ "$(uname -m)" == "aarch64" ]] && SHARED_MEMORY_SIZE="120"
+
 echo "Hot restart test using dynamic base id"
 
 TEST_INDEX=0
@@ -128,7 +132,7 @@ function run_testsuite() {
   # string, compare it against a hard-coded string.
   start_test Checking for consistency of /hot_restart_version
   CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" 2>&1)
-  EXPECTED_CLI_HOT_RESTART_VERSION="11.104"
+  EXPECTED_CLI_HOT_RESTART_VERSION="11.${SHARED_MEMORY_SIZE}"
   echo "The Envoy's hot restart version is ${CLI_HOT_RESTART_VERSION}"
   echo "Now checking that the above version is what we expected."
   check [ "${CLI_HOT_RESTART_VERSION}" = "${EXPECTED_CLI_HOT_RESTART_VERSION}" ]
@@ -136,7 +140,7 @@ function run_testsuite() {
   start_test Checking for consistency of /hot_restart_version with --use-fake-symbol-table "$FAKE_SYMBOL_TABLE"
   CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" \
     --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" 2>&1)
-  EXPECTED_CLI_HOT_RESTART_VERSION="11.104"
+  EXPECTED_CLI_HOT_RESTART_VERSION="11.${SHARED_MEMORY_SIZE}"
   check [ "${CLI_HOT_RESTART_VERSION}" = "${EXPECTED_CLI_HOT_RESTART_VERSION}" ]
 
   start_test Checking for match of --hot-restart-version and admin /hot_restart_version


### PR DESCRIPTION
Enable hotrestart in ARM64, the hotrestart_test failed before due to different size of `pthread_mutext_t` (48 in aarch64 vs 40 in x86_64).

Risk Level: Low
Testing: local, CI
Docs Changes:
Release Notes:
Fixes #12397 