### PR TITLE
lua, test: Remove set_allow_unexpected_disconnects

### DIFF
--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -133,7 +133,6 @@ public:
       result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
       RELEASE_ASSERT(result, result.message());
       xds_stream_->startGrpcStream();
-      fake_upstreams_[3]->set_allow_unexpected_disconnects(true);
 
       EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TypeUrl::get().RouteConfiguration, "",
                                               {route_config_name}, true));


### PR DESCRIPTION
Commit Message: This removes set_allow_unexpected_disconnects in Lua filter integration test.

Risk Level: Low
Testing: Fix test
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>