### PR TITLE
[Windows] Fixes: Injected resource monitor test

### DIFF
--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -96,6 +96,11 @@ std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {
   // 0x1a will be treated as EOF
   std::ifstream file(path, std::ios_base::binary);
   if (file.fail()) {
+    auto last_error = ::GetLastError();
+    if (last_error == ERROR_FILE_NOT_FOUND) {
+      throw EnvoyException(absl::StrCat("Invalid path: ", path));
+    }
+
     throw EnvoyException(absl::StrCat("unable to read file: ", path));
   }
 

--- a/test/extensions/resource_monitors/injected_resource/BUILD
+++ b/test/extensions/resource_monitors/injected_resource/BUILD
@@ -15,7 +15,7 @@ envoy_package()
 envoy_cc_test(
     name = "injected_resource_monitor_test",
     srcs = ["injected_resource_monitor_test.cc"],
-    tags = ["fails_on_windows"],
+    args = ["-l trace --gtest_filter=*InjectedResourceMonitorTest.ReportsErrorOnFileRead*"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/stats:isolated_store_lib",

--- a/test/extensions/resource_monitors/injected_resource/BUILD
+++ b/test/extensions/resource_monitors/injected_resource/BUILD
@@ -15,7 +15,6 @@ envoy_package()
 envoy_cc_test(
     name = "injected_resource_monitor_test",
     srcs = ["injected_resource_monitor_test.cc"],
-    args = ["-l trace --gtest_filter=*InjectedResourceMonitorTest.ReportsErrorOnFileRead*"],
     deps = [
         "//source/common/event:dispatcher_lib",
         "//source/common/stats:isolated_store_lib",


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

On Posix when we check of `illegalPath` we use the `realpath` system call which sets the `errno` to `FILE_NOT_FOUND` if the file is not there.

On Windows on the other side we do the validation manually and thus we never detect if the file is there until we try to open it. This leads to some incosistencies between the exception messages in different platforms.

To unify them, on Windows if opening the fails we check the `LastError` and if it is `ERROR_FILE_NOT_FOUND` we throw the same exception as Posix would do. This offers a better experience to the user since the exception message is more relevant to the actual error.

Additional Description:

Validated that the test passes on Windows on 2k+ runs thus removing the tag.

Risk Level: Low
Testing: Existing tests already pass
Docs Changes: N/A ( Windows is not released yet)
Release Notes: N/A ( Windows is not released yet)