### PR TITLE
[redis]: fix bug that the per-command stats  calculate wrong

### DIFF
--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -117,6 +117,7 @@ SplitRequestPtr SimpleRequest::create(Router& router,
   }
 
   if (!request_ptr->handle_) {
+    command_stats.error_.inc();
     callbacks.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
     return nullptr;
   }
@@ -203,6 +204,7 @@ SplitRequestPtr MGETRequest::create(Router& router, Common::Redis::RespValuePtr&
     }
 
     if (!pending_request.handle_) {
+      command_stats.error_.inc();
       pending_request.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
     }
   }
@@ -281,6 +283,7 @@ SplitRequestPtr MSETRequest::create(Router& router, Common::Redis::RespValuePtr&
     }
 
     if (!pending_request.handle_) {
+      command_stats.error_.inc();
       pending_request.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
     }
   }
@@ -352,6 +355,7 @@ SplitRequestPtr SplitKeysSumResultRequest::create(Router& router,
     }
 
     if (!pending_request.handle_) {
+      command_stats.error_.inc();
       pending_request.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
     }
   }


### PR DESCRIPTION
fix bug that the per-command stats does not calculate the 'no upstream host' error, which makes the per-command total is not equal with the sum of success and error.

Signed-off-by: Agent-Tao <hohojiang@126.com>

Additional Description:
the per-command stats in redis, e.g

redis.egress_redis.command.get.error: 0
redis.egress_redis.command.get.success: 2
redis.egress_redis.command.get.total: 4

if envoy return  (error) no upstream host, the error do not inc, so the total > success + error which is strange.
furthermore，EvalRequest works well，this PR makes other type of request works well like EvalRequest.

Risk Level:
Low

Testing:
Yes

