### PR TITLE
docs: Update x-envoy-upstream-service-time description to be more accurate

### DIFF
--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -361,8 +361,8 @@ x-envoy-upstream-service-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Contains the time in milliseconds spent by the upstream host processing the request and the network 
-latency between envoy and upstream host. This is useful if the client wants to determine service time 
-compared to network latency between client and envoy. This header is set on responses.
+latency between Envoy and upstream host. This is useful if the client wants to determine service time 
+compared to network latency between client and Envoy. This header is set on responses.
 
 .. _config_http_filters_router_x-envoy-overloaded_set:
 

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -360,9 +360,9 @@ HTTP response headers set on downstream responses
 x-envoy-upstream-service-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Contains the time in milliseconds spent by the upstream host processing the request. This is useful
-if the client wants to determine service time compared to network latency. This header is set on
-responses.
+Contains the time in milliseconds spent by the upstream host processing the request and the network 
+latency between envoy and upstream host. This is useful if the client wants to determine service time 
+compared to network latency between client and envoy. This header is set on responses.
 
 .. _config_http_filters_router_x-envoy-overloaded_set:
 

--- a/docs/root/configuration/http/http_filters/router_filter.rst
+++ b/docs/root/configuration/http/http_filters/router_filter.rst
@@ -360,8 +360,8 @@ HTTP response headers set on downstream responses
 x-envoy-upstream-service-time
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Contains the time in milliseconds spent by the upstream host processing the request and the network 
-latency between Envoy and upstream host. This is useful if the client wants to determine service time 
+Contains the time in milliseconds spent by the upstream host processing the request and the network
+latency between Envoy and upstream host. This is useful if the client wants to determine service time
 compared to network latency between client and Envoy. This header is set on responses.
 
 .. _config_http_filters_router_x-envoy-overloaded_set:


### PR DESCRIPTION
Commit Message: Update docs of `x-envoy-upstream-service-time`.

From the source code, `x-envoy-upstream-service-time` includes the latency of the network from envoy to upstream host and the time cost of upstream host generating responses. But the description in the docs is ambiguous and may lead to confusion in understanding it. Relevant: #12437.

https://github.com/envoyproxy/envoy/blob/d58bdcf86e1fe9ec843c126e778b44e33102bb7a/source/common/router/router.cc#L1268-L1276

Risk Level: N/A
Testing: N/A
Docs Changes: Docs only
Release Notes: N/A

Signed-off-by: wbpcode <comems@msn.com>