### PR TITLE
h2, codec: Skip setting data_flags for empty trailers

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -388,8 +388,8 @@ ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* 
           // We need to tell the library to not set end stream so that we can emit the trailers.
           *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
           submitTrailers(*pending_trailers_to_encode_);
-          pending_trailers_to_encode_.reset();
         }
+        pending_trailers_to_encode_.reset();
       }
     }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -227,9 +227,14 @@ void ConnectionImpl::StreamImpl::encodeTrailersBase(const HeaderMap& trailers) {
   if (pending_send_data_.length() > 0) {
     // In this case we want trailers to come after we release all pending body data that is
     // waiting on window updates. We need to save the trailers so that we can emit them later.
+    // However, for empty trailers, we don't need to to save the trailers.
     ASSERT(!pending_trailers_to_encode_);
-    pending_trailers_to_encode_ = cloneTrailers(trailers);
-    createPendingFlushTimer();
+    const bool skip_encoding_empty_trailers =
+        trailers.empty() && parent_.skip_encoding_empty_trailers_;
+    if (!skip_encoding_empty_trailers) {
+      pending_trailers_to_encode_ = cloneTrailers(trailers);
+      createPendingFlushTimer();
+    }
   } else {
     submitTrailers(trailers);
     auto status = parent_.sendPendingFrames();
@@ -381,14 +386,9 @@ ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* 
     if (local_end_stream_ && pending_send_data_.length() <= length) {
       *data_flags |= NGHTTP2_DATA_FLAG_EOF;
       if (pending_trailers_to_encode_) {
-        const bool skip_encoding_empty_trailers =
-            pending_trailers_to_encode_->empty() && parent_.skip_encoding_empty_trailers_;
-        // For empty trailers, we don't need to set the data flags and submit it again.
-        if (!skip_encoding_empty_trailers) {
-          // We need to tell the library to not set end stream so that we can emit the trailers.
-          *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-          submitTrailers(*pending_trailers_to_encode_);
-        }
+        // We need to tell the library to not set end stream so that we can emit the trailers.
+        *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+        submitTrailers(*pending_trailers_to_encode_);
         pending_trailers_to_encode_.reset();
       }
     }

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -377,8 +377,8 @@ ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* 
           // We need to tell the library to not set end stream so that we can emit the trailers.
           *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
           submitTrailers(*pending_trailers_to_encode_);
-          pending_trailers_to_encode_.reset();
         }
+        pending_trailers_to_encode_.reset();
       }
     }
 

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -370,10 +370,15 @@ ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* 
     if (local_end_stream_ && pending_send_data_.length() <= length) {
       *data_flags |= NGHTTP2_DATA_FLAG_EOF;
       if (pending_trailers_to_encode_) {
-        // We need to tell the library to not set end stream so that we can emit the trailers.
-        *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-        submitTrailers(*pending_trailers_to_encode_);
-        pending_trailers_to_encode_.reset();
+        const bool skip_encoding_empty_trailers =
+            pending_trailers_to_encode_->empty() && parent_.skip_encoding_empty_trailers_;
+        // For empty trailers, we don't need to set the data flags and submit it again.
+        if (!skip_encoding_empty_trailers) {
+          // We need to tell the library to not set end stream so that we can emit the trailers.
+          *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+          submitTrailers(*pending_trailers_to_encode_);
+          pending_trailers_to_encode_.reset();
+        }
       }
     }
 

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -222,9 +222,14 @@ void ConnectionImpl::StreamImpl::encodeTrailersBase(const HeaderMap& trailers) {
   if (pending_send_data_.length() > 0) {
     // In this case we want trailers to come after we release all pending body data that is
     // waiting on window updates. We need to save the trailers so that we can emit them later.
+    // However, for empty trailers, we don't need to to save the trailers.
     ASSERT(!pending_trailers_to_encode_);
-    pending_trailers_to_encode_ = cloneTrailers(trailers);
-    createPendingFlushTimer();
+    const bool skip_encoding_empty_trailers =
+        trailers.empty() && parent_.skip_encoding_empty_trailers_;
+    if (!skip_encoding_empty_trailers) {
+      pending_trailers_to_encode_ = cloneTrailers(trailers);
+      createPendingFlushTimer();
+    }
   } else {
     submitTrailers(trailers);
     parent_.sendPendingFrames();
@@ -370,14 +375,9 @@ ssize_t ConnectionImpl::StreamImpl::onDataSourceRead(uint64_t length, uint32_t* 
     if (local_end_stream_ && pending_send_data_.length() <= length) {
       *data_flags |= NGHTTP2_DATA_FLAG_EOF;
       if (pending_trailers_to_encode_) {
-        const bool skip_encoding_empty_trailers =
-            pending_trailers_to_encode_->empty() && parent_.skip_encoding_empty_trailers_;
-        // For empty trailers, we don't need to set the data flags and submit it again.
-        if (!skip_encoding_empty_trailers) {
-          // We need to tell the library to not set end stream so that we can emit the trailers.
-          *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
-          submitTrailers(*pending_trailers_to_encode_);
-        }
+        // We need to tell the library to not set end stream so that we can emit the trailers.
+        *data_flags |= NGHTTP2_DATA_FLAG_NO_END_STREAM;
+        submitTrailers(*pending_trailers_to_encode_);
         pending_trailers_to_encode_.reset();
       }
     }

--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5699757025263616
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5699757025263616
@@ -1,0 +1,69 @@
+actions {
+  client_drain {
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":scheme"
+        value: "T"
+      }
+      headers {
+        key: ":method"
+        value: "%"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+    }
+    metadata {
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 16761078
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 142541011
+    }
+    dispatching_action {
+      continue_headers {
+      }
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      trailers {
+      }
+    }
+    dispatching_action {
+      data: 0
+    }
+  }
+}

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -337,7 +337,7 @@ public:
         ENVOY_LOG_MISC(debug, "Setting dispatching action  on {} in state {} {}", stream_index_,
                        static_cast<int>(request_.stream_state_),
                        static_cast<int>(response_.stream_state_));
-        auto request_action = stream_action.request().directional_action_selector_case();
+        auto request_action = stream_action.dispatching_action().directional_action_selector_case();
         if (request_action == test::common::http::DirectionalAction::kHeaders) {
           EXPECT_CALL(request_.request_decoder_, decodeHeaders_(_, _))
               .WillOnce(InvokeWithoutArgs(

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1246,7 +1246,7 @@ TEST_P(Http2IntegrationTest, PauseAndResumeHeadersOnly) {
 }
 
 // Verify the case when we have large pending data with empty trailers. It should not introduce
-// stack-overflow. This is a regression test for
+// stack-overflow (on ASan build). This is a regression test for
 // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24714.
 TEST_P(Http2IntegrationTest, EmptyTrailers) {
   initialize();


### PR DESCRIPTION
Commit Message: This skips setting `data_flags` for empty pending trailers.

Risk Level: Low
Testing: integration test, fuzz
Docs Changes: N/A
Release Notes: N/A

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24714
