### PR TITLE
compressor: unfriend CompressorFilterTest from CompressorFilter

### DIFF
--- a/source/extensions/filters/http/common/compressor/compressor.h
+++ b/source/extensions/filters/http/common/compressor/compressor.h
@@ -118,10 +118,6 @@ public:
   Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap&) override;
 
 private:
-  // TODO(gsagula): This is here temporarily and just to facilitate testing. Ideally all
-  // the logic in these private member functions would be available in another class.
-  friend class CompressorFilterTest;
-
   bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) const;
   bool isAcceptEncodingAllowed(const Http::ResponseHeaderMap& headers) const;
   bool isContentTypeAllowed(Http::ResponseHeaderMap& headers) const;

--- a/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
@@ -46,7 +46,7 @@ private:
 };
 
 class CompressorFilterTest : public testing::Test {
-protected:
+public:
   CompressorFilterTest() {
     ON_CALL(runtime_.snapshot_, featureEnabled("test.filter_enabled", 100))
         .WillByDefault(Return(true));
@@ -56,51 +56,13 @@ protected:
     setUpFilter(R"EOF(
 {
   "compressor_library": {
+     "name": "test",
      "typed_config": {
        "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
      }
   }
 }
 )EOF");
-  }
-
-  // CompressorFilter private member functions
-  void sanitizeEtagHeader(Http::ResponseHeaderMap& headers) {
-    filter_->sanitizeEtagHeader(headers);
-  }
-
-  void insertVaryHeader(Http::ResponseHeaderMap& headers) { filter_->insertVaryHeader(headers); }
-
-  bool isContentTypeAllowed(Http::ResponseHeaderMap& headers) {
-    return filter_->isContentTypeAllowed(headers);
-  }
-
-  bool isEtagAllowed(Http::ResponseHeaderMap& headers) { return filter_->isEtagAllowed(headers); }
-
-  bool hasCacheControlNoTransform(Http::ResponseHeaderMap& headers) {
-    return filter_->hasCacheControlNoTransform(headers);
-  }
-
-  bool isAcceptEncodingAllowed(const std::string accept_encoding,
-                               const std::unique_ptr<CompressorFilter>& filter = nullptr) {
-    Http::TestResponseHeaderMapImpl headers;
-    if (filter) {
-      filter->accept_encoding_ = std::make_unique<std::string>(accept_encoding);
-      return filter->isAcceptEncodingAllowed(headers);
-    } else {
-      NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-      filter_->setDecoderFilterCallbacks(decoder_callbacks);
-      filter_->accept_encoding_ = std::make_unique<std::string>(accept_encoding);
-      return filter_->isAcceptEncodingAllowed(headers);
-    }
-  }
-
-  bool isMinimumContentLength(Http::ResponseHeaderMap& headers) {
-    return filter_->isMinimumContentLength(headers);
-  }
-
-  bool isTransferEncodingAllowed(Http::ResponseHeaderMap& headers) {
-    return filter_->isTransferEncodingAllowed(headers);
   }
 
   // CompressorFilterTest Helpers
@@ -110,6 +72,7 @@ protected:
     config_ =
         std::make_shared<TestCompressorFilterConfig>(compressor, "test.", stats_, runtime_, "test");
     filter_ = std::make_unique<CompressorFilter>(config_);
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
   }
 
@@ -123,54 +86,58 @@ protected:
     expected_str_ += data_.toString();
   }
 
-  void drainBuffer() {
-    const uint64_t data_len = data_.length();
-    data_.drain(data_len);
-  }
-
-  void doRequest(Http::TestRequestHeaderMapImpl&& headers, bool end_stream) {
-    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, end_stream));
+  void doRequest(Http::TestRequestHeaderMapImpl&& headers) {
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+    Buffer::OwnedImpl data("hello");
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+    Http::TestRequestTrailerMapImpl trailers;
+    EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers));
   }
 
   void doResponseCompression(Http::TestResponseHeaderMapImpl& headers, bool with_trailers) {
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter_->setDecoderFilterCallbacks(decoder_callbacks);
-    uint64_t content_length;
-    ASSERT_TRUE(absl::SimpleAtoi(headers.get_("content-length"), &content_length));
-    feedBuffer(content_length);
-    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
-    EXPECT_EQ("", headers.get_("content-length"));
-    EXPECT_EQ("test", headers.get_("content-encoding"));
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, !with_trailers));
-    if (with_trailers) {
-      Buffer::OwnedImpl trailers_buffer;
-      EXPECT_CALL(encoder_callbacks_, addEncodedData(_, true))
-          .WillOnce(Invoke([&](Buffer::Instance& data, bool) { data_.move(data); }));
-      Http::TestResponseTrailerMapImpl trailers;
-      EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(trailers));
-    }
-    verifyCompressedData();
-    drainBuffer();
-    EXPECT_EQ(1U, stats_.counter("test.test.compressed").value());
+    doResponse(headers, true, with_trailers);
   }
 
   void doResponseNoCompression(Http::TestResponseHeaderMapImpl& headers) {
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter_->setDecoderFilterCallbacks(decoder_callbacks);
-    uint64_t content_length;
-    ASSERT_TRUE(absl::SimpleAtoi(headers.get_("content-length"), &content_length));
-    feedBuffer(content_length);
+    doResponse(headers, false, true);
+  }
+
+  void doResponse(Http::TestResponseHeaderMapImpl& headers, bool with_compression,
+                  bool with_trailers) {
+    uint64_t buffer_content_size;
+    if (!absl::SimpleAtoi(headers.get_("content-length"), &buffer_content_size)) {
+      ASSERT_TRUE(
+          StringUtil::CaseInsensitiveCompare()(headers.get_("transfer-encoding"), "chunked"));
+      // In case of chunked stream just feed the buffer with 1000 bytes.
+      buffer_content_size = 1000;
+    }
+    feedBuffer(buffer_content_size);
     Http::TestResponseHeaderMapImpl continue_headers;
     EXPECT_EQ(Http::FilterHeadersStatus::Continue,
               filter_->encode100ContinueHeaders(continue_headers));
     Http::MetadataMap metadata_map{{"metadata", "metadata"}};
     EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->encodeMetadata(metadata_map));
     EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
-    EXPECT_EQ("", headers.get_("content-encoding"));
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, false));
-    Http::TestResponseTrailerMapImpl trailers;
-    EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(trailers));
-    EXPECT_EQ(1, stats_.counter("test.test.not_compressed").value());
+
+    if (with_compression) {
+      EXPECT_EQ("", headers.get_("content-length"));
+      EXPECT_EQ("test", headers.get_("content-encoding"));
+      EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, !with_trailers));
+      if (with_trailers) {
+        EXPECT_CALL(encoder_callbacks_, addEncodedData(_, true))
+            .WillOnce(Invoke([&](Buffer::Instance& data, bool) { data_.move(data); }));
+        Http::TestResponseTrailerMapImpl trailers;
+        EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(trailers));
+      }
+      verifyCompressedData();
+      EXPECT_EQ(1, stats_.counter("test.test.compressed").value());
+    } else {
+      EXPECT_EQ("", headers.get_("content-encoding"));
+      EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, false));
+      Http::TestResponseTrailerMapImpl trailers;
+      EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(trailers));
+      EXPECT_EQ(1, stats_.counter("test.test.not_compressed").value());
+    }
   }
 
   std::shared_ptr<TestCompressorFilterConfig> config_;
@@ -179,6 +146,7 @@ protected:
   std::string expected_str_;
   Stats::TestUtil::TestStore stats_;
   NiceMock<Runtime::MockLoader> runtime_;
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
 };
 
@@ -191,6 +159,7 @@ TEST_F(CompressorFilterTest, DecodeHeadersWithRuntimeDisabled) {
     "runtime_key": "foo_key"
   },
   "compressor_library": {
+     "name": "test",
      "typed_config": {
        "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
      }
@@ -200,7 +169,7 @@ TEST_F(CompressorFilterTest, DecodeHeadersWithRuntimeDisabled) {
   EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true))
       .Times(2)
       .WillRepeatedly(Return(false));
-  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
+  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}});
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
   doResponseNoCompression(headers);
   EXPECT_FALSE(headers.has("vary"));
@@ -216,728 +185,52 @@ TEST_F(CompressorFilterTest, DefaultConfigValues) {
 
 // Acceptance Testing with default configuration.
 TEST_F(CompressorFilterTest, AcceptanceTestEncoding) {
-  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
-  Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
-  Http::TestRequestTrailerMapImpl trailers;
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers));
+  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}});
 
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
   doResponseCompression(headers, false);
 }
 
 TEST_F(CompressorFilterTest, AcceptanceTestEncodingWithTrailers) {
-  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}}, false);
-  Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
-  Http::TestRequestTrailerMapImpl trailers;
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers));
+  doRequest({{":method", "get"}, {"accept-encoding", "deflate, test"}});
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
   config_->setExpectedCompressCalls(2);
   doResponseCompression(headers, true);
 }
 
-// Verifies hasCacheControlNoTransform function.
-TEST_F(CompressorFilterTest, HasCacheControlNoTransform) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "no-cache"}};
-    EXPECT_FALSE(hasCacheControlNoTransform(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "no-transform"}};
-    EXPECT_TRUE(hasCacheControlNoTransform(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"cache-control", "No-Transform"}};
-    EXPECT_TRUE(hasCacheControlNoTransform(headers));
-  }
-}
-
-// Verifies that compression is skipped when cache-control header has no-transform value.
-TEST_F(CompressorFilterTest, HasCacheControlNoTransformNoCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test;q=1, deflate"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"cache-control", "no-transform"}};
-  doResponseNoCompression(headers);
-  EXPECT_FALSE(headers.has("vary"));
-}
-
-// Verifies that compression is NOT skipped when cache-control header does NOT have no-transform
-// value.
-TEST_F(CompressorFilterTest, HasCacheControlNoTransformCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"cache-control", "no-cache"}};
-  doResponseCompression(headers, false);
-}
-
 TEST_F(CompressorFilterTest, NoAcceptEncodingHeader) {
-  doRequest({{":method", "get"}, {}}, true);
+  doRequest({{":method", "get"}, {}});
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
   doResponseNoCompression(headers);
   EXPECT_EQ(1, stats_.counter("test.test.no_accept_header").value());
   EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
 }
 
-// Verifies isAcceptEncodingAllowed function.
-TEST_F(CompressorFilterTest, IsAcceptEncodingAllowed) {
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("deflate, test, br"));
-    EXPECT_EQ(1, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("deflate, test;q=1.0, *;q=0.5"));
-    EXPECT_EQ(2, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("\tdeflate\t, test\t ; q\t =\t 1.0,\t * ;q=0.5"));
-    EXPECT_EQ(3, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("deflate,test;q=1.0,*;q=0"));
-    EXPECT_EQ(4, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("deflate, test;q=0.2, br;q=1"));
-    EXPECT_EQ(5, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("*"));
-    EXPECT_EQ(1, stats_.counter("test.test.header_wildcard").value());
-    EXPECT_EQ(5, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("*;q=1"));
-    EXPECT_EQ(2, stats_.counter("test.test.header_wildcard").value());
-    EXPECT_EQ(5, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    // test header is not valid due to q=0.
-    EXPECT_FALSE(isAcceptEncodingAllowed("test;q=0,*;q=1"));
-    EXPECT_EQ(5, stats_.counter("test.test.header_compressor_used").value());
-    EXPECT_EQ(1, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity, *;q=0"));
-    EXPECT_EQ(1, stats_.counter("test.test.header_identity").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity;q=0.5, *;q=0"));
-    EXPECT_EQ(2, stats_.counter("test.test.header_identity").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity;q=0, *;q=0"));
-    EXPECT_EQ(2, stats_.counter("test.test.header_identity").value());
-    EXPECT_EQ(2, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("xyz;q=1, br;q=0.2, *"));
-    EXPECT_EQ(3, stats_.counter("test.test.header_wildcard").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("xyz;q=1, br;q=0.2, *;q=0"));
-    EXPECT_EQ(3, stats_.counter("test.test.header_wildcard").value());
-    EXPECT_EQ(3, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("xyz;q=1, br;q=0.2"));
-    EXPECT_EQ(4, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity"));
-    EXPECT_EQ(3, stats_.counter("test.test.header_identity").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity;q=1"));
-    EXPECT_EQ(4, stats_.counter("test.test.header_identity").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity;q=0"));
-    EXPECT_EQ(4, stats_.counter("test.test.header_identity").value());
-    EXPECT_EQ(5, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    // Test that we return identity and ignore the invalid wildcard.
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity, *;q=0"));
-    EXPECT_EQ(5, stats_.counter("test.test.header_identity").value());
-    EXPECT_EQ(5, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    EXPECT_TRUE(isAcceptEncodingAllowed("deflate, test;Q=.5, br"));
-    EXPECT_EQ(6, stats_.counter("test.test.header_compressor_used").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity;Q=0"));
-    EXPECT_EQ(5, stats_.counter("test.test.header_identity").value());
-    EXPECT_EQ(6, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed(""));
-    EXPECT_EQ(5, stats_.counter("test.test.header_identity").value());
-    EXPECT_EQ(7, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    // Compressor "test2" from an independent filter chain should not overshadow "test".
-    // The independence is simulated with a new instance DecoderFilterCallbacks set for "test2".
-    Stats::TestUtil::TestStore stats;
-    NiceMock<Runtime::MockLoader> runtime;
-    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
-{
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF",
-                              compressor);
-    CompressorFilterConfigSharedPtr config2;
-    config2 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats, runtime, "test2");
-    std::unique_ptr<CompressorFilter> filter2 = std::make_unique<CompressorFilter>(config2);
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter2->setDecoderFilterCallbacks(decoder_callbacks);
-
-    EXPECT_TRUE(isAcceptEncodingAllowed("test;Q=.5,test2;q=0.75"));
-    EXPECT_TRUE(isAcceptEncodingAllowed("test;Q=.5,test2;q=0.75", filter2));
-    EXPECT_EQ(0, stats_.counter("test.test.header_compressor_overshadowed").value());
-    EXPECT_EQ(7, stats_.counter("test.test.header_compressor_used").value());
-    EXPECT_EQ(1, stats.counter("test2.test2.header_compressor_used").value());
-  }
-  {
-    EXPECT_FALSE(isAcceptEncodingAllowed("test;q=invalid"));
-    EXPECT_EQ(8, stats_.counter("test.test.header_not_valid").value());
-  }
-  {
-    // check if the legacy "header_gzip" counter is incremented for gzip compression filter
-    Stats::TestUtil::TestStore stats;
-    ;
-    NiceMock<Runtime::MockLoader> runtime;
-    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
-{
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF",
-                              compressor);
-    CompressorFilterConfigSharedPtr config2;
-    config2 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats, runtime, "gzip");
-    std::unique_ptr<CompressorFilter> gzip_filter = std::make_unique<CompressorFilter>(config2);
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    gzip_filter->setDecoderFilterCallbacks(decoder_callbacks);
-
-    EXPECT_TRUE(isAcceptEncodingAllowed("gzip;q=0.75", gzip_filter));
-    EXPECT_EQ(1, stats.counter("test2.gzip.header_gzip").value());
-    // This fake Accept-Encoding is ignored as a cached decision is used.
-    EXPECT_TRUE(isAcceptEncodingAllowed("fake", gzip_filter));
-    EXPECT_EQ(2, stats.counter("test2.gzip.header_gzip").value());
-  }
-  {
-    // check if identity stat is increased twice (the second time via the cached path).
-    Stats::TestUtil::TestStore stats;
-    ;
-    NiceMock<Runtime::MockLoader> runtime;
-    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
-{
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF",
-                              compressor);
-    CompressorFilterConfigSharedPtr config2;
-    config2 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats, runtime, "test");
-    std::unique_ptr<CompressorFilter> filter2 = std::make_unique<CompressorFilter>(config2);
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter2->setDecoderFilterCallbacks(decoder_callbacks);
-
-    EXPECT_FALSE(isAcceptEncodingAllowed("identity", filter2));
-    EXPECT_EQ(1, stats.counter("test2.test.header_identity").value());
-    // This fake Accept-Encoding is ignored as a cached decision is used.
-    EXPECT_FALSE(isAcceptEncodingAllowed("fake", filter2));
-    EXPECT_EQ(2, stats.counter("test2.test.header_identity").value());
-  }
-  {
-    // check if not_valid stat is increased twice (the second time via the cached path).
-    Stats::TestUtil::TestStore stats;
-    ;
-    NiceMock<Runtime::MockLoader> runtime;
-    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
-{
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF",
-                              compressor);
-    CompressorFilterConfigSharedPtr config2;
-    config2 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats, runtime, "test");
-    std::unique_ptr<CompressorFilter> filter2 = std::make_unique<CompressorFilter>(config2);
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter2->setDecoderFilterCallbacks(decoder_callbacks);
-
-    EXPECT_FALSE(isAcceptEncodingAllowed("test;q=invalid", filter2));
-    EXPECT_EQ(1, stats.counter("test2.test.header_not_valid").value());
-    // This fake Accept-Encoding is ignored as a cached decision is used.
-    EXPECT_FALSE(isAcceptEncodingAllowed("fake", filter2));
-    EXPECT_EQ(2, stats.counter("test2.test.header_not_valid").value());
-  }
-  {
-    // Test that encoding decision is cached when used by multiple filters.
-    Stats::TestUtil::TestStore stats;
-    ;
-    NiceMock<Runtime::MockLoader> runtime;
-    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
-{
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF",
-                              compressor);
-    CompressorFilterConfigSharedPtr config1;
-    config1 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test1.", stats, runtime, "test1");
-    std::unique_ptr<CompressorFilter> filter1 = std::make_unique<CompressorFilter>(config1);
-    CompressorFilterConfigSharedPtr config2;
-    config2 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats, runtime, "test2");
-    std::unique_ptr<CompressorFilter> filter2 = std::make_unique<CompressorFilter>(config2);
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter1->setDecoderFilterCallbacks(decoder_callbacks);
-    filter2->setDecoderFilterCallbacks(decoder_callbacks);
-
-    std::string accept_encoding = "test1;Q=.5,test2;q=0.75";
-    EXPECT_FALSE(isAcceptEncodingAllowed(accept_encoding, filter1));
-    EXPECT_TRUE(isAcceptEncodingAllowed(accept_encoding, filter2));
-    EXPECT_EQ(1, stats.counter("test1.test1.header_compressor_overshadowed").value());
-    EXPECT_EQ(1, stats.counter("test2.test2.header_compressor_used").value());
-    EXPECT_FALSE(isAcceptEncodingAllowed(accept_encoding, filter1));
-    EXPECT_EQ(2, stats.counter("test1.test1.header_compressor_overshadowed").value());
-    // These fake Accept-Encoding header is ignored. Instead the cached decision is used.
-    EXPECT_TRUE(isAcceptEncodingAllowed("fake", filter2));
-    EXPECT_EQ(2, stats.counter("test2.test2.header_compressor_used").value());
-  }
-  {
-    // Test that first registered filter is used when handling wildcard.
-    Stats::TestUtil::TestStore stats;
-    ;
-    NiceMock<Runtime::MockLoader> runtime;
-    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
-    TestUtility::loadFromJson(R"EOF(
-{
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF",
-                              compressor);
-    CompressorFilterConfigSharedPtr config1;
-    config1 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test1.", stats, runtime, "test1");
-    std::unique_ptr<CompressorFilter> filter1 = std::make_unique<CompressorFilter>(config1);
-    CompressorFilterConfigSharedPtr config2;
-    config2 =
-        std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats, runtime, "test2");
-    std::unique_ptr<CompressorFilter> filter2 = std::make_unique<CompressorFilter>(config2);
-    NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-    filter1->setDecoderFilterCallbacks(decoder_callbacks);
-    filter2->setDecoderFilterCallbacks(decoder_callbacks);
-
-    std::string accept_encoding = "*";
-    EXPECT_TRUE(isAcceptEncodingAllowed(accept_encoding, filter1));
-    EXPECT_FALSE(isAcceptEncodingAllowed(accept_encoding, filter2));
-    EXPECT_EQ(1, stats.counter("test1.test1.header_wildcard").value());
-    EXPECT_EQ(1, stats.counter("test2.test2.header_wildcard").value());
-  }
-}
-
-// Verifies that compression is skipped when accept-encoding header is not allowed.
-TEST_F(CompressorFilterTest, AcceptEncodingNoCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test;q=0, deflate"}}, true);
+TEST_F(CompressorFilterTest, CacheIdentityDecision) {
+  // check if identity stat is increased twice (the second time via the cached path).
+  config_->setExpectedCompressCalls(0);
+  doRequest({{":method", "get"}, {"accept-encoding", "identity"}});
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  doResponseNoCompression(headers);
-  // Even if compression is disallowed by a client we must let her know the resource is
-  // compressible.
-  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
+  EXPECT_EQ(1, stats_.counter("test.test.header_identity").value());
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
+  EXPECT_EQ(2, stats_.counter("test.test.header_identity").value());
 }
 
-// Verifies that compression is NOT skipped when accept-encoding header is allowed.
-TEST_F(CompressorFilterTest, AcceptEncodingCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}}, true);
+TEST_F(CompressorFilterTest, CacheHeaderNotValidDecision) {
+  // check if not_valid stat is increased twice (the second time via the cached path).
+  config_->setExpectedCompressCalls(0);
+  doRequest({{":method", "get"}, {"accept-encoding", "test;q=invalid"}});
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  doResponseCompression(headers, false);
-}
-
-// Verifies isMinimumContentLength function.
-TEST_F(CompressorFilterTest, IsMinimumContentLength) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "31"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "29"}};
-    EXPECT_FALSE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-
-  setUpFilter(R"EOF(
-{
-  "content_length": 500,
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "501"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
-    EXPECT_TRUE(isMinimumContentLength(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-length", "499"}};
-    EXPECT_FALSE(isMinimumContentLength(headers));
-  }
-}
-
-// Verifies that compression is skipped when content-length header is NOT allowed.
-TEST_F(CompressorFilterTest, ContentLengthNoCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "10"}};
-  doResponseNoCompression(headers);
-  EXPECT_FALSE(headers.has("vary"));
-}
-
-// Verifies that compression is NOT skipped when content-length header is allowed.
-TEST_F(CompressorFilterTest, ContentLengthCompression) {
-  setUpFilter(R"EOF(
-{
-  "content_length": 500,
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "1000"}};
-  doResponseCompression(headers, false);
-}
-
-// Verifies isContentTypeAllowed function.
-TEST_F(CompressorFilterTest, IsContentTypeAllowed) {
-
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/html"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "text/plain"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/javascript"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/svg+xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/json;charset=utf-8"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/json"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "application/xhtml+xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "Application/XHTML+XML"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
-    EXPECT_FALSE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "\ttext/html\t"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-
-  setUpFilter(R"EOF(
-    {
-      "content_type": [
-        "text/html",
-        "xyz/svg+xml",
-        "Test/INSENSITIVE"
-      ],
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-    }
-  )EOF");
-
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "xyz/svg+xml"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "xyz/false"}};
-    EXPECT_FALSE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "image/jpeg"}};
-    EXPECT_FALSE(isContentTypeAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"content-type", "test/insensitive"}};
-    EXPECT_TRUE(isContentTypeAllowed(headers));
-  }
-}
-
-// Verifies that compression is skipped when content-type header is NOT allowed.
-TEST_F(CompressorFilterTest, ContentTypeNoCompression) {
-  setUpFilter(R"EOF(
-    {
-      "content_type": [
-        "text/html",
-        "text/css",
-        "text/plain",
-        "application/javascript",
-        "application/json",
-        "font/eot",
-        "image/svg+xml"
-      ],
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-    }
-  )EOF");
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"content-type", "image/jpeg"}};
-  doResponseNoCompression(headers);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
   EXPECT_EQ(1, stats_.counter("test.test.header_not_valid").value());
-  // Assert the resource is not compressible.
-  EXPECT_FALSE(headers.has("vary"));
-}
-
-// Verifies that compression is NOT skipped when content-encoding header is allowed.
-TEST_F(CompressorFilterTest, ContentTypeCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"},
-                                          {"content-length", "256"},
-                                          {"content-type", "application/json;charset=utf-8"}};
-  doResponseCompression(headers, false);
-}
-
-// Verifies sanitizeEtagHeader function.
-TEST_F(CompressorFilterTest, SanitizeEtagHeader) {
-  {
-    std::string etag_header{R"EOF(W/"686897696a7c876b7e")EOF"};
-    Http::TestResponseHeaderMapImpl headers = {{"etag", etag_header}};
-    sanitizeEtagHeader(headers);
-    EXPECT_EQ(etag_header, headers.get_("etag"));
-  }
-  {
-    std::string etag_header{R"EOF(w/"686897696a7c876b7e")EOF"};
-    Http::TestResponseHeaderMapImpl headers = {{"etag", etag_header}};
-    sanitizeEtagHeader(headers);
-    EXPECT_EQ(etag_header, headers.get_("etag"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
-    sanitizeEtagHeader(headers);
-    EXPECT_FALSE(headers.has("etag"));
-  }
-}
-
-// Verifies isEtagAllowed function.
-TEST_F(CompressorFilterTest, IsEtagAllowed) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(0, stats_.counter("test.test.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(0, stats_.counter("test.test.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(0, stats_.counter("test.test.not_compressed_etag").value());
-  }
-
-  setUpFilter(R"EOF(
-{
-  "disable_on_etag_header": true,
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
-    EXPECT_FALSE(isEtagAllowed(headers));
-    EXPECT_EQ(1, stats_.counter("test.test.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"etag", "686897696a7c876b7e"}};
-    EXPECT_FALSE(isEtagAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.test.not_compressed_etag").value());
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isEtagAllowed(headers));
-    EXPECT_EQ(2, stats_.counter("test.test.not_compressed_etag").value());
-  }
-}
-
-// Verifies that compression is skipped when etag header is NOT allowed.
-TEST_F(CompressorFilterTest, EtagNoCompression) {
-  setUpFilter(R"EOF(
-{
-  "disable_on_etag_header": true,
-  "compressor_library": {
-     "typed_config": {
-       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
-     }
-  }
-}
-)EOF");
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"etag", R"EOF(W/"686897696a7c876b7e")EOF"}};
-  doResponseNoCompression(headers);
-  EXPECT_EQ(1, stats_.counter("test.test.not_compressed_etag").value());
-  EXPECT_FALSE(headers.has("vary"));
-}
-
-// Verifies that compression is not skipped when strong etag header is present.
-TEST_F(CompressorFilterTest, EtagCompression) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"etag", "686897696a7c876b7e"}};
-  doResponseCompression(headers, false);
-  EXPECT_FALSE(headers.has("etag"));
-  EXPECT_EQ("test", headers.get_("content-encoding"));
-}
-
-// Verifies isTransferEncodingAllowed function.
-TEST_F(CompressorFilterTest, IsTransferEncodingAllowed) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    EXPECT_TRUE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "chunked"}};
-    EXPECT_TRUE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Chunked"}};
-    EXPECT_TRUE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "deflate"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "Deflate"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "test"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", "test, chunked"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"transfer-encoding", " test\t,  chunked\t"}};
-    EXPECT_FALSE(isTransferEncodingAllowed(headers));
-  }
-}
-
-// Tests compression when Transfer-Encoding header exists.
-TEST_F(CompressorFilterTest, TransferEncodingChunked) {
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"transfer-encoding", "chunked"}};
-  doResponseCompression(headers, false);
-}
-
-// Tests compression when Transfer-Encoding header exists.
-TEST_F(CompressorFilterTest, AcceptanceTransferEncoding) {
-
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"transfer-encoding", "chunked, deflate"}};
-  doResponseNoCompression(headers);
-  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
+  EXPECT_EQ(2, stats_.counter("test.test.header_not_valid").value());
 }
 
 // Content-Encoding: upstream response is already encoded.
 TEST_F(CompressorFilterTest, ContentEncodingAlreadyEncoded) {
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  filter_->setDecoderFilterCallbacks(decoder_callbacks);
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
+  doRequest({{":method", "get"}, {"accept-encoding", "test"}});
   Http::TestResponseHeaderMapImpl response_headers{
       {":method", "get"}, {"content-length", "256"}, {"content-encoding", "deflate, gzip"}};
   feedBuffer(256);
@@ -945,11 +238,11 @@ TEST_F(CompressorFilterTest, ContentEncodingAlreadyEncoded) {
   EXPECT_TRUE(response_headers.has("content-length"));
   EXPECT_FALSE(response_headers.has("transfer-encoding"));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, false));
+  EXPECT_EQ(1U, stats_.counter("test.test.not_compressed").value());
 }
 
 // No compression when upstream response is empty.
 TEST_F(CompressorFilterTest, EmptyResponse) {
-
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {":status", "204"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, true));
   EXPECT_EQ("", headers.get_("content-length"));
@@ -957,74 +250,8 @@ TEST_F(CompressorFilterTest, EmptyResponse) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data_, true));
 }
 
-// Verifies insertVaryHeader function.
-TEST_F(CompressorFilterTest, InsertVaryHeader) {
-  {
-    Http::TestResponseHeaderMapImpl headers = {};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "Cookie"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Cookie, Accept-Encoding", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "accept-encoding"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("accept-encoding, Accept-Encoding", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "Accept-Encoding, Cookie"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Accept-Encoding, Cookie", headers.get_("vary"));
-  }
-  {
-    Http::TestResponseHeaderMapImpl headers = {{"vary", "Accept-Encoding"}};
-    insertVaryHeader(headers);
-    EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
-  }
-}
-
-// Filter should set Vary header value with `accept-encoding`.
-TEST_F(CompressorFilterTest, NoVaryHeader) {
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  filter_->setDecoderFilterCallbacks(decoder_callbacks);
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
-  doResponseCompression(headers, false);
-  EXPECT_TRUE(headers.has("vary"));
-  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
-}
-
-// Filter should set Vary header value with `accept-encoding` and preserve other values.
-TEST_F(CompressorFilterTest, VaryOtherValues) {
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  filter_->setDecoderFilterCallbacks(decoder_callbacks);
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"vary", "User-Agent, Cookie"}};
-  doResponseCompression(headers, false);
-  EXPECT_TRUE(headers.has("vary"));
-  EXPECT_EQ("User-Agent, Cookie, Accept-Encoding", headers.get_("vary"));
-}
-
-// Vary header should have only one `accept-encoding`value.
-TEST_F(CompressorFilterTest, VaryAlreadyHasAcceptEncoding) {
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  filter_->setDecoderFilterCallbacks(decoder_callbacks);
-  doRequest({{":method", "get"}, {"accept-encoding", "test"}}, true);
-  Http::TestResponseHeaderMapImpl headers{
-      {":method", "get"}, {"content-length", "256"}, {"vary", "accept-encoding"}};
-  doResponseCompression(headers, false);
-  EXPECT_TRUE(headers.has("vary"));
-  EXPECT_EQ("accept-encoding, Accept-Encoding", headers.get_("vary"));
-}
-
 // Verify removeAcceptEncoding header.
 TEST_F(CompressorFilterTest, RemoveAcceptEncodingHeader) {
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  filter_->setDecoderFilterCallbacks(decoder_callbacks);
   {
     Http::TestRequestHeaderMapImpl headers = {{"accept-encoding", "deflate, test, gzip, br"}};
     setUpFilter(R"EOF(
@@ -1055,6 +282,438 @@ TEST_F(CompressorFilterTest, RemoveAcceptEncodingHeader) {
     EXPECT_TRUE(headers.has("accept-encoding"));
     EXPECT_EQ("deflate, test, gzip, br", headers.get_("accept-encoding"));
   }
+}
+
+class IsAcceptEncodingAllowedTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, bool, int, int, int, int>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    IsAcceptEncodingAllowedTestSuite, IsAcceptEncodingAllowedTest,
+    testing::Values(std::make_tuple("deflate, test, br", true, 1, 0, 0, 0),
+                    std::make_tuple("deflate, test;q=1.0, *;q=0.5", true, 1, 0, 0, 0),
+                    std::make_tuple("\tdeflate\t, test\t ; q\t =\t 1.0,\t * ;q=0.5", true, 1, 0, 0,
+                                    0),
+                    std::make_tuple("deflate,test;q=1.0,*;q=0", true, 1, 0, 0, 0),
+                    std::make_tuple("deflate, test;q=0.2, br;q=1", true, 1, 0, 0, 0),
+                    std::make_tuple("*", true, 0, 1, 0, 0),
+                    std::make_tuple("*;q=1", true, 0, 1, 0, 0),
+                    std::make_tuple("xyz;q=1, br;q=0.2, *", true, 0, 1, 0, 0),
+                    std::make_tuple("deflate, test;Q=.5, br", true, 1, 0, 0, 0),
+                    std::make_tuple("test;q=0,*;q=1", false, 0, 0, 1, 0),
+                    std::make_tuple("identity, *;q=0", false, 0, 0, 0, 1),
+                    std::make_tuple("identity", false, 0, 0, 0, 1),
+                    std::make_tuple("identity, *;q=0", false, 0, 0, 0, 1),
+                    std::make_tuple("identity;q=1", false, 0, 0, 0, 1),
+                    std::make_tuple("identity;q=0", false, 0, 0, 1, 0),
+                    std::make_tuple("identity;Q=0", false, 0, 0, 1, 0),
+                    std::make_tuple("identity;q=0.5, *;q=0", false, 0, 0, 0, 1),
+                    std::make_tuple("identity;q=0, *;q=0", false, 0, 0, 1, 0),
+                    std::make_tuple("xyz;q=1, br;q=0.2, *;q=0", false, 0, 0, 1, 0),
+                    std::make_tuple("xyz;q=1, br;q=0.2", false, 0, 0, 1, 0),
+                    std::make_tuple("", false, 0, 0, 1, 0),
+                    std::make_tuple("test;q=invalid", false, 0, 0, 1, 0)));
+
+TEST_P(IsAcceptEncodingAllowedTest, Validate) {
+  std::string accept_encoding = std::get<0>(GetParam());
+  bool is_compression_expected = std::get<1>(GetParam());
+  int compressor_used = std::get<2>(GetParam());
+  int wildcard = std::get<3>(GetParam());
+  int not_valid = std::get<4>(GetParam());
+  int identity = std::get<5>(GetParam());
+
+  doRequest({{":method", "get"}, {"accept-encoding", accept_encoding}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ(compressor_used, stats_.counter("test.test.header_compressor_used").value());
+  EXPECT_EQ(wildcard, stats_.counter("test.test.header_wildcard").value());
+  EXPECT_EQ(not_valid, stats_.counter("test.test.header_not_valid").value());
+  EXPECT_EQ(identity, stats_.counter("test.test.header_identity").value());
+  // Even if compression is disallowed by a client we must let her know the resource is
+  // compressible.
+  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+}
+
+class IsContentTypeAllowedTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, bool, bool>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    IsContentTypeAllowedTestSuite, IsContentTypeAllowedTest,
+    testing::Values(
+        std::make_tuple("text/html", true, false), std::make_tuple("text/xml", true, false),
+        std::make_tuple("text/plain", true, false), std::make_tuple("text/css", true, false),
+        std::make_tuple("application/javascript", true, false),
+        std::make_tuple("application/x-javascript", true, false),
+        std::make_tuple("text/javascript", true, false),
+        std::make_tuple("text/x-javascript", true, false),
+        std::make_tuple("text/ecmascript", true, false), std::make_tuple("text/js", true, false),
+        std::make_tuple("text/jscript", true, false), std::make_tuple("text/x-js", true, false),
+        std::make_tuple("application/ecmascript", true, false),
+        std::make_tuple("application/x-json", true, false),
+        std::make_tuple("application/xml", true, false),
+        std::make_tuple("application/json", true, false),
+        std::make_tuple("image/svg+xml", true, false),
+        std::make_tuple("application/xhtml+xml", true, false),
+        std::make_tuple("application/json;charset=utf-8", true, false),
+        std::make_tuple("Application/XHTML+XML", true, false),
+        std::make_tuple("\ttext/html\t", true, false), std::make_tuple("image/jpeg", false, false),
+        std::make_tuple("xyz/svg+xml", true, true), std::make_tuple("xyz/false", false, true),
+        std::make_tuple("image/jpeg", false, true),
+        std::make_tuple("test/insensitive", true, true)));
+
+TEST_P(IsContentTypeAllowedTest, Validate) {
+  std::string content_type = std::get<0>(GetParam());
+  bool should_compress = std::get<1>(GetParam());
+  bool is_custom_config = std::get<2>(GetParam());
+
+  if (is_custom_config) {
+    setUpFilter(R"EOF(
+      {
+        "content_type": [
+          "text/html",
+          "xyz/svg+xml",
+          "Test/INSENSITIVE"
+        ],
+    "compressor_library": {
+       "name": "test",
+       "typed_config": {
+         "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+       }
+    }
+      }
+    )EOF");
+  }
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"content-type", content_type}};
+  doResponse(headers, should_compress, false);
+  EXPECT_EQ(should_compress ? 0 : 1, stats_.counter("test.test.header_not_valid").value());
+  EXPECT_EQ(should_compress, headers.has("vary"));
+}
+
+class CompressWithEtagTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, std::string, bool>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    CompressWithEtagSuite, CompressWithEtagTest,
+    testing::Values(std::make_tuple("etag", R"EOF(W/"686897696a7c876b7e")EOF", true),
+                    std::make_tuple("etag", R"EOF(w/"686897696a7c876b7e")EOF", true),
+                    std::make_tuple("etag", "686897696a7c876b7e", false),
+                    std::make_tuple("x-garbage", "garbagevalue", false)));
+
+TEST_P(CompressWithEtagTest, CompressionIsEnabledOnEtag) {
+  std::string header_name = std::get<0>(GetParam());
+  std::string header_value = std::get<1>(GetParam());
+  bool is_weak_etag = std::get<2>(GetParam());
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {header_name, header_value}};
+  doResponseCompression(headers, false);
+  EXPECT_EQ(0, stats_.counter("test.test.not_compressed_etag").value());
+  EXPECT_EQ("test", headers.get_("content-encoding"));
+  if (is_weak_etag) {
+    EXPECT_EQ(header_value, headers.get_("etag"));
+  } else {
+    EXPECT_FALSE(headers.has("etag"));
+  }
+}
+
+TEST_P(CompressWithEtagTest, CompressionIsDisabledOnEtag) {
+  std::string header_name = std::get<0>(GetParam());
+  std::string header_value = std::get<1>(GetParam());
+
+  setUpFilter(R"EOF(
+{
+  "disable_on_etag_header": true,
+  "compressor_library": {
+     "name": "test",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF");
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {header_name, header_value}};
+  if (StringUtil::CaseInsensitiveCompare()("etag", header_name)) {
+    doResponseNoCompression(headers);
+    EXPECT_EQ(1, stats_.counter("test.test.not_compressed_etag").value());
+    EXPECT_FALSE(headers.has("vary"));
+    EXPECT_TRUE(headers.has("etag"));
+  } else {
+    doResponseCompression(headers, false);
+    EXPECT_EQ(0, stats_.counter("test.test.not_compressed_etag").value());
+    EXPECT_EQ("test", headers.get_("content-encoding"));
+    EXPECT_TRUE(headers.has("vary"));
+    EXPECT_FALSE(headers.has("etag"));
+  }
+}
+
+class HasCacheControlNoTransformTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, bool>> {};
+
+INSTANTIATE_TEST_SUITE_P(HasCacheControlNoTransformTestSuite, HasCacheControlNoTransformTest,
+                         testing::Values(std::make_tuple("no-cache", true),
+                                         std::make_tuple("no-transform", false),
+                                         std::make_tuple("No-Transform", false)));
+
+TEST_P(HasCacheControlNoTransformTest, Validate) {
+  std::string cache_control = std::get<0>(GetParam());
+  bool is_compression_expected = std::get<1>(GetParam());
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {"cache-control", cache_control}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ(is_compression_expected, headers.has("vary"));
+}
+
+class IsMinimumContentLengthTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, std::string, std::string, bool>> {
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    IsMinimumContentLengthTestSuite, IsMinimumContentLengthTest,
+    testing::Values(std::make_tuple("content-length", "31", "", true),
+                    std::make_tuple("content-length", "29", "", false),
+                    std::make_tuple("transfer-encoding", "chunked", "", true),
+                    std::make_tuple("transfer-encoding", "Chunked", "", true),
+                    std::make_tuple("transfer-encoding", "chunked", "\"content_length\": 500,",
+                                    true),
+                    std::make_tuple("content-length", "501", "\"content_length\": 500,", true),
+                    std::make_tuple("content-length", "499", "\"content_length\": 500,", false)));
+
+TEST_P(IsMinimumContentLengthTest, Validate) {
+  std::string header_name = std::get<0>(GetParam());
+  std::string header_value = std::get<1>(GetParam());
+  std::string content_length_config = std::get<2>(GetParam());
+  bool is_compression_expected = std::get<3>(GetParam());
+
+  setUpFilter(fmt::format(R"EOF(
+{{
+  {}
+  "compressor_library": {{
+     "name": "test",
+     "typed_config": {{
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }}
+  }}
+}}
+)EOF",
+                          content_length_config));
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {header_name, header_value}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ(is_compression_expected, headers.has("vary"));
+}
+
+class IsTransferEncodingAllowedTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, std::string, bool>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    IsTransferEncodingAllowedSuite, IsTransferEncodingAllowedTest,
+    testing::Values(std::make_tuple("transfer-encoding", "chunked", true),
+                    std::make_tuple("transfer-encoding", "Chunked", true),
+                    std::make_tuple("transfer-encoding", "deflate", false),
+                    std::make_tuple("transfer-encoding", "Deflate", false),
+                    std::make_tuple("transfer-encoding", "test", false),
+                    std::make_tuple("transfer-encoding", "chunked, test", false),
+                    std::make_tuple("transfer-encoding", "test, chunked", false),
+                    std::make_tuple("transfer-encoding", "test\t, chunked\t", false),
+                    std::make_tuple("x-garbage", "no_value", true)));
+
+TEST_P(IsTransferEncodingAllowedTest, Validate) {
+  std::string header_name = std::get<0>(GetParam());
+  std::string header_value = std::get<1>(GetParam());
+  bool is_compression_expected = std::get<2>(GetParam());
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {header_name, header_value}};
+  doResponse(headers, is_compression_expected, false);
+  EXPECT_EQ("Accept-Encoding", headers.get_("vary"));
+}
+
+class InsertVaryHeaderTest
+    : public CompressorFilterTest,
+      public testing::WithParamInterface<std::tuple<std::string, std::string, std::string>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    InsertVaryHeaderTestSuite, InsertVaryHeaderTest,
+    testing::Values(std::make_tuple("x-garbage", "Cookie", "Accept-Encoding"),
+                    std::make_tuple("vary", "Cookie", "Cookie, Accept-Encoding"),
+                    std::make_tuple("vary", "accept-encoding", "accept-encoding, Accept-Encoding"),
+                    std::make_tuple("vary", "Accept-Encoding, Cookie", "Accept-Encoding, Cookie"),
+                    std::make_tuple("vary", "User-Agent, Cookie",
+                                    "User-Agent, Cookie, Accept-Encoding"),
+                    std::make_tuple("vary", "Accept-Encoding", "Accept-Encoding")));
+
+TEST_P(InsertVaryHeaderTest, Validate) {
+  std::string header_name = std::get<0>(GetParam());
+  std::string header_value = std::get<1>(GetParam());
+  std::string expected = std::get<2>(GetParam());
+
+  doRequest({{":method", "get"}, {"accept-encoding", "test"}});
+  Http::TestResponseHeaderMapImpl headers{
+      {":method", "get"}, {"content-length", "256"}, {header_name, header_value}};
+  doResponseCompression(headers, false);
+  EXPECT_EQ(expected, headers.get_("vary"));
+}
+
+class MultipleFiltersTest : public testing::Test {
+protected:
+  void SetUp() override {
+    envoy::extensions::filters::http::compressor::v3::Compressor compressor;
+    TestUtility::loadFromJson(R"EOF(
+{
+  "compressor_library": {
+     "name": "test1",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF",
+                              compressor);
+    auto config1 = std::make_shared<TestCompressorFilterConfig>(compressor, "test1.", stats1_,
+                                                                runtime_, "test1");
+    config1->setExpectedCompressCalls(0);
+    filter1_ = std::make_unique<CompressorFilter>(config1);
+
+    TestUtility::loadFromJson(R"EOF(
+{
+  "compressor_library": {
+     "name": "test2",
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF",
+                              compressor);
+    auto config2 = std::make_shared<TestCompressorFilterConfig>(compressor, "test2.", stats2_,
+                                                                runtime_, "test2");
+    config2->setExpectedCompressCalls(0);
+    filter2_ = std::make_unique<CompressorFilter>(config2);
+  }
+
+  NiceMock<Runtime::MockLoader> runtime_;
+  Stats::TestUtil::TestStore stats1_;
+  Stats::TestUtil::TestStore stats2_;
+  std::unique_ptr<CompressorFilter> filter1_;
+  std::unique_ptr<CompressorFilter> filter2_;
+};
+
+TEST_F(MultipleFiltersTest, IndependentFilters) {
+  // The compressor "test1" from an independent filter chain should not overshadow "test2".
+  // The independence is simulated with different instances of DecoderFilterCallbacks set for
+  // "test1" and "test2".
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks1;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks1);
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks2;
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks2);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1;Q=.5,test2;q=0.75"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers1{{":method", "get"}, {"content-length", "256"}};
+  Http::TestResponseHeaderMapImpl headers2{{":method", "get"}, {"content-length", "256"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers1, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers2, false));
+  EXPECT_EQ(0, stats1_.counter("test1.test1.header_compressor_overshadowed").value());
+  EXPECT_EQ(0, stats2_.counter("test2.test2.header_compressor_overshadowed").value());
+  EXPECT_EQ(1, stats1_.counter("test1.test1.compressed").value());
+  EXPECT_EQ(1, stats1_.counter("test1.test1.header_compressor_used").value());
+  EXPECT_EQ(1, stats2_.counter("test2.test2.compressed").value());
+  EXPECT_EQ(1, stats2_.counter("test2.test2.header_compressor_used").value());
+}
+
+TEST_F(MultipleFiltersTest, CacheEncodingDecision) {
+  // Test that encoding decision is cached when used by multiple filters.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "test1;Q=.5,test2;q=0.75"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(1, stats1_.counter("test1.test1.header_compressor_overshadowed").value());
+  EXPECT_EQ(1, stats2_.counter("test2.test2.header_compressor_used").value());
+  // Reset headers as content-length got removed by filter2.
+  headers = {{":method", "get"}, {"content-length", "256"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers, false));
+  EXPECT_EQ(2, stats1_.counter("test1.test1.header_compressor_overshadowed").value());
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers, false));
+  EXPECT_EQ(2, stats2_.counter("test2.test2.header_compressor_used").value());
+}
+
+TEST_F(MultipleFiltersTest, UseFirstRegisteredFilterWhenWildcard) {
+  // Test that first registered filter is used when handling wildcard.
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter1_->setDecoderFilterCallbacks(decoder_callbacks);
+  filter2_->setDecoderFilterCallbacks(decoder_callbacks);
+
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"}, {"accept-encoding", "*"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->decodeHeaders(req_headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers1{{":method", "get"}, {"content-length", "256"}};
+  Http::TestResponseHeaderMapImpl headers2{{":method", "get"}, {"content-length", "256"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter1_->encodeHeaders(headers1, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter2_->encodeHeaders(headers2, false));
+  EXPECT_EQ(1, stats1_.counter("test1.test1.compressed").value());
+  EXPECT_EQ(0, stats2_.counter("test2.test2.compressed").value());
+  EXPECT_EQ(1, stats1_.counter("test1.test1.header_wildcard").value());
+  EXPECT_EQ(1, stats2_.counter("test2.test2.header_wildcard").value());
+}
+
+TEST(LegacyTest, GzipStats) {
+  // check if the legacy "header_gzip" counter is incremented for gzip compression filter
+  Stats::TestUtil::TestStore stats;
+  NiceMock<Runtime::MockLoader> runtime;
+  envoy::extensions::filters::http::compressor::v3::Compressor compressor;
+  TestUtility::loadFromJson(R"EOF(
+{
+  "compressor_library": {
+     "typed_config": {
+       "@type": "type.googleapis.com/envoy.extensions.compression.gzip.compressor.v3.Gzip"
+     }
+  }
+}
+)EOF",
+                            compressor);
+  auto config =
+      std::make_shared<TestCompressorFilterConfig>(compressor, "test.", stats, runtime, "gzip");
+  config->setExpectedCompressCalls(0);
+  auto gzip_filter = std::make_unique<CompressorFilter>(config);
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  gzip_filter->setDecoderFilterCallbacks(decoder_callbacks);
+  Http::TestRequestHeaderMapImpl req_headers{{":method", "get"},
+                                             {"accept-encoding", "gzip;q=0.75"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, gzip_filter->decodeHeaders(req_headers, false));
+  Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, gzip_filter->encodeHeaders(headers, false));
+  EXPECT_EQ(1, stats.counter("test.gzip.header_gzip").value());
+  EXPECT_EQ(1, stats.counter("test.gzip.compressed").value());
+  // Reset headers as content-length got removed by gzip_filter.
+  headers = {{":method", "get"}, {"content-length", "256"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, gzip_filter->encodeHeaders(headers, false));
+  EXPECT_EQ(2, stats.counter("test.gzip.header_gzip").value());
+  EXPECT_EQ(2, stats.counter("test.gzip.compressed").value());
 }
 
 } // namespace Compressors

--- a/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/common/compressor/compressor_filter_test.cc
@@ -315,12 +315,12 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("test;q=invalid", false, 0, 0, 1, 0)));
 
 TEST_P(IsAcceptEncodingAllowedTest, Validate) {
-  std::string accept_encoding = std::get<0>(GetParam());
-  bool is_compression_expected = std::get<1>(GetParam());
-  int compressor_used = std::get<2>(GetParam());
-  int wildcard = std::get<3>(GetParam());
-  int not_valid = std::get<4>(GetParam());
-  int identity = std::get<5>(GetParam());
+  const std::string& accept_encoding = std::get<0>(GetParam());
+  const bool is_compression_expected = std::get<1>(GetParam());
+  const int compressor_used = std::get<2>(GetParam());
+  const int wildcard = std::get<3>(GetParam());
+  const int not_valid = std::get<4>(GetParam());
+  const int identity = std::get<5>(GetParam());
 
   doRequest({{":method", "get"}, {"accept-encoding", accept_encoding}});
   Http::TestResponseHeaderMapImpl headers{{":method", "get"}, {"content-length", "256"}};
@@ -363,9 +363,9 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("test/insensitive", true, true)));
 
 TEST_P(IsContentTypeAllowedTest, Validate) {
-  std::string content_type = std::get<0>(GetParam());
-  bool should_compress = std::get<1>(GetParam());
-  bool is_custom_config = std::get<2>(GetParam());
+  const std::string& content_type = std::get<0>(GetParam());
+  const bool should_compress = std::get<1>(GetParam());
+  const bool is_custom_config = std::get<2>(GetParam());
 
   if (is_custom_config) {
     setUpFilter(R"EOF(
@@ -405,9 +405,9 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("x-garbage", "garbagevalue", false)));
 
 TEST_P(CompressWithEtagTest, CompressionIsEnabledOnEtag) {
-  std::string header_name = std::get<0>(GetParam());
-  std::string header_value = std::get<1>(GetParam());
-  bool is_weak_etag = std::get<2>(GetParam());
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const bool is_weak_etag = std::get<2>(GetParam());
 
   doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
   Http::TestResponseHeaderMapImpl headers{
@@ -423,8 +423,8 @@ TEST_P(CompressWithEtagTest, CompressionIsEnabledOnEtag) {
 }
 
 TEST_P(CompressWithEtagTest, CompressionIsDisabledOnEtag) {
-  std::string header_name = std::get<0>(GetParam());
-  std::string header_value = std::get<1>(GetParam());
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
 
   setUpFilter(R"EOF(
 {
@@ -465,8 +465,8 @@ INSTANTIATE_TEST_SUITE_P(HasCacheControlNoTransformTestSuite, HasCacheControlNoT
                                          std::make_tuple("No-Transform", false)));
 
 TEST_P(HasCacheControlNoTransformTest, Validate) {
-  std::string cache_control = std::get<0>(GetParam());
-  bool is_compression_expected = std::get<1>(GetParam());
+  const std::string& cache_control = std::get<0>(GetParam());
+  const bool is_compression_expected = std::get<1>(GetParam());
 
   doRequest({{":method", "get"}, {"accept-encoding", "test, deflate"}});
   Http::TestResponseHeaderMapImpl headers{
@@ -492,10 +492,10 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("content-length", "499", "\"content_length\": 500,", false)));
 
 TEST_P(IsMinimumContentLengthTest, Validate) {
-  std::string header_name = std::get<0>(GetParam());
-  std::string header_value = std::get<1>(GetParam());
-  std::string content_length_config = std::get<2>(GetParam());
-  bool is_compression_expected = std::get<3>(GetParam());
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const std::string& content_length_config = std::get<2>(GetParam());
+  const bool is_compression_expected = std::get<3>(GetParam());
 
   setUpFilter(fmt::format(R"EOF(
 {{
@@ -533,9 +533,9 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("x-garbage", "no_value", true)));
 
 TEST_P(IsTransferEncodingAllowedTest, Validate) {
-  std::string header_name = std::get<0>(GetParam());
-  std::string header_value = std::get<1>(GetParam());
-  bool is_compression_expected = std::get<2>(GetParam());
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const bool is_compression_expected = std::get<2>(GetParam());
 
   doRequest({{":method", "get"}, {"accept-encoding", "test"}});
   Http::TestResponseHeaderMapImpl headers{
@@ -559,9 +559,9 @@ INSTANTIATE_TEST_SUITE_P(
                     std::make_tuple("vary", "Accept-Encoding", "Accept-Encoding")));
 
 TEST_P(InsertVaryHeaderTest, Validate) {
-  std::string header_name = std::get<0>(GetParam());
-  std::string header_value = std::get<1>(GetParam());
-  std::string expected = std::get<2>(GetParam());
+  const std::string& header_name = std::get<0>(GetParam());
+  const std::string& header_value = std::get<1>(GetParam());
+  const std::string& expected = std::get<2>(GetParam());
 
   doRequest({{":method", "get"}, {"accept-encoding", "test"}});
   Http::TestResponseHeaderMapImpl headers{


### PR DESCRIPTION
Commit Message: compressor: unfriend CompressorFilterTest from CompressorFilter
Additional Description: Currently the test code validating the CompressorFilter class requires access to the private methods of the class. Refactor the tests to use only public methods of the class.
Risk Level: Low
Testing: run unit tests
Docs Changes: N/A
Release Notes: N/A
