### PR TITLE
Fix Kafka Repository Location

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -658,7 +658,7 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         version = "2.4.1",
         sha256 = "2177cbd14118999e1d76fec628ca78ace7e6f841219dbc6035027c796bbe1a2a",
         strip_prefix = "kafka_2.12-{version}",
-        urls = ["http://us.mirrors.quenda.co/apache/kafka/{version}/kafka_2.12-{version}.tgz"],
+        urls = ["https://mirrors.gigenet.com/apache/kafka/{version}/kafka_2.12-{version}.tgz"],
         use_category = ["test"],
     ),
     kafka_python_client = dict(


### PR DESCRIPTION
Commit Message: Update mirror used to fetch kafka dependency to a valid, working mirror.
Additional Description: Resolves #13011 
Risk Level: low
Testing: covered by CI
Docs Changes: n/a
Release Notes: n/a