### PR TITLE
Use pyyaml safe_load

### DIFF
--- a/tools/config_validation/validate_fragment.py
+++ b/tools/config_validation/validate_fragment.py
@@ -69,4 +69,4 @@ if __name__ == '__main__':
   message_type = parsed_args.message_type
   content = parsed_args.s if (parsed_args.fragment_path is None) else pathlib.Path(
       parsed_args.fragment_path).read_text()
-  ValidateFragment(message_type, yaml.load(content, Loader=yaml.FullLoader))
+  ValidateFragment(message_type, yaml.safe_load(content))

--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -589,7 +589,7 @@ class RstFormatVisitor(visitor.Visitor):
     with open(r.Rlocation('envoy/docs/protodoc_manifest.yaml'), 'r') as f:
       # Load as YAML, emit as JSON and then parse as proto to provide type
       # checking.
-      protodoc_manifest_untyped = yaml.load(f.read())
+      protodoc_manifest_untyped = yaml.safe_load(f.read())
       self.protodoc_manifest = manifest_pb2.Manifest()
       json_format.Parse(json.dumps(protodoc_manifest_untyped), self.protodoc_manifest)
 


### PR DESCRIPTION

Commit Message: Replace pyyaml.load with pyyaml.safe_load
Additional Description:

From my testing there doesnt seem to be any problem switching to `safe_load` in protodoc

Im not sure whether the use in `config_validation` requires a `FullLoader` but i think if it does we should comment it instead

Risk Level: medium without being fixed
Testing: rebuilding docs has been tested with the change to the protodoc compiler
Docs Changes: n/a
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fixes #12533 
[Optional Deprecated:]
