### PR TITLE
github: tune issue template config.yml.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: {Crash,security} bugs
-    url: mailto:envoy-security@googlegroups.com
-    about: Please file any crash or security bug with envoy-security@googlegroups.com.
+  - name: "{Crash,security} bugs"
+    url: https://github.com/envoyproxy/envoy/security/policy
+    about: "Please file any crash or security bug with envoy-security@googlegroups.com."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+# Security Reporting Process
+
+Please report any security issue or Envoy crash report to
+envoy-security@googlegroups.com where the issue will be triaged appropriately.
+Thank you in advance for helping to keep Envoy secure.
+
 # Security Release Process
 
 Envoy is a large growing community of volunteers, users, and vendors. The Envoy community has


### PR DESCRIPTION
I don't think it liked the mailto:, it's still possible to open blank issues and the contact info
isn't appearing in the template selector. Here's a slightly different approach where we use the
security policy instead.

Signed-off-by: Harvey Tuch <htuch@google.com>