### PR TITLE
hcm: log before onDestroy

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -511,7 +511,8 @@ public:
    * network calls, etc. The reason there is an onDestroy() method vs. doing this type of cleanup
    * in the destructor is due to the deferred deletion model that Envoy uses to avoid stack unwind
    * complications. Filters must not invoke either encoder or decoder filter callbacks after having
-   * onDestroy() invoked.
+   * onDestroy() invoked. Filters that cross-register as access log handlers receive log() before
+   * onDestroy().
    */
   virtual void onDestroy() PURE;
 };

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -580,6 +580,13 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
 }
 
 ConnectionManagerImpl::ActiveStream::~ActiveStream() {
+  if (connection_manager_.remote_close_) {
+    filter_manager_.streamInfo().setResponseCodeDetails(
+        StreamInfo::ResponseCodeDetails::get().DownstreamRemoteDisconnect);
+    filter_manager_.streamInfo().setResponseFlag(
+        StreamInfo::ResponseFlag::DownstreamConnectionTermination);
+  }
+
   if (connection_manager_.codec_->protocol() < Protocol::Http2) {
     // For HTTP/2 there are still some reset cases where details are not set.
     // For HTTP/1 there shouldn't be any. Regression-proof this.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -203,6 +203,9 @@ void ConnectionManagerImpl::doDeferredStreamDestroy(ActiveStream& stream) {
   }
   stream.filter_manager_.disarmRequestTimeout();
 
+  stream.completeRequest();
+  stream.filter_manager_.log();
+
   stream.filter_manager_.destroyFilters();
 
   read_callbacks_->connection().dispatcher().deferredDelete(stream.removeFromList(streams_));
@@ -576,7 +579,7 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
       connection_manager_.read_callbacks_->connection().requestedServerName());
 }
 
-ConnectionManagerImpl::ActiveStream::~ActiveStream() {
+void ConnectionManagerImpl::ActiveStream::completeRequest() {
   filter_manager_.streamInfo().onRequestComplete();
   Upstream::HostDescriptionConstSharedPtr upstream_host =
       connection_manager_.read_callbacks_->upstreamHost();

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -601,7 +601,6 @@ void ConnectionManagerImpl::ActiveStream::completeRequest() {
     filter_manager_.streamInfo().setResponseFlag(
         StreamInfo::ResponseFlag::DownstreamConnectionTermination);
   }
-
   if (connection_manager_.codec_->protocol() < Protocol::Http2) {
     // For HTTP/2 there are still some reset cases where details are not set.
     // For HTTP/1 there shouldn't be any. Regression-proof this.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -579,6 +579,14 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
       connection_manager_.read_callbacks_->connection().requestedServerName());
 }
 
+ConnectionManagerImpl::ActiveStream::~ActiveStream() {
+  if (connection_manager_.codec_->protocol() < Protocol::Http2) {
+    // For HTTP/2 there are still some reset cases where details are not set.
+    // For HTTP/1 there shouldn't be any. Regression-proof this.
+    ASSERT(filter_manager_.streamInfo().responseCodeDetails().has_value());
+  }
+}
+
 void ConnectionManagerImpl::ActiveStream::completeRequest() {
   filter_manager_.streamInfo().onRequestComplete();
   Upstream::HostDescriptionConstSharedPtr upstream_host =
@@ -600,11 +608,6 @@ void ConnectionManagerImpl::ActiveStream::completeRequest() {
         StreamInfo::ResponseCodeDetails::get().DownstreamRemoteDisconnect);
     filter_manager_.streamInfo().setResponseFlag(
         StreamInfo::ResponseFlag::DownstreamConnectionTermination);
-  }
-  if (connection_manager_.codec_->protocol() < Protocol::Http2) {
-    // For HTTP/2 there are still some reset cases where details are not set.
-    // For HTTP/1 there shouldn't be any. Regression-proof this.
-    ASSERT(filter_manager_.streamInfo().responseCodeDetails().has_value());
   }
 
   connection_manager_.stats_.named_.downstream_rq_active_.dec();

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -153,7 +153,7 @@ private:
                         public ScopeTrackedObject,
                         public FilterManagerCallbacks {
     ActiveStream(ConnectionManagerImpl& connection_manager, uint32_t buffer_limit);
-    ~ActiveStream() override;
+    void completeRequest();
 
     void chargeStats(const ResponseHeaderMap& headers);
     const Network::Connection* connection();

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -153,7 +153,6 @@ private:
                         public ScopeTrackedObject,
                         public FilterManagerCallbacks {
     ActiveStream(ConnectionManagerImpl& connection_manager, uint32_t buffer_limit);
-    ~ActiveStream() override;
     void completeRequest();
 
     void chargeStats(const ResponseHeaderMap& headers);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -153,6 +153,7 @@ private:
                         public ScopeTrackedObject,
                         public FilterManagerCallbacks {
     ActiveStream(ConnectionManagerImpl& connection_manager, uint32_t buffer_limit);
+    ~ActiveStream() override;
     void completeRequest();
 
     void chargeStats(const ResponseHeaderMap& headers);

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -437,11 +437,6 @@ public:
         stream_info_(protocol, time_source, parent_filter_state, filter_state_life_span) {}
   ~FilterManager() override {
     ASSERT(state_.destroyed_);
-    for (const auto& log_handler : access_log_handlers_) {
-      log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
-                       stream_info_);
-    }
-
     ASSERT(state_.filter_call_state_ == 0);
   }
 
@@ -471,6 +466,13 @@ public:
     addStreamEncoderFilterWorker(filter, true);
   }
   void addAccessLogHandler(AccessLog::InstanceSharedPtr handler) override;
+
+  void log() {
+    for (const auto& log_handler : access_log_handlers_) {
+      log_handler->log(request_headers_.get(), response_headers_.get(), response_trailers_.get(),
+                       stream_info_);
+    }
+  }
 
   void destroyFilters() {
     state_.destroyed_ = true;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -4869,7 +4869,9 @@ TEST_F(HttpConnectionManagerImplTest, HitFilterWatermarkLimits) {
         EXPECT_FALSE(stream_info.hasAnyResponseFlag());
       }));
 
-  doRemoteClose();
+  expectOnDestroy();
+  EXPECT_CALL(stream_, removeCallbacks(_));
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::LocalClose);
 }
 
 TEST_F(HttpConnectionManagerImplTest, HitRequestBufferLimits) {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -297,6 +297,12 @@ public:
     }
   }
 
+  void doRemoteClose(bool deferred = true) {
+    EXPECT_CALL(stream_, removeCallbacks(_));
+    expectOnDestroy(deferred);
+    filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  }
+
   // Http::ConnectionManagerConfig
   const std::list<AccessLog::InstanceSharedPtr>& accessLogs() override { return access_logs_; }
   ServerConnectionPtr createCodec(Network::Connection&, const Buffer::Instance&,
@@ -591,9 +597,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFiltersProxy
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFilters) {
@@ -619,9 +623,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFilters) {
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, PauseResume100Continue) {
@@ -654,9 +656,7 @@ TEST_F(HttpConnectionManagerImplTest, PauseResume100Continue) {
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(std::move(response_headers), false);
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/10923.
@@ -736,9 +736,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderOverwritten) {
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   EXPECT_EQ("custom-value", altered_headers->getServerValue());
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 // When configured APPEND_IF_ABSENT if the server header is present it will be retained.
@@ -752,9 +750,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderAppendPresent) {
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   EXPECT_EQ("foo", altered_headers->getServerValue());
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 // When configured APPEND_IF_ABSENT if the server header is absent the server name will be set.
@@ -768,9 +764,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderAppendAbsent) {
       sendResponseHeaders(ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}});
   EXPECT_EQ("custom-value", altered_headers->getServerValue());
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 // When configured PASS_THROUGH, the server name will pass through.
@@ -784,9 +778,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderPassthroughPresent) {
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   EXPECT_EQ("foo", altered_headers->getServerValue());
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 // When configured PASS_THROUGH, the server header will not be added if absent.
@@ -800,9 +792,7 @@ TEST_F(HttpConnectionManagerImplTest, ServerHeaderPassthroughAbsent) {
       sendResponseHeaders(ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}});
   EXPECT_TRUE(altered_headers->Server() == nullptr);
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
@@ -1253,10 +1243,7 @@ TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateNotSet) {
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   ASSERT_TRUE(modified_headers);
   EXPECT_TRUE(modified_headers->Date());
-
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateEnabledDateNotSet) {
@@ -1270,10 +1257,7 @@ TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateEnabledDateNotSet) {
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}, {"server", "foo"}}});
   ASSERT_TRUE(modified_headers);
   EXPECT_TRUE(modified_headers->Date());
-
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateSet) {
@@ -1290,10 +1274,7 @@ TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateSet) {
   ASSERT_TRUE(modified_headers);
   ASSERT_TRUE(modified_headers->Date());
   EXPECT_NE(expected_date, modified_headers->getDateValue());
-
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateEnabledDateSet) {
@@ -1310,10 +1291,7 @@ TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateEnabledDateSet) {
   ASSERT_TRUE(modified_headers);
   ASSERT_TRUE(modified_headers->Date());
   EXPECT_EQ(expected_date, modified_headers->getDateValue());
-
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateFromCache) {
@@ -1332,10 +1310,7 @@ TEST_F(HttpConnectionManagerImplTest, PreserveUpstreamDateDisabledDateFromCache)
   ASSERT_TRUE(modified_headers);
   ASSERT_TRUE(modified_headers->Date());
   EXPECT_EQ(expected_date, modified_headers->getDateValue());
-
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
@@ -1847,6 +1822,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
                                          {"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}}};
         decoder->decodeHeaders(std::move(headers), true);
 
+        filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->encodeHeaders(std::move(response_headers), true);
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
@@ -4740,10 +4716,7 @@ TEST_F(HttpConnectionManagerImplTest, UnderlyingConnectionWatermarksPassedOnWith
     EXPECT_CALL(callbacks2, onAboveWriteBufferHighWatermark());
     decoder_filters_[0]->callbacks_->addDownstreamWatermarkCallbacks(callbacks2);
   }
-
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, UnderlyingConnectionWatermarksUnwoundWithLazyCreation) {
@@ -4808,9 +4781,7 @@ TEST_F(HttpConnectionManagerImplTest, UnderlyingConnectionWatermarksUnwoundWithL
     EXPECT_CALL(callbacks, onBelowWriteBufferLowWatermark()).Times(0);
     decoder_filters_[0]->callbacks_->addDownstreamWatermarkCallbacks(callbacks);
   }
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, AlterFilterWatermarkLimits) {
@@ -4840,9 +4811,7 @@ TEST_F(HttpConnectionManagerImplTest, AlterFilterWatermarkLimits) {
   decoder_filters_[0]->callbacks_->setDecoderBufferLimit(100);
   EXPECT_EQ(100, decoder_filters_[0]->callbacks_->decoderBufferLimit());
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, HitFilterWatermarkLimits) {
@@ -4900,9 +4869,7 @@ TEST_F(HttpConnectionManagerImplTest, HitFilterWatermarkLimits) {
         EXPECT_FALSE(stream_info.hasAnyResponseFlag());
       }));
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::LocalClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, HitRequestBufferLimits) {
@@ -4926,9 +4893,7 @@ TEST_F(HttpConnectionManagerImplTest, HitRequestBufferLimits) {
   const auto rc_details = encoder_filters_[1]->callbacks_->streamInfo().responseCodeDetails();
   EXPECT_EQ("request_payload_too_large", rc_details.value());
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 // Return 413 from an intermediate filter and make sure we don't continue the filter chain.
@@ -4973,9 +4938,7 @@ TEST_F(HttpConnectionManagerImplTest, HitRequestBufferLimitsIntermediateFilter) 
   Buffer::OwnedImpl fake_input("1234");
   conn_manager_->onData(fake_input, false);
 
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  expectOnDestroy(false);
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose(false);
 }
 
 TEST_F(HttpConnectionManagerImplTest, HitResponseBufferLimitsBeforeHeaders) {
@@ -5990,9 +5953,7 @@ TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnDecodingPat
   EXPECT_CALL(*decoder_filters_[1], decodeComplete());
   decoder_filters_[0]->callbacks_->continueDecoding();
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnDecodingPathSecondFilter) {
@@ -6017,9 +5978,7 @@ TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnDecodingPat
   EXPECT_CALL(*decoder_filters_[1], decodeComplete());
   decoder_filters_[1]->callbacks_->continueDecoding();
 
-  expectOnDestroy();
-  EXPECT_CALL(stream_, removeCallbacks(_));
-  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+  doRemoteClose();
 }
 
 TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnEncodingPath) {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: call log() before onDestroy(), as well as populate final stream info details at the time of log() rather than the deferred destruction.

Additional Description:
Risk Level: low (might affect timings of events)
Testing: unit
Docs Changes: none
Release Notes: none
Fixes #12616 
Fixes #12840 