### PR TITLE
test: Enable test sharding for //test/common/http:conn_manager_impl_test

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -192,6 +192,7 @@ envoy_cc_fuzz_test(
 envoy_cc_test(
     name = "conn_manager_impl_test",
     srcs = ["conn_manager_impl_test.cc"],
+    shard_count = 3,
     deps = [
         "//include/envoy/access_log:access_log_interface",
         "//include/envoy/buffer:buffer_interface",


### PR DESCRIPTION
Commit Message:
test: Enable test sharding for //test/common/http:conn_manager_impl_test
Test runtime in CI under config clang-tsan is dangerously close to the 300sec timeout.
Additional Description:
Risk Level: n/a test-only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a