### PR TITLE
Make header value prefix() methods const

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -36,7 +36,9 @@ Bug Fixes
 * csrf: fixed issues with regards to origin and host header parsing.
 * dynamic_forward_proxy: only perform DNS lookups for routes to Dynamic Forward Proxy clusters since other cluster types handle DNS lookup themselves.
 * fault: fixed an issue with `active_faults` gauge not being decremented for when abort faults were injected.
+* fault: made the HeaderNameValues::prefix() method const.
 * grpc-web: fixed an issue with failing HTTP/2 requests on some browsers. Notably, WebKit-based browsers (https://bugs.webkit.org/show_bug.cgi?id=210108), Internet Explorer 11, and Edge (pre-Chromium).
+* http: made the HeaderValues::prefix() method const.
 * rocketmq_proxy network-level filter: fixed an issue involving incorrect header lengths. In debug mode it causes crash and in release mode it causes underflow.
 
 Removed Config or Runtime

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -119,7 +119,7 @@ using CustomHeaders = ConstSingleton<CustomHeaderValues>;
  */
 class HeaderValues {
 public:
-  const char* prefix() { return ThreadSafeSingleton<PrefixValue>::get().prefix(); }
+  const char* prefix() const { return ThreadSafeSingleton<PrefixValue>::get().prefix(); }
 
   const LowerCaseString Age{"age"};
   const LowerCaseString ProxyAuthenticate{"proxy-authenticate"};

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -18,7 +18,7 @@ namespace Fault {
 
 class HeaderNameValues {
 public:
-  const char* prefix() { return ThreadSafeSingleton<Http::PrefixValue>::get().prefix(); }
+  const char* prefix() const { return ThreadSafeSingleton<Http::PrefixValue>::get().prefix(); }
 
   const Http::LowerCaseString AbortRequest{absl::StrCat(prefix(), "-fault-abort-request")};
   const Http::LowerCaseString AbortRequestPercentage{


### PR DESCRIPTION
The Envoy::Http::HeaderValues::prefix() method is marked non-const.
However, the only way to access that method is through a
ConstSingleton meaning that the prefix() method can only be called
with a const_cast, which is ugly.

Given that the prefix() method’s implementation is read-only in
spirit (since once the prefix() method is called, it will always
return the same value), there should be no change in functionality by
making the prefix() method const.

The same argument applies to the
Envoy::Extensions::Filters::Common:Fault::HeaderNameValues::prefix()
method, so I have also made it const.

Risk Level: Low
Testing: bazel build //source/common/http/... //source/extensions/filters/common/fault/... && bazel test //test/integration:header_prefix_integration_test
Docs Changes: N/A
Release Notes: const bug fix notes added

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>