### PR TITLE
macos/homebrew: bazelisk is in homebrew-core now

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -13,7 +13,7 @@ sudo chmod +x /usr/local/bin/bazel
 
 On macOS, run the following command:
 ```
-brew install bazelbuild/tap/bazelisk
+brew install bazelisk
 ```
 
 On Windows, run the following commands:

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -39,11 +39,10 @@ fi
 
 # Required as bazel and a foreign bazelisk are installed in the latest macos vm image, we have
 # to unlink/overwrite them to install bazelisk
-echo "Installing bazelbuild/tap/bazelisk"
-brew tap bazelbuild/tap
-brew reinstall --force bazelbuild/tap/bazelisk
-if ! brew link --overwrite bazelbuild/tap/bazelisk; then
-    echo "Failed to install and link bazelbuild/tap/bazelisk"
+echo "Installing bazelisk"
+brew reinstall --force bazelisk
+if ! brew link --overwrite bazelisk; then
+    echo "Failed to install and link bazelisk"
     exit 1
 fi
 

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -46,4 +46,6 @@ if ! brew link --overwrite bazelisk; then
     exit 1
 fi
 
+bazel version
+
 pip3 install slackclient


### PR DESCRIPTION
See https://formulae.brew.sh/formula/bazelisk and
https://github.com/bazelbuild/homebrew-tap/pull/98

----

This should have been a trivial README change. I've also changed the other occurance of `bazelbuild/tap/bazelisk`, so let's see what CI thinks about that.