### PR TITLE
Windows: Fix ext authz integration test flake

### DIFF
--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -629,7 +629,7 @@ TEST_P(ExtAuthzLocalReplyIntegrationTest, DeniedHeaderTest) {
     server_uri:
       uri: "ext_authz:9000"
       cluster: "ext_authz"
-      timeout: 0.25s
+      timeout: 300s
   )EOF";
     TestUtility::loadFromYaml(ext_authz_config, proto_config);
 


### PR DESCRIPTION
Commit Message: Windows: Fix ext authz integration test flake
Additional Description: Bump timeout to ext authz service to 300s
Risk Level: Low
Testing: Modifies integration test, checked on Windows
Docs Changes: N/A
Release Notes: N/A
Fixes https://github.com/envoyproxy/envoy/issues/12895
