### PR TITLE
Fix regression of /build_* in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bazel-*
 BROWSE
 /build
+/build_*
 *.bzlc
 .cache
 .clangd


### PR DESCRIPTION
Commit Message:
This is a regression of 887637c1277134df9bea3ad9ac958e38ca69f6db that should be retained.
This patch re-add it into the gitignore file.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: git status
Docs Changes: None
Release Notes: None