### PR TITLE
doc: clarify handling of duplicate xDS resource names

### DIFF
--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -453,7 +453,7 @@ Duplicate Resource Names
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is an error for a server to send a single response that contains the same resource name
-twice.  Clients should NACK responses that contain multiple instances of the same resource name.
+twice. Clients should NACK responses that contain multiple instances of the same resource name.
 
 Deleting Resources
 ^^^^^^^^^^^^^^^^^^

--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -449,6 +449,12 @@ no mechanism for providing incremental updates of repeated fields within a named
 Most notably, there is currently no mechanism for incrementally updating individual
 endpoints within an EDS response.
 
+Duplicate Resource Names
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is an error for a server to send a single response that contains the same resource name
+twice.  Clients must NACK responses that contain multiple instances of the same resource name.
+
 Deleting Resources
 ^^^^^^^^^^^^^^^^^^
 

--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -453,7 +453,7 @@ Duplicate Resource Names
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is an error for a server to send a single response that contains the same resource name
-twice.  Clients must NACK responses that contain multiple instances of the same resource name.
+twice.  Clients should NACK responses that contain multiple instances of the same resource name.
 
 Deleting Resources
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: doc: clarify handling of duplicate xDS resource names
Additional Description: Updates the xDS protocol spec.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A

CC @htuch 