### PR TITLE
http: fixing incorrect "downstream disconnect" flag in access logs

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -18,7 +18,7 @@ Minor Behavior Changes
 * http: changed Envoy to send error headers and body when possible. This behavior may be temporarily reverted by setting `envoy.reloadable_features.allow_response_for_timeout` to false.
 * http: changed empty trailers encoding behavior by sending empty data with ``end_stream`` true (instead of sending empty trailers) for HTTP/2. This behavior can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.http2_skip_encoding_empty_trailers`` to false.
 * http: clarified and enforced 1xx handling. Multiple 100-continue headers are coalesced when proxying. 1xx headers other than {100, 101} are dropped.
-* http: fixed a bug in access logs where early stream termination could be incorrectly tagged as a downstream disconnect.
+* http: fixed a bug in access logs where early stream termination could be incorrectly tagged as a downstream disconnect, and disconnects after partial response were not flagged.
 * http: fixed the 100-continue response path to properly handle upstream failure by sending 5xx responses. This behavior can be temporarily reverted by setting `envoy.reloadable_features.allow_500_after_100` to false.
 * http: the per-stream FilterState maintained by the HTTP connection manager will now provide read/write access to the downstream connection FilterState. As such, code that relies on interacting with this might
   see a change in behavior.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -18,6 +18,7 @@ Minor Behavior Changes
 * http: changed Envoy to send error headers and body when possible. This behavior may be temporarily reverted by setting `envoy.reloadable_features.allow_response_for_timeout` to false.
 * http: changed empty trailers encoding behavior by sending empty data with ``end_stream`` true (instead of sending empty trailers) for HTTP/2. This behavior can be reverted temporarily by setting runtime feature ``envoy.reloadable_features.http2_skip_encoding_empty_trailers`` to false.
 * http: clarified and enforced 1xx handling. Multiple 100-continue headers are coalesced when proxying. 1xx headers other than {100, 101} are dropped.
+* http: fixed a bug in access logs where early stream termination could be incorrectly tagged as a downstream disconnect.
 * http: fixed the 100-continue response path to properly handle upstream failure by sending 5xx responses. This behavior can be temporarily reverted by setting `envoy.reloadable_features.allow_500_after_100` to false.
 * http: the per-stream FilterState maintained by the HTTP connection manager will now provide read/write access to the downstream connection FilterState. As such, code that relies on interacting with this might
   see a change in behavior.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -621,17 +621,14 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
     }
   }
 
-  // TODO(alyssawilk) this is not true. Fix.
-  // A downstream disconnect can be identified for HTTP requests when the upstream returns with a 0
-  // response code and when no other response flags are set.
-  if (!filter_manager_.streamInfo().hasAnyResponseFlag() &&
-      !filter_manager_.streamInfo().responseCode()) {
-    filter_manager_.streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::DownstreamConnectionTermination);
-  }
   if (connection_manager_.remote_close_) {
     filter_manager_.streamInfo().setResponseCodeDetails(
         StreamInfo::ResponseCodeDetails::get().DownstreamRemoteDisconnect);
+    if (!filter_manager_.streamInfo().hasAnyResponseFlag() &&
+        !filter_manager_.streamInfo().responseCode()) {
+      filter_manager_.streamInfo().setResponseFlag(
+          StreamInfo::ResponseFlag::DownstreamConnectionTermination);
+    }
   }
 
   if (connection_manager_.codec_->protocol() < Protocol::Http2) {

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -624,11 +624,8 @@ ConnectionManagerImpl::ActiveStream::~ActiveStream() {
   if (connection_manager_.remote_close_) {
     filter_manager_.streamInfo().setResponseCodeDetails(
         StreamInfo::ResponseCodeDetails::get().DownstreamRemoteDisconnect);
-    if (!filter_manager_.streamInfo().hasAnyResponseFlag() &&
-        !filter_manager_.streamInfo().responseCode()) {
-      filter_manager_.streamInfo().setResponseFlag(
-          StreamInfo::ResponseFlag::DownstreamConnectionTermination);
-    }
+    filter_manager_.streamInfo().setResponseFlag(
+        StreamInfo::ResponseFlag::DownstreamConnectionTermination);
   }
 
   if (connection_manager_.codec_->protocol() < Protocol::Http2) {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -172,6 +172,9 @@ public:
       EXPECT_CALL(filter_factory_, createFilterChain(_))
           .WillOnce(Invoke([num_decoder_filters, num_encoder_filters, req,
                             this](FilterChainFactoryCallbacks& callbacks) -> void {
+            if (log_handler_.get()) {
+              callbacks.addAccessLogHandler(log_handler_);
+            }
             for (int i = 0; i < num_decoder_filters; i++) {
               callbacks.addStreamDecoderFilter(
                   StreamDecoderFilterSharedPtr{decoder_filters_[req * num_decoder_filters + i]});
@@ -434,6 +437,7 @@ public:
   MockResponseEncoder response_encoder_;
   std::vector<MockStreamDecoderFilter*> decoder_filters_;
   std::vector<MockStreamEncoderFilter*> encoder_filters_;
+  std::shared_ptr<AccessLog::MockInstance> log_handler_;
 };
 
 TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
@@ -4754,6 +4758,8 @@ TEST_F(HttpConnectionManagerImplTest, AlterFilterWatermarkLimits) {
 }
 
 TEST_F(HttpConnectionManagerImplTest, HitFilterWatermarkLimits) {
+  log_handler_ = std::make_shared<NiceMock<AccessLog::MockInstance>>();
+
   initial_buffer_limit_ = 1;
   streaming_filter_ = true;
   setup(false, "");
@@ -4799,6 +4805,12 @@ TEST_F(HttpConnectionManagerImplTest, HitFilterWatermarkLimits) {
   EXPECT_CALL(callbacks, onBelowWriteBufferLowWatermark());
   EXPECT_CALL(callbacks2, onBelowWriteBufferLowWatermark()).Times(0);
   encoder_filters_[1]->callbacks_->setEncoderBufferLimit((buffer_len + 1) * 2);
+
+  EXPECT_CALL(*log_handler_, log(_, _, _, _))
+      .WillOnce(Invoke([](const HeaderMap*, const HeaderMap*, const HeaderMap*,
+                          const StreamInfo::StreamInfo& stream_info) {
+        EXPECT_FALSE(stream_info.hasAnyResponseFlag());
+      }));
 }
 
 TEST_F(HttpConnectionManagerImplTest, HitRequestBufferLimits) {

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -437,13 +437,16 @@ TEST_P(IntegrationTest, BadFirstline) {
 }
 
 TEST_P(IntegrationTest, MissingDelimiter) {
-  useAccessLog("%RESPONSE_CODE_DETAILS%");
+  useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   initialize();
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
                                 "GET / HTTP/1.1\r\nHost: host\r\nfoo bar\r\n\r\n", &response);
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 400 Bad Request\r\n"));
-  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http1.codec_error"));
+  std::string log = waitForAccessLog(access_log_name_);
+  EXPECT_THAT(log, HasSubstr("http1.codec_error"));
+  EXPECT_THAT(log, HasSubstr("DPE"));
+  EXPECT_THAT(log, Not(HasSubstr("DC")));
 }
 
 TEST_P(IntegrationTest, InvalidCharacterInFirstline) {


### PR DESCRIPTION
Additional Description:
There are a bunch of reasons a stream may be torn down without response headers, e.g. client side reset, duration timeout, early recreateStream etc.

If Envoy wants to ensure that response flag is generally set it needs to be a part of sendLocalReply and reset stream interfaces.  This at least prevents misinformation from being propagated.

Risk Level: Medium (who knows if someone depends on this for logs scripts)
Testing: new unit test
Docs Changes: n/a
Release Notes: inline
