### PR TITLE
formatter: use absl instead of std

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -203,7 +203,7 @@ ProtobufWkt::Struct JsonFormatterImpl::toStruct(const Http::RequestHeaderMap& re
         auto* fields = output.mutable_fields();
         JsonFormatMapVisitor visitor{json_format_map_callback, providers_callback};
         for (const auto& pair : *format.value_) {
-          ProtobufWkt::Value value = std::visit(visitor, pair.second);
+          ProtobufWkt::Value value = absl::visit(visitor, pair.second);
           if (omit_empty_values_ && value.kind_case() == ProtobufWkt::Value::kNullValue) {
             continue;
           }


### PR DESCRIPTION
Fixes a compilation issue with Envoy Mobile on iOS caused by usage of `std::` rather than `absl::` introduced in https://github.com/envoyproxy/envoy/commit/9d466c71ab217317d3e989b261eb496877348a47, which is unavailable on iOS 11.

Past discussion of this issue: https://github.com/envoyproxy/envoy/issues/12341#issuecomment-667322800

cc @Pchelolo

Risk Level: Low
Testing: CI
Docs Changes: None

Signed-off-by: Michael Rebello <me@michaelrebello.com>