### PR TITLE
Add support for nested JSON format in json logging mode

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -93,7 +93,7 @@ would be rendered as the number ``123``.
 Format dictionaries have the following restrictions:
 
 * The dictionary must map strings to strings (specifically, strings to command operators). Nesting
-  is not currently supported.
+  is supported.
 * When using the ``typed_json_format`` command operators will only produce typed output if the
   command operator is the only string that appears in the dictionary value. For example,
   ``"%DURATION%"`` will log a numeric duration value, but ``"%DURATION%.0"`` will log a string

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -50,6 +50,7 @@ New Features
 ------------
 * access log: added a :ref:`dynamic metadata filter<envoy_v3_api_msg_config.accesslog.v3.MetadataFilter>` for access logs, which filters whether to log based on matching dynamic metadata.
 * access log: added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_access_log_format_response_flags>` as a response flag.
+* access log: added support for nested objects in :ref:`JSON logging mode <config_access_log_format_dictionaries>`.
 * build: enable building envoy :ref:`arm64 images <arm_binaries>` by buildx tool in x86 CI platform.
 * dynamic_forward_proxy: added :ref:`use_tcp_for_dns_lookups<envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` option to use TCP for DNS lookups in order to match the DNS options for :ref:`Clusters<envoy_v3_api_msg_config.cluster.v3.Cluster>`.
 * ext_authz filter: added support for emitting dynamic metadata for both :ref:`HTTP <config_http_filters_ext_authz_dynamic_metadata>` and :ref:`network <config_network_filters_ext_authz_dynamic_metadata>` filters.

--- a/source/common/formatter/substitution_format_string.cc
+++ b/source/common/formatter/substitution_format_string.cc
@@ -6,7 +6,6 @@ namespace Envoy {
 namespace Formatter {
 namespace {
 
-absl::flat_hash_map<std::string, std::string>
 convertJsonFormatToMap(const ProtobufWkt::Struct& json_format) {
   absl::flat_hash_map<std::string, std::string> output;
   for (const auto& pair : json_format.fields()) {

--- a/source/common/formatter/substitution_format_string.cc
+++ b/source/common/formatter/substitution_format_string.cc
@@ -4,27 +4,6 @@
 
 namespace Envoy {
 namespace Formatter {
-namespace {
-
-convertJsonFormatToMap(const ProtobufWkt::Struct& json_format) {
-  absl::flat_hash_map<std::string, std::string> output;
-  for (const auto& pair : json_format.fields()) {
-    if (pair.second.kind_case() != ProtobufWkt::Value::kStringValue) {
-      throw EnvoyException("Only string values are supported in the JSON access log format.");
-    }
-    output.emplace(pair.first, pair.second.string_value());
-  }
-  return output;
-}
-
-} // namespace
-
-FormatterPtr
-SubstitutionFormatStringUtils::createJsonFormatter(const ProtobufWkt::Struct& struct_format,
-                                                   bool preserve_types) {
-  auto json_format_map = convertJsonFormatToMap(struct_format);
-  return std::make_unique<JsonFormatterImpl>(json_format_map, preserve_types);
-}
 
 FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
     const envoy::config::core::v3::SubstitutionFormatString& config) {
@@ -32,7 +11,7 @@ FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
     return std::make_unique<FormatterImpl>(config.text_format());
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat: {
-    return createJsonFormatter(config.json_format(), true);
+    return std::make_unique<JsonFormatterImpl>(config.json_format(), true);
   }
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/common/formatter/substitution_format_string.h
+++ b/source/common/formatter/substitution_format_string.h
@@ -20,12 +20,6 @@ public:
    */
   static FormatterPtr
   fromProtoConfig(const envoy::config::core::v3::SubstitutionFormatString& config);
-
-  /**
-   * Generate a Json formatter object from proto::Struct config
-   */
-  static FormatterPtr createJsonFormatter(const ProtobufWkt::Struct& struct_format,
-                                          bool preserve_types);
 };
 
 } // namespace Formatter

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -49,6 +49,9 @@ const std::regex& getStartTimeNewlinePattern() {
 }
 const std::regex& getNewlinePattern() { CONSTRUCT_ON_FIRST_USE(std::regex, "\n"); }
 
+template <class... Ts> struct JsonFormatMapVisitor : Ts... { using Ts::operator()...; };
+template <class... Ts> JsonFormatMapVisitor(Ts...) -> JsonFormatMapVisitor<Ts...>;
+
 } // namespace
 
 const std::string SubstitutionFormatUtils::DEFAULT_FORMAT =
@@ -109,14 +112,6 @@ std::string FormatterImpl::format(const Http::RequestHeaderMap& request_headers,
   return log_line;
 }
 
-JsonFormatterImpl::JsonFormatterImpl(
-    const absl::flat_hash_map<std::string, std::string>& format_mapping, bool preserve_types)
-    : preserve_types_(preserve_types) {
-  for (const auto& pair : format_mapping) {
-    json_output_format_.emplace(pair.first, SubstitutionFormatParser::parse(pair.second));
-  }
-}
-
 std::string JsonFormatterImpl::format(const Http::RequestHeaderMap& request_headers,
                                       const Http::ResponseHeaderMap& response_headers,
                                       const Http::ResponseTrailerMap& response_trailers,
@@ -129,37 +124,60 @@ std::string JsonFormatterImpl::format(const Http::RequestHeaderMap& request_head
   return absl::StrCat(log_line, "\n");
 }
 
+JsonFormatMap JsonFormatterImpl::toFormatMap(const ProtobufWkt::Struct& json_format) const {
+  auto output = std::make_unique<std::map<std::string, JsonFormatMapValue>>();
+  for (const auto& pair : json_format.fields()) {
+    switch (pair.second.kind_case()) {
+    case ProtobufWkt::Value::kStringValue:
+      output->emplace(pair.first, SubstitutionFormatParser::parse(pair.second.string_value()));
+      break;
+    case ProtobufWkt::Value::kStructValue:
+      output->emplace(pair.first, toFormatMap(pair.second.struct_value()));
+      break;
+    default:
+      throw EnvoyException(
+          "Only string/object values are supported in the JSON access log format.");
+    }
+  }
+  return {std::move(output)};
+};
+
 ProtobufWkt::Struct JsonFormatterImpl::toStruct(const Http::RequestHeaderMap& request_headers,
                                                 const Http::ResponseHeaderMap& response_headers,
                                                 const Http::ResponseTrailerMap& response_trailers,
                                                 const StreamInfo::StreamInfo& stream_info,
                                                 absl::string_view local_reply_body) const {
-  ProtobufWkt::Struct output;
-  auto* fields = output.mutable_fields();
-  for (const auto& pair : json_output_format_) {
-    const auto& providers = pair.second;
-    ASSERT(!providers.empty());
-
-    if (providers.size() == 1) {
-      const auto& provider = providers.front();
-      const auto val =
-          preserve_types_ ? provider->formatValue(request_headers, response_headers,
-                                                  response_trailers, stream_info, local_reply_body)
-                          : ValueUtil::stringValue(
-                                provider->format(request_headers, response_headers,
-                                                 response_trailers, stream_info, local_reply_body));
-      (*fields)[pair.first] = val;
-    } else {
-      // Multiple providers forces string output.
-      std::string str;
-      for (const auto& provider : providers) {
-        str += provider->format(request_headers, response_headers, response_trailers, stream_info,
-                                local_reply_body);
-      }
-      (*fields)[pair.first] = ValueUtil::stringValue(str);
-    }
-  }
-  return output;
+  const std::function<ProtobufWkt::Value(const std::vector<FormatterProviderPtr>&)>
+      providers_callback = [&](const std::vector<FormatterProviderPtr>& providers) {
+        ASSERT(!providers.empty());
+        if (providers.size() == 1) {
+          const auto& provider = providers.front();
+          if (preserve_types_) {
+            return provider->formatValue(request_headers, response_headers, response_trailers,
+                                         stream_info, local_reply_body);
+          }
+          return ValueUtil::stringValue(provider->format(
+              request_headers, response_headers, response_trailers, stream_info, local_reply_body));
+        }
+        // Multiple providers forces string output.
+        std::string str;
+        for (const auto& provider : providers) {
+          str += provider->format(request_headers, response_headers, response_trailers, stream_info,
+                                  local_reply_body);
+        }
+        return ValueUtil::stringValue(str);
+      };
+  const std::function<ProtobufWkt::Value(const JsonFormatMap&)> json_format_map_callback =
+      [&](const JsonFormatMap& format) {
+        ProtobufWkt::Struct output;
+        auto* fields = output.mutable_fields();
+        for (const auto& pair : *format.value_) {
+          (*fields)[pair.first] = std::visit(
+              JsonFormatMapVisitor{json_format_map_callback, providers_callback}, pair.second);
+        }
+        return ValueUtil::structValue(output);
+      };
+  return json_format_map_callback(json_output_format_).struct_value();
 }
 
 void SubstitutionFormatParser::parseCommandHeader(const std::string& token, const size_t start,

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -17,6 +17,14 @@
 namespace Envoy {
 namespace Formatter {
 
+// We actually need a map to formatters, we can pass the ProtobufStruct, no need to reformat it.
+struct JsonMap;
+using JsonMapPtr = std::unique_ptr<JsonMap>;
+using JsonMapValue = absl::variant<std::string, JsonMapPtr>;
+struct JsonMap {
+  absl::flat_hash_map<std::string, JsonMapValue> values_;
+};
+
 /**
  * Access log format parser.
  */

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -17,14 +17,6 @@
 namespace Envoy {
 namespace Formatter {
 
-// We actually need a map to formatters, we can pass the ProtobufStruct, no need to reformat it.
-struct JsonMap;
-using JsonMapPtr = std::unique_ptr<JsonMap>;
-using JsonMapValue = absl::variant<std::string, JsonMapPtr>;
-struct JsonMap {
-  absl::flat_hash_map<std::string, JsonMapValue> values_;
-};
-
 /**
  * Access log format parser.
  */
@@ -108,10 +100,17 @@ private:
   std::vector<FormatterProviderPtr> providers_;
 };
 
+struct JsonFormatMap;
+using JsonFormatMapValue =
+    absl::variant<const std::vector<FormatterProviderPtr>, const JsonFormatMap>;
+struct JsonFormatMap {
+  std::unique_ptr<std::map<std::string, JsonFormatMapValue>> value_;
+};
+
 class JsonFormatterImpl : public Formatter {
 public:
-  JsonFormatterImpl(const absl::flat_hash_map<std::string, std::string>& format_mapping,
-                    bool preserve_types);
+  JsonFormatterImpl(const ProtobufWkt::Struct& format_mapping, bool preserve_types)
+      : preserve_types_(preserve_types), json_output_format_(toFormatMap(format_mapping)) {}
 
   // Formatter::format
   std::string format(const Http::RequestHeaderMap& request_headers,
@@ -122,13 +121,14 @@ public:
 
 private:
   const bool preserve_types_;
-  std::map<const std::string, const std::vector<FormatterProviderPtr>> json_output_format_;
+  const JsonFormatMap json_output_format_;
 
   ProtobufWkt::Struct toStruct(const Http::RequestHeaderMap& request_headers,
                                const Http::ResponseHeaderMap& response_headers,
                                const Http::ResponseTrailerMap& response_trailers,
                                const StreamInfo::StreamInfo& stream_info,
                                absl::string_view local_reply_body) const;
+  JsonFormatMap toFormatMap(const ProtobufWkt::Struct& json_format) const;
 };
 
 /**

--- a/test/common/formatter/substitution_format_string_test.cc
+++ b/test/common/formatter/substitution_format_string_test.cc
@@ -21,7 +21,8 @@ public:
     EXPECT_CALL(stream_info_, responseCode()).WillRepeatedly(Return(response_code));
   }
 
-  Http::TestRequestHeaderMapImpl request_headers_{{":method", "GET"}, {":path", "/bar/foo"}};
+  Http::TestRequestHeaderMapImpl request_headers_{
+      {":method", "GET"}, {":path", "/bar/foo"}, {"content-type", "application/json"}};
   Http::TestResponseHeaderMapImpl response_headers_;
   Http::TestResponseTrailerMapImpl response_trailers_;
   StreamInfo::MockStreamInfo stream_info_;
@@ -54,6 +55,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJson) {
     text: "plain text"
     path: "%REQ(:path)%"
     code: "%RESPONSE_CODE%"
+    headers:
+      content-type: "%REQ(CONTENT-TYPE)%"
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
@@ -64,7 +67,10 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestFromProtoConfigJson) {
   const std::string expected = R"EOF({
     "text": "plain text",
     "path": "/bar/foo",
-    "code": 200
+    "code": 200,
+    "headers": {
+      "content-type": "application/json"
+    }
 })EOF";
   EXPECT_TRUE(TestUtility::jsonStringEqual(out_json, expected));
 }
@@ -79,17 +85,12 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestInvalidConfigs) {
   json_format:
     field: 200
 )",
-      R"(
-  json_format:
-    field:
-      nest_field: "value"
-)",
   };
   for (const auto& yaml : invalid_configs) {
     TestUtility::loadFromYaml(yaml, config_);
-    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatStringUtils::fromProtoConfig(config_),
-                              EnvoyException,
-                              "Only string values are supported in the JSON access log format.");
+    EXPECT_THROW_WITH_MESSAGE(
+        SubstitutionFormatStringUtils::fromProtoConfig(config_), EnvoyException,
+        "Only string/object values are supported in the JSON access log format.");
   }
 }
 

--- a/test/common/formatter/substitution_formatter_speed_test.cc
+++ b/test/common/formatter/substitution_formatter_speed_test.cc
@@ -11,18 +11,20 @@ namespace Envoy {
 namespace {
 
 std::unique_ptr<Envoy::Formatter::JsonFormatterImpl> makeJsonFormatter(bool typed) {
-  absl::flat_hash_map<std::string, std::string> JsonLogFormat = {
-      {"remote_address", "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
-      {"start_time", "%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%"},
-      {"method", "%REQ(:METHOD)%"},
-      {"url", "%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"},
-      {"protocol", "%PROTOCOL%"},
-      {"respoinse_code", "%RESPONSE_CODE%"},
-      {"bytes_sent", "%BYTES_SENT%"},
-      {"duration", "%DURATION%"},
-      {"referer", "%REQ(REFERER)%"},
-      {"user-agent", "%REQ(USER-AGENT)%"}};
-
+  ProtobufWkt::Struct JsonLogFormat;
+  const std::string format_yaml = R"EOF(
+    remote_address: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'
+    start_time: '%START_TIME(%Y/%m/%dT%H:%M:%S%z %s)%'
+    method: '%REQ(:METHOD)%'
+    url: '%REQ(X-FORWARDED-PROTO)%://%REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+    protocol: '%PROTOCOL%'
+    respoinse_code: '%RESPONSE_CODE%'
+    bytes_sent: '%BYTES_SENT%'
+    duration: '%DURATION%'
+    referer: '%REQ(REFERER)%'
+    user-agent: '%REQ(USER-AGENT)%'
+  )EOF";
+  TestUtility::loadFromYaml(format_yaml, JsonLogFormat);
   return std::make_unique<Envoy::Formatter::JsonFormatterImpl>(JsonLogFormat, typed);
 }
 

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1523,13 +1523,54 @@ TEST(SubstitutionFormatterTest, JsonFormatterPlainStringTest) {
   absl::node_hash_map<std::string, std::string> expected_json_map = {
       {"plain_string", "plain_string_value"}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"plain_string", "plain_string_value"}};
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    plain_string: plain_string_value
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(
       formatter.format(request_header, response_header, response_trailer, stream_info, body),
       expected_json_map);
+}
+
+TEST(SubstitutionFormatterTest, JsonFormatterNestedObject) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header;
+  Http::TestResponseHeaderMapImpl response_header;
+  Http::TestResponseTrailerMapImpl response_trailer;
+  std::string body;
+
+  envoy::config::core::v3::Metadata metadata;
+  populateMetadataTestData(metadata);
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    level_one:
+      level_two:
+        level_three:
+          plain_string: plain_string_value
+          protocol: '%PROTOCOL%'
+  )EOF",
+                            key_mapping);
+  JsonFormatterImpl formatter(key_mapping, false);
+
+  const std::string expected = R"EOF({
+    "level_one": {
+      "level_two": {
+        "level_three": {
+          "plain_string": "plain_string_value",
+          "protocol": "HTTP/1.1"
+        }
+      }
+    }
+  })EOF";
+  std::string out_json =
+      formatter.format(request_header, response_header, response_trailer, stream_info, body);
+  EXPECT_TRUE(TestUtility::jsonStringEqual(out_json, expected));
 }
 
 TEST(SubstitutionFormatterTest, JsonFormatterSingleOperatorTest) {
@@ -1546,7 +1587,11 @@ TEST(SubstitutionFormatterTest, JsonFormatterSingleOperatorTest) {
 
   absl::node_hash_map<std::string, std::string> expected_json_map = {{"protocol", "HTTP/1.1"}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {{"protocol", "%PROTOCOL%"}};
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    protocol: '%PROTOCOL%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(
@@ -1567,11 +1612,14 @@ TEST(SubstitutionFormatterTest, JsonFormatterNonExistentHeaderTest) {
       {"nonexistent_response_header", "-"},
       {"some_response_header", "SOME_RESPONSE_HEADER"}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"protocol", "%PROTOCOL%"},
-      {"some_request_header", "%REQ(some_request_header)%"},
-      {"nonexistent_response_header", "%RESP(nonexistent_response_header)%"},
-      {"some_response_header", "%RESP(some_response_header)%"}};
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    protocol: '%PROTOCOL%'
+    some_request_header: '%REQ(some_request_header)%'
+    nonexistent_response_header: '%RESP(nonexistent_response_header)%'
+    some_response_header: '%RESP(some_response_header)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
@@ -1597,15 +1645,14 @@ TEST(SubstitutionFormatterTest, JsonFormatterAlternateHeaderTest) {
       {"response_absent_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER"},
       {"response_present_header_or_response_absent_header", "RESPONSE_PRESENT_HEADER"}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"request_present_header_or_request_absent_header",
-       "%REQ(request_present_header?request_absent_header)%"},
-      {"request_absent_header_or_request_present_header",
-       "%REQ(request_absent_header?request_present_header)%"},
-      {"response_absent_header_or_response_absent_header",
-       "%RESP(response_absent_header?response_present_header)%"},
-      {"response_present_header_or_response_absent_header",
-       "%RESP(response_present_header?response_absent_header)%"}};
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    request_present_header_or_request_absent_header: '%REQ(request_present_header?request_absent_header)%'
+    request_absent_header_or_request_present_header: '%REQ(request_absent_header?request_present_header)%'
+    response_absent_header_or_response_absent_header: '%RESP(response_absent_header?response_present_header)%'
+    response_present_header_or_response_absent_header: '%RESP(response_present_header?response_absent_header)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
@@ -1633,11 +1680,13 @@ TEST(SubstitutionFormatterTest, JsonFormatterDynamicMetadataTest) {
       {"test_obj", "{\"inner_key\":\"inner_value\"}"},
       {"test_obj.inner_key", "\"inner_value\""}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key", "%DYNAMIC_METADATA(com.test:test_key)%"},
-      {"test_obj", "%DYNAMIC_METADATA(com.test:test_obj)%"},
-      {"test_obj.inner_key", "%DYNAMIC_METADATA(com.test:test_obj:inner_key)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%DYNAMIC_METADATA(com.test:test_key)%'
+    test_obj: '%DYNAMIC_METADATA(com.test:test_obj)%'
+    test_obj.inner_key: '%DYNAMIC_METADATA(com.test:test_obj:inner_key)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(
@@ -1657,11 +1706,13 @@ TEST(SubstitutionFormatterTest, JsonFormatterTypedDynamicMetadataTest) {
   EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
   EXPECT_CALL(Const(stream_info), dynamicMetadata()).WillRepeatedly(ReturnRef(metadata));
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key", "%DYNAMIC_METADATA(com.test:test_key)%"},
-      {"test_obj", "%DYNAMIC_METADATA(com.test:test_obj)%"},
-      {"test_obj.inner_key", "%DYNAMIC_METADATA(com.test:test_obj:inner_key)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%DYNAMIC_METADATA(com.test:test_key)%'
+    test_obj: '%DYNAMIC_METADATA(com.test:test_obj)%'
+    test_obj.inner_key: '%DYNAMIC_METADATA(com.test:test_obj:inner_key)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, true);
 
   const std::string json =
@@ -1693,9 +1744,12 @@ TEST(SubstitutionFormatterTest, JsonFormatterFilterStateTest) {
   absl::node_hash_map<std::string, std::string> expected_json_map = {
       {"test_key", "\"test_value\""}, {"test_obj", "{\"inner_key\":\"inner_value\"}"}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key", "%FILTER_STATE(test_key)%"}, {"test_obj", "%FILTER_STATE(test_obj)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%FILTER_STATE(test_key)%'
+    test_obj: '%FILTER_STATE(test_obj)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(
@@ -1717,9 +1771,12 @@ TEST(SubstitutionFormatterTest, JsonFormatterTypedFilterStateTest) {
                                      StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key", "%FILTER_STATE(test_key)%"}, {"test_obj", "%FILTER_STATE(test_obj)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%FILTER_STATE(test_key)%'
+    test_obj: '%FILTER_STATE(test_obj)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, true);
 
   std::string json =
@@ -1751,10 +1808,12 @@ TEST(SubstitutionFormatterTest, FilterStateSpeciferTest) {
       {"test_key_typed", "\"test_value By TYPED\""},
   };
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key_plain", "%FILTER_STATE(test_key:PLAIN)%"},
-      {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key_plain: '%FILTER_STATE(test_key:PLAIN)%'
+    test_key_typed: '%FILTER_STATE(test_key:TYPED)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(
@@ -1775,10 +1834,12 @@ TEST(SubstitutionFormatterTest, TypedFilterStateSpeciferTest) {
       StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key_plain", "%FILTER_STATE(test_key:PLAIN)%"},
-      {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key_plain: '%FILTER_STATE(test_key:PLAIN)%'
+    test_key_typed: '%FILTER_STATE(test_key:TYPED)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, true);
 
   std::string json =
@@ -1804,10 +1865,12 @@ TEST(SubstitutionFormatterTest, FilterStateErrorSpeciferTest) {
       StreamInfo::FilterState::StateType::ReadOnly);
 
   // 'ABCDE' is error specifier.
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"test_key_plain", "%FILTER_STATE(test_key:ABCDE)%"},
-      {"test_key_typed", "%FILTER_STATE(test_key:TYPED)%"}};
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key_plain: '%FILTER_STATE(test_key:ABCDE)%'
+    test_key_typed: '%FILTER_STATE(test_key:TYPED)%'
+  )EOF",
+                            key_mapping);
   EXPECT_THROW_WITH_MESSAGE(JsonFormatterImpl formatter(key_mapping, false), EnvoyException,
                             "Invalid filter state serialize type, only support PLAIN/TYPED.");
 }
@@ -1830,12 +1893,15 @@ TEST(SubstitutionFormatterTest, JsonFormatterStartTimeTest) {
       {"default", "2018-03-28T23:35:58.000Z"},
       {"all_zeroes", "000000000.0.00.000"}};
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"simple_date", "%START_TIME(%Y/%m/%d)%"},
-      {"test_time", "%START_TIME(%s)%"},
-      {"bad_format", "%START_TIME(bad_format)%"},
-      {"default", "%START_TIME%"},
-      {"all_zeroes", "%START_TIME(%f.%1f.%2f.%3f)%"}};
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    simple_date: '%START_TIME(%Y/%m/%d)%'
+    test_time: '%START_TIME(%s)%'
+    bad_format: '%START_TIME(bad_format)%'
+    default: '%START_TIME%'
+    all_zeroes: '%START_TIME(%f.%1f.%2f.%3f)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
   verifyJsonOutput(
@@ -1855,10 +1921,11 @@ TEST(SubstitutionFormatterTest, JsonFormatterMultiTokenTest) {
     absl::node_hash_map<std::string, std::string> expected_json_map = {
         {"multi_token_field", "HTTP/1.1 plainstring SOME_REQUEST_HEADER SOME_RESPONSE_HEADER"}};
 
-    absl::flat_hash_map<std::string, std::string> key_mapping = {
-        {"multi_token_field",
-         "%PROTOCOL% plainstring %REQ(some_request_header)% %RESP(some_response_header)%"}};
-
+    ProtobufWkt::Struct key_mapping;
+    TestUtility::loadFromYaml(R"EOF(
+      multi_token_field: '%PROTOCOL% plainstring %REQ(some_request_header)% %RESP(some_response_header)%'
+    )EOF",
+                              key_mapping);
     for (const bool preserve_types : {false, true}) {
       JsonFormatterImpl formatter(key_mapping, preserve_types);
 
@@ -1896,12 +1963,13 @@ TEST(SubstitutionFormatterTest, JsonFormatterTypedTest) {
                                      StreamInfo::FilterState::StateType::ReadOnly);
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
-  absl::flat_hash_map<std::string, std::string> key_mapping = {
-      {"request_duration", "%REQUEST_DURATION%"},
-      {"request_duration_multi", "%REQUEST_DURATION%ms"},
-      {"filter_state", "%FILTER_STATE(test_obj)%"},
-  };
-
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    request_duration: '%REQUEST_DURATION%'
+    request_duration_multi: '%REQUEST_DURATION%ms'
+    filter_state: '%FILTER_STATE(test_obj)%'
+  )EOF",
+                            key_mapping);
   JsonFormatterImpl formatter(key_mapping, true);
 
   const auto json =


### PR DESCRIPTION
This adds support for nesting in JSON logging mode. There is another opportunity for improvement - support static non-string values, but I guess we can do this separately.

Commit Message: Add support for nested JSON format in json logging mode
Additional Description:
Risk Level: Low, feature only used if nested objects are configured, thus opt-in
Testing: unit tests
Docs Changes: yes
Release Notes: added to current.rst
Fixes #12582 

cc @aa-stripe 