### PR TITLE
server: consolidate overload manager cross-thread updates

### DIFF
--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -228,8 +228,16 @@ void OverloadManagerImpl::start() {
   }
 
   timer_ = dispatcher_.createTimer([this]() -> void {
+    // Guarantee that all resource updates get flushed after no more than one refresh_interval_.
+    flushResourceUpdates();
+
+    // Start a new flush epoch. If all resource updates complete before this callback runs, the last
+    // resource update will call flushResourceUpdates to flush the whole batch early.
+    ++flush_epoch_;
+    flush_awaiting_updates_ = resources_.size();
+
     for (auto& resource : resources_) {
-      resource.second.update();
+      resource.second.update(flush_epoch_);
     }
 
     timer_->enableTimer(refresh_interval_);
@@ -266,32 +274,54 @@ ThreadLocalOverloadState& OverloadManagerImpl::getThreadLocalOverloadState() {
   return tls_->getTyped<ThreadLocalOverloadStateImpl>();
 }
 
-void OverloadManagerImpl::updateResourcePressure(const std::string& resource, double pressure) {
-  auto action_range = resource_to_actions_.equal_range(resource);
-  std::for_each(action_range.first, action_range.second,
-                [&](ResourceToActionMap::value_type& entry) {
-                  const std::string& action = entry.second;
-                  auto action_it = actions_.find(action);
-                  ASSERT(action_it != actions_.end());
-                  const OverloadActionState old_state = action_it->second.getState();
-                  if (action_it->second.updateResourcePressure(resource, pressure)) {
-                    const auto state = action_it->second.getState();
+void OverloadManagerImpl::updateResourcePressure(const std::string& resource, double pressure,
+                                                 int flush_epoch) {
+  auto [start, end] = resource_to_actions_.equal_range(resource);
 
-                    if (old_state.isSaturated() != state.isSaturated()) {
-                      ENVOY_LOG(debug, "Overload action {} became {}", action,
-                                (state.isSaturated() ? "saturated" : "scaling"));
-                    }
-                    tls_->runOnAllThreads([this, action, state] {
-                      tls_->getTyped<ThreadLocalOverloadStateImpl>().setState(action, state);
-                    });
-                    auto callback_range = action_to_callbacks_.equal_range(action);
-                    std::for_each(callback_range.first, callback_range.second,
-                                  [&](ActionToCallbackMap::value_type& cb_entry) {
-                                    auto& cb = cb_entry.second;
-                                    cb.dispatcher_.post([&, state]() { cb.callback_(state); });
-                                  });
-                  }
-                });
+  std::for_each(start, end, [&](ResourceToActionMap::value_type& entry) {
+    const std::string& action = entry.second;
+    auto action_it = actions_.find(action);
+    ASSERT(action_it != actions_.end());
+    const OverloadActionState old_state = action_it->second.getState();
+    if (action_it->second.updateResourcePressure(resource, pressure)) {
+      const auto state = action_it->second.getState();
+
+      if (old_state.isSaturated() != state.isSaturated()) {
+        ENVOY_LOG(debug, "Overload action {} became {}", action,
+                  (state.isSaturated() ? "saturated" : "scaling"));
+      }
+      state_updates_to_flush_.insert_or_assign(action, state);
+      auto [callbacks_start, callbacks_end] = action_to_callbacks_.equal_range(action);
+      std::for_each(callbacks_start, callbacks_end, [&](ActionToCallbackMap::value_type& cb_entry) {
+        callbacks_to_flush_.insert_or_assign(&cb_entry.second, state);
+      });
+    }
+  });
+
+  // Eagerly flush updates if this is the last call to updateResourcePressure expected for the
+  // current epoch.
+  --flush_awaiting_updates_;
+  if (flush_epoch == flush_epoch_ && flush_awaiting_updates_ == 0) {
+    flushResourceUpdates();
+  }
+}
+
+void OverloadManagerImpl::flushResourceUpdates() {
+  if (!state_updates_to_flush_.empty()) {
+    auto shared_updates = std::make_shared<absl::flat_hash_map<std::string, OverloadActionState>>();
+    std::swap(*shared_updates, state_updates_to_flush_);
+
+    tls_->runOnAllThreads([this, updates = std::move(shared_updates)] {
+      for (const auto& [action, state] : *updates) {
+        tls_->getTyped<ThreadLocalOverloadStateImpl>().setState(action, state);
+      }
+    });
+  }
+
+  for (const auto& [cb, state] : callbacks_to_flush_) {
+    cb->dispatcher_.post([cb = cb, state = state]() { cb->callback_(state); });
+  }
+  callbacks_to_flush_.clear();
 }
 
 OverloadManagerImpl::Resource::Resource(const std::string& name, ResourceMonitorPtr monitor,
@@ -302,9 +332,10 @@ OverloadManagerImpl::Resource::Resource(const std::string& name, ResourceMonitor
       failed_updates_counter_(makeCounter(stats_scope, name, "failed_updates")),
       skipped_updates_counter_(makeCounter(stats_scope, name, "skipped_updates")) {}
 
-void OverloadManagerImpl::Resource::update() {
+void OverloadManagerImpl::Resource::update(int flush_epoch) {
   if (!pending_update_) {
     pending_update_ = true;
+    flush_epoch_ = flush_epoch;
     monitor_->updateResourceUsage(*this);
     return;
   }
@@ -314,7 +345,7 @@ void OverloadManagerImpl::Resource::update() {
 
 void OverloadManagerImpl::Resource::onSuccess(const ResourceUsage& usage) {
   pending_update_ = false;
-  manager_.updateResourcePressure(name_, usage.resource_pressure_);
+  manager_.updateResourcePressure(name_, usage.resource_pressure_, flush_epoch_);
   pressure_gauge_.set(usage.resource_pressure_ * 100); // convert to percent
 }
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -389,7 +389,8 @@ TEST_F(OverloadManagerImplTest, FlushesUpdatesEvenWithOneUnresponsive) {
   timer_cb_();
 
   EXPECT_FALSE(action_state.isSaturated());
-  // A second timer callback will flush the update from monitor 2, even though monitor 1 is unresponsive.
+  // A second timer callback will flush the update from monitor 2, even though monitor 1 is
+  // unresponsive.
   timer_cb_();
   EXPECT_TRUE(action_state.isSaturated());
 }

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -31,32 +31,48 @@ namespace {
 
 class FakeResourceMonitor : public ResourceMonitor {
 public:
-  FakeResourceMonitor(Event::Dispatcher& dispatcher)
-      : success_(true), pressure_(0), error_("fake error"), dispatcher_(dispatcher) {}
+  FakeResourceMonitor(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher), response_(0.0) {}
 
-  void setPressure(double pressure) {
-    success_ = true;
-    pressure_ = pressure;
+  void setPressure(double pressure) { response_ = pressure; }
+
+  void setError() { response_ = EnvoyException("fake_error"); }
+
+  void setUpdateAsync(bool new_update_async) {
+    callbacks_.reset();
+    update_async_ = new_update_async;
   }
 
-  void setError() { success_ = false; }
-
   void updateResourceUsage(ResourceMonitor::Callbacks& callbacks) override {
-    if (success_) {
-      Server::ResourceUsage usage;
-      usage.resource_pressure_ = pressure_;
-      dispatcher_.post([&, usage]() { callbacks.onSuccess(usage); });
+    if (update_async_) {
+      callbacks_.emplace(callbacks);
     } else {
-      EnvoyException& error = error_;
-      dispatcher_.post([&, error]() { callbacks.onFailure(error); });
+      publishUpdate(callbacks);
+    }
+  }
+
+  void publishUpdate() {
+    if (update_async_) {
+      ASSERT(callbacks_.has_value());
+      publishUpdate(*callbacks_);
     }
   }
 
 private:
-  bool success_;
-  double pressure_;
-  EnvoyException error_;
+  void publishUpdate(ResourceMonitor::Callbacks& callbacks) {
+    if (absl::holds_alternative<double>(response_)) {
+      Server::ResourceUsage usage;
+      usage.resource_pressure_ = absl::get<double>(response_);
+      dispatcher_.post([&, usage]() { callbacks.onSuccess(usage); });
+    } else {
+      EnvoyException& error = absl::get<EnvoyException>(response_);
+      dispatcher_.post([&, error]() { callbacks.onFailure(error); });
+    }
+  }
+
   Event::Dispatcher& dispatcher_;
+  absl::variant<double, EnvoyException> response_;
+  bool update_async_ = false;
+  absl::optional<std::reference_wrapper<ResourceMonitor::Callbacks>> callbacks_;
 };
 
 template <class ConfigType>
@@ -139,26 +155,6 @@ protected:
           scaled {
             scaling_threshold: 0.5
             saturation_threshold: 0.8
-          }
-        }
-      }
-    )EOF";
-  }
-
-  std::string getConfigSimple() {
-    return R"EOF(
-      refresh_interval {
-        seconds: 1
-      }
-      resource_monitors {
-        name: "envoy.resource_monitors.fake_resource1"
-      }
-      actions {
-        name: "envoy.overload_actions.dummy_action"
-        triggers {
-          name: "envoy.resource_monitors.fake_resource1"
-          threshold {
-            value: 0.9
           }
         }
       }
@@ -354,19 +350,64 @@ TEST_F(OverloadManagerImplTest, FailedUpdates) {
   manager->stop();
 }
 
+TEST_F(OverloadManagerImplTest, AggregatesMultipleResourceUpdates) {
+  setDispatcherExpectation();
+  auto manager(createOverloadManager(getConfig()));
+  manager->start();
+
+  const OverloadActionState& action_state =
+      manager->getThreadLocalOverloadState().getState("envoy.overload_actions.dummy_action");
+
+  factory1_.monitor_->setUpdateAsync(true);
+
+  // Monitor 2 will respond immediately at the timer callback, but that won't push an update to the
+  // thread-local state because monitor 1 hasn't finished its update yet.
+  factory2_.monitor_->setPressure(1.0);
+  timer_cb_();
+
+  EXPECT_FALSE(action_state.isSaturated());
+
+  // Once the last monitor publishes, the change to the action takes effect.
+  factory1_.monitor_->publishUpdate();
+  EXPECT_TRUE(action_state.isSaturated());
+}
+
+TEST_F(OverloadManagerImplTest, FlushesUpdatesEvenWithOneUnresponsive) {
+  setDispatcherExpectation();
+  auto manager(createOverloadManager(getConfig()));
+  manager->start();
+
+  const OverloadActionState& action_state =
+      manager->getThreadLocalOverloadState().getState("envoy.overload_actions.dummy_action");
+
+  // Set monitor 1 to async, but never publish updates for it.
+  factory1_.monitor_->setUpdateAsync(true);
+
+  // Monitor 2 will respond immediately at the timer callback, but that won't push an update to the
+  // thread-local state because monitor 1 hasn't finished its update yet.
+  factory2_.monitor_->setPressure(1.0);
+  timer_cb_();
+
+  EXPECT_FALSE(action_state.isSaturated());
+  // A second timer callback will flush the update from monitor 2, even though monitor 1 is unresponsive.
+  timer_cb_();
+  EXPECT_TRUE(action_state.isSaturated());
+}
+
 TEST_F(OverloadManagerImplTest, SkippedUpdates) {
   setDispatcherExpectation();
 
-  // Save the post callback instead of executing it.
-  // Note that this test works for only one resource. If using the default config,
-  // two events fire, so a list of all post_cb's between timer_cb_'s would need to be invoked.
-  Event::PostCb post_cb;
-  ON_CALL(dispatcher_, post(_)).WillByDefault(Invoke([&](Event::PostCb cb) { post_cb = cb; }));
-
-  auto manager(createOverloadManager(getConfigSimple()));
+  auto manager(createOverloadManager(getConfig()));
   manager->start();
   Stats::Counter& skipped_updates =
       stats_.counter("overload.envoy.resource_monitors.fake_resource1.skipped_updates");
+  Stats::Gauge& pressure_gauge1 =
+      stats_.gauge("overload.envoy.resource_monitors.fake_resource1.pressure",
+                   Stats::Gauge::ImportMode::NeverImport);
+
+  factory1_.monitor_->setUpdateAsync(true);
+  EXPECT_EQ(0, pressure_gauge1.value());
+  factory1_.monitor_->setPressure(0.3);
 
   timer_cb_();
   EXPECT_EQ(0, skipped_updates.value());
@@ -374,7 +415,10 @@ TEST_F(OverloadManagerImplTest, SkippedUpdates) {
   EXPECT_EQ(1, skipped_updates.value());
   timer_cb_();
   EXPECT_EQ(2, skipped_updates.value());
-  post_cb();
+
+  factory1_.monitor_->publishUpdate();
+  EXPECT_EQ(30, pressure_gauge1.value());
+
   timer_cb_();
   EXPECT_EQ(2, skipped_updates.value());
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -104,8 +104,9 @@ protected:
   OverloadManagerImplTest()
       : factory1_("envoy.resource_monitors.fake_resource1"),
         factory2_("envoy.resource_monitors.fake_resource2"),
-        factory3_("envoy.resource_monitors.fake_resource3"), factory4_("envoy.resource_monitors.fake_resource4"), register_factory1_(factory1_),
-        register_factory2_(factory2_), register_factory3_(factory3_),register_factory4_(factory4_),
+        factory3_("envoy.resource_monitors.fake_resource3"),
+        factory4_("envoy.resource_monitors.fake_resource4"), register_factory1_(factory1_),
+        register_factory2_(factory2_), register_factory3_(factory3_), register_factory4_(factory4_),
         api_(Api::createApiForTest(stats_)) {}
 
   void setDispatcherExpectation() {


### PR DESCRIPTION
Commit Message: Consolidate Overload Manager cross-thread updates 
Additional Description:
Reduce the number of TLS updates that the overload manager performs by
consolidating all updates from a given update attempt into a single
publish event to the thread-local stores. This makes updates for scaled
triggers less expensive at the cost of some latency. Before this change,
updates were applied immediately; with this change, they are applied at
most one overload manager update period after being measured.

Risk Level: medium
Testing: ran all tests that depend on //source/server:overload_manager_impl
Docs Changes: n/a
Release Notes: n/a

Addresses some feedback on #12352
