### PR TITLE
Windows: Fix //test/common/filesystem:watcher_impl_test

### DIFF
--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -43,7 +43,7 @@ void LibeventScheduler::run(Dispatcher::RunType mode) {
     // This is because libevent only supports level triggering on Windows, and so the write
     // event callbacks will trigger every time through the loop. Adding EVLOOP_ONCE ensures the
     // loop will run at most once
-    flag |= EVLOOP_NONBLOCK | EVLOOP_ONCE;
+    flag |= EVLOOP_ONCE;
 #endif
     break;
   case Dispatcher::RunType::Block:

--- a/test/common/filesystem/BUILD
+++ b/test/common/filesystem/BUILD
@@ -29,7 +29,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "watcher_impl_test",
     srcs = ["watcher_impl_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:assert_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -156,6 +156,7 @@ void TestEnvironment::renameFile(const std::string& old_name, const std::string&
 #ifdef WIN32
   // use MoveFileEx, since ::rename will not overwrite an existing file. See
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rename-wrename?view=vs-2017
+  // Note MoveFileEx cannot overwrite a directory as documented, nor a symlink, apparently.
   const BOOL rc = ::MoveFileEx(old_name.c_str(), new_name.c_str(), MOVEFILE_REPLACE_EXISTING);
   ASSERT_NE(0, rc);
 #else


### PR DESCRIPTION
Commit Message:
Windows: Fix //test/common/filesystem:watcher_impl_test

- Tests that used a non-blocking libevent event loop are flaky on
  Windows (and would be flaky on other platforms if event notifications
  routinely took longer to be propagated) since the event loop could exit
  before an event notification. Switching to use a blocking event loop
  in places where we expect a callback to be fired prevents early exit before
filesystem events are evaluated.
- Skip SymlinkAtomicRename test as Windows does not have an atomic file
  move API that can move a directory/symlink where the new name is a non-empty
  existing directory/symlink (MoveFileEx can atomically replace a file
  with a file however).

Additional Description:
Risk Level: Low
Testing: Modifies unit tests, checked on Windows locally
Docs Changes: N/A
Release Notes: N/A