### PR TITLE
docs: Add missing bug fix release note for udp_proxy

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -48,6 +48,7 @@ Bug Fixes
 * http: made the HeaderValues::prefix() method const.
 * jwt_authn: supports jwt payload without "iss" field.
 * rocketmq_proxy network-level filter: fixed an issue involving incorrect header lengths. In debug mode it causes crash and in release mode it causes underflow.
+* udp_proxy: fixed an issue with race condition. When the udp_proxy is activated and if hot restarting is triggered, sometimes it causes crash.
 
 Removed Config or Runtime
 -------------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -48,7 +48,7 @@ Bug Fixes
 * http: made the HeaderValues::prefix() method const.
 * jwt_authn: supports jwt payload without "iss" field.
 * rocketmq_proxy network-level filter: fixed an issue involving incorrect header lengths. In debug mode it causes crash and in release mode it causes underflow.
-* udp_proxy: fixed an issue with race condition. When the udp_proxy is activated and if hot restarting is triggered, sometimes it causes crash.
+* udp_proxy: fixed a crash due to UDP packets being processed after listener removal.
 
 Removed Config or Runtime
 -------------------------


### PR DESCRIPTION
Commit Message:
This bug fix release note should be added in https://github.com/envoyproxy/envoy/pull/11914 but is was missed.

Signed-off-by: DongRyeol Cha <dr83.cha@samsung.com>
Additional Description: None
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: added in current.rst