### PR TITLE
[fuzz] fix some shared state between test iteration

### DIFF
--- a/test/extensions/filters/network/common/fuzz/uber_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_readfilter.cc
@@ -22,6 +22,7 @@ void UberFilterFuzzer::reset() {
   Event::MockDispatcher& mock_dispatcher =
       dynamic_cast<Event::MockDispatcher&>(read_filter_callbacks_->connection_.dispatcher_);
   mock_dispatcher.clearDeferredDeleteList();
+  factory_context_.admin_.config_tracker_.config_tracker_callbacks_.clear();
   read_filter_.reset();
 }
 
@@ -94,7 +95,6 @@ void UberFilterFuzzer::fuzz(
     checkInvalidInputForFuzzer(filter_name, message.get());
     ENVOY_LOG_MISC(info, "Config content after decoded: {}", message->DebugString());
     cb_ = factory.createFilterFactoryFromProto(*message, factory_context_);
-
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Controlled exception in filter setup {}", e.what());
     return;


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: There was some shared state when the HCM was creating singletons. This clears the map.
Risk Level: Low
Testing: Checked bug fix in PR that reproduces https://github.com/envoyproxy/envoy/pull/12530
