### PR TITLE
build: Fix that cpu usage of bazel for dev

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -110,6 +110,8 @@ else
   TEST_TARGETS="${COVERAGE_TEST_TARGETS} @com_googlesource_quiche//:ci_tests"
 fi
 
+BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --local_cpu_resources=${NUM_CPUS}"
+
 if [[ "$CI_TARGET" == "bazel.release" ]]; then
   # When testing memory consumption, we want to test against exact byte-counts
   # where possible. As these differ between platforms and compile options, we


### PR DESCRIPTION
Commit Message:
The envoy build system has a very useful funtionality that can limit cpu usage for bazel.
The bazel eat up so many cpu cores if there is no limitation option for that. :(

The some computers that like as my computer is frozen because bazel eat up all my cores of computer. :(
So, the NUM_CPUS variable is very useful for development environment so that this patch set
the --local_cpu_resources option to limit maximum cpus that can consume by bazel.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: bazel build and test
Docs Changes: None
Release Notes: None