### PR TITLE
Removes nice mocks from parent class in listener_factory_context

### DIFF
--- a/test/extensions/filters/listener/original_src/BUILD
+++ b/test/extensions/filters/listener/original_src/BUILD
@@ -27,7 +27,6 @@ envoy_extension_cc_test(
     name = "original_src_config_factory_test",
     srcs = ["original_src_config_factory_test.cc"],
     extension_name = "envoy.filters.listener.original_src",
-    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/listener/original_src:config",
         "//source/extensions/filters/listener/original_src:config_lib",

--- a/test/extensions/filters/udp/dns_filter/BUILD
+++ b/test/extensions/filters/udp/dns_filter/BUILD
@@ -28,7 +28,6 @@ envoy_extension_cc_test(
     name = "dns_filter_test",
     srcs = ["dns_filter_test.cc"],
     extension_name = "envoy.filters.udp_listener.dns_filter",
-    tags = ["fails_on_windows"],
     deps = [
         ":dns_filter_test_lib",
         "//source/extensions/filters/udp/dns_filter:dns_filter_lib",

--- a/test/mocks/server/listener_factory_context.cc
+++ b/test/mocks/server/listener_factory_context.cc
@@ -1,12 +1,44 @@
 #include "listener_factory_context.h"
 
+#include <string>
+
+#include "common/singleton/manager_impl.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
-MockListenerFactoryContext::MockListenerFactoryContext() = default;
+
+using ::testing::ReturnRef;
+
+MockListenerFactoryContext::MockListenerFactoryContext()
+    : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
+      grpc_context_(scope_.symbolTable()), http_context_(scope_.symbolTable()) {
+  ON_CALL(*this, getServerFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
+  ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
+  ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
+  ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
+  ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
+  ON_CALL(*this, initManager()).WillByDefault(ReturnRef(init_manager_));
+  ON_CALL(*this, lifecycleNotifier()).WillByDefault(ReturnRef(lifecycle_notifier_));
+  ON_CALL(*this, localInfo()).WillByDefault(ReturnRef(local_info_));
+  ON_CALL(*this, random()).WillByDefault(ReturnRef(random_));
+  ON_CALL(*this, runtime()).WillByDefault(ReturnRef(runtime_loader_));
+  ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
+  ON_CALL(*this, singletonManager()).WillByDefault(ReturnRef(*singleton_manager_));
+  ON_CALL(*this, threadLocal()).WillByDefault(ReturnRef(thread_local_));
+  ON_CALL(*this, admin()).WillByDefault(ReturnRef(admin_));
+  ON_CALL(*this, listenerScope()).WillByDefault(ReturnRef(listener_scope_));
+  ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
+  ON_CALL(*this, timeSource()).WillByDefault(ReturnRef(time_system_));
+  ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
+  ON_CALL(*this, messageValidationContext()).WillByDefault(ReturnRef(validation_context_));
+  ON_CALL(*this, messageValidationVisitor())
+      .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
+  ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
+}
 
 MockListenerFactoryContext::~MockListenerFactoryContext() = default;
 

--- a/test/mocks/server/listener_factory_context.h
+++ b/test/mocks/server/listener_factory_context.h
@@ -5,16 +5,77 @@
 #include "factory_context.h"
 #include "gmock/gmock.h"
 
+#include "envoy/server/configuration.h"
+
+#include "extensions/transport_sockets/tls/context_manager_impl.h"
+
+#include "admin.h"
+#include "drain_manager.h"
+#include "gmock/gmock.h"
+#include "instance.h"
+#include "overload_manager.h"
+#include "server_lifecycle_notifier.h"
+
 namespace Envoy {
 namespace Server {
 namespace Configuration {
-class MockListenerFactoryContext : public MockFactoryContext, public ListenerFactoryContext {
+class MockListenerFactoryContext : public ListenerFactoryContext {
 public:
   MockListenerFactoryContext();
   ~MockListenerFactoryContext() override;
 
   const Network::ListenerConfig& listenerConfig() const override { return listener_config_; }
   MOCK_METHOD(const Network::ListenerConfig&, listenerConfig_, (), (const));
+  MOCK_METHOD(ServerFactoryContext&, getServerFactoryContext, (), (const));
+  MOCK_METHOD(TransportSocketFactoryContext&, getTransportSocketFactoryContext, (), (const));
+  MOCK_METHOD(AccessLog::AccessLogManager&, accessLogManager, ());
+  MOCK_METHOD(Upstream::ClusterManager&, clusterManager, ());
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
+  MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());
+  MOCK_METHOD(bool, healthCheckFailed, ());
+  MOCK_METHOD(Init::Manager&, initManager, ());
+  MOCK_METHOD(ServerLifecycleNotifier&, lifecycleNotifier, ());
+  MOCK_METHOD(Envoy::Random::RandomGenerator&, random, ());
+  MOCK_METHOD(Envoy::Runtime::Loader&, runtime, ());
+  MOCK_METHOD(Stats::Scope&, scope, ());
+  MOCK_METHOD(Singleton::Manager&, singletonManager, ());
+  MOCK_METHOD(OverloadManager&, overloadManager, ());
+  MOCK_METHOD(ThreadLocal::Instance&, threadLocal, ());
+  MOCK_METHOD(Server::Admin&, admin, ());
+  MOCK_METHOD(Stats::Scope&, listenerScope, ());
+  MOCK_METHOD(const LocalInfo::LocalInfo&, localInfo, (), (const));
+  MOCK_METHOD(const envoy::config::core::v3::Metadata&, listenerMetadata, (), (const));
+  MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));
+  MOCK_METHOD(TimeSource&, timeSource, ());
+  Event::TestTimeSystem& timeSystem() { return time_system_; }
+  Grpc::Context& grpcContext() override { return grpc_context_; }
+  Http::Context& httpContext() override { return http_context_; }
+  MOCK_METHOD(ProcessContextOptRef, processContext, ());
+  MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
+  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
+  MOCK_METHOD(Api::Api&, api, ());
+
+  testing::NiceMock<MockServerFactoryContext> server_factory_context_;
+  testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
+  testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
+  testing::NiceMock<Event::MockDispatcher> dispatcher_;
+  testing::NiceMock<MockDrainManager> drain_manager_;
+  testing::NiceMock<Init::MockManager> init_manager_;
+  testing::NiceMock<MockServerLifecycleNotifier> lifecycle_notifier_;
+  testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  testing::NiceMock<Envoy::Random::MockRandomGenerator> random_;
+  testing::NiceMock<Envoy::Runtime::MockLoader> runtime_loader_;
+  testing::NiceMock<Stats::MockIsolatedStatsStore> scope_;
+  testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
+  Singleton::ManagerPtr singleton_manager_;
+  testing::NiceMock<MockAdmin> admin_;
+  Stats::IsolatedStoreImpl listener_scope_;
+  Event::GlobalTimeSystem time_system_;
+  testing::NiceMock<ProtobufMessage::MockValidationContext> validation_context_;
+  testing::NiceMock<MockOverloadManager> overload_manager_;
+  Grpc::ContextImpl grpc_context_;
+  Http::ContextImpl http_context_;
+  testing::NiceMock<Api::MockApi> api_;
 
   Network::MockListenerConfig listener_config_;
 };

--- a/test/mocks/server/listener_factory_context.h
+++ b/test/mocks/server/listener_factory_context.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include "envoy/server/listener_manager.h"
-
-#include "factory_context.h"
-#include "gmock/gmock.h"
 
 #include "envoy/server/configuration.h"
+#include "envoy/server/listener_manager.h"
 
 #include "extensions/transport_sockets/tls/context_manager_impl.h"
 

--- a/test/mocks/server/listener_factory_context.h
+++ b/test/mocks/server/listener_factory_context.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include "envoy/server/configuration.h"
 #include "envoy/server/listener_manager.h"
 


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Similar to #11480. Removes mock class inheritance in `MockListenerFactoryContext ` which prohibits `NiceMocks` from behaving as expected on Windows\MSVC.

Additional Description:

Both tests have been passing locally in 1k runs.

Risk Level: Low (Test only)
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
