### PR TITLE
docs: fix reference in http ext_authz filter

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_authz_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_authz_filter.rst
@@ -10,7 +10,7 @@ The external authorization filter calls an external gRPC or HTTP service to chec
 HTTP request is authorized or not.
 If the request is deemed unauthorized, then the request will be denied normally with 403 (Forbidden) response.
 Note that sending additional custom metadata from the authorization service to the upstream, to the downstream or to the authorization service is
-also possible. This is explained in more details at :ref:`HTTP filter <envoy_v3_api_msg_extensions.filters.network.ext_authz.v3.ExtAuthz>`.
+also possible. This is explained in more details at :ref:`HTTP filter <envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.ExtAuthz>`.
 
 The content of the requests that are passed to an authorization service is specified by
 :ref:`CheckRequest <envoy_v3_api_msg_service.auth.v3.CheckRequest>`.
@@ -19,7 +19,7 @@ The content of the requests that are passed to an authorization service is speci
 
 The HTTP filter, using a gRPC/HTTP service, can be configured as follows. You can see all the
 configuration options at
-:ref:`HTTP filter <envoy_v3_api_msg_extensions.filters.network.ext_authz.v3.ExtAuthz>`.
+:ref:`HTTP filter <envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.ExtAuthz>`.
 
 Configuration Examples
 -----------------------------


### PR DESCRIPTION
Commit Message: docs: fix reference in http ext_authz filter
Additional Description: The http ext_authz filter overview page should reference the configuration reference for the http ext_authz filter, not the network ext_authz filter.
Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a

Signed-off-by: Martin Matusiak <numerodix@gmail.com>