### PR TITLE
xds: allow empty delta update

### DIFF
--- a/source/common/config/watch_map.cc
+++ b/source/common/config/watch_map.cc
@@ -203,6 +203,12 @@ void WatchMap::onConfigUpdate(
     }
     cur_watch->callbacks_.onConfigUpdate({}, resource_to_remove, system_version_info);
   }
+  // notify empty update
+  if (added_resources.empty() && removed_resources.empty()) {
+    for (auto& cur_watch : wildcard_watches_) {
+      cur_watch->callbacks_.onConfigUpdate({}, {}, system_version_info);
+    }
+  }
 }
 
 void WatchMap::onConfigUpdateFailed(ConfigUpdateFailureReason reason, const EnvoyException* e) {

--- a/test/common/config/new_grpc_mux_impl_test.cc
+++ b/test/common/config/new_grpc_mux_impl_test.cc
@@ -90,7 +90,8 @@ TEST_F(NewGrpcMuxImplTest, DiscoveryResponseNonexistentSub) {
         std::make_unique<envoy::service::discovery::v3::DeltaDiscoveryResponse>();
     unexpected_response->set_type_url(type_url);
     unexpected_response->set_system_version_info("0");
-    EXPECT_CALL(callbacks_, onConfigUpdate(_, _, "0")).Times(0);
+    // empty response should call onConfigUpdate on wildcard watch
+    EXPECT_CALL(callbacks_, onConfigUpdate(_, _, "0")).Times(1);
     grpc_mux_->onDiscoveryResponse(std::move(unexpected_response), control_plane_stats_);
   }
   {

--- a/test/common/config/new_grpc_mux_impl_test.cc
+++ b/test/common/config/new_grpc_mux_impl_test.cc
@@ -91,7 +91,7 @@ TEST_F(NewGrpcMuxImplTest, DiscoveryResponseNonexistentSub) {
     unexpected_response->set_type_url(type_url);
     unexpected_response->set_system_version_info("0");
     // empty response should call onConfigUpdate on wildcard watch
-    EXPECT_CALL(callbacks_, onConfigUpdate(_, _, "0")).Times(1);
+    EXPECT_CALL(callbacks_, onConfigUpdate(_, _, "0"));
     grpc_mux_->onDiscoveryResponse(std::move(unexpected_response), control_plane_stats_);
   }
   {

--- a/test/common/config/watch_map_test.cc
+++ b/test/common/config/watch_map_test.cc
@@ -116,6 +116,12 @@ TEST(WatchMapTest, Basic) {
   Watch* watch = watch_map.addWatch(callbacks, resource_decoder);
 
   {
+    // nothing is interested, so become wildcard watch
+    // should callback with empty resource
+    expectDeltaAndSotwUpdate(callbacks, {}, {}, "version1");
+    doDeltaAndSotwUpdate(watch_map, {}, {}, "version1");
+  }
+  {
     // The watch is interested in Alice and Bob...
     std::set<std::string> update_to({"alice", "bob"});
     AddedRemoved added_removed = watch_map.updateWatchInterest(watch, update_to);


### PR DESCRIPTION
Commit Message:
when delta xds recv empty repsonce, it should be call *onConfigUpdate*, instead of do nothing, and stop init process 15s (initial_fetch_timeout)

Additional Description:
a first delta xds repsonce can't call wildcard subscription's *onConfigUpdate* (ex: empty CDS), and  stop init process 15s. It don't like SOTW part: https://github.com/envoyproxy/envoy/blob/7f4e35e79ba48e2c6643918e15d0542d881de97b/source/common/config/watch_map.cc#L104-L115
Risk Level: Low 
Testing: Manual Pass
Docs Changes: None
Release Notes: None
