### PR TITLE
buffer impl: add cast for android compilation

### DIFF
--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -40,7 +40,7 @@ public:
   // SliceData
   absl::Span<uint8_t> getMutableData() override {
     RELEASE_ASSERT(isMutable(), "Not allowed to call getMutableData if slice is immutable");
-    return {base_ + data_, reservable_ - data_};
+    return {base_ + data_, static_cast<absl::Span<uint8_t>::size_type>(reservable_ - data_)};
   }
 
   /**


### PR DESCRIPTION
Commit Message: add cast for android compilation
Additional Description: https://github.com/envoyproxy/envoy/pull/12439 added a return value that had issues with implicit narrowing when building envoy mobile for android. This explicit cast fixes the build issues.
Risk Level: low using the expected type for the constructor as the static_cast type.
Testing: local build of envoy mobile for android. CI

Signed-off-by: Jose Nino <jnino@lyft.com>