### PR TITLE
Windows: Fix and enable now-passing UDP tests

### DIFF
--- a/test/extensions/filters/udp/dns_filter/BUILD
+++ b/test/extensions/filters/udp/dns_filter/BUILD
@@ -43,7 +43,6 @@ envoy_extension_cc_test(
     name = "dns_filter_integration_test",
     srcs = ["dns_filter_integration_test.cc"],
     extension_name = "envoy.filters.udp_listener.dns_filter",
-    tags = ["fails_on_windows"],
     deps = [
         ":dns_filter_test_lib",
         "//source/extensions/filters/udp/dns_filter:config",
@@ -57,7 +56,6 @@ envoy_extension_cc_test(
     name = "dns_filter_utils_test",
     srcs = ["dns_filter_utils_test.cc"],
     extension_name = "envoy.filters.udp_listener.dns_filter",
-    tags = ["fails_on_windows"],
     deps = [
         ":dns_filter_test_lib",
         "//source/extensions/filters/udp/dns_filter:config",

--- a/test/extensions/filters/udp/udp_proxy/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/BUILD
@@ -31,7 +31,6 @@ envoy_extension_cc_test(
     name = "udp_proxy_integration_test",
     srcs = ["udp_proxy_integration_test.cc"],
     extension_name = "envoy.filters.udp_listener.udp_proxy",
-    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/udp/udp_proxy:config",
         "//test/integration:integration_lib",

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
@@ -112,10 +112,10 @@ TEST_P(UdpProxyIntegrationTest, HelloWorldOnNonLocalAddress) {
   if (version_ == Network::Address::IpVersion::v4) {
     // Kernel regards any 127.x.x.x as local address.
     listener_address = std::make_shared<Network::Address::Ipv4Instance>(
-#ifndef __APPLE__
-        "127.0.0.3",
-#else
+#if defined(__APPLE__) || defined(WIN32)
         "127.0.0.1",
+#else
+        "127.0.0.3",
 #endif
         port);
   } else {

--- a/test/extensions/stats_sinks/common/statsd/BUILD
+++ b/test/extensions/stats_sinks/common/statsd/BUILD
@@ -32,7 +32,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "udp_statsd_test",
     srcs = ["udp_statsd_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -43,6 +43,8 @@ public:
   std::vector<std::string> buffer_writes;
 };
 
+// Skipping this test as Datagram sockets are not currently supported by UDS on Windows
+#ifndef WIN32
 // Regression test for https://github.com/envoyproxy/envoy/issues/8911
 TEST(UdpOverUdsStatsdSinkTest, InitWithPipeAddress) {
   auto uds_address = std::make_shared<Network::Address::PipeInstance>(
@@ -71,6 +73,7 @@ TEST(UdpOverUdsStatsdSinkTest, InitWithPipeAddress) {
   receive_buffer.read(sock.ioHandle(), 32);
   EXPECT_EQ("envoy.test_counter:1|c", receive_buffer.toString());
 }
+#endif
 
 class UdpStatsdSinkTest : public testing::TestWithParam<Network::Address::IpVersion> {};
 INSTANTIATE_TEST_SUITE_P(IpVersions, UdpStatsdSinkTest,


### PR DESCRIPTION
Commit Message:
Windows: Fix and enable now-passing UDP tests

- Skip test that tries to use UDS with UDP, not supported on Windows (empirically tested on latest Windows 2019 LTS and as per: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/)
- Match Apple and do not test sending from 127.0.0.x, WSASendMsg fails with WSAEINVAL
  - See: https://docs.microsoft.com/en-us/windows/win32/winsock/tcp-ip-raw-sockets-2
  - `UDP datagrams with an invalid source address cannot be sent over raw sockets. The IP source address for any outgoing UDP datagram must exist on a network interface or the datagram is dropped. This change was made to limit the ability of malicious code to create distributed denial-of-service attacks and limits the ability to send spoofed packets (TCP/IP packets with a forged source IP address).`
  - The WSAEINVAL error comes from the fake upstream when it is attempting to send a message back to the downstream client with 127.0.0.3 as the source address (sending to Envoy at 127.0.0.3 from the client works fine)

Additional Description: N/A
Risk Level: Low
Testing: Enables various unit/integration tests, checked on Windows+RBE
Docs Changes: N/A
Release Notes: N/A
