### PR TITLE
hcm: allow setting headers/trailers without encoding

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 
-#include "bazel-out/k8-fastbuild/bin/include/envoy/http/_virtual_includes/header_map_interface/envoy/http/header_map.h"
 #include "envoy/access_log/access_log.h"
 #include "envoy/common/scope_tracker.h"
 #include "envoy/event/dispatcher.h"

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -171,10 +171,13 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                       absl::string_view details) override;
-  void encode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override;
-  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void set100ContinueHeaders(ResponseHeaderMapPtr&& headers) override;
+  void encode100ContinueHeaders() override;
+  void setResponseHeaders(ResponseHeaderMapPtr&& headers) override;
+  void encodeHeaders(bool end_stream) override;
   void encodeData(Buffer::Instance& data, bool end_stream) override;
-  void encodeTrailers(ResponseTrailerMapPtr&& trailers) override;
+  void setResponseTrailers(ResponseTrailerMapPtr&& trailers) override;
+  void encodeTrailers() override;
   void encodeMetadata(MetadataMapPtr&& metadata_map_ptr) override;
   void onDecoderFilterAboveWriteBufferHighWatermark() override;
   void onDecoderFilterBelowWriteBufferLowWatermark() override;

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -87,7 +87,7 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
             if (modify_headers != nullptr) {
               modify_headers(*headers);
             }
-            encodeHeaders(std::move(headers), end_stream);
+            StreamDecoderFilterCallbacks::encodeHeaders(std::move(headers), end_stream);
           },
           [this](Buffer::Instance& data, bool end_stream) -> void {
             encodeData(data, end_stream);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -165,9 +165,7 @@ public:
   void set100ContinueHeaders(ResponseHeaderMapPtr&& headers) override {
     continue_headers_ = std::move(headers);
   }
-  void encode100ContinueHeaders() override {
-    encode100ContinueHeaders_(*continue_headers_);
-  }
+  void encode100ContinueHeaders() override { encode100ContinueHeaders_(*continue_headers_); }
   void setResponseHeaders(ResponseHeaderMapPtr&& headers) override {
     response_headers_ = std::move(headers);
   }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->

This makes it possible to hand over ownership over the upstream
headers/trailers without immediately starting the encoding process. This
will allow the upstream FM to perform its own encoding prior to starting
the HCM encoding.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
Part of #10455 
