### PR TITLE
tls: replace getX509ExtensionValue

### DIFF
--- a/include/envoy/ssl/connection.h
+++ b/include/envoy/ssl/connection.h
@@ -137,17 +137,6 @@ public:
    *         connection.
    **/
   virtual const std::string& tlsVersion() const PURE;
-
-  /**
-   * Retrieves the contents of the ``ASN.1`` object stored as an X.509 extension from the peer cert,
-   * if a peer cert exists and it contains the specified extension.
-   *
-   * Note: This is used out of tree, check with @snowp before removing.
-   * @param extension_name name of extension to look up.
-   * @return absl::optional<std::string> the raw octets of the extension ``ASN.1`` object, if it
-   * exists.
-   */
-  virtual absl::optional<std::string> x509Extension(absl::string_view extension_name) const PURE;
 };
 
 using ConnectionInfoConstSharedPtr = std::shared_ptr<const ConnectionInfo>;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -506,15 +506,6 @@ const std::string& SslHandshakerImpl::tlsVersion() const {
   return cached_tls_version_;
 }
 
-absl::optional<std::string>
-SslHandshakerImpl::x509Extension(absl::string_view extension_name) const {
-  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl()));
-  if (!cert) {
-    return absl::nullopt;
-  }
-  return Utility::getX509ExtensionValue(*cert, extension_name);
-}
-
 Network::PostIoAction SslHandshakerImpl::doHandshake() {
   ASSERT(state_ != Ssl::SocketState::HandshakeComplete && state_ != Ssl::SocketState::ShutdownSent);
   int rc = SSL_do_handshake(ssl());

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -78,7 +78,6 @@ public:
   uint16_t ciphersuiteId() const override;
   std::string ciphersuiteString() const override;
   const std::string& tlsVersion() const override;
-  absl::optional<std::string> x509Extension(absl::string_view extension_name) const override;
 
   // Ssl::Handshaker
   Network::PostIoAction doHandshake() override;

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -4,6 +4,7 @@
 #include "common/network/address_impl.h"
 
 #include "absl/strings/str_join.h"
+#include "openssl/x509v3.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -152,38 +153,35 @@ int32_t Utility::getDaysUntilExpiration(const X509* cert, TimeSource& time_sourc
   return 0;
 }
 
-absl::optional<std::string> Utility::getX509ExtensionValue(const X509& cert,
-                                                           absl::string_view extension_name) {
-  X509_EXTENSIONS* extensions(X509_get0_extensions(&cert));
-
-  if (extensions == nullptr) {
+absl::optional<std::string>
+Utility::getCertificateExtensionValue(X509& cert, absl::string_view extension_name) {
+  ASN1_OBJECT* oid = OBJ_txt2obj(std::string(extension_name).c_str(), 1 /* don't search names */);
+  if (oid == nullptr) {
     return absl::nullopt;
   }
 
-  const size_t extension_count = sk_X509_EXTENSION_num(extensions);
-
-  for (size_t i = 0; i < extension_count; ++i) {
-    X509_EXTENSION* extension = sk_X509_EXTENSION_value(extensions, i);
-
-    ASN1_OBJECT* extension_object = X509_EXTENSION_get_object(extension);
-    const size_t size = OBJ_obj2txt(nullptr, 0, extension_object, 0);
-    std::vector<char> buffer;
-    // +1 to allow for NULL byte.
-    buffer.resize(size + 1);
-    OBJ_obj2txt(buffer.data(), buffer.size(), extension_object, 0);
-
-    if (absl::string_view(buffer.data(), size) == extension_name) {
-      ASN1_OCTET_STRING* octet_string = X509_EXTENSION_get_data(extension);
-      const unsigned char* octet_string_data = octet_string->data;
-      long xlen;
-      int tag, xclass;
-      ASN1_get_object(&octet_string_data, &xlen, &tag, &xclass, octet_string->length);
-
-      return std::string(reinterpret_cast<const char*>(octet_string_data), xlen);
-    }
+  int pos = X509_get_ext_by_OBJ(&cert, oid, -1);
+  ASN1_OBJECT_free(oid);
+  if (pos < 0) {
+    return absl::nullopt;
   }
 
-  return absl::nullopt;
+  X509_EXTENSION* extension = X509_get_ext(&cert, pos);
+  if (extension == nullptr) {
+    return absl::nullopt;
+  }
+
+  const ASN1_OCTET_STRING* octet_string = X509_EXTENSION_get_data(extension);
+  if (octet_string == nullptr) {
+    return absl::nullopt;
+  }
+
+  // Return the entire DER-encoded value for this extension. Correct decoding depends on
+  // knowledge of the expected structure of the extension's value.
+  const unsigned char* octet_string_data = ASN1_STRING_get0_data(octet_string);
+  const int octet_string_length = ASN1_STRING_length(octet_string);
+
+  return std::string(reinterpret_cast<const char*>(octet_string_data), octet_string_length);
 }
 
 SystemTime Utility::getValidFrom(const X509& cert) {

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -153,22 +153,22 @@ int32_t Utility::getDaysUntilExpiration(const X509* cert, TimeSource& time_sourc
   return 0;
 }
 
-absl::optional<std::string>
-Utility::getCertificateExtensionValue(X509& cert, absl::string_view extension_name) {
+absl::string_view Utility::getCertificateExtensionValue(X509& cert,
+                                                        absl::string_view extension_name) {
   bssl::UniquePtr<ASN1_OBJECT> oid(
       OBJ_txt2obj(std::string(extension_name).c_str(), 1 /* don't search names */));
   if (oid == nullptr) {
-    return absl::nullopt;
+    return {};
   }
 
   int pos = X509_get_ext_by_OBJ(&cert, oid.get(), -1);
   if (pos < 0) {
-    return absl::nullopt;
+    return {};
   }
 
   X509_EXTENSION* extension = X509_get_ext(&cert, pos);
   if (extension == nullptr) {
-    return absl::nullopt;
+    return {};
   }
 
   const ASN1_OCTET_STRING* octet_string = X509_EXTENSION_get_data(extension);
@@ -179,7 +179,8 @@ Utility::getCertificateExtensionValue(X509& cert, absl::string_view extension_na
   const unsigned char* octet_string_data = ASN1_STRING_get0_data(octet_string);
   const int octet_string_length = ASN1_STRING_length(octet_string);
 
-  return std::string(reinterpret_cast<const char*>(octet_string_data), octet_string_length);
+  return {reinterpret_cast<const char*>(octet_string_data),
+          static_cast<absl::string_view::size_type>(octet_string_length)};
 }
 
 SystemTime Utility::getValidFrom(const X509& cert) {

--- a/source/extensions/transport_sockets/tls/utility.h
+++ b/source/extensions/transport_sockets/tls/utility.h
@@ -55,11 +55,11 @@ std::string getSubjectFromCertificate(X509& cert);
 /**
  * Retrieves the value of a specific X509 extension from the cert, if present.
  * @param cert the certificate.
- * @param extension_name the name of the extension to extract.
- * @return absl::optional<std::string> the value of the extension field, if present.
+ * @param extension_name the name of the extension to extract in dotted number format
+ * @return absl::optional<std::string> the DER-encoded value of the extension field, if present.
  */
-absl::optional<std::string> getX509ExtensionValue(const X509& cert,
-                                                  absl::string_view extension_name);
+absl::optional<std::string> getCertificateExtensionValue(X509& cert,
+                                                         absl::string_view extension_name);
 
 /**
  * Returns the days until this certificate is valid.

--- a/source/extensions/transport_sockets/tls/utility.h
+++ b/source/extensions/transport_sockets/tls/utility.h
@@ -56,10 +56,9 @@ std::string getSubjectFromCertificate(X509& cert);
  * Retrieves the value of a specific X509 extension from the cert, if present.
  * @param cert the certificate.
  * @param extension_name the name of the extension to extract in dotted number format
- * @return absl::optional<std::string> the DER-encoded value of the extension field, if present.
+ * @return absl::string_view the DER-encoded value of the extension field or empty if not present.
  */
-absl::optional<std::string> getCertificateExtensionValue(X509& cert,
-                                                         absl::string_view extension_name);
+absl::string_view getCertificateExtensionValue(X509& cert, absl::string_view extension_name);
 
 /**
  * Returns the days until this certificate is valid.

--- a/test/extensions/transport_sockets/tls/utility_test.cc
+++ b/test/extensions/transport_sockets/tls/utility_test.cc
@@ -132,10 +132,10 @@ TEST(UtilityTest, TestGetCertificationExtensionValue) {
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/extensions_cert.pem"));
   EXPECT_EQ("\xc\x9Something", Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.8"));
   EXPECT_EQ("\x30\x3\x1\x1\xFF", Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.9"));
-  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.10"));
-  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, "1.2.3.4"));
-  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, ""));
-  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, "foo"));
+  EXPECT_EQ("", Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.10"));
+  EXPECT_EQ("", Utility::getCertificateExtensionValue(*cert, "1.2.3.4"));
+  EXPECT_EQ("", Utility::getCertificateExtensionValue(*cert, ""));
+  EXPECT_EQ("", Utility::getCertificateExtensionValue(*cert, "foo"));
 }
 
 } // namespace

--- a/test/extensions/transport_sockets/tls/utility_test.cc
+++ b/test/extensions/transport_sockets/tls/utility_test.cc
@@ -127,6 +127,17 @@ TEST(UtilityTest, GetLastCryptoError) {
   EXPECT_FALSE(Utility::getLastCryptoError().has_value());
 }
 
+TEST(UtilityTest, TestGetCertificationExtensionValue) {
+  bssl::UniquePtr<X509> cert = readCertFromFile(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/extensions_cert.pem"));
+  EXPECT_EQ("\xc\x9Something", Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.8"));
+  EXPECT_EQ("\x30\x3\x1\x1\xFF", Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.9"));
+  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, "1.2.3.4.5.6.7.10"));
+  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, "1.2.3.4"));
+  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, ""));
+  EXPECT_EQ(absl::nullopt, Utility::getCertificateExtensionValue(*cert, "foo"));
+}
+
 } // namespace
 } // namespace Tls
 } // namespace TransportSockets

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -58,7 +58,6 @@ public:
   MOCK_METHOD(uint16_t, ciphersuiteId, (), (const));
   MOCK_METHOD(std::string, ciphersuiteString, (), (const));
   MOCK_METHOD(const std::string&, tlsVersion, (), (const));
-  MOCK_METHOD(absl::optional<std::string>, x509Extension, (absl::string_view), (const));
 };
 
 class MockClientContext : public ClientContext {


### PR DESCRIPTION
The existing access for X509 extension values is unused in Envoy, but
will be used in the near future for detection of certificates with the
OCSP must-staple extension (see #12685). The existing implementation,
however, assumes that all extension values can be safely decoded with
ASN1_get_object, which is incorrect. Here we replace getX509ExtensionValue
with a corrected implementation that produces different output (that is,
the entire value octet string versus a partially decoded value). We
remove (unused) access to extensions from Envoy::Ssl::Connection and
rename the utility method to insure that downstream projects do not
unintentionally consume the altered return value.

Risk Level: low, not used in Envoy
Testing: moved existing unit tests
Docs Changes: n/a
Release Notes: n/a

Signed-off-by: Stephan Zuercher <zuercher@gmail.com>
