### PR TITLE
build: fix shadowed definition of exclude_testdata function in run_clang_tidy.sh

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -41,12 +41,12 @@ function exclude_macos_impl() {
 }
 
 # Do not run incremental clang-tidy on check_format testdata files.
-function exclude_testdata() {
+function exclude_check_format_testdata() {
   grep -v tools/testdata/check_format/
 }
 
 # Do not run clang-tidy on envoy_headersplit testdata files.
-function exclude_testdata() {
+function exclude_headersplit_testdata() {
   grep -v tools/envoy_headersplit/
 }
 
@@ -56,7 +56,7 @@ function exclude_third_party() {
 }
 
 function filter_excludes() {
-  exclude_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party
+  exclude_check_format_testdata | exclude_headersplit_testdata | exclude_win32_impl | exclude_macos_impl | exclude_third_party
 }
 
 function run_clang_tidy() {


### PR DESCRIPTION
Commit Message:
build: fix shadowed definition of exclude_testdata function in run_clang_tidy.sh
Additional Description:
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a