### PR TITLE
make FANCY_LOG macro use fully-qualified namespace for getFancyContext()

### DIFF
--- a/source/common/common/fancy_logger.h
+++ b/source/common/common/fancy_logger.h
@@ -94,7 +94,7 @@ FancyContext& getFancyContext();
     static std::atomic<spdlog::logger*> flogger{0};                                                \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
     if (!local_flogger) {                                                                          \
-      getFancyContext().initFancyLogger(FANCY_KEY, flogger);                                       \
+      ::Envoy::getFancyContext().initFancyLogger(FANCY_KEY, flogger);                              \
       local_flogger = flogger.load(std::memory_order_relaxed);                                     \
     }                                                                                              \
     local_flogger->log(spdlog::source_loc{__FILE__, __LINE__, __func__},                           \
@@ -119,7 +119,7 @@ FancyContext& getFancyContext();
  */
 #define FANCY_FLUSH_LOG()                                                                          \
   do {                                                                                             \
-    SpdLoggerSharedPtr p = getFancyContext().getFancyLogEntry(FANCY_KEY);                          \
+    SpdLoggerSharedPtr p = ::Envoy::getFancyContext().getFancyLogEntry(FANCY_KEY);                 \
     if (p) {                                                                                       \
       p->flush();                                                                                  \
     }                                                                                              \


### PR DESCRIPTION
This makes the macro usable from downstream extensions that will likely
not be in the Envoy namespace.

Signed-off-by: Michael Puncel <mpuncel@squareup.com>


Commit Message: make FANCY_LOG macro use fully-qualified namespace for getFancyContext()

This makes the macro usable from downstream extensions that will likely
not be in the Envoy namespace.

Additional Description: Commit b7138814dde530b8c2957e806ea40879a4fdce32 introduced this issue, where ENVOY_LOG now depends on the FANCY_LOG macro
Risk Level: Low
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A

