### PR TITLE
statsd: revert visibility to public

### DIFF
--- a/source/extensions/stat_sinks/statsd/BUILD
+++ b/source/extensions/stat_sinks/statsd/BUILD
@@ -16,10 +16,6 @@ envoy_cc_extension(
     hdrs = ["config.h"],
     security_posture = "data_plane_agnostic",
     # Legacy test use. TODO(#9953) clean up.
-    visibility = [
-        "//:extension_config",
-        "//test/server:__subpackages__",
-    ],
     deps = [
         "//include/envoy/registry",
         "//source/common/network:address_lib",


### PR DESCRIPTION
Commit Message: reverts visibility of the statd sink to public.
Additional Description: similar to #12579 
Risk Level: low
Testing: local build, CI

Signed-off-by: Jose Nino <jnino@lyft.com>
