### PR TITLE
docs: Fix broken code block style

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -151,7 +151,7 @@ by using a volume.
 By default the Docker image will run as the ``envoy`` user created at build time.
 
 The ``uid`` and ``gid`` of this user can be set at runtime using the ``ENVOY_UID`` and ``ENVOY_GID``
-environment variables. This can be done, for example, on the Docker command line:
+environment variables. This can be done, for example, on the Docker command line::
 
   $ docker run -d --name envoy -e ENVOY_UID=777 -e ENVOY_GID=777 -p 9901:9901 -p 10000:10000 envoy:v1
 


### PR DESCRIPTION
Signed-off-by: Takao Shibata <chise.alter.pasta@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Fix broken code block style in docs
Additional Description: n/a
Risk Level: low
Testing: n/a
Docs Changes: Fix broken code block style in `docs/root/start/start.rst`
Release Notes: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]