### PR TITLE
Base64 update with absl::Base64

### DIFF
--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -21,6 +21,7 @@
 #include "common/protobuf/protobuf.h"
 
 #include "absl/container/fixed_array.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 
 namespace Envoy {
@@ -109,7 +110,9 @@ Common::getGrpcStatusDetailsBin(const Http::HeaderMap& trailers) {
   }
 
   // Some implementations use non-padded base64 encoding for grpc-status-details-bin.
-  auto decoded_value = Base64::decodeWithoutPadding(details_header->value().getStringView());
+  std::string decoded_value;
+  absl::WebSafeBase64Unescape(details_header->value().getStringView(), &decoded_value);
+  // auto decoded_value = Base64::decodeWithoutPadding(details_header->value().getStringView());
   if (decoded_value.empty()) {
     return absl::nullopt;
   }

--- a/source/common/grpc/google_async_client_impl.cc
+++ b/source/common/grpc/google_async_client_impl.cc
@@ -12,6 +12,7 @@
 #include "common/grpc/google_grpc_utils.h"
 #include "common/tracing/http_tracer_impl.h"
 
+#include "absl/strings/escaping.h"
 #include "grpcpp/support/proto_buffer_reader.h"
 
 namespace Envoy {
@@ -362,7 +363,8 @@ void GoogleAsyncStreamImpl::metadataTranslate(
   for (const auto& it : grpc_metadata) {
     auto key = Http::LowerCaseString(std::string(it.first.data(), it.first.size()));
     if (absl::EndsWith(key.get(), "-bin")) {
-      auto value = Base64::encode(it.second.data(), it.second.size());
+      // auto value = Base64::encode(it.second.data(), it.second.size());
+      auto value = absl::Base64Escape(std::string(it.second.data(), it.second.size()));
       header_map.addCopy(key, value);
       continue;
     }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -23,6 +23,7 @@
 
 #include "extensions/filters/http/well_known_names.h"
 
+#include "absl/strings/escaping.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/string_view.h"
 
@@ -351,7 +352,10 @@ void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::I
   headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   if (!json_resp.body().empty()) {
     if (json_resp.is_base64_encoded()) {
-      body.add(Base64::decode(json_resp.body()));
+      std::string decoded;
+      absl::Base64Unescape(json_resp.body(), &decoded);
+      body.add(decoded);
+      // body.add(Base64::decode(json_resp.body()));
     } else {
       body.add(json_resp.body());
     }

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -126,9 +126,11 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool en
   std::string decoded;
   absl::Base64Unescape(
       std::string(static_cast<const char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
-                  decoding_buffer_.length()), &decoded);
+                  decoding_buffer_.length()),
+      &decoded);
   // const std::string decoded = Base64::decode(
-  //     std::string(static_cast<const char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
+  //     std::string(static_cast<const
+  //     char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
   //                 decoding_buffer_.length()));
   if (decoded.empty()) {
     // Error happened when decoding base64.

--- a/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
+++ b/source/extensions/filters/http/grpc_web/grpc_web_filter.cc
@@ -12,6 +12,8 @@
 #include "common/http/headers.h"
 #include "common/http/utility.h"
 
+#include "absl/strings/escaping.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -121,9 +123,13 @@ Http::FilterDataStatus GrpcWebFilter::decodeData(Buffer::Instance& data, bool en
 
   const uint64_t needed = available / 4 * 4 - decoding_buffer_.length();
   decoding_buffer_.move(data, needed);
-  const std::string decoded = Base64::decode(
+  std::string decoded;
+  absl::Base64Unescape(
       std::string(static_cast<const char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
-                  decoding_buffer_.length()));
+                  decoding_buffer_.length()), &decoded);
+  // const std::string decoded = Base64::decode(
+  //     std::string(static_cast<const char*>(decoding_buffer_.linearize(decoding_buffer_.length())),
+  //                 decoding_buffer_.length()));
   if (decoded.empty()) {
     // Error happened when decoding base64.
     decoder_callbacks_->sendLocalReply(Http::Code::BadRequest,

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -10,6 +10,7 @@
 
 #include "extensions/filters/http/well_known_names.h"
 
+#include "absl/strings/escaping.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/string_view.h"
 
@@ -165,7 +166,10 @@ bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta
   }
 
   if (encode == envoy::extensions::filters::http::header_to_metadata::v3::Config::BASE64) {
-    value = Base64::decodeWithoutPadding(value);
+    std::string decoded_value;
+    absl::WebSafeBase64Unescape(value, &decoded_value);
+    value = decoded_value;
+    // value = Base64::decodeWithoutPadding(value);
     if (value.empty()) {
       ENVOY_LOG(debug, "Base64 decode failed");
       return false;

--- a/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
@@ -79,9 +79,8 @@ public:
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   static void Base64Encode(const uint8_t* data, size_t data_len, std::string* output) {
-    *output =
-        absl::WebSafeBase64Escape(std::string(reinterpret_cast<const char*>(data), data_len));
-        // Envoy::Base64::encode(reinterpret_cast<const char*>(data), data_len, /*add_padding=*/false);
+    *output = absl::WebSafeBase64Escape(std::string(reinterpret_cast<const char*>(data), data_len));
+    // Envoy::Base64::encode(reinterpret_cast<const char*>(data), data_len, /*add_padding=*/false);
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quiche_text_utils_impl.h
@@ -80,7 +80,8 @@ public:
   // NOLINTNEXTLINE(readability-identifier-naming)
   static void Base64Encode(const uint8_t* data, size_t data_len, std::string* output) {
     *output =
-        Envoy::Base64::encode(reinterpret_cast<const char*>(data), data_len, /*add_padding=*/false);
+        absl::WebSafeBase64Escape(std::string(reinterpret_cast<const char*>(data), data_len));
+        // Envoy::Base64::encode(reinterpret_cast<const char*>(data), data_len, /*add_padding=*/false);
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -124,10 +124,10 @@ void OpenTracingSpan::injectContext(Http::RequestHeaderMap& request_headers) {
       return;
     }
     const std::string current_span_context = oss.str();
-    request_headers.setInline(
-        ot_span_context_handle.handle(),
-        absl::Base64Escape(current_span_context));
-        // Base64::encode(current_span_context.c_str(), current_span_context.length()));
+    request_headers.setInline(ot_span_context_handle.handle(),
+                              absl::Base64Escape(current_span_context));
+    // request_headers.setInline(ot_span_context_handle.handle(),
+    // Base64::encode(current_span_context.c_str(), current_span_context.length()));
   } else {
     // Inject the context using the tracer's standard HTTP header format.
     const OpenTracingHTTPHeadersWriter writer{request_headers};
@@ -170,7 +170,8 @@ Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
     opentracing::expected<std::unique_ptr<opentracing::SpanContext>> parent_span_ctx_maybe;
     std::string parent_context;
     absl::Base64Unescape(
-        std::string(request_headers.getInlineValue(ot_span_context_handle.handle())), &parent_context);
+        std::string(request_headers.getInlineValue(ot_span_context_handle.handle())),
+        &parent_context);
     // std::string parent_context = Base64::decode(
     //     std::string(request_headers.getInlineValue(ot_span_context_handle.handle())));
 

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -7,6 +7,7 @@
 
 #include "common/common/base64.h"
 
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
 #include "google/devtools/cloudtrace/v2/tracing.grpc.pb.h"
 #include "opencensus/exporters/trace/ocagent/ocagent_exporter.h"
@@ -211,7 +212,8 @@ void Span::injectContext(Http::RequestHeaderMap& request_headers) {
 
     case OpenCensusConfig::GRPC_TRACE_BIN: {
       std::string val = ::opencensus::trace::propagation::ToGrpcTraceBinHeader(ctx);
-      val = Base64::encode(val.data(), val.size(), /*add_padding=*/false);
+      val = absl::WebSafeBase64Escape(val);
+      // val = Base64::encode(val.data(), val.size(), /*add_padding=*/false);
       request_headers.setReferenceKey(Constants::get().GRPC_TRACE_BIN, val);
       break;
     }

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -25,6 +25,7 @@
 #include "extensions/transport_sockets/tls/utility.h"
 
 #include "absl/container/node_hash_set.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "openssl/evp.h"
@@ -252,7 +253,9 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
 
     if (!cert_validation_config->verifyCertificateSpkiList().empty()) {
       for (const auto& hash : cert_validation_config->verifyCertificateSpkiList()) {
-        const auto decoded = Base64::decode(hash);
+        std::string decoded;
+        absl::Base64Unescape(hash, &decoded);
+        // const auto decoded = Base64::decode(hash);
         if (decoded.size() != SHA256_DIGEST_LENGTH) {
           throw EnvoyException(absl::StrCat("Invalid base64-encoded SHA-256 ", hash));
         }

--- a/test/common/common/base64_fuzz_test.cc
+++ b/test/common/common/base64_fuzz_test.cc
@@ -1,18 +1,11 @@
 #include "common/common/base64.h"
 
-#include "absl/strings/escaping.h"
-
 #include "test/fuzz/fuzz_runner.h"
+
+#include "absl/strings/escaping.h"
 
 namespace Envoy {
 namespace Fuzz {
-
-// DEFINE_FUZZER(const uint8_t* buf, size_t len) {
-//   Envoy::Base64::encode(reinterpret_cast<const char*>(buf), len);
-//   Envoy::Base64::decode(std::string(reinterpret_cast<const char*>(buf), len));
-//   Envoy::Base64Url::encode(reinterpret_cast<const char*>(buf), len);
-//   Envoy::Base64Url::decode(std::string(reinterpret_cast<const char*>(buf), len));
-// }
 
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
   const std::string str(reinterpret_cast<const char*>(buf), len);

--- a/test/common/common/base64_fuzz_test.cc
+++ b/test/common/common/base64_fuzz_test.cc
@@ -1,15 +1,30 @@
 #include "common/common/base64.h"
 
+#include "absl/strings/escaping.h"
+
 #include "test/fuzz/fuzz_runner.h"
 
 namespace Envoy {
 namespace Fuzz {
 
+// DEFINE_FUZZER(const uint8_t* buf, size_t len) {
+//   Envoy::Base64::encode(reinterpret_cast<const char*>(buf), len);
+//   Envoy::Base64::decode(std::string(reinterpret_cast<const char*>(buf), len));
+//   Envoy::Base64Url::encode(reinterpret_cast<const char*>(buf), len);
+//   Envoy::Base64Url::decode(std::string(reinterpret_cast<const char*>(buf), len));
+// }
+
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
-  Envoy::Base64::encode(reinterpret_cast<const char*>(buf), len);
-  Envoy::Base64::decode(std::string(reinterpret_cast<const char*>(buf), len));
-  Envoy::Base64Url::encode(reinterpret_cast<const char*>(buf), len);
-  Envoy::Base64Url::decode(std::string(reinterpret_cast<const char*>(buf), len));
+  const std::string str(reinterpret_cast<const char*>(buf), len);
+  std::string decoded, web_safe_decoded;
+  absl::Base64Escape(str);
+  absl::Base64Unescape(str, &decoded);
+  absl::WebSafeBase64Escape(str);
+  absl::WebSafeBase64Unescape(str, &web_safe_decoded);
+  // Envoy::Base64::encode(reinterpret_cast<const char*>(buf), len);
+  // Envoy::Base64::decode(std::string(reinterpret_cast<const char*>(buf), len));
+  // Envoy::Base64Url::encode(reinterpret_cast<const char*>(buf), len);
+  // Envoy::Base64Url::decode(std::string(reinterpret_cast<const char*>(buf), len));
 }
 
 } // namespace Fuzz

--- a/test/common/common/base64_test.cc
+++ b/test/common/common/base64_test.cc
@@ -5,6 +5,7 @@
 
 #include "test/test_common/printers.h"
 
+#include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -149,13 +149,11 @@ TEST_F(ProtobufUtilityTest, MessageUtilHash) {
   std::string a2_decoded;
   absl::Base64Unescape("CgsKA2NkZRIEGgJpagoLCgJhYhIFGgNmZ2g=", &a2_decoded);
   a2.set_value(a2_decoded);
-  // a2.set_value(Base64::decode("CgsKA2NkZRIEGgJpagoLCgJhYhIFGgNmZ2g="));
 
   ProtobufWkt::Any a3 = a1;
   std::string a3_decoded;
   absl::Base64Unescape("CgsKAmFiEgUaA2ZnaAoLCgNjZGUSBBoCaWo=", &a3_decoded);
   a3.set_value(a3_decoded);
-  // a3.set_value(Base64::decode("CgsKAmFiEgUaA2ZnaAoLCgNjZGUSBBoCaWo="));
 
   EXPECT_EQ(MessageUtil::hash(a1), MessageUtil::hash(a2));
   EXPECT_EQ(MessageUtil::hash(a2), MessageUtil::hash(a3));

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -29,6 +29,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/container/node_hash_set.h"
+#include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
 #include "udpa/type/v1/typed_struct.pb.h"
 
@@ -145,9 +146,16 @@ TEST_F(ProtobufUtilityTest, MessageUtilHash) {
   // The two base64 encoded Struct to test map is identical to the struct above, this tests whether
   // a map is deterministically serialized and hashed.
   ProtobufWkt::Any a2 = a1;
-  a2.set_value(Base64::decode("CgsKA2NkZRIEGgJpagoLCgJhYhIFGgNmZ2g="));
+  std::string a2_decoded;
+  absl::Base64Unescape("CgsKA2NkZRIEGgJpagoLCgJhYhIFGgNmZ2g=", &a2_decoded);
+  a2.set_value(a2_decoded);
+  // a2.set_value(Base64::decode("CgsKA2NkZRIEGgJpagoLCgJhYhIFGgNmZ2g="));
+
   ProtobufWkt::Any a3 = a1;
-  a3.set_value(Base64::decode("CgsKAmFiEgUaA2ZnaAoLCgNjZGUSBBoCaWo="));
+  std::string a3_decoded;
+  absl::Base64Unescape("CgsKAmFiEgUaA2ZnaAoLCgNjZGUSBBoCaWo=", &a3_decoded);
+  a3.set_value(a3_decoded);
+  // a3.set_value(Base64::decode("CgsKAmFiEgUaA2ZnaAoLCgNjZGUSBBoCaWo="));
 
   EXPECT_EQ(MessageUtil::hash(a1), MessageUtil::hash(a2));
   EXPECT_EQ(MessageUtil::hash(a2), MessageUtil::hash(a3));

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -22,6 +22,7 @@
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/escaping.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -289,27 +290,34 @@ api_config_source:
       credentials_factory_name: envoy.grpc_credentials.file_based_metadata
   )",
                             config_source);
+  std::string decoded;
+  absl::Base64Unescape("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
+                                 "C90b2tlbhILeC10b2tlbi1iaW4=", &decoded);
   config_source.mutable_api_config_source()
       ->mutable_grpc_services(0)
       ->mutable_google_grpc()
       ->mutable_call_credentials(0)
       ->mutable_from_plugin()
       ->mutable_typed_config()
-      ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
-                                 "C90b2tlbhILeC10b2tlbi1iaW4="));
+      ->set_value(decoded);
+      // ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
+      //                            "C90b2tlbhILeC10b2tlbi1iaW4="));
   auto secret_provider1 =
       secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
 
   // The base64 encoded proto binary is identical to the one above, but in different field order.
   // It is also identical to the YAML below.
+  absl::Base64Unescape("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
+                                 "2VydmljZWFjY291bnQvdG9rZW4=", &decoded);
   config_source.mutable_api_config_source()
       ->mutable_grpc_services(0)
       ->mutable_google_grpc()
       ->mutable_call_credentials(0)
       ->mutable_from_plugin()
       ->mutable_typed_config()
-      ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
-                                 "2VydmljZWFjY291bnQvdG9rZW4="));
+      ->set_value(decoded);
+      // ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
+      //                            "2VydmljZWFjY291bnQvdG9rZW4="));
   auto secret_provider2 =
       secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
 

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -292,7 +292,8 @@ api_config_source:
                             config_source);
   std::string decoded;
   absl::Base64Unescape("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
-                                 "C90b2tlbhILeC10b2tlbi1iaW4=", &decoded);
+                       "C90b2tlbhILeC10b2tlbi1iaW4=",
+                       &decoded);
   config_source.mutable_api_config_source()
       ->mutable_grpc_services(0)
       ->mutable_google_grpc()
@@ -300,15 +301,16 @@ api_config_source:
       ->mutable_from_plugin()
       ->mutable_typed_config()
       ->set_value(decoded);
-      // ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
-      //                            "C90b2tlbhILeC10b2tlbi1iaW4="));
+  // ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
+  //                            "C90b2tlbhILeC10b2tlbi1iaW4="));
   auto secret_provider1 =
       secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
 
   // The base64 encoded proto binary is identical to the one above, but in different field order.
   // It is also identical to the YAML below.
   absl::Base64Unescape("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
-                                 "2VydmljZWFjY291bnQvdG9rZW4=", &decoded);
+                       "2VydmljZWFjY291bnQvdG9rZW4=",
+                       &decoded);
   config_source.mutable_api_config_source()
       ->mutable_grpc_services(0)
       ->mutable_google_grpc()
@@ -316,8 +318,8 @@ api_config_source:
       ->mutable_from_plugin()
       ->mutable_typed_config()
       ->set_value(decoded);
-      // ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
-      //                            "2VydmljZWFjY291bnQvdG9rZW4="));
+  // ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
+  //                            "2VydmljZWFjY291bnQvdG9rZW4="));
   auto secret_provider2 =
       secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
 

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -301,8 +301,6 @@ api_config_source:
       ->mutable_from_plugin()
       ->mutable_typed_config()
       ->set_value(decoded);
-  // ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
-  //                            "C90b2tlbhILeC10b2tlbi1iaW4="));
   auto secret_provider1 =
       secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
 
@@ -318,8 +316,6 @@ api_config_source:
       ->mutable_from_plugin()
       ->mutable_typed_config()
       ->set_value(decoded);
-  // ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
-  //                            "2VydmljZWFjY291bnQvdG9rZW4="));
   auto secret_provider2 =
       secret_manager->findOrCreateTlsCertificateProvider(config_source, "abc.com", secret_context);
 

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -17,6 +17,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/escaping.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -363,7 +364,10 @@ TEST_P(GrpcWebFilterTest, Unary) {
   if (accept_binary_response()) {
     EXPECT_EQ(std::string(TRAILERS, TRAILERS_SIZE), trailers_buffer.toString());
   } else if (accept_text_response()) {
-    EXPECT_EQ(std::string(TRAILERS, TRAILERS_SIZE), Base64::decode(trailers_buffer.toString()));
+    std::string decoded;
+    absl::Base64Unescape(trailers_buffer.toString(), &decoded);
+    EXPECT_EQ(std::string(TRAILERS, TRAILERS_SIZE), decoded);
+    // EXPECT_EQ(std::string(TRAILERS, TRAILERS_SIZE), Base64::decode(trailers_buffer.toString()));
   } else {
     FAIL() << "Unsupported gRPC-Web response content-type: "
            << response_headers.getContentTypeValue();

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -13,6 +13,7 @@
 #include "test/mocks/stream_info/mocks.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/escaping.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -235,7 +236,8 @@ response_rules:
 )EOF";
   initializeFilter(response_config_yaml);
   std::string data = "Non-ascii-characters";
-  const auto encoded = Base64::encode(data.c_str(), data.size());
+  const auto encoded = absl::Base64Escape(data);
+  // const auto encoded = Base64::encode(data.c_str(), data.size());
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-authenticated", encoded}};
   std::map<std::string, std::string> expected = {{"auth", data}};
   Http::TestResponseHeaderMapImpl empty_headers;
@@ -273,7 +275,8 @@ response_rules:
 
   std::string data;
   ASSERT_TRUE(value.SerializeToString(&data));
-  const auto encoded = Base64::encode(data.c_str(), data.size());
+  const auto encoded = absl::Base64Escape(data);
+  // const auto encoded = Base64::encode(data.c_str(), data.size());
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-authenticated", encoded}};
   std::map<std::string, ProtobufWkt::Value> expected = {{"auth", value}};
 
@@ -317,7 +320,8 @@ response_rules:
 )EOF";
   initializeFilter(response_config_yaml);
   std::string data = "invalid";
-  const auto encoded = Base64::encode(data.c_str(), data.size());
+  const auto encoded = absl::Base64Escape(data);
+  // const auto encoded = Base64::encode(data.c_str(), data.size());
   Http::TestResponseHeaderMapImpl incoming_headers{{"x-authenticated", encoded}};
 
   EXPECT_CALL(encoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -27,6 +27,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/escaping.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -640,7 +641,9 @@ TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
 
     // Context can be parsed fine.
     const opentracing::Tracer& tracer = driver_->tracer();
-    std::string context = Base64::decode(injected_ctx);
+    std::string context;
+    absl::Base64Unescape(injected_ctx, &context);
+    // std::string context = Base64::decode(injected_ctx);
     std::istringstream iss{context, std::ios::binary};
     EXPECT_TRUE(tracer.Extract(iss));
 
@@ -709,10 +712,14 @@ TEST_F(LightStepDriverTest, SpawnChild) {
   childViaHeaders->injectContext(base1);
   childViaSpawn->injectContext(base2);
 
-  std::string base1_context =
-      Base64::decode(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)));
-  std::string base2_context =
-      Base64::decode(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)));
+  std::string base1_context;
+  absl::Base64Unescape(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)), &base1_context);
+  // std::string base1_context = 
+      // Base64::decode(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)));
+  std::string base2_context;
+  absl::Base64Unescape(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)), &base2_context);
+  // std::string base2_context = 
+      // Base64::decode(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)));
 
   EXPECT_FALSE(base1_context.empty());
   EXPECT_FALSE(base2_context.empty());

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -713,13 +713,15 @@ TEST_F(LightStepDriverTest, SpawnChild) {
   childViaSpawn->injectContext(base2);
 
   std::string base1_context;
-  absl::Base64Unescape(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)), &base1_context);
-  // std::string base1_context = 
-      // Base64::decode(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)));
+  absl::Base64Unescape(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)),
+                       &base1_context);
+  // std::string base1_context =
+  // Base64::decode(std::string(base1.get_(Http::CustomHeaders::get().OtSpanContext)));
   std::string base2_context;
-  absl::Base64Unescape(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)), &base2_context);
-  // std::string base2_context = 
-      // Base64::decode(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)));
+  absl::Base64Unescape(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)),
+                       &base2_context);
+  // std::string base2_context =
+  // Base64::decode(std::string(base2.get_(Http::CustomHeaders::get().OtSpanContext)));
 
   EXPECT_FALSE(base1_context.empty());
   EXPECT_FALSE(base2_context.empty());

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -15,6 +15,8 @@
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 
+#include "absl/strings/escaping.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opencensus/trace/exporter/span_data.h"
@@ -240,7 +242,8 @@ void testIncomingHeaders(
                                   ::opencensus::trace::propagation::ToTraceParentHeader(ctx)));
   {
     std::string expected = ::opencensus::trace::propagation::ToGrpcTraceBinHeader(ctx);
-    expected = Base64::encode(expected.data(), expected.size(), /*add_padding=*/false);
+    expected = absl::WebSafeBase64Escape(expected);
+    // expected = Base64::encode(expected.data(), expected.size(), /*add_padding=*/false);
     EXPECT_THAT(hdrs, ContainHeader("grpc-trace-bin", expected));
   }
   EXPECT_THAT(hdrs,

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -16,7 +16,6 @@
 #include "test/mocks/tracing/mocks.h"
 
 #include "absl/strings/escaping.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "opencensus/trace/exporter/span_data.h"


### PR DESCRIPTION
Related Issue: https://github.com/envoyproxy/envoy/issues/12694

Description:
This pull request helps to replace the current ```Base64::encode/decode``` with ```absl::Base64```.
The current code base provide base64 encoding and decoding with or without padding. Abseil has supported to do that. To be more specific:
```Base64::encode(src_data, src_len, padding=true)``` can be replaced with ```absl::Base64Escape(std::string src)```.
```Base64::encode(src_data, src_len, padding=false)``` can be replaced with ```absl::Base64WebSafeEscape(std::string src)```.
```Base64Url::encode(src_data, src_len)``` can be replaced with ```absl::Base64WebSafeEscape(std::string src)```.

```Base64::decode(std::string src)``` can be replaced with ```absl::Base64Unescape(src, *dst)```.
```Base64::decodeWithoutPadding(std::string src)``` can be replaced with ```absl::Base64WebSafeUnescape(src, *dst)```.
```Base64Url::decode(std::string src)``` can be replaced with ```absl::Base64WebSafeEscape(std::string src)```.

The doc of absl::Base64: https://github.com/abseil/abseil-cpp/blob/master/absl/strings/escaping.h