### PR TITLE
tidy: Fix some clang-tidy errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 BROWSE
 /build
 /build_*
+*.bak
 *.bzlc
 .cache
 .clangd

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -69,7 +69,7 @@ if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
     -clang-tidy-binary=${CLANG_TIDY} \
     -clang-apply-replacements-binary=${CLANG_APPLY_REPLACEMENTS} \
     -export-fixes=${FIX_YAML} \
-    -j ${NUM_CPUS:-0} -p 1 -quiet \
+    -j ${NUM_CPUS:-0} -p . -quiet \
     ${APPLY_CLANG_TIDY_FIXES:+-fix}
 elif [[ -n "${DIFF_REF}" ]]; then
   echo "Running clang-tidy-diff against ref ${DIFF_REF}"

--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -90,6 +90,7 @@ envoy_cc_library(
     hdrs = ["hash_policy.h"],
     deps = [
         ":header_map_interface",
+        "//include/envoy/stream_info:filter_state_interface",
         "//include/envoy/network:address_interface",
     ],
 )

--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -90,8 +90,8 @@ envoy_cc_library(
     hdrs = ["hash_policy.h"],
     deps = [
         ":header_map_interface",
-        "//include/envoy/stream_info:filter_state_interface",
         "//include/envoy/network:address_interface",
+        "//include/envoy/stream_info:filter_state_interface",
     ],
 )
 

--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "envoy/common/pure.h"

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -45,6 +45,7 @@ CODEC_LIB_DEPS = [
     "//source/common/http:status_lib",
     "//source/common/http:utility_lib",
     "//source/common/runtime:runtime_features_lib",
+    "//source/common/common:statusor_lib",
     "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
 ]
 
@@ -58,9 +59,7 @@ envoy_cc_library(
         "abseil_inlined_vector",
         "abseil_algorithm",
     ],
-    deps = CODEC_LIB_DEPS + [
-        "//source/common/common:statusor_lib",
-    ],
+    deps = CODEC_LIB_DEPS,
 )
 
 envoy_cc_library(

--- a/test/extensions/filters/http/cors/cors_filter_test.cc
+++ b/test/extensions/filters/http/cors/cors_filter_test.cc
@@ -60,7 +60,7 @@ public:
     filter_.setEncoderFilterCallbacks(encoder_callbacks_);
   }
 
-  bool IsCorsRequest() { return filter_.is_cors_request_; }
+  bool isCoreRequest() { return filter_.is_cors_request_; }
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
@@ -81,7 +81,7 @@ TEST_F(CorsFilterTest, RequestWithoutOrigin) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -99,7 +99,7 @@ TEST_F(CorsFilterTest, RequestWithOrigin) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -115,7 +115,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithoutOrigin) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -131,7 +131,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOrigin) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -202,7 +202,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabled) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -218,7 +218,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithoutAccessRequestMethod) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -244,7 +244,7 @@ TEST_F(CorsFilterTest, OptionsRequestMatchingOriginByWildcard) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -274,7 +274,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabledShadowDisabled) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -302,7 +302,7 @@ TEST_F(CorsFilterTest, OptionsRequestWithOriginCorsEnabledShadowEnabled) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -322,7 +322,7 @@ TEST_F(CorsFilterTest, OptionsRequestNotMatchingOrigin) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -341,7 +341,7 @@ TEST_F(CorsFilterTest, OptionsRequestEmptyOriginList) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -372,7 +372,7 @@ TEST_F(CorsFilterTest, ValidOptionsRequestWithAllowCredentialsTrue) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -398,7 +398,7 @@ TEST_F(CorsFilterTest, ValidOptionsRequestWithAllowCredentialsFalse) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -524,7 +524,7 @@ TEST_F(CorsFilterTest, RedirectRoute) {
       .WillByDefault(Return(&direct_response_entry_));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers_, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers_));
 
@@ -579,7 +579,7 @@ TEST_F(CorsFilterTest, NoCorsEntry) {
       .WillByDefault(Return(nullptr));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -611,7 +611,7 @@ TEST_F(CorsFilterTest, NoRouteCorsEntry) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -641,7 +641,7 @@ TEST_F(CorsFilterTest, NoVHostCorsEntry) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -672,7 +672,7 @@ TEST_F(CorsFilterTest, OptionsRequestMatchingOriginByRegex) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(true, IsCorsRequest());
+  EXPECT_EQ(true, isCoreRequest());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));
@@ -693,7 +693,7 @@ TEST_F(CorsFilterTest, OptionsRequestNotMatchingOriginByRegex) {
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  EXPECT_EQ(false, IsCorsRequest());
+  EXPECT_EQ(false, isCoreRequest());
   EXPECT_EQ(1, stats_.counter("test.cors.origin_invalid").value());
   EXPECT_EQ(0, stats_.counter("test.cors.origin_valid").value());
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data_, false));

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -104,7 +104,7 @@ public:
 };
 
 template <bool failure_mode_allow_value, bool http_client>
-envoy::extensions::filters::http::ext_authz::v3::ExtAuthz GetFilterConfig() {
+envoy::extensions::filters::http::ext_authz::v3::ExtAuthz getFilterConfig() {
   const std::string http_config = R"EOF(
   http_service:
     server_uri:
@@ -126,8 +126,8 @@ envoy::extensions::filters::http::ext_authz::v3::ExtAuthz GetFilterConfig() {
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedFilterConfig, HttpFilterTestParam,
-                         Values(&GetFilterConfig<true, true>, &GetFilterConfig<false, false>,
-                                &GetFilterConfig<true, false>, &GetFilterConfig<false, true>));
+                         Values(&getFilterConfig<true, true>, &getFilterConfig<false, false>,
+                                &getFilterConfig<true, false>, &getFilterConfig<false, true>));
 
 // Test that the per route config is properly merged: more specific keys override previous keys.
 TEST_F(HttpFilterTest, MergeConfig) {

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -71,12 +71,12 @@ public:
            request_content_type() == Http::Headers::get().ContentTypeValues.GrpcWebProto;
   }
 
-  bool accept_text_response() const {
+  bool acceptTextResponse() const {
     return request_accept() == Http::Headers::get().ContentTypeValues.GrpcWebText ||
            request_accept() == Http::Headers::get().ContentTypeValues.GrpcWebTextProto;
   }
 
-  bool accept_binary_response() const {
+  bool acceptBinaryResponse() const {
     return request_accept() == Http::Headers::get().ContentTypeValues.GrpcWeb ||
            request_accept() == Http::Headers::get().ContentTypeValues.GrpcWebProto;
   }
@@ -313,10 +313,10 @@ TEST_P(GrpcWebFilterTest, Unary) {
   response_headers.addCopy(Http::Headers::get().Status, "200");
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, false));
   EXPECT_EQ("200", response_headers.get_(Http::Headers::get().Status.get()));
-  if (accept_binary_response()) {
+  if (acceptBinaryResponse()) {
     EXPECT_EQ(Http::Headers::get().ContentTypeValues.GrpcWebProto,
               response_headers.getContentTypeValue());
-  } else if (accept_text_response()) {
+  } else if (acceptTextResponse()) {
     EXPECT_EQ(Http::Headers::get().ContentTypeValues.GrpcWebTextProto,
               response_headers.getContentTypeValue());
   } else {
@@ -324,7 +324,7 @@ TEST_P(GrpcWebFilterTest, Unary) {
   }
 
   // Tests response data.
-  if (accept_binary_response()) {
+  if (acceptBinaryResponse()) {
     Buffer::OwnedImpl response_buffer;
     Buffer::OwnedImpl encoded_buffer;
     for (size_t i = 0; i < MESSAGE_SIZE; i++) {
@@ -333,7 +333,7 @@ TEST_P(GrpcWebFilterTest, Unary) {
       encoded_buffer.move(response_buffer);
     }
     EXPECT_EQ(std::string(MESSAGE, MESSAGE_SIZE), encoded_buffer.toString());
-  } else if (accept_text_response()) {
+  } else if (acceptTextResponse()) {
     Buffer::OwnedImpl response_buffer;
     Buffer::OwnedImpl encoded_buffer;
     for (size_t i = 0; i < TEXT_MESSAGE_SIZE; i++) {
@@ -360,9 +360,9 @@ TEST_P(GrpcWebFilterTest, Unary) {
   response_trailers.addCopy(Http::Headers::get().GrpcStatus, "0");
   response_trailers.addCopy(Http::Headers::get().GrpcMessage, "ok");
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
-  if (accept_binary_response()) {
+  if (acceptBinaryResponse()) {
     EXPECT_EQ(std::string(TRAILERS, TRAILERS_SIZE), trailers_buffer.toString());
-  } else if (accept_text_response()) {
+  } else if (acceptTextResponse()) {
     EXPECT_EQ(std::string(TRAILERS, TRAILERS_SIZE), Base64::decode(trailers_buffer.toString()));
   } else {
     FAIL() << "Unsupported gRPC-Web response content-type: "

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -77,8 +77,6 @@ public:
             }));
   }
 
-  int called_count() const { return called_count_; }
-
 private:
   Http::MockAsyncClientRequest request_;
   std::string response_body_;


### PR DESCRIPTION
Commit Message: This fixes some clang-tidy errors (including `clang-diagnostic-error`).

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

Risk Level: Low
Testing: Manual, CI
Docs Changes: N/A
Release Notes: N/A