### PR TITLE
network: socket and address build cleanup

### DIFF
--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -110,8 +110,16 @@ envoy_cc_library(
     deps = [
         ":address_interface",
         ":io_handle_interface",
-        "//include/envoy/config:typed_config_interface",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "socket_interface_interface",
+    hdrs = ["socket_interface.h"],
+    deps = [
+        ":socket_interface",
+        "//include/envoy/config:typed_config_interface",
     ],
 )
 

--- a/include/envoy/network/socket.h
+++ b/include/envoy/network/socket.h
@@ -232,47 +232,5 @@ using SocketPtr = std::unique_ptr<Socket>;
 using SocketSharedPtr = std::shared_ptr<Socket>;
 using SocketOptRef = absl::optional<std::reference_wrapper<Socket>>;
 
-class SocketInterface {
-public:
-  virtual ~SocketInterface() = default;
-
-  /**
-   * Low level api to create a socket in the underlying host stack. Does not create a
-   * @ref Network::SocketImpl
-   * @param type type of socket requested
-   * @param addr_type type of address used with the socket
-   * @param version IP version if address type is IP
-   * @param socket_v6only if the socket is ipv6 version only
-   * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
-   */
-  virtual IoHandlePtr socket(Socket::Type type, Address::Type addr_type, Address::IpVersion version,
-                             bool socket_v6only) const PURE;
-
-  /**
-   * Low level api to create a socket in the underlying host stack. Does not create an
-   * @ref Network::SocketImpl
-   * @param socket_type type of socket requested
-   * @param addr address that is gleaned for address type and version if needed
-   * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
-   */
-  virtual IoHandlePtr socket(Socket::Type socket_type,
-                             const Address::InstanceConstSharedPtr addr) const PURE;
-
-  /**
-   * Wrap socket file descriptor in IoHandle
-   * @param fd socket file descriptor to be wrapped
-   * @return @ref Network::IoHandlePtr that wraps the socket file descriptor
-   */
-  virtual IoHandlePtr socket(os_fd_t fd) PURE;
-
-  /**
-   * Returns true if the given family is supported on this machine.
-   * @param domain the IP family.
-   */
-  virtual bool ipFamilySupported(int domain) PURE;
-};
-
-using SocketInterfacePtr = std::unique_ptr<SocketInterface>;
-
 } // namespace Network
 } // namespace Envoy

--- a/include/envoy/network/socket_interface.h
+++ b/include/envoy/network/socket_interface.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "envoy/common/platform.h"
+#include "envoy/common/pure.h"
+#include "envoy/network/socket.h"
+
+namespace Envoy {
+namespace Network {
+class SocketInterface {
+public:
+  virtual ~SocketInterface() = default;
+
+  /**
+   * Low level api to create a socket in the underlying host stack. Does not create a
+   * @ref Network::SocketImpl
+   * @param type type of socket requested
+   * @param addr_type type of address used with the socket
+   * @param version IP version if address type is IP
+   * @param socket_v6only if the socket is ipv6 version only
+   * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
+   */
+  virtual IoHandlePtr socket(Socket::Type type, Address::Type addr_type, Address::IpVersion version,
+                             bool socket_v6only) const PURE;
+
+  /**
+   * Low level api to create a socket in the underlying host stack. Does not create an
+   * @ref Network::SocketImpl
+   * @param socket_type type of socket requested
+   * @param addr address that is gleaned for address type and version if needed
+   * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
+   */
+  virtual IoHandlePtr socket(Socket::Type socket_type,
+                             const Address::InstanceConstSharedPtr addr) const PURE;
+
+  /**
+   * Wrap socket file descriptor in IoHandle
+   * @param fd socket file descriptor to be wrapped
+   * @return @ref Network::IoHandlePtr that wraps the socket file descriptor
+   */
+  virtual IoHandlePtr socket(os_fd_t fd) PURE;
+
+  /**
+   * Returns true if the given family is supported on this machine.
+   * @param domain the IP family.
+   */
+  virtual bool ipFamilySupported(int domain) PURE;
+};
+
+using SocketInterfacePtr = std::unique_ptr<SocketInterface>;
+
+/**
+ * Create IoHandle for given address
+ * @param type type of socket to be requested
+ * @param addr address that is gleaned for address type, version and socket interface name
+ * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
+ */
+static inline IoHandlePtr ioHandleForAddr(Socket::Type type,
+                                          const Address::InstanceConstSharedPtr addr) {
+  return addr->socketInterface().socket(type, addr);
+}
+
+} // namespace Network
+} // namespace Envoy

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -10,21 +10,11 @@ envoy_package()
 
 envoy_cc_library(
     name = "address_lib",
-    srcs = [
-        "address_impl.cc",
-        "io_socket_handle_impl.cc",
-    ],
-    hdrs = [
-        "address_impl.h",
-        "io_socket_handle_impl.h",
-    ],
+    srcs = ["address_impl.cc"],
+    hdrs = ["address_impl.h"],
     deps = [
-        ":io_socket_error_lib",
         ":socket_interface_lib",
-        "//include/envoy/buffer:buffer_interface",
         "//include/envoy/network:address_interface",
-        "//include/envoy/network:io_handle_interface",
-        "//include/envoy/network:socket_interface",
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
@@ -180,29 +170,43 @@ envoy_cc_library(
     hdrs = ["socket_interface.h"],
     deps = [
         "//include/envoy/config:typed_config_interface",
-        "//include/envoy/network:socket_interface",
+        "//include/envoy/network:socket_interface_interface",
         "//include/envoy/registry",
         "//include/envoy/server:bootstrap_extension_config_interface",
     ],
 )
 
 envoy_cc_library(
-    name = "socket_lib",
+    name = "default_socket_interface_lib",
     srcs = [
-        "socket_impl.cc",
+        "io_socket_handle_impl.cc",
         "socket_interface_impl.cc",
     ],
     hdrs = [
-        "socket_impl.h",
+        "io_socket_handle_impl.h",
         "socket_interface_impl.h",
     ],
     deps = [
         ":address_lib",
+        ":io_socket_error_lib",
         ":socket_interface_lib",
+        ":socket_lib",
+        "//include/envoy/network:io_handle_interface",
+        "//source/common/api:os_sys_calls_lib",
+        "@envoy_api//envoy/extensions/network/socket_interface/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "socket_lib",
+    srcs = ["socket_impl.cc"],
+    hdrs = ["socket_impl.h"],
+    deps = [
         "//include/envoy/network:socket_interface",
+        "//include/envoy/network:socket_interface_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
-        "@envoy_api//envoy/extensions/network/socket_interface/v3:pkg_cc_proto",
     ],
 )
 
@@ -338,6 +342,7 @@ envoy_cc_library(
     hdrs = ["utility.h"],
     deps = [
         ":address_lib",
+        ":default_socket_interface_lib",
         ":socket_lib",
         "//include/envoy/network:connection_interface",
         "//include/envoy/network:listener_interface",

--- a/source/common/network/addr_family_aware_socket_option_impl.cc
+++ b/source/common/network/addr_family_aware_socket_option_impl.cc
@@ -7,7 +7,6 @@
 #include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
 #include "common/network/address_impl.h"
-#include "common/network/socket_interface_impl.h"
 #include "common/network/socket_option_impl.h"
 
 namespace Envoy {

--- a/source/common/network/listen_socket_impl.h
+++ b/source/common/network/listen_socket_impl.h
@@ -8,10 +8,10 @@
 #include "envoy/network/connection.h"
 #include "envoy/network/listen_socket.h"
 #include "envoy/network/socket.h"
+#include "envoy/network/socket_interface.h"
 
 #include "common/common/assert.h"
 #include "common/network/socket_impl.h"
-#include "common/network/socket_interface_impl.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/socket_impl.cc
+++ b/source/common/network/socket_impl.cc
@@ -1,12 +1,10 @@
 #include "common/network/socket_impl.h"
 
 #include "envoy/common/exception.h"
+#include "envoy/network/socket_interface.h"
 
 #include "common/api/os_sys_calls_impl.h"
 #include "common/common/utility.h"
-#include "common/network/address_impl.h"
-#include "common/network/io_socket_handle_impl.h"
-#include "common/network/socket_interface_impl.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/socket_interface.h
+++ b/source/common/network/socket_interface.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "envoy/config/typed_config.h"
-#include "envoy/network/socket.h"
+#include "envoy/network/socket_interface.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/bootstrap_extension_config.h"
 
@@ -51,17 +51,6 @@ static inline const SocketInterface* socketInterface(std::string name) {
 
 using SocketInterfaceSingleton = InjectableSingleton<SocketInterface>;
 using SocketInterfaceLoader = ScopedInjectableLoader<SocketInterface>;
-
-/**
- * Create IoHandle for given address
- * @param type type of socket to be requested
- * @param addr address that is gleaned for address type, version and socket interface name
- * @return @ref Network::IoHandlePtr that wraps the underlying socket file descriptor
- */
-static inline IoHandlePtr ioHandleForAddr(Socket::Type type,
-                                          const Address::InstanceConstSharedPtr addr) {
-  return addr->socketInterface().socket(type, addr);
-}
 
 } // namespace Network
 } // namespace Envoy

--- a/source/common/network/socket_interface_impl.cc
+++ b/source/common/network/socket_interface_impl.cc
@@ -2,11 +2,9 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/extensions/network/socket_interface/v3/default_socket_interface.pb.h"
-#include "envoy/network/socket.h"
 
 #include "common/api/os_sys_calls_impl.h"
 #include "common/common/utility.h"
-#include "common/network/address_impl.h"
 #include "common/network/io_socket_handle_impl.h"
 
 namespace Envoy {

--- a/source/common/network/socket_interface_impl.h
+++ b/source/common/network/socket_interface_impl.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "envoy/network/address.h"
 #include "envoy/network/socket.h"
 
 #include "common/network/socket_interface.h"

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -6,7 +6,7 @@
 #include "envoy/network/filter.h"
 #include "envoy/upstream/cluster_manager.h"
 
-#include "common/network/socket_interface_impl.h"
+#include "common/network/socket_interface.h"
 #include "common/network/utility.h"
 
 #include "absl/container/flat_hash_set.h"

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -17,7 +17,7 @@
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
 #include "common/config/utility.h"
-#include "common/network/socket_interface_impl.h"
+#include "common/network/socket_interface.h"
 #include "common/network/utility.h"
 #include "common/stats/symbol_table_impl.h"
 

--- a/source/extensions/tracers/xray/daemon_broker.cc
+++ b/source/extensions/tracers/xray/daemon_broker.cc
@@ -3,7 +3,7 @@
 #include "envoy/network/address.h"
 
 #include "common/buffer/buffer_impl.h"
-#include "common/network/socket_interface_impl.h"
+#include "common/network/socket_interface.h"
 #include "common/network/utility.h"
 #include "common/protobuf/utility.h"
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -45,6 +45,7 @@ envoy_cc_library(
         "//source/common/common:utility_lib",
         "//source/common/config:runtime_utility_lib",
         "//source/common/config:utility_lib",
+        "//source/common/network:default_socket_interface_lib",
         "//source/common/network:resolver_lib",
         "//source/common/network:socket_interface_lib",
         "//source/common/network:socket_option_factory_lib",

--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -6,7 +6,7 @@
 #include "common/common/empty_string.h"
 #include "common/common/fmt.h"
 #include "common/config/utility.h"
-#include "common/network/socket_interface_impl.h"
+#include "common/network/socket_interface.h"
 #include "common/protobuf/utility.h"
 
 #include "server/configuration_impl.h"

--- a/test/common/network/addr_family_aware_socket_option_impl_test.cc
+++ b/test/common/network/addr_family_aware_socket_option_impl_test.cc
@@ -3,7 +3,7 @@
 
 #include "common/network/addr_family_aware_socket_option_impl.h"
 #include "common/network/io_socket_handle_impl.h"
-#include "common/network/socket_interface_impl.h"
+#include "common/network/socket_interface.h"
 #include "common/network/utility.h"
 
 #include "test/common/network/socket_option_test.h"

--- a/test/test_common/network_utility.cc
+++ b/test/test_common/network_utility.cc
@@ -10,6 +10,7 @@
 #include "common/network/address_impl.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/network/raw_buffer_socket.h"
+#include "common/network/socket_interface.h"
 #include "common/network/socket_option_factory.h"
 #include "common/network/utility.h"
 #include "common/runtime/runtime_impl.h"


### PR DESCRIPTION
- split socket interface from socket
- add default socket interface library
- move io handle to default socket interface library from address

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a