### PR TITLE
http: remove deprecated connection_header_sanitization runtime guard

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -42,6 +42,7 @@ Removed Config or Runtime
 * http: removed legacy header sanitization and the runtime guard `envoy.reloadable_features.strict_header_validation`.
 * http: removed legacy transfer-encoding enforcement and runtime guard `envoy.reloadable_features.reject_unsupported_transfer_encodings`.
 * http: removed configurable strict host validation and runtime guard `envoy.reloadable_features.strict_authority_validation`.
+* http: removed the connection header sanitization runtime guard `envoy.reloadable_features.connection_header_sanitization`.
 
 New Features
 ------------

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -448,8 +448,6 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
     : connection_(connection), stats_(stats),
       header_key_formatter_(std::move(header_key_formatter)), processing_trailers_(false),
       handling_upgrade_(false), reset_stream_called_(false), deferred_end_stream_headers_(false),
-      connection_header_sanitization_(Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.connection_header_sanitization")),
       enable_trailers_(enable_trailers),
       strict_1xx_and_204_headers_(Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.strict_1xx_and_204_response_headers")),
@@ -848,7 +846,7 @@ int ServerConnectionImpl::onHeadersComplete() {
     ENVOY_CONN_LOG(trace, "Server: onHeadersComplete size={}", connection_, headers->size());
     const char* method_string = http_method_str(static_cast<http_method>(parser_.method));
 
-    if (!handling_upgrade_ && connection_header_sanitization_ && headers->Connection()) {
+    if (!handling_upgrade_ && headers->Connection()) {
       // If we fail to sanitize the request, return a 400 to the client
       if (!Utility::sanitizeConnectionHeader(*headers)) {
         absl::string_view header_value = headers->getConnectionValue();

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -253,7 +253,6 @@ protected:
   // HTTP/1 message has been flushed from the parser. This allows raising an HTTP/2 style headers
   // block with end stream set to true with no further protocol data remaining.
   bool deferred_end_stream_headers_ : 1;
-  const bool connection_header_sanitization_ : 1;
   const bool enable_trailers_ : 1;
   const bool strict_1xx_and_204_headers_ : 1;
 

--- a/source/common/http/http1/codec_impl_legacy.cc
+++ b/source/common/http/http1/codec_impl_legacy.cc
@@ -453,8 +453,6 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
     : connection_(connection), stats_(stats),
       header_key_formatter_(std::move(header_key_formatter)), processing_trailers_(false),
       handling_upgrade_(false), reset_stream_called_(false), deferred_end_stream_headers_(false),
-      connection_header_sanitization_(Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.connection_header_sanitization")),
       enable_trailers_(enable_trailers),
       strict_1xx_and_204_headers_(Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.strict_1xx_and_204_response_headers")),
@@ -853,7 +851,7 @@ int ServerConnectionImpl::onHeadersComplete() {
     ENVOY_CONN_LOG(trace, "Server: onHeadersComplete size={}", connection_, headers->size());
     const char* method_string = http_method_str(static_cast<http_method>(parser_.method));
 
-    if (!handling_upgrade_ && connection_header_sanitization_ && headers->Connection()) {
+    if (!handling_upgrade_ && headers->Connection()) {
       // If we fail to sanitize the request, return a 400 to the client
       if (!Utility::sanitizeConnectionHeader(*headers)) {
         absl::string_view header_value = headers->getConnectionValue();

--- a/source/common/http/http1/codec_impl_legacy.h
+++ b/source/common/http/http1/codec_impl_legacy.h
@@ -257,7 +257,6 @@ protected:
   // HTTP/1 message has been flushed from the parser. This allows raising an HTTP/2 style headers
   // block with end stream set to true with no further protocol data remaining.
   bool deferred_end_stream_headers_ : 1;
-  const bool connection_header_sanitization_ : 1;
   const bool enable_trailers_ : 1;
   const bool strict_1xx_and_204_headers_ : 1;
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -55,7 +55,6 @@ constexpr const char* runtime_features[] = {
     // Enabled
     "envoy.reloadable_features.http1_flood_protection",
     "envoy.reloadable_features.test_feature_true",
-    "envoy.reloadable_features.connection_header_sanitization",
     // Begin alphabetically sorted section.
     "envoy.reloadable_features.activate_fds_next_event_loop",
     "envoy.reloadable_features.allow_500_after_100",


### PR DESCRIPTION
http:  Remove deprecated envoy.reloadable_features.connection_header_sanitization runtime guard

Signed-off-by: Alvin Baptiste <alvinsb@gmail.com>

Commit Message: http: remove deprecated runtime guard for connection header sanitization
Additional Description: 
Risk Level: Low
Testing: `bazel test //test/...`
Release Notes: Added
Fixes #11933
Removed: envoy.reloadable_features.connection_header_sanitization
