### PR TITLE
ENVOY_LOG_MISC macro: use fully qualifed namespace

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -369,7 +369,7 @@ protected:
  * Convenience macro to log to the misc logger, which allows for logging without of direct access to
  * a logger.
  */
-#define GET_MISC_LOGGER() Logger::Registry::getLog(Logger::Id::misc)
+#define GET_MISC_LOGGER() ::Envoy::Logger::Registry::getLog(::Envoy::Logger::Id::misc)
 #define ENVOY_LOG_MISC(LEVEL, ...) ENVOY_LOG_TO_LOGGER(GET_MISC_LOGGER(), LEVEL, ##__VA_ARGS__)
 
 /**


### PR DESCRIPTION
Helpful for when external repositories would like to consume this macro.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>

---- 

Risk Level: Low
