### PR TITLE
scoped_rds_integration_test migrate from api v2 to api v3.

### DIFF
--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -101,7 +101,7 @@ ScopedRdsConfigSubscription::ScopedRdsConfigSubscription(
     : DeltaConfigSubscriptionInstance("SRDS", manager_identifier, config_provider_manager,
                                       factory_context),
       Envoy::Config::SubscriptionBase<envoy::config::route::v3::ScopedRouteConfiguration>(
-          rds_config_source.resource_api_version(),
+          scoped_rds.scoped_rds_config_source().resource_api_version(),
           factory_context.messageValidationContext().dynamicValidationVisitor(), "name"),
       factory_context_(factory_context), name_(name), scope_key_builder_(scope_key_builder),
       scope_(factory_context.scope().createScope(stat_prefix + "scoped_rds." + name + ".")),

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -77,28 +77,40 @@ fragments:
           scoped_routes->set_name(srds_config_name_);
           *scoped_routes->mutable_scope_key_builder() = scope_key_builder;
 
+          // Set resource api version for rds.
+          envoy::config::core::v3::ConfigSource* rds_config_source =
+              scoped_routes->mutable_rds_config_source();
+          rds_config_source->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+
+          // Set transport api version for rds.
           envoy::config::core::v3::ApiConfigSource* rds_api_config_source =
-              scoped_routes->mutable_rds_config_source()->mutable_api_config_source();
+              rds_config_source->mutable_api_config_source();
+          rds_api_config_source->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
+
+          // Add grpc service for rds.
           rds_api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
           envoy::config::core::v3::GrpcService* grpc_service =
               rds_api_config_source->add_grpc_services();
           setGrpcService(*grpc_service, "rds_cluster", getRdsFakeUpstream().localAddress());
 
-          envoy::config::core::v3::ApiConfigSource* srds_api_config_source =
-              scoped_routes->mutable_scoped_rds()
-                  ->mutable_scoped_rds_config_source()
-                  ->mutable_api_config_source();
+          // Set resource api version for scoped rds.
           envoy::config::core::v3::ConfigSource* srds_config_source =
               scoped_routes->mutable_scoped_rds()->mutable_scoped_rds_config_source();
           srds_config_source->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+
+          // Set Transport api version for scoped_rds.
+          envoy::config::core::v3::ApiConfigSource* srds_api_config_source =
+              srds_config_source->mutable_api_config_source();
+          srds_api_config_source->set_transport_api_version(
+              envoy::config::core::v3::ApiVersion::V3);
+
+          // Add grpc service for scoped rds.
           if (isDelta()) {
             srds_api_config_source->set_api_type(
                 envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
           } else {
             srds_api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
           }
-          srds_api_config_source->set_transport_api_version(
-              envoy::config::core::v3::ApiVersion::V3);
           grpc_service = srds_api_config_source->add_grpc_services();
           setGrpcService(*grpc_service, "srds_cluster", getScopedRdsFakeUpstream().localAddress());
         });
@@ -166,12 +178,14 @@ fragments:
   }
 
   void sendRdsResponse(const std::string& route_config, const std::string& version) {
-    API_NO_BOOST(envoy::api::v2::DiscoveryResponse) response;
+    envoy::service::discovery::v3::DiscoveryResponse response;
+    std::string route_conguration_type_url =
+        "type.googleapis.com/envoy.config.route.v3.RouteConfiguration";
     response.set_version_info(version);
-    response.set_type_url(Config::TypeUrl::get().RouteConfiguration);
+    response.set_type_url(route_conguration_type_url);
     auto route_configuration =
         TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(route_config);
-    response.add_resources()->PackFrom(API_DOWNGRADE(route_configuration));
+    response.add_resources()->PackFrom(route_configuration);
     ASSERT(rds_upstream_info_.stream_by_resource_name_[route_configuration.name()] != nullptr);
     rds_upstream_info_.stream_by_resource_name_[route_configuration.name()]->sendGrpcMessage(
         response);
@@ -192,10 +206,11 @@ fragments:
                                   const std::vector<std::string>& to_delete_list,
                                   const std::string& version) {
     ASSERT(scoped_rds_upstream_info_.stream_by_resource_name_[srds_config_name_] != nullptr);
-
-    envoy::api::v2::DeltaDiscoveryResponse response;
+    std::string scoped_route_configuration_type_url =
+        "type.googleapis.com/envoy.config.route.v3.ScopedRouteConfiguration";
+    envoy::service::discovery::v3::DeltaDiscoveryResponse response;
     response.set_system_version_info(version);
-    response.set_type_url(Config::TypeUrl::get().ScopedRouteConfiguration);
+    response.set_type_url(scoped_route_configuration_type_url);
 
     for (const auto& scope_name : to_delete_list) {
       *response.add_removed_resources() = scope_name;
@@ -216,9 +231,11 @@ fragments:
                                  const std::string& version) {
     ASSERT(scoped_rds_upstream_info_.stream_by_resource_name_[srds_config_name_] != nullptr);
 
-    API_NO_BOOST(envoy::api::v2::DiscoveryResponse) response;
+    std::string scoped_route_configuration_type_url =
+        "type.googleapis.com/envoy.config.route.v3.ScopedRouteConfiguration";
+    envoy::service::discovery::v3::DiscoveryResponse response;
     response.set_version_info(version);
-    response.set_type_url(Config::TypeUrl::get().ScopedRouteConfiguration);
+    response.set_type_url(scoped_route_configuration_type_url);
 
     for (const auto& resource_proto : resource_protos) {
       envoy::config::route::v3::ScopedRouteConfiguration scoped_route_proto;

--- a/test/test_common/resources.h
+++ b/test/test_common/resources.h
@@ -19,7 +19,7 @@ public:
   const std::string RouteConfiguration{"type.googleapis.com/envoy.api.v2.RouteConfiguration"};
   const std::string VirtualHost{"type.googleapis.com/envoy.api.v2.route.VirtualHost"};
   const std::string ScopedRouteConfiguration{
-      "type.googleapis.com/envoy.api.v2.ScopedRouteConfiguration"};
+      "type.googleapis.com/envoy.api.v3.ScopedRouteConfiguration"};
   const std::string Runtime{"type.googleapis.com/envoy.service.discovery.v2.Runtime"};
 };
 

--- a/test/test_common/resources.h
+++ b/test/test_common/resources.h
@@ -19,7 +19,7 @@ public:
   const std::string RouteConfiguration{"type.googleapis.com/envoy.api.v2.RouteConfiguration"};
   const std::string VirtualHost{"type.googleapis.com/envoy.api.v2.route.VirtualHost"};
   const std::string ScopedRouteConfiguration{
-      "type.googleapis.com/envoy.api.v3.ScopedRouteConfiguration"};
+      "type.googleapis.com/envoy.api.v2.ScopedRouteConfiguration"};
   const std::string Runtime{"type.googleapis.com/envoy.service.discovery.v2.Runtime"};
 };
 


### PR DESCRIPTION
Commit Message: Migrate the integration test of scoped rds from api v2 to api v3. Fix a bug in scoped_rds.cc: ScopedRdsConfigSubscription should use the resource version of srds,  not the resource version of rds.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
