### PR TITLE
github: final issue filing tweak.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "{Crash,security} bugs"
+  - name: "Crash bug"
     url: https://github.com/envoyproxy/envoy/security/policy
-    about: "Please file any crash or security bug with envoy-security@googlegroups.com."
+    about: "Please file any crash bug with envoy-security@googlegroups.com."


### PR DESCRIPTION
Avoid redundancy between the extra crash bug entry and GitHub's auto-populated "Report a security
vulnerability" option.

Signed-off-by: Harvey Tuch <htuch@google.com>