### PR TITLE
test: shard hds_integration_test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -805,6 +805,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "hds_integration_test",
     srcs = ["hds_integration_test.cc"],
+    shard_count = 2,
     tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",


### PR DESCRIPTION
This should avoid TSAN timeout flakes.

Risk Level: None
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
