### PR TITLE
xds: keep a reference to old config in the filter config provider

### DIFF
--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -67,7 +67,7 @@ void DynamicFilterConfigProviderImpl::onConfigUpdate(Envoy::Http::FilterFactoryC
       [this, config]() {
         // This happens after all workers have discarded the previous config so it can be safely
         // deleted on the main thread by an update with the new config.
-        this->config_ = config;
+        this->current_config_ = config;
       });
 }
 

--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -63,10 +63,11 @@ void DynamicFilterConfigProviderImpl::onConfigUpdate(Envoy::Http::FilterFactoryC
           cb();
         }
         return previous;
-      }, [this, config]() {
-         // This happens after all workers have discarded the previous config so it can be safely
-         // deleted on the main thread by an update with the new config.
-         this->config_ = config;
+      },
+      [this, config]() {
+        // This happens after all workers have discarded the previous config so it can be safely
+        // deleted on the main thread by an update with the new config.
+        this->config_ = config;
       });
 }
 

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -52,7 +52,9 @@ private:
 
   FilterConfigSubscriptionSharedPtr subscription_;
   const std::set<std::string> require_type_urls_;
-  absl::optional<Envoy::Http::FilterFactoryCb> config_{absl::nullopt};
+  // Currently applied configuration to ensure that the main thread deletes the last reference to
+  // it.
+  absl::optional<Envoy::Http::FilterFactoryCb> current_config_{absl::nullopt};
   ThreadLocal::SlotPtr tls_;
 
   // Local initialization target to ensure that the subscription starts in

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -52,7 +52,7 @@ private:
 
   FilterConfigSubscriptionSharedPtr subscription_;
   const std::set<std::string> require_type_urls_;
-  absl::optional<Envoy::Http::FilterFactoryCb> config_;
+  absl::optional<Envoy::Http::FilterFactoryCb> config_{absl::nullopt};
   ThreadLocal::SlotPtr tls_;
 
   // Local initialization target to ensure that the subscription starts in

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -52,6 +52,7 @@ private:
 
   FilterConfigSubscriptionSharedPtr subscription_;
   const std::set<std::string> require_type_urls_;
+  absl::optional<Envoy::Http::FilterFactoryCb> config_;
   ThreadLocal::SlotPtr tls_;
 
   // Local initialization target to ensure that the subscription starts in

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -883,10 +883,10 @@ envoy_cc_test(
     tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
-        "//source/extensions/filters/http/rbac:config",
         "//test/common/grpc:grpc_client_integration_lib",
+        "//test/integration/filters:set_response_code_filter_config_proto_cc_proto",
+        "//test/integration/filters:set_response_code_filter_lib",
         "//test/test_common:utility_lib",
-        "@envoy_api//envoy/extensions/filters/http/rbac/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/extension/v3:pkg_cc_proto",
     ],

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -2,6 +2,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
     "envoy_package",
+    "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
@@ -170,6 +171,25 @@ envoy_cc_test_library(
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//test/extensions/filters/http/common:empty_http_filter_config_lib",
     ],
+)
+
+envoy_cc_test_library(
+    name = "set_response_code_filter_lib",
+    srcs = [
+        "set_response_code_filter.cc",
+    ],
+    deps = [
+        ":set_response_code_filter_config_proto_cc_proto",
+        "//include/envoy/http:filter_interface",
+        "//include/envoy/registry",
+        "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "set_response_code_filter_config_proto",
+    srcs = [":set_response_code_filter_config.proto"],
 )
 
 envoy_cc_test_library(

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -2,7 +2,6 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_test_library",
     "envoy_package",
-    "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
@@ -171,25 +170,6 @@ envoy_cc_test_library(
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//test/extensions/filters/http/common:empty_http_filter_config_lib",
     ],
-)
-
-envoy_cc_test_library(
-    name = "set_response_code_filter_lib",
-    srcs = [
-        "set_response_code_filter.cc",
-    ],
-    deps = [
-        ":set_response_code_filter_config_proto_cc_proto",
-        "//include/envoy/http:filter_interface",
-        "//include/envoy/registry",
-        "//source/extensions/filters/http/common:factory_base_lib",
-        "//source/extensions/filters/http/common:pass_through_filter_lib",
-    ],
-)
-
-envoy_proto_library(
-    name = "set_response_code_filter_config_proto",
-    srcs = [":set_response_code_filter_config.proto"],
 )
 
 envoy_cc_test_library(

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -1,0 +1,57 @@
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+
+#include "extensions/filters/http/common/factory_base.h"
+#include "extensions/filters/http/common/pass_through_filter.h"
+
+#include "test/integration/filters/set_response_code_filter_config.pb.h"
+#include "test/integration/filters/set_response_code_filter_config.pb.validate.h"
+
+#include "absl/strings/match.h"
+
+namespace Envoy {
+
+// A test filter that responds directly with a code on a prefix match.
+class SetResponseCodeFilter : public Http::PassThroughFilter {
+public:
+  SetResponseCodeFilter(const std::string& prefix, uint32_t code,
+                        Server::Configuration::FactoryContext& context)
+      : prefix_(prefix), code_(code), tls_slot_(context.threadLocal().allocateSlot()) {}
+
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
+    if (absl::StartsWith(headers.Path()->value().getStringView(), prefix_)) {
+      decoder_callbacks_->sendLocalReply(static_cast<Http::Code>(code_), "", nullptr, absl::nullopt,
+                                         "");
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+private:
+  const std::string prefix_;
+  const uint32_t code_;
+  // Allocate a slot to validate that it is destroyed on a main thread only.
+  ThreadLocal::SlotPtr tls_slot_;
+};
+
+class SetResponseCodeFilterFactory : public Extensions::HttpFilters::Common::FactoryBase<
+                                         test::integration::filters::SetResponseCodeFilterConfig> {
+public:
+  SetResponseCodeFilterFactory() : FactoryBase("set-response-code-filter") {}
+
+private:
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const test::integration::filters::SetResponseCodeFilterConfig& proto_config,
+      const std::string&, Server::Configuration::FactoryContext& context) override {
+    auto filter_config = std::make_shared<SetResponseCodeFilter>(proto_config.prefix(),
+                                                                 proto_config.code(), context);
+    return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamFilter(filter_config);
+    };
+  }
+};
+
+REGISTER_FACTORY(SetResponseCodeFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+} // namespace Envoy

--- a/test/integration/filters/set_response_code_filter_config.proto
+++ b/test/integration/filters/set_response_code_filter_config.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package test.integration.filters;
+
+import "validate/validate.proto";
+
+message SetResponseCodeFilterConfig {
+  string prefix = 1;
+  uint32 code = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+}


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Some filter factories allocate TLS slots shared via shared pointers. On a filter config update, the last filter factory reference happens to be deleted on a worker thread, which causes a runtime failure since TLS slots must be deleted on the main thread. The solution is to prolong the life of the filter factory using main thread completion callback.
Fixes https://github.com/envoyproxy/envoy-wasm/issues/601
Additional Description:
Risk Level: low
Testing: manual
Docs Changes:
Release Notes: