### PR TITLE
cluster: validate that `max_retries` and `retry_budget` are exclusive

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -11,6 +11,7 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* cluster: :ref:`circuit breaker threshold configuration <envoy_v3_api_msg_config.cluster.v3.CircuitBreakers.Thresholds>` now validates that only one of `max_retries` and `retry_budget` may be used.
 * compressor: always insert `Vary` headers for compressible resources even if it's decided not to compress a response due to incompatible `Accept-Encoding` value. The `Vary` header needs to be inserted to let a caching proxy in front of Envoy know that the requested resource still can be served with compression applied.
 * decompressor: headers-only requests were incorrectly not advertising accept-encoding when configured to do so. This is now fixed.
 * http: added :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to local replies.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1179,6 +1179,12 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::config::cluster::v3::Cluste
   absl::optional<double> budget_percent;
   absl::optional<uint32_t> min_retry_concurrency;
   if (it != thresholds.cend()) {
+    // Catch case where max_retries is set but will be ignored!
+    if (it->has_max_retries() && it->has_retry_budget()) {
+      throw EnvoyException(fmt::format(
+          "Cannot use both max_retries and retry_budget in cluster: '{}'", cluster_name));
+    }
+
     max_connections = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_connections, max_connections);
     max_pending_requests =
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_pending_requests, max_pending_requests);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1181,8 +1181,7 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::config::cluster::v3::Cluste
   if (it != thresholds.cend()) {
     // Catch case where max_retries is set but will be ignored!
     if (it->has_max_retries() && it->has_retry_budget()) {
-      throw EnvoyException(fmt::format(
-          "Cannot use both max_retries and retry_budget in cluster: '{}'", cluster_name));
+      throw EnvoyException("Cannot use both max_retries and retry_budget in cluster");
     }
 
     max_connections = PROTOBUF_GET_WRAPPED_OR_DEFAULT(*it, max_connections, max_connections);

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2549,7 +2549,7 @@ TEST_F(StrictDnsClusterImplTest, CircuitBreakersMaxRetriesAndRetryBudgetExclusio
   EXPECT_THROW_WITH_REGEX(StrictDnsClusterImpl(cluster_config, runtime_, dns_resolver_,
                                                factory_context, std::move(scope), false),
                           EnvoyException,
-                          "Cannot use both max_retries and retry_budget in cluster: 'my-cluster'");
+                          "Cannot use both max_retries and retry_budget in cluster");
 }
 
 TEST_F(ClusterInfoImplTest, Timeouts) {


### PR DESCRIPTION
Commit Message: cluster: validate that `max_retries` and `retry_budget` are exclusive
Additional Description: The circuit breaker fields `max_retries` are `retry_budget` are already exclusive: if the latter is set the former is ignored and this is stated in the docs. This PR adds validation to disallow both from being set at the same time.
Risk Level: low
Testing: added new unit test + did manual testing (via static bootstrap, and via filesystem based xds) to verify that setting both fields causes the new cluster config to be rejected
Docs Changes: not changed - already contains this information
Release Notes: updated

Signed-off-by: Martin Matusiak <numerodix@gmail.com>