### PR TITLE
thrift proxy: fix build issue when thrift extensions are disabled

### DIFF
--- a/test/extensions/filters/network/thrift_proxy/filters/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/filters/BUILD
@@ -1,16 +1,20 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
     "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_extension_cc_test(
     name = "pass_through_filter_test",
     srcs = ["pass_through_filter_test.cc"],
+    extension_name = "envoy.filters.network.thrift_proxy",
     deps = [
         "//source/extensions/filters/network/thrift_proxy/filters:pass_through_filter_lib",
         "//test/extensions/filters/network/thrift_proxy:mocks",


### PR DESCRIPTION
Use envoy_extension_cc_test to ensure that thrift proxy tests are disabled when the thrift proxy extensions are disabled.

Risk Level: Low
Testing: Build with extensions disabled and enabled
Docs Changes: n/a
Release Notes: n/a
Fixes: #12696 
