### PR TITLE
udp: Fix potential bug that call the virtual method in destructor

### DIFF
--- a/source/common/network/udp_listener_impl.cc
+++ b/source/common/network/udp_listener_impl.cc
@@ -45,15 +45,17 @@ UdpListenerImpl::UdpListenerImpl(Event::DispatcherImpl& dispatcher, SocketShared
 }
 
 UdpListenerImpl::~UdpListenerImpl() {
-  disable();
+  disableEvent();
   file_event_.reset();
 }
 
-void UdpListenerImpl::disable() { file_event_->setEnabled(0); }
+void UdpListenerImpl::disable() { disableEvent(); }
 
 void UdpListenerImpl::enable() {
   file_event_->setEnabled(Event::FileReadyType::Read | Event::FileReadyType::Write);
 }
+
+void UdpListenerImpl::disableEvent() { file_event_->setEnabled(0); }
 
 void UdpListenerImpl::onSocketEvent(short flags) {
   ASSERT((flags & (Event::FileReadyType::Read | Event::FileReadyType::Write)));

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -54,6 +54,7 @@ protected:
 
 private:
   void onSocketEvent(short flags);
+  void disableEvent();
 
   TimeSource& time_source_;
   Event::FileEventPtr file_event_;


### PR DESCRIPTION
Commit Message:
As you know that the virtual method should not be called in destructor
because it is not guaranteed if virtual function table exist on destructor stage.

There are no crash or abnormal behavior now but it is definitely a potential bug.

So, this patch changes the virtual function calling to non virtual function calling.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>

Additional Description: None
Risk Level: Low
Testing: bazel test
Docs Changes: None
Release Notes: None