### PR TITLE
network: refactor tcp listener to use file events

### DIFF
--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -155,6 +155,12 @@ public:
    * @see man 2 write
    */
   virtual SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) PURE;
+
+  /**
+   * @see man 2 accept
+   */
+  virtual SysCallSocketResult accept(os_fd_t socket, struct sockaddr* addr, socklen_t* addrlen,
+                                     int flags) PURE;
 };
 
 using OsSysCallsPtr = std::unique_ptr<OsSysCalls>;

--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -157,7 +157,7 @@ public:
   virtual SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) PURE;
 
   /**
-   * @see man 2 accept
+   * @see man 2 accept. The fds returned are configured to be non-blocking.
    */
   virtual SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen) PURE;
 };

--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -159,8 +159,7 @@ public:
   /**
    * @see man 2 accept
    */
-  virtual SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen,
-                                     int flags) PURE;
+  virtual SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen) PURE;
 };
 
 using OsSysCallsPtr = std::unique_ptr<OsSysCalls>;

--- a/include/envoy/api/os_sys_calls.h
+++ b/include/envoy/api/os_sys_calls.h
@@ -159,7 +159,7 @@ public:
   /**
    * @see man 2 accept
    */
-  virtual SysCallSocketResult accept(os_fd_t socket, struct sockaddr* addr, socklen_t* addrlen,
+  virtual SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen,
                                      int flags) PURE;
 };
 

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -120,9 +120,6 @@ struct msghdr {
 #define SOCKET_FAILURE(rc) ((rc) == SOCKET_ERROR)
 #define SET_SOCKET_INVALID(sock) (sock) = INVALID_SOCKET
 
-// Envoy socket flags
-#define ENVOY_SOCK_NONBLOCK 0x1
-
 // arguments to shutdown
 #define ENVOY_SHUT_RD SD_RECEIVE
 #define ENVOY_SHUT_WR SD_SEND
@@ -199,13 +196,6 @@ typedef int os_fd_t;
 #define SOCKET_INVALID(sock) ((sock) == -1)
 #define SOCKET_FAILURE(rc) ((rc) == -1)
 #define SET_SOCKET_INVALID(sock) (sock) = -1
-
-// Envoy socket flags
-#if defined(__linux__)
-#define ENVOY_SOCK_NONBLOCK SOCK_NONBLOCK
-#else
-#define ENVOY_SOCK_NONBLOCK 0x1
-#endif
 
 // arguments to shutdown
 #define ENVOY_SHUT_RD SHUT_RD

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -120,6 +120,9 @@ struct msghdr {
 #define SOCKET_FAILURE(rc) ((rc) == SOCKET_ERROR)
 #define SET_SOCKET_INVALID(sock) (sock) = INVALID_SOCKET
 
+// Envoy socket flags
+#define ENVOY_SOCK_NONBLOCK 0x1
+
 // arguments to shutdown
 #define ENVOY_SHUT_RD SD_RECEIVE
 #define ENVOY_SHUT_WR SD_SEND
@@ -196,6 +199,13 @@ typedef int os_fd_t;
 #define SOCKET_INVALID(sock) ((sock) == -1)
 #define SOCKET_FAILURE(rc) ((rc) == -1)
 #define SET_SOCKET_INVALID(sock) (sock) = -1
+
+// Envoy socket flags
+#if defined(__linux__)
+#define ENVOY_SOCK_NONBLOCK SOCK_NONBLOCK
+#else
+#define ENVOY_SOCK_NONBLOCK 0x1
+#endif
 
 // arguments to shutdown
 #define ENVOY_SHUT_RD SHUT_RD

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -166,6 +166,16 @@ public:
   virtual Api::SysCallIntResult listen(int backlog) PURE;
 
   /**
+   * Accept on listening handle
+   * @param addr remote address to be returned
+   * @param addrlen remote address length
+   * @param flags flags to be applied to accepted session
+   * @return accepted IoHandlePtr
+   */
+  virtual std::unique_ptr<IoHandle> accept(struct sockaddr* addr, socklen_t* addrlen,
+                                           int flags) PURE;
+
+  /**
    * Connect to address. The handle should have been created with a call to socket()
    * on this object.
    * @param address remote address to connect to.

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -172,8 +172,7 @@ public:
    * @param flags flags to be applied to accepted session
    * @return accepted IoHandlePtr
    */
-  virtual std::unique_ptr<IoHandle> accept(struct sockaddr* addr, socklen_t* addrlen,
-                                           int flags) PURE;
+  virtual std::unique_ptr<IoHandle> accept(struct sockaddr* addr, socklen_t* addrlen) PURE;
 
   /**
    * Connect to address. The handle should have been created with a call to socket()

--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -187,8 +187,8 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
   return {rc, rc != -1 ? 0 : errno};
 }
 
-SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, struct sockaddr* addr,
-                                           socklen_t* addrlen, int flags) {
+SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen,
+                                           int flags) {
   os_fd_t rc;
 
 #if defined(__linux__)

--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -187,12 +187,11 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
   return {rc, rc != -1 ? 0 : errno};
 }
 
-SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen,
-                                           int flags) {
+SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen) {
   os_fd_t rc;
 
 #if defined(__linux__)
-  rc = ::accept4(sockfd, addr, addrlen, flags);
+  rc = ::accept4(sockfd, addr, addrlen, SOCK_NONBLOCK);
   // If failed with EINVAL try without flags
   if (rc >= 0 || errno != EINVAL) {
     return {rc, rc != -1 ? 0 : errno};
@@ -200,7 +199,7 @@ SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, sockl
 #endif
 
   rc = ::accept(sockfd, addr, addrlen);
-  if (rc >= 0 && (flags & ENVOY_SOCK_NONBLOCK)) {
+  if (rc >= 0) {
     setsocketblocking(rc, false);
   }
 

--- a/source/common/api/posix/os_sys_calls_impl.h
+++ b/source/common/api/posix/os_sys_calls_impl.h
@@ -43,8 +43,7 @@ public:
   SysCallIntResult socketpair(int domain, int type, int protocol, os_fd_t sv[2]) override;
   SysCallIntResult listen(os_fd_t sockfd, int backlog) override;
   SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) override;
-  SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen,
-                             int flags) override;
+  SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen) override;
 };
 
 using OsSysCallsSingleton = ThreadSafeSingleton<OsSysCallsImpl>;

--- a/source/common/api/posix/os_sys_calls_impl.h
+++ b/source/common/api/posix/os_sys_calls_impl.h
@@ -43,6 +43,8 @@ public:
   SysCallIntResult socketpair(int domain, int type, int protocol, os_fd_t sv[2]) override;
   SysCallIntResult listen(os_fd_t sockfd, int backlog) override;
   SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) override;
+  SysCallSocketResult accept(os_fd_t socket, struct sockaddr* addr, socklen_t* addrlen,
+                             int flags) override;
 };
 
 using OsSysCallsSingleton = ThreadSafeSingleton<OsSysCallsImpl>;

--- a/source/common/api/posix/os_sys_calls_impl.h
+++ b/source/common/api/posix/os_sys_calls_impl.h
@@ -43,7 +43,7 @@ public:
   SysCallIntResult socketpair(int domain, int type, int protocol, os_fd_t sv[2]) override;
   SysCallIntResult listen(os_fd_t sockfd, int backlog) override;
   SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) override;
-  SysCallSocketResult accept(os_fd_t socket, struct sockaddr* addr, socklen_t* addrlen,
+  SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen,
                              int flags) override;
 };
 

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -344,5 +344,14 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
   return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
 }
 
+SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, struct sockaddr* addr,
+                                           socklen_t* addrlen, int flags) {
+  const os_fd_t rc = ::accept(sockfd, addr, addrlen);
+  if (rc > 0 && (flags & SOCK_NONBLOCK)) {
+    setsocketblocking(sockfd, false);
+  }
+  return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
+}
+
 } // namespace Api
 } // namespace Envoy

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -344,15 +344,13 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
   return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
 }
 
-SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen,
-                                           int flags) {
+SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlens) {
   const os_fd_t rc = ::accept(sockfd, addr, addrlen);
   if (SOCKET_INVALID(rc)) {
     return {rc, ::WSAGetLastError()};
   }
-  if (flags & ENVOY_SOCK_NONBLOCK) {
-    setsocketblocking(rc, false);
-  }
+
+  setsocketblocking(rc, false);
   return {rc, 0};
 }
 

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -344,13 +344,16 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
   return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
 }
 
-SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, struct sockaddr* addr,
-                                           socklen_t* addrlen, int flags) {
+SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen,
+                                           int flags) {
   const os_fd_t rc = ::accept(sockfd, addr, addrlen);
-  if (rc > 0 && (flags & ENVOY_SOCK_NONBLOCK)) {
+  if (SOCKET_INVALID(rc)) {
+    return {rc, ::WSAGetLastError()};
+  }
+  if (flags & ENVOY_SOCK_NONBLOCK) {
     setsocketblocking(rc, false);
   }
-  return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
+  return {rc, 0};
 }
 
 } // namespace Api

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -344,7 +344,7 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
   return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
 }
 
-SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlens) {
+SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, sockaddr* addr, socklen_t* addrlen) {
   const os_fd_t rc = ::accept(sockfd, addr, addrlen);
   if (SOCKET_INVALID(rc)) {
     return {rc, ::WSAGetLastError()};

--- a/source/common/api/win32/os_sys_calls_impl.cc
+++ b/source/common/api/win32/os_sys_calls_impl.cc
@@ -347,8 +347,8 @@ SysCallSizeResult OsSysCallsImpl::write(os_fd_t sockfd, const void* buffer, size
 SysCallSocketResult OsSysCallsImpl::accept(os_fd_t sockfd, struct sockaddr* addr,
                                            socklen_t* addrlen, int flags) {
   const os_fd_t rc = ::accept(sockfd, addr, addrlen);
-  if (rc > 0 && (flags & SOCK_NONBLOCK)) {
-    setsocketblocking(sockfd, false);
+  if (rc > 0 && (flags & ENVOY_SOCK_NONBLOCK)) {
+    setsocketblocking(rc, false);
   }
   return {rc, rc != -1 ? 0 : ::WSAGetLastError()};
 }

--- a/source/common/api/win32/os_sys_calls_impl.h
+++ b/source/common/api/win32/os_sys_calls_impl.h
@@ -44,7 +44,7 @@ public:
   SysCallIntResult socketpair(int domain, int type, int protocol, os_fd_t sv[2]) override;
   SysCallIntResult listen(os_fd_t sockfd, int backlog) override;
   SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) override;
-  SysCallSocketResult accept(os_fd_t socket, struct sockaddr* addr, socklen_t* addrlen,
+  SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen,
                              int flags) override;
 };
 

--- a/source/common/api/win32/os_sys_calls_impl.h
+++ b/source/common/api/win32/os_sys_calls_impl.h
@@ -44,8 +44,7 @@ public:
   SysCallIntResult socketpair(int domain, int type, int protocol, os_fd_t sv[2]) override;
   SysCallIntResult listen(os_fd_t sockfd, int backlog) override;
   SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) override;
-  SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen,
-                             int flags) override;
+  SysCallSocketResult accept(os_fd_t socket, sockaddr* addr, socklen_t* addrlen) override;
 };
 
 using OsSysCallsSingleton = ThreadSafeSingleton<OsSysCallsImpl>;

--- a/source/common/api/win32/os_sys_calls_impl.h
+++ b/source/common/api/win32/os_sys_calls_impl.h
@@ -44,6 +44,8 @@ public:
   SysCallIntResult socketpair(int domain, int type, int protocol, os_fd_t sv[2]) override;
   SysCallIntResult listen(os_fd_t sockfd, int backlog) override;
   SysCallSizeResult write(os_fd_t socket, const void* buffer, size_t length) override;
+  SysCallSocketResult accept(os_fd_t socket, struct sockaddr* addr, socklen_t* addrlen,
+                             int flags) override;
 };
 
 using OsSysCallsSingleton = ThreadSafeSingleton<OsSysCallsImpl>;

--- a/source/common/event/libevent.h
+++ b/source/common/event/libevent.h
@@ -34,7 +34,6 @@ private:
 };
 
 using BasePtr = CSmartPtr<event_base, event_base_free>;
-using ListenerPtr = CSmartPtr<evconnlistener, evconnlistener_free>;
 
 } // namespace Libevent
 } // namespace Event

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -247,7 +247,6 @@ envoy_cc_library(
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",
         "//source/common/event:dispatcher_includes",
-        "//source/common/event:libevent_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/network/base_listener_impl.h
+++ b/source/common/network/base_listener_impl.h
@@ -3,10 +3,7 @@
 #include "envoy/network/listener.h"
 
 #include "common/event/dispatcher_impl.h"
-#include "common/event/libevent.h"
 #include "common/network/listen_socket_impl.h"
-
-#include "event2/event.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -389,7 +389,7 @@ Api::SysCallIntResult IoSocketHandleImpl::listen(int backlog) {
 
 IoHandlePtr IoSocketHandleImpl::accept(struct sockaddr* addr, socklen_t* addrlen, int flags) {
   auto result = Api::OsSysCallsSingleton::get().accept(fd_, addr, addrlen, flags);
-  if (result.rc_ < 0) {
+  if (SOCKET_INVALID(result.rc_)) {
     return nullptr;
   }
 

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -387,6 +387,15 @@ Api::SysCallIntResult IoSocketHandleImpl::listen(int backlog) {
   return Api::OsSysCallsSingleton::get().listen(fd_, backlog);
 }
 
+IoHandlePtr IoSocketHandleImpl::accept(struct sockaddr* addr, socklen_t* addrlen, int flags) {
+  auto result = Api::OsSysCallsSingleton::get().accept(fd_, addr, addrlen, flags);
+  if (result.rc_ < 0) {
+    return nullptr;
+  }
+
+  return std::make_unique<IoSocketHandleImpl>(result.rc_, socket_v6only_);
+}
+
 Api::SysCallIntResult IoSocketHandleImpl::connect(Address::InstanceConstSharedPtr address) {
   return Api::OsSysCallsSingleton::get().connect(fd_, address->sockAddr(), address->sockAddrLen());
 }

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -387,8 +387,8 @@ Api::SysCallIntResult IoSocketHandleImpl::listen(int backlog) {
   return Api::OsSysCallsSingleton::get().listen(fd_, backlog);
 }
 
-IoHandlePtr IoSocketHandleImpl::accept(struct sockaddr* addr, socklen_t* addrlen, int flags) {
-  auto result = Api::OsSysCallsSingleton::get().accept(fd_, addr, addrlen, flags);
+IoHandlePtr IoSocketHandleImpl::accept(struct sockaddr* addr, socklen_t* addrlen) {
+  auto result = Api::OsSysCallsSingleton::get().accept(fd_, addr, addrlen);
   if (SOCKET_INVALID(result.rc_)) {
     return nullptr;
   }

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -49,6 +49,7 @@ public:
 
   Api::SysCallIntResult bind(Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult listen(int backlog) override;
+  IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen, int flags) override;
   Api::SysCallIntResult connect(Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult setOption(int level, int optname, const void* optval,
                                   socklen_t optlen) override;

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -49,7 +49,7 @@ public:
 
   Api::SysCallIntResult bind(Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult listen(int backlog) override;
-  IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen, int flags) override;
+  IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen) override;
   Api::SysCallIntResult connect(Address::InstanceConstSharedPtr address) override;
   Api::SysCallIntResult setOption(int level, int optname, const void* optval,
                                   socklen_t optlen) override;

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -43,8 +43,7 @@ template <typename T> class NetworkListenSocket : public ListenSocketImpl {
 public:
   NetworkListenSocket(const Address::InstanceConstSharedPtr& address,
                       const Network::Socket::OptionsSharedPtr& options, bool bind_to_port)
-      : ListenSocketImpl(Network::SocketInterfaceSingleton::get().socket(T::type, address),
-                         address) {
+      : ListenSocketImpl(Network::ioHandleForAddr(T::type, address), address) {
     RELEASE_ASSERT(SOCKET_VALID(io_handle_->fd()), "");
 
     setPrebindSocketOptions();

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -91,16 +91,11 @@ void ListenerImpl::onSocketEvent(short flags) {
 }
 
 void ListenerImpl::setupServerSocket(Event::DispatcherImpl& dispatcher, Socket& socket) {
-#ifdef WIN32
-  auto trigger = Event::FileTriggerType::Level;
-#else
-  auto trigger = Event::FileTriggerType::Edge;
-#endif
   // TODO(fcoras): make listen backlog configurable
   socket.ioHandle().listen(128);
   file_event_ = dispatcher.createFileEvent(
-      socket.ioHandle().fd(), [this](uint32_t events) -> void { onSocketEvent(events); }, trigger,
-      Event::FileReadyType::Read);
+      socket.ioHandle().fd(), [this](uint32_t events) -> void { onSocketEvent(events); },
+      Event::FileTriggerType::Level, Event::FileReadyType::Read);
 
   RELEASE_ASSERT(file_event_, "file event must be valid");
 

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -49,11 +49,11 @@ void ListenerImpl::onSocketEvent(short flags) {
       PANIC(fmt::format("listener accept failure: {}", errorDetails(errno)));
     }
 
-    struct sockaddr_storage remote_addr;
+    sockaddr_storage remote_addr;
     socklen_t remote_addr_len = sizeof(remote_addr);
 
-    IoHandlePtr io_handle = socket_->ioHandle().accept(
-        reinterpret_cast<struct sockaddr*>(&remote_addr), &remote_addr_len, ENVOY_SOCK_NONBLOCK);
+    IoHandlePtr io_handle = socket_->ioHandle().accept(reinterpret_cast<sockaddr*>(&remote_addr),
+                                                       &remote_addr_len, ENVOY_SOCK_NONBLOCK);
     if (io_handle == nullptr) {
       break;
     }

--- a/source/common/network/listener_impl.cc
+++ b/source/common/network/listener_impl.cc
@@ -14,8 +14,6 @@
 #include "common/network/address_impl.h"
 #include "common/network/io_socket_handle_impl.h"
 
-#include "event2/listener.h"
-
 namespace Envoy {
 namespace Network {
 
@@ -55,7 +53,7 @@ void ListenerImpl::onSocketEvent(short flags) {
     socklen_t remote_addr_len = sizeof(remote_addr);
 
     IoHandlePtr io_handle = socket_->ioHandle().accept(
-        reinterpret_cast<struct sockaddr*>(&remote_addr), &remote_addr_len, SOCK_NONBLOCK);
+        reinterpret_cast<struct sockaddr*>(&remote_addr), &remote_addr_len, ENVOY_SOCK_NONBLOCK);
     if (io_handle == nullptr) {
       break;
     }
@@ -121,7 +119,7 @@ ListenerImpl::ListenerImpl(Event::DispatcherImpl& dispatcher, SocketSharedPtr so
 
 ListenerImpl::~ListenerImpl() {
   if (file_event_.get()) {
-    disable();
+    file_event_->setEnabled(0);
     file_event_.reset();
   }
 }

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -16,7 +16,6 @@ class ListenerImpl : public BaseListenerImpl {
 public:
   ListenerImpl(Event::DispatcherImpl& dispatcher, SocketSharedPtr socket, ListenerCallbacks& cb,
                bool bind_to_port);
-  ~ListenerImpl() override;
   void disable() override;
   void enable() override;
 

--- a/source/common/network/listener_impl.h
+++ b/source/common/network/listener_impl.h
@@ -16,7 +16,7 @@ class ListenerImpl : public BaseListenerImpl {
 public:
   ListenerImpl(Event::DispatcherImpl& dispatcher, SocketSharedPtr socket, ListenerCallbacks& cb,
                bool bind_to_port);
-
+  ~ListenerImpl() override;
   void disable() override;
   void enable() override;
 
@@ -28,15 +28,13 @@ protected:
   ListenerCallbacks& cb_;
 
 private:
-  static void listenCallback(evconnlistener*, evutil_socket_t fd, sockaddr* remote_addr,
-                             int remote_addr_len, void* arg);
-  static void errorCallback(evconnlistener* listener, void* context);
+  void onSocketEvent(short flags);
 
   // Returns true if global connection limit has been reached and the accepted socket should be
   // rejected/closed. If the accepted socket is to be admitted, false is returned.
   static bool rejectCxOverGlobalLimit();
 
-  Event::Libevent::ListenerPtr listener_;
+  Event::FileEventPtr file_event_;
 };
 
 } // namespace Network

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -68,6 +68,9 @@ public:
     return io_handle_.bind(address);
   }
   Api::SysCallIntResult listen(int backlog) override { return io_handle_.listen(backlog); }
+  Network::IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen, int flags) override {
+    return io_handle_.accept(addr, addrlen, flags);
+  }
   Api::SysCallIntResult connect(Network::Address::InstanceConstSharedPtr address) override {
     return io_handle_.connect(address);
   }

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -68,8 +68,8 @@ public:
     return io_handle_.bind(address);
   }
   Api::SysCallIntResult listen(int backlog) override { return io_handle_.listen(backlog); }
-  Network::IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen, int flags) override {
-    return io_handle_.accept(addr, addrlen, flags);
+  Network::IoHandlePtr accept(struct sockaddr* addr, socklen_t* addrlen) override {
+    return io_handle_.accept(addr, addrlen);
   }
   Api::SysCallIntResult connect(Network::Address::InstanceConstSharedPtr address) override {
     return io_handle_.connect(address);

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -32,6 +32,7 @@ public:
   MOCK_METHOD(bool, supportsUdpGro, (), (const));
   MOCK_METHOD(Api::SysCallIntResult, bind, (Address::InstanceConstSharedPtr address));
   MOCK_METHOD(Api::SysCallIntResult, listen, (int backlog));
+  MOCK_METHOD(IoHandlePtr, accept, (struct sockaddr * addr, socklen_t* addrlen, int flags));
   MOCK_METHOD(Api::SysCallIntResult, connect, (Address::InstanceConstSharedPtr address));
   MOCK_METHOD(Api::SysCallIntResult, setOption,
               (int level, int optname, const void* optval, socklen_t optlen));

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -32,7 +32,7 @@ public:
   MOCK_METHOD(bool, supportsUdpGro, (), (const));
   MOCK_METHOD(Api::SysCallIntResult, bind, (Address::InstanceConstSharedPtr address));
   MOCK_METHOD(Api::SysCallIntResult, listen, (int backlog));
-  MOCK_METHOD(IoHandlePtr, accept, (struct sockaddr * addr, socklen_t* addrlen, int flags));
+  MOCK_METHOD(IoHandlePtr, accept, (struct sockaddr * addr, socklen_t* addrlen));
   MOCK_METHOD(Api::SysCallIntResult, connect, (Address::InstanceConstSharedPtr address));
   MOCK_METHOD(Api::SysCallIntResult, setOption,
               (int level, int optname, const void* optval, socklen_t optlen));


### PR DESCRIPTION
IoHandle specific, implicitly, socket interface specific,
implementations of listen and accept are now used to accept new
IoHandles, instead of the os specific sycalls libevent leverages
internally for listeners.

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Medium
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
