### PR TITLE
compdb: treat envoy headers as c++17

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -42,10 +42,9 @@ USE_CATEGORIES_WITH_CPE_OPTIONAL = ["build", "test", "other"]
 
 DEPENDENCY_REPOSITORIES = dict(
     bazel_compdb = dict(
-        sha256 = "943f1a57e01d030b9c649f9e41fdafd871e8b0e8a1431f93c6673c38b9c15b3b",
-        strip_prefix = "bazel-compilation-database-c37b909045eb72d29a47f77cc1e9b519dd5c10b6",
-        # 2020-07-31
-        urls = ["https://github.com/grailbio/bazel-compilation-database/archive/c37b909045eb72d29a47f77cc1e9b519dd5c10b6.tar.gz"],
+        sha256 = "bcecfd622c4ef272fd4ba42726a52e140b961c4eac23025f18b346c968a8cfb4",
+        strip_prefix = "bazel-compilation-database-0.4.5",
+        urls = ["https://github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz"],
         use_category = ["build"],
     ),
     bazel_gazelle = dict(

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -73,6 +73,9 @@ def modifyCompileCommand(target, args):
   if isHeader(target["file"]):
     options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
     options += " -Wno-unused-function"
+    if not target["file"].startswith("external/"):
+      # *.h file is treated as C header by default while our headers files are all C++17.
+      options = "-x c++ -std=c++17 -fexceptions " + options
 
   target["command"] = " ".join([cc, options])
   return target


### PR DESCRIPTION
This should eliminates most failures of clang_tidy on master.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
