### PR TITLE
docs: Fix broken reST style

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -185,6 +185,7 @@ following are the command line options that Envoy supports.
   variable which should be passed to this option in most cases.
 
 .. option:: --enable-fine-grain-logging
+
   *(optional)* Enables fine-grain logger with file level log control and runtime update at administration
   interface. If enabled, main log macros including `ENVOY_LOG`, `ENVOY_CONN_LOG`, `ENVOY_STREAM_LOG` and
   `ENVOY_FLUSH_LOG` will use a per-file logger, and the usage doesn't need `Envoy::Logger::Loggable` any 


### PR DESCRIPTION
Signed-off-by: Takao Shibata <chise.alter.pasta@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Fix broken reST style in docs
Additional Description: reST style at `--enable-fine-grain-logging` in https://www.envoyproxy.io/docs/envoy/latest/operations/cli is broken like following image.

![image](https://user-images.githubusercontent.com/1219666/90325363-a778ae00-dfb5-11ea-977e-d22839c78d2e.png)

Risk Level: low
Testing: n/a
Docs Changes: Fix broken reST style in `docs/root/start/start.rst`
Release Notes: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
