### PR TITLE
ci: not collect build event profile

### DIFF
--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -82,7 +82,6 @@ export BAZEL_QUERY_OPTIONS="${BAZEL_OPTIONS}"
 # Use https://docs.bazel.build/versions/master/command-line-reference.html#flag--experimental_repository_cache_hardlinks
 # to save disk space.
 export BAZEL_BUILD_OPTIONS=" ${BAZEL_OPTIONS} --verbose_failures --show_task_finish --experimental_generate_json_trace_profile \
-  --build_event_json_file=${BUILD_DIR}/build_event.json \
   --test_output=errors --repository_cache=${BUILD_DIR}/repository_cache --experimental_repository_cache_hardlinks \
   ${BAZEL_BUILD_EXTRA_OPTIONS} ${BAZEL_EXTRA_TEST_OPTIONS}"
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -31,7 +31,6 @@ echo "building for ${ENVOY_BUILD_ARCH}"
 function collect_build_profile() {
   declare -g build_profile_count=${build_profile_count:-1}
   mv -f "$(bazel info output_base)/command.profile.gz" "${ENVOY_BUILD_PROFILE}/${build_profile_count}-$1.profile.gz" || true
-  mv -f ${BUILD_DIR}/build_event.json "${ENVOY_BUILD_PROFILE}/${build_profile_count}-$1.build_event.json" || true
   ((build_profile_count++))
 }
 


### PR DESCRIPTION
Turns out it doesn't work with remote cache and coverage.
    https://github.com/bazelbuild/bazel/issues/12013
    
With this we can enable S3 cache for ARM and coverage builds.
