### PR TITLE
fix build failure if OS doesn't support IPV6_TRANSPARENT

### DIFF
--- a/source/common/api/posix/os_sys_calls_impl.cc
+++ b/source/common/api/posix/os_sys_calls_impl.cc
@@ -111,7 +111,7 @@ bool OsSysCallsImpl::supportsUdpGso() const {
 }
 
 bool OsSysCallsImpl::supportsIpTransparent() const {
-#if !defined(__linux__)
+#if !defined(__linux__) || !defined(IPV6_TRANSPARENT)
   return false;
 #else
   // The linux kernel supports IP_TRANSPARENT by following patch(starting from v2.6.28) :


### PR DESCRIPTION
Signed-off-by: Bill Gallagher <bgallagher@lyft.com>

Commit Message: fix build failure if OS doesn't support IPV6_TRANSPARENT
Additional Description: the build currently fails with: external/envoy/source/common/api/posix/os_sys_calls_impl.cc:145:51: error: use of undeclared identifier 'IPV6_TRANSPARENT'
Risk Level: low

