### PR TITLE
Windows: Fix mysql tests

### DIFF
--- a/source/extensions/filters/network/mysql_proxy/mysql_codec.h
+++ b/source/extensions/filters/network/mysql_proxy/mysql_codec.h
@@ -97,16 +97,6 @@ public:
     MysqlResponse = 1,
   };
 
-  PACKED_STRUCT(struct header_fields {
-    uint32_t length_ : 24;
-    uint8_t seq_ : 8;
-  });
-
-  union MySQLHeader {
-    header_fields fields_;
-    uint32_t bits_;
-  };
-
   virtual ~MySQLCodec() = default;
 
   int decode(Buffer::Instance& data, uint8_t seq, uint32_t len) {

--- a/source/extensions/filters/network/mysql_proxy/mysql_utils.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_utils.cc
@@ -20,12 +20,10 @@ void BufferHelper::addUint32(Buffer::Instance& buffer, uint32_t val) {
 void BufferHelper::addString(Buffer::Instance& buffer, const std::string& str) { buffer.add(str); }
 
 std::string BufferHelper::encodeHdr(const std::string& cmd_str, uint8_t seq) {
-  MySQLCodec::MySQLHeader mysqlhdr;
-  mysqlhdr.fields_.length_ = cmd_str.length();
-  mysqlhdr.fields_.seq_ = seq;
-
   Buffer::OwnedImpl buffer;
-  addUint32(buffer, mysqlhdr.bits_);
+  // First byte contains sequence number, next 3 bytes contain cmd string size
+  uint32_t header = (seq << 24) | (cmd_str.length() & MYSQL_HDR_PKT_SIZE_MASK);
+  addUint32(buffer, header);
 
   std::string e_string = buffer.toString();
   e_string.append(cmd_str);

--- a/test/extensions/filters/network/mysql_proxy/BUILD
+++ b/test/extensions/filters/network/mysql_proxy/BUILD
@@ -40,7 +40,6 @@ envoy_extension_cc_test(
         "mysql_filter_test.cc",
     ],
     extension_name = "envoy.filters.network.mysql_proxy",
-    tags = ["fails_on_windows"],
     deps = [
         ":mysql_test_utils_lib",
         "//source/extensions/filters/network/mysql_proxy:config",
@@ -57,7 +56,6 @@ envoy_extension_cc_test(
         "mysql_test_config.yaml",
     ],
     extension_name = "envoy.filters.network.mysql_proxy",
-    tags = ["fails_on_windows"],
     deps = [
         ":mysql_test_utils_lib",
         "//source/common/tcp_proxy",


### PR DESCRIPTION
Commit Message:
Windows: Fix mysql tests

Using a union to encode mysql header relied on undefined behavior of
unions in C++: "It's undefined behavior to read from the member of the
union that wasn't most recently written. Many compilers implement, as a
non-standard language extension, the ability to read inactive members of
a union." In conjunction with the `bits_` field of the union not being
initialized, this caused invalid sequence numbers to be set and parsed from
the header. Replaced usage of union with bit shift/mask.
Additional Description:
See: https://en.cppreference.com/w/cpp/language/union
Risk Level: Low
Testing: Covered by unit/integration tests, passing on Windows locally
Docs Changes: N/A
Release Notes: N/A