### PR TITLE
Add shellcheck to ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -229,7 +229,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:f741613fc395cc489a630122eeb5e611b3cb1a5e
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:e7ea4e81bbd5028abb9d3a2f2c0afe063d9b62c0
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     description: "A regular build executor based on ubuntu image"
     docker:
       # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-      - image: envoyproxy/envoy-build-ubuntu:f741613fc395cc489a630122eeb5e611b3cb1a5e
+      - image: envoyproxy/envoy-build-ubuntu:e7ea4e81bbd5028abb9d3a2f2c0afe063d9b62c0
     resource_class: xlarge
     working_directory: /source
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/envoy-ci/envoy-build:f741613fc395cc489a630122eeb5e611b3cb1a5e
+FROM gcr.io/envoy-ci/envoy-build:e7ea4e81bbd5028abb9d3a2f2c0afe063d9b62c0
 
 ARG USERNAME=vscode
 ARG USER_UID=501

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -15,4 +15,4 @@ echo "build ${BAZEL_BUILD_EXTRA_OPTIONS}" | tee -a ~/.bazelrc
 # TODO(lizan): Fix API tooling and enable this again
 #echo "build --symlink_prefix=/" >> ~/.bazelrc
 
-[[ ! -z "${BUILD_DIR}" ]] && sudo chown -R "$(id -u):$(id -g)" ${BUILD_DIR}
+[[ -n "${BUILD_DIR}" ]] && sudo chown -R "$(id -u):$(id -g)" "${BUILD_DIR}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -367,6 +367,7 @@ elif [[ "$CI_TARGET" == "check_format" ]]; then
   echo "check_format_test..."
   ./tools/code_format/check_format_test_helper.sh --log=WARN
   echo "check_format..."
+  ./tools/code_format/check_shellcheck_format.sh
   ./tools/code_format/check_format.py check
   ./tools/code_format/format_python_tools.sh check
   ./tools/proto_format/proto_format.sh check --test

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -30,5 +30,10 @@ docker run --rm ${ENVOY_DOCKER_OPTIONS} -e HTTP_PROXY=${http_proxy} -e HTTPS_PRO
   -e ENVOY_SRCDIR -e ENVOY_BUILD_TARGET -e SYSTEM_PULLREQUEST_TARGETBRANCH -e SYSTEM_PULLREQUEST_PULLREQUESTNUMBER \
   -e GCS_ARTIFACT_BUCKET -e BUILD_SOURCEBRANCHNAME -e BAZELISK_BASE_URL -e ENVOY_BUILD_ARCH -e SLACK_TOKEN -e BUILD_URI\
   -e REPO_URI -v "$PWD":/source --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${ENVOY_BUILD_IMAGE}" \
-  /bin/bash -lc "groupadd --gid $(id -g) -f envoygroup && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home \
-  --home-dir /build envoybuild && usermod -a -G pcap envoybuild && sudo -EHs -u envoybuild bash -c \"cd /source && $*\""
+  /bin/bash -lc "\
+  	    apt-get update \
+	    && apt-get install --no-install-recommends -qq -y shellcheck \
+	    && groupadd --gid $(id -g) -f envoygroup \
+	    && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /build envoybuild \
+	    && usermod -a -G pcap envoybuild \
+	    && sudo -EHs -u envoybuild bash -c \"cd /source && $*\""

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -31,9 +31,7 @@ docker run --rm ${ENVOY_DOCKER_OPTIONS} -e HTTP_PROXY=${http_proxy} -e HTTPS_PRO
   -e GCS_ARTIFACT_BUCKET -e BUILD_SOURCEBRANCHNAME -e BAZELISK_BASE_URL -e ENVOY_BUILD_ARCH -e SLACK_TOKEN -e BUILD_URI\
   -e REPO_URI -v "$PWD":/source --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN "${ENVOY_BUILD_IMAGE}" \
   /bin/bash -lc "\
-  	    apt-get update \
-	    && apt-get install --no-install-recommends -qq -y shellcheck \
-	    && groupadd --gid $(id -g) -f envoygroup \
+	    groupadd --gid $(id -g) -f envoygroup \
 	    && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /build envoybuild \
 	    && usermod -a -G pcap envoybuild \
 	    && sudo -EHs -u envoybuild bash -c \"cd /source && $*\""

--- a/configs/configgen.sh
+++ b/configs/configgen.sh
@@ -11,7 +11,7 @@ mkdir -p "$OUT_DIR/certs"
 mkdir -p "$OUT_DIR/lib"
 "$CONFIGGEN" "$OUT_DIR"
 
-for FILE in $*; do
+for FILE in "$@"; do
   case "$FILE" in
   *.pem)
     cp "$FILE" "$OUT_DIR/certs"
@@ -21,7 +21,7 @@ for FILE in $*; do
     ;;
   *)
 
-    FILENAME="$(echo $FILE | sed -e 's/.*examples\///g')"
+    FILENAME="$(echo "$FILE" | sed -e 's/.*examples\///g')"
     # Configuration filenames may conflict. To avoid this we use the full path.
     cp -v "$FILE" "$OUT_DIR/${FILENAME//\//_}"
     ;;
@@ -29,4 +29,4 @@ for FILE in $*; do
 done
 
 # tar is having issues with -C for some reason so just cd into OUT_DIR.
-(cd "$OUT_DIR"; tar -hcvf example_configs.tar *.yaml certs/*.pem lib/*.lua)
+(cd "$OUT_DIR"; tar -hcvf example_configs.tar -- *.yaml certs/*.pem lib/*.lua)

--- a/configs/google-vrp/launch_envoy.sh
+++ b/configs/google-vrp/launch_envoy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cd /etc/envoy
+cd /etc/envoy || exit
 envoy "$@"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# set SPHINX_SKIP_CONFIG_VALIDATION environment variable to true to skip 
+# set SPHINX_SKIP_CONFIG_VALIDATION environment variable to true to skip
 # validation of configuration examples
 
 . tools/shell_utils.sh
@@ -35,7 +35,7 @@ else
 fi
 
 SCRIPT_DIR="$(dirname "$0")"
-SRC_DIR="$(dirname "$dir")"
+SRC_DIR="$(dirname "$SCRIPT_DIR")"
 API_DIR="${SRC_DIR}"/api
 CONFIGS_DIR="${SRC_DIR}"/configs
 BUILD_DIR=build_docs
@@ -55,11 +55,16 @@ pip3 install -r "${SCRIPT_DIR}"/requirements.txt
 # files still.
 rm -rf bazel-bin/external/envoy_api_canonical
 
-export EXTENSION_DB_PATH="$(realpath "${BUILD_DIR}/extension_db.json")"
+EXTENSION_DB_PATH="$(realpath "${BUILD_DIR}/extension_db.json")"
+export EXTENSION_DB_PATH
 
 # This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
-BAZEL_BUILD_OPTIONS+=" --remote_download_outputs=all --strategy=protodoc=sandboxed,local
-    --action_env=ENVOY_BLOB_SHA --action_env=EXTENSION_DB_PATH"
+IFS=" " read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
+BAZEL_BUILD_OPTIONS+=(
+    "--remote_download_outputs=all"
+    "--strategy=protodoc=sandboxed,local"
+    "--action_env=ENVOY_BLOB_SHA"
+    "--action_env=EXTENSION_DB_PATH")
 
 # Generate extension database. This maps from extension name to extension
 # metadata, based on the envoy_cc_extension() Bazel target attributes.
@@ -74,27 +79,29 @@ mkdir -p "${GENERATED_RST_DIR}"/intro/arch_overview/security
 ./docs/generate_external_dep_rst.py "${GENERATED_RST_DIR}"/intro/arch_overview/security
 
 function generate_api_rst() {
+  local proto_target
   declare -r API_VERSION=$1
   echo "Generating ${API_VERSION} API RST..."
 
   # Generate the extensions docs
-  bazel build ${BAZEL_BUILD_OPTIONS} @envoy_api_canonical//:"${API_VERSION}"_protos --aspects \
+  bazel build "${BAZEL_BUILD_OPTIONS[@]}" @envoy_api_canonical//:"${API_VERSION}"_protos --aspects \
     tools/protodoc/protodoc.bzl%protodoc_aspect --output_groups=rst
 
   # Fill in boiler plate for extensions that have google.protobuf.Empty as their
   # config.
-  bazel run ${BAZEL_BUILD_OPTIONS} //tools/protodoc:generate_empty \
-    "${PWD}"/docs/empty_extensions.json "${PWD}/${GENERATED_RST_DIR}"/api-"${API_VERSION}"/config
+  bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/protodoc:generate_empty \
+    "${PWD}"/docs/empty_extensions.json "${PWD}/${GENERATED_RST_DIR}/api-${API_VERSION}"/config
 
   # We do ** matching below to deal with Bazel cache blah (source proto artifacts
   # are nested inside source package targets).
   shopt -s globstar
 
   # Find all source protos.
-  declare -r PROTO_TARGET=$(bazel query "labels(srcs, labels(deps, @envoy_api_canonical//:${API_VERSION}_protos))")
+  proto_target=$(bazel query "labels(srcs, labels(deps, @envoy_api_canonical//:${API_VERSION}_protos))")
+  declare -r proto_target
 
   # Only copy in the protos we care about and know how to deal with in protodoc.
-  for p in ${PROTO_TARGET}
+  for p in ${proto_target}
   do
     declare PROTO_FILE_WITHOUT_PREFIX="${p#@envoy_api_canonical//}"
     declare PROTO_FILE_CANONICAL="${PROTO_FILE_WITHOUT_PREFIX/://}"
@@ -130,11 +137,11 @@ cp -f "${API_DIR}"/xds_protocol.rst "${GENERATED_RST_DIR}/api-docs/xds_protocol.
 mkdir -p "${GENERATED_RST_DIR}"/configuration/best_practices
 cp -f "${CONFIGS_DIR}"/google-vrp/envoy-edge.yaml "${GENERATED_RST_DIR}"/configuration/best_practices
 
-rsync -rav  $API_DIR/diagrams "${GENERATED_RST_DIR}/api-docs"
+rsync -rav  "${API_DIR}/diagrams" "${GENERATED_RST_DIR}/api-docs"
 
 rsync -av "${SCRIPT_DIR}"/root/ "${SCRIPT_DIR}"/conf.py "${SCRIPT_DIR}"/_ext "${GENERATED_RST_DIR}"
 
-# To speed up validate_fragment invocations in validating_code_block 
-bazel build ${BAZEL_BUILD_OPTIONS} //tools/config_validation:validate_fragment
+# To speed up validate_fragment invocations in validating_code_block
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/config_validation:validate_fragment
 
 sphinx-build -W --keep-going -b html "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -11,7 +11,7 @@ set -e
 
 DOCS_DIR=generated/docs
 CHECKOUT_DIR=../envoy-docs
-BUILD_SHA=`git rev-parse HEAD`
+BUILD_SHA=$(git rev-parse HEAD)
 
 if [ -n "$CIRCLE_TAG" ]
 then

--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+
+EXCLUDED_SHELLFILES=${EXCLUDED_SHELLFILES:-"^tools|^test|^examples|^ci|^bin|^source|^bazel"}
+
+
+find_shell_files () {
+    local shellfiles
+    shellfiles=()
+    shellfiles+=("$(git grep "^#!/bin/bash" | cut -d: -f1)")
+    shellfiles+=("$(git grep "^#!/bin/sh" | cut -d: -f1)")
+    shellfiles+=("$(find . -name "*.sh" | cut -d/ -f2-)")
+    shellfiles=("$(echo "${shellfiles[@]}" | tr ' ' '\n' | sort | uniq)")
+    for file in "${shellfiles[@]}"; do
+	echo "$file"
+    done
+}
+
+run_shellcheck_on () {
+    local file
+    file="$1"
+    echo "Shellcheck: ${file}"
+    shellcheck -x "$file" &> /dev/null || {
+	echo " >>> FAILED: $file"
+	shellcheck -x "$file"
+    }
+}
+
+run_shellchecks () {
+    local all_shellfiles failed failure filtered_shellfiles skipped_count success_count
+    failed=()
+    readarray -t all_shellfiles <<< "$(find_shell_files)"
+    readarray -t filtered_shellfiles <<< "$(find_shell_files | grep -vE "${EXCLUDED_SHELLFILES}")"
+
+    for file in "${filtered_shellfiles[@]}"; do
+	run_shellcheck_on "$file" || {
+	    failed+=("$file")
+	}
+    done
+    if [[ "${#failed[@]}" -ne 0 ]]; then
+	echo -e "\nShellcheck failures:" >&2
+	for failure in "${failed[@]}"; do
+	    echo "$failure" >&2
+	done
+    fi
+    skipped_count=$((${#all_shellfiles[@]} - ${#filtered_shellfiles[@]}))
+    success_count=$((${#filtered_shellfiles[@]} - ${#failed[@]}))
+
+    echo -e "\nShellcheck totals (skipped/failed/success): ${skipped_count}/${#failed[@]}/${success_count}"
+    if [[ "${#failed[@]}" -ne 0 ]]; then
+	return 1
+    fi
+}
+
+run_shellchecks

--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -19,10 +19,7 @@ run_shellcheck_on () {
     local file
     file="$1"
     echo "Shellcheck: ${file}"
-    shellcheck -x "$file" &> /dev/null || {
-	echo " >>> FAILED: $file"
-	shellcheck -x "$file"
-    }
+    shellcheck -f diff -x "$file"
 }
 
 run_shellchecks () {

--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-EXCLUDED_SHELLFILES=${EXCLUDED_SHELLFILES:-"^tools|^test|^examples|^ci|^bin|^source|^bazel"}
+EXCLUDED_SHELLFILES=${EXCLUDED_SHELLFILES:-"^tools|^test|^examples|^ci|^bin|^source|^bazel|^.github"}
 
 
 find_shell_files () {

--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -19,7 +19,8 @@ run_shellcheck_on () {
     local file
     file="$1"
     echo "Shellcheck: ${file}"
-    shellcheck -f diff -x "$file"
+    # TODO: add -f diff when shellcheck version allows (ubuntu > bionic)
+    shellcheck -x "$file"
 }
 
 run_shellchecks () {


### PR DESCRIPTION
Add shellcheck to ci and fix some scripts that fail linting

This PR adds the framework for running shellcheck in ci

Im not sure if where i have hooked it in is the best place, apart from anything shellcheck does not give very reliable fixes - so it does not provide a patch to remedy as other code formatting ci does.

I have fixed some of the low-hanging fruit, but figured that it would probably be a good idea to fix other parts in separate PRs as they touch other parts of the code base

Signed-off-by: Ryan Northey <ryan@synca.io>


Commit Message: Add shellcheck to ci
Additional Description:
Risk Level: low/medium
Testing: 
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Partial fix for #7793 
[Optional Deprecated:]
