### PR TITLE
support pfadd and pfcount command for redis HyperLogLog in redis filter

### DIFF
--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -26,12 +26,12 @@ struct SupportedCommands {
         "hexists", "hget", "hgetall", "hincrby", "hincrbyfloat", "hkeys", "hlen", "hmget", "hmset",
         "hscan", "hset", "hsetnx", "hstrlen", "hvals", "incr", "incrby", "incrbyfloat", "lindex",
         "linsert", "llen", "lpop", "lpush", "lpushx", "lrange", "lrem", "lset", "ltrim", "persist",
-        "pexpire", "pexpireat", "psetex", "pttl", "restore", "rpop", "rpush", "rpushx", "sadd",
-        "scard", "set", "setbit", "setex", "setnx", "setrange", "sismember", "smembers", "spop",
-        "srandmember", "srem", "sscan", "strlen", "ttl", "type", "zadd", "zcard", "zcount",
-        "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange", "zrangebylex", "zrangebyscore",
-        "zrank", "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore", "zrevrange",
-        "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan", "zscore");
+        "pexpire", "pexpireat", "pfadd", "pfcount", "psetex", "pttl", "restore", "rpop", "rpush",
+        "rpushx", "sadd", "scard", "set", "setbit", "setex", "setnx", "setrange", "sismember",
+        "smembers", "spop", "srandmember", "srem", "sscan", "strlen", "ttl", "type", "zadd",
+        "zcard", "zcount", "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange", "zrangebylex",
+        "zrangebyscore", "zrank", "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore",
+        "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan", "zscore");
   }
 
   /**
@@ -76,9 +76,9 @@ struct SupportedCommands {
         absl::flat_hash_set<std::string>, "append", "bitfield", "decr", "decrby", "del", "expire",
         "expireat", "eval", "evalsha", "geoadd", "hdel", "hincrby", "hincrbyfloat", "hmset", "hset",
         "hsetnx", "incr", "incrby", "incrbyfloat", "linsert", "lpop", "lpush", "lpushx", "lrem",
-        "lset", "ltrim", "mset", "persist", "pexpire", "pexpireat", "psetex", "restore", "rpop",
-        "rpush", "rpushx", "sadd", "set", "setbit", "setex", "setnx", "setrange", "spop", "srem",
-        "zadd", "zincrby", "touch", "zpopmin", "zpopmax", "zrem", "zremrangebylex",
+        "lset", "ltrim", "mset", "persist", "pexpire", "pexpireat", "pfadd", "psetex", "restore",
+        "rpop", "rpush", "rpushx", "sadd", "set", "setbit", "setex", "setnx", "setrange", "spop",
+        "srem", "zadd", "zincrby", "touch", "zpopmin", "zpopmax", "zrem", "zremrangebylex",
         "zremrangebyrank", "zremrangebyscore", "unlink");
   }
 


### PR DESCRIPTION

Commit Message:
now redis filter do not support pfadd and pfcount ,which is very useful as a counter. this pull request solve the problem.

Additional Description:
Risk Level:
Low
Testing:
manual

Docs Changes:
none
Release Notes:
none
