### PR TITLE
Added regexp to extract UDP statistics.

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -82,6 +82,9 @@ TagNameValues::TagNameValues() {
   // tcp.(<stat_prefix>.)<base_stat>
   addRegex(TCP_PREFIX, R"(^tcp\.((.*?)\.)\w+?$)");
 
+  // udp.(<stat_prefix>.)<base_stat>
+  addRegex(UDP_PREFIX, R"(^udp\.((.*?)\.)\w+?$)");
+
   // auth.clientssl.(<stat_prefix>.)<base_stat>
   addRegex(CLIENTSSL_PREFIX, R"(^auth\.clientssl\.((.*?)\.)\w+?$)");
 

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -95,6 +95,8 @@ public:
   const std::string RATELIMIT_PREFIX = "envoy.ratelimit_prefix";
   // Stats prefix for the TCP Proxy network filter
   const std::string TCP_PREFIX = "envoy.tcp_prefix";
+  // Stats prefix for the UDP Proxy network filter
+  const std::string UDP_PREFIX = "envoy.udp_prefix";
   // Downstream cluster for the Fault http filter
   const std::string FAULT_DOWNSTREAM_CLUSTER = "envoy.fault_downstream_cluster";
   // Operation name for the Dynamo http filter

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -317,6 +317,14 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   regex_tester.testRegex("tcp.tcp_prefix.downstream_flow_control_resumed_reading_total",
                          "tcp.downstream_flow_control_resumed_reading_total", {tcp_prefix});
 
+  // UDP Prefix
+  Tag udp_prefix;
+  udp_prefix.name_ = tag_names.UDP_PREFIX;
+  udp_prefix.value_ = "udp_prefix";
+
+  regex_tester.testRegex("udp.udp_prefix.downstream_flow_control_resumed_reading_total",
+                         "udp.downstream_flow_control_resumed_reading_total", {udp_prefix});
+
   // Fault Downstream Cluster
   Tag fault_connection_manager;
   fault_connection_manager.name_ = tag_names.HTTP_CONN_MANAGER_PREFIX;


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>

Commit Message: Added regexp for UDP to extract UDP statistics.
Additional Description: Added stats prefix for UDP proxy network filter.
Risk Level: Low
Testing:
Docs Changes:
Release Notes: 
Fixes #13021 

