### PR TITLE
[Windows] Enables various common network tests

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -50,8 +50,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "codec_client_test",
     srcs = ["codec_client_test.cc"],
-    # IpVersions/CodecNetworkTest.SendData/IPv4: Test times out on Windows.
-    tags = ["fails_on_windows"],
     deps = [
         ":common_lib",
         "//source/common/buffer:buffer_lib",

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -283,7 +283,7 @@ public:
   CodecNetworkTest() : api_(Api::createApiForTest()), stream_info_(api_->timeSource()) {
     dispatcher_ = api_->allocateDispatcher("test_thread");
     auto socket = std::make_shared<Network::TcpListenSocket>(
-        Network::Test::getAnyAddress(GetParam()), nullptr, true);
+        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
     Network::ClientConnectionPtr client_connection = dispatcher_->createClientConnection(
         socket->localAddress(), source_address_, Network::Test::createRawBufferSocket(), nullptr);
     upstream_listener_ = dispatcher_->createListener(std::move(socket), listener_callbacks_, true);

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -74,8 +74,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "connection_impl_test",
     srcs = ["connection_impl_test.cc"],
-    # Times out on Windows
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/common:empty_string",
@@ -181,8 +179,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "listener_impl_test",
     srcs = ["listener_impl_test.cc"],
-    # Times out on Windows
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/network:address_lib",

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -107,7 +107,7 @@ protected:
       dispatcher_ = api_->allocateDispatcher("test_thread");
     }
     socket_ = std::make_shared<Network::TcpListenSocket>(
-      Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
+        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
     client_connection_ = std::make_unique<Network::TestClientConnectionImpl>(
         *dispatcher_, socket_->localAddress(), source_address_,
@@ -292,7 +292,7 @@ TEST_P(ConnectionImplTest, ImmediateConnectError) {
   // immediate error return from connect().
   Address::InstanceConstSharedPtr broadcast_address;
   socket_ = std::make_shared<Network::TcpListenSocket>(
-    Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
+      Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   if (socket_->localAddress()->ip()->version() == Address::IpVersion::v4) {
     broadcast_address = std::make_shared<Address::Ipv4Instance>("224.0.0.1", 0);
   } else {
@@ -807,7 +807,7 @@ TEST_P(ConnectionImplTest, ReadWatermarks) {
   std::shared_ptr<MockReadFilter> client_read_filter(new NiceMock<MockReadFilter>());
   client_connection_->addReadFilter(client_read_filter);
   connect();
-  
+
   auto on_filter_data_exit = [&](Buffer::Instance&, bool) -> FilterStatus {
     dispatcher_->exit();
     return FilterStatus::StopIteration;
@@ -819,8 +819,7 @@ TEST_P(ConnectionImplTest, ReadWatermarks) {
   {
     Buffer::OwnedImpl buffer("data");
     server_connection_->write(buffer, false);
-    EXPECT_CALL(*client_read_filter, onData(_, false))
-        .WillOnce(Invoke(on_filter_data_exit));
+    EXPECT_CALL(*client_read_filter, onData(_, false)).WillOnce(Invoke(on_filter_data_exit));
     dispatcher_->run(Event::Dispatcher::RunType::Block);
 
     EXPECT_TRUE(testClientConnection()->readBuffer().highWatermarkTriggered());
@@ -843,8 +842,7 @@ TEST_P(ConnectionImplTest, ReadWatermarks) {
   {
     Buffer::OwnedImpl buffer("bye");
     server_connection_->write(buffer, false);
-    EXPECT_CALL(*client_read_filter, onData(_, false))
-        .WillOnce(Invoke(on_filter_data_exit));
+    EXPECT_CALL(*client_read_filter, onData(_, false)).WillOnce(Invoke(on_filter_data_exit));
     dispatcher_->run(Event::Dispatcher::RunType::Block);
 
     EXPECT_TRUE(testClientConnection()->readBuffer().highWatermarkTriggered());
@@ -1133,7 +1131,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   }
   dispatcher_ = api_->allocateDispatcher("test_thread");
   socket_ = std::make_shared<Network::TcpListenSocket>(
-    Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
+        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
 
   client_connection_ = dispatcher_->createClientConnection(
@@ -2239,7 +2237,7 @@ public:
     const uint32_t buffer_size = 256 * 1024;
     dispatcher_ = api_->allocateDispatcher("test_thread");
     socket_ = std::make_shared<Network::TcpListenSocket>(
-      Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
+        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
     listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
 
     client_connection_ = dispatcher_->createClientConnection(

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1131,7 +1131,7 @@ TEST_P(ConnectionImplTest, BindFailureTest) {
   }
   dispatcher_ = api_->allocateDispatcher("test_thread");
   socket_ = std::make_shared<Network::TcpListenSocket>(
-        Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
+      Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   listener_ = dispatcher_->createListener(socket_, listener_callbacks_, true);
 
   client_connection_ = dispatcher_->createClientConnection(

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -208,7 +208,7 @@ TEST_P(ListenerImplTest, GlobalConnectionLimitEnforcement) {
 
 TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
   auto socket = std::make_shared<TcpListenSocket>(
-        Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
+      Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
   // Do not redirect since use_original_dst is false.
@@ -285,7 +285,7 @@ TEST_P(ListenerImplTest, DisableAndEnableListener) {
   testing::InSequence s1;
 
   auto socket = std::make_shared<TcpListenSocket>(
-    Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
+      Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   MockListenerCallbacks listener_callbacks;
   MockConnectionCallbacks connection_callbacks;
   TestListenerImpl listener(dispatcherImpl(), socket, listener_callbacks, true);

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -207,8 +207,8 @@ TEST_P(ListenerImplTest, GlobalConnectionLimitEnforcement) {
 }
 
 TEST_P(ListenerImplTest, WildcardListenerUseActualDst) {
-  auto socket =
-      std::make_shared<TcpListenSocket>(Network::Test::getAnyAddress(version_), nullptr, true);
+  auto socket = std::make_shared<TcpListenSocket>(
+        Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   Network::MockListenerCallbacks listener_callbacks;
   Network::MockConnectionHandler connection_handler;
   // Do not redirect since use_original_dst is false.
@@ -284,8 +284,8 @@ TEST_P(ListenerImplTest, WildcardListenerIpv4Compat) {
 TEST_P(ListenerImplTest, DisableAndEnableListener) {
   testing::InSequence s1;
 
-  auto socket =
-      std::make_shared<TcpListenSocket>(Network::Test::getAnyAddress(version_), nullptr, true);
+  auto socket = std::make_shared<TcpListenSocket>(
+    Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   MockListenerCallbacks listener_callbacks;
   MockConnectionCallbacks connection_callbacks;
   TestListenerImpl listener(dispatcherImpl(), socket, listener_callbacks, true);


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Commit Message:

This patch enables the following tests on Windows:

1. //test/common/http:codec_client_test
2. //test/common/network:listener_impl_test
3. //test/common/network:connection_impl_test

To do so we swap the addresses to use `getCanonicalLoopbackAddress` instead of `getAnyAddress` and we add synchronization in `ConnectionImplTest.ReadWatermarks` tests.

Additional Description: N/A
Risk Level: Low
Testing: Unit tests changed
Docs Changes: N/A
Release Notes: N/A
