### PR TITLE
cluster manager: Add option to create pool per downstream connection

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -43,7 +43,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 51]
+// [#next-free-field: 52]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -917,6 +917,10 @@ message Cluster {
   // [#not-implemented-hide:]
   // Prefetch configuration for this cluster.
   PrefetchPolicy prefetch_policy = 50;
+
+  // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
+  // connection pool for every downstream connection
+  bool connection_pool_per_downstream_connection = 51;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -45,7 +45,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 51]
+// [#next-free-field: 52]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.cluster.v3.Cluster";
 
@@ -912,6 +912,10 @@ message Cluster {
   // [#not-implemented-hide:]
   // Prefetch configuration for this cluster.
   PrefetchPolicy prefetch_policy = 50;
+
+  // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
+  // connection pool for every downstream connection
+  bool connection_pool_per_downstream_connection = 51;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -61,6 +61,7 @@ New Features
 * access log: added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_access_log_format_response_flags>` as a response flag.
 * access log: added support for nested objects in :ref:`JSON logging mode <config_access_log_format_dictionaries>`.
 * build: enable building envoy :ref:`arm64 images <arm_binaries>` by buildx tool in x86 CI platform.
+* cluster: added new :ref:`connection_pool_per_downstream_connection <envoy_v3_api_field_config.cluster.v3.Cluster.connection_pool_per_downstream_connection>` flag, which enable creation of a new connection pool for each downstream connection.
 * dns_filter: added support for answering :ref:`service record<envoy_v3_api_msg_data.dns.v3.DnsTable.DnsService>` queries.
 * dynamic_forward_proxy: added :ref:`use_tcp_for_dns_lookups<envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.use_tcp_for_dns_lookups>` option to use TCP for DNS lookups in order to match the DNS options for :ref:`Clusters<envoy_v3_api_msg_config.cluster.v3.Cluster>`.
 * ext_authz filter: added support for emitting dynamic metadata for both :ref:`HTTP <config_http_filters_ext_authz_dynamic_metadata>` and :ref:`network <config_network_filters_ext_authz_dynamic_metadata>` filters.

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -44,7 +44,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 51]
+// [#next-free-field: 52]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Cluster";
 
@@ -915,6 +915,10 @@ message Cluster {
   // [#not-implemented-hide:]
   // Prefetch configuration for this cluster.
   PrefetchPolicy prefetch_policy = 50;
+
+  // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
+  // connection pool for every downstream connection
+  bool connection_pool_per_downstream_connection = 51;
 
   repeated core.v3.Address hidden_envoy_deprecated_hosts = 7 [deprecated = true];
 

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -45,7 +45,7 @@ message ClusterCollection {
 }
 
 // Configuration for a single upstream cluster.
-// [#next-free-field: 51]
+// [#next-free-field: 52]
 message Cluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.cluster.v3.Cluster";
 
@@ -924,6 +924,10 @@ message Cluster {
   // [#not-implemented-hide:]
   // Prefetch configuration for this cluster.
   PrefetchPolicy prefetch_policy = 50;
+
+  // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
+  // connection pool for every downstream connection
+  bool connection_pool_per_downstream_connection = 51;
 }
 
 // [#not-implemented-hide:] Extensible load balancing policy configuration.

--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -128,6 +128,12 @@ public:
   virtual uint64_t id() const PURE;
 
   /**
+   * @param vector of bytes to which the connection should append hash key data. Any data already in
+   * the key vector must not be modified.
+   */
+  virtual void hashKey(std::vector<uint8_t>& hash) const PURE;
+
+  /**
    * @return std::string the next protocol to use as selected by network level negotiation. (E.g.,
    *         ALPN). If network level negotiation is not supported by the connection or no protocol
    *         has been negotiated the empty string is returned.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -929,6 +929,12 @@ public:
   virtual bool drainConnectionsOnHostRemoval() const PURE;
 
   /**
+   *  @return whether to create a new connection pool for each downstream connection routed to
+   *          the cluster
+   */
+  virtual bool connectionPoolPerDownstreamConnection() const PURE;
+
+  /**
    * @return true if this cluster is configured to ignore hosts for the purpose of load balancing
    * computations until they have been health checked for the first time.
    */

--- a/source/common/network/connection_impl_base.cc
+++ b/source/common/network/connection_impl_base.cc
@@ -3,11 +3,24 @@
 namespace Envoy {
 namespace Network {
 
+void ConnectionImplBaseUtility::addIdToHashKey(std::vector<uint8_t>& hash_key,
+                                               uint64_t connection_id) {
+  // Pack the connection_id into sizeof(connection_id) uint8_t entries in the hash_key vector
+  hash_key.reserve(hash_key.size() + sizeof(connection_id));
+  for (unsigned i = 0; i < sizeof(connection_id); ++i) {
+    hash_key.push_back(0xFF & (connection_id >> (8 * i)));
+  }
+}
+
 ConnectionImplBase::ConnectionImplBase(Event::Dispatcher& dispatcher, uint64_t id)
     : dispatcher_(dispatcher), id_(id) {}
 
 void ConnectionImplBase::addConnectionCallbacks(ConnectionCallbacks& cb) {
   callbacks_.push_back(&cb);
+}
+
+void ConnectionImplBase::hashKey(std::vector<uint8_t>& hash) const {
+  ConnectionImplBaseUtility::addIdToHashKey(hash, id());
 }
 
 void ConnectionImplBase::setConnectionStats(const ConnectionStats& stats) {

--- a/source/common/network/connection_impl_base.cc
+++ b/source/common/network/connection_impl_base.cc
@@ -3,9 +3,8 @@
 namespace Envoy {
 namespace Network {
 
-void ConnectionImplBaseUtility::addIdToHashKey(std::vector<uint8_t>& hash_key,
-                                               uint64_t connection_id) {
-  // Pack the connection_id into sizeof(connection_id) uint8_t entries in the hash_key vector
+void ConnectionImplBase::addIdToHashKey(std::vector<uint8_t>& hash_key, uint64_t connection_id) {
+  // Pack the connection_id into sizeof(connection_id) uint8_t entries in the hash_key vector.
   hash_key.reserve(hash_key.size() + sizeof(connection_id));
   for (unsigned i = 0; i < sizeof(connection_id); ++i) {
     hash_key.push_back(0xFF & (connection_id >> (8 * i)));
@@ -19,9 +18,7 @@ void ConnectionImplBase::addConnectionCallbacks(ConnectionCallbacks& cb) {
   callbacks_.push_back(&cb);
 }
 
-void ConnectionImplBase::hashKey(std::vector<uint8_t>& hash) const {
-  ConnectionImplBaseUtility::addIdToHashKey(hash, id());
-}
+void ConnectionImplBase::hashKey(std::vector<uint8_t>& hash) const { addIdToHashKey(hash, id()); }
 
 void ConnectionImplBase::setConnectionStats(const ConnectionStats& stats) {
   ASSERT(!connection_stats_,

--- a/source/common/network/connection_impl_base.h
+++ b/source/common/network/connection_impl_base.h
@@ -8,6 +8,19 @@
 namespace Envoy {
 namespace Network {
 
+/**
+ * Utility functions for the connection implementation base class.
+ */
+class ConnectionImplBaseUtility {
+public:
+  /**
+   * Add a connection id to a hash key
+   * @param hash_key the current hash key -- the function will only append to this vector
+   * @param connection_id the 64-bit connection id
+   */
+  static void addIdToHashKey(std::vector<uint8_t>& hash_key, uint64_t connection_id);
+};
+
 class ConnectionImplBase : public FilterManagerConnection,
                            protected Logger::Loggable<Logger::Id::connection> {
 public:
@@ -17,6 +30,7 @@ public:
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
   uint64_t id() const override { return id_; }
+  void hashKey(std::vector<uint8_t>& hash) const override;
   void setConnectionStats(const ConnectionStats& stats) override;
   void setDelayedCloseTimeout(std::chrono::milliseconds timeout) override;
 

--- a/source/common/network/connection_impl_base.h
+++ b/source/common/network/connection_impl_base.h
@@ -8,10 +8,8 @@
 namespace Envoy {
 namespace Network {
 
-/**
- * Utility functions for the connection implementation base class.
- */
-class ConnectionImplBaseUtility {
+class ConnectionImplBase : public FilterManagerConnection,
+                           protected Logger::Loggable<Logger::Id::connection> {
 public:
   /**
    * Add a connection id to a hash key
@@ -19,11 +17,7 @@ public:
    * @param connection_id the 64-bit connection id
    */
   static void addIdToHashKey(std::vector<uint8_t>& hash_key, uint64_t connection_id);
-};
 
-class ConnectionImplBase : public FilterManagerConnection,
-                           protected Logger::Loggable<Logger::Id::connection> {
-public:
   ConnectionImplBase(Event::Dispatcher& dispatcher, uint64_t id);
 
   // Network::Connection

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1325,6 +1325,12 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::connPool(
     have_transport_socket_options = true;
   }
 
+  // If configured, use the downstream connection id in pool hash key
+  if (cluster_info_->connectionPoolPerDownstreamConnection() && context &&
+      context->downstreamConnection()) {
+    context->downstreamConnection()->hashKey(hash_key);
+  }
+
   ConnPoolsContainer& container = *parent_.getHttpConnPoolsContainer(host, true);
 
   // Note: to simplify this, we assume that the factory is only called in the scope of this

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -718,6 +718,8 @@ ClusterInfoImpl::ClusterInfoImpl(
       common_lb_config_(config.common_lb_config()),
       cluster_socket_options_(parseClusterSocketOptions(config, bind_config)),
       drain_connections_on_host_removal_(config.ignore_health_on_host_removal()),
+      connection_pool_per_downstream_connection_(
+          config.connection_pool_per_downstream_connection()),
       warm_hosts_(!config.health_checks().empty() &&
                   common_lb_config_.ignore_new_hosts_until_first_hc()),
       upstream_http_protocol_options_(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -612,6 +612,9 @@ public:
   };
 
   bool drainConnectionsOnHostRemoval() const override { return drain_connections_on_host_removal_; }
+  bool connectionPoolPerDownstreamConnection() const override {
+    return connection_pool_per_downstream_connection_;
+  }
   bool warmHosts() const override { return warm_hosts_; }
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>&
   upstreamHttpProtocolOptions() const override {
@@ -684,6 +687,7 @@ private:
   const envoy::config::cluster::v3::Cluster::CommonLbConfig common_lb_config_;
   const Network::ConnectionSocket::OptionsSharedPtr cluster_socket_options_;
   const bool drain_connections_on_host_removal_;
+  const bool connection_pool_per_downstream_connection_;
   const bool warm_hosts_;
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -98,6 +98,7 @@ protected:
         return parent_.parent_.factory_context_.dispatcher();
       }
       uint64_t id() const override { return 12345; }
+      void hashKey(std::vector<uint8_t>&) const override {}
       std::string nextProtocol() const override { return EMPTY_STRING; }
       void noDelay(bool) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
       void readDisable(bool) override {}

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -77,13 +77,13 @@ TEST(ConnectionImplUtility, updateBufferStats) {
 
 TEST(ConnectionImplBaseUtility, addIdToHashKey) {
   uint64_t connection_id = 0x0123456789abcdef;
-  std::vector<uint8_t> hash{{255, 254, 253, 252}};
-  ConnectionImplBaseUtility::addIdToHashKey(hash, connection_id);
+  std::vector<uint8_t> hash{{0xff, 0xfe, 0xfd, 0xfc}};
+  ConnectionImplBase::addIdToHashKey(hash, connection_id);
   ASSERT_EQ(12, hash.size());
-  EXPECT_EQ(255, hash[0]);
-  EXPECT_EQ(254, hash[1]);
-  EXPECT_EQ(253, hash[2]);
-  EXPECT_EQ(252, hash[3]);
+  EXPECT_EQ(0xff, hash[0]);
+  EXPECT_EQ(0xfe, hash[1]);
+  EXPECT_EQ(0xfd, hash[2]);
+  EXPECT_EQ(0xfc, hash[3]);
   EXPECT_EQ(0xef, hash[4]);
   EXPECT_EQ(0xcd, hash[5]);
   EXPECT_EQ(0xab, hash[6]);

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -75,6 +75,25 @@ TEST(ConnectionImplUtility, updateBufferStats) {
   ConnectionImplUtility::updateBufferStats(3, 3, previous_total, counter, gauge);
 }
 
+TEST(ConnectionImplBaseUtility, addIdToHashKey) {
+  uint64_t connection_id = 0x0123456789abcdef;
+  std::vector<uint8_t> hash{{255, 254, 253, 252}};
+  ConnectionImplBaseUtility::addIdToHashKey(hash, connection_id);
+  ASSERT_EQ(12, hash.size());
+  EXPECT_EQ(255, hash[0]);
+  EXPECT_EQ(254, hash[1]);
+  EXPECT_EQ(253, hash[2]);
+  EXPECT_EQ(252, hash[3]);
+  EXPECT_EQ(0xef, hash[4]);
+  EXPECT_EQ(0xcd, hash[5]);
+  EXPECT_EQ(0xab, hash[6]);
+  EXPECT_EQ(0x89, hash[7]);
+  EXPECT_EQ(0x67, hash[8]);
+  EXPECT_EQ(0x45, hash[9]);
+  EXPECT_EQ(0x23, hash[10]);
+  EXPECT_EQ(0x01, hash[11]);
+}
+
 class ConnectionImplDeathTest : public testing::TestWithParam<Address::IpVersion> {};
 INSTANTIATE_TEST_SUITE_P(IpVersions, ConnectionImplDeathTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -19,6 +19,7 @@ using ::testing::Mock;
 using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnNew;
+using ::testing::ReturnRef;
 using ::testing::SaveArg;
 
 envoy::config::bootstrap::v3::Bootstrap parseBootstrapFromV3Yaml(const std::string& yaml,
@@ -3906,6 +3907,52 @@ cluster_manager:
   const auto cluster = cluster_manager_->get("new_cluster");
   EXPECT_EQ(1, cluster->prioritySet().hostSetsPerPriority().size());
 }
+
+TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
+  const std::string yaml = R"EOF(
+  static_resources:
+    clusters:
+    - name: cluster_1
+      connect_timeout: 0.250s
+      lb_policy: ROUND_ROBIN
+      type: STATIC
+      connection_pool_per_downstream_connection: true
+      load_assignment:
+        cluster_name: cluster_1
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 11001
+  )EOF";
+  create(parseBootstrapFromV3Yaml(yaml));
+  NiceMock<MockLoadBalancerContext> lb_context;
+  NiceMock<Network::MockConnection> downstream_connection;
+  Network::Socket::OptionsSharedPtr options_to_return = nullptr;
+  ON_CALL(lb_context, downstreamConnection()).WillByDefault(Return(&downstream_connection));
+  ON_CALL(downstream_connection, socketOptions()).WillByDefault(ReturnRef(options_to_return));
+
+  std::vector<Http::ConnectionPool::MockInstance*> conn_pool_vector;
+  for (size_t i = 0; i < 3; ++i) {
+    conn_pool_vector.push_back(new Http::ConnectionPool::MockInstance());
+    EXPECT_CALL(factory_, allocateConnPool_(_, _, _)).WillOnce(Return(conn_pool_vector.back()));
+    EXPECT_CALL(downstream_connection, hashKey)
+        .WillOnce(Invoke([i](std::vector<uint8_t>& hash_key) { hash_key.push_back(i); }));
+    EXPECT_EQ(conn_pool_vector.back(),
+              cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default,
+                                                       Http::Protocol::Http11, &lb_context));
+  }
+
+  // Check that the first entry is still in the pool map
+  EXPECT_CALL(downstream_connection, hashKey).WillOnce(Invoke([](std::vector<uint8_t>& hash_key) {
+    hash_key.push_back(0);
+  }));
+  EXPECT_EQ(conn_pool_vector.front(),
+            cluster_manager_->httpConnPoolForCluster("cluster_1", ResourcePriority::Default,
+                                                     Http::Protocol::Http11, &lb_context));
+} // namespace
 } // namespace
 } // namespace Upstream
 } // namespace Envoy

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -60,6 +60,7 @@ public:
   MOCK_METHOD(void, close, (ConnectionCloseType type));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(uint64_t, id, (), (const));
+  MOCK_METHOD(void, hashKey, (std::vector<uint8_t>&), (const));
   MOCK_METHOD(bool, initializeReadFilters, ());
   MOCK_METHOD(std::string, nextProtocol, (), (const));
   MOCK_METHOD(void, noDelay, (bool enable));
@@ -106,6 +107,7 @@ public:
   MOCK_METHOD(void, close, (ConnectionCloseType type));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(uint64_t, id, (), (const));
+  MOCK_METHOD(void, hashKey, (std::vector<uint8_t>&), (const));
   MOCK_METHOD(bool, initializeReadFilters, ());
   MOCK_METHOD(std::string, nextProtocol, (), (const));
   MOCK_METHOD(void, noDelay, (bool enable));
@@ -155,6 +157,7 @@ public:
   MOCK_METHOD(void, close, (ConnectionCloseType type));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(uint64_t, id, (), (const));
+  MOCK_METHOD(void, hashKey, (std::vector<uint8_t>&), (const));
   MOCK_METHOD(bool, initializeReadFilters, ());
   MOCK_METHOD(std::string, nextProtocol, (), (const));
   MOCK_METHOD(void, noDelay, (bool enable));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -129,6 +129,7 @@ public:
   MOCK_METHOD(const Network::ConnectionSocket::OptionsSharedPtr&, clusterSocketOptions, (),
               (const));
   MOCK_METHOD(bool, drainConnectionsOnHostRemoval, (), (const));
+  MOCK_METHOD(bool, connectionPoolPerDownstreamConnection, (), (const));
   MOCK_METHOD(bool, warmHosts, (), (const));
   MOCK_METHOD(const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>&,
               upstreamHttpProtocolOptions, (), (const));


### PR DESCRIPTION
Commit Message:
* Add connect_pool_per_downstream_connection flag to the cluster config (disabled by default)
* Add a `hashKey` method to Connection in order to be able to hash on the connection ID

Additional Description:
This is one part of the resolution for #12370 that allows for the downstream connection ID to be used as part of the hash key for the connection pool lookup.

Risk Level: Low (disabled by default)
Testing:
* Unit tests
* Manual testing to validate that a new pool is created for each downstream connection only when the option is enabled

Docs Changes: API comment
Release Notes: Updated for new flag
