### PR TITLE
logger: Allow use of ENVOY_LOG/FANCY_LOG outside the Envoy namespace

### DIFF
--- a/source/common/common/fancy_logger.h
+++ b/source/common/common/fancy_logger.h
@@ -94,7 +94,7 @@ FancyContext& getFancyContext();
     static std::atomic<spdlog::logger*> flogger{0};                                                \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_relaxed);                       \
     if (!local_flogger) {                                                                          \
-      getFancyContext().initFancyLogger(FANCY_KEY, flogger);                                       \
+      Envoy::getFancyContext().initFancyLogger(FANCY_KEY, flogger);                                \
       local_flogger = flogger.load(std::memory_order_relaxed);                                     \
     }                                                                                              \
     local_flogger->log(spdlog::source_loc{__FILE__, __LINE__, __func__},                           \
@@ -119,7 +119,7 @@ FancyContext& getFancyContext();
  */
 #define FANCY_FLUSH_LOG()                                                                          \
   do {                                                                                             \
-    SpdLoggerSharedPtr p = getFancyContext().getFancyLogEntry(FANCY_KEY);                          \
+    SpdLoggerSharedPtr p = Envoy::getFancyContext().getFancyLogEntry(FANCY_KEY);                   \
     if (p) {                                                                                       \
       p->flush();                                                                                  \
     }                                                                                              \


### PR DESCRIPTION
Allow use of ENVOY_LOG/FANCY_LOG in proprietary filters outside the Envoy namespace.

Risk Level: Low
Testing: Build proprietary filter using ENVOY_LOG
Docs Changes: n/a
Release Notes: n/a
Fixes: #12728
