### PR TITLE
Updated instructions on how to run tsan tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,7 @@ build --action_env=LLVM_CONFIG
 build --action_env=PATH
 
 # Skip system ICU linking.
-#build --@com_googlesource_googleurl//build_config:system_icu=0
+build --@com_googlesource_googleurl//build_config:system_icu=0
 
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,7 @@ build --action_env=LLVM_CONFIG
 build --action_env=PATH
 
 # Skip system ICU linking.
-build --@com_googlesource_googleurl//build_config:system_icu=0
+#build --@com_googlesource_googleurl//build_config:system_icu=0
 
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled
@@ -310,3 +310,4 @@ build:windows --dynamic_mode=off
 
 try-import %workspace%/clang.bazelrc
 try-import %workspace%/user.bazelrc
+try-import %workspace%/local_tsan.bazelrc

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -501,10 +501,43 @@ bazel test -c dbg --config=clang-asan //test/...
 ```
 
 [Thread sanitizer (TSAN)](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) tests rely on
-a TSAN-instrumented version of libc++ and have to be run under the docker sandbox:
+a TSAN-instrumented version of libc++ and can be run under the docker sandbox:
 
 ```
 bazel test -c dbg --config=docker-tsan //test/...
+```
+
+Alternatively, you can build a local copy of TSAN-instrumented libc++. Follow the [quick start](#quick-start-bazel-build-for-developers) instruction to setup Clang+LLVM environment. Download LLVM sources from the [LLVM official site](https://github.com/llvm/llvm-project)
+
+```
+curl -sSfL "https://github.com/llvm/llvm-project/archive/llvmorg-10.0.0.tar.gz" | tar zx
+
+```
+
+Configure and build a TSAN-instrumented libc++. Please note that `LLVM_USE_SANITIZER=Thread` preprocessor definition is used to enable TSAN instrumentation, and `CMAKE_INSTALL_PREFIX="/opt/libcxx_tsan"` defines the installation directory path.
+
+```
+mkdir tsan
+pushd tsan
+
+cmake -GNinja -DLLVM_ENABLE_PROJECTS="libcxxabi;libcxx" -DLLVM_USE_LINKER=lld -DLLVM_USE_SANITIZER=Thread -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX="/opt/libcxx_tsan" "../llvm-project-llvmorg-10.0.0/llvm"
+ninja install-cxx install-cxxabi
+
+rm -rf /opt/libcxx_tsan/include
+```
+
+Generate local_tsan.bazelrc containing bazel configuration for tsan tests:
+
+```
+bazel/setup_local_tsan.sh </path/to/instrumented/libc++/home>
+
+```
+
+To execute TSAN tests using the local instrumented libc++ library pass `--config=local-tsan` to bazel:
+
+```
+bazel test --config=local-tsan //test/...
 ```
 
 For [memory sanitizer (MSAN)](https://github.com/google/sanitizers/wiki/MemorySanitizer) testing,

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -500,10 +500,11 @@ If you have clang-5.0 or newer, additional checks are provided with:
 bazel test -c dbg --config=clang-asan //test/...
 ```
 
-Similarly, for [thread sanitizer (TSAN)](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) testing:
+[Thread sanitizer (TSAN)](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual) tests rely on
+a TSAN-instrumented version of libc++ and have to be run under the docker sandbox:
 
 ```
-bazel test -c dbg --config=clang-tsan //test/...
+bazel test -c dbg --config=docker-tsan //test/...
 ```
 
 For [memory sanitizer (MSAN)](https://github.com/google/sanitizers/wiki/MemorySanitizer) testing,

--- a/bazel/setup_local_tsan.sh
+++ b/bazel/setup_local_tsan.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+BAZELRC_FILE="${BAZELRC_FILE:-$(bazel info workspace)/local_tsan.bazelrc}"
+
+LIBCXX_PREFIX=$1
+
+if [[ ! -e "${LIBCXX_PREFIX}/lib" ]]; then
+  echo "Error: cannot find /lib in ${LIBCXX_PREFIX}."
+  exit 1
+fi
+
+
+echo "# Generated file, do not edit. Delete this file if you no longer use local tsan-instrumented libc++
+build:local-tsan --config=libc++
+build:local-tsan --linkopt=-L${LIBCXX_PREFIX}/lib
+build:local-tsan --linkopt=-Wl,-rpath,${LIBCXX_PREFIX}/lib
+build:local-tsan --config=clang-tsan
+" > ${BAZELRC_FILE}
+

--- a/bazel/setup_local_tsan.sh
+++ b/bazel/setup_local_tsan.sh
@@ -12,8 +12,8 @@ fi
 
 echo "# Generated file, do not edit. Delete this file if you no longer use local tsan-instrumented libc++
 build:local-tsan --config=libc++
+build:local-tsan --config=clang-tsan
 build:local-tsan --linkopt=-L${LIBCXX_PREFIX}/lib
 build:local-tsan --linkopt=-Wl,-rpath,${LIBCXX_PREFIX}/lib
-build:local-tsan --config=clang-tsan
 " > ${BAZELRC_FILE}
 


### PR DESCRIPTION
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

Updated developer dcos with details on how to execute tsan tests now that we have a tsan-instrumented libc++
