### PR TITLE
Add InvalidSignatureException to supported error types

### DIFF
--- a/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
@@ -39,6 +39,7 @@ const std::vector<std::string> RequestParser::SUPPORTED_ERROR_TYPES{
     "ConditionalCheckFailedException",
     "IdempotentParameterMismatchException",
     "IncompleteSignatureException",
+    "InvalidSignatureException",
     "ItemCollectionSizeLimitExceededException",
     "LimitExceededException",
     "MissingAuthenticationTokenException",

--- a/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
+++ b/source/extensions/filters/http/dynamo/dynamo_request_parser.cc
@@ -16,7 +16,7 @@ namespace Dynamo {
 
 /**
  * Basic json request/response format:
- * http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Appendix.CurrentAPI.html
+ * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations_Amazon_DynamoDB.html
  */
 const Http::LowerCaseString RequestParser::X_AMZ_TARGET("X-AMZ-TARGET");
 
@@ -39,7 +39,6 @@ const std::vector<std::string> RequestParser::SUPPORTED_ERROR_TYPES{
     "ConditionalCheckFailedException",
     "IdempotentParameterMismatchException",
     "IncompleteSignatureException",
-    "InvalidSignatureException",
     "ItemCollectionSizeLimitExceededException",
     "LimitExceededException",
     "MissingAuthenticationTokenException",
@@ -50,7 +49,10 @@ const std::vector<std::string> RequestParser::SUPPORTED_ERROR_TYPES{
     "TransactionCanceledException",
     "TransactionInProgressException",
     "UnrecognizedClientException",
-    "ValidationException"};
+    "ValidationException",
+    // Errors not listed in the error handling section of DynamoDB developer guide, but observed in runtime
+    "InvalidSignatureException", // https://github.com/aws/aws-sdk-go/issues/2598#issuecomment-526398896
+};
 // clang-format on
 
 const std::vector<std::string> RequestParser::BATCH_OPERATIONS{"BatchGetItem", "BatchWriteItem"};


### PR DESCRIPTION
Commit Message: Add `InvalidSignatureException` to supported error types and allow error type being captured by stats.
Risk Level: Low

Signed-off-by: Bob Wang bobwang@lyft.com