### PR TITLE
Updated the extending envoy documentation to include a missing extension point.

### DIFF
--- a/docs/root/extending/extending.rst
+++ b/docs/root/extending/extending.rst
@@ -21,6 +21,7 @@ types including:
 * :ref:`Request ID <arch_overview_tracing>`
 * Transport sockets
 * BoringSSL private key methods
+* :ref:`Internal redirect policy <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`
 
 As of this writing there is no high level extension developer documentation. The
 :repo:`existing extensions <source/extensions>` are a good way to learn what is possible.


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

Commit Message: Updated the extending envoy documentation to include a missing extension point.
Additional Description: See PR #12416 for additional context of this.
Risk Level: low 
Testing: built the documents to ensure they generate correctly.
Docs Changes: 
Release Notes:
[Optional Runtime guard:] 
[Optional Fixes #Issue]
[Optional Deprecated:]
