### PR TITLE
header-to-metadata: enforce move on std::string param

### DIFF
--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -216,7 +216,7 @@ const std::string& HeaderToMetadataFilter::decideNamespace(const std::string& ns
 }
 
 // add metadata['key']= value depending on header present or missing case
-void HeaderToMetadataFilter::applyKeyValue(std::string value, const Rule& rule,
+void HeaderToMetadataFilter::applyKeyValue(std::string&& value, const Rule& rule,
                                            const KeyValuePair& keyval, StructMap& np) {
   if (!keyval.value().empty()) {
     value = keyval.value();
@@ -244,10 +244,10 @@ void HeaderToMetadataFilter::writeHeaderToMetadata(Http::HeaderMap& headers,
     absl::optional<std::string> value = rule.selector_->extract(headers);
 
     if (value && proto_rule.has_on_header_present()) {
-      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_present(),
+      applyKeyValue(value.value_or(""), rule, proto_rule.on_header_present(),
                     structs_by_namespace);
     } else if (!value && proto_rule.has_on_header_missing()) {
-      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_missing(),
+      applyKeyValue(value.value_or(""), rule, proto_rule.on_header_missing(),
                     structs_by_namespace);
     }
   }

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -244,10 +244,10 @@ void HeaderToMetadataFilter::writeHeaderToMetadata(Http::HeaderMap& headers,
     absl::optional<std::string> value = rule.selector_->extract(headers);
 
     if (value && proto_rule.has_on_header_present()) {
-      applyKeyValue(value.value_or(""), rule, proto_rule.on_header_present(),
+      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_present(),
                     structs_by_namespace);
     } else if (!value && proto_rule.has_on_header_missing()) {
-      applyKeyValue(value.value_or(""), rule, proto_rule.on_header_missing(),
+      applyKeyValue(std::move(value).value_or(""), rule, proto_rule.on_header_missing(),
                     structs_by_namespace);
     }
   }

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -190,7 +190,7 @@ private:
                              Http::StreamFilterCallbacks& callbacks);
   bool addMetadata(StructMap&, const std::string&, const std::string&, std::string, ValueType,
                    ValueEncode) const;
-  void applyKeyValue(std::string, const Rule&, const KeyValuePair&, StructMap&);
+  void applyKeyValue(std::string&&, const Rule&, const KeyValuePair&, StructMap&);
   const std::string& decideNamespace(const std::string& nspace) const;
   const Config* getConfig() const;
 };


### PR DESCRIPTION
Ensure we never copy the value string when calling calling applyKeyValue().

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
