### PR TITLE
api: add node field to csds request

### DIFF
--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -62,8 +62,8 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v3.NodeMatcher node_matchers = 1;
 
-  // An opaque identifier for the csds request.
-  string id = 2;
+  // The node making the csds request.
+  config.core.v3.Node node = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -61,6 +61,9 @@ message ClientStatusRequest {
   // Management server can use these match criteria to identify clients.
   // The match follows OR semantics.
   repeated type.matcher.v3.NodeMatcher node_matchers = 1;
+
+  // [#not-implemented-hide:]
+  string id = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -62,7 +62,7 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v3.NodeMatcher node_matchers = 1;
 
-  // [#not-implemented-hide:]
+  // An opaque identifier for the csds request.
   string id = 2;
 }
 
@@ -83,7 +83,6 @@ message PerXdsConfig {
 
     admin.v3.ScopedRoutesConfigDump scoped_route_config = 5;
 
-    // [#not-implemented-hide:]
     admin.v3.EndpointsConfigDump endpoint_config = 6;
   }
 }

--- a/api/envoy/service/status/v4alpha/csds.proto
+++ b/api/envoy/service/status/v4alpha/csds.proto
@@ -62,8 +62,8 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v4alpha.NodeMatcher node_matchers = 1;
 
-  // An opaque identifier for the csds request.
-  string id = 2;
+  // The node making the csds request.
+  config.core.v4alpha.Node node = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/api/envoy/service/status/v4alpha/csds.proto
+++ b/api/envoy/service/status/v4alpha/csds.proto
@@ -62,7 +62,7 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v4alpha.NodeMatcher node_matchers = 1;
 
-  // [#not-implemented-hide:]
+  // An opaque identifier for the csds request.
   string id = 2;
 }
 
@@ -83,7 +83,6 @@ message PerXdsConfig {
 
     admin.v4alpha.ScopedRoutesConfigDump scoped_route_config = 5;
 
-    // [#not-implemented-hide:]
     admin.v4alpha.EndpointsConfigDump endpoint_config = 6;
   }
 }

--- a/api/envoy/service/status/v4alpha/csds.proto
+++ b/api/envoy/service/status/v4alpha/csds.proto
@@ -61,6 +61,9 @@ message ClientStatusRequest {
   // Management server can use these match criteria to identify clients.
   // The match follows OR semantics.
   repeated type.matcher.v4alpha.NodeMatcher node_matchers = 1;
+
+  // [#not-implemented-hide:]
+  string id = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/generated_api_shadow/envoy/service/status/v3/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v3/csds.proto
@@ -62,8 +62,8 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v3.NodeMatcher node_matchers = 1;
 
-  // An opaque identifier for the csds request.
-  string id = 2;
+  // The node making the csds request.
+  config.core.v3.Node node = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/generated_api_shadow/envoy/service/status/v3/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v3/csds.proto
@@ -61,6 +61,9 @@ message ClientStatusRequest {
   // Management server can use these match criteria to identify clients.
   // The match follows OR semantics.
   repeated type.matcher.v3.NodeMatcher node_matchers = 1;
+
+  // [#not-implemented-hide:]
+  string id = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/generated_api_shadow/envoy/service/status/v3/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v3/csds.proto
@@ -62,7 +62,7 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v3.NodeMatcher node_matchers = 1;
 
-  // [#not-implemented-hide:]
+  // An opaque identifier for the csds request.
   string id = 2;
 }
 
@@ -83,7 +83,6 @@ message PerXdsConfig {
 
     admin.v3.ScopedRoutesConfigDump scoped_route_config = 5;
 
-    // [#not-implemented-hide:]
     admin.v3.EndpointsConfigDump endpoint_config = 6;
   }
 }

--- a/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
@@ -62,8 +62,8 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v4alpha.NodeMatcher node_matchers = 1;
 
-  // An opaque identifier for the csds request.
-  string id = 2;
+  // The node making the csds request.
+  config.core.v4alpha.Node node = 2;
 }
 
 // Detailed config (per xDS) with status.

--- a/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
@@ -62,7 +62,7 @@ message ClientStatusRequest {
   // The match follows OR semantics.
   repeated type.matcher.v4alpha.NodeMatcher node_matchers = 1;
 
-  // [#not-implemented-hide:]
+  // An opaque identifier for the csds request.
   string id = 2;
 }
 
@@ -83,7 +83,6 @@ message PerXdsConfig {
 
     admin.v4alpha.ScopedRoutesConfigDump scoped_route_config = 5;
 
-    // [#not-implemented-hide:]
     admin.v4alpha.EndpointsConfigDump endpoint_config = 6;
   }
 }

--- a/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
@@ -61,6 +61,9 @@ message ClientStatusRequest {
   // Management server can use these match criteria to identify clients.
   // The match follows OR semantics.
   repeated type.matcher.v4alpha.NodeMatcher node_matchers = 1;
+
+  // [#not-implemented-hide:]
+  string id = 2;
 }
 
 // Detailed config (per xDS) with status.


### PR DESCRIPTION
Commit Message: added an `node` field to csds request to identify the CSDS client to the CSDS server, and removed the `[#not-implemented-hide:]` for the `endpoint_config` since it has been implemented in #11577
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yutong Li <yutongli@google.com>
/cc @fuqianggao @alexburnos 