### PR TITLE
clean up: Change some NOT_IMPLEMENTED to NOT_REACHED

### DIFF
--- a/source/common/network/hash_policy.cc
+++ b/source/common/network/hash_policy.cc
@@ -29,7 +29,7 @@ HashPolicyImpl::HashPolicyImpl(
     hash_impl_ = std::make_unique<SourceIpHashMethod>();
     break;
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -326,7 +326,7 @@ bool Utility::isLoopbackAddress(const Address::Instance& address) {
     absl::uint128 addr = address.ip()->ipv6()->address();
     return 0 == memcmp(&addr, &in6addr_loopback, sizeof(in6addr_loopback));
   }
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 Address::InstanceConstSharedPtr Utility::getCanonicalIpv4LoopbackAddress() {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1127,7 +1127,7 @@ VirtualHostImpl::VirtualHostImpl(const envoy::config::route::v3::VirtualHost& vi
       routes_.emplace_back(new ConnectRouteEntryImpl(*this, route, factory_context, validator));
       break;
     }
-    case envoy::config::route::v3::RouteMatch::PathSpecifierCase::PATH_SPECIFIER_NOT_SET:
+    default:
       NOT_REACHED_GCOVR_EXCL_LINE;
     }
 

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -73,7 +73,7 @@ ConfigUtility::parsePriority(const envoy::config::core::v3::RoutingPriority& pri
   case envoy::config::core::v3::HIGH:
     return Upstream::ResourcePriority::High;
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -103,7 +103,7 @@ Http::Code ConfigUtility::parseRedirectResponseCode(
   case envoy::config::route::v3::RedirectAction::PERMANENT_REDIRECT:
     return Http::Code::PermanentRedirect;
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 
@@ -156,7 +156,7 @@ Http::Code ConfigUtility::parseClusterNotFoundResponseCode(
   case envoy::config::route::v3::RouteAction::NOT_FOUND:
     return Http::Code::NotFound;
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
 }
 

--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -159,8 +159,6 @@ MatcherConstPtr Matcher::create(const RequirementRule& rule) {
     // matching in the filter fuzzer implementation:
     // //test/extensions/filters/http/common/fuzz/uber_per_filter.cc
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-  // path specifier is required.
-  case RouteMatch::PathSpecifierCase::PATH_SPECIFIER_NOT_SET:
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -297,10 +297,8 @@ unsigned ContextConfigImpl::tlsVersionFromProto(
   case envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3:
     return TLS1_3_VERSION;
   default:
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    NOT_REACHED_GCOVR_EXCL_LINE;
   }
-
-  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 const unsigned ClientContextConfigImpl::DEFAULT_MIN_VERSION = TLS1_2_VERSION;


### PR DESCRIPTION
Commit Message:
Change some NOT_IMPLEMENTED to NOT_REACHED in case of actually cannot be reached cases.
The NOT_IMPLEMENTED means that it can be filled with meaningful code later but not yet.
The NOT_REACHED means that it never occur so, it is a bug if reach here.

So, I change it to NOT_REACHED actually cannot be reached.
And a default value for protobuf of oneof cannot be selected by config and there is no
valid meaning for logic so I removed it as well.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: bazel test
Docs Changes: None
Release Notes: None