### PR TITLE
Add the bazel output file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ user.bazelrc
 CMakeLists.txt
 cmake-build-debug
 /linux
+bazel.output.txt


### PR DESCRIPTION
Commit Message:
The bazel.output.txt file is created by bazel build but it is not a part of source code.
It is better to be ignored.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: git status
Docs Changes: None
Release Notes: None