### PR TITLE
http connection manager: use absl instead of std

### DIFF
--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -243,7 +243,8 @@ private:
       return response_headers_ ? absl::make_optional(std::ref(*response_headers_)) : absl::nullopt;
     }
     Http::ResponseTrailerMapOptRef responseTrailers() override {
-      return response_trailers_ ? absl::make_optional(std::ref(*response_trailers_)) : absl::nullopt;
+      return response_trailers_ ? absl::make_optional(std::ref(*response_trailers_))
+                                : absl::nullopt;
     }
 
     void endStream() override {

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -231,19 +231,19 @@ private:
 
     // TODO(snowp): Create shared OptRef/OptConstRef helpers
     Http::RequestHeaderMapOptRef requestHeaders() override {
-      return request_headers_ ? std::make_optional(std::ref(*request_headers_)) : absl::nullopt;
+      return request_headers_ ? absl::make_optional(std::ref(*request_headers_)) : absl::nullopt;
     }
     Http::RequestTrailerMapOptRef requestTrailers() override {
-      return request_trailers_ ? std::make_optional(std::ref(*request_trailers_)) : absl::nullopt;
+      return request_trailers_ ? absl::make_optional(std::ref(*request_trailers_)) : absl::nullopt;
     }
     Http::ResponseHeaderMapOptRef continueHeaders() override {
-      return continue_headers_ ? std::make_optional(std::ref(*continue_headers_)) : absl::nullopt;
+      return continue_headers_ ? absl::make_optional(std::ref(*continue_headers_)) : absl::nullopt;
     }
     Http::ResponseHeaderMapOptRef responseHeaders() override {
-      return response_headers_ ? std::make_optional(std::ref(*response_headers_)) : absl::nullopt;
+      return response_headers_ ? absl::make_optional(std::ref(*response_headers_)) : absl::nullopt;
     }
     Http::ResponseTrailerMapOptRef responseTrailers() override {
-      return response_trailers_ ? std::make_optional(std::ref(*response_trailers_)) : absl::nullopt;
+      return response_trailers_ ? absl::make_optional(std::ref(*response_trailers_)) : absl::nullopt;
     }
 
     void endStream() override {

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -691,12 +691,12 @@ def checkSourceLine(line, file_path, reportError):
   # See: https://github.com/envoyproxy/envoy/issues/12341
   if tokenInLine("std::any", line):
     reportError("Don't use std::any; use absl::any instead")
+  if tokenInLine("std::make_optional", line):
+    reportError("Don't use std::make_optional; use absl::make_optional instead")
   if tokenInLine("std::optional", line):
     reportError("Don't use std::optional; use absl::optional instead")
   if tokenInLine("std::variant", line):
     reportError("Don't use std::variant; use absl::variant instead")
-  if tokenInLine("std::visit", line):
-    reportError("Don't use std::visit; use absl::visit instead")
   if "__attribute__((packed))" in line and file_path != "./include/envoy/common/platform.h":
     # __attribute__((packed)) is not supported by MSVC, we have a PACKED_STRUCT macro that
     # can be used instead

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -695,6 +695,8 @@ def checkSourceLine(line, file_path, reportError):
     reportError("Don't use std::optional; use absl::optional instead")
   if tokenInLine("std::variant", line):
     reportError("Don't use std::variant; use absl::variant instead")
+  if tokenInLine("std::visit", line):
+    reportError("Don't use std::visit; use absl::visit instead")
   if "__attribute__((packed))" in line and file_path != "./include/envoy/common/platform.h":
     # __attribute__((packed)) is not supported by MSVC, we have a PACKED_STRUCT macro that
     # can be used instead

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -243,6 +243,8 @@ def runChecks():
       "std_unordered_set.cc", "Don't use std::unordered_set; use absl::flat_hash_set instead " +
       "or absl::node_hash_set if pointer stability of keys/values is required")
   errors += checkUnfixableError("std_any.cc", "Don't use std::any; use absl::any instead")
+  errors += checkUnfixableError("std_make_optional.cc",
+                                "Don't use std::make_optional; use absl::make_optional instead")
   errors += checkUnfixableError("std_optional.cc",
                                 "Don't use std::optional; use absl::optional instead")
   errors += checkUnfixableError("std_variant.cc",

--- a/tools/testdata/check_format/std_make_optional.cc
+++ b/tools/testdata/check_format/std_make_optional.cc
@@ -1,0 +1,8 @@
+#include <optional>
+
+namespace Envoy {
+    void foo() {
+      uint64_t value = 1;
+      uint64_t optional_value = std::make_optional<uint64_t>(value);
+    }
+} // namespace Envoy


### PR DESCRIPTION
Fixes a compilation issue with Envoy Mobile on iOS caused by usage of `std::` rather than `absl::` introduced in https://github.com/envoyproxy/envoy/commit/3f1c9d7866a5ce557c7754d06420a5cbb17dfe8c, which is unavailable on iOS 11.

I also added a test to ensure this doesn't happen again.

Past discussion of this issue: https://github.com/envoyproxy/envoy/issues/12341#issuecomment-667322800

cc @snowp

Risk Level: Low
Testing: CI
Docs Changes: None

Signed-off-by: Michael Rebello <me@michaelrebello.com>
