### PR TITLE
Adds PlatformDefaultTriggerType for FileTriggerType 

### DIFF
--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -22,9 +22,10 @@ enum class FileTriggerType { Level, Edge };
 
 static constexpr FileTriggerType PlatformDefaultTriggerType 
 #ifdef WIN32
-      {FileTriggerType::Level};
+    // Libevent only supports Level trigger on Windows.
+    {FileTriggerType::Level};
 #else
-      {FileTriggerType::Edge};
+    {FileTriggerType::Edge};
 #endif
 
 /**

--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -20,7 +20,7 @@ struct FileReadyType {
 
 enum class FileTriggerType { Level, Edge };
 
-static constexpr FileTriggerType PlatformDefaultTriggerType 
+static constexpr FileTriggerType PlatformDefaultTriggerType
 #ifdef WIN32
     // Libevent only supports Level trigger on Windows.
     {FileTriggerType::Level};

--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -20,6 +20,13 @@ struct FileReadyType {
 
 enum class FileTriggerType { Level, Edge };
 
+static constexpr FileTriggerType PlatformDefaultTriggerType 
+#ifdef WIN32
+      {FileTriggerType::Level};
+#else
+      {FileTriggerType::Edge};
+#endif
+
 /**
  * Callback invoked when a FileEvent is ready for reading or writing.
  */

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -48,15 +48,7 @@ void LibeventScheduler::run(Dispatcher::RunType mode) {
   int flag = 0;
   switch (mode) {
   case Dispatcher::RunType::NonBlock:
-    flag = EVLOOP_NONBLOCK;
-#ifdef WIN32
-    // On Windows, EVLOOP_NONBLOCK will cause the libevent event_base_loop to run forever.
-    // This is because libevent only supports level triggering on Windows, and so the write
-    // event callbacks will trigger every time through the loop. Adding EVLOOP_ONCE ensures the
-    // loop will run at most once
-    flag |= EVLOOP_ONCE;
-#endif
-    break;
+    flag = LibeventScheduler::flagsBasedOnEventType();
   case Dispatcher::RunType::Block:
     // The default flags have 'block' behavior. See
     // http://www.wangafu.net/~nickm/libevent-book/Ref3_eventloop.html

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -108,6 +108,18 @@ private:
   static void onPrepareForStats(evwatch*, const evwatch_prepare_cb_info* info, void* arg);
   static void onCheckForStats(evwatch*, const evwatch_check_cb_info*, void* arg);
 
+  static constexpr int flagsBasedOnEventType() {
+    if (Event::PlatformDefaultTriggerType == FileTriggerType::Level)
+    {
+      // On Windows, EVLOOP_NONBLOCK will cause the libevent event_base_loop to run forever.
+      // This is because libevent only supports level triggering on Windows, and so the write
+      // event callbacks will trigger every time through the loop. Adding EVLOOP_ONCE ensures the
+      // loop will run at most once
+      return EVLOOP_NONBLOCK | EVLOOP_ONCE;
+    }
+    return EVLOOP_NONBLOCK;
+  }
+
   Libevent::BasePtr libevent_;
   DispatcherStats* stats_{}; // stats owned by the containing DispatcherImpl
   bool timeout_set_{};       // whether there is a poll timeout in the current event loop iteration

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -109,8 +109,7 @@ private:
   static void onCheckForStats(evwatch*, const evwatch_check_cb_info*, void* arg);
 
   static constexpr int flagsBasedOnEventType() {
-    if (Event::PlatformDefaultTriggerType == FileTriggerType::Level)
-    {
+    if (Event::PlatformDefaultTriggerType == FileTriggerType::Level) {
       // On Windows, EVLOOP_NONBLOCK will cause the libevent event_base_loop to run forever.
       // This is because libevent only supports level triggering on Windows, and so the write
       // event callbacks will trigger every time through the loop. Adding EVLOOP_ONCE ensures the

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -109,7 +109,7 @@ private:
   static void onCheckForStats(evwatch*, const evwatch_check_cb_info*, void* arg);
 
   static constexpr int flagsBasedOnEventType() {
-    if (Event::PlatformDefaultTriggerType == FileTriggerType::Level) {
+    if constexpr (Event::PlatformDefaultTriggerType == FileTriggerType::Level) {
       // On Windows, EVLOOP_NONBLOCK will cause the libevent event_base_loop to run forever.
       // This is because libevent only supports level triggering on Windows, and so the write
       // event callbacks will trigger every time through the loop. Adding EVLOOP_ONCE ensures the

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -65,7 +65,6 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
     connecting_ = true;
   }
 
-  // Libevent only supports Level trigger on Windows.
   Event::FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
   // We never ask for both early close and read at the same time. If we are reading, we want to

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -66,11 +66,8 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
   }
 
   // Libevent only supports Level trigger on Windows.
-#ifdef WIN32
-  Event::FileTriggerType trigger = Event::FileTriggerType::Level;
-#else
-  Event::FileTriggerType trigger = Event::FileTriggerType::Edge;
-#endif
+  Event::FileTriggerType trigger = Event::PlatformDefaultTriggerType;
+
   // We never ask for both early close and read at the same time. If we are reading, we want to
   // consume all available data.
   file_event_ = dispatcher_.createFileEvent(

--- a/source/common/network/udp_listener_impl.cc
+++ b/source/common/network/udp_listener_impl.cc
@@ -33,7 +33,7 @@ UdpListenerImpl::UdpListenerImpl(Event::DispatcherImpl& dispatcher, SocketShared
     : BaseListenerImpl(dispatcher, std::move(socket)), cb_(cb), time_source_(time_source) {
   file_event_ = dispatcher_.createFileEvent(
       socket_->ioHandle().fd(), [this](uint32_t events) -> void { onSocketEvent(events); },
-      Event::FileTriggerType::Edge, Event::FileReadyType::Read | Event::FileReadyType::Write);
+      Event::PlatformDefaultTriggerType, Event::FileReadyType::Read | Event::FileReadyType::Write);
 
   ASSERT(file_event_);
 

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -93,7 +93,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
             break;
           }
         },
-        Event::FileTriggerType::Edge, Event::FileReadyType::Read | Event::FileReadyType::Closed);
+        Event::PlatformDefaultTriggerType, Event::FileReadyType::Read | Event::FileReadyType::Closed);
     return Network::FilterStatus::StopIteration;
   }
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/listener/http_inspector/http_inspector.cc
+++ b/source/extensions/filters/listener/http_inspector/http_inspector.cc
@@ -93,7 +93,8 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
             break;
           }
         },
-        Event::PlatformDefaultTriggerType, Event::FileReadyType::Read | Event::FileReadyType::Closed);
+        Event::PlatformDefaultTriggerType,
+        Event::FileReadyType::Read | Event::FileReadyType::Closed);
     return Network::FilterStatus::StopIteration;
   }
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -74,7 +74,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
         ASSERT(events == Event::FileReadyType::Read);
         onRead();
       },
-      Event::FileTriggerType::Edge, Event::FileReadyType::Read);
+      Event::PlatformDefaultTriggerType, Event::FileReadyType::Read);
   cb_ = &cb;
   return Network::FilterStatus::StopIteration;
 }

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -115,7 +115,7 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
             break;
           }
         },
-        Event::FileTriggerType::Edge, Event::FileReadyType::Read | Event::FileReadyType::Closed);
+        Event::PlatformDefaultTriggerType, Event::FileReadyType::Read | Event::FileReadyType::Closed);
     return Network::FilterStatus::StopIteration;
   }
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -115,7 +115,8 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
             break;
           }
         },
-        Event::PlatformDefaultTriggerType, Event::FileReadyType::Read | Event::FileReadyType::Closed);
+        Event::PlatformDefaultTriggerType,
+        Event::FileReadyType::Read | Event::FileReadyType::Closed);
     return Network::FilterStatus::StopIteration;
   }
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -159,7 +159,7 @@ UdpProxyFilter::ActiveSession::ActiveSession(ClusterInfo& cluster,
       //       is bound until the first packet is sent to the upstream host.
       io_handle_(cluster.filter_.createIoHandle(host)),
       socket_event_(cluster.filter_.read_callbacks_->udpListener().dispatcher().createFileEvent(
-          io_handle_->fd(), [this](uint32_t) { onReadReady(); }, Event::FileTriggerType::Edge,
+          io_handle_->fd(), [this](uint32_t) { onReadReady(); }, Event::PlatformDefaultTriggerType,
           Event::FileReadyType::Read)) {
   ENVOY_LOG(debug, "creating new session: downstream={} local={} upstream={}",
             addresses_.peer_->asStringView(), addresses_.local_->asStringView(),

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -28,7 +28,7 @@ void HotRestartingParent::initialize(Event::Dispatcher& dispatcher, Server::Inst
         ASSERT(events == Event::FileReadyType::Read);
         onSocketEvent();
       },
-      Event::FileTriggerType::Edge, Event::FileReadyType::Read);
+      Event::PlatformDefaultTriggerType, Event::FileReadyType::Read);
   internal_ = std::make_unique<Internal>(&server);
 }
 

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -89,11 +89,7 @@ TEST_P(FileEventImplActivateTest, Activate) {
   ReadyWatcher closed_event;
   EXPECT_CALL(closed_event, ready()).Times(1);
 
-#ifdef WIN32
-  const FileTriggerType trigger = FileTriggerType::Level;
-#else
-  const FileTriggerType trigger = FileTriggerType::Edge;
-#endif
+  const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
   Event::FileEventPtr file_event = dispatcher->createFileEvent(
       fd,
@@ -133,11 +129,7 @@ TEST_P(FileEventImplActivateTest, ActivateChaining) {
   evwatch_prepare_new(&static_cast<DispatcherImpl*>(dispatcher.get())->base(), onWatcherReady,
                       &prepare_watcher);
 
-#ifdef WIN32
-  const FileTriggerType trigger = FileTriggerType::Level;
-#else
-  const FileTriggerType trigger = FileTriggerType::Edge;
-#endif
+  const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
   Event::FileEventPtr file_event = dispatcher->createFileEvent(
       fd,
@@ -213,11 +205,7 @@ TEST_P(FileEventImplActivateTest, SetEnableCancelsActivate) {
   evwatch_prepare_new(&static_cast<DispatcherImpl*>(dispatcher.get())->base(), onWatcherReady,
                       &prepare_watcher);
 
-#ifdef WIN32
-  const FileTriggerType trigger = FileTriggerType::Level;
-#else
-  const FileTriggerType trigger = FileTriggerType::Edge;
-#endif
+const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
   Event::FileEventPtr file_event = dispatcher->createFileEvent(
       fd,
@@ -318,11 +306,8 @@ TEST_F(FileEventImplTest, SetEnabled) {
   ReadyWatcher write_event;
   EXPECT_CALL(write_event, ready()).Times(2);
 
-#ifdef WIN32
-  const FileTriggerType trigger = FileTriggerType::Level;
-#else
-  const FileTriggerType trigger = FileTriggerType::Edge;
-#endif
+  const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
+
   Event::FileEventPtr file_event = dispatcher_->createFileEvent(
       fds_[0],
       [&](uint32_t events) -> void {

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -205,7 +205,7 @@ TEST_P(FileEventImplActivateTest, SetEnableCancelsActivate) {
   evwatch_prepare_new(&static_cast<DispatcherImpl*>(dispatcher.get())->base(), onWatcherReady,
                       &prepare_watcher);
 
-const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
+  const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
   Event::FileEventPtr file_event = dispatcher->createFileEvent(
       fd,

--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, UdpListenerImplTest,
 // Test that socket options are set after the listener is setup.
 TEST_P(UdpListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
   MockUdpListenerCallbacks listener_callbacks;
-  auto socket = std::make_shared<Network::UdpListenSocket>(Network::Test::getCanonicalLoopbackAddress(version_),
+  auto socket = std::make_shared<Network::UdpListenSocket>(Network::Test::getAnyAddress(version_),
                                                            nullptr, true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket->addOption(option);

--- a/test/common/network/udp_listener_impl_test.cc
+++ b/test/common/network/udp_listener_impl_test.cc
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, UdpListenerImplTest,
 // Test that socket options are set after the listener is setup.
 TEST_P(UdpListenerImplTest, UdpSetListeningSocketOptionsSuccess) {
   MockUdpListenerCallbacks listener_callbacks;
-  auto socket = std::make_shared<Network::UdpListenSocket>(Network::Test::getAnyAddress(version_),
+  auto socket = std::make_shared<Network::UdpListenSocket>(Network::Test::getCanonicalLoopbackAddress(version_),
                                                            nullptr, true);
   std::shared_ptr<MockSocketOption> option = std::make_shared<MockSocketOption>();
   socket->addOption(option);

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -47,7 +47,7 @@ public:
           .WillOnce(Return(Api::SysCallSizeResult{static_cast<ssize_t>(0), 0}));
 
       EXPECT_CALL(dispatcher_,
-                  createFileEvent_(_, _, Event::FileTriggerType::Edge,
+                  createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
                                    Event::FileReadyType::Read | Event::FileReadyType::Closed))
           .WillOnce(DoAll(SaveArg<1>(&file_event_callback_),
                           ReturnNew<NiceMock<Event::MockFileEvent>>()));

--- a/test/extensions/filters/listener/proxy_protocol/BUILD
+++ b/test/extensions/filters/listener/proxy_protocol/BUILD
@@ -15,7 +15,6 @@ envoy_extension_cc_test(
     name = "proxy_protocol_test",
     srcs = ["proxy_protocol_test.cc"],
     extension_name = "envoy.filters.listener.proxy_protocol",
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -50,7 +50,7 @@ public:
               return Api::SysCallSizeResult{static_cast<ssize_t>(0), 0};
             }));
     EXPECT_CALL(dispatcher_,
-                createFileEvent_(_, _, Event::FileTriggerType::Edge,
+                createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
                                  Event::FileReadyType::Read | Event::FileReadyType::Closed))
         .WillOnce(
             DoAll(SaveArg<1>(&file_event_callback_), ReturnNew<NiceMock<Event::MockFileEvent>>()));
@@ -273,7 +273,7 @@ TEST_P(TlsInspectorTest, InlineReadSucceed) {
 
   // No event is created if the inline recv parse the hello.
   EXPECT_CALL(dispatcher_,
-              createFileEvent_(_, _, Event::FileTriggerType::Edge,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType,
                                Event::FileReadyType::Read | Event::FileReadyType::Closed))
       .Times(0);
 

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -164,7 +164,7 @@ public:
         .WillOnce(Return(ByMove(Network::IoHandlePtr{test_sessions_.back().io_handle_})));
     EXPECT_CALL(*new_session.io_handle_, fd());
     EXPECT_CALL(callbacks_.udp_listener_.dispatcher_,
-                createFileEvent_(_, _, Event::FileTriggerType::Edge, Event::FileReadyType::Read))
+                createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
         .WillOnce(DoAll(SaveArg<1>(&new_session.file_event_cb_), Return(nullptr)));
     // Internal Buffer is Empty, flush will be a no-op
     ON_CALL(callbacks_.udp_listener_, flush())

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -163,8 +163,9 @@ public:
     EXPECT_CALL(*filter_, createIoHandle(_))
         .WillOnce(Return(ByMove(Network::IoHandlePtr{test_sessions_.back().io_handle_})));
     EXPECT_CALL(*new_session.io_handle_, fd());
-    EXPECT_CALL(callbacks_.udp_listener_.dispatcher_,
-                createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+    EXPECT_CALL(
+        callbacks_.udp_listener_.dispatcher_,
+        createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
         .WillOnce(DoAll(SaveArg<1>(&new_session.file_event_cb_), Return(nullptr)));
     // Internal Buffer is Empty, flush will be a no-op
     ON_CALL(callbacks_.udp_listener_, flush())


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Adds `PlatformDefaultTriggerType ` which is used to create file events. The main motivation for using this is the following:

1. Easier to swap out between `FileTriggerType`. This is useful for UNIX devs to debug issues that might affect Windows.
2. Removes various `#ifdef`s around the codebase.

With this change, `proxy_protocol_test` now passes on Windows. 

Additional Description:
Risk Level: Low (No-Op, Most of the changes are calculated at compile time
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
