### PR TITLE
tidy: allow run clang_tidy with file

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -127,7 +127,7 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.fuzz <test>` &mdash; build and run a specified fuzz test or test dir under `-c dbg --config=asan-fuzzer` with clang. If specifying a single fuzz test, must use the full target name with "_with_libfuzzer" for `<test>`.
 * `bazel.compile_time_options` &mdash; build Envoy and run tests with various compile-time options toggled to their non-default state, to ensure they still build.
 * `bazel.compile_time_options <test>` &mdash; build Envoy and run a specified test or test dir with various compile-time options toggled to their non-default state, to ensure they still build.
-* `bazel.clang_tidy` &mdash; build and run clang-tidy over all source files.
+* `bazel.clang_tidy <files>` &mdash; build and run clang-tidy specified source files, if no files specified, runs against the diff with the last GitHub commit.
 * `check_format`&mdash; run `clang-format` and `buildifier` on entire source tree.
 * `fix_format`&mdash; run and enforce `clang-format` and `buildifier` on entire source tree.
 * `check_spelling`&mdash; run `misspell` on entire project.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -284,7 +284,7 @@ elif [[ "$CI_TARGET" == "bazel.coverage" || "$CI_TARGET" == "bazel.fuzz_coverage
   exit 0
 elif [[ "$CI_TARGET" == "bazel.clang_tidy" ]]; then
   setup_clang_toolchain
-  NUM_CPUS=$NUM_CPUS ci/run_clang_tidy.sh
+  NUM_CPUS=$NUM_CPUS ci/run_clang_tidy.sh ${TEST_TARGETS}
   exit 0
 elif [[ "$CI_TARGET" == "bazel.coverity" ]]; then
   # Coverity Scan version 2017.07 fails to analyze the entirely of the Envoy

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -99,9 +99,9 @@ function bazel_binary_build() {
 }
 
 CI_TARGET=$1
+shift
 
 if [[ $# -gt 1 ]]; then
-  shift
   COVERAGE_TEST_TARGETS=$*
   TEST_TARGETS="$COVERAGE_TEST_TARGETS"
 else
@@ -284,7 +284,7 @@ elif [[ "$CI_TARGET" == "bazel.coverage" || "$CI_TARGET" == "bazel.fuzz_coverage
   exit 0
 elif [[ "$CI_TARGET" == "bazel.clang_tidy" ]]; then
   setup_clang_toolchain
-  NUM_CPUS=$NUM_CPUS ci/run_clang_tidy.sh ${TEST_TARGETS}
+  NUM_CPUS=$NUM_CPUS ci/run_clang_tidy.sh $*
   exit 0
 elif [[ "$CI_TARGET" == "bazel.coverity" ]]; then
   # Coverity Scan version 2017.07 fails to analyze the entirely of the Envoy

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -79,7 +79,7 @@ else
   if [[ -z "${DIFF_REF}" ]]; then
     if [[ "${BUILD_REASON}" == "PullRequest" ]]; then
       DIFF_REF="remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}"
-    else [[ "${BUILD_REASON}" == *CI ]]; then
+    elif [[ "${BUILD_REASON}" == *CI ]]; then
       DIFF_REF="HEAD^"
     else
       DIFF_REF=$(${ENVOY_SRCDIR}/tools/git/last_github_commit.sh)

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -2,7 +2,10 @@
 
 set -eo pipefail
 
-ENVOY_SRCDIR=${ENVOY_SRCDIR:-$(cd $(dirname $0)/.. && pwd)}
+# ENVOY_SRCDIR should point to where Envoy source lives, while SRCDIR could be a downstream build
+# (for example envoy-filter-example).
+[[ -z "${ENVOY_SRCDIR}" ]] && ENVOY_SRCDIR="${PWD}"
+[[ -z "${SRCDIR}" ]] && SRCDIR="${ENVOY_SRCDIR}"
 
 export LLVM_CONFIG=${LLVM_CONFIG:-llvm-config}
 LLVM_PREFIX=${LLVM_PREFIX:-$(${LLVM_CONFIG} --prefix)}
@@ -20,14 +23,6 @@ fi
 rm clang-tidy-config-errors.txt
 
 echo "Generating compilation database..."
-
-cp -f .bazelrc .bazelrc.bak
-
-function cleanup() {
-  cp -f .bazelrc.bak .bazelrc
-  rm -f .bazelrc.bak
-}
-trap cleanup EXIT
 
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
@@ -59,32 +54,39 @@ function filter_excludes() {
   exclude_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party
 }
 
-if [[ -z "${DIFF_REF}" && "${BUILD_REASON}" != "PullRequest" ]]; then
-  DIFF_REF=HEAD^
-fi
-
-if [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
-  echo "Running full clang-tidy..."
+function run_clang_tidy() {
   python3 "${LLVM_PREFIX}/share/clang/run-clang-tidy.py" \
     -clang-tidy-binary=${CLANG_TIDY} \
     -clang-apply-replacements-binary=${CLANG_APPLY_REPLACEMENTS} \
-    -export-fixes=${FIX_YAML} \
-    -j ${NUM_CPUS:-0} -p 1 -quiet \
-    ${APPLY_CLANG_TIDY_FIXES:+-fix}
-elif [[ -n "${DIFF_REF}" ]]; then
-  echo "Running clang-tidy-diff against ref ${DIFF_REF}"
-  git diff ${DIFF_REF} | filter_excludes | \
+    -export-fixes=${FIX_YAML} -j ${NUM_CPUS:-0} -p ${SRCDIR} -quiet \
+    ${APPLY_CLANG_TIDY_FIXES:+-fix} $@
+}
+
+function run_clang_tidy_diff() {
+  git diff $1 | filter_excludes | \
     python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
       -clang-tidy-binary=${CLANG_TIDY} \
-      -export-fixes=${FIX_YAML} \
-      -j ${NUM_CPUS:-0} -p 1 -quiet
+      -export-fixes=${FIX_YAML} -j ${NUM_CPUS:-0} -p 1 -quiet
+}
+
+if [[ $# -gt 0 ]]; then
+  echo "Running clang-tidy on: $@"
+  run_clang_tidy $@
+elif [[ "${RUN_FULL_CLANG_TIDY}" == 1 ]]; then
+  echo "Running a full clang-tidy"
+  run_clang_tidy
 else
-  echo "Running clang-tidy-diff against master branch..."
-  git diff "remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}" | filter_excludes | \
-    python3 "${LLVM_PREFIX}/share/clang/clang-tidy-diff.py" \
-      -clang-tidy-binary=${CLANG_TIDY} \
-      -export-fixes=${FIX_YAML} \
-      -j ${NUM_CPUS:-0} -p 1 -quiet
+  if [[ -z "${DIFF_REF}" ]]; then
+    if [[ "${BUILD_REASON}" == "PullRequest" ]]; then
+      DIFF_REF="remotes/origin/${SYSTEM_PULLREQUEST_TARGETBRANCH}"
+    else [[ "${BUILD_REASON}" == *CI ]]; then
+      DIFF_REF="HEAD^"
+    else
+      DIFF_REF=$(${ENVOY_SRCDIR}/tools/git/last_github_commit.sh)
+    fi
+  fi
+  echo "Running clang-tidy-diff against ${DIFF_REF} ($(git rev-parse ${DIFF_REF})), current HEAD ($(git rev-parse HEAD))"
+  run_clang_tidy_diff ${DIFF_REF}
 fi
 
 if [[ -s "${FIX_YAML}" ]]; then


### PR DESCRIPTION
Refactor `ci/clang_tidy.sh` and `ci/do_ci.sh` to allow run clang-tidy for specified source file. Make running clang_tidy with build container or within devcontainer easier.

Risk Level: Low
Testing: Local, CI
Docs Changes: Yes
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
