### PR TITLE
tcp_proxy: use dynamicMetadata() from StreamInfo for load balancing

### DIFF
--- a/docs/root/configuration/listeners/network_filters/tcp_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/tcp_proxy_filter.rst
@@ -34,6 +34,9 @@ To define metadata that a suitable upstream host must match, use one of the foll
    and :ref:`ClusterWeight.metadata_match<envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.WeightedCluster.ClusterWeight.metadata_match>`
    to define required metadata for a weighted upstream cluster (metadata from the latter will be merged on top of the former).
 
+In addition, dynamic metadata can be set by earlier network filters on the `StreamInfo`. Setting the dynamic metadata
+must happen before `onNewConnection()` is called on the `TcpProxy` filter to affect load balancing.
+
 .. _config_network_filters_tcp_proxy_stats:
 
 Statistics

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -72,6 +72,7 @@ New Features
 * stats: allow configuring histogram buckets for stats sinks and admin endpoints that support it.
 * tap: added :ref:`generic body matcher<envoy_v3_api_msg_config.tap.v3.HttpGenericBodyMatch>` to scan http requests and responses for text or hex patterns.
 * tcp: switched the TCP connection pool to the new "shared" connection pool, sharing a common code base with HTTP and HTTP/2. Any unexpected behavioral changes can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
+* tcp_proxy: allow ealier network filters to set metadataMatchCriteria on the connection StreamInfo to influence load balancing.
 * watchdog: support randomizing the watchdog's kill timeout to prevent synchronized kills via a maximium jitter parameter :ref:`max_kill_timeout_jitter<envoy_v3_api_field_config.bootstrap.v3.Watchdog.max_kill_timeout_jitter>`.
 * xds: added :ref:`extension config discovery<envoy_v3_api_msg_config.core.v3.ExtensionConfigSource>` support for HTTP filters.
 

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -265,14 +265,7 @@ public:
                        Ssl::ConnectionInfoConstSharedPtr ssl_info);
 
   // Upstream::LoadBalancerContext
-  const Router::MetadataMatchCriteria* metadataMatchCriteria() override {
-    if (route_) {
-      return route_->metadataMatchCriteria();
-    }
-    return nullptr;
-  }
-
-  // Upstream::LoadBalancerContext
+  const Router::MetadataMatchCriteria* metadataMatchCriteria() override;
   absl::optional<uint64_t> computeHashKey() override {
     auto hash_policy = config_->hashPolicy();
     if (hash_policy) {
@@ -376,6 +369,7 @@ protected:
                                                           // read filter.
   std::unique_ptr<GenericUpstream> upstream_;
   RouteConstSharedPtr route_;
+  Router::MetadataMatchCriteriaConstPtr metadata_match_criteria_;
   Network::TransportSocketOptionsSharedPtr transport_socket_options_;
   uint32_t connect_attempts_{};
   bool connecting_{};

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1361,6 +1361,104 @@ TEST_F(TcpProxyTest, WeightedClusterWithMetadataMatch) {
   }
 }
 
+// Test that metadata match criteria provided on the StreamInfo is used.
+TEST_F(TcpProxyTest, StreamInfoDynamicMetadata) {
+  configure(defaultConfig());
+
+  ProtobufWkt::Value val;
+  val.set_string_value("val");
+
+  envoy::config::core::v3::Metadata metadata;
+  ProtobufWkt::Struct& map =
+      (*metadata.mutable_filter_metadata())[Envoy::Config::MetadataFilters::get().ENVOY_LB];
+  (*map.mutable_fields())["test"] = val;
+  EXPECT_CALL(filter_callbacks_.connection_.stream_info_, dynamicMetadata())
+      .WillOnce(ReturnRef(metadata));
+
+  // filter_callbacks_.connection.raise
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
+  filter_->initializeReadFilterCallbacks(filter_callbacks_);
+
+  Upstream::LoadBalancerContext* context;
+
+  // EXPECT_CALL(factory_context_.random_, random()).WillOnce(Return(0));
+  EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster(_, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&context), Return(nullptr)));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+
+  EXPECT_NE(nullptr, context);
+
+  const auto effective_criteria = context->metadataMatchCriteria();
+  EXPECT_NE(nullptr, effective_criteria);
+
+  const auto& effective_criterions = effective_criteria->metadataMatchCriteria();
+  EXPECT_EQ(1, effective_criterions.size());
+
+  EXPECT_EQ("test", effective_criterions[0]->name());
+  EXPECT_EQ(HashedValue(val), effective_criterions[0]->value());
+}
+
+// Test that if both streamInfo and configuration add metadata match criteria, they
+// are merged.
+TEST_F(TcpProxyTest, StreamInfoDynamicMetadataAndConfigMerged) {
+  const std::string yaml = R"EOF(
+  stat_prefix: name
+  weighted_clusters:
+    clusters:
+    - name: cluster1
+      weight: 1
+      metadata_match:
+        filter_metadata:
+          envoy.lb:
+            k0: v0
+            k1: from_config
+)EOF";
+
+  config_ = std::make_shared<Config>(constructConfigFromYaml(yaml, factory_context_));
+
+  ProtobufWkt::Value v0, v1, v2;
+  v0.set_string_value("v0");
+  v1.set_string_value("from_streaminfo"); // 'v1' is overridden with this value by streamInfo.
+  v2.set_string_value("v2");
+  HashedValue hv0(v0), hv1(v1), hv2(v2);
+
+  envoy::config::core::v3::Metadata metadata;
+  ProtobufWkt::Struct& map =
+      (*metadata.mutable_filter_metadata())[Envoy::Config::MetadataFilters::get().ENVOY_LB];
+  (*map.mutable_fields())["k1"] = v1;
+  (*map.mutable_fields())["k2"] = v2;
+  EXPECT_CALL(filter_callbacks_.connection_.stream_info_, dynamicMetadata())
+      .WillOnce(ReturnRef(metadata));
+
+  // filter_callbacks_.connection.raise
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
+  filter_->initializeReadFilterCallbacks(filter_callbacks_);
+
+  Upstream::LoadBalancerContext* context;
+
+  // EXPECT_CALL(factory_context_.random_, random()).WillOnce(Return(0));
+  EXPECT_CALL(factory_context_.cluster_manager_, tcpConnPoolForCluster(_, _, _))
+      .WillOnce(DoAll(SaveArg<2>(&context), Return(nullptr)));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+
+  EXPECT_NE(nullptr, context);
+
+  const auto effective_criteria = context->metadataMatchCriteria();
+  EXPECT_NE(nullptr, effective_criteria);
+
+  const auto& effective_criterions = effective_criteria->metadataMatchCriteria();
+  EXPECT_EQ(3, effective_criterions.size());
+
+  EXPECT_EQ("k0", effective_criterions[0]->name());
+  EXPECT_EQ(hv0, effective_criterions[0]->value());
+
+  EXPECT_EQ("k1", effective_criterions[1]->name());
+  EXPECT_EQ(hv1, effective_criterions[1]->value());
+
+  EXPECT_EQ("k2", effective_criterions[2]->name());
+  EXPECT_EQ(hv2, effective_criterions[2]->value());
+}
+
 TEST_F(TcpProxyTest, DEPRECATED_FEATURE_TEST(DisconnectBeforeData)) {
   configure(defaultConfig());
   filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -975,6 +975,11 @@ envoy_cc_test(
     ],
 )
 
+envoy_proto_library(
+    name = "tcp_proxy_integration_proto",
+    srcs = [":tcp_proxy_integration_test.proto"],
+)
+
 envoy_cc_test(
     name = "tcp_proxy_integration_test",
     srcs = [
@@ -988,17 +993,20 @@ envoy_cc_test(
     tags = ["fails_on_windows"],
     deps = [
         ":integration_lib",
+        ":tcp_proxy_integration_proto_cc_proto",
         "//source/common/config:api_version_lib",
         "//source/common/event:dispatcher_includes",
         "//source/common/event:dispatcher_lib",
         "//source/common/network:utility_lib",
         "//source/extensions/access_loggers/file:config",
+        "//source/extensions/filters/network/common:factory_base_lib",
         "//source/extensions/filters/network/tcp_proxy:config",
         "//source/extensions/transport_sockets/tls:config",
         "//source/extensions/transport_sockets/tls:context_config_lib",
         "//source/extensions/transport_sockets/tls:context_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/secret:secret_mocks",
+        "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -678,7 +678,8 @@ AssertionResult FakeRawConnection::waitForData(uint64_t num_bytes, std::string* 
   auto end_time = time_system_.monotonicTime() + timeout;
   while (data_.size() != num_bytes) {
     if (time_system_.monotonicTime() >= end_time) {
-      return AssertionFailure() << "Timed out waiting for data.";
+      return AssertionFailure() << fmt::format(
+                 "Timed out waiting for data. Got '{}', waiting for {} bytes.", data_, num_bytes);
     }
     time_system_.waitFor(lock_, connection_event_, 5ms); // Safe since CondVar::waitFor won't throw.
   }

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -12,10 +12,14 @@
 #include "common/config/api_version.h"
 #include "common/network/utility.h"
 
+#include "extensions/filters/network/common/factory_base.h"
 #include "extensions/transport_sockets/tls/context_manager_impl.h"
 
 #include "test/integration/ssl_utility.h"
+#include "test/integration/tcp_proxy_integration_test.pb.h"
+#include "test/integration/tcp_proxy_integration_test.pb.validate.h"
 #include "test/integration/utility.h"
+#include "test/test_common/registry.h"
 
 #include "gtest/gtest.h"
 
@@ -557,15 +561,19 @@ TEST_P(TcpProxyIntegrationTest, TestCloseOnHealthFailure) {
 
 class TcpProxyMetadataMatchIntegrationTest : public TcpProxyIntegrationTest {
 public:
+  TcpProxyMetadataMatchIntegrationTest(uint32_t tcp_proxy_filter_index = 0)
+      : tcp_proxy_filter_index_(tcp_proxy_filter_index) {}
   void initialize() override;
 
-  void expectEndpointToMatchRoute();
-  void expectEndpointNotToMatchRoute();
+  void expectEndpointToMatchRoute(
+      std::function<std::string(IntegrationTcpClient&)> initial_data_cb = nullptr);
+  void expectEndpointNotToMatchRoute(const std::string& write_data = "hello");
 
   envoy::config::core::v3::Metadata lbMetadata(std::map<std::string, std::string> values);
 
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy tcp_proxy_;
   envoy::config::core::v3::Metadata endpoint_metadata_;
+  const uint32_t tcp_proxy_filter_index_;
 };
 
 envoy::config::core::v3::Metadata
@@ -594,7 +602,7 @@ void TcpProxyMetadataMatchIntegrationTest::initialize() {
     ASSERT(static_resources->listeners_size() == 1);
     static_resources->mutable_listeners(0)
         ->mutable_filter_chains(0)
-        ->mutable_filters(0)
+        ->mutable_filters(tcp_proxy_filter_index_)
         ->mutable_typed_config()
         ->PackFrom(tcp_proxy_);
 
@@ -624,16 +632,23 @@ void TcpProxyMetadataMatchIntegrationTest::initialize() {
 }
 
 // Verifies successful connection.
-void TcpProxyMetadataMatchIntegrationTest::expectEndpointToMatchRoute() {
+void TcpProxyMetadataMatchIntegrationTest::expectEndpointToMatchRoute(
+    std::function<std::string(IntegrationTcpClient&)> initial_data_cb) {
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
-  ASSERT_TRUE(tcp_client->write("hello"));
+  std::string expected_upstream_data;
+  if (initial_data_cb) {
+    expected_upstream_data = initial_data_cb(*tcp_client);
+  } else {
+    expected_upstream_data = "hello";
+    ASSERT_TRUE(tcp_client->write(expected_upstream_data));
+  }
   FakeRawConnectionPtr fake_upstream_connection;
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
-  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(expected_upstream_data.length()));
   ASSERT_TRUE(fake_upstream_connection->write("world"));
   tcp_client->waitForData("world");
   ASSERT_TRUE(tcp_client->write("hello", true));
-  ASSERT_TRUE(fake_upstream_connection->waitForData(10));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5 + expected_upstream_data.length()));
   ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
   ASSERT_TRUE(fake_upstream_connection->write("", true));
   ASSERT_TRUE(fake_upstream_connection->waitForDisconnect(true));
@@ -643,9 +658,10 @@ void TcpProxyMetadataMatchIntegrationTest::expectEndpointToMatchRoute() {
 }
 
 // Verifies connection failure.
-void TcpProxyMetadataMatchIntegrationTest::expectEndpointNotToMatchRoute() {
+void TcpProxyMetadataMatchIntegrationTest::expectEndpointNotToMatchRoute(
+    const std::string& write_data) {
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("tcp_proxy"));
-  ASSERT_TRUE(tcp_client->write("hello", false, false));
+  ASSERT_TRUE(tcp_client->write(write_data, false, false));
 
   // TODO(yskopets): 'tcp_client->waitForDisconnect(true);' gets stuck indefinitely on Linux builds,
   // e.g. on 'envoy-linux (bazel compile_time_options)' and 'envoy-linux (bazel release)'
@@ -841,6 +857,135 @@ TEST_P(TcpProxyMetadataMatchIntegrationTest,
   initialize();
 
   expectEndpointNotToMatchRoute();
+}
+
+class InjectDynamicMetadata : public Network::ReadFilter {
+public:
+  InjectDynamicMetadata(const std::string& key) : key_(key) {}
+
+  Network::FilterStatus onData(Buffer::Instance& data, bool) override {
+    if (!metadata_set_) {
+      // To allow testing a write that returns `StopIteration`, only proceed
+      // when more than 1 byte is received.
+      if (data.length() < 2) {
+        ASSERT(data.length() == 1);
+
+        // Echo data back to test can verify it was received.
+        Buffer::OwnedImpl copy(data);
+        read_callbacks_->connection().write(copy, false);
+        return Network::FilterStatus::StopIteration;
+      }
+
+      const char* str = reinterpret_cast<const char*>(data.linearize(data.length()));
+      ProtobufWkt::Value val;
+      val.set_string_value(std::string(str, data.length()));
+
+      ProtobufWkt::Struct& map =
+          (*read_callbacks_->connection()
+                .streamInfo()
+                .dynamicMetadata()
+                .mutable_filter_metadata())[Envoy::Config::MetadataFilters::get().ENVOY_LB];
+      (*map.mutable_fields())[key_] = val;
+
+      // Put this back in the state that TcpProxy expects.
+      read_callbacks_->connection().readDisable(true);
+
+      metadata_set_ = true;
+    }
+    return Network::FilterStatus::Continue;
+  }
+
+  Network::FilterStatus onNewConnection() override {
+    // TcpProxy disables read; must re-enable so we can read headers.
+    read_callbacks_->connection().readDisable(false);
+
+    // Stop until we read the value and can set the metadata for TcpProxy.
+    return Network::FilterStatus::StopIteration;
+  }
+
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
+    read_callbacks_ = &callbacks;
+  }
+
+  const std::string key_;
+  Network::ReadFilterCallbacks* read_callbacks_{};
+  bool metadata_set_{false};
+};
+
+class InjectDynamicMetadataFactory : public Extensions::NetworkFilters::Common::FactoryBase<
+                                         test::integration::tcp_proxy::InjectDynamicMetadata> {
+public:
+  InjectDynamicMetadataFactory() : FactoryBase("test.inject_dynamic_metadata") {}
+
+private:
+  Network::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const test::integration::tcp_proxy::InjectDynamicMetadata& cfg,
+                                    Server::Configuration::FactoryContext&) override {
+    std::string key = cfg.key();
+    return [key](Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(std::make_shared<InjectDynamicMetadata>(key));
+    };
+  }
+};
+
+class TcpProxyDynamicMetadataMatchIntegrationTest : public TcpProxyMetadataMatchIntegrationTest {
+public:
+  TcpProxyDynamicMetadataMatchIntegrationTest() : TcpProxyMetadataMatchIntegrationTest(1) {
+    config_helper_.addNetworkFilter(R"EOF(
+      name: test.inject_dynamic_metadata
+      typed_config:
+        "@type": type.googleapis.com/test.integration.tcp_proxy.InjectDynamicMetadata
+        key: role
+)EOF");
+  }
+
+  InjectDynamicMetadataFactory factory_;
+  Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> register_factory_{
+      factory_};
+};
+
+INSTANTIATE_TEST_SUITE_P(TcpProxyIntegrationTestParams, TcpProxyDynamicMetadataMatchIntegrationTest,
+                         testing::ValuesIn(getProtocolTestParams()), protocolTestParamsToString);
+
+TEST_P(TcpProxyDynamicMetadataMatchIntegrationTest, DynamicMetadataMatch) {
+  tcp_proxy_.set_stat_prefix("tcp_stats");
+
+  // Note: role isn't set here; it will be set in the dynamic metadata.
+  tcp_proxy_.mutable_metadata_match()->MergeFrom(
+      lbMetadata({{"version", "v1"}, {"stage", "prod"}}));
+  auto* cluster_0 = tcp_proxy_.mutable_weighted_clusters()->add_clusters();
+  cluster_0->set_name("cluster_0");
+  cluster_0->set_weight(1);
+  endpoint_metadata_ = lbMetadata({{"role", "primary"}, {"version", "v1"}, {"stage", "prod"}});
+
+  initialize();
+
+  expectEndpointToMatchRoute([](IntegrationTcpClient& tcp_client) -> std::string {
+    // Break the write into two; validate that the first is received before sending the second. This
+    // validates that a downstream filter can use this functionality, even if it can't make a
+    // decision after the first `onData()`.
+    EXPECT_TRUE(tcp_client.write("p", false));
+    tcp_client.waitForData("p");
+    tcp_client.clearData();
+    EXPECT_TRUE(tcp_client.write("rimary", false));
+    return "primary";
+  });
+}
+
+TEST_P(TcpProxyDynamicMetadataMatchIntegrationTest, DynamicMetadataNonMatch) {
+  tcp_proxy_.set_stat_prefix("tcp_stats");
+
+  // Note: role isn't set here; it will be set in the dynamic metadata.
+  tcp_proxy_.mutable_metadata_match()->MergeFrom(
+      lbMetadata({{"version", "v1"}, {"stage", "prod"}}));
+  auto* cluster_0 = tcp_proxy_.mutable_weighted_clusters()->add_clusters();
+  cluster_0->set_name("cluster_0");
+  cluster_0->set_weight(1);
+  endpoint_metadata_ = lbMetadata({{"role", "primary"}, {"version", "v1"}, {"stage", "prod"}});
+
+  initialize();
+
+  expectEndpointNotToMatchRoute("does_not_match_role_primary");
 }
 
 INSTANTIATE_TEST_SUITE_P(TcpProxyIntegrationTestParams, TcpProxySslIntegrationTest,

--- a/test/integration/tcp_proxy_integration_test.proto
+++ b/test/integration/tcp_proxy_integration_test.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test.integration.tcp_proxy;
+
+message InjectDynamicMetadata {
+  string key = 1;
+}


### PR DESCRIPTION
Commit Message: 
This allows earlier network filters to set dynamicMetadata() on
the connection StreamInfo to influence load balancing (such as subset_lb).

Signed-off-by: Greg Greenway <ggreenway@apple.com>

Risk Level: Low
Testing: Added UT and integration tests
Docs Changes: Added
Release Notes: Added