### PR TITLE
Added PGV constraint for serverName.

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -298,7 +298,7 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10;
+  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -298,7 +298,8 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
+  string server_name = 10
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -297,7 +297,8 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
+  string server_name = 10
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -297,7 +297,7 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10;
+  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -300,7 +300,7 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10;
+  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -300,7 +300,8 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
+  string server_name = 10
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -297,7 +297,8 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
+  string server_name = 10
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -297,7 +297,7 @@ message HttpConnectionManager {
 
   // An optional override that the connection manager will write to the server
   // header in responses. If not set, the default is *envoy*.
-  string server_name = 10;
+  string server_name = 10 [(validate.rules).string = {pattern: "^[^\000\r\n]*$"}];
 
   // Defines the action to be applied to the Server header on the response path.
   // By default, Envoy will overwrite the header with the value specified in

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -97,6 +97,18 @@ http_filters:
                             "Didn't find a registered implementation for name: 'foo'");
 }
 
+TEST_F(HttpConnectionManagerConfigTest, InvalidServerName) {
+  const std::string yaml_string = R"EOF(
+server_name: >
+  foo
+route_config:
+  name: local_route
+stat_prefix: router
+  )EOF";
+
+  EXPECT_THROW(createHttpConnectionManagerConfig(yaml_string), ProtoValidationException);
+}
+
 TEST_F(HttpConnectionManagerConfigTest, RouterInverted) {
   const std::string yaml_string = R"EOF(
 codec_type: http1


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>

Commit Message: Added PGV constraint for serverName. It shouldn't contain \0\n\r. 
Additional Description: Added PGV constraint to not allow \0\n\r in serverName.Currently, header doesn't allow \0\r\n.
Risk Level:
Testing: config_test
Docs Changes:
Release Notes:
 Fixes #12709 
