### PR TITLE
Add const qualifier to returned pointers in MockIp and MockResolvedAddress

### DIFF
--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -413,8 +413,8 @@ public:
   MOCK_METHOD(const std::string&, addressAsString, (), (const));
   MOCK_METHOD(bool, isAnyAddress, (), (const));
   MOCK_METHOD(bool, isUnicastAddress, (), (const));
-  MOCK_METHOD(Address::Ipv4*, ipv4, (), (const));
-  MOCK_METHOD(Address::Ipv6*, ipv6, (), (const));
+  MOCK_METHOD(const Address::Ipv4*, ipv4, (), (const));
+  MOCK_METHOD(const Address::Ipv6*, ipv6, (), (const));
   MOCK_METHOD(uint32_t, port, (), (const));
   MOCK_METHOD(Address::IpVersion, version, (), (const));
   MOCK_METHOD(bool, v6only, (), (const));
@@ -432,11 +432,11 @@ public:
 
   MOCK_METHOD(Api::SysCallIntResult, bind, (os_fd_t), (const));
   MOCK_METHOD(Api::SysCallIntResult, connect, (os_fd_t), (const));
-  MOCK_METHOD(Address::Ip*, ip, (), (const));
-  MOCK_METHOD(Address::Pipe*, pipe, (), (const));
+  MOCK_METHOD(const Address::Ip*, ip, (), (const));
+  MOCK_METHOD(const Address::Pipe*, pipe, (), (const));
   MOCK_METHOD(IoHandlePtr, socket, (Socket::Type), (const));
   MOCK_METHOD(Address::Type, type, (), (const));
-  MOCK_METHOD(sockaddr*, sockAddr, (), (const));
+  MOCK_METHOD(const sockaddr*, sockAddr, (), (const));
   MOCK_METHOD(socklen_t, sockAddrLen, (), (const));
 
   const std::string& asString() const override { return physical_; }


### PR DESCRIPTION
Compared to their superclasses, the MockIp and MockResolvedAddress
classes drop the const qualifier from the pointers they return.
Since the non-mock class implementing these methods return const
pointers, it’s difficult to use non-mock classes with these mocks
without resorting to hacks like const_cast.

Risk Level: low
Testing: bazel test //test/extensions/filters/network/rocketmq_proxy/... //test/common/network:resolver_test //test/common/router:config_impl_test
Documentation: N/A
Release Notes: N/A

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

