### PR TITLE
build: Fix that selective testing does not work

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -101,7 +101,7 @@ function bazel_binary_build() {
 CI_TARGET=$1
 shift
 
-if [[ $# -gt 1 ]]; then
+if [[ $# -ge 1 ]]; then
   COVERAGE_TEST_TARGETS=$*
   TEST_TARGETS="$COVERAGE_TEST_TARGETS"
 else


### PR DESCRIPTION
Commit Message:
As you know that the envoy build system has a functionality that can choose some tests
to do test manually.

But now, to do that, I need to add a dummy argument when I execute the do_ci.sh
like as following:
/ci/run_envoy_docker.sh "./ci/do_ci.sh bazel.dev '' //test/common/network:udp_listener_impl_test".

So, this patch fixes that selective testing works like as previous behavior.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: bazel test
Docs Changes: None
Release Notes: None