### PR TITLE
[fuzz] Fix OSS Fuzz crashes due to validation issues in RBAC Config

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -101,7 +101,7 @@ message RBAC {
   //    key namespace 'envoy.common'. If no policies match, it is set to `false`.
   //    Other actions do not modify this key.
   //
-  Action action = 1;
+  Action action = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   map<string, Policy> policies = 2;

--- a/api/envoy/config/rbac/v4alpha/rbac.proto
+++ b/api/envoy/config/rbac/v4alpha/rbac.proto
@@ -100,7 +100,7 @@ message RBAC {
   //    key namespace 'envoy.common'. If no policies match, it is set to `false`.
   //    Other actions do not modify this key.
   //
-  Action action = 1;
+  Action action = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   map<string, Policy> policies = 2;

--- a/generated_api_shadow/envoy/config/rbac/v3/rbac.proto
+++ b/generated_api_shadow/envoy/config/rbac/v3/rbac.proto
@@ -101,7 +101,7 @@ message RBAC {
   //    key namespace 'envoy.common'. If no policies match, it is set to `false`.
   //    Other actions do not modify this key.
   //
-  Action action = 1;
+  Action action = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   map<string, Policy> policies = 2;

--- a/generated_api_shadow/envoy/config/rbac/v4alpha/rbac.proto
+++ b/generated_api_shadow/envoy/config/rbac/v4alpha/rbac.proto
@@ -100,7 +100,7 @@ message RBAC {
   //    key namespace 'envoy.common'. If no policies match, it is set to `false`.
   //    Other actions do not modify this key.
   //
-  Action action = 1;
+  Action action = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Maps from policy name to policy. A match occurs when at least one policy matches the request.
   map<string, Policy> policies = 2;

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6246534715539456
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6246534715539456
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.rbac"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC"
+    value: "\022\002\010\004"
+  }
+}


### PR DESCRIPTION
Commit Message: Fix OSS Fuzz Crashes due to validation issue in RBAC Config
Additional Description: Added validation that action enum is within range
Risk Level: low
Testing: passes added regression tests
Docs Changes: N/A
Release Notes: N/A
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24824&sort=-opened&can=1&q=proj%3Aenvoy%20status%3DNew

Signed-off-by: Zach Reyes <zasweq@google.com>