### PR TITLE
build: Add support for aarch64 cross-compilation with gcc

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -76,6 +76,8 @@ jobs:
       matrix:
         gcc:
           CI_TARGET: "bazel.gcc"
+        gcc_cross_aarch64:
+          CI_TARGET: "bazel.gcc.cross_aarch64"
         clang_tidy:
           CI_TARGET: "bazel.clang_tidy"
         asan:

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -270,6 +270,11 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_aarch64_cross",
+    values = {"cpu": "aarch64-cross"},
+)
+
+config_setting(
     name = "linux_ppc",
     values = {"cpu": "ppc"},
 )

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -258,6 +258,16 @@ Or use our configuration with Remote Execution or Docker sandbox, pass `--config
 
 If you want to make libc++ as default, add a line `build --config=libc++` to the `user.bazelrc` file in Envoy source root.
 
+## Cross-compilation for aarch64
+
+To build Envoy for aarch64 target on x86_64:
+```
+bazel build \
+    --crosstool_top=@envoy_build_tools//toolchains/configs/linux/gcc/bazel_3.4.1/cc:toolchain \
+    --cpu=aarch64-cross \
+    //source/exe:envoy-static
+```
+
 ## Using a compiler toolchain in a non-standard location
 
 By setting the `CC` and `LD_LIBRARY_PATH` in the environment that Bazel executes from as

--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -77,7 +77,7 @@ def envoy_cmake_external(
         copy_pdb = False,
         pdb_name = "",
         cmake_files_dir = "$BUILD_TMPDIR/CMakeFiles",
-        generate_crosstool_file = False,
+        generate_crosstool_file = True,
         **kwargs):
     cache_entries.update({"CMAKE_BUILD_TYPE": "Bazel"})
     cache_entries_debug = dict(cache_entries)
@@ -108,11 +108,6 @@ def envoy_cmake_external(
             "//conditions:default": cache_entries_debug,
         }),
         cmake_options = cmake_options,
-        # TODO(lizan): Make this always true
-        generate_crosstool_file = select({
-            "@envoy//bazel:windows_x86_64": True,
-            "//conditions:default": generate_crosstool_file,
-        }),
         lib_source = lib_source,
         make_commands = make_commands,
         postfix_script = pf,

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -16,6 +16,7 @@ configure_make(
         "--disable-libunwind",
     ] + select({
         "//bazel:apple": ["AR=/usr/bin/ar"],
+        "//bazel:linux_aarch64_cross": ["--host aarch64-linux-gnu"],
         "//conditions:default": [],
     }),
     lib_source = "@com_github_gperftools_gperftools//:all",
@@ -46,6 +47,10 @@ configure_make(
         # TODO(htuch): Remove when #6084 is fixed
         "//bazel:asan_build": {"ENVOY_CONFIG_ASAN": "1"},
         "//bazel:msan_build": {"ENVOY_CONFIG_MSAN": "1"},
+        "//bazel:linux_aarch64_cross": {
+            "CC": "gcc",
+            "CROSS": "aarch64-linux-gnu-",
+        },
         "//conditions:default": {},
     }),
     lib_source = "@com_github_luajit_luajit//:all",
@@ -67,6 +72,10 @@ configure_make(
         # TODO(htuch): Remove when #6084 is fixed
         "//bazel:asan_build": {"ENVOY_CONFIG_ASAN": "1"},
         "//bazel:msan_build": {"ENVOY_CONFIG_MSAN": "1"},
+        "//bazel:linux_aarch64_cross": {
+            "CC": "gcc",
+            "CROSS": "aarch64-linux-gnu-",
+        },
         "//conditions:default": {},
     }),
     lib_source = "@com_github_moonjit_moonjit//:all",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -67,10 +67,10 @@ DEPENDENCY_REPOSITORIES = dict(
         use_category = ["build"],
     ),
     envoy_build_tools = dict(
-        sha256 = "88e58fdb42021e64a0b35ae3554a82e92f5c37f630a4dab08a132fc77f8db4b7",
-        strip_prefix = "envoy-build-tools-1d6573e60207efaae6436b25ecc594360294f63a",
-        # 2020-07-18
-        urls = ["https://github.com/envoyproxy/envoy-build-tools/archive/1d6573e60207efaae6436b25ecc594360294f63a.tar.gz"],
+        sha256 = "9c014ba5054455c270fc490c86e0213ca0b8cb98cfd888c78135ad0c0a69f36d",
+        strip_prefix = "envoy-build-tools-3324f56f51c0e91a72b353f1decae6a721f5a02d",
+        # WIP(mrostecki): Switch to upstream repo as soon as the PR is merged.
+        urls = ["https://github.com/mrostecki/envoy-build-tools/archive/3324f56f51c0e91a72b353f1decae6a721f5a02d.tar.gz"],
         use_category = ["build"],
     ),
     boringssl = dict(

--- a/ci/README.md
+++ b/ci/README.md
@@ -116,9 +116,11 @@ The `./ci/run_envoy_docker.sh './ci/do_ci.sh <TARGET>'` targets are:
 * `bazel.sizeopt` &mdash; build Envoy static binary and run tests under `-c opt --config=sizeopt` with clang.
 * `bazel.sizeopt <test>` &mdash; build Envoy static binary and run a specified test or test dir under `-c opt --config=sizeopt` with clang.
 * `bazel.sizeopt.server_only` &mdash; build Envoy static binary under `-c opt --config=sizeopt` with clang.
-* `bazel.coverage` &mdash; build and run tests under `-c dbg` with gcc, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
+* `bazel.gcc` &mdash; build Envoy static binary and run tests under `-c opt` with gcc.
+* `bazel.gcc.cross_aarch64` &mdash; cross-build Envoy static binary for aarch64 target with gcc.
+* `bazel.coverage` &mdash; build and run tests under `-c dbg` with clang, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
 * `bazel.coverage <test>` &mdash; build and run a specified test or test dir under `-c dbg` with gcc, generating coverage information in `$ENVOY_DOCKER_BUILD_DIR/envoy/generated/coverage/coverage.html`.
-* `bazel.coverity` &mdash; build Envoy static binary and run Coverity Scan static analysis.
+* `bazel.coverity` &mdash; build Envoy static binary with gcc and run Coverity Scan static analysis.
 * `bazel.msan` &mdash; build and run tests under `-c dbg --config=clang-msan` with clang.
 * `bazel.msan <test>` &mdash; build and run a specified test or test dir under `-c dbg --config=clang-msan` with clang.
 * `bazel.tsan` &mdash; build and run tests under `-c dbg --config=clang-tsan` with clang.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -154,6 +154,14 @@ elif [[ "$CI_TARGET" == "bazel.gcc" ]]; then
   echo "bazel release build with gcc..."
   bazel_binary_build release
   exit 0
+elif [[ "$CI_TARGET" == "bazel.gcc.cross_aarch64" ]]; then
+  BAZEL_BUILD_OPTIONS+="--crosstool_top=@envoy_build_tools//toolchains/configs/linux/gcc/bazel_3.4.1/cc:toolchain"
+  BAZEL_BUILD_OPTIONS+="--cpu=aarch64-cross"
+  setup_gcc_toolchain
+
+  echo "bazel release aarch64 cross build with gcc..."
+  bazel_binary_build release
+  exit 0
 elif [[ "$CI_TARGET" == "bazel.debug" ]]; then
   setup_clang_toolchain
   echo "Testing ${TEST_TARGETS}"

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -71,6 +71,7 @@ New Features
 * tcp: switched the TCP connection pool to the new "shared" connection pool, sharing a common code base with HTTP and HTTP/2. Any unexpected behavioral changes can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
 * watchdog: support randomizing the watchdog's kill timeout to prevent synchronized kills via a maximium jitter parameter :ref:`max_kill_timeout_jitter<envoy_v3_api_field_config.bootstrap.v3.Watchdog.max_kill_timeout_jitter>`.
 * xds: added :ref:`extension config discovery<envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP filters.
+* build: added support for aarch64 cross-compilation with gcc.
 
 Deprecated
 ----------


### PR DESCRIPTION
This change adds the possibility to cross-compile Envoy for aarch64
target on k8 host by using the new toolchain from envoy-build-tools.

The following command should be used to build with that toolchain:

```
bazel build \
    --crosstool_top=@envoy_build_tools//toolchains/configs/linux/gcc/bazel_3.4.1/cc:toolchain \
    --cpu=aarch64-cross \
    //source/exe:envoy-static
```

Risk Level: Low
Testing: new CI job
Docs Changes: added (CI and Bazel README)
Release Notes: added

Signed-off-by: Ilya Dmitrichenko <errordeveloper@gmail.com>
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>
