### PR TITLE
test: deflaking unexpected disconnects permanently

### DIFF
--- a/test/extensions/clusters/aggregate/cluster_integration_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_integration_test.cc
@@ -132,10 +132,8 @@ public:
 
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
                                                   timeSystem(), enable_half_close_));
-    fake_upstreams_[FirstUpstreamIndex]->set_allow_unexpected_disconnects(false);
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
                                                   timeSystem(), enable_half_close_));
-    fake_upstreams_[SecondUpstreamIndex]->set_allow_unexpected_disconnects(false);
     cluster1_ = ConfigHelper::buildStaticCluster(
         FirstClusterName, fake_upstreams_[FirstUpstreamIndex]->localAddress()->ip()->port(),
         Network::Test::getLoopbackAddressString(GetParam()));
@@ -166,7 +164,6 @@ public:
     result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
     RELEASE_ASSERT(result, result.message());
     xds_stream_->startGrpcStream();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   }
 
   envoy::config::cluster::v3::Cluster cluster1_;

--- a/test/extensions/clusters/redis/redis_cluster_integration_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_integration_test.cc
@@ -262,8 +262,6 @@ protected:
                              const std::string& auth_password = "") {
     std::string cluster_slot_request = makeBulkStringArray({"CLUSTER", "SLOTS"});
 
-    fake_upstreams_[stream_index]->set_allow_unexpected_disconnects(true);
-
     std::string proxied_cluster_slot_request;
 
     FakeRawConnectionPtr fake_upstream_connection_;

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -310,9 +310,6 @@ TEST_P(ProxyFilterIntegrationTest, UpstreamTlsInvalidSAN) {
   upstream_tls_ = true;
   upstream_cert_name_ = "upstream";
   setup();
-  // The upstream connection is going to fail handshake so make sure it can read and we expect
-  // it to disconnect.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   fake_upstreams_[0]->setReadDisableOnNewConnection(false);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -369,7 +369,6 @@ public:
     HttpIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(
         new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   }
 
   // By default, HTTP Service uses case sensitive string matcher.
@@ -591,7 +590,6 @@ public:
     HttpIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(
         new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   }
 
   void cleanup() {

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -40,7 +40,6 @@ public:
   void createUpstreams() override {
     fake_upstreams_.emplace_back(new FakeUpstream(
         createUpstreamSslContext(), 0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   }
 
   Network::TransportSocketFactoryPtr createUpstreamSslContext() {

--- a/test/extensions/filters/http/squash/squash_filter_integration_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_integration_test.cc
@@ -73,7 +73,6 @@ public:
     HttpIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(
         new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
-    fake_upstreams_.back()->set_allow_unexpected_disconnects(true);
   }
 
   /**

--- a/test/extensions/filters/network/thrift_proxy/integration_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/integration_test.cc
@@ -259,7 +259,6 @@ TEST_P(ThriftConnManagerIntegrationTest, EarlyClose) {
       request_bytes_.toString().substr(0, request_bytes_.length() - 5);
 
   FakeUpstream* expected_upstream = getExpectedUpstream(false);
-  expected_upstream->set_allow_unexpected_disconnects(true);
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   ASSERT_TRUE(tcp_client->write(partial_request));
@@ -377,7 +376,6 @@ TEST_P(ThriftConnManagerIntegrationTest, OnewayEarlyClosePartialRequest) {
       request_bytes_.toString().substr(0, request_bytes_.length() - 1);
 
   FakeUpstream* expected_upstream = getExpectedUpstream(true);
-  expected_upstream->set_allow_unexpected_disconnects(true);
 
   IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
   ASSERT_TRUE(tcp_client->write(partial_request));

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -325,8 +325,6 @@ TEST_P(QuicHttpIntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
 
   initialize();
 
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder =
@@ -482,7 +480,6 @@ TEST_P(QuicHttpIntegrationTest, ConnectionMigration) {
 
 TEST_P(QuicHttpIntegrationTest, StopAcceptingConnectionsWhenOverloaded) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Put envoy in overloaded state and check that it doesn't accept the new client connection.
   updateResource(file_updater_1_, 0.9);
@@ -522,7 +519,6 @@ TEST_P(QuicHttpIntegrationTest, StopAcceptingConnectionsWhenOverloaded) {
 
 TEST_P(QuicHttpIntegrationTest, NoNewStreamsWhenOverloaded) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   updateResource(file_updater_1_, 0.7);
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -28,7 +28,6 @@ public:
     HttpIntegrationTest::createUpstreams();
     fake_upstreams_.emplace_back(
         new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
-    fake_upstreams_.back()->set_allow_unexpected_disconnects(true);
   }
 
   void initialize() override {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -170,33 +170,4 @@ going on. If your failure mode isn't documented below, ideally some combination
 of cerr << logging and trace logs will help you sort out what is going on (and
 please add to this document as you figure it out!)
 
-## Unexpected disconnects
-
-As commented in `HttpIntegrationTest::cleanupUpstreamAndDownstream()`, the
-tear-down sequence between upstream, Envoy, and client is somewhat sensitive to
-ordering. If a given unit test does not use the provided member variables, for
-example opens multiple client or upstream connections, the test author should be
-aware of test best practices for clean-up which boil down to "Clean up upstream
-first".
-
-Upstream connections run in their own threads, so if the client disconnects with
-open streams, there's a race where Envoy detects the disconnect, and kills the
-corresponding upstream stream, which is indistinguishable from an unexpected
-disconnect and triggers test failure. Because the client is run from the main
-thread, if upstream is closed first, the client will not detect the inverse
-close, so no test failure will occur.
-
-## Unparented upstream connections
-
-The most common failure mode here is if the test adds additional fake
-upstreams for *DS connections (ADS, EDS etc) which are not properly shut down
-(for a very sensitive test framework)
-
-The failure mode here is that during test teardown one closes the DS connection
-and then shuts down Envoy. Unfortunately as Envoy is running in its own thread,
-it will try to re-establish the *DS connection, sometimes creating a connection
-which is then "unparented". The solution here is to explicitly allow Envoy
-reconnects before closing the connection, using
-
-`my_ds_upstream_->set_allow_unexpected_disconnects(true);`
 

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -94,7 +94,7 @@ AutonomousUpstream::~AutonomousUpstream() {
 
 bool AutonomousUpstream::createNetworkFilterChain(Network::Connection& connection,
                                                   const std::vector<Network::FilterFactoryCb>&) {
-  shared_connections_.emplace_back(new SharedConnectionWrapper(connection, true));
+  shared_connections_.emplace_back(new SharedConnectionWrapper(connection));
   AutonomousHttpConnectionPtr http_connection(
       new AutonomousHttpConnection(*this, *shared_connections_.back(), http_type_, *this));
   testing::AssertionResult result = http_connection->initialize();

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -386,8 +386,6 @@ void BaseIntegrationTest::createXdsUpstream() {
         std::move(context), 0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
   }
   xds_upstream_ = fake_upstreams_[1].get();
-  // Don't ASSERT fail if an xDS reconnect ends up unparented.
-  xds_upstream_->set_allow_unexpected_disconnects(true);
 }
 
 void BaseIntegrationTest::createXdsConnection() {

--- a/test/integration/cds_integration_test.cc
+++ b/test/integration/cds_integration_test.cc
@@ -73,10 +73,8 @@ public:
     // cluster in the bootstrap config - which we don't want since we're testing dynamic CDS!
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
                                                   timeSystem(), enable_half_close_));
-    fake_upstreams_[UpstreamIndex1]->set_allow_unexpected_disconnects(false);
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
                                                   timeSystem(), enable_half_close_));
-    fake_upstreams_[UpstreamIndex2]->set_allow_unexpected_disconnects(false);
     cluster1_ = ConfigHelper::buildStaticCluster(
         ClusterName1, fake_upstreams_[UpstreamIndex1]->localAddress()->ip()->port(),
         Network::Test::getLoopbackAddressString(ipVersion()));
@@ -122,7 +120,6 @@ public:
     RELEASE_ASSERT(result, result.message());
     xds_stream_->startGrpcStream();
     verifyGrpcServiceMethod();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   }
 
   envoy::config::cluster::v3::Cluster cluster1_;

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -79,7 +79,6 @@ TEST_P(DrainCloseIntegrationTest, AdminGracefulDrain) {
   drain_strategy_ = Server::DrainStrategy::Immediate;
   drain_time_ = std::chrono::seconds(999);
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   uint32_t http_port = lookupPort("http");
   codec_client_ = makeHttpConnection(http_port);
 
@@ -134,7 +133,6 @@ TEST_P(DrainCloseIntegrationTest, RepeatedAdminGracefulDrain) {
   // behaviour isn't conflated with whether the drain sequence has started.
   drain_time_ = std::chrono::seconds(999);
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   uint32_t http_port = lookupPort("http");
   codec_client_ = makeHttpConnection(http_port);
 

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -147,11 +147,6 @@ TEST_P(EdsIntegrationTest, Http2UpdatePriorities) {
   codec_client_type_ = envoy::type::v3::HTTP2;
   initializeTest(true);
 
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-  fake_upstreams_[1]->set_allow_unexpected_disconnects(true);
-  fake_upstreams_[2]->set_allow_unexpected_disconnects(true);
-  fake_upstreams_[3]->set_allow_unexpected_disconnects(true);
-
   setEndpointsInPriorities(2, 2);
 
   setEndpointsInPriorities(4, 0);
@@ -164,7 +159,6 @@ TEST_P(EdsIntegrationTest, Http2UpdatePriorities) {
 TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
   codec_client_type_ = envoy::type::v3::HTTP2;
   initializeTest(true);
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   setEndpoints(1, 0, 0, false);
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
   EXPECT_EQ(0, test_server_->gauge("cluster.cluster_0.membership_healthy")->value());
@@ -214,7 +208,6 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
 // then fails health checking is removed.
 TEST_P(EdsIntegrationTest, RemoveAfterHcFail) {
   initializeTest(true);
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   setEndpoints(1, 0, 0, false);
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
   EXPECT_EQ(0, test_server_->gauge("cluster.cluster_0.membership_healthy")->value());
@@ -244,7 +237,6 @@ TEST_P(EdsIntegrationTest, EndpointWarmingSuccessfulHc) {
 
   // Endpoints are initially excluded.
   initializeTest(true);
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   setEndpoints(1, 0, 0, false);
 
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
@@ -267,7 +259,6 @@ TEST_P(EdsIntegrationTest, EndpointWarmingFailedHc) {
 
   // Endpoints are initially excluded.
   initializeTest(true);
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   setEndpoints(1, 0, 0, false);
 
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());

--- a/test/integration/extension_discovery_integration_test.cc
+++ b/test/integration/extension_discovery_integration_test.cc
@@ -98,9 +98,6 @@ public:
     // Create the extension config discovery upstream (fake_upstreams_[1]).
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
                                                   timeSystem(), enable_half_close_));
-    for (auto& upstream : fake_upstreams_) {
-      upstream->set_allow_unexpected_disconnects(true);
-    }
   }
 
   void waitXdsStream() {

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -447,7 +447,7 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
       api_(Api::createApiForTest(stats_store_)), time_system_(time_system),
       dispatcher_(api_->allocateDispatcher("fake_upstream")),
       handler_(new Server::ConnectionHandlerImpl(*dispatcher_)),
-      allow_unexpected_disconnects_(false), read_disable_on_new_connection_(true),
+      allow_unexpected_disconnects_(true), read_disable_on_new_connection_(true),
       enable_half_close_(enable_half_close), listener_(*this),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {
   thread_ = api_->threadFactory().createThread([this]() -> void { threadRoutine(); });

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -447,8 +447,8 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
       api_(Api::createApiForTest(stats_store_)), time_system_(time_system),
       dispatcher_(api_->allocateDispatcher("fake_upstream")),
       handler_(new Server::ConnectionHandlerImpl(*dispatcher_)),
-      allow_unexpected_disconnects_(true), read_disable_on_new_connection_(true),
-      enable_half_close_(enable_half_close), listener_(*this),
+      read_disable_on_new_connection_(true), enable_half_close_(enable_half_close),
+      listener_(*this),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {
   thread_ = api_->threadFactory().createThread([this]() -> void { threadRoutine(); });
   server_initialized_.waitReady();
@@ -470,8 +470,7 @@ bool FakeUpstream::createNetworkFilterChain(Network::Connection& connection,
   if (read_disable_on_new_connection_) {
     connection.readDisable(true);
   }
-  auto connection_wrapper =
-      std::make_unique<SharedConnectionWrapper>(connection, allow_unexpected_disconnects_);
+  auto connection_wrapper = std::make_unique<SharedConnectionWrapper>(connection);
   LinkedList::moveIntoListBack(std::move(connection_wrapper), new_connections_);
   return true;
 }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -251,18 +251,8 @@ class SharedConnectionWrapper : public Network::ConnectionCallbacks,
 public:
   using DisconnectCallback = std::function<void()>;
 
-  SharedConnectionWrapper(Network::Connection& connection, bool allow_unexpected_disconnects)
-      : connection_(connection), allow_unexpected_disconnects_(allow_unexpected_disconnects) {
+  SharedConnectionWrapper(Network::Connection& connection) : connection_(connection) {
     connection_.addConnectionCallbacks(*this);
-    addDisconnectCallback([this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) {
-      RELEASE_ASSERT(parented_ || allow_unexpected_disconnects_,
-                     "An queued upstream connection was torn down without being associated "
-                     "with a fake connection. Either manage the connection via "
-                     "waitForRawConnection() or waitForHttpConnection(), or "
-                     "set_allow_unexpected_disconnects(true).\n See "
-                     "https://github.com/envoyproxy/envoy/blob/master/test/integration/README.md#"
-                     "unparented-upstream-connections");
-    });
   }
 
   Common::CallbackHandle* addDisconnectCallback(DisconnectCallback callback) {
@@ -313,12 +303,12 @@ public:
 
   // Execute some function on the connection's dispatcher. This involves a cross-thread post and
   // wait-for-completion. If the connection is disconnected, either prior to post or when the
-  // dispatcher schedules the callback, we silently ignore if allow_unexpected_disconnects_
-  // is set.
+  // dispatcher schedules the callback, we silently ignore.
   ABSL_MUST_USE_RESULT
   testing::AssertionResult
   executeOnDispatcher(std::function<void(Network::Connection&)> f,
-                      std::chrono::milliseconds timeout = TestUtility::DefaultTimeout) {
+                      std::chrono::milliseconds timeout = TestUtility::DefaultTimeout,
+                      bool allow_disconnects = true) {
     absl::MutexLock lock(&lock_);
     if (disconnected_) {
       return testing::AssertionSuccess();
@@ -343,13 +333,8 @@ public:
     if (!time_system.waitFor(lock_, absl::Condition(&callback_ready_event), timeout)) {
       return testing::AssertionFailure() << "Timed out while executing on dispatcher.";
     }
-    if (unexpected_disconnect && !allow_unexpected_disconnects_) {
-      return testing::AssertionFailure()
-             << "The connection disconnected unexpectedly, and allow_unexpected_disconnects_ is "
-                "false."
-                "\n See "
-                "https://github.com/envoyproxy/envoy/blob/master/test/integration/README.md#"
-                "unexpected-disconnects";
+    if (unexpected_disconnect && !allow_disconnects) {
+      ENVOY_LOG_MISC(warn, "executeOnDispatcher failed due to disconnect\n");
     }
     return testing::AssertionSuccess();
   }
@@ -367,7 +352,6 @@ private:
   Common::CallbackManager<> disconnect_callback_manager_ ABSL_GUARDED_BY(lock_);
   bool parented_ ABSL_GUARDED_BY(lock_){};
   bool disconnected_ ABSL_GUARDED_BY(lock_){};
-  const bool allow_unexpected_disconnects_;
 };
 
 using SharedConnectionWrapperPtr = std::unique_ptr<SharedConnectionWrapper>;
@@ -613,7 +597,6 @@ public:
   void createUdpListenerFilterChain(Network::UdpListenerFilterManager& udp_listener,
                                     Network::UdpReadFilterCallbacks& callbacks) override;
 
-  void set_allow_unexpected_disconnects(bool value) { allow_unexpected_disconnects_ = value; }
   void setReadDisableOnNewConnection(bool value) { read_disable_on_new_connection_ = value; }
   Event::TestTimeSystem& timeSystem() { return time_system_; }
 
@@ -740,7 +723,6 @@ private:
   // consumed_connections_. This allows later the Connection destruction (when the FakeUpstream is
   // deleted) on the same thread that allocated the connection.
   std::list<SharedConnectionWrapperPtr> consumed_connections_ ABSL_GUARDED_BY(lock_);
-  bool allow_unexpected_disconnects_;
   bool read_disable_on_new_connection_;
   const bool enable_half_close_;
   FakeListener listener_;

--- a/test/integration/h1_fuzz.cc
+++ b/test/integration/h1_fuzz.cc
@@ -14,7 +14,6 @@ void H1FuzzIntegrationTest::replay(const test::integration::CaptureFuzzTestCase&
                                    bool ignore_response) {
   PERSISTENT_FUZZ_VAR bool initialized = [this]() -> bool {
     initialize();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
     return true;
   }();
   UNREFERENCED_PARAMETER(initialized);

--- a/test/integration/h2_fuzz.cc
+++ b/test/integration/h2_fuzz.cc
@@ -164,7 +164,6 @@ void H2FuzzIntegrationTest::replay(const test::integration::H2CaptureFuzzTestCas
                                    bool ignore_response) {
   PERSISTENT_FUZZ_VAR bool initialized = [this]() -> bool {
     initialize();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
     return true;
   }();
   UNREFERENCED_PARAMETER(initialized);

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -35,7 +35,6 @@ public:
     fake_upstreams_.emplace_back(
         new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
     hds_upstream_ = fake_upstreams_.back().get();
-    hds_upstream_->set_allow_unexpected_disconnects(true);
     HttpIntegrationTest::createUpstreams();
   }
 
@@ -61,10 +60,8 @@ public:
     // Endpoint connections
     host_upstream_ =
         std::make_unique<FakeUpstream>(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem());
-    host_upstream_->set_allow_unexpected_disconnects(true);
     host2_upstream_ =
         std::make_unique<FakeUpstream>(0, FakeHttpConnection::Type::HTTP1, version_, timeSystem());
-    host2_upstream_->set_allow_unexpected_disconnects(true);
   }
 
   // Sets up a connection between Envoy and the management server.

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -188,8 +188,6 @@ public:
 
   void TearDown() override {
     if (eds_connection_ != nullptr) {
-      // Don't ASSERT fail if an EDS reconnect ends up unparented.
-      fake_upstreams_[1]->set_allow_unexpected_disconnects(true);
       AssertionResult result = eds_connection_->close();
       RELEASE_ASSERT(result, result.message());
       result = eds_connection_->waitForDisconnect();

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -517,7 +517,6 @@ TEST_P(Http2MetadataIntegrationTest, ProxyLargeMetadataInRequest) {
 TEST_P(Http2MetadataIntegrationTest, RequestMetadataReachSizeLimit) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
   request_encoder_ = &encoder_decoder.first;
@@ -830,7 +829,6 @@ TEST_P(Http2IntegrationTest, GrpcRetry) { testGrpcRetry(); }
 // Verify the case where there is an HTTP/2 codec/protocol error with an active stream.
 TEST_P(Http2IntegrationTest, CodecErrorAfterStreamStart) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   // Sends a request.
@@ -906,9 +904,6 @@ TEST_P(Http2IntegrationTest, GrpcRequestTimeout) {
       });
   initialize();
 
-  // Envoy will close some number of connections when request times out.
-  // Make sure they don't cause assertion failures when we ignore them.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
   // With upstream request timeout Envoy should send a gRPC-Status "DEADLINE EXCEEDED".
   // TODO: Properly map request timeout to "DEADLINE EXCEEDED" instead of "SERVICE UNAVAILABLE".
@@ -1573,7 +1568,6 @@ TEST_P(Http2FrameIntegrationTest, SetDetailsTwice) {
   autonomous_upstream_ = true;
   useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Send two concatenated frames, the first with too many headers, and the second an invalid frame
   // (push_promise)
@@ -1737,7 +1731,6 @@ TEST_P(Http2FloodMitigationTest, Data) {
   autonomous_upstream_ = true;
   autonomous_allow_incomplete_streams_ = true;
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Do not read from the socket and send request that causes autonomous upstream
   // to respond with 1000 DATA frames. The Http2FloodMitigationTest::beginSession()
@@ -1819,7 +1812,6 @@ TEST_P(Http2FloodMitigationTest, TooManyStreams) {
   // keep client streams open, eventually maxing them out and causing client connection to be
   // closed.
   writev_matcher_->setSourcePort(fake_upstreams_[0]->localAddress()->ip()->port());
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Exceed the number of streams allowed by the server. The server should stop reading from the
   // client.
@@ -1871,7 +1863,6 @@ TEST_P(Http2FloodMitigationTest, EmptyHeadersContinuation) {
 TEST_P(Http2FloodMitigationTest, EmptyData) {
   useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   uint32_t request_idx = 0;
   auto request = Http2Frame::makePostRequest(request_idx, "host", "/");
@@ -1899,7 +1890,6 @@ TEST_P(Http2FloodMitigationTest, PriorityIdleStream) {
 
 TEST_P(Http2FloodMitigationTest, PriorityOpenStream) {
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Open stream.
   uint32_t request_idx = 0;
@@ -1915,7 +1905,6 @@ TEST_P(Http2FloodMitigationTest, PriorityOpenStream) {
 TEST_P(Http2FloodMitigationTest, PriorityClosedStream) {
   autonomous_upstream_ = true;
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Open stream.
   uint32_t request_idx = 0;
@@ -1933,7 +1922,6 @@ TEST_P(Http2FloodMitigationTest, PriorityClosedStream) {
 
 TEST_P(Http2FloodMitigationTest, WindowUpdate) {
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Open stream.
   uint32_t request_idx = 0;
@@ -1978,7 +1966,6 @@ TEST_P(Http2FloodMitigationTest, ZerolenHeaderAllowed) {
       });
   autonomous_upstream_ = true;
   beginSession();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Send invalid request.
   uint32_t request_idx = 0;

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -372,7 +372,6 @@ typed_config:
 
   // Now send an overly large response body. At some point, too much data will
   // be buffered, the stream will be reset, and the connection will disconnect.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   upstream_request_->encodeData(1024 * 65, false);
   ASSERT_TRUE(upstream_request_->waitForReset());
   ASSERT_TRUE(fake_upstream_connection_->close());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1082,7 +1082,6 @@ void HttpIntegrationTest::testLargeRequestTrailers(uint32_t size, uint32_t max_s
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
   request_encoder_ = &encoder_decoder.first;
@@ -1239,7 +1238,6 @@ void HttpIntegrationTest::testAdminDrain(Http::CodecClient::Type admin_request_t
                                                  {":authority", "host"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest(0);
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   upstream_request_->encodeHeaders(default_response_headers_, false);
 
@@ -1281,7 +1279,6 @@ void HttpIntegrationTest::testMaxStreamDuration() {
   });
 
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
@@ -1314,7 +1311,6 @@ void HttpIntegrationTest::testMaxStreamDurationWithRetry(bool invoke_retry_upstr
       {":method", "POST"},    {":path", "/test/long/url"},     {":scheme", "http"},
       {":authority", "host"}, {"x-forwarded-for", "10.0.0.1"}, {"x-envoy-retry-on", "5xx"}};
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder = codec_client_->startRequest(retriable_header);

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -40,7 +40,6 @@ public:
 
   IntegrationStreamDecoderPtr setupPerStreamIdleTimeoutTest(const char* method = "GET") {
     initialize();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
     codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
     auto encoder_decoder =
         codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", method},
@@ -192,7 +191,6 @@ TEST_P(IdleTimeoutIntegrationTest, PerStreamIdleTimeoutWithLargeBuffer) {
   enable_per_stream_idle_timeout_ = true;
   initialize();
 
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   response->waitForEndStream();
@@ -356,7 +354,6 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutTriggersOnRawIncompleteRequestW
   enable_request_timeout_ = true;
 
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   std::string raw_response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.1", &raw_response, true);
@@ -370,7 +367,6 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutDoesNotTriggerOnRawCompleteRequ
   enable_request_timeout_ = true;
 
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   std::string raw_response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.1\r\n\r\n", &raw_response, true);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -311,7 +311,6 @@ TEST_P(IntegrationTest, ResponseFramedByConnectionCloseWithReadLimits) {
   initialize();
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();
@@ -370,7 +369,6 @@ TEST_P(IntegrationTest, UpstreamDisconnectWithTwoRequests) {
     circuit_breakers->add_thresholds()->mutable_max_connections()->set_value(1);
   });
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -437,7 +435,6 @@ TEST_P(IntegrationTest, HittingGrpcFilterLimitBufferingHeaders) {
   // Send the overly large response. Because the grpc_http1_bridge filter buffers and buffer
   // limits are exceeded, this will be translated into an unknown gRPC error.
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   upstream_request_->encodeData(1024 * 65, false);
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
 
@@ -519,7 +516,6 @@ TEST_P(IntegrationTest, InvalidVersion) {
 // Expect that malformed trailers to break the connection
 TEST_P(IntegrationTest, BadTrailer) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
                                 "POST / HTTP/1.1\r\n"
@@ -536,7 +532,6 @@ TEST_P(IntegrationTest, BadTrailer) {
 // Expect malformed headers to break the connection
 TEST_P(IntegrationTest, BadHeader) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
                                 "POST / HTTP/1.1\r\n"
@@ -1007,9 +1002,6 @@ TEST_P(IntegrationTest, TestFailedBind) {
   config_helper_.setSourceAddress("8.8.8.8");
 
   initialize();
-  // Envoy will create and close some number of connections when trying to bind.
-  // Make sure they don't cause assertion failures when we ignore them.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
   // With no ability to successfully bind on an upstream connection Envoy should
   // send a 500.
@@ -1075,8 +1067,6 @@ TEST_P(IntegrationTest, TestDelayedConnectionTeardownOnGracefulClose) {
   config_helper_.setBufferLimits(1024, 1024);
   initialize();
 
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder =
@@ -1112,8 +1102,6 @@ TEST_P(IntegrationTest, TestDelayedConnectionTeardownConfig) {
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.mutable_delayed_close_timeout()->set_seconds(0); });
   initialize();
-
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -1152,8 +1140,6 @@ TEST_P(IntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
       });
 
   initialize();
-
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -95,9 +95,6 @@ protected:
     // Create the RDS upstream (fake_upstreams_[2]).
     fake_upstreams_.emplace_back(new FakeUpstream(0, FakeHttpConnection::Type::HTTP2, version_,
                                                   timeSystem(), enable_half_close_));
-    for (auto& upstream : fake_upstreams_) {
-      upstream->set_allow_unexpected_disconnects(true);
-    }
   }
 
   void resetFakeUpstreamInfo(FakeUpstreamInfo* upstream_info) {

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -61,7 +61,6 @@ INSTANTIATE_TEST_SUITE_P(Protocols, OverloadIntegrationTest,
 
 TEST_P(OverloadIntegrationTest, CloseStreamsWhenOverloaded) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Put envoy in overloaded state and check that it drops new requests.
   // Test both header-only and header+body requests since the code paths are slightly different.
@@ -108,7 +107,6 @@ TEST_P(OverloadIntegrationTest, DisableKeepaliveWhenOverloaded) {
   }
 
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Put envoy in overloaded state and check that it disables keepalive
   updateResource(0.8);
@@ -138,7 +136,6 @@ TEST_P(OverloadIntegrationTest, DisableKeepaliveWhenOverloaded) {
 
 TEST_P(OverloadIntegrationTest, StopAcceptingConnectionsWhenOverloaded) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Put envoy in overloaded state and check that it doesn't accept the new client connection.
   updateResource(0.95);

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -98,7 +98,6 @@ TEST_P(ProtocolIntegrationTest, TrailerSupportHttp1) {
 TEST_P(ProtocolIntegrationTest, ShutdownWithActiveConnPoolConnections) {
   auto response = makeHeaderOnlyRequest(nullptr, 0);
   // Shut down the server with active connection pool connections.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   test_server_.reset();
   checkSimpleRequestSuccess(0U, 0U, response.get());
 }
@@ -802,9 +801,6 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // Envoy will likely connect and proxy some unspecified amount of data before
-  // hitting the buffer limit and disconnecting. Ignore this if it happens.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   auto response = codec_client_->makeRequestWithBody(
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/dynamo/url"},
@@ -850,7 +846,6 @@ TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
 
   // Now send an overly large response body. At some point, too much data will
   // be buffered, the stream will be reset, and the connection will disconnect.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   upstream_request_->encodeData(1024 * 65, false);
   if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
@@ -1015,10 +1010,6 @@ TEST_P(ProtocolIntegrationTest, 304WithBody) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
-    // The invalid data will trigger disconnect.
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-  }
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
   waitForNextUpstreamRequest();
@@ -1420,7 +1411,6 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersRejected) {
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
@@ -1558,7 +1548,6 @@ TEST_P(ProtocolIntegrationTest, LargeRequestMethod) {
     ASSERT(downstreamProtocol() == Http::CodecClient::Type::HTTP2);
     if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
       auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
-      fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
       ASSERT_TRUE(
           fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
       response->waitForEndStream();
@@ -1947,7 +1936,6 @@ TEST_P(DownstreamProtocolIntegrationTest, TestPrefetch) {
 TEST_P(DownstreamProtocolIntegrationTest, BasicMaxStreamTimeout) {
   config_helper_.setDownstreamMaxStreamDuration(std::chrono::milliseconds(500));
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
@@ -1969,7 +1957,6 @@ TEST_P(DownstreamProtocolIntegrationTest, BasicMaxStreamTimeoutLegacy) {
                                     "false");
   config_helper_.setDownstreamMaxStreamDuration(std::chrono::milliseconds(500));
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
@@ -1989,7 +1976,6 @@ TEST_P(DownstreamProtocolIntegrationTest, BasicMaxStreamTimeoutLegacy) {
 // Make sure that invalid authority headers get blocked at or before the HCM.
 TEST_P(DownstreamProtocolIntegrationTest, InvalidAuthority) {
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -118,7 +118,6 @@ TEST_P(RedirectIntegrationTest, BasicInternalRedirect) {
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.set_via("via_value"); });
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -153,7 +152,6 @@ TEST_P(RedirectIntegrationTest, InternalRedirectWithThreeHopLimit) {
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.set_via("via_value"); });
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -199,7 +197,6 @@ TEST_P(RedirectIntegrationTest, InternalRedirectToDestinationWithBody) {
     "@type": type.googleapis.com/google.protobuf.Empty
   )EOF");
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -249,7 +246,6 @@ TEST_P(RedirectIntegrationTest, InternalRedirectPreventedByPreviousRoutesPredica
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.set_via("via_value"); });
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -307,7 +303,6 @@ TEST_P(RedirectIntegrationTest, InternalRedirectPreventedByAllowListedRoutesPred
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.set_via("via_value"); });
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -367,7 +362,6 @@ TEST_P(RedirectIntegrationTest, InternalRedirectPreventedBySafeCrossSchemePredic
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.set_via("via_value"); });
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -88,7 +88,6 @@ public:
     registerTestServerPorts({});
     initial_load_success_ = test_server_->counter("runtime.load_success")->value();
     initial_keys_ = test_server_->gauge("runtime.num_keys")->value();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   }
 
   void acceptXdsConnection() {

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -131,7 +131,6 @@ fragments:
   void resetFakeUpstreamInfo(FakeUpstreamInfo* upstream_info) {
     ASSERT(upstream_info->upstream_ != nullptr);
 
-    upstream_info->upstream_->set_allow_unexpected_disconnects(true);
     AssertionResult result = upstream_info->connection_->close();
     RELEASE_ASSERT(result, result.message());
     result = upstream_info->connection_->waitForDisconnect();

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -493,7 +493,6 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, BasicSuccess) {
   };
 
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // There is a race condition here; there are two static clusters:
   // backend cluster_0 with sds and sds_cluster. cluster_0 is created first, its init_manager
@@ -517,7 +516,6 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
     sendSdsResponse(getWrongSecret(client_cert_));
   };
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Make a simple request, should get 503
   BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -547,7 +547,6 @@ TEST_P(TcpProxyIntegrationTest, TestCloseOnHealthFailure) {
   ASSERT_TRUE(fake_upstream_connection->waitForData(10));
 
   ASSERT_TRUE(fake_upstream_health_connection->waitForData(8));
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   ASSERT_TRUE(fake_upstream_health_connection->close());
   ASSERT_TRUE(fake_upstream_health_connection->waitForDisconnect());
 

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -133,9 +133,6 @@ TEST_P(ConnectTerminationIntegrationTest, TestTimeout) {
 
 TEST_P(ConnectTerminationIntegrationTest, BuggyHeaders) {
   initialize();
-  // It's possible that the FIN is received before we set half close on the
-  // upstream connection, so allow unexpected disconnects.
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
   // Sending a header-only request is probably buggy, but rather than having a
   // special corner case it is treated as a regular half close.
@@ -170,7 +167,6 @@ TEST_P(ConnectTerminationIntegrationTest, BasicMaxStreamDuration) {
   });
 
   initialize();
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
   setUpConnection();
   sendBidirectionalData();
 

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -171,7 +171,6 @@ public:
     result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
     RELEASE_ASSERT(result, result.message());
     xds_stream_->startGrpcStream();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
     EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "",
                                             {"my_route"}, true));
@@ -294,7 +293,6 @@ public:
     result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
     RELEASE_ASSERT(result, result.message());
     xds_stream_->startGrpcStream();
-    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
 
     EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "",
                                             {"my_route"}, true));

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -416,8 +416,6 @@ TEST_P(LdsIntegrationTest, ReloadConfig) {
   // the initial LDS file has loaded.
   EXPECT_EQ(1, test_server_->counter("listener_manager.lds.update_success")->value());
 
-  fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-
   // HTTP 1.0 is disabled by default.
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"), "GET / HTTP/1.0\r\n\r\n", &response, true);


### PR DESCRIPTION
Allowing unexpected disconnects by default.

Risk Level: Low
Testing: tests pass
Docs Changes: n/a
Release Notes: n/a
Fixes #12861
