### PR TITLE
Revert buffer filter visibility back to public

### DIFF
--- a/source/extensions/filters/http/buffer/BUILD
+++ b/source/extensions/filters/http/buffer/BUILD
@@ -39,7 +39,6 @@ envoy_cc_extension(
     hdrs = ["config.h"],
     security_posture = "robust_to_untrusted_downstream",
     # Legacy test use. TODO(#9953) clean up.
-    visibility = ["//visibility:public"],
     deps = [
         "//include/envoy/registry",
         "//source/extensions/filters/http:well_known_names",

--- a/source/extensions/filters/http/buffer/BUILD
+++ b/source/extensions/filters/http/buffer/BUILD
@@ -39,10 +39,7 @@ envoy_cc_extension(
     hdrs = ["config.h"],
     security_posture = "robust_to_untrusted_downstream",
     # Legacy test use. TODO(#9953) clean up.
-    visibility = [
-        "//:extension_config",
-        "//test:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "//include/envoy/registry",
         "//source/extensions/filters/http:well_known_names",


### PR DESCRIPTION
Signed-off-by: Lisa Lu <lisalu@lyft.com>

Commit Message: Revert buffer filter visibility back to public
Additional Description: After bringing in #12337, we are unable to build the router check tool as we build it with the buffer filter extension, which is no longer visible to the target we use. This change reverts the visibility change for the buffer filter back to public.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Part of #12444
