### PR TITLE
Windows: Change known-working test tags

### DIFF
--- a/test/extensions/common/proxy_protocol/BUILD
+++ b/test/extensions/common/proxy_protocol/BUILD
@@ -22,7 +22,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "proxy_protocol_regression_test",
     srcs = ["proxy_protocol_regression_test.cc"],
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -57,7 +57,6 @@ envoy_extension_cc_test(
     name = "ext_authz_integration_test",
     srcs = ["ext_authz_integration_test.cc"],
     extension_name = "envoy.filters.http.ext_authz",
-    tags = ["flaky_on_windows"],
     deps = [
         "//source/extensions/filters/http/ext_authz:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/http/oauth2/BUILD
+++ b/test/extensions/filters/http/oauth2/BUILD
@@ -26,9 +26,6 @@ envoy_extension_cc_test(
     name = "oauth_integration_test",
     srcs = ["oauth_integration_test.cc"],
     extension_name = "envoy.filters.http.oauth2",
-    tags = [
-        "fails_on_windows",
-    ],
     deps = [
         "//source/extensions/filters/http/oauth2:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/filters/listener/http_inspector/BUILD
+++ b/test/extensions/filters/listener/http_inspector/BUILD
@@ -20,7 +20,6 @@ envoy_extension_cc_test(
     # *used* to rely on Event::FileTriggerType::Edge and we got away with it
     # because we mock the dispatcher. Need to verify that the scenario is
     # actually working.
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/common:hex_lib",
         "//source/common/http:utility_lib",

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -39,6 +39,8 @@ envoy_extension_cc_test(
     name = "tsi_handshaker_test",
     srcs = ["tsi_handshaker_test.cc"],
     extension_name = "envoy.transport_sockets.alts",
+    # Fails intermittantly on local build
+    tags = ["flaky_on_windows"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//source/extensions/transport_sockets/alts:tsi_handshaker",

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -74,6 +74,8 @@ envoy_cc_test(
         "gen_unittest_certs.sh",
         "//test/extensions/transport_sockets/tls/test_data:certs",
     ],
+    # Fails intermittantly on local build
+    tags = ["flaky_on_windows"],
     deps = [
         ":ssl_test_utils",
         "//source/common/json:json_loader_lib",

--- a/test/extensions/transport_sockets/tls/ocsp/BUILD
+++ b/test/extensions/transport_sockets/tls/ocsp/BUILD
@@ -17,6 +17,10 @@ envoy_cc_test(
         "gen_unittest_ocsp_data.sh",
     ],
     external_deps = ["ssl"],
+    # TODO: Diagnose intermittent failure on Windows; this script uses the
+    # locally deployed openssl for test cert creation and manipulation, rather
+    # than envoy's current build of the most current openssl tool
+    tags = ["flaky_on_windows"],
     deps = [
         "//source/common/filesystem:filesystem_lib",
         "//source/extensions/transport_sockets/tls:utility_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -351,6 +351,7 @@ envoy_cc_test(
     srcs = [
         "http_subset_lb_integration_test.cc",
     ],
+    # Consistently times out in CI on Windows, but observed to pass locally
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -538,6 +539,7 @@ envoy_cc_test(
     # As this test has many pauses for idle timeouts, it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 2,
+    # Consistently fails in CI on Windows, but observed to pass locally
     tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
@@ -706,7 +708,8 @@ envoy_cc_test(
         "websocket_integration_test.cc",
         "websocket_integration_test.h",
     ],
-    tags = ["fails_on_windows"],
+    # Consistently fails in CI on Windows, but observed to pass locally
+    tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
@@ -774,7 +777,8 @@ envoy_cc_test(
 envoy_cc_test(
     name = "load_stats_integration_test",
     srcs = ["load_stats_integration_test.cc"],
-    tags = ["fails_on_windows"],
+    # Consistently timing out on Windows, observed to pass locally
+    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/config:utility_lib",
@@ -793,6 +797,7 @@ envoy_cc_test(
     name = "hds_integration_test",
     srcs = ["hds_integration_test.cc"],
     shard_count = 2,
+    # Alternately timing out and failing in CI on windows; observed to pass locally
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -974,6 +979,8 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     shard_count = 2,
+    # Fails intermittantly on local build
+    tags = ["flaky_on_windows"],
     deps = [
         ":integration_lib",
         ":tcp_proxy_integration_proto_cc_proto",
@@ -1049,7 +1056,7 @@ envoy_cc_test(
         "uds_integration_test.cc",
         "uds_integration_test.h",
     ],
-    tags = ["flaky_on_windows"],
+    tags = ["fails_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/event:dispatcher_includes",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -127,6 +127,7 @@ envoy_cc_test(
     name = "guarddog_impl_test",
     size = "small",
     srcs = ["guarddog_impl_test.cc"],
+    # Fails intermittantly on local build
     tags = ["flaky_on_windows"],
     deps = [
         "//include/envoy/common:time_interface",


### PR DESCRIPTION
Commit Message:
Change known-working test flags for windows

- Five more tests now passing
- Four verified flaky
- Two moved from fail -> passing but known flaky
- One moved from flake -> fails (although sometimes timeout instead)

Risk Level: n/a
Testing: local + rbe on windows
Docs Changes: n/a
Release Notes: n/a
