### PR TITLE
Windows: override msvc-cl config if BAZEL_BUILD_EXTRA_OPTIONS set

### DIFF
--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -25,7 +25,9 @@ if [ ! -e "/$drive/$drive" ]; then
 fi
 
 BAZEL_STARTUP_OPTIONS="--output_base=c:/_eb"
-BAZEL_BUILD_OPTIONS="-c opt --config=msvc-cl --show_task_finish --verbose_failures \
+# Default to msvc-cl if not overridden
+BAZEL_BUILD_EXTRA_OPTIONS=${BAZEL_BUILD_EXTRA_OPTIONS:---config=msvc-cl}
+BAZEL_BUILD_OPTIONS="-c opt --show_task_finish --verbose_failures \
   --test_output=errors ${BAZEL_BUILD_EXTRA_OPTIONS} ${BAZEL_EXTRA_TEST_OPTIONS}"
 
 # Test to validate updates of all dependency libraries in bazel/external and bazel/foreign_cc


### PR DESCRIPTION
Commit Message: Windows: override msvc-cl config if BAZEL_BUILD_EXTRA_OPTIONS set
Additional Description: Will allow us to cleanly add a clang-cl build in CI
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
