### PR TITLE
Switch RateLimit headers spec version to latest

### DIFF
--- a/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -29,8 +29,8 @@ message RateLimit {
     // X-RateLimit headers disabled.
     OFF = 0;
 
-    // Use `draft RFC Version 02 <https://tools.ietf.org/id/draft-polli-ratelimit-headers-02.html>`_.
-    DRAFT_VERSION_02 = 1;
+    // Use `draft RFC Version 03 <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
+    DRAFT_VERSION_03 = 1;
   }
 
   // The rate limit domain to use when calling the rate limit service.
@@ -94,7 +94,7 @@ message RateLimit {
   // above represent the window that is closest to reaching its limit.
   //
   // For more information about the headers specification see selected version of
-  // the `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-02.html>`_.
+  // the `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
   //
   // Disabled by default.
   XRateLimitHeadersRFCVersion enable_x_ratelimit_headers = 8

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -59,7 +59,7 @@ New Features
 * load balancer: added a :ref:`configuration<envoy_v3_api_msg_config.cluster.v3.Cluster.LeastRequestLbConfig>` option to specify the active request bias used by the least request load balancer.
 * lua: added Lua APIs to access :ref:`SSL connection info <config_http_filters_lua_ssl_socket_info>` object.
 * postgres network filter: :ref:`metadata <config_network_filters_postgres_proxy_dynamic_metadata>` is produced based on SQL query.
-* ratelimit: added :ref:`enable_x_ratelimit_headers <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option to enable `X-RateLimit-*` headers as defined in `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-02.html>`_.
+* ratelimit: added :ref:`enable_x_ratelimit_headers <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option to enable `X-RateLimit-*` headers as defined in `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
 * router: added new
   :ref:`envoy-ratelimited<config_http_filters_router_retry_policy-envoy-ratelimited>`
   retry policy, which allows retrying envoy's own rate limited responses.

--- a/generated_api_shadow/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto
@@ -29,8 +29,8 @@ message RateLimit {
     // X-RateLimit headers disabled.
     OFF = 0;
 
-    // Use `draft RFC Version 02 <https://tools.ietf.org/id/draft-polli-ratelimit-headers-02.html>`_.
-    DRAFT_VERSION_02 = 1;
+    // Use `draft RFC Version 03 <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
+    DRAFT_VERSION_03 = 1;
   }
 
   // The rate limit domain to use when calling the rate limit service.
@@ -94,7 +94,7 @@ message RateLimit {
   // above represent the window that is closest to reaching its limit.
   //
   // For more information about the headers specification see selected version of
-  // the `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-02.html>`_.
+  // the `draft RFC <https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html>`_.
   //
   // Disabled by default.
   XRateLimitHeadersRFCVersion enable_x_ratelimit_headers = 8

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -45,7 +45,7 @@ public:
         failure_mode_deny_(config.failure_mode_deny()),
         enable_x_ratelimit_headers_(
             config.enable_x_ratelimit_headers() ==
-            envoy::extensions::filters::http::ratelimit::v3::RateLimit::DRAFT_VERSION_02),
+            envoy::extensions::filters::http::ratelimit::v3::RateLimit::DRAFT_VERSION_03),
         rate_limited_grpc_status_(
             config.rate_limited_as_resource_exhausted()
                 ? absl::make_optional(Grpc::Status::WellKnownGrpcStatus::ResourceExhausted)

--- a/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
@@ -211,7 +211,7 @@ class RatelimitFilterHeadersEnabledIntegrationTest : public RatelimitIntegration
 public:
   RatelimitFilterHeadersEnabledIntegrationTest() {
     enable_x_ratelimit_headers_ =
-        envoy::extensions::filters::http::ratelimit::v3::RateLimit::DRAFT_VERSION_02;
+        envoy::extensions::filters::http::ratelimit::v3::RateLimit::DRAFT_VERSION_03;
   }
 };
 

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -77,7 +77,7 @@ public:
 
   const std::string enable_x_ratelimit_headers_config_ = R"EOF(
   domain: foo
-  enable_x_ratelimit_headers: DRAFT_VERSION_02
+  enable_x_ratelimit_headers: DRAFT_VERSION_03
   )EOF";
 
   const std::string filter_config_ = R"EOF(


### PR DESCRIPTION
Signed-off-by: Petr Pchelko <ppchelko@wikimedia.org>

Followup for a new feature introduced by #12410 Apologies for not noticing that a later draft was introduced recently. I think we should start with supporting the latest available spec draft, so update version 2 to version 3. The change is technically backwards-incompatible, but the new feature was introduced one day ago, nobody could have been so fast to depend on it.

Commit Message: Switch X-RateLimit headers spec version to 3
Risk Level: Low
Testing: Existing unit/integration tests
Docs Changes: rate_limit.proto and release notes
Release Notes: changed current.rst

cc @unleashed 
