### PR TITLE
tidy: mark virtual functions called in ctor/dtor final

### DIFF
--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -60,7 +60,7 @@ public:
   // Network::Connection
   void addBytesSentCallback(BytesSentCb cb) override;
   void enableHalfClose(bool enabled) override;
-  void close(ConnectionCloseType type) override;
+  void close(ConnectionCloseType type) final;
   std::string nextProtocol() const override { return transport_socket_->protocol(); }
   void noDelay(bool enable) override;
   void readDisable(bool disable) override;
@@ -132,7 +132,7 @@ protected:
   bool consumerWantsToRead();
 
   // Network::ConnectionImplBase
-  void closeConnectionImmediately() override;
+  void closeConnectionImmediately() final;
 
   void closeSocket(ConnectionEvent close_type);
 

--- a/source/common/ssl/certificate_validation_context_config_impl.h
+++ b/source/common/ssl/certificate_validation_context_config_impl.h
@@ -21,7 +21,7 @@ public:
   const std::string& certificateRevocationList() const override {
     return certificate_revocation_list_;
   }
-  const std::string& certificateRevocationListPath() const override {
+  const std::string& certificateRevocationListPath() const final {
     return certificate_revocation_list_path_;
   }
   const std::vector<std::string>& verifySubjectAltNameList() const override {

--- a/source/common/stats/allocator_impl.cc
+++ b/source/common/stats/allocator_impl.cc
@@ -63,7 +63,7 @@ public:
   }
 
   // Metric
-  SymbolTable& symbolTable() override { return alloc_.symbolTable(); }
+  SymbolTable& symbolTable() final { return alloc_.symbolTable(); }
   bool used() const override { return flags_ & Metric::Flags::Used; }
 
   // RefcountInterface

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -108,7 +108,7 @@ public:
   void recordValue(uint64_t value) override { parent_.deliverHistogramToSinks(*this, value); }
 
   bool used() const override { return true; }
-  SymbolTable& symbolTable() override { return parent_.symbolTable(); }
+  SymbolTable& symbolTable() final { return parent_.symbolTable(); }
 
 private:
   Unit unit_;

--- a/source/common/stats/scope_prefixer.h
+++ b/source/common/stats/scope_prefixer.h
@@ -49,8 +49,8 @@ public:
   HistogramOptConstRef findHistogram(StatName name) const override;
   TextReadoutOptConstRef findTextReadout(StatName name) const override;
 
-  const SymbolTable& constSymbolTable() const override { return scope_.constSymbolTable(); }
-  SymbolTable& symbolTable() override { return scope_.symbolTable(); }
+  const SymbolTable& constSymbolTable() const final { return scope_.constSymbolTable(); }
+  SymbolTable& symbolTable() final { return scope_.symbolTable(); }
 
   NullGaugeImpl& nullGauge(const std::string& str) override { return scope_.nullGauge(str); }
 

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -59,7 +59,7 @@ public:
   void recordValue(uint64_t value) override;
 
   // Stats::Metric
-  SymbolTable& symbolTable() override { return symbol_table_; }
+  SymbolTable& symbolTable() final { return symbol_table_; }
   bool used() const override { return used_; }
 
 private:
@@ -334,13 +334,14 @@ private:
     ScopePtr createScope(const std::string& name) override {
       return parent_.createScope(symbolTable().toString(prefix_.statName()) + "." + name);
     }
-    const SymbolTable& constSymbolTable() const override { return parent_.constSymbolTable(); }
-    SymbolTable& symbolTable() override { return parent_.symbolTable(); }
+    const SymbolTable& constSymbolTable() const final { return parent_.constSymbolTable(); }
+    SymbolTable& symbolTable() final { return parent_.symbolTable(); }
 
     Counter& counterFromString(const std::string& name) override {
       StatNameManagedStorage storage(name, symbolTable());
       return counterFromStatName(storage.statName());
     }
+
     Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override {
       StatNameManagedStorage storage(name, symbolTable());
       return gaugeFromStatName(storage.statName(), import_mode);

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -322,7 +322,7 @@ public:
     bool on_high_watermark_called_{false};
   };
 
-  virtual StreamInfo::StreamInfo& getStreamInfo();
+  StreamInfo::StreamInfo& getStreamInfo();
 
 protected:
   struct DownstreamCallbacks : public Network::ConnectionCallbacks {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -196,7 +196,7 @@ public:
   }
   void healthFlagClear(HealthFlag flag) override { health_flags_ &= ~enumToInt(flag); }
   bool healthFlagGet(HealthFlag flag) const override { return health_flags_ & enumToInt(flag); }
-  void healthFlagSet(HealthFlag flag) override { health_flags_ |= enumToInt(flag); }
+  void healthFlagSet(HealthFlag flag) final { health_flags_ |= enumToInt(flag); }
 
   ActiveHealthFailureType getActiveHealthFailureType() const override {
     return active_health_failure_type_;

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
@@ -89,7 +89,7 @@ private:
     Network::Address::InstanceConstSharedPtr address() override { return address_; }
     const std::string& resolvedHost() const override { return resolved_host_; }
     bool isIpAddress() const override { return is_ip_address_; }
-    void touch() override { last_used_time_ = time_source_.monotonicTime().time_since_epoch(); }
+    void touch() final { last_used_time_ = time_source_.monotonicTime().time_since_epoch(); }
 
     TimeSource& time_source_;
     const std::string resolved_host_;

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -22,7 +22,7 @@ public:
 
   ~JwksFetcherImpl() override { cancel(); }
 
-  void cancel() override {
+  void cancel() final {
     if (request_ && !complete_) {
       request_->cancel();
       ENVOY_LOG(debug, "fetch pubkey [uri = {}]: canceled", uri_->uri());

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -115,7 +115,7 @@ public:
     return it->second;
   }
 
-  JwksData* findByProvider(const std::string& provider) override {
+  JwksData* findByProvider(const std::string& provider) final {
     const auto it = jwks_data_map_.find(provider);
     if (it == jwks_data_map_.end()) {
       return nullptr;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -226,7 +226,7 @@ private:
   }
 
   // Upstream::ClusterUpdateCallbacks
-  void onClusterAddOrUpdate(Upstream::ThreadLocalCluster& cluster) override;
+  void onClusterAddOrUpdate(Upstream::ThreadLocalCluster& cluster) final;
   void onClusterRemoval(const std::string& cluster_name) override;
 
   const UdpProxyFilterConfigSharedPtr config_;


### PR DESCRIPTION
Prevents undefined behavior and let clang-tidy not warn about it.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>

