### PR TITLE
Support 'repository' in envoy_cc_benchmark_binary

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -245,10 +245,12 @@ def envoy_cc_test_binary(
 def envoy_cc_benchmark_binary(
         name,
         deps = [],
+        repository = "",
         **kargs):
     envoy_cc_test_binary(
         name,
-        deps = deps + ["//test/benchmark:main"],
+        deps = deps + [repository + "//test/benchmark:main"],
+        repository = repository,
         **kargs
     )
 


### PR DESCRIPTION
Signed-off-by: John Murray <murray@stripe.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Support 'repository' in envoy_cc_benchmark_binary
Additional Description: Added necessary `repository` support for `envoy_cc_benchmark_binary` so that this can be used for custom filter builds.
Risk Level: low
Testing: manual
Docs Changes: n/a
Release Notes: n/a
