### PR TITLE
api: deprecate the node.listening_addresses field

### DIFF
--- a/api/envoy/admin/v4alpha/config_dump.proto
+++ b/api/envoy/admin/v4alpha/config_dump.proto
@@ -93,7 +93,7 @@ message ListenersConfigDump {
         "envoy.admin.v3.ListenersConfigDump.DynamicListenerState";
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time
     // that the listener was loaded. In the future, discrete per-listener versions may be supported
     // by the API.
     string version_info = 1;
@@ -134,7 +134,7 @@ message ListenersConfigDump {
     UpdateFailureState error_state = 5;
   }
 
-  // This is the :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` in the
+  // This is the :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` in the
   // last processed LDS discovery response. If there are only static bootstrap listeners, this field
   // will be "".
   string version_info = 1;
@@ -170,7 +170,7 @@ message ClustersConfigDump {
         "envoy.admin.v3.ClustersConfigDump.DynamicCluster";
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time
     // that the cluster was loaded. In the future, discrete per-cluster versions may be supported by
     // the API.
     string version_info = 1;
@@ -182,7 +182,7 @@ message ClustersConfigDump {
     google.protobuf.Timestamp last_updated = 3;
   }
 
-  // This is the :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` in the
+  // This is the :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` in the
   // last processed CDS discovery response. If there are only static bootstrap clusters, this field
   // will be "".
   string version_info = 1;
@@ -225,7 +225,7 @@ message RoutesConfigDump {
         "envoy.admin.v3.RoutesConfigDump.DynamicRouteConfig";
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time that
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time that
     // the route configuration was loaded.
     string version_info = 1;
 
@@ -273,7 +273,7 @@ message ScopedRoutesConfigDump {
     string name = 1;
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time that
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time that
     // the scoped routes configuration was loaded.
     string version_info = 2;
 
@@ -366,7 +366,7 @@ message EndpointsConfigDump {
         "envoy.admin.v3.EndpointsConfigDump.DynamicEndpointConfig";
 
     // [#not-implemented-hide:] This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time that
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time that
     // the endpoint configuration was loaded.
     string version_info = 1;
 

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -196,7 +196,7 @@ message Node {
   // for filtering :ref:`listeners <config_listeners>` to be returned. For example,
   // if there is a listener bound to port 80, the list can optionally contain the
   // SocketAddress `(0.0.0.0,80)`. The field is optional and just a hint.
-  repeated Address listening_addresses = 11;
+  repeated Address listening_addresses = 11 [deprecated = true];
 }
 
 // Metadata provides additional inputs to filters based on matched listeners,

--- a/api/envoy/config/core/v4alpha/base.proto
+++ b/api/envoy/config/core/v4alpha/base.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.config.core.v4alpha;
 
-import "envoy/config/core/v4alpha/address.proto";
 import "envoy/config/core/v4alpha/backoff.proto";
 import "envoy/config/core/v4alpha/http_uri.proto";
 import "envoy/type/v3/percent.proto";
@@ -135,9 +134,9 @@ message Extension {
 message Node {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.core.v3.Node";
 
-  reserved 5;
+  reserved 5, 11;
 
-  reserved "build_version";
+  reserved "build_version", "listening_addresses";
 
   // An opaque node identifier for the Envoy node. This also provides the local
   // service node name. It should be set if any of the following features are
@@ -190,12 +189,6 @@ message Node {
   // See :ref:`the list of features <client_features>` that xDS client may
   // support.
   repeated string client_features = 10;
-
-  // Known listening ports on the node as a generic hint to the management server
-  // for filtering :ref:`listeners <config_listeners>` to be returned. For example,
-  // if there is a listener bound to port 80, the list can optionally contain the
-  // SocketAddress `(0.0.0.0,80)`. The field is optional and just a hint.
-  repeated Address listening_addresses = 11;
 }
 
 // Metadata provides additional inputs to filters based on matched listeners,

--- a/api/envoy/config/metrics/v4alpha/metrics_service.proto
+++ b/api/envoy/config/metrics/v4alpha/metrics_service.proto
@@ -36,6 +36,6 @@ message MetricsServiceConfig {
   // If true, counters are reported as the delta between flushing intervals. Otherwise, the current
   // counter value is reported. Defaults to false.
   // Eventually (https://github.com/envoyproxy/envoy/issues/10968) if this value is not set, the
-  // sink will take updates from the :ref:`MetricsResponse <envoy_api_msg_service.metrics.v3.StreamMetricsResponse>`.
+  // sink will take updates from the :ref:`MetricsResponse <envoy_api_msg_service.metrics.v4alpha.StreamMetricsResponse>`.
   google.protobuf.BoolValue report_counters_as_deltas = 2;
 }

--- a/api/envoy/config/route/v4alpha/scoped_route.proto
+++ b/api/envoy/config/route/v4alpha/scoped_route.proto
@@ -107,7 +107,7 @@ message ScopedRouteConfiguration {
   // The name assigned to the routing scope.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // The resource name to use for a :ref:`envoy_api_msg_service.discovery.v3.DiscoveryRequest` to an
+  // The resource name to use for a :ref:`envoy_api_msg_service.discovery.v4alpha.DiscoveryRequest` to an
   // RDS server to fetch the :ref:`envoy_api_msg_config.route.v4alpha.RouteConfiguration` associated
   // with this scope.
   string route_configuration_name = 2 [(validate.rules).string = {min_bytes: 1}];

--- a/api/envoy/service/accesslog/v4alpha/BUILD
+++ b/api/envoy/service/accesslog/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/data/accesslog/v3:pkg",
+        "//envoy/service/accesslog/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/service/accesslog/v4alpha/als.proto
+++ b/api/envoy/service/accesslog/v4alpha/als.proto
@@ -1,0 +1,87 @@
+syntax = "proto3";
+
+package envoy.service.accesslog.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+import "envoy/data/accesslog/v3/accesslog.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.accesslog.v4alpha";
+option java_outer_classname = "AlsProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: gRPC Access Log Service (ALS)]
+
+// Service for streaming access logs from Envoy to an access log server.
+service AccessLogService {
+  // Envoy will connect and send StreamAccessLogsMessage messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure. The server should
+  // disconnect if it expects Envoy to reconnect. In the future we may decide to add a different
+  // API for "critical" access logs in which Envoy will buffer access logs for some period of time
+  // until it gets an ACK so it could then retry. This API is designed for high throughput with the
+  // expectation that it might be lossy.
+  rpc StreamAccessLogs(stream StreamAccessLogsMessage) returns (StreamAccessLogsResponse) {
+  }
+}
+
+// Empty response for the StreamAccessLogs API. Will never be sent. See below.
+message StreamAccessLogsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.accesslog.v3.StreamAccessLogsResponse";
+}
+
+// Stream message for the StreamAccessLogs API. Envoy will open a stream to the server and stream
+// access logs without ever expecting a response.
+message StreamAccessLogsMessage {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.accesslog.v3.StreamAccessLogsMessage";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.accesslog.v3.StreamAccessLogsMessage.Identifier";
+
+    // The node sending the access log messages over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+
+    // The friendly name of the log configured in :ref:`CommonGrpcAccessLogConfig
+    // <envoy_api_msg_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig>`.
+    string log_name = 2 [(validate.rules).string = {min_bytes: 1}];
+  }
+
+  // Wrapper for batches of HTTP access log entries.
+  message HTTPAccessLogEntries {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.accesslog.v3.StreamAccessLogsMessage.HTTPAccessLogEntries";
+
+    repeated data.accesslog.v3.HTTPAccessLogEntry log_entry = 1
+        [(validate.rules).repeated = {min_items: 1}];
+  }
+
+  // Wrapper for batches of TCP access log entries.
+  message TCPAccessLogEntries {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.accesslog.v3.StreamAccessLogsMessage.TCPAccessLogEntries";
+
+    repeated data.accesslog.v3.TCPAccessLogEntry log_entry = 1
+        [(validate.rules).repeated = {min_items: 1}];
+  }
+
+  // Identifier data that will only be sent in the first message on the stream. This is effectively
+  // structured metadata and is a performance optimization.
+  Identifier identifier = 1;
+
+  // Batches of log entries of a single type. Generally speaking, a given stream should only
+  // ever include one type of log entry.
+  oneof log_entries {
+    option (validate.required) = true;
+
+    HTTPAccessLogEntries http_logs = 2;
+
+    TCPAccessLogEntries tcp_logs = 3;
+  }
+}

--- a/api/envoy/service/discovery/v4alpha/BUILD
+++ b/api/envoy/service/discovery/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/discovery/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/service/discovery/v4alpha/ads.proto
+++ b/api/envoy/service/discovery/v4alpha/ads.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v4alpha;
+
+import "envoy/service/discovery/v4alpha/discovery.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v4alpha";
+option java_outer_classname = "AdsProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Aggregated Discovery Service (ADS)]
+
+// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// and listeners are retained in the package `envoy.api.v2` for backwards
+// compatibility with existing management servers. New development in discovery
+// services should proceed in the package `envoy.service.discovery.v2`.
+
+// See https://github.com/lyft/envoy-api#apis for a description of the role of
+// ADS and how it is intended to be used by a management server. ADS requests
+// have the same structure as their singleton xDS counterparts, but can
+// multiplex many resource types on a single stream. The type_url in the
+// DiscoveryRequest/DiscoveryResponse provides sufficient information to recover
+// the multiplexed singleton APIs at the Envoy instance and management server.
+service AggregatedDiscoveryService {
+  // This is a gRPC-only API.
+  rpc StreamAggregatedResources(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaAggregatedResources(stream DeltaDiscoveryRequest)
+      returns (stream DeltaDiscoveryResponse) {
+  }
+}
+
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message AdsDummy {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.AdsDummy";
+}

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -1,0 +1,279 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "google/protobuf/any.proto";
+import "google/rpc/status.proto";
+
+import "udpa/core/v1/resource_locator.proto";
+import "udpa/core/v1/resource_name.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v4alpha";
+option java_outer_classname = "DiscoveryProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Common discovery API components]
+
+// A DiscoveryRequest requests a set of versioned resources of the same type for
+// a given Envoy node on some API.
+// [#next-free-field: 7]
+message DiscoveryRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DiscoveryRequest";
+
+  // The version_info provided in the request messages will be the version_info
+  // received with the most recent successfully processed response or empty on
+  // the first request. It is expected that no new request is sent after a
+  // response is received until the Envoy instance is ready to ACK/NACK the new
+  // configuration. ACK/NACK takes place by returning the new API config version
+  // as applied or the previous API config version respectively. Each type_url
+  // (see below) has an independent version associated with it.
+  string version_info = 1;
+
+  // The node making the request.
+  config.core.v4alpha.Node node = 2;
+
+  // List of resources to subscribe to, e.g. list of cluster names or a route
+  // configuration name. If this is empty, all resources for the API are
+  // returned. LDS/CDS may have empty resource_names, which will cause all
+  // resources for the Envoy instance to be returned. The LDS and CDS responses
+  // will then imply a number of resources that need to be fetched via EDS/RDS,
+  // which will be explicitly enumerated in resource_names.
+  repeated string resource_names = 3;
+
+  // Type of the resource that is being requested, e.g.
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit
+  // in requests made via singleton xDS APIs such as CDS, LDS, etc. but is
+  // required for ADS.
+  string type_url = 4;
+
+  // nonce corresponding to DiscoveryResponse being ACK/NACKed. See above
+  // discussion on version_info and the DiscoveryResponse nonce comment. This
+  // may be empty only if 1) this is a non-persistent-stream xDS such as HTTP,
+  // or 2) the client has not yet accepted an update in this xDS stream (unlike
+  // delta, where it is populated only for new explicit ACKs).
+  string response_nonce = 5;
+
+  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_service.discovery.v4alpha.DiscoveryResponse>`
+  // failed to update configuration. The *message* field in *error_details* provides the Envoy
+  // internal exception related to the failure. It is only intended for consumption during manual
+  // debugging, the string provided is not guaranteed to be stable across Envoy versions.
+  google.rpc.Status error_detail = 6;
+}
+
+// [#next-free-field: 7]
+message DiscoveryResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DiscoveryResponse";
+
+  // The version of the response data.
+  string version_info = 1;
+
+  // The response resources. These resources are typed and depend on the API being called.
+  repeated google.protobuf.Any resources = 2;
+
+  // [#not-implemented-hide:]
+  // Canary is used to support two Envoy command line flags:
+  //
+  // * --terminate-on-canary-transition-failure. When set, Envoy is able to
+  //   terminate if it detects that configuration is stuck at canary. Consider
+  //   this example sequence of updates:
+  //   - Management server applies a canary config successfully.
+  //   - Management server rolls back to a production config.
+  //   - Envoy rejects the new production config.
+  //   Since there is no sensible way to continue receiving configuration
+  //   updates, Envoy will then terminate and apply production config from a
+  //   clean slate.
+  // * --dry-run-canary. When set, a canary response will never be applied, only
+  //   validated via a dry run.
+  bool canary = 3;
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the 'resources' repeated Any (if non-empty).
+  string type_url = 4;
+
+  // For gRPC based subscriptions, the nonce provides a way to explicitly ack a
+  // specific DiscoveryResponse in a following DiscoveryRequest. Additional
+  // messages may have been sent by Envoy to the management server for the
+  // previous version on the stream prior to this DiscoveryResponse, that were
+  // unprocessed at response send time. The nonce allows the management server
+  // to ignore any further DiscoveryRequests for the previous version until a
+  // DiscoveryRequest bearing the nonce. The nonce is optional and is not
+  // required for non-stream based xDS implementations.
+  string nonce = 5;
+
+  // [#not-implemented-hide:]
+  // The control plane instance that sent the response.
+  config.core.v4alpha.ControlPlane control_plane = 6;
+}
+
+// DeltaDiscoveryRequest and DeltaDiscoveryResponse are used in a new gRPC
+// endpoint for Delta xDS.
+//
+// With Delta xDS, the DeltaDiscoveryResponses do not need to include a full
+// snapshot of the tracked resources. Instead, DeltaDiscoveryResponses are a
+// diff to the state of a xDS client.
+// In Delta XDS there are per-resource versions, which allow tracking state at
+// the resource granularity.
+// An xDS Delta session is always in the context of a gRPC bidirectional
+// stream. This allows the xDS server to keep track of the state of xDS clients
+// connected to it.
+//
+// In Delta xDS the nonce field is required and used to pair
+// DeltaDiscoveryResponse to a DeltaDiscoveryRequest ACK or NACK.
+// Optionally, a response message level system_version_info is present for
+// debugging purposes only.
+//
+// DeltaDiscoveryRequest plays two independent roles. Any DeltaDiscoveryRequest
+// can be either or both of: [1] informing the server of what resources the
+// client has gained/lost interest in (using resource_names_subscribe and
+// resource_names_unsubscribe), or [2] (N)ACKing an earlier resource update from
+// the server (using response_nonce, with presence of error_detail making it a NACK).
+// Additionally, the first message (for a given type_url) of a reconnected gRPC stream
+// has a third role: informing the server of the resources (and their versions)
+// that the client already possesses, using the initial_resource_versions field.
+//
+// As with state-of-the-world, when multiple resource types are multiplexed (ADS),
+// all requests/acknowledgments/updates are logically walled off by type_url:
+// a Cluster ACK exists in a completely separate world from a prior Route NACK.
+// In particular, initial_resource_versions being sent at the "start" of every
+// gRPC stream actually entails a message for each type_url, each with its own
+// initial_resource_versions.
+// [#next-free-field: 10]
+message DeltaDiscoveryRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DeltaDiscoveryRequest";
+
+  // The node making the request.
+  config.core.v4alpha.Node node = 1;
+
+  // Type of the resource that is being requested, e.g.
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This does not need to be set if
+  // resources are only referenced via *udpa_resource_subscribe* and
+  // *udpa_resources_unsubscribe*.
+  string type_url = 2;
+
+  // DeltaDiscoveryRequests allow the client to add or remove individual
+  // resources to the set of tracked resources in the context of a stream.
+  // All resource names in the resource_names_subscribe list are added to the
+  // set of tracked resources and all resource names in the resource_names_unsubscribe
+  // list are removed from the set of tracked resources.
+  //
+  // *Unlike* state-of-the-world xDS, an empty resource_names_subscribe or
+  // resource_names_unsubscribe list simply means that no resources are to be
+  // added or removed to the resource list.
+  // *Like* state-of-the-world xDS, the server must send updates for all tracked
+  // resources, but can also send updates for resources the client has not subscribed to.
+  //
+  // NOTE: the server must respond with all resources listed in resource_names_subscribe,
+  // even if it believes the client has the most recent version of them. The reason:
+  // the client may have dropped them, but then regained interest before it had a chance
+  // to send the unsubscribe message. See DeltaSubscriptionStateTest.RemoveThenAdd.
+  //
+  // These two fields can be set in any DeltaDiscoveryRequest, including ACKs
+  // and initial_resource_versions.
+  //
+  // A list of Resource names to add to the list of tracked resources.
+  repeated string resource_names_subscribe = 3;
+
+  // As with *resource_names_subscribe* but used when subscribing to resources indicated
+  // by a *udpa.core.v1.ResourceLocator*. The directives in the resource locator
+  // are ignored and the context parameters are matched with
+  // *context_param_specifier* specific semantics.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_subscribe = 8;
+
+  // A list of Resource names to remove from the list of tracked resources.
+  repeated string resource_names_unsubscribe = 4;
+
+  // As with *resource_names_unsubscribe* but used when unsubscribing to resources indicated by a
+  // *udpa.core.v1.ResourceLocator*. This must match a previously subscribed
+  // resource locator provided in *udpa_resources_subscribe*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_unsubscribe = 9;
+
+  // Informs the server of the versions of the resources the xDS client knows of, to enable the
+  // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
+  // It will not be populated: [1] in the very first stream of a session, since the client will
+  // not yet have any resources,  [2] in any message after the first in a stream (for a given
+  // type_url), since the server will already be correctly tracking the client's state.
+  // (In ADS, the first message *of each type_url* of a reconnected stream populates this map.)
+  // The map's keys are names of xDS resources known to the xDS client.
+  // The map's values are opaque resource versions.
+  map<string, string> initial_resource_versions = 5;
+
+  // When the DeltaDiscoveryRequest is a ACK or NACK message in response
+  // to a previous DeltaDiscoveryResponse, the response_nonce must be the
+  // nonce in the DeltaDiscoveryResponse.
+  // Otherwise (unlike in DiscoveryRequest) response_nonce must be omitted.
+  string response_nonce = 6;
+
+  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_service.discovery.v4alpha.DiscoveryResponse>`
+  // failed to update configuration. The *message* field in *error_details*
+  // provides the Envoy internal exception related to the failure.
+  google.rpc.Status error_detail = 7;
+}
+
+// [#next-free-field: 8]
+message DeltaDiscoveryResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DeltaDiscoveryResponse";
+
+  // The version of the response data (used for debugging).
+  string system_version_info = 1;
+
+  // The response resources. These are typed resources, whose types must match
+  // the type_url field.
+  repeated Resource resources = 2;
+
+  // field id 3 IS available!
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the Any within 'resources' if 'resources' is non-empty.
+  // This does not need to be set if *udpa_removed_resources* is used instead of
+  // *removed_resources*.
+  string type_url = 4;
+
+  // Resources names of resources that have be deleted and to be removed from the xDS Client.
+  // Removed resources for missing resources can be ignored.
+  repeated string removed_resources = 6;
+
+  // As with *removed_resources* but used when a removed resource was named in
+  // its *Resource*s with a *udpa.core.v1.ResourceName*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceName udpa_removed_resources = 7;
+
+  // The nonce provides a way for DeltaDiscoveryRequests to uniquely
+  // reference a DeltaDiscoveryResponse when (N)ACKing. The nonce is required.
+  string nonce = 5;
+}
+
+// [#next-free-field: 6]
+message Resource {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.Resource";
+
+  oneof name_specifier {
+    // The resource's name, to distinguish it from others of the same type of resource.
+    string name = 3;
+
+    // Used instead of *name* when a resource with a *udpa.core.v1.ResourceName* is delivered.
+    udpa.core.v1.ResourceName udpa_resource_name = 5;
+  }
+
+  // The aliases are a list of other names that this resource can go by.
+  repeated string aliases = 4;
+
+  // The resource level version. It allows xDS to track the state of individual
+  // resources.
+  string version = 1;
+
+  // The resource being tracked.
+  google.protobuf.Any resource = 2;
+}

--- a/api/envoy/service/event_reporting/v4alpha/BUILD
+++ b/api/envoy/service/event_reporting/v4alpha/BUILD
@@ -8,10 +8,7 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/event_reporting/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/service/event_reporting/v4alpha/event_reporting_service.proto
+++ b/api/envoy/service/event_reporting/v4alpha/event_reporting_service.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package envoy.service.event_reporting.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "google/protobuf/any.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.event_reporting.v4alpha";
+option java_outer_classname = "EventReportingServiceProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: gRPC Event Reporting Service]
+
+// [#not-implemented-hide:]
+// Service for streaming different types of events from Envoy to a server. The examples of
+// such events may be health check or outlier detection events.
+service EventReportingService {
+  // Envoy will connect and send StreamEventsRequest messages forever.
+  // The management server may send StreamEventsResponse to configure event stream. See below.
+  // This API is designed for high throughput with the expectation that it might be lossy.
+  rpc StreamEvents(stream StreamEventsRequest) returns (stream StreamEventsResponse) {
+  }
+}
+
+// [#not-implemented-hide:]
+// An events envoy sends to the management server.
+message StreamEventsRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.event_reporting.v3.StreamEventsRequest";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.event_reporting.v3.StreamEventsRequest.Identifier";
+
+    // The node sending the event messages over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data that will only be sent in the first message on the stream. This is effectively
+  // structured metadata and is a performance optimization.
+  Identifier identifier = 1;
+
+  // Batch of events. When the stream is already active, it will be the events occurred
+  // since the last message had been sent. If the server receives unknown event type, it should
+  // silently ignore it.
+  //
+  // The following events are supported:
+  //
+  // * :ref:`HealthCheckEvent <envoy_api_msg_data.core.v3.HealthCheckEvent>`
+  // * :ref:`OutlierDetectionEvent <envoy_api_msg_data.cluster.v3.OutlierDetectionEvent>`
+  repeated google.protobuf.Any events = 2 [(validate.rules).repeated = {min_items: 1}];
+}
+
+// [#not-implemented-hide:]
+// The management server may send envoy a StreamEventsResponse to tell which events the server
+// is interested in. In future, with aggregated event reporting service, this message will
+// contain, for example, clusters the envoy should send events for, or event types the server
+// wants to process.
+message StreamEventsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.event_reporting.v3.StreamEventsResponse";
+}

--- a/api/envoy/service/load_stats/v4alpha/BUILD
+++ b/api/envoy/service/load_stats/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/config/endpoint/v3:pkg",
+        "//envoy/service/load_stats/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/service/load_stats/v4alpha/lrs.proto
+++ b/api/envoy/service/load_stats/v4alpha/lrs.proto
@@ -1,0 +1,103 @@
+syntax = "proto3";
+
+package envoy.service.load_stats.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+import "envoy/config/endpoint/v3/load_report.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.load_stats.v4alpha";
+option java_outer_classname = "LrsProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Load Reporting service (LRS)]
+
+// Load Reporting Service is an Envoy API to emit load reports. Envoy will initiate a bi-directional
+// stream with a management server. Upon connecting, the management server can send a
+// :ref:`LoadStatsResponse <envoy_api_msg_service.load_stats.v4alpha.LoadStatsResponse>` to a node it is
+// interested in getting the load reports for. Envoy in this node will start sending
+// :ref:`LoadStatsRequest <envoy_api_msg_service.load_stats.v4alpha.LoadStatsRequest>`. This is done periodically
+// based on the :ref:`load reporting interval <envoy_api_field_service.load_stats.v4alpha.LoadStatsResponse.load_reporting_interval>`
+// For details, take a look at the :ref:`Load Reporting Service sandbox example <install_sandboxes_load_reporting_service>`.
+
+service LoadReportingService {
+  // Advanced API to allow for multi-dimensional load balancing by remote
+  // server. For receiving LB assignments, the steps are:
+  // 1, The management server is configured with per cluster/zone/load metric
+  //    capacity configuration. The capacity configuration definition is
+  //    outside of the scope of this document.
+  // 2. Envoy issues a standard {Stream,Fetch}Endpoints request for the clusters
+  //    to balance.
+  //
+  // Independently, Envoy will initiate a StreamLoadStats bidi stream with a
+  // management server:
+  // 1. Once a connection establishes, the management server publishes a
+  //    LoadStatsResponse for all clusters it is interested in learning load
+  //    stats about.
+  // 2. For each cluster, Envoy load balances incoming traffic to upstream hosts
+  //    based on per-zone weights and/or per-instance weights (if specified)
+  //    based on intra-zone LbPolicy. This information comes from the above
+  //    {Stream,Fetch}Endpoints.
+  // 3. When upstream hosts reply, they optionally add header <define header
+  //    name> with ASCII representation of EndpointLoadMetricStats.
+  // 4. Envoy aggregates load reports over the period of time given to it in
+  //    LoadStatsResponse.load_reporting_interval. This includes aggregation
+  //    stats Envoy maintains by itself (total_requests, rpc_errors etc.) as
+  //    well as load metrics from upstream hosts.
+  // 5. When the timer of load_reporting_interval expires, Envoy sends new
+  //    LoadStatsRequest filled with load reports for each cluster.
+  // 6. The management server uses the load reports from all reported Envoys
+  //    from around the world, computes global assignment and prepares traffic
+  //    assignment destined for each zone Envoys are located in. Goto 2.
+  rpc StreamLoadStats(stream LoadStatsRequest) returns (stream LoadStatsResponse) {
+  }
+}
+
+// A load report Envoy sends to the management server.
+message LoadStatsRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.load_stats.v3.LoadStatsRequest";
+
+  // Node identifier for Envoy instance.
+  config.core.v4alpha.Node node = 1;
+
+  // A list of load stats to report.
+  repeated config.endpoint.v3.ClusterStats cluster_stats = 2;
+}
+
+// The management server sends envoy a LoadStatsResponse with all clusters it
+// is interested in learning load stats about.
+message LoadStatsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.load_stats.v3.LoadStatsResponse";
+
+  // Clusters to report stats for.
+  // Not populated if *send_all_clusters* is true.
+  repeated string clusters = 1;
+
+  // If true, the client should send all clusters it knows about.
+  // Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their
+  // :ref:`client_features<envoy_api_field_config.core.v4alpha.Node.client_features>` field will honor this field.
+  bool send_all_clusters = 4;
+
+  // The minimum interval of time to collect stats over. This is only a minimum for two reasons:
+  //
+  // 1. There may be some delay from when the timer fires until stats sampling occurs.
+  // 2. For clusters that were already feature in the previous *LoadStatsResponse*, any traffic
+  //    that is observed in between the corresponding previous *LoadStatsRequest* and this
+  //    *LoadStatsResponse* will also be accumulated and billed to the cluster. This avoids a period
+  //    of inobservability that might otherwise exists between the messages. New clusters are not
+  //    subject to this consideration.
+  google.protobuf.Duration load_reporting_interval = 2;
+
+  // Set to *true* if the management server supports endpoint granularity
+  // report.
+  bool report_endpoint_granularity = 3;
+}

--- a/api/envoy/service/metrics/v4alpha/BUILD
+++ b/api/envoy/service/metrics/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/metrics/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@prometheus_metrics_model//:client_model",
     ],
 )

--- a/api/envoy/service/metrics/v4alpha/metrics_service.proto
+++ b/api/envoy/service/metrics/v4alpha/metrics_service.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package envoy.service.metrics.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "metrics.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.metrics.v4alpha";
+option java_outer_classname = "MetricsServiceProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Metrics service]
+
+// Service for streaming metrics to server that consumes the metrics data. It uses Prometheus metric
+// data model as a standard to represent metrics information.
+service MetricsService {
+  // Envoy will connect and send StreamMetricsMessage messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure.
+  rpc StreamMetrics(stream StreamMetricsMessage) returns (StreamMetricsResponse) {
+  }
+}
+
+message StreamMetricsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.metrics.v3.StreamMetricsResponse";
+}
+
+message StreamMetricsMessage {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.metrics.v3.StreamMetricsMessage";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.metrics.v3.StreamMetricsMessage.Identifier";
+
+    // The node sending metrics over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data effectively is a structured metadata. As a performance optimization this will
+  // only be sent in the first message on the stream.
+  Identifier identifier = 1;
+
+  // A list of metric entries
+  repeated io.prometheus.client.MetricFamily envoy_metrics = 2;
+}

--- a/api/envoy/service/tap/v4alpha/tapds.proto
+++ b/api/envoy/service/tap/v4alpha/tapds.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package envoy.service.tap.v4alpha;
 
 import "envoy/config/tap/v4alpha/common.proto";
-import "envoy/service/discovery/v3/discovery.proto";
+import "envoy/service/discovery/v4alpha/discovery.proto";
 
 import "google/api/annotations.proto";
 
@@ -21,15 +21,16 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // [#not-implemented-hide:] Tap discovery service.
 service TapDiscoveryService {
-  rpc StreamTapConfigs(stream discovery.v3.DiscoveryRequest)
-      returns (stream discovery.v3.DiscoveryResponse) {
+  rpc StreamTapConfigs(stream discovery.v4alpha.DiscoveryRequest)
+      returns (stream discovery.v4alpha.DiscoveryResponse) {
   }
 
-  rpc DeltaTapConfigs(stream discovery.v3.DeltaDiscoveryRequest)
-      returns (stream discovery.v3.DeltaDiscoveryResponse) {
+  rpc DeltaTapConfigs(stream discovery.v4alpha.DeltaDiscoveryRequest)
+      returns (stream discovery.v4alpha.DeltaDiscoveryResponse) {
   }
 
-  rpc FetchTapConfigs(discovery.v3.DiscoveryRequest) returns (discovery.v3.DiscoveryResponse) {
+  rpc FetchTapConfigs(discovery.v4alpha.DiscoveryRequest)
+      returns (discovery.v4alpha.DiscoveryResponse) {
     option (google.api.http).post = "/v3/discovery:tap_configs";
     option (google.api.http).body = "*";
   }

--- a/api/envoy/service/trace/v4alpha/BUILD
+++ b/api/envoy/service/trace/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/trace/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@opencensus_proto//opencensus/proto/trace/v1:trace_proto",
     ],
 )

--- a/api/envoy/service/trace/v4alpha/trace_service.proto
+++ b/api/envoy/service/trace/v4alpha/trace_service.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package envoy.service.trace.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "google/api/annotations.proto";
+
+import "opencensus/proto/trace/v1/trace.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.trace.v4alpha";
+option java_outer_classname = "TraceServiceProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Trace service]
+
+// Service for streaming traces to server that consumes the trace data. It
+// uses OpenCensus data model as a standard to represent trace information.
+service TraceService {
+  // Envoy will connect and send StreamTracesMessage messages forever. It does
+  // not expect any response to be sent as nothing would be done in the case
+  // of failure.
+  rpc StreamTraces(stream StreamTracesMessage) returns (StreamTracesResponse) {
+  }
+}
+
+message StreamTracesResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.trace.v3.StreamTracesResponse";
+}
+
+message StreamTracesMessage {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.trace.v3.StreamTracesMessage";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.trace.v3.StreamTracesMessage.Identifier";
+
+    // The node sending the access log messages over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data effectively is a structured metadata.
+  // As a performance optimization this will only be sent in the first message
+  // on the stream.
+  Identifier identifier = 1;
+
+  // A list of Span entries
+  repeated opencensus.proto.trace.v1.Span spans = 2;
+}

--- a/generated_api_shadow/envoy/admin/v4alpha/config_dump.proto
+++ b/generated_api_shadow/envoy/admin/v4alpha/config_dump.proto
@@ -93,7 +93,7 @@ message ListenersConfigDump {
         "envoy.admin.v3.ListenersConfigDump.DynamicListenerState";
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time
     // that the listener was loaded. In the future, discrete per-listener versions may be supported
     // by the API.
     string version_info = 1;
@@ -134,7 +134,7 @@ message ListenersConfigDump {
     UpdateFailureState error_state = 5;
   }
 
-  // This is the :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` in the
+  // This is the :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` in the
   // last processed LDS discovery response. If there are only static bootstrap listeners, this field
   // will be "".
   string version_info = 1;
@@ -170,7 +170,7 @@ message ClustersConfigDump {
         "envoy.admin.v3.ClustersConfigDump.DynamicCluster";
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time
     // that the cluster was loaded. In the future, discrete per-cluster versions may be supported by
     // the API.
     string version_info = 1;
@@ -182,7 +182,7 @@ message ClustersConfigDump {
     google.protobuf.Timestamp last_updated = 3;
   }
 
-  // This is the :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` in the
+  // This is the :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` in the
   // last processed CDS discovery response. If there are only static bootstrap clusters, this field
   // will be "".
   string version_info = 1;
@@ -225,7 +225,7 @@ message RoutesConfigDump {
         "envoy.admin.v3.RoutesConfigDump.DynamicRouteConfig";
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time that
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time that
     // the route configuration was loaded.
     string version_info = 1;
 
@@ -273,7 +273,7 @@ message ScopedRoutesConfigDump {
     string name = 1;
 
     // This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time that
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time that
     // the scoped routes configuration was loaded.
     string version_info = 2;
 
@@ -366,7 +366,7 @@ message EndpointsConfigDump {
         "envoy.admin.v3.EndpointsConfigDump.DynamicEndpointConfig";
 
     // [#not-implemented-hide:] This is the per-resource version information. This version is currently taken from the
-    // :ref:`version_info <envoy_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field at the time that
+    // :ref:`version_info <envoy_api_field_service.discovery.v4alpha.DiscoveryResponse.version_info>` field at the time that
     // the endpoint configuration was loaded.
     string version_info = 1;
 

--- a/generated_api_shadow/envoy/config/core/v3/base.proto
+++ b/generated_api_shadow/envoy/config/core/v3/base.proto
@@ -192,7 +192,7 @@ message Node {
   // for filtering :ref:`listeners <config_listeners>` to be returned. For example,
   // if there is a listener bound to port 80, the list can optionally contain the
   // SocketAddress `(0.0.0.0,80)`. The field is optional and just a hint.
-  repeated Address listening_addresses = 11;
+  repeated Address listening_addresses = 11 [deprecated = true];
 
   string hidden_envoy_deprecated_build_version = 5 [deprecated = true];
 }

--- a/generated_api_shadow/envoy/config/core/v4alpha/base.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/base.proto
@@ -195,7 +195,7 @@ message Node {
   // for filtering :ref:`listeners <config_listeners>` to be returned. For example,
   // if there is a listener bound to port 80, the list can optionally contain the
   // SocketAddress `(0.0.0.0,80)`. The field is optional and just a hint.
-  repeated Address listening_addresses = 11;
+  repeated Address hidden_envoy_deprecated_listening_addresses = 11 [deprecated = true];
 }
 
 // Metadata provides additional inputs to filters based on matched listeners,

--- a/generated_api_shadow/envoy/config/metrics/v4alpha/metrics_service.proto
+++ b/generated_api_shadow/envoy/config/metrics/v4alpha/metrics_service.proto
@@ -36,6 +36,6 @@ message MetricsServiceConfig {
   // If true, counters are reported as the delta between flushing intervals. Otherwise, the current
   // counter value is reported. Defaults to false.
   // Eventually (https://github.com/envoyproxy/envoy/issues/10968) if this value is not set, the
-  // sink will take updates from the :ref:`MetricsResponse <envoy_api_msg_service.metrics.v3.StreamMetricsResponse>`.
+  // sink will take updates from the :ref:`MetricsResponse <envoy_api_msg_service.metrics.v4alpha.StreamMetricsResponse>`.
   google.protobuf.BoolValue report_counters_as_deltas = 2;
 }

--- a/generated_api_shadow/envoy/config/route/v4alpha/scoped_route.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/scoped_route.proto
@@ -107,7 +107,7 @@ message ScopedRouteConfiguration {
   // The name assigned to the routing scope.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
 
-  // The resource name to use for a :ref:`envoy_api_msg_service.discovery.v3.DiscoveryRequest` to an
+  // The resource name to use for a :ref:`envoy_api_msg_service.discovery.v4alpha.DiscoveryRequest` to an
   // RDS server to fetch the :ref:`envoy_api_msg_config.route.v4alpha.RouteConfiguration` associated
   // with this scope.
   string route_configuration_name = 2 [(validate.rules).string = {min_bytes: 1}];

--- a/generated_api_shadow/envoy/service/accesslog/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/accesslog/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/data/accesslog/v3:pkg",
+        "//envoy/service/accesslog/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/accesslog/v4alpha/als.proto
+++ b/generated_api_shadow/envoy/service/accesslog/v4alpha/als.proto
@@ -1,0 +1,87 @@
+syntax = "proto3";
+
+package envoy.service.accesslog.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+import "envoy/data/accesslog/v3/accesslog.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.accesslog.v4alpha";
+option java_outer_classname = "AlsProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: gRPC Access Log Service (ALS)]
+
+// Service for streaming access logs from Envoy to an access log server.
+service AccessLogService {
+  // Envoy will connect and send StreamAccessLogsMessage messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure. The server should
+  // disconnect if it expects Envoy to reconnect. In the future we may decide to add a different
+  // API for "critical" access logs in which Envoy will buffer access logs for some period of time
+  // until it gets an ACK so it could then retry. This API is designed for high throughput with the
+  // expectation that it might be lossy.
+  rpc StreamAccessLogs(stream StreamAccessLogsMessage) returns (StreamAccessLogsResponse) {
+  }
+}
+
+// Empty response for the StreamAccessLogs API. Will never be sent. See below.
+message StreamAccessLogsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.accesslog.v3.StreamAccessLogsResponse";
+}
+
+// Stream message for the StreamAccessLogs API. Envoy will open a stream to the server and stream
+// access logs without ever expecting a response.
+message StreamAccessLogsMessage {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.accesslog.v3.StreamAccessLogsMessage";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.accesslog.v3.StreamAccessLogsMessage.Identifier";
+
+    // The node sending the access log messages over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+
+    // The friendly name of the log configured in :ref:`CommonGrpcAccessLogConfig
+    // <envoy_api_msg_extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig>`.
+    string log_name = 2 [(validate.rules).string = {min_bytes: 1}];
+  }
+
+  // Wrapper for batches of HTTP access log entries.
+  message HTTPAccessLogEntries {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.accesslog.v3.StreamAccessLogsMessage.HTTPAccessLogEntries";
+
+    repeated data.accesslog.v3.HTTPAccessLogEntry log_entry = 1
+        [(validate.rules).repeated = {min_items: 1}];
+  }
+
+  // Wrapper for batches of TCP access log entries.
+  message TCPAccessLogEntries {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.accesslog.v3.StreamAccessLogsMessage.TCPAccessLogEntries";
+
+    repeated data.accesslog.v3.TCPAccessLogEntry log_entry = 1
+        [(validate.rules).repeated = {min_items: 1}];
+  }
+
+  // Identifier data that will only be sent in the first message on the stream. This is effectively
+  // structured metadata and is a performance optimization.
+  Identifier identifier = 1;
+
+  // Batches of log entries of a single type. Generally speaking, a given stream should only
+  // ever include one type of log entry.
+  oneof log_entries {
+    option (validate.required) = true;
+
+    HTTPAccessLogEntries http_logs = 2;
+
+    TCPAccessLogEntries tcp_logs = 3;
+  }
+}

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/discovery/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/ads.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/ads.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v4alpha;
+
+import "envoy/service/discovery/v4alpha/discovery.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v4alpha";
+option java_outer_classname = "AdsProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Aggregated Discovery Service (ADS)]
+
+// [#not-implemented-hide:] Discovery services for endpoints, clusters, routes,
+// and listeners are retained in the package `envoy.api.v2` for backwards
+// compatibility with existing management servers. New development in discovery
+// services should proceed in the package `envoy.service.discovery.v2`.
+
+// See https://github.com/lyft/envoy-api#apis for a description of the role of
+// ADS and how it is intended to be used by a management server. ADS requests
+// have the same structure as their singleton xDS counterparts, but can
+// multiplex many resource types on a single stream. The type_url in the
+// DiscoveryRequest/DiscoveryResponse provides sufficient information to recover
+// the multiplexed singleton APIs at the Envoy instance and management server.
+service AggregatedDiscoveryService {
+  // This is a gRPC-only API.
+  rpc StreamAggregatedResources(stream DiscoveryRequest) returns (stream DiscoveryResponse) {
+  }
+
+  rpc DeltaAggregatedResources(stream DeltaDiscoveryRequest)
+      returns (stream DeltaDiscoveryResponse) {
+  }
+}
+
+// [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
+// services: https://github.com/google/protobuf/issues/4221
+message AdsDummy {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.AdsDummy";
+}

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -1,0 +1,279 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "google/protobuf/any.proto";
+import "google/rpc/status.proto";
+
+import "udpa/core/v1/resource_locator.proto";
+import "udpa/core/v1/resource_name.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v4alpha";
+option java_outer_classname = "DiscoveryProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Common discovery API components]
+
+// A DiscoveryRequest requests a set of versioned resources of the same type for
+// a given Envoy node on some API.
+// [#next-free-field: 7]
+message DiscoveryRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DiscoveryRequest";
+
+  // The version_info provided in the request messages will be the version_info
+  // received with the most recent successfully processed response or empty on
+  // the first request. It is expected that no new request is sent after a
+  // response is received until the Envoy instance is ready to ACK/NACK the new
+  // configuration. ACK/NACK takes place by returning the new API config version
+  // as applied or the previous API config version respectively. Each type_url
+  // (see below) has an independent version associated with it.
+  string version_info = 1;
+
+  // The node making the request.
+  config.core.v4alpha.Node node = 2;
+
+  // List of resources to subscribe to, e.g. list of cluster names or a route
+  // configuration name. If this is empty, all resources for the API are
+  // returned. LDS/CDS may have empty resource_names, which will cause all
+  // resources for the Envoy instance to be returned. The LDS and CDS responses
+  // will then imply a number of resources that need to be fetched via EDS/RDS,
+  // which will be explicitly enumerated in resource_names.
+  repeated string resource_names = 3;
+
+  // Type of the resource that is being requested, e.g.
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit
+  // in requests made via singleton xDS APIs such as CDS, LDS, etc. but is
+  // required for ADS.
+  string type_url = 4;
+
+  // nonce corresponding to DiscoveryResponse being ACK/NACKed. See above
+  // discussion on version_info and the DiscoveryResponse nonce comment. This
+  // may be empty only if 1) this is a non-persistent-stream xDS such as HTTP,
+  // or 2) the client has not yet accepted an update in this xDS stream (unlike
+  // delta, where it is populated only for new explicit ACKs).
+  string response_nonce = 5;
+
+  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_service.discovery.v4alpha.DiscoveryResponse>`
+  // failed to update configuration. The *message* field in *error_details* provides the Envoy
+  // internal exception related to the failure. It is only intended for consumption during manual
+  // debugging, the string provided is not guaranteed to be stable across Envoy versions.
+  google.rpc.Status error_detail = 6;
+}
+
+// [#next-free-field: 7]
+message DiscoveryResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DiscoveryResponse";
+
+  // The version of the response data.
+  string version_info = 1;
+
+  // The response resources. These resources are typed and depend on the API being called.
+  repeated google.protobuf.Any resources = 2;
+
+  // [#not-implemented-hide:]
+  // Canary is used to support two Envoy command line flags:
+  //
+  // * --terminate-on-canary-transition-failure. When set, Envoy is able to
+  //   terminate if it detects that configuration is stuck at canary. Consider
+  //   this example sequence of updates:
+  //   - Management server applies a canary config successfully.
+  //   - Management server rolls back to a production config.
+  //   - Envoy rejects the new production config.
+  //   Since there is no sensible way to continue receiving configuration
+  //   updates, Envoy will then terminate and apply production config from a
+  //   clean slate.
+  // * --dry-run-canary. When set, a canary response will never be applied, only
+  //   validated via a dry run.
+  bool canary = 3;
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the 'resources' repeated Any (if non-empty).
+  string type_url = 4;
+
+  // For gRPC based subscriptions, the nonce provides a way to explicitly ack a
+  // specific DiscoveryResponse in a following DiscoveryRequest. Additional
+  // messages may have been sent by Envoy to the management server for the
+  // previous version on the stream prior to this DiscoveryResponse, that were
+  // unprocessed at response send time. The nonce allows the management server
+  // to ignore any further DiscoveryRequests for the previous version until a
+  // DiscoveryRequest bearing the nonce. The nonce is optional and is not
+  // required for non-stream based xDS implementations.
+  string nonce = 5;
+
+  // [#not-implemented-hide:]
+  // The control plane instance that sent the response.
+  config.core.v4alpha.ControlPlane control_plane = 6;
+}
+
+// DeltaDiscoveryRequest and DeltaDiscoveryResponse are used in a new gRPC
+// endpoint for Delta xDS.
+//
+// With Delta xDS, the DeltaDiscoveryResponses do not need to include a full
+// snapshot of the tracked resources. Instead, DeltaDiscoveryResponses are a
+// diff to the state of a xDS client.
+// In Delta XDS there are per-resource versions, which allow tracking state at
+// the resource granularity.
+// An xDS Delta session is always in the context of a gRPC bidirectional
+// stream. This allows the xDS server to keep track of the state of xDS clients
+// connected to it.
+//
+// In Delta xDS the nonce field is required and used to pair
+// DeltaDiscoveryResponse to a DeltaDiscoveryRequest ACK or NACK.
+// Optionally, a response message level system_version_info is present for
+// debugging purposes only.
+//
+// DeltaDiscoveryRequest plays two independent roles. Any DeltaDiscoveryRequest
+// can be either or both of: [1] informing the server of what resources the
+// client has gained/lost interest in (using resource_names_subscribe and
+// resource_names_unsubscribe), or [2] (N)ACKing an earlier resource update from
+// the server (using response_nonce, with presence of error_detail making it a NACK).
+// Additionally, the first message (for a given type_url) of a reconnected gRPC stream
+// has a third role: informing the server of the resources (and their versions)
+// that the client already possesses, using the initial_resource_versions field.
+//
+// As with state-of-the-world, when multiple resource types are multiplexed (ADS),
+// all requests/acknowledgments/updates are logically walled off by type_url:
+// a Cluster ACK exists in a completely separate world from a prior Route NACK.
+// In particular, initial_resource_versions being sent at the "start" of every
+// gRPC stream actually entails a message for each type_url, each with its own
+// initial_resource_versions.
+// [#next-free-field: 10]
+message DeltaDiscoveryRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DeltaDiscoveryRequest";
+
+  // The node making the request.
+  config.core.v4alpha.Node node = 1;
+
+  // Type of the resource that is being requested, e.g.
+  // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This does not need to be set if
+  // resources are only referenced via *udpa_resource_subscribe* and
+  // *udpa_resources_unsubscribe*.
+  string type_url = 2;
+
+  // DeltaDiscoveryRequests allow the client to add or remove individual
+  // resources to the set of tracked resources in the context of a stream.
+  // All resource names in the resource_names_subscribe list are added to the
+  // set of tracked resources and all resource names in the resource_names_unsubscribe
+  // list are removed from the set of tracked resources.
+  //
+  // *Unlike* state-of-the-world xDS, an empty resource_names_subscribe or
+  // resource_names_unsubscribe list simply means that no resources are to be
+  // added or removed to the resource list.
+  // *Like* state-of-the-world xDS, the server must send updates for all tracked
+  // resources, but can also send updates for resources the client has not subscribed to.
+  //
+  // NOTE: the server must respond with all resources listed in resource_names_subscribe,
+  // even if it believes the client has the most recent version of them. The reason:
+  // the client may have dropped them, but then regained interest before it had a chance
+  // to send the unsubscribe message. See DeltaSubscriptionStateTest.RemoveThenAdd.
+  //
+  // These two fields can be set in any DeltaDiscoveryRequest, including ACKs
+  // and initial_resource_versions.
+  //
+  // A list of Resource names to add to the list of tracked resources.
+  repeated string resource_names_subscribe = 3;
+
+  // As with *resource_names_subscribe* but used when subscribing to resources indicated
+  // by a *udpa.core.v1.ResourceLocator*. The directives in the resource locator
+  // are ignored and the context parameters are matched with
+  // *context_param_specifier* specific semantics.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_subscribe = 8;
+
+  // A list of Resource names to remove from the list of tracked resources.
+  repeated string resource_names_unsubscribe = 4;
+
+  // As with *resource_names_unsubscribe* but used when unsubscribing to resources indicated by a
+  // *udpa.core.v1.ResourceLocator*. This must match a previously subscribed
+  // resource locator provided in *udpa_resources_subscribe*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resources_unsubscribe = 9;
+
+  // Informs the server of the versions of the resources the xDS client knows of, to enable the
+  // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
+  // It will not be populated: [1] in the very first stream of a session, since the client will
+  // not yet have any resources,  [2] in any message after the first in a stream (for a given
+  // type_url), since the server will already be correctly tracking the client's state.
+  // (In ADS, the first message *of each type_url* of a reconnected stream populates this map.)
+  // The map's keys are names of xDS resources known to the xDS client.
+  // The map's values are opaque resource versions.
+  map<string, string> initial_resource_versions = 5;
+
+  // When the DeltaDiscoveryRequest is a ACK or NACK message in response
+  // to a previous DeltaDiscoveryResponse, the response_nonce must be the
+  // nonce in the DeltaDiscoveryResponse.
+  // Otherwise (unlike in DiscoveryRequest) response_nonce must be omitted.
+  string response_nonce = 6;
+
+  // This is populated when the previous :ref:`DiscoveryResponse <envoy_api_msg_service.discovery.v4alpha.DiscoveryResponse>`
+  // failed to update configuration. The *message* field in *error_details*
+  // provides the Envoy internal exception related to the failure.
+  google.rpc.Status error_detail = 7;
+}
+
+// [#next-free-field: 8]
+message DeltaDiscoveryResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.DeltaDiscoveryResponse";
+
+  // The version of the response data (used for debugging).
+  string system_version_info = 1;
+
+  // The response resources. These are typed resources, whose types must match
+  // the type_url field.
+  repeated Resource resources = 2;
+
+  // field id 3 IS available!
+
+  // Type URL for resources. Identifies the xDS API when muxing over ADS.
+  // Must be consistent with the type_url in the Any within 'resources' if 'resources' is non-empty.
+  // This does not need to be set if *udpa_removed_resources* is used instead of
+  // *removed_resources*.
+  string type_url = 4;
+
+  // Resources names of resources that have be deleted and to be removed from the xDS Client.
+  // Removed resources for missing resources can be ignored.
+  repeated string removed_resources = 6;
+
+  // As with *removed_resources* but used when a removed resource was named in
+  // its *Resource*s with a *udpa.core.v1.ResourceName*.
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceName udpa_removed_resources = 7;
+
+  // The nonce provides a way for DeltaDiscoveryRequests to uniquely
+  // reference a DeltaDiscoveryResponse when (N)ACKing. The nonce is required.
+  string nonce = 5;
+}
+
+// [#next-free-field: 6]
+message Resource {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.Resource";
+
+  oneof name_specifier {
+    // The resource's name, to distinguish it from others of the same type of resource.
+    string name = 3;
+
+    // Used instead of *name* when a resource with a *udpa.core.v1.ResourceName* is delivered.
+    udpa.core.v1.ResourceName udpa_resource_name = 5;
+  }
+
+  // The aliases are a list of other names that this resource can go by.
+  repeated string aliases = 4;
+
+  // The resource level version. It allows xDS to track the state of individual
+  // resources.
+  string version = 1;
+
+  // The resource being tracked.
+  google.protobuf.Any resource = 2;
+}

--- a/generated_api_shadow/envoy/service/event_reporting/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/event_reporting/v4alpha/BUILD
@@ -8,10 +8,7 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/event_reporting/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/event_reporting/v4alpha/event_reporting_service.proto
+++ b/generated_api_shadow/envoy/service/event_reporting/v4alpha/event_reporting_service.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package envoy.service.event_reporting.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "google/protobuf/any.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.event_reporting.v4alpha";
+option java_outer_classname = "EventReportingServiceProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: gRPC Event Reporting Service]
+
+// [#not-implemented-hide:]
+// Service for streaming different types of events from Envoy to a server. The examples of
+// such events may be health check or outlier detection events.
+service EventReportingService {
+  // Envoy will connect and send StreamEventsRequest messages forever.
+  // The management server may send StreamEventsResponse to configure event stream. See below.
+  // This API is designed for high throughput with the expectation that it might be lossy.
+  rpc StreamEvents(stream StreamEventsRequest) returns (stream StreamEventsResponse) {
+  }
+}
+
+// [#not-implemented-hide:]
+// An events envoy sends to the management server.
+message StreamEventsRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.event_reporting.v3.StreamEventsRequest";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.event_reporting.v3.StreamEventsRequest.Identifier";
+
+    // The node sending the event messages over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data that will only be sent in the first message on the stream. This is effectively
+  // structured metadata and is a performance optimization.
+  Identifier identifier = 1;
+
+  // Batch of events. When the stream is already active, it will be the events occurred
+  // since the last message had been sent. If the server receives unknown event type, it should
+  // silently ignore it.
+  //
+  // The following events are supported:
+  //
+  // * :ref:`HealthCheckEvent <envoy_api_msg_data.core.v3.HealthCheckEvent>`
+  // * :ref:`OutlierDetectionEvent <envoy_api_msg_data.cluster.v3.OutlierDetectionEvent>`
+  repeated google.protobuf.Any events = 2 [(validate.rules).repeated = {min_items: 1}];
+}
+
+// [#not-implemented-hide:]
+// The management server may send envoy a StreamEventsResponse to tell which events the server
+// is interested in. In future, with aggregated event reporting service, this message will
+// contain, for example, clusters the envoy should send events for, or event types the server
+// wants to process.
+message StreamEventsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.event_reporting.v3.StreamEventsResponse";
+}

--- a/generated_api_shadow/envoy/service/load_stats/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/load_stats/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/config/endpoint/v3:pkg",
+        "//envoy/service/load_stats/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/load_stats/v4alpha/lrs.proto
+++ b/generated_api_shadow/envoy/service/load_stats/v4alpha/lrs.proto
@@ -1,0 +1,103 @@
+syntax = "proto3";
+
+package envoy.service.load_stats.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+import "envoy/config/endpoint/v3/load_report.proto";
+
+import "google/protobuf/duration.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.load_stats.v4alpha";
+option java_outer_classname = "LrsProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Load Reporting service (LRS)]
+
+// Load Reporting Service is an Envoy API to emit load reports. Envoy will initiate a bi-directional
+// stream with a management server. Upon connecting, the management server can send a
+// :ref:`LoadStatsResponse <envoy_api_msg_service.load_stats.v4alpha.LoadStatsResponse>` to a node it is
+// interested in getting the load reports for. Envoy in this node will start sending
+// :ref:`LoadStatsRequest <envoy_api_msg_service.load_stats.v4alpha.LoadStatsRequest>`. This is done periodically
+// based on the :ref:`load reporting interval <envoy_api_field_service.load_stats.v4alpha.LoadStatsResponse.load_reporting_interval>`
+// For details, take a look at the :ref:`Load Reporting Service sandbox example <install_sandboxes_load_reporting_service>`.
+
+service LoadReportingService {
+  // Advanced API to allow for multi-dimensional load balancing by remote
+  // server. For receiving LB assignments, the steps are:
+  // 1, The management server is configured with per cluster/zone/load metric
+  //    capacity configuration. The capacity configuration definition is
+  //    outside of the scope of this document.
+  // 2. Envoy issues a standard {Stream,Fetch}Endpoints request for the clusters
+  //    to balance.
+  //
+  // Independently, Envoy will initiate a StreamLoadStats bidi stream with a
+  // management server:
+  // 1. Once a connection establishes, the management server publishes a
+  //    LoadStatsResponse for all clusters it is interested in learning load
+  //    stats about.
+  // 2. For each cluster, Envoy load balances incoming traffic to upstream hosts
+  //    based on per-zone weights and/or per-instance weights (if specified)
+  //    based on intra-zone LbPolicy. This information comes from the above
+  //    {Stream,Fetch}Endpoints.
+  // 3. When upstream hosts reply, they optionally add header <define header
+  //    name> with ASCII representation of EndpointLoadMetricStats.
+  // 4. Envoy aggregates load reports over the period of time given to it in
+  //    LoadStatsResponse.load_reporting_interval. This includes aggregation
+  //    stats Envoy maintains by itself (total_requests, rpc_errors etc.) as
+  //    well as load metrics from upstream hosts.
+  // 5. When the timer of load_reporting_interval expires, Envoy sends new
+  //    LoadStatsRequest filled with load reports for each cluster.
+  // 6. The management server uses the load reports from all reported Envoys
+  //    from around the world, computes global assignment and prepares traffic
+  //    assignment destined for each zone Envoys are located in. Goto 2.
+  rpc StreamLoadStats(stream LoadStatsRequest) returns (stream LoadStatsResponse) {
+  }
+}
+
+// A load report Envoy sends to the management server.
+message LoadStatsRequest {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.load_stats.v3.LoadStatsRequest";
+
+  // Node identifier for Envoy instance.
+  config.core.v4alpha.Node node = 1;
+
+  // A list of load stats to report.
+  repeated config.endpoint.v3.ClusterStats cluster_stats = 2;
+}
+
+// The management server sends envoy a LoadStatsResponse with all clusters it
+// is interested in learning load stats about.
+message LoadStatsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.load_stats.v3.LoadStatsResponse";
+
+  // Clusters to report stats for.
+  // Not populated if *send_all_clusters* is true.
+  repeated string clusters = 1;
+
+  // If true, the client should send all clusters it knows about.
+  // Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their
+  // :ref:`client_features<envoy_api_field_config.core.v4alpha.Node.client_features>` field will honor this field.
+  bool send_all_clusters = 4;
+
+  // The minimum interval of time to collect stats over. This is only a minimum for two reasons:
+  //
+  // 1. There may be some delay from when the timer fires until stats sampling occurs.
+  // 2. For clusters that were already feature in the previous *LoadStatsResponse*, any traffic
+  //    that is observed in between the corresponding previous *LoadStatsRequest* and this
+  //    *LoadStatsResponse* will also be accumulated and billed to the cluster. This avoids a period
+  //    of inobservability that might otherwise exists between the messages. New clusters are not
+  //    subject to this consideration.
+  google.protobuf.Duration load_reporting_interval = 2;
+
+  // Set to *true* if the management server supports endpoint granularity
+  // report.
+  bool report_endpoint_granularity = 3;
+}

--- a/generated_api_shadow/envoy/service/metrics/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/metrics/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/metrics/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@prometheus_metrics_model//:client_model",
     ],
 )

--- a/generated_api_shadow/envoy/service/metrics/v4alpha/metrics_service.proto
+++ b/generated_api_shadow/envoy/service/metrics/v4alpha/metrics_service.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package envoy.service.metrics.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "metrics.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.metrics.v4alpha";
+option java_outer_classname = "MetricsServiceProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Metrics service]
+
+// Service for streaming metrics to server that consumes the metrics data. It uses Prometheus metric
+// data model as a standard to represent metrics information.
+service MetricsService {
+  // Envoy will connect and send StreamMetricsMessage messages forever. It does not expect any
+  // response to be sent as nothing would be done in the case of failure.
+  rpc StreamMetrics(stream StreamMetricsMessage) returns (StreamMetricsResponse) {
+  }
+}
+
+message StreamMetricsResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.metrics.v3.StreamMetricsResponse";
+}
+
+message StreamMetricsMessage {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.metrics.v3.StreamMetricsMessage";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.metrics.v3.StreamMetricsMessage.Identifier";
+
+    // The node sending metrics over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data effectively is a structured metadata. As a performance optimization this will
+  // only be sent in the first message on the stream.
+  Identifier identifier = 1;
+
+  // A list of metric entries
+  repeated io.prometheus.client.MetricFamily envoy_metrics = 2;
+}

--- a/generated_api_shadow/envoy/service/tap/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/tap/v4alpha/BUILD
@@ -10,7 +10,7 @@ api_proto_package(
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/tap/v4alpha:pkg",
         "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v3:pkg",
+        "//envoy/service/discovery/v4alpha:pkg",
         "//envoy/service/tap/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/generated_api_shadow/envoy/service/tap/v4alpha/tapds.proto
+++ b/generated_api_shadow/envoy/service/tap/v4alpha/tapds.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package envoy.service.tap.v4alpha;
 
 import "envoy/config/tap/v4alpha/common.proto";
-import "envoy/service/discovery/v3/discovery.proto";
+import "envoy/service/discovery/v4alpha/discovery.proto";
 
 import "google/api/annotations.proto";
 
@@ -21,15 +21,16 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // [#not-implemented-hide:] Tap discovery service.
 service TapDiscoveryService {
-  rpc StreamTapConfigs(stream discovery.v3.DiscoveryRequest)
-      returns (stream discovery.v3.DiscoveryResponse) {
+  rpc StreamTapConfigs(stream discovery.v4alpha.DiscoveryRequest)
+      returns (stream discovery.v4alpha.DiscoveryResponse) {
   }
 
-  rpc DeltaTapConfigs(stream discovery.v3.DeltaDiscoveryRequest)
-      returns (stream discovery.v3.DeltaDiscoveryResponse) {
+  rpc DeltaTapConfigs(stream discovery.v4alpha.DeltaDiscoveryRequest)
+      returns (stream discovery.v4alpha.DeltaDiscoveryResponse) {
   }
 
-  rpc FetchTapConfigs(discovery.v3.DiscoveryRequest) returns (discovery.v3.DiscoveryResponse) {
+  rpc FetchTapConfigs(discovery.v4alpha.DiscoveryRequest)
+      returns (discovery.v4alpha.DiscoveryResponse) {
     option (google.api.http).post = "/v3/discovery:tap_configs";
     option (google.api.http).body = "*";
   }

--- a/generated_api_shadow/envoy/service/trace/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/trace/v4alpha/BUILD
@@ -8,10 +8,8 @@ api_proto_package(
     has_services = True,
     deps = [
         "//envoy/config/core/v4alpha:pkg",
-        "//envoy/config/tap/v4alpha:pkg",
-        "//envoy/data/tap/v3:pkg",
-        "//envoy/service/discovery/v4alpha:pkg",
-        "//envoy/service/tap/v3:pkg",
+        "//envoy/service/trace/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@opencensus_proto//opencensus/proto/trace/v1:trace_proto",
     ],
 )

--- a/generated_api_shadow/envoy/service/trace/v4alpha/trace_service.proto
+++ b/generated_api_shadow/envoy/service/trace/v4alpha/trace_service.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package envoy.service.trace.v4alpha;
+
+import "envoy/config/core/v4alpha/base.proto";
+
+import "google/api/annotations.proto";
+
+import "opencensus/proto/trace/v1/trace.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.service.trace.v4alpha";
+option java_outer_classname = "TraceServiceProto";
+option java_multiple_files = true;
+option java_generic_services = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Trace service]
+
+// Service for streaming traces to server that consumes the trace data. It
+// uses OpenCensus data model as a standard to represent trace information.
+service TraceService {
+  // Envoy will connect and send StreamTracesMessage messages forever. It does
+  // not expect any response to be sent as nothing would be done in the case
+  // of failure.
+  rpc StreamTraces(stream StreamTracesMessage) returns (StreamTracesResponse) {
+  }
+}
+
+message StreamTracesResponse {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.trace.v3.StreamTracesResponse";
+}
+
+message StreamTracesMessage {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.trace.v3.StreamTracesMessage";
+
+  message Identifier {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.trace.v3.StreamTracesMessage.Identifier";
+
+    // The node sending the access log messages over the stream.
+    config.core.v4alpha.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data effectively is a structured metadata.
+  // As a performance optimization this will only be sent in the first message
+  // on the stream.
+  Identifier identifier = 1;
+
+  // A list of Span entries
+  repeated opencensus.proto.trace.v1.Span spans = 2;
+}


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: deprecate the node.listening_addresses field
Additional Description: This was added for gRPC server support, but we've decided to use resource names instead to explicitly request the listeners we want by name.  This is more in-line with the new naming scheme described in the "xDS Transport Next Steps" design.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

CC @htuch 