### PR TITLE
tidy: use libstdc++

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -283,8 +283,10 @@ elif [[ "$CI_TARGET" == "bazel.coverage" || "$CI_TARGET" == "bazel.fuzz_coverage
   collect_build_profile coverage
   exit 0
 elif [[ "$CI_TARGET" == "bazel.clang_tidy" ]]; then
+  # clang-tidy will warn on standard library issues with libc++
+  ENVOY_STDLIB="libstdc++"
   setup_clang_toolchain
-  NUM_CPUS=$NUM_CPUS ci/run_clang_tidy.sh $*
+  NUM_CPUS=$NUM_CPUS ci/run_clang_tidy.sh "$@"
   exit 0
 elif [[ "$CI_TARGET" == "bazel.coverity" ]]; then
   # Coverity Scan version 2017.07 fails to analyze the entirely of the Envoy


### PR DESCRIPTION
I thought I was forcing this before, probably got lost when we switched default std library.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
