### PR TITLE
Fix Envoy Version Test - Label Agnostic

### DIFF
--- a/test/exe/version_out_test.sh
+++ b/test/exe/version_out_test.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 ENVOY_BIN=${TEST_SRCDIR}/envoy/source/exe/envoy-static
 
 COMMIT=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-dev)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9\-_]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\1/p')
 
 EXPECTED=$(cat ${TEST_SRCDIR}/envoy/bazel/raw_build_id.ldscript)
 
@@ -15,7 +15,7 @@ if [[ ${COMMIT} != ${EXPECTED} ]]; then
 fi
 
 VERSION=$(${ENVOY_BIN} --version | \
-  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-dev)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
+  sed -n -E 's/.*version: ([0-9a-f]{40})\/([0-9]+\.[0-9]+\.[0-9]+)(-[a-zA-Z0-9\-_]+)?\/(Clean|Modified)\/(RELEASE|DEBUG)\/([a-zA-Z-]+)$/\2\3/p')
 
 EXPECTED=$(cat ${TEST_SRCDIR}/envoy/VERSION)
 


### PR DESCRIPTION
Commit Message:

To support internal builds of Envoy that may assign a label other than
`dev`, there is no good reason that this test should hardcode that value
in and can still be correct.

Additional Description: Resolves #11920 
Risk Level: low
Testing: Is a test
Docs Changes: n/a
Release Notes: n/a