### PR TITLE
build: cleaning up legacy library dependency

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -443,6 +443,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/http:request_id_extension_interface",
         "//include/envoy/server:request_id_extension_config_interface",
+        "//source/common/common:random_generator_lib",
         "//source/common/config:utility_lib",
         "//source/common/runtime:runtime_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",

--- a/source/common/runtime/BUILD
+++ b/source/common/runtime/BUILD
@@ -61,7 +61,6 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/common:empty_string",
         "//source/common/common:minimal_logger_lib",
-        "//source/common/common:random_generator_lib",  #FIXME
         "//source/common/common:thread_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:api_version_lib",

--- a/source/extensions/tracers/xray/BUILD
+++ b/source/extensions/tracers/xray/BUILD
@@ -44,6 +44,7 @@ envoy_cc_library(
         "//include/envoy/tracing:http_tracer_interface",
         "//source/common/common:hex_lib",
         "//source/common/common:macros",
+        "//source/common/common:random_generator_lib",
         "//source/common/http:header_map_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/protobuf:utility_lib",

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -71,6 +71,7 @@ envoy_cc_test_binary(
         "benchmark",
     ],
     deps = [
+        "//source/common/common:random_generator_lib",
         "//source/common/common:utility_lib",
         "//source/common/runtime:runtime_lib",
         "//source/common/stats:recent_lookups_lib",


### PR DESCRIPTION
Runtime has no explicit deps on random, it was just a legacy library include.

Risk Level: Low (could break downstream builds not including what they use)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a