### PR TITLE
Add clang-cl RBE toolchain for Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -184,6 +184,11 @@ build:rbe-toolchain-msvc-cl --platforms=@rbe_windows_msvc_cl//config:platform
 build:rbe-toolchain-msvc-cl --crosstool_top=@rbe_windows_msvc_cl//cc:toolchain
 build:rbe-toolchain-msvc-cl --extra_toolchains=@rbe_windows_msvc_cl//config:cc-toolchain
 
+build:rbe-toolchain-clang-cl --host_platform=@rbe_windows_clang_cl//config:platform
+build:rbe-toolchain-clang-cl --platforms=@rbe_windows_clang_cl//config:platform
+build:rbe-toolchain-clang-cl --crosstool_top=@rbe_windows_clang_cl//cc:toolchain
+build:rbe-toolchain-clang-cl --extra_toolchains=@rbe_windows_clang_cl//config:cc-toolchain
+
 build:remote --spawn_strategy=remote,sandboxed,local
 build:remote --strategy=Javac=remote,sandboxed,local
 build:remote --strategy=Closure=remote,sandboxed,local
@@ -215,11 +220,16 @@ build:remote-msan --config=rbe-toolchain-clang-libc++
 build:remote-msan --config=rbe-toolchain-msan
 
 build:remote-msvc-cl --config=remote-windows
+build:remote-msvc-cl --config=msvc-cl
 build:remote-msvc-cl --config=rbe-toolchain-msvc-cl
+
+build:remote-clang-cl --config=remote-windows
+build:remote-clang-cl --config=clang-cl
+build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:923df85a4ba7f30dcd0cb6b0c6d8d604f0e20f48
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:f741613fc395cc489a630122eeb5e611b3cb1a5e
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     description: "A regular build executor based on ubuntu image"
     docker:
       # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-      - image: envoyproxy/envoy-build-ubuntu:923df85a4ba7f30dcd0cb6b0c6d8d604f0e20f48
+      - image: envoyproxy/envoy-build-ubuntu:f741613fc395cc489a630122eeb5e611b3cb1a5e
     resource_class: xlarge
     working_directory: /source
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/envoy-ci/envoy-build:923df85a4ba7f30dcd0cb6b0c6d8d604f0e20f48
+FROM gcr.io/envoy-ci/envoy-build:f741613fc395cc489a630122eeb5e611b3cb1a5e
 
 ARG USERNAME=vscode
 ARG USER_UID=501

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -81,10 +81,10 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
     envoy_build_tools = dict(
         project_name = "envoy-build-tools",
         project_url = "https://github.com/envoyproxy/envoy-build-tools",
-        version = "1d6573e60207efaae6436b25ecc594360294f63a",
-        sha256 = "88e58fdb42021e64a0b35ae3554a82e92f5c37f630a4dab08a132fc77f8db4b7",
+        version = "2d13ad4157997715a4939bd218a89c81c26ff28e",
+        sha256 = "0dc8ce5eb645ae069ce710c1010975456f723ffd4fc788a03dacfcd0647b05b9",
         strip_prefix = "envoy-build-tools-{version}",
-        # 2020-07-18
+        # 2020-08-21
         urls = ["https://github.com/envoyproxy/envoy-build-tools/archive/{version}.tar.gz"],
         use_category = ["build"],
     ),


### PR DESCRIPTION
Commit Message:
Add clang-cl RBE toolchain for Windows

Bumps envoy-build-tools to latest as of 2020/08/21 and envoy build
container image

clang-cl toolchain not yet enabled in CI as not all dependencies
compile, will submit a draft PR demonstrating compilation failures
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A