### PR TITLE
api: add CSDS request exclude_config

### DIFF
--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -64,7 +64,6 @@ message ClientStatusRequest {
 
   // The node making the csds request.
   config.core.v3.Node node = 2;
-  
   // When true, response will include status, but no config.
   bool exclude_config = 3;
 }

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -64,7 +64,7 @@ message ClientStatusRequest {
 
   // The node making the csds request.
   config.core.v3.Node node = 2;
-  // When true, response will include status, but no config.
+  // When true, response will include status, but Config Dump objects will contain only version_info field.
   bool exclude_config = 3;
 }
 

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -64,6 +64,9 @@ message ClientStatusRequest {
 
   // The node making the csds request.
   config.core.v3.Node node = 2;
+  
+  // When true, response will include status, but no config.
+  bool exclude_config = 3;
 }
 
 // Detailed config (per xDS) with status.


### PR DESCRIPTION
Commit Message: allow CSDS requests to exclude config for smaller response payloads
Additional Description: in large meshes, config dump may grow to the order of megabytes.  allowing clients to request status only provides support for these large meshes.
Risk Level: Low
Testing: None.  I don't see any canonical implementation of CSDS, meaning this API is never used directly in Envoy.
Docs Changes: Documentation is inline.
Release Notes: Not required, IMHO.  Happy to add if others feel it is merited.

Fixes #12339

