### PR TITLE
docs: dynamic forward proxy is no longer alpha.

### DIFF
--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -3,10 +3,6 @@
 Dynamic forward proxy
 =====================
 
-.. attention::
-
-  HTTP dynamic forward proxy support should be considered alpha and not production ready.
-
 * HTTP dynamic forward proxy :ref:`architecture overview <arch_overview_http_dynamic_forward_proxy>`
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig>`
 * This filter should be configured with the name *envoy.filters.http.dynamic_forward_proxy*

--- a/docs/root/intro/arch_overview/http/http_proxy.rst
+++ b/docs/root/intro/arch_overview/http/http_proxy.rst
@@ -3,10 +3,6 @@
 HTTP dynamic forward proxy
 ==========================
 
-.. attention::
-
-  HTTP dynamic forward proxy support should be considered alpha and not production ready.
-
 Through the combination of both an :ref:`HTTP filter <config_http_filters_dynamic_forward_proxy>` and
 :ref:`custom cluster <envoy_v3_api_msg_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig>`,
 Envoy supports HTTP dynamic forward proxy. This means that Envoy can perform the role of an HTTP


### PR DESCRIPTION
Signed-off-by: Harvey Tuch <htuch@google.com>
