### PR TITLE
Fix access_log_manager_impl unused variable warning

### DIFF
--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -20,8 +20,8 @@ AccessLogManagerImpl::~AccessLogManagerImpl() {
 }
 
 void AccessLogManagerImpl::reopen() {
-  for (auto& [log_key, log_file_ptr] : access_logs_) {
-    log_file_ptr->reopen();
+  for (auto& iter : access_logs_) {
+    iter.second->reopen();
   }
 }
 


### PR DESCRIPTION
Commit Message:
Fix access_log_manager_impl unused variable warning

Don't use structured binding to iterate access logs, log_key is unused
Additional Description:
Should help a little with bazelci: https://buildkite.com/bazel/envoy/builds
Risk Level: Low
Testing: Test compile of envoy-static target
Docs Changes: N/A
Release Notes: N/A
