### PR TITLE
ASAN Build - Option to skip SSL integration test

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -210,13 +210,16 @@ elif [[ "$CI_TARGET" == "bazel.asan" ]]; then
     bazel_with_collection test ${BAZEL_BUILD_OPTIONS} ${ENVOY_FILTER_EXAMPLE_TESTS}
     popd
   fi
-  # Also validate that integration test traffic tapping (useful when debugging etc.)
-  # works. This requires that we set TAP_PATH. We do this under bazel.asan to
-  # ensure a debug build in CI.
-  echo "Validating integration test traffic tapping..."
-  bazel_with_collection test ${BAZEL_BUILD_OPTIONS} \
-    --run_under=@envoy//bazel/test:verify_tap_test.sh \
-    //test/extensions/transport_sockets/tls/integration:ssl_integration_test
+
+  if [ "${CI_SKIP_INTEGRATION_TEST_TRAFFIC_TAPPING}" != "1" ] ; then
+    # Also validate that integration test traffic tapping (useful when debugging etc.)
+    # works. This requires that we set TAP_PATH. We do this under bazel.asan to
+    # ensure a debug build in CI.
+    echo "Validating integration test traffic tapping..."
+    bazel_with_collection test ${BAZEL_BUILD_OPTIONS} \
+      --run_under=@envoy//bazel/test:verify_tap_test.sh \
+      //test/extensions/transport_sockets/tls/integration:ssl_integration_test
+  fi
   exit 0
 elif [[ "$CI_TARGET" == "bazel.tsan" ]]; then
   setup_clang_toolchain


### PR DESCRIPTION
Commit Message:

> Provide an option to skip the SSL integration test that is run during
the ASAN builds. This keeps the `bazel.asan` build target useful for
custom builds in which envoy does not sit at the root directory (as the
integration test directly targets the root repository).

Additional Description:

Internal builds may make use of the `bazel.asan` target within `do_ci.sh` to test targets that live outside of the envoy repository, making use of the `TEST_TARGETS` parameter (collected from arguments passed into the script). Explicitly testing `//test/extensions/transport_sockets/tls/integration:ssl_integration_test` breaks this workflow.

Risk Level: low
Testing

 + Default behavior covered by existing testing
 + Optional behavior tested manually in internal build

Docs Changes: n/a
Release Notes: n/a
