### PR TITLE
[redis]:fix bug that the per-command stats for SimpleRequest calculate wrong

### DIFF
--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -117,6 +117,7 @@ SplitRequestPtr SimpleRequest::create(Router& router,
   }
 
   if (!request_ptr->handle_) {
+    command_stats.error_.inc();
     callbacks.onResponse(Common::Redis::Utility::makeError(Response::get().NoUpstreamHost));
     return nullptr;
   }

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -345,6 +345,9 @@ TEST_P(RedisSingleServerRequestTest, NoUpstream) {
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   handle_ = splitter_.makeRequest(std::move(request), callbacks_);
   EXPECT_EQ(nullptr, handle_);
+  std::string lower_command = absl::AsciiStrToLower(GetParam());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command." + lower_command + ".total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command." + lower_command + ".error").value());
 };
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestTest, RedisSingleServerRequestTest,


### PR DESCRIPTION
fix bug that the per-command stats for SimpleRequest does not calculate the 'no upstream host' error, which makes the per-command total is not equal with the sum of success and error.

Signed-off-by: Agent-Tao <hohojiang@126.com>


Additional Description:

the per-command stats of SimpleRequest in redis, like get, e.g

redis.egress_redis.command.get.error: 0
redis.egress_redis.command.get.success: 2
redis.egress_redis.command.get.total: 4

if envoy return (error) no upstream host, the error count do not inc, so the total > success + error which is strange.
furthermore，EvalRequest works well，this PR makes SimpleRequest  works well like EvalRequest. 



Risk Level:
Low

Testing:
yes
