### PR TITLE
doc: Fix small typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,7 @@ should only be done to correct a DCO mistake.
 
 ## Triggering CI re-run without making changes
 
-To rerun failed tasks in CI, add a comment with the the line
+To rerun failed tasks in CI, add a comment with the line
 
 ```
 /retest

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -86,7 +86,7 @@ public:
   struct RecvMsgPerPacketInfo {
     // The destination address from transport header.
     Address::InstanceConstSharedPtr local_address_;
-    // The the source address from transport header.
+    // The source address from transport header.
     Address::InstanceConstSharedPtr peer_address_;
     // The payload length of this packet.
     unsigned int msg_len_{0};

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -839,7 +839,7 @@ ServerConnectionImpl::ServerConnectionImpl(
       headers_with_underscores_action_(headers_with_underscores_action) {}
 
 uint32_t ServerConnectionImpl::getHeadersSize() {
-  // Add in the the size of the request URL if processing request headers.
+  // Add in the size of the request URL if processing request headers.
   const uint32_t url_size = (!processing_trailers_ && active_request_.has_value())
                                 ? active_request_.value().request_url_.size()
                                 : 0;

--- a/source/common/http/http1/codec_impl_legacy.cc
+++ b/source/common/http/http1/codec_impl_legacy.cc
@@ -782,7 +782,7 @@ ServerConnectionImpl::ServerConnectionImpl(
       headers_with_underscores_action_(headers_with_underscores_action) {}
 
 uint32_t ServerConnectionImpl::getHeadersSize() {
-  // Add in the the size of the request URL if processing request headers.
+  // Add in the size of the request URL if processing request headers.
   const uint32_t url_size = (!processing_trailers_ && active_request_.has_value())
                                 ? active_request_.value().request_url_.size()
                                 : 0;

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -204,7 +204,7 @@ void Span::setTag(absl::string_view name, absl::string_view value) {
   } else if (name == PeerAddress) {
     http_request_annotations_.emplace(SpanClientIp, ValueUtil::stringValue(std::string(value)));
     // In this case, PeerAddress refers to the client's actual IP address, not
-    // the address specified in the the HTTP X-Forwarded-For header.
+    // the address specified in the HTTP X-Forwarded-For header.
     http_request_annotations_.emplace(SpanXForwardedFor, ValueUtil::boolValue(false));
   } else {
     custom_annotations_.emplace(name, value);

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -74,7 +74,7 @@ private:
   Http::StreamEncoderFilterSharedPtr encoder_filter_;
   AccessLog::InstanceSharedPtr access_logger_;
 
-  // Headers/trailers need to be saved for the lifetime of the the filter,
+  // Headers/trailers need to be saved for the lifetime of the filter,
   // so save them as member variables.
   // TODO(nareddyt): Use for access logging in a followup PR.
   Http::TestRequestHeaderMapImpl request_headers_;


### PR DESCRIPTION
Commit Message:
There are duplicated words in the docs and comments.
Removed the duplication of them.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: Typo fixes
Docs Changes: Typo fixes
Release Notes: None