### PR TITLE
Preserve protobuf comments in generated go code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,7 @@ build --action_env=BAZEL_LINKOPTS=-lm
 build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --enable_platform_specific_config
+build --experimental_proto_descriptor_sets_include_source_info
 
 # Enable position independent code, this option is not supported on Windows and default on on macOS.
 build:linux --copt=-fPIC

--- a/.bazelrc
+++ b/.bazelrc
@@ -18,7 +18,6 @@ build --action_env=BAZEL_LINKOPTS=-lm
 build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --enable_platform_specific_config
-build --experimental_proto_descriptor_sets_include_source_info
 
 # Enable position independent code, this option is not supported on Windows and default on on macOS.
 build:linux --copt=-fPIC

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -29,7 +29,10 @@ def generateProtobufs(output):
   # Each rule has the form @envoy_api//foo/bar:baz_go_proto.
   # First build all the rules to ensure we have the output files.
   # We preserve source info so comments are retained on generated code.
-  check_call(['bazel', 'build', '-c', 'fastbuild', '--experimental_proto_descriptor_sets_include_source_info'] + go_protos)
+  check_call([
+      'bazel', 'build', '-c', 'fastbuild',
+      '--experimental_proto_descriptor_sets_include_source_info'
+  ] + go_protos)
 
   for rule in go_protos:
     # Example rule:

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -28,7 +28,8 @@ def generateProtobufs(output):
 
   # Each rule has the form @envoy_api//foo/bar:baz_go_proto.
   # First build all the rules to ensure we have the output files.
-  check_call(['bazel', 'build', '-c', 'fastbuild'] + go_protos)
+  # We preserve source info so comments are retained on generated code.
+  check_call(['bazel', 'build', '-c', 'fastbuild', '--experimental_proto_descriptor_sets_include_source_info'] + go_protos)
 
   for rule in go_protos:
     # Example rule:


### PR DESCRIPTION
<details>
 <summary>Diff of one of the output for example</summary>

```diff
3c3
< //    protoc-gen-go v1.25.0
---
> //    protoc-gen-go v1.22.0
32a33,34
> // :ref:`Circuit breaking<arch_overview_circuit_break>` settings can be
> // specified individually for each defined priority.
37a40,44
>       // If multiple :ref:`Thresholds<envoy_api_msg_config.cluster.v3.CircuitBreakers.Thresholds>`
>       // are defined with the same :ref:`RoutingPriority<envoy_api_enum_config.core.v3.RoutingPriority>`,
>       // the first one in the list is used. If no Thresholds is defined for a given
>       // :ref:`RoutingPriority<envoy_api_enum_config.core.v3.RoutingPriority>`, the default values
>       // are used.
79a87,89
> // A Thresholds defines CircuitBreaker settings for a
> // :ref:`RoutingPriority<envoy_api_enum_config.core.v3.RoutingPriority>`.
> // [#next-free-field: 9]
85,92c95,132
<       Priority           v3.RoutingPriority                      `protobuf:"varint,1,opt,name=priority,proto3,enum=envoy.config.core.v3.RoutingPriority" json:"priority,omitempty"`
<       MaxConnections     *wrappers.UInt32Value                   `protobuf:"bytes,2,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
<       MaxPendingRequests *wrappers.UInt32Value                   `protobuf:"bytes,3,opt,name=max_pending_requests,json=maxPendingRequests,proto3" json:"max_pending_requests,omitempty"`
<       MaxRequests        *wrappers.UInt32Value                   `protobuf:"bytes,4,opt,name=max_requests,json=maxRequests,proto3" json:"max_requests,omitempty"`
<       MaxRetries         *wrappers.UInt32Value                   `protobuf:"bytes,5,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
<       RetryBudget        *CircuitBreakers_Thresholds_RetryBudget `protobuf:"bytes,8,opt,name=retry_budget,json=retryBudget,proto3" json:"retry_budget,omitempty"`
<       TrackRemaining     bool                                    `protobuf:"varint,6,opt,name=track_remaining,json=trackRemaining,proto3" json:"track_remaining,omitempty"`
<       MaxConnectionPools *wrappers.UInt32Value                   `protobuf:"bytes,7,opt,name=max_connection_pools,json=maxConnectionPools,proto3" json:"max_connection_pools,omitempty"`
---
>       // The :ref:`RoutingPriority<envoy_api_enum_config.core.v3.RoutingPriority>`
>       // the specified CircuitBreaker settings apply to.
>       Priority v3.RoutingPriority `protobuf:"varint,1,opt,name=priority,proto3,enum=envoy.config.core.v3.RoutingPriority" json:"priority,omitempty"`
>       // The maximum number of connections that Envoy will make to the upstream
>       // cluster. If not specified, the default is 1024.
>       MaxConnections *wrappers.UInt32Value `protobuf:"bytes,2,opt,name=max_connections,json=maxConnections,proto3" json:"max_connections,omitempty"`
>       // The maximum number of pending requests that Envoy will allow to the
>       // upstream cluster. If not specified, the default is 1024.
>       MaxPendingRequests *wrappers.UInt32Value `protobuf:"bytes,3,opt,name=max_pending_requests,json=maxPendingRequests,proto3" json:"max_pending_requests,omitempty"`
>       // The maximum number of parallel requests that Envoy will make to the
>       // upstream cluster. If not specified, the default is 1024.
>       MaxRequests *wrappers.UInt32Value `protobuf:"bytes,4,opt,name=max_requests,json=maxRequests,proto3" json:"max_requests,omitempty"`
>       // The maximum number of parallel retries that Envoy will allow to the
>       // upstream cluster. If not specified, the default is 3.
>       MaxRetries *wrappers.UInt32Value `protobuf:"bytes,5,opt,name=max_retries,json=maxRetries,proto3" json:"max_retries,omitempty"`
>       // Specifies a limit on concurrent retries in relation to the number of active requests. This
>       // parameter is optional.
>       //
>       // .. note::
>       //
>       //    If this field is set, the retry budget will override any configured retry circuit
>       //    breaker.
>       RetryBudget *CircuitBreakers_Thresholds_RetryBudget `protobuf:"bytes,8,opt,name=retry_budget,json=retryBudget,proto3" json:"retry_budget,omitempty"`
>       // If track_remaining is true, then stats will be published that expose
>       // the number of resources remaining until the circuit breakers open. If
>       // not specified, the default is false.
>       //
>       // .. note::
>       //
>       //    If a retry budget is used in lieu of the max_retries circuit breaker,
>       //    the remaining retry resources remaining will not be tracked.
>       TrackRemaining bool `protobuf:"varint,6,opt,name=track_remaining,json=trackRemaining,proto3" json:"track_remaining,omitempty"`
>       // The maximum number of connection pools per cluster that Envoy will concurrently support at
>       // once. If not specified, the default is unlimited. Set this for clusters which create a
>       // large number of connection pools. See
>       // :ref:`Circuit Breaking <arch_overview_circuit_break_cluster_maximum_connection_pools>` for
>       // more details.
>       MaxConnectionPools *wrappers.UInt32Value `protobuf:"bytes,7,opt,name=max_connection_pools,json=maxConnectionPools,proto3" json:"max_connection_pools,omitempty"`
188c228,237
<       BudgetPercent       *v31.Percent          `protobuf:"bytes,1,opt,name=budget_percent,json=budgetPercent,proto3" json:"budget_percent,omitempty"`
---
>       // Specifies the limit on concurrent retries as a percentage of the sum of active requests and
>       // active pending requests. For example, if there are 100 active requests and the
>       // budget_percent is set to 25, there may be 25 active retries.
>       //
>       // This parameter is optional. Defaults to 20%.
>       BudgetPercent *v31.Percent `protobuf:"bytes,1,opt,name=budget_percent,json=budgetPercent,proto3" json:"budget_percent,omitempty"`
>       // Specifies the minimum retry concurrency allowed for the retry budget. The limit on the
>       // number of active retries may never go below this number.
>       //
>       // This parameter is optional. Defaults to 3.
```

</details>

Signed-off-by: John Howard <howardjohn@google.com>

https://github.com/bazelbuild/rules_go/issues/2646 has some additional information on this

Commit Message: Preserve protobuf comments in generated go code
Additional Description:
Risk Level: Low
Testing: None. Not sure how the testing for these works, but I assume at some point it will be imported to go-control-plane at which point it would break if something were to go wrong. In general this is just changing comments though.
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fixes https://github.com/envoyproxy/go-control-plane/issues/233
[Optional Deprecated:]
