### PR TITLE
lint: add rule to use absl::make_optional over std::make_optional

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -696,6 +696,8 @@ def checkSourceLine(line, file_path, reportError):
     reportError("Don't use std::optional; use absl::optional instead")
   if tokenInLine("std::variant", line):
     reportError("Don't use std::variant; use absl::variant instead")
+  if tokenInLine("std::visit", line):
+    reportError("Don't use std::visit; use absl::visit instead")
   if "__attribute__((packed))" in line and file_path != "./include/envoy/common/platform.h":
     # __attribute__((packed)) is not supported by MSVC, we have a PACKED_STRUCT macro that
     # can be used instead

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -243,6 +243,8 @@ def runChecks():
       "std_unordered_set.cc", "Don't use std::unordered_set; use absl::flat_hash_set instead " +
       "or absl::node_hash_set if pointer stability of keys/values is required")
   errors += checkUnfixableError("std_any.cc", "Don't use std::any; use absl::any instead")
+  errors += checkUnfixableError("std_make_optional.cc",
+                                "Don't use std::make_optional; use absl::make_optional instead")
   errors += checkUnfixableError("std_optional.cc",
                                 "Don't use std::optional; use absl::optional instead")
   errors += checkUnfixableError("std_variant.cc",

--- a/tools/testdata/check_format/std_make_optional.cc
+++ b/tools/testdata/check_format/std_make_optional.cc
@@ -1,0 +1,8 @@
+#include <optional>
+
+namespace Envoy {
+    void foo() {
+      uint64_t value = 1;
+      uint64_t optional_value = std::make_optional<uint64_t>(value);
+    }
+} // namespace Envoy


### PR DESCRIPTION
This should prevent cases like https://github.com/envoyproxy/envoy/pull/13039.

Risk Level: Low
Testing: Added in PR

Signed-off-by: Michael Rebello <me@michaelrebello.com>
