### PR TITLE
Allow FakeHttpConnection to gracefully handle GOAWAY frame

### DIFF
--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -444,7 +444,8 @@ public:
 
   // Http::ServerConnectionCallbacks
   Http::RequestDecoder& newStream(Http::ResponseEncoder& response_encoder, bool) override;
-  void onGoAway(Http::GoAwayErrorCode) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  // Should only be called for HTTP2
+  void onGoAway(Http::GoAwayErrorCode code) override;
 
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {
@@ -473,6 +474,7 @@ private:
     FakeHttpConnection& parent_;
   };
 
+  const Type type_;
   Http::ServerConnectionPtr codec_;
   std::list<FakeStreamPtr> new_streams_ ABSL_GUARDED_BY(lock_);
 };


### PR DESCRIPTION
Allow FakeHttpConnection to gracefully handle GOAWAY frame.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
