### PR TITLE
hcm: refactor AS/FM trailer/header ownership model

### DIFF
--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -583,8 +583,6 @@ private:
     // of this by updating the calls to sendLocalReply to pass ownership over the headers + adding
     // asserts that we don't call the overload that doesn't pass ownership unless decodeData has
     // been called.
-    // TODO(snowp): This is no good since create FC moves the ptr as well, fix
-    // ASSERT(request_headers_ == nullptr);
     request_headers_ = request_headers;
   }
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -193,8 +193,8 @@ envoy_cc_fuzz_test(
 
 envoy_cc_test(
     name = "conn_manager_impl_test",
-    srcs = ["conn_manager_impl_test.cc"],
     size = "large",
+    srcs = ["conn_manager_impl_test.cc"],
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -194,6 +194,7 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "conn_manager_impl_test",
     srcs = ["conn_manager_impl_test.cc"],
+    size = "large",
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->

In order to reuse FilterManager for upstream HTTP filters, we need a compatible ownership
model for the headers/trailers being processed. The upstream case is the more limited one,
so this PR changes the FilterManager API to better fit those limitations.

Notably:
- headers/trailers being decoded are *not* owned by the FM unless created by a filter (in the
addDecodedTrailers case). This ensures that we are compatible with how the headers in the upstream
case are owned by the HCM and cannot be moved into the FM.
- headers/trailers are moved *into* the FM by the encoding functions on the StreamDecoderCallbacks,
  then moved *out* of the FM when filter processing has completed. This allows the router to move
  these headers back into the HCM.

A consequence of this is that the ActiveStream has to do some additional work to keep the headers/trailers
alive, and some added complexity around where to look for response headers/trailers.

To facilitate this a few notable changes were needed:
- track whether we've seen upstream headers via `state_.received_response_headers_`, as we no longer hold
  a pointer to the upstream headers for the entire lifetime of FM
- move access logging out to AS, as the access logging happens after the ownership of response headers/trailers
  has been moved out of FM

There are also some minor refactors in this PR that could be split out/reverted if necessary:
- change visibility of helper localy reply functions
- remove trailers/headers as an argument to the private en/decode functions, as the passed parameter is always
  a reference to a field on the FM
- pass the reference to the request headers to FM when needed instead of using a `setRequestHeaders`. I'm not convinced
  this simplifies things, but was a previous TODO

Risk Level: Medium/High
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
Part of #10455 