### PR TITLE
sendLocalReply:call modify_headers before call encode_headers

### DIFF
--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -375,7 +375,7 @@ private:
     Utility::sendLocalReply(
         remote_closed_,
         Utility::EncodeFunctions{
-            nullptr,
+            nullptr, nullptr,
             [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
               if (modify_headers != nullptr) {
                 modify_headers(*headers);

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -780,15 +780,13 @@ void FilterManager::sendLocalReplyViaFilterChain(
   Utility::sendLocalReply(
       state_.destroyed_,
       Utility::EncodeFunctions{
+          modify_headers,
           [this](ResponseHeaderMap& response_headers, Code& code, std::string& body,
                  absl::string_view& content_type) -> void {
             local_reply_.rewrite(request_headers_.get(), response_headers, stream_info_, code, body,
                                  content_type);
           },
           [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
-            if (modify_headers != nullptr) {
-              modify_headers(*headers);
-            }
             response_headers_ = std::move(headers);
             // TODO: Start encoding from the last decoder filter that saw the
             // request instead.
@@ -812,16 +810,13 @@ void FilterManager::sendDirectLocalReply(
   Http::Utility::sendLocalReply(
       state_.destroyed_,
       Utility::EncodeFunctions{
+          modify_headers,
           [&](ResponseHeaderMap& response_headers, Code& code, std::string& body,
               absl::string_view& content_type) -> void {
             local_reply_.rewrite(request_headers_.get(), response_headers, stream_info_, code, body,
                                  content_type);
           },
           [&](ResponseHeaderMapPtr&& response_headers, bool end_stream) -> void {
-            if (modify_headers != nullptr) {
-              modify_headers(*response_headers);
-            }
-
             // Move the response headers into the FilterManager to make sure they're visible to
             // access logs.
             response_headers_ = std::move(response_headers);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -476,7 +476,8 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
     response_headers->setContentLength(body_text.size());
     // If the `rewrite` function has changed body_text or content-type is not set, set it.
     // This allows `modify_headers` function to set content-type for the body. For example,
-    // router.direct_response is calling sendLocalReply and wants to set conent-type for the body.
+    // router direct response is calling sendLocalReply and may need to set conent-type for
+    // the body.
     if (body_text != local_reply_data.body_text_ || response_headers->ContentType() == nullptr) {
       response_headers->setReferenceContentType(content_type);
     }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -476,7 +476,7 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
     response_headers->setContentLength(body_text.size());
     // If the `rewrite` function has changed body_text or content-type is not set, set it.
     // This allows `modify_headers` function to set content-type for the body. For example,
-    // router direct response is calling this function and may need to set conent-type for
+    // router.direct_response is calling sendLocalReply and may need to set content-type for
     // the body.
     if (body_text != local_reply_data.body_text_ || response_headers->ContentType() == nullptr) {
       response_headers->setReferenceContentType(content_type);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -418,7 +418,7 @@ void Utility::sendLocalReply(const bool& is_reset, StreamDecoderFilterCallbacks&
                              const LocalReplyData& local_reply_data) {
   sendLocalReply(
       is_reset,
-      Utility::EncodeFunctions{nullptr,
+      Utility::EncodeFunctions{nullptr, nullptr,
                                [&](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
                                  callbacks.encodeHeaders(std::move(headers), end_stream);
                                },
@@ -441,6 +441,9 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
   ResponseHeaderMapPtr response_headers{createHeaderMap<ResponseHeaderMapImpl>(
       {{Headers::get().Status, std::to_string(enumToInt(response_code))}})};
 
+  if (encode_functions.modify_headers_) {
+    encode_functions.modify_headers_(*response_headers);
+  }
   if (encode_functions.rewrite_) {
     encode_functions.rewrite_(*response_headers, response_code, body_text, content_type);
   }
@@ -463,13 +466,22 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
       }
       response_headers->setGrpcMessage(PercentEncoding::encode(body_text));
     }
+    // The `modify_headers` function may have added content-length, remove it.
+    response_headers->removeContentLength();
     encode_functions.encode_headers_(std::move(response_headers), true); // Trailers only response
     return;
   }
 
   if (!body_text.empty()) {
     response_headers->setContentLength(body_text.size());
-    response_headers->setReferenceContentType(content_type);
+    // If the `rewrite` function has changed body_text or content-type is not set, set it.
+    if (body_text != local_reply_data.body_text_ || response_headers->ContentType() == nullptr) {
+      response_headers->setReferenceContentType(content_type);
+    }
+  } else {
+    // The `modify_headers` function may have added content-length and content-type, remove them.
+    response_headers->removeContentLength();
+    response_headers->removeContentType();
   }
 
   if (local_reply_data.is_head_request_) {
@@ -478,7 +490,7 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
   }
 
   encode_functions.encode_headers_(std::move(response_headers), body_text.empty());
-  // encode_headers()) may have changed the referenced is_reset so we need to test it
+  // encode_headers() may have changed the referenced is_reset so we need to test it
   if (!body_text.empty() && !is_reset) {
     Buffer::OwnedImpl buffer(body_text);
     encode_functions.encode_data_(buffer, true);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -481,6 +481,9 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
     if (body_text != local_reply_data.body_text_ || response_headers->ContentType() == nullptr) {
       response_headers->setReferenceContentType(content_type);
     }
+  } else {
+    response_headers->removeContentLength();
+    response_headers->removeContentType();
   }
 
   if (local_reply_data.is_head_request_) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -475,13 +475,11 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
   if (!body_text.empty()) {
     response_headers->setContentLength(body_text.size());
     // If the `rewrite` function has changed body_text or content-type is not set, set it.
+    // This allows `modify_headers` function to set content-type for the body. For example,
+    // router.direct_response is calling sendLocalReply and wants to set conent-type for the body.
     if (body_text != local_reply_data.body_text_ || response_headers->ContentType() == nullptr) {
       response_headers->setReferenceContentType(content_type);
     }
-  } else {
-    // The `modify_headers` function may have added content-length and content-type, remove them.
-    response_headers->removeContentLength();
-    response_headers->removeContentType();
   }
 
   if (local_reply_data.is_head_request_) {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -476,7 +476,7 @@ void Utility::sendLocalReply(const bool& is_reset, const EncodeFunctions& encode
     response_headers->setContentLength(body_text.size());
     // If the `rewrite` function has changed body_text or content-type is not set, set it.
     // This allows `modify_headers` function to set content-type for the body. For example,
-    // router direct response is calling sendLocalReply and may need to set conent-type for
+    // router direct response is calling this function and may need to set conent-type for
     // the body.
     if (body_text != local_reply_data.body_text_ || response_headers->ContentType() == nullptr) {
       response_headers->setReferenceContentType(content_type);

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -270,6 +270,8 @@ bool isWebSocketUpgradeRequest(const RequestHeaderMap& headers);
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config);
 
 struct EncodeFunctions {
+  // Function to modify locally generated response headers.
+  std::function<void(ResponseHeaderMap& headers)> modify_headers_;
   // Function to rewrite locally generated response.
   std::function<void(ResponseHeaderMap& response_headers, Code& code, std::string& body,
                      absl::string_view& content_type)>

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -108,7 +108,7 @@ public:
     Http::Utility::sendLocalReply(
         false,
         Http::Utility::EncodeFunctions(
-            {nullptr,
+            {nullptr, nullptr,
              [&](Http::ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
                encoder_.encodeHeaders(*headers, end_stream);
              },

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -140,7 +140,7 @@ TEST_P(IntegrationTest, PerWorkerStatsAndBalancing) {
   check_listener_stats(0, 1);
 }
 
-TEST_P(IntegrationTest, RouterDirectResponse) {
+TEST_P(IntegrationTest, RouterDirectResponseWithBody) {
   const std::string body = "Response body";
   const std::string file_path = TestEnvironment::writeStringToFileForTest("test_envoy", body);
   static const std::string domain("direct.example.com");
@@ -157,6 +157,11 @@ TEST_P(IntegrationTest, RouterDirectResponse) {
         header_value_option = route_config->mutable_response_headers_to_add()->Add();
         header_value_option->mutable_header()->set_key("content-type");
         header_value_option->mutable_header()->set_value("text/html");
+        header_value_option->mutable_append()->set_value(false);
+        // Add a wrong content-length.
+        header_value_option = route_config->mutable_response_headers_to_add()->Add();
+        header_value_option->mutable_header()->set_key("content-length");
+        header_value_option->mutable_header()->set_value("2000");
         header_value_option->mutable_append()->set_value(false);
         auto* virtual_host = route_config->add_virtual_hosts();
         virtual_host->set_name(domain);
@@ -178,7 +183,53 @@ TEST_P(IntegrationTest, RouterDirectResponse) {
                                  ->value()
                                  .getStringView());
   EXPECT_EQ("text/html", response->headers().getContentTypeValue());
+  // Verify content-length is correct.
+  EXPECT_EQ(fmt::format("{}", body.size()), response->headers().getContentLengthValue());
   EXPECT_EQ(body, response->body());
+}
+
+TEST_P(IntegrationTest, RouterDirectResponseEmptyBody) {
+  static const std::string domain("direct.example.com");
+  static const std::string prefix("/");
+  static const Http::Code status(Http::Code::OK);
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        auto* route_config = hcm.mutable_route_config();
+        auto* header_value_option = route_config->mutable_response_headers_to_add()->Add();
+        header_value_option->mutable_header()->set_key("x-additional-header");
+        header_value_option->mutable_header()->set_value("example-value");
+        header_value_option->mutable_append()->set_value(false);
+        header_value_option = route_config->mutable_response_headers_to_add()->Add();
+        header_value_option->mutable_header()->set_key("content-type");
+        header_value_option->mutable_header()->set_value("text/html");
+        header_value_option->mutable_append()->set_value(false);
+        // Add a wrong content-length.
+        header_value_option = route_config->mutable_response_headers_to_add()->Add();
+        header_value_option->mutable_header()->set_key("content-length");
+        header_value_option->mutable_header()->set_value("2000");
+        header_value_option->mutable_append()->set_value(false);
+        auto* virtual_host = route_config->add_virtual_hosts();
+        virtual_host->set_name(domain);
+        virtual_host->add_domains(domain);
+        virtual_host->add_routes()->mutable_match()->set_prefix(prefix);
+        virtual_host->mutable_routes(0)->mutable_direct_response()->set_status(
+            static_cast<uint32_t>(status));
+      });
+  initialize();
+
+  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
+      lookupPort("http"), "GET", "/", "", downstream_protocol_, version_, "direct.example.com");
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ("example-value", response->headers()
+                                 .get(Envoy::Http::LowerCaseString("x-additional-header"))
+                                 ->value()
+                                 .getStringView());
+  // Content-type header is removed.
+  EXPECT_EQ(nullptr, response->headers().ContentType());
+  // Content-length header is correct.
+  EXPECT_EQ("0", response->headers().getContentLengthValue());
 }
 
 TEST_P(IntegrationTest, ConnectionClose) {

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -82,7 +82,7 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
   Utility::sendLocalReply(
       stream_destroyed_,
       Utility::EncodeFunctions{
-          nullptr,
+          nullptr, nullptr,
           [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
             if (modify_headers != nullptr) {
               modify_headers(*headers);


### PR DESCRIPTION
To fix https://github.com/envoyproxy/envoy/issues/12690

There is a conflict between "modify_headers" in this [API](https://github.com/envoyproxy/envoy/blob/master/include/envoy/http/filter.h#L340) and "local_reply_config" in [HCM](https://github.com/envoyproxy/envoy/blob/e8216a8cf79c54e3e0a77ab729ebf27f4e79eb1b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#L535)

When "local_reply_config" is used, the local reply body and its type is generated by Utility::sendLocalReply(), modify_headers should not override it, otherwise it will be wrong.

The modify_headers function is used by many places: route_direct_response and ext_authz.  
*  ext_authz use it to send ext_authz response headers and body to the client in "denied" case.
* route_direct_response use it to send specified response_headers.  It may want to specify the content-type.

Detail changes:
* pass `modify_headers` funtion into Utilitty::sendLocalReply() so it can be called separately.
* call `modify_headers` first in Utilitty::sendLocalReply()
* if body size is not empty, set content-length
* if body_text is modified by local_reply_config, or content-type is not set by `modify_headers`, set it

Risk Level: Low
Testing:  Added integration test.
Docs Changes: N/A
Release Notes: N/A
Fixes #12690
