### PR TITLE
[server] fix uncaught throws in secondary cluster initialization

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -527,6 +527,7 @@ void InstanceImpl::onRuntimeReady() {
     clusterManager().initializeSecondaryClusters(bootstrap_);
   } catch (const EnvoyException& e) {
     ENVOY_LOG(warn, "Skipping initialization of secondary cluster: {}", e.what());
+    shutdown();
   }
 
   if (bootstrap_.has_hds_config()) {
@@ -546,6 +547,7 @@ void InstanceImpl::onRuntimeReady() {
           *api_);
     } catch (const EnvoyException& e) {
       ENVOY_LOG(warn, "Skipping initialization of HDS cluster: {}", e.what());
+      shutdown();
     }
   }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -523,21 +523,30 @@ void InstanceImpl::onClusterManagerPrimaryInitializationComplete() {
 
 void InstanceImpl::onRuntimeReady() {
   // Begin initializing secondary clusters after RTDS configuration has been applied.
-  clusterManager().initializeSecondaryClusters(bootstrap_);
+  try {
+    clusterManager().initializeSecondaryClusters(bootstrap_);
+  } catch (const EnvoyException& e) {
+    ENVOY_LOG(warn, "Skipping initialization of secondary cluster: {}", e.what());
+  }
 
   if (bootstrap_.has_hds_config()) {
     const auto& hds_config = bootstrap_.hds_config();
-    async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
-        *config_.clusterManager(), thread_local_, time_source_, *api_, grpc_context_.statNames());
-    hds_delegate_ = std::make_unique<Upstream::HdsDelegate>(
-        stats_store_,
-        Config::Utility::factoryForGrpcApiConfigSource(*async_client_manager_, hds_config,
-                                                       stats_store_, false)
-            ->create(),
-        hds_config.transport_api_version(), *dispatcher_, Runtime::LoaderSingleton::get(),
-        stats_store_, *ssl_context_manager_, *random_generator_, info_factory_, access_log_manager_,
-        *config_.clusterManager(), *local_info_, *admin_, *singleton_manager_, thread_local_,
-        messageValidationContext().dynamicValidationVisitor(), *api_);
+    try {
+      async_client_manager_ = std::make_unique<Grpc::AsyncClientManagerImpl>(
+          *config_.clusterManager(), thread_local_, time_source_, *api_, grpc_context_.statNames());
+      hds_delegate_ = std::make_unique<Upstream::HdsDelegate>(
+          stats_store_,
+          Config::Utility::factoryForGrpcApiConfigSource(*async_client_manager_, hds_config,
+                                                         stats_store_, false)
+              ->create(),
+          hds_config.transport_api_version(), *dispatcher_, Runtime::LoaderSingleton::get(),
+          stats_store_, *ssl_context_manager_, *random_generator_, info_factory_,
+          access_log_manager_, *config_.clusterManager(), *local_info_, *admin_,
+          *singleton_manager_, thread_local_, messageValidationContext().dynamicValidationVisitor(),
+          *api_);
+    } catch (const EnvoyException& e) {
+      ENVOY_LOG(warn, "Skipping initialization of HDS cluster: {}", e.what());
+    }
   }
 
   // If there is no global limit to the number of active connections, warn on startup.

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5671992025153536
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5671992025153536
@@ -1,0 +1,122 @@
+static_resources {
+  clusters {
+    name: "ser"
+    connect_timeout {
+      nanos: 813
+    }
+    per_connection_buffer_limit_bytes {
+    }
+    lb_policy: RING_HASH
+    health_checks {
+      timeout {
+        nanos: 95
+      }
+      interval {
+        seconds: 165537
+        nanos: 95
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+      }
+      http_health_check {
+        host: "h"
+        path: "&"
+      }
+      no_traffic_interval {
+        nanos: 25344
+      }
+      healthy_edge_interval {
+        nanos: 95
+      }
+    }
+    http2_protocol_options {
+    }
+    outlier_detection {
+      enforcing_consecutive_local_origin_failure {
+        value: 64
+      }
+    }
+    load_assignment {
+      cluster_name: "."
+      endpoints {
+        locality {
+          sub_zone: "\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+          metadata {
+            filter_metadata {
+              key: ")"
+              value {
+              }
+            }
+          }
+        }
+      }
+      endpoints {
+        locality {
+          sub_zone: "\037\037\037\037\037\037\037\037\037\000\037\037\037\037\037\037\037\037\037\037\037\001\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\031\037\037\037\037\037\037\037\037\037\037\037\037"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: DRAINING
+        }
+      }
+      endpoints {
+        priority: 16
+      }
+      endpoints {
+      }
+      endpoints {
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+        }
+        load_balancing_weight {
+          value: 32768
+        }
+        priority: 16
+      }
+    }
+    least_request_lb_config {
+      choice_count {
+        value: 2046820352
+      }
+    }
+    use_tcp_for_dns_lookups: true
+  }
+}
+stats_flush_interval {
+  nanos: 16777216
+}
+admin {
+  access_log_path: "f"
+  socket_options {
+    level: 4702337453602635775
+  }
+}
+hds_config {
+  cluster_names: "\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177\177"
+}
+enable_dispatcher_stats: true
+use_tcp_for_dns_lookups: true

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5793498489159680
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5793498489159680
@@ -1,0 +1,235 @@
+static_resources {
+  clusters {
+    name: "9NP3372036854775807"
+    connect_timeout {
+      nanos: 250000050
+    }
+    http2_protocol_options {
+      max_outbound_frames {
+        value: 40
+      }
+      stream_error_on_invalid_http_messaging: true
+    }
+    outlier_detection {
+      base_ejection_time {
+        nanos: 25344
+      }
+      enforcing_success_rate {
+        value: 2
+      }
+      success_rate_request_volume {
+        value: 40
+      }
+      enforcing_consecutive_gateway_failure {
+        value: 2
+      }
+      consecutive_local_origin_failure {
+        value: 2
+      }
+    }
+    load_assignment {
+      cluster_name: "."
+      endpoints {
+        locality {
+          sub_zone: "\037\037\037\037\037\037\037\037\037\000\037\037\037\037\037\037\037\037\037\037\037\001\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\031\037\037\037\037\037\037\037\037\037\037\037\037"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: DRAINING
+        }
+      }
+      endpoints {
+        locality {
+          zone: "\177"
+          sub_zone: "\177"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+          metadata {
+            filter_metadata {
+              key: "\177"
+              value {
+              }
+            }
+          }
+        }
+      }
+      endpoints {
+        priority: 16
+      }
+      endpoints {
+        proximity {
+          value: 2
+        }
+      }
+      endpoints {
+        priority: 36
+      }
+    }
+    track_timeout_budgets: true
+  }
+  clusters {
+    name: "ser"
+    connect_timeout {
+      nanos: 813
+    }
+    per_connection_buffer_limit_bytes {
+    }
+    lb_policy: RING_HASH
+    health_checks {
+      timeout {
+        seconds: 1999999
+        nanos: 95
+      }
+      interval {
+        seconds: 165537
+        nanos: 95
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+      }
+      http_health_check {
+        host: "h"
+        path: "&"
+      }
+      no_traffic_interval {
+        nanos: 25344
+      }
+      healthy_edge_interval {
+        nanos: 54784
+      }
+      always_log_health_check_failures: true
+      transport_socket_match_criteria {
+        fields {
+          key: ""
+          value {
+            number_value: 0
+          }
+        }
+        fields {
+          key: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+          value {
+          }
+        }
+      }
+    }
+    outlier_detection {
+      base_ejection_time {
+        nanos: 243315247
+      }
+      enforcing_success_rate {
+        value: 2
+      }
+      success_rate_request_volume {
+        value: 40
+      }
+      consecutive_gateway_failure {
+        value: 512
+      }
+      enforcing_consecutive_gateway_failure {
+        value: 2
+      }
+      consecutive_local_origin_failure {
+        value: 2
+      }
+    }
+    common_lb_config {
+    }
+    alt_stat_name: "\360\240\240\240\360\240\240\240\360\240\240\240\360\240\240\240\360\240\240\240\360\240\240\240\360\240\240\240\340\240\240"
+    common_http_protocol_options {
+      idle_timeout {
+        nanos: 95
+      }
+    }
+    load_assignment {
+      cluster_name: ".."
+      endpoints {
+        locality {
+          sub_zone: "\037\037\037\037\037\037\037\037\037\000\037\037\037\037\037\037\037\037\037\037\037\001\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\031\037\037\037\037\037\037\037\037\037\037\037\037"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+          metadata {
+            filter_metadata {
+              key: "\177"
+              value {
+              }
+            }
+          }
+        }
+        priority: 2
+      }
+      endpoints {
+        locality {
+          sub_zone: "\177"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+        }
+      }
+      endpoints {
+        priority: 16
+      }
+      endpoints {
+        proximity {
+          value: 2
+        }
+      }
+      endpoints {
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+        }
+      }
+    }
+    use_tcp_for_dns_lookups: true
+  }
+}
+watchdog {
+  miss_timeout {
+    nanos: 4096
+  }
+}
+hds_config {
+  api_type: GRPC
+  grpc_services {
+    envoy_grpc {
+      cluster_name: "\\"
+    }
+  }
+  transport_api_version: V2
+}

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-6508841374842880
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-6508841374842880
@@ -1,0 +1,135 @@
+static_resources {
+  clusters {
+    name: "ser"
+    connect_timeout {
+      nanos: 813
+    }
+    lb_policy: RING_HASH
+    health_checks {
+      timeout {
+        nanos: 926363914
+      }
+      interval {
+        seconds: 165537
+        nanos: 95
+      }
+      unhealthy_threshold {
+      }
+      healthy_threshold {
+      }
+      http_health_check {
+        host: "h"
+        path: "\001"
+      }
+      no_traffic_interval {
+        nanos: 25344
+      }
+      healthy_edge_interval {
+        nanos: 54784
+      }
+    }
+    ignore_health_on_host_removal: true
+    load_assignment {
+      cluster_name: "."
+      endpoints {
+        locality {
+          sub_zone: "\037\037\037\037\037\037\037\037\037\037\037U4037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\001\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+        }
+      }
+      endpoints {
+        locality {
+          sub_zone: "\037\037\037\037\037\037\037\037\037\000\037\037\037\037\037\037\037\037\037\037\037\001\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\037\031\037\037\037\037\037\037\037\037\037\037\037\037"
+        }
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: DRAINING
+        }
+      }
+      endpoints {
+        priority: 16
+      }
+      endpoints {
+      }
+      endpoints {
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "."
+              }
+            }
+          }
+          health_status: HEALTHY
+        }
+        priority: 64
+      }
+    }
+    use_tcp_for_dns_lookups: true
+    track_timeout_budgets: true
+  }
+  clusters {
+    name: "7"
+    connect_timeout {
+      nanos: 926363914
+    }
+    http_protocol_options {
+      allow_absolute_url {
+        value: true
+      }
+      enable_trailers: true
+    }
+    dns_lookup_family: V6_ONLY
+    transport_socket {
+      name: "raw_buffer"
+    }
+    protocol_selection: USE_DOWNSTREAM_PROTOCOL
+    common_lb_config {
+      healthy_panic_threshold {
+      }
+    }
+  }
+}
+cluster_manager {
+  load_stats_config {
+    api_type: GRPC
+    grpc_services {
+      google_grpc {
+        target_uri: "2"
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "\"a"
+            token_lifetime_seconds: 140737488355326
+          }
+        }
+        call_credentials {
+          service_account_jwt_access {
+            json_key: "\"a"
+            token_lifetime_seconds: 140737488355326
+          }
+        }
+        stat_prefix: "*"
+        credentials_factory_name: "unix"
+      }
+    }
+    request_timeout {
+      nanos: 14024704
+    }
+  }
+}
+header_prefix: "\001"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message:
Fuzzing testcases produced cases where callbacks after server initialization caused crashes, due to secondary cluster initialization. They're due to exceptions somewhere in the callstack of `factoryForGrpcApiConfigSource`, due to bad configuration for the grpc service configuration.

The secondary clusters are initialized in the server callback `onRuntimeReady`, so we fix this by guarding the cluster initialization by a try/catch block and warning if initialization for these clusters fails.

Risk Level: Low
Testing: Regression tests added
Fixes:
https://github.com/envoyproxy/envoy/issues/12520
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24065
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23673
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22108

I'm not thrilled by adding try/catches everywhere, welcome to suggestions for better fixes.

