### PR TITLE
doc: fix format

### DIFF
--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -25,7 +25,7 @@ message SubstitutionFormatString {
     //
     // .. code-block:: none
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
     //
     // The following plain text will be created:
     //
@@ -44,8 +44,8 @@ message SubstitutionFormatString {
     // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -23,13 +23,13 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   upstream connect error:204:path=/foo
     //
@@ -41,7 +41,7 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
     //    status: %RESPONSE_CODE%

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -29,7 +29,7 @@ message SubstitutionFormatString {
     //
     // .. code-block:: none
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
     //
     // The following plain text will be created:
     //
@@ -48,8 +48,8 @@ message SubstitutionFormatString {
     // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -27,13 +27,13 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   upstream connect error:204:path=/foo
     //
@@ -45,7 +45,7 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
     //    status: %RESPONSE_CODE%

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -589,7 +589,7 @@ message LocalReplyConfig {
   //  json_format:
   //    status: "%RESPONSE_CODE%"
   //    message: "%LOCAL_REPLY_BODY%"
-  //    path: "$REQ(:path)%""
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -571,20 +571,20 @@ message LocalReplyConfig {
   //
   // Example one: plain/text body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: none
   //
   //   upstream connect error:503:path=/foo
   //
   //  Example two: application/json body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
   //    status: %RESPONSE_CODE%

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -573,7 +573,7 @@ message LocalReplyConfig {
   //
   // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
@@ -587,9 +587,9 @@ message LocalReplyConfig {
   // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%""
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -573,20 +573,20 @@ message LocalReplyConfig {
   //
   // Example one: plain/text body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: none
   //
   //   upstream connect error:503:path=/foo
   //
   //  Example two: application/json body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
   //    status: %RESPONSE_CODE%

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -575,7 +575,7 @@ message LocalReplyConfig {
   //
   // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
@@ -589,9 +589,9 @@ message LocalReplyConfig {
   // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/docs/root/configuration/http/http_conn_man/local_reply.rst
+++ b/docs/root/configuration/http/http_conn_man/local_reply.rst
@@ -19,7 +19,7 @@ The local response content returned by Envoy can be customized. A list of :ref:`
 
 Example of a LocalReplyConfig
 
-.. code-block::
+.. code-block:: yaml
 
   mappers:
   - filter:

--- a/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
@@ -22,7 +22,7 @@ If :ref:`payload_passthrough <envoy_v3_api_field_extensions.filters.http.aws_lam
 However, if :ref:`payload_passthrough <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.payload_passthrough>`
 is set to ``false``, then the HTTP request is transformed to a JSON payload with the following schema:
 
-.. code-block::
+.. code-block:: json
 
     {
         "rawPath": "/path/to/resource",

--- a/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
@@ -22,7 +22,7 @@ If :ref:`payload_passthrough <envoy_v3_api_field_extensions.filters.http.aws_lam
 However, if :ref:`payload_passthrough <envoy_v3_api_field_extensions.filters.http.aws_lambda.v3.Config.payload_passthrough>`
 is set to ``false``, then the HTTP request is transformed to a JSON payload with the following schema:
 
-.. code-block:: json
+.. code-block:: none
 
     {
         "rawPath": "/path/to/resource",
@@ -30,7 +30,7 @@ is set to ``false``, then the HTTP request is transformed to a JSON payload with
         "headers": {"header-key": "header-value", ... },
         "queryStringParameters": {"key": "value", ...},
         "body": "...",
-        "isBase64Encoded": true|false
+        "isBase64Encoded": "true|false"
     }
 
 - ``rawPath`` is the HTTP request resource path (including the query string)

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -9,7 +9,7 @@ JWKS is needed to verify JWT signatures. They can be specified in the filter con
 
 Following are supported JWT alg:
 
-.. code-block::
+.. code-block:: none
 
    ES256, ES384, ES512,
    HS256, HS384, HS512,

--- a/docs/root/configuration/http/http_filters/oauth2_filter.rst
+++ b/docs/root/configuration/http/http_filters/oauth2_filter.rst
@@ -14,7 +14,7 @@ OAuth2
 Example configuration
 ---------------------
 
-.. code-block::
+.. code-block:: yaml
 
    http_filters:
    - name: oauth2

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -25,7 +25,7 @@ message SubstitutionFormatString {
     //
     // .. code-block:: none
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
     //
     // The following plain text will be created:
     //
@@ -44,8 +44,8 @@ message SubstitutionFormatString {
     // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -23,13 +23,13 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   upstream connect error:204:path=/foo
     //
@@ -41,7 +41,7 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
     //    status: %RESPONSE_CODE%

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -29,7 +29,7 @@ message SubstitutionFormatString {
     //
     // .. code-block:: none
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
     //
     // The following plain text will be created:
     //
@@ -48,8 +48,8 @@ message SubstitutionFormatString {
     // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -27,13 +27,13 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
     //
     // The following plain text will be created:
     //
-    // .. code-block::
+    // .. code-block:: none
     //
     //   upstream connect error:204:path=/foo
     //
@@ -45,7 +45,7 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
     //    status: %RESPONSE_CODE%

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -578,7 +578,7 @@ message LocalReplyConfig {
   //
   // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
@@ -592,9 +592,9 @@ message LocalReplyConfig {
   // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -576,20 +576,20 @@ message LocalReplyConfig {
   //
   // Example one: plain/text body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: none
   //
   //   upstream connect error:503:path=/foo
   //
   //  Example two: application/json body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
   //    status: %RESPONSE_CODE%

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -573,20 +573,20 @@ message LocalReplyConfig {
   //
   // Example one: plain/text body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: none
   //
   //   upstream connect error:503:path=/foo
   //
   //  Example two: application/json body_format.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
   //    status: %RESPONSE_CODE%

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -575,7 +575,7 @@ message LocalReplyConfig {
   //
   // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%"
   //
   // The following response body in `plain/text` format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
@@ -589,9 +589,9 @@ message LocalReplyConfig {
   // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.


### PR DESCRIPTION
Commit Message:
Massage the doc build complain at alien dev machines.

Additional Description:
I may have a weird env so docs/build.sh always complains.
This fix should pass universally. 

Risk Level:
Testing:
Docs Changes: 
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
