### PR TITLE
Add dev docs for examples verify.sh

### DIFF
--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -52,7 +52,7 @@ You may wish to grep the responses, or check return codes to ensure the commands
 Likewise, if the documentation asks the user to browse to a page - for example http://localhost:8000 -
 then you should add a test to ensure that the given URL responds as expected.
 
-If an example web page is also expected to make further Javascript `HTTP` requests in order to function, then add
+If an example web page is also expected to make further JavaScript `HTTP` requests in order to function, then add
 tests for requests that mimick this interaction.
 
 A number of utility functions have been added to simplify browser testing.

--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -13,7 +13,7 @@ and stop your sandbox.
 Given a sandbox with a single `docker` composition, adding the following
 to `verify.sh` will test that the sandbox can be started and stopped.
 
-```
+```bash
 #!/bin/bash -e
 
 export NAME=example-sandbox
@@ -33,7 +33,7 @@ often be the same as the directory name.
 There is a utility function `run_log` that can be used to indicate in test logs what
 is being executed and why, for example:
 
-```
+```bash
 run_log "Checking foo.txt was created"
 ls foo.txt
 
@@ -47,35 +47,35 @@ The tests should follow the steps laid out in the documentation.
 
 For example, if the documentation provides a series of `bash` commands to execute, add these in order to `verify.sh`.
 
-You may wish to grep the response, or check the return code to ensure the command responds as expected.
+You may wish to grep the responses, or check return codes to ensure the commands respond as expected.
 
-Likewise, if the documentation asks the user to browse to a page - eg http://localhost:8000 - then you should add a test
-to ensure that the given url responds as expected.
+Likewise, if the documentation asks the user to browse to a page - for example http://localhost:8000 -
+then you should add a test to ensure that the given URL responds as expected.
 
-If an example web page is also expected to make further javascript http requests in order to function, then add
+If an example web page is also expected to make further Javascript `HTTP` requests in order to function, then add
 tests for requests that mimick this interaction.
 
 A number of utility functions have been added to simplify browser testing.
 
 #### Utility functions: `responds_with`
 
-The `responds_with` function can be used to ensure a request to a given url responds with
+The `responds_with` function can be used to ensure a request to a given URL responds with
 expected http content.
 
-It follows the form `responds_with <expected_content> <url> <curl_args>`
+It follows the form `responds_with <expected_content> <url> [<curl_args>]`
 
 For example, a simple `GET` request:
 
-```
+```bash
 responds_with \
     "Hello, world" \
     http://localhost:8000
 ```
 
-This is a more complicated example that uses an `https` `POST` request and sends some
+This is a more complicated example that uses an `HTTPS` `POST` request and sends some
 additional headers:
 
-```
+```bash
 responds_with \
     "Hello, postie" \
     https://localhost:8000/some-endpoint \
@@ -89,7 +89,7 @@ responds_with \
 
 You can check that a request responds with an expected header as follows:
 
-```
+```bash
 responds_with_header \
     "HTTP/1.1 403 Forbidden" \
     "http://localhost:8000/?name=notdown"
@@ -101,7 +101,7 @@ responds_with_header \
 
 You can also check that a request *does not* respond with a given header:
 
-```
+```bash
 responds_without_header \
     "X-Secret: treasure" \
     "http://localhost:8000"
@@ -118,7 +118,7 @@ the steps in your `verify.sh`
 For example, to wait 10 seconds after `docker-compose up -d` has been called, set the
 following:
 
-```
+```bash
 #!/bin/bash -e
 
 export NAME=example-sandbox
@@ -141,7 +141,7 @@ By default `PATHS=.`, but you can change this to a comma-separated list of paths
 For example a sandbox containing `frontend/docker-compose.yml` and `backend/docker-compose.yml`,
 might use a `verify.sh` with:
 
-```
+```bash
 #!/bin/bash -e
 
 export NAME=example-sandbox
@@ -162,7 +162,7 @@ you can use the `bring_up_example` function.
 
 For example:
 
-```
+```bash
 #!/bin/bash -e
 
 export NAME=example-sandbox
@@ -179,8 +179,8 @@ bring_up_example
 # add example tests here...
 ```
 
-If your sandbox has multiple `$PATHS`, `bring_up_example` will bring all
-all of your compositions up.
+If your sandbox has multiple compositions, and uses the `$PATHS` env var described above,
+`bring_up_example` will bring all of your compositions up.
 
 
 ### Additional arguments to `docker-compose up -d`
@@ -191,7 +191,7 @@ env var.
 For example, to scale a composition with a service named `http_service`, you
 should add the following:
 
-```
+```bash
 #!/bin/bash -e
 
 export NAME=example-sandbox
@@ -207,4 +207,4 @@ export UPARGS="--scale http_service=2"
 
 If your example asks the user to run commands inside containers, you can
 mimick this using `docker-compose exec -T`. The `-T` flag is necessary as the
-tests do not have access to a `tty` in the ci pipeline.
+tests do not have access to a `tty` in the CI pipeline.

--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -60,7 +60,7 @@ A number of utility functions have been added to simplify browser testing.
 #### Utility functions: `responds_with`
 
 The `responds_with` function can be used to ensure a request to a given URL responds with
-expected http content.
+expected `HTTP` content.
 
 It follows the form `responds_with <expected_content> <url> [<curl_args>]`
 
@@ -134,11 +134,11 @@ export DELAY=10
 
 For your example to work it may need more than one `docker` composition to be run.
 
-You can set where to find the `docker-compose.yml` files with the `PATHS` argument.
+You can set where to find the `docker-compose.yaml` files with the `PATHS` argument.
 
 By default `PATHS=.`, but you can change this to a comma-separated list of paths.
 
-For example a sandbox containing `frontend/docker-compose.yml` and `backend/docker-compose.yml`,
+For example a sandbox containing `frontend/docker-compose.yaml` and `backend/docker-compose.yaml`,
 might use a `verify.sh` with:
 
 ```bash

--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -2,7 +2,7 @@
 
 ## Add a `verify.sh` test to your sandbox
 
-Sandboxes are tested as part of the continous integration process, which expects
+Sandboxes are tested as part of the continuous integration process, which expects
 each sandbox to have a `verify.sh` script containing tests for the example.
 
 ### Basic layout of the `verify.sh` script


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: Add dev docs for examples verify.sh
Additional Description:
Adds docs for adding example sandboxes

Documentation for #12491  - separated here so as not to complexify that pr any further.

Risk Level: low
Testing:
Docs Changes: yep
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] related to #12491 
[Optional Deprecated:]
