### PR TITLE
http: response details for HTTP/2

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -416,8 +416,10 @@ public:
    *
    * @param headers supplies the headers to be encoded.
    * @param end_stream supplies whether this is a header only request/response.
+   * @param details supplies the details of why this response was sent.
    */
-  virtual void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) PURE;
+  virtual void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
+                             absl::string_view details) PURE;
 
   /**
    * Called with data to be encoded, optionally indicating end of stream.

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -94,7 +94,8 @@ AsyncStreamImpl::AsyncStreamImpl(AsyncClientImpl& parent, AsyncClient::StreamCal
   // TODO(mattklein123): Correctly set protocol in stream info when we support access logging.
 }
 
-void AsyncStreamImpl::encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
+void AsyncStreamImpl::encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
+                                    absl::string_view) {
   ENVOY_LOG(debug, "async http request response headers (end_stream={}):\n{}", end_stream,
             *headers);
   ASSERT(!remote_closed_);

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -367,30 +367,30 @@ private:
                       std::function<void(ResponseHeaderMap& headers)> modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                       absl::string_view details) override {
-    stream_info_.setResponseCodeDetails(details);
     if (encoded_response_headers_) {
       resetStream();
       return;
     }
     Utility::sendLocalReply(
         remote_closed_,
-        Utility::EncodeFunctions{
-            nullptr, nullptr,
-            [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
-              if (modify_headers != nullptr) {
-                modify_headers(*headers);
-              }
-              encodeHeaders(std::move(headers), end_stream);
-            },
-            [this](Buffer::Instance& data, bool end_stream) -> void {
-              encodeData(data, end_stream);
-            }},
+        Utility::EncodeFunctions{nullptr, nullptr,
+                                 [this, modify_headers, &details](ResponseHeaderMapPtr&& headers,
+                                                                  bool end_stream) -> void {
+                                   if (modify_headers != nullptr) {
+                                     modify_headers(*headers);
+                                   }
+                                   encodeHeaders(std::move(headers), end_stream, details);
+                                 },
+                                 [this](Buffer::Instance& data, bool end_stream) -> void {
+                                   encodeData(data, end_stream);
+                                 }},
         Utility::LocalReplyData{is_grpc_request_, code, body, grpc_status, is_head_request_});
   }
   // The async client won't pause if sending an Expect: 100-Continue so simply
   // swallows any incoming encode100Continue.
   void encode100ContinueHeaders(ResponseHeaderMapPtr&&) override {}
-  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
+                     absl::string_view details) override;
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(ResponseTrailerMapPtr&& trailers) override;
   void encodeMetadata(MetadataMapPtr&&) override {}

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -601,12 +601,10 @@ void ConnectionManagerImpl::ActiveStream::completeRequest() {
     filter_manager_.streamInfo().setResponseFlag(
         StreamInfo::ResponseFlag::DownstreamConnectionTermination);
   }
-  if (connection_manager_.codec_->protocol() < Protocol::Http2) {
-    // For HTTP/2 there are still some reset cases where details are not set.
-    // For HTTP/1 there shouldn't be any. Regression-proof this.
+  // TODO(danzh) bring HTTP/3 to parity here.
+  if (connection_manager_.codec_->protocol() != Protocol::Http3) {
     ASSERT(filter_manager_.streamInfo().responseCodeDetails().has_value());
   }
-
   connection_manager_.stats_.named_.downstream_rq_active_.dec();
   if (filter_manager_.streamInfo().healthCheck()) {
     connection_manager_.config_.tracingStats().health_check_.inc();

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -340,7 +340,6 @@ void ActiveStreamDecoderFilter::sendLocalReply(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
-  parent_.stream_info_.setResponseCodeDetails(details);
   parent_.sendLocalReply(is_grpc_request_, code, body, modify_headers, grpc_status, details);
 }
 
@@ -354,7 +353,9 @@ void ActiveStreamDecoderFilter::encode100ContinueHeaders(ResponseHeaderMapPtr&& 
   }
 }
 
-void ActiveStreamDecoderFilter::encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
+void ActiveStreamDecoderFilter::encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
+                                              absl::string_view details) {
+  parent_.stream_info_.setResponseCodeDetails(details);
   parent_.filter_manager_callbacks_.setResponseHeaders(std::move(headers));
   parent_.encodeHeaders(nullptr, *parent_.filter_manager_callbacks_.responseHeaders(), end_stream);
 }
@@ -781,7 +782,6 @@ void FilterManager::sendLocalReply(
     //
     sendDirectLocalReply(code, body, modify_headers, state_.is_head_request_, grpc_status);
   } else {
-    stream_info_.setResponseCodeDetails(details);
     // If we land in this branch, response headers have already been sent to the client.
     // All we can do at this point is reset the stream.
     ENVOY_STREAM_LOG(debug, "Resetting stream due to {}. Prior headers have already been sent",

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -173,7 +173,8 @@ struct ActiveStreamDecoderFilter : public ActiveStreamFilterBase,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                       absl::string_view details) override;
   void encode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override;
-  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
+                     absl::string_view details) override;
   void encodeData(Buffer::Instance& data, bool end_stream) override;
   void encodeTrailers(ResponseTrailerMapPtr&& trailers) override;
   void encodeMetadata(MetadataMapPtr&& metadata_map_ptr) override;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -28,6 +28,7 @@ namespace Envoy {
 namespace Http {
 namespace Http2 {
 
+// TODO(alyssawilk) docs.
 class Http2ResponseCodeDetailValues {
 public:
   // Invalid HTTP header field was received and stream is going to be
@@ -45,9 +46,9 @@ public:
   const absl::string_view inbound_empty_frame_flood = "http2.inbound_empty_frames_flood";
   // Envoy was configured to drop requests with header keys beginning with underscores.
   const absl::string_view invalid_underscore = "http2.unexpected_underscore";
-  // The upstream refused the stream.
+  // The peer refused the stream.
   const absl::string_view remote_refused = "http2.remote_refuse";
-  // The upstream reset the stream.
+  // The peer reset the stream.
   const absl::string_view remote_reset = "http2.remote_reset";
 
   const absl::string_view errorDetails(int error_code) const {

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -45,6 +45,10 @@ public:
   const absl::string_view inbound_empty_frame_flood = "http2.inbound_empty_frames_flood";
   // Envoy was configured to drop requests with header keys beginning with underscores.
   const absl::string_view invalid_underscore = "http2.unexpected_underscore";
+  // The upstream refused the stream.
+  const absl::string_view remote_refused = "http2.remote_refuse";
+  // The upstream reset the stream.
+  const absl::string_view remote_reset = "http2.remote_reset";
 
   const absl::string_view errorDetails(int error_code) const {
     switch (error_code) {
@@ -922,8 +926,13 @@ int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
         // the connection.
         reason = StreamResetReason::LocalReset;
       } else {
-        reason = error_code == NGHTTP2_REFUSED_STREAM ? StreamResetReason::RemoteRefusedStreamReset
-                                                      : StreamResetReason::RemoteReset;
+        if (error_code == NGHTTP2_REFUSED_STREAM) {
+          reason = StreamResetReason::RemoteRefusedStreamReset;
+          stream->setDetails(Http2ResponseCodeDetails::get().remote_refused);
+        } else {
+          reason = StreamResetReason::RemoteReset;
+          stream->setDetails(Http2ResponseCodeDetails::get().remote_reset);
+        }
       }
 
       stream->runResetCallbacks(reason);

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -46,6 +46,10 @@ public:
   const absl::string_view inbound_empty_frame_flood = "http2.inbound_empty_frames_flood";
   // Envoy was configured to drop requests with header keys beginning with underscores.
   const absl::string_view invalid_underscore = "http2.unexpected_underscore";
+  // The upstream refused the stream.
+  const absl::string_view remote_refused = "http2.remote_refuse";
+  // The upstream reset the stream.
+  const absl::string_view remote_reset = "http2.remote_reset";
 
   const absl::string_view errorDetails(int error_code) const {
     switch (error_code) {
@@ -900,8 +904,13 @@ int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
         // the connection.
         reason = StreamResetReason::LocalReset;
       } else {
-        reason = error_code == NGHTTP2_REFUSED_STREAM ? StreamResetReason::RemoteRefusedStreamReset
-                                                      : StreamResetReason::RemoteReset;
+        if (error_code == NGHTTP2_REFUSED_STREAM) {
+          reason = StreamResetReason::RemoteRefusedStreamReset;
+          stream->setDetails(Http2ResponseCodeDetails::get().remote_refused);
+        } else {
+          reason = StreamResetReason::RemoteReset;
+          stream->setDetails(Http2ResponseCodeDetails::get().remote_reset);
+        }
       }
 
       stream->runResetCallbacks(reason);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -435,9 +435,11 @@ Utility::parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions&
 
 void Utility::sendLocalReply(const bool& is_reset, StreamDecoderFilterCallbacks& callbacks,
                              const LocalReplyData& local_reply_data) {
-  absl::string_view details = (callbacks.streamInfo().responseCodeDetails().has_value()
-                                   ? callbacks.streamInfo().responseCodeDetails().value()
-                                   : "");
+  absl::string_view details = "";
+  if (callbacks.streamInfo().responseCodeDetails().has_value()) {
+    details = callbacks.streamInfo().responseCodeDetails().value();
+  };
+
   sendLocalReply(
       is_reset,
       Utility::EncodeFunctions{nullptr, nullptr,

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -435,7 +435,7 @@ Utility::parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions&
 
 void Utility::sendLocalReply(const bool& is_reset, StreamDecoderFilterCallbacks& callbacks,
                              const LocalReplyData& local_reply_data) {
-  absl::string_view details = "";
+  absl::string_view details;
   if (callbacks.streamInfo().responseCodeDetails().has_value()) {
     details = callbacks.streamInfo().responseCodeDetails().value();
   };

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -435,11 +435,14 @@ Utility::parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions&
 
 void Utility::sendLocalReply(const bool& is_reset, StreamDecoderFilterCallbacks& callbacks,
                              const LocalReplyData& local_reply_data) {
+  absl::string_view details = (callbacks.streamInfo().responseCodeDetails().has_value()
+                                   ? callbacks.streamInfo().responseCodeDetails().value()
+                                   : "");
   sendLocalReply(
       is_reset,
       Utility::EncodeFunctions{nullptr, nullptr,
                                [&](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
-                                 callbacks.encodeHeaders(std::move(headers), end_stream);
+                                 callbacks.encodeHeaders(std::move(headers), end_stream, details);
                                },
                                [&](Buffer::Instance& data, bool end_stream) -> void {
                                  callbacks.encodeData(data, end_stream);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1300,9 +1300,8 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
     onUpstreamComplete(upstream_request);
   }
 
-  callbacks_->streamInfo().setResponseCodeDetails(
-      StreamInfo::ResponseCodeDetails::get().ViaUpstream);
-  callbacks_->encodeHeaders(std::move(headers), end_stream);
+  callbacks_->encodeHeaders(std::move(headers), end_stream,
+                            StreamInfo::ResponseCodeDetails::get().ViaUpstream);
 }
 
 void Filter::onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_request,

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -451,7 +451,8 @@ void CacheFilter::encodeCachedResponse() {
   // If the filter is encoding, 304 response headers and cached headers are merged in encodeHeaders.
   // If the filter is decoding, we need to serve response headers from cache directly.
   if (filter_state_ == FilterState::DecodeServingFromCache) {
-    decoder_callbacks_->encodeHeaders(std::move(lookup_result_->headers_), end_stream);
+    decoder_callbacks_->encodeHeaders(std::move(lookup_result_->headers_), end_stream,
+                                      CacheResponseCodeDetails::get().ResponseFromCacheFilter);
   }
 
   if (lookup_result_->content_length_ > 0) {

--- a/source/extensions/filters/http/cors/cors_filter.cc
+++ b/source/extensions/filters/http/cors/cors_filter.cc
@@ -109,9 +109,8 @@ Http::FilterHeadersStatus CorsFilter::decodeHeaders(Http::RequestHeaderMap& head
     response_headers->setInline(access_control_max_age_handle.handle(), maxAge());
   }
 
-  decoder_callbacks_->streamInfo().setResponseCodeDetails(
-      HttpResponseCodeDetails::get().CorsResponse);
-  decoder_callbacks_->encodeHeaders(std::move(response_headers), true);
+  decoder_callbacks_->encodeHeaders(std::move(response_headers), true,
+                                    HttpResponseCodeDetails::get().CorsResponse);
 
   return Http::FilterHeadersStatus::StopIteration;
 }

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -761,8 +761,8 @@ void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
 
 void Filter::DecoderCallbacks::respond(Http::ResponseHeaderMapPtr&& headers, Buffer::Instance* body,
                                        lua_State*) {
-  callbacks_->streamInfo().setResponseCodeDetails(HttpResponseCodeDetails::get().LuaResponse);
-  callbacks_->encodeHeaders(std::move(headers), body == nullptr);
+  callbacks_->encodeHeaders(std::move(headers), body == nullptr,
+                            HttpResponseCodeDetails::get().LuaResponse);
   if (body && !parent_.destroyed_) {
     callbacks_->encodeData(*body, true);
   }

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -57,10 +57,10 @@ const std::string& queryParamsError() { CONSTRUCT_ON_FIRST_USE(std::string, "err
 const std::string& queryParamsCode() { CONSTRUCT_ON_FIRST_USE(std::string, "code"); }
 const std::string& queryParamsState() { CONSTRUCT_ON_FIRST_USE(std::string, "state"); }
 
-constexpr char REDIRECT_RACE[] = "oath.race_redirect";
-constexpr char REDIRECT_LOGGED_IN[] = "oath.logged_in";
-constexpr char REDIRECT_FOR_CREDENTIALS[] = "oath.missing_credentials";
-constexpr char SIGN_OUT[] = "oath.sign_out";
+constexpr absl::string_view REDIRECT_RACE = "oath.race_redirect";
+constexpr absl::string_view REDIRECT_LOGGED_IN = "oath.logged_in";
+constexpr absl::string_view REDIRECT_FOR_CREDENTIALS = "oath.missing_credentials";
+constexpr absl::string_view SIGN_OUT = "oath.sign_out";
 
 template <class T>
 std::vector<Http::HeaderUtility::HeaderData> headerMatchers(const T& matcher_protos) {

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -57,6 +57,11 @@ const std::string& queryParamsError() { CONSTRUCT_ON_FIRST_USE(std::string, "err
 const std::string& queryParamsCode() { CONSTRUCT_ON_FIRST_USE(std::string, "code"); }
 const std::string& queryParamsState() { CONSTRUCT_ON_FIRST_USE(std::string, "state"); }
 
+constexpr char REDIRECT_RACE[] = "oath.race_redirect";
+constexpr char REDIRECT_LOGGED_IN[] = "oath.logged_in";
+constexpr char REDIRECT_FOR_CREDENTIALS[] = "oath.missing_credentials";
+constexpr char SIGN_OUT[] = "oath.sign_out";
+
 template <class T>
 std::vector<Http::HeaderUtility::HeaderData> headerMatchers(const T& matcher_protos) {
   std::vector<Http::HeaderUtility::HeaderData> matchers;
@@ -219,7 +224,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
           Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
               {{Http::Headers::get().Status, std::to_string(enumToInt(Http::Code::Found))},
                {Http::Headers::get().Location, state}})};
-      decoder_callbacks_->encodeHeaders(std::move(response_headers), true);
+      decoder_callbacks_->encodeHeaders(std::move(response_headers), true, REDIRECT_RACE);
     }
 
     // Continue on with the filter stack.
@@ -272,7 +277,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
         fmt::format(AuthorizationEndpointFormat, config_->authorizationEndpoint(),
                     config_->clientId(), escaped_redirect_uri, escaped_state);
     response_headers->setLocation(new_url);
-    decoder_callbacks_->encodeHeaders(std::move(response_headers), true);
+    decoder_callbacks_->encodeHeaders(std::move(response_headers), true, REDIRECT_FOR_CREDENTIALS);
 
     config_->stats().oauth_unauthorized_rq_.inc();
 
@@ -348,7 +353,7 @@ Http::FilterHeadersStatus OAuth2Filter::signOutUser(const Http::RequestHeaderMap
   response_headers->addReference(Http::Headers::get().SetCookie, SignoutCookieValue);
   response_headers->addReference(Http::Headers::get().SetCookie, SignoutBearerTokenValue);
   response_headers->setLocation(new_path);
-  decoder_callbacks_->encodeHeaders(std::move(response_headers), true);
+  decoder_callbacks_->encodeHeaders(std::move(response_headers), true, SIGN_OUT);
 
   return Http::FilterHeadersStatus::StopAllIterationAndBuffer;
 }
@@ -419,7 +424,7 @@ void OAuth2Filter::finishFlow() {
 
   response_headers->setLocation(state_);
 
-  decoder_callbacks_->encodeHeaders(std::move(response_headers), true);
+  decoder_callbacks_->encodeHeaders(std::move(response_headers), true, REDIRECT_LOGGED_IN);
   config_->stats().oauth_success_.inc();
   decoder_callbacks_->continueDecoding();
 }

--- a/source/server/admin/admin_filter.cc
+++ b/source/server/admin/admin_filter.cc
@@ -70,10 +70,9 @@ void AdminFilter::onComplete() {
   RELEASE_ASSERT(request_headers_, "");
   Http::Code code = admin_server_callback_func_(path, *header_map, response, *this);
   Utility::populateFallbackResponseHeaders(code, *header_map);
-  decoder_callbacks_->streamInfo().setResponseCodeDetails(
-      StreamInfo::ResponseCodeDetails::get().AdminFilterResponse);
   decoder_callbacks_->encodeHeaders(std::move(header_map),
-                                    end_stream_on_complete_ && response.length() == 0);
+                                    end_stream_on_complete_ && response.length() == 0,
+                                    StreamInfo::ResponseCodeDetails::get().AdminFilterResponse);
 
   if (response.length() > 0) {
     decoder_callbacks_->encodeData(response, end_stream_on_complete_);

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -854,7 +854,7 @@ TEST_F(AsyncClientImplTest, ResetInOnHeaders) {
   Http::StreamDecoderFilterCallbacks* filter_callbacks =
       static_cast<Http::AsyncStreamImpl*>(stream);
   filter_callbacks->encodeHeaders(
-      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false);
+      ResponseHeaderMapPtr(new TestResponseHeaderMapImpl{{":status", "200"}}), false, "details");
 }
 
 TEST_F(AsyncClientImplTest, RemoteResetAfterStreamStart) {

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -489,7 +489,7 @@ public:
         if (CodeUtility::is1xx(status) && status != enumToInt(Http::Code::SwitchingProtocols)) {
           headers->setReferenceKey(Headers::get().Status, "200");
         }
-        decoder_filter_->callbacks_->encodeHeaders(std::move(headers), end_stream);
+        decoder_filter_->callbacks_->encodeHeaders(std::move(headers), end_stream, "details");
         state = end_stream ? StreamState::Closed : StreamState::PendingDataOrTrailers;
       }
       break;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -278,7 +278,7 @@ public:
         .WillOnce(Return(FilterHeadersStatus::Continue));
     EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
     decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-    decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+    decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
     return altered_response_headers;
   }
 
@@ -499,7 +499,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponse) {
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         // Drain 2 so that on the 2nd iteration we will hit zero.
         data.drain(2);
@@ -555,7 +555,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponse) {
         filter->callbacks_->encode100ContinueHeaders(std::move(continue_headers));
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -595,7 +595,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFiltersProxy
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   doRemoteClose();
 }
@@ -621,7 +621,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithEncoderFilters) {
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   doRemoteClose();
 }
@@ -654,7 +654,7 @@ TEST_F(HttpConnectionManagerImplTest, PauseResume100Continue) {
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[1]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[1]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   doRemoteClose();
 }
@@ -708,7 +708,7 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithDecoderPause) {
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -1453,7 +1453,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
         data.drain(4);
         return Http::okStatus();
@@ -1523,7 +1523,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
         data.drain(4);
         return Http::okStatus();
@@ -1591,7 +1591,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
         data.drain(4);
         return Http::okStatus();
@@ -1658,7 +1658,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
 
         data.drain(4);
@@ -1740,7 +1740,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
 
         data.drain(4);
@@ -1824,7 +1824,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
 
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
 
         data.drain(4);
@@ -1909,7 +1909,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{
             {":status", "200"}, {"x-envoy-decorator-operation", "testOp"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
         filter->callbacks_->activeSpan().setTag("service-cluster", "scoobydoo");
 
         data.drain(4);
@@ -1967,7 +1967,7 @@ TEST_F(HttpConnectionManagerImplTest,
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{
             {":status", "200"}, {"x-envoy-decorator-operation", "testOp"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -2025,7 +2025,7 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLog) {
 
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -2113,7 +2113,7 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogWithTrailers) {
 
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
         ResponseTrailerMapPtr response_trailers{new TestResponseTrailerMapImpl{{"x-trailer", "1"}}};
         filter->callbacks_->encodeTrailers(std::move(response_trailers));
@@ -2261,7 +2261,7 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogSsl) {
 
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
         ResponseTrailerMapPtr response_trailers{new TestResponseTrailerMapImpl{{"x-trailer", "1"}}};
         filter->callbacks_->encodeTrailers(std::move(response_trailers));
@@ -2306,7 +2306,7 @@ TEST_F(HttpConnectionManagerImplTest, DoNotStartSpanIfTracingIsNotEnabled) {
 
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -2700,7 +2700,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterUpstreamHeaders) 
 
     ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
     EXPECT_CALL(*idle_timer, enableTimer(_, _));
-    filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+    filter->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
     EXPECT_CALL(*idle_timer, disableTimer());
     idle_timer->invokeCallback();
@@ -2756,7 +2756,7 @@ TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutAfterBidiData) {
     ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
     EXPECT_CALL(*idle_timer, enableTimer(_, _));
     filter->callbacks_->streamInfo().setResponseCodeDetails("");
-    filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+    filter->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
     EXPECT_CALL(*idle_timer, enableTimer(_, _));
     decoder->decodeData(data, false);
@@ -3007,7 +3007,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnEncodeHeaders) {
     EXPECT_CALL(*request_timer, disableTimer()).Times(2);
     ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
     filter->callbacks_->streamInfo().setResponseCodeDetails("");
-    filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+    filter->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
     return Http::okStatus();
   }));
 
@@ -3304,7 +3304,7 @@ TEST_F(HttpConnectionManagerImplTest, FooUpgradeDrainClose) {
         filter->decoder_callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{
             {":status", "101"}, {"Connection", "upgrade"}, {"upgrade", "foo"}}};
-        filter->decoder_callbacks_->encodeHeaders(std::move(response_headers), false);
+        filter->decoder_callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -3436,7 +3436,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainCloseRaceWithClose) {
   EXPECT_CALL(*drain_timer, enableTimer(_, _));
   expectOnDestroy();
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
   // Fake a protocol error that races with the drain timeout. This will cause a local close.
   // Also fake the local close not closing immediately.
@@ -3536,7 +3536,7 @@ TEST_F(HttpConnectionManagerImplTest, DrainClose) {
   EXPECT_CALL(drain_close_, drainClose()).WillOnce(Return(true));
   EXPECT_CALL(*codec_, shutdownNotice());
   filter->callbacks_->streamInfo().setResponseCodeDetails("");
-  filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
   EXPECT_EQ(ssl_connection_.get(), filter->callbacks_->connection()->ssl().get());
 
   EXPECT_CALL(*codec_, goAway());
@@ -3583,7 +3583,7 @@ TEST_F(HttpConnectionManagerImplTest, ResponseBeforeRequestComplete) {
 
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 }
 
 TEST_F(HttpConnectionManagerImplTest, DisconnectOnProxyConnectionDisconnect) {
@@ -3618,7 +3618,7 @@ TEST_F(HttpConnectionManagerImplTest, DisconnectOnProxyConnectionDisconnect) {
 
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 }
 
 TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
@@ -3657,7 +3657,7 @@ TEST_F(HttpConnectionManagerImplTest, ResponseStartBeforeRequestComplete) {
         EXPECT_EQ("", headers.getServerValue());
       }));
   filter->callbacks_->streamInfo().setResponseCodeDetails("");
-  filter->callbacks_->encodeHeaders(std::move(response_headers), false);
+  filter->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   // Finish the request.
   EXPECT_CALL(*filter, decodeData(_, true));
@@ -3867,7 +3867,7 @@ TEST_F(HttpConnectionManagerImplTest, IdleTimeout) {
   EXPECT_CALL(*idle_timer, enableTimer(_, _));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   filter->callbacks_->streamInfo().setResponseCodeDetails("");
-  filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
   Event::MockTimer* drain_timer = setUpTimer();
   EXPECT_CALL(*drain_timer, enableTimer(_, _));
@@ -3935,7 +3935,7 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionDuration) {
 
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   filter->callbacks_->streamInfo().setResponseCodeDetails("");
-  filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
   Event::MockTimer* drain_timer = setUpTimer();
   EXPECT_CALL(*drain_timer, enableTimer(_, _));
@@ -3984,7 +3984,8 @@ TEST_F(HttpConnectionManagerImplTest, IntermediateBufferingEarlyResponse) {
         // Now filter 2 will send a complete response.
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
-        decoder_filters_[1]->callbacks_->encodeHeaders(std::move(response_headers), true);
+        decoder_filters_[1]->callbacks_->encodeHeaders(std::move(response_headers), true,
+                                                       "details");
         return FilterHeadersStatus::StopIteration;
       }));
 
@@ -4144,7 +4145,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInTrailersCallback) {
   // invoke encodeHeaders
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
 
   // set up encodeData expectations
   EXPECT_CALL(*encoder_filters_[1], encodeData(_, false))
@@ -4236,7 +4237,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddTrailersInDataCallbackNoTrailers)
   // invoke encodeHeaders
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
 
   // set up encodeData expectations
   EXPECT_CALL(*encoder_filters_[1], encodeData(_, true))
@@ -4323,7 +4324,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyInTrailersCallback) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
 
   EXPECT_CALL(*encoder_filters_[1], encodeData(_, false))
       .WillOnce(Return(FilterDataStatus::Continue));
@@ -4396,7 +4397,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyInTrailersCallback_NoDataFram
       .WillOnce(Return(FilterHeadersStatus::StopIteration));
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
 
   EXPECT_CALL(*encoder_filters_[0], encodeTrailers(_))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterTrailersStatus {
@@ -4460,7 +4461,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyInTrailersCallback_ContinueAf
       .WillOnce(Return(FilterHeadersStatus::StopIteration));
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
 
   EXPECT_CALL(*encoder_filters_[0], encodeTrailers(_))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterTrailersStatus {
@@ -4544,7 +4545,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyDuringDecodeData) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
   Buffer::OwnedImpl data1("good");
   decoder_filters_[1]->callbacks_->encodeData(data1, false);
   Buffer::OwnedImpl data2("bye");
@@ -4601,7 +4602,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyInline) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true, "details");
 }
 
 TEST_F(HttpConnectionManagerImplTest, Filter) {
@@ -4709,7 +4710,7 @@ TEST_F(HttpConnectionManagerImplTest, UpstreamWatermarkCallbacks) {
   expectOnDestroy();
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true, "details");
 }
 
 TEST_F(HttpConnectionManagerImplTest, UnderlyingConnectionWatermarksPassedOnWithLazyCreation) {
@@ -4894,7 +4895,7 @@ TEST_F(HttpConnectionManagerImplTest, HitFilterWatermarkLimits) {
   EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, false))
       .WillOnce(Return(FilterHeadersStatus::StopIteration));
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   MockDownstreamWatermarkCallbacks callbacks;
   decoder_filters_[0]->callbacks_->addDownstreamWatermarkCallbacks(callbacks);
@@ -5011,7 +5012,7 @@ TEST_F(HttpConnectionManagerImplTest, HitResponseBufferLimitsBeforeHeaders) {
   EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, false))
       .WillOnce(Return(FilterHeadersStatus::StopIteration));
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   // Now overload the buffer with response data. The filter returns
   // StopIterationAndBuffer, which will trigger an early response.
@@ -5054,7 +5055,7 @@ TEST_F(HttpConnectionManagerImplTest, HitResponseBufferLimitsAfterHeaders) {
       .WillOnce(Return(FilterHeadersStatus::Continue));
   EXPECT_CALL(response_encoder_, encodeHeaders(_, false));
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   // Now overload the buffer with response data. The filter returns
   // StopIterationAndBuffer, which will trigger an early reset.
@@ -5200,7 +5201,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterContinueAndEndStreamHeaders) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), false);
+      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), false, "details");
 
   Buffer::OwnedImpl response_body("response");
   decoder_filters_[1]->callbacks_->encodeData(response_body, true);
@@ -5246,7 +5247,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterContinueAndEndStreamData) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), false);
+      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), false, "details");
 
   Buffer::OwnedImpl response_body("response");
   decoder_filters_[1]->callbacks_->encodeData(response_body, true);
@@ -5295,7 +5296,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterContinueAndEndStreamTrailers) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), false);
+      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), false, "details");
 
   Buffer::OwnedImpl response_body("response");
   decoder_filters_[1]->callbacks_->encodeData(response_body, false);
@@ -5348,7 +5349,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterContinueDontEndStreamInjectBody) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), true);
+      makeHeaderMap<TestResponseHeaderMapImpl>({{":status", "200"}}), true, "details");
 
   EXPECT_CALL(*encoder_filters_[0], encodeData(_, true))
       .WillOnce(Return(FilterDataStatus::Continue));
@@ -5399,7 +5400,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterAddBodyContinuation) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true, "details");
 
   EXPECT_CALL(*encoder_filters_[0], encodeHeaders(_, false))
       .WillOnce(Return(FilterHeadersStatus::Continue));
@@ -5514,7 +5515,7 @@ TEST_F(HttpConnectionManagerImplTest, AddDataWithAllContinue) {
 
   decoder_filters_[2]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[2]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true, "details");
 }
 
 // This test verifies proper sequences of decodeData() and encodeData() are called
@@ -5602,7 +5603,7 @@ TEST_F(HttpConnectionManagerImplTest, AddDataWithStopAndContinue) {
 
   decoder_filters_[2]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[2]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true, "details");
 
   EXPECT_CALL(*encoder_filters_[1], encodeHeaders(_, true))
       .WillOnce(InvokeWithoutArgs([&]() -> FilterHeadersStatus {
@@ -5693,7 +5694,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterDirectDecodeEncodeDataNoTrailers) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
   Buffer::OwnedImpl response_body("response");
   decoder_filters_[1]->callbacks_->encodeData(response_body, true);
 
@@ -5784,7 +5785,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterDirectDecodeEncodeDataTrailers) {
 
   decoder_filters_[1]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[1]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
   Buffer::OwnedImpl response_body("response");
   decoder_filters_[1]->callbacks_->encodeData(response_body, false);
   decoder_filters_[1]->callbacks_->encodeTrailers(
@@ -5879,7 +5880,7 @@ TEST_F(HttpConnectionManagerImplTest, MultipleFilters) {
   EXPECT_EQ(ssl_connection_.get(), encoder_filters_[1]->callbacks_->connection()->ssl().get());
   decoder_filters_[2]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[2]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
   Buffer::OwnedImpl response_body("response");
   decoder_filters_[2]->callbacks_->encodeData(response_body, false);
   decoder_filters_[2]->callbacks_->encodeTrailers(
@@ -5978,7 +5979,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableHttp1KeepAliveWhenOverloaded) {
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -6037,7 +6038,7 @@ TEST_P(DrainH2HttpConnectionManagerImplTest, DisableHttp2KeepAliveWhenOverloaded
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -6115,7 +6116,7 @@ TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnEncodingPat
       }));
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
-  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false);
+  decoder_filters_[0]->callbacks_->encodeHeaders(std::move(response_headers), false, "details");
 
   // Invoke encodeData while all iteration is stopped and make sure the filters do not have
   // encodeData called.
@@ -6167,7 +6168,7 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenDraining) {
 
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
-        filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+        filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
         data.drain(4);
         return Http::okStatus();
@@ -6589,7 +6590,7 @@ TEST_F(HttpConnectionManagerImplTest, TestUpstreamResponseHeadersSize) {
 
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true, "details");
 }
 
 TEST_F(HttpConnectionManagerImplTest, TestUpstreamResponseBodySize) {
@@ -6639,7 +6640,7 @@ TEST_F(HttpConnectionManagerImplTest, TestUpstreamResponseBodySize) {
 
   decoder_filters_[0]->callbacks_->streamInfo().setResponseCodeDetails("");
   decoder_filters_[0]->callbacks_->encodeHeaders(
-      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false);
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, false, "details");
 
   EXPECT_CALL(response_encoder_, encodeData(_, true));
   expectOnDestroy();
@@ -6684,7 +6685,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderOnlyRequestAndResponseUsingHttp3) {
 
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   filter->callbacks_->streamInfo().setResponseCodeDetails("");
-  filter->callbacks_->encodeHeaders(std::move(response_headers), true);
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 
   EXPECT_EQ(1U, stats_.named_.downstream_rq_2xx_.value());
   EXPECT_EQ(1U, listener_stats_.downstream_rq_2xx_.value());

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -609,6 +609,7 @@ TEST(HttpUtility, SendLocalReply) {
 
   EXPECT_CALL(callbacks, encodeHeaders_(_, false));
   EXPECT_CALL(callbacks, encodeData(_, true));
+  EXPECT_CALL(callbacks, streamInfo());
   Utility::sendLocalReply(
       is_reset, callbacks,
       Utility::LocalReplyData{false, Http::Code::PayloadTooLarge, "large", absl::nullopt, false});
@@ -618,6 +619,7 @@ TEST(HttpUtility, SendLocalGrpcReply) {
   MockStreamDecoderFilterCallbacks callbacks;
   bool is_reset = false;
 
+  EXPECT_CALL(callbacks, streamInfo());
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.getStatusValue(), "200");
@@ -645,6 +647,7 @@ TEST(HttpUtility, SendLocalGrpcReplyWithUpstreamJsonPayload) {
 }
   )EOF";
 
+  EXPECT_CALL(callbacks, streamInfo());
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.getStatusValue(), "200");
@@ -663,6 +666,7 @@ TEST(HttpUtility, SendLocalGrpcReplyWithUpstreamJsonPayload) {
 TEST(HttpUtility, RateLimitedGrpcStatus) {
   MockStreamDecoderFilterCallbacks callbacks;
 
+  EXPECT_CALL(callbacks, streamInfo()).Times(testing::AnyNumber());
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_NE(headers.GrpcStatus(), nullptr);
@@ -691,6 +695,7 @@ TEST(HttpUtility, SendLocalReplyDestroyedEarly) {
   MockStreamDecoderFilterCallbacks callbacks;
   bool is_reset = false;
 
+  EXPECT_CALL(callbacks, streamInfo());
   EXPECT_CALL(callbacks, encodeHeaders_(_, false)).WillOnce(InvokeWithoutArgs([&]() -> void {
     is_reset = true;
   }));
@@ -703,6 +708,7 @@ TEST(HttpUtility, SendLocalReplyDestroyedEarly) {
 TEST(HttpUtility, SendLocalReplyHeadRequest) {
   MockStreamDecoderFilterCallbacks callbacks;
   bool is_reset = false;
+  EXPECT_CALL(callbacks, streamInfo());
   EXPECT_CALL(callbacks, encodeHeaders_(_, true))
       .WillOnce(Invoke([&](const ResponseHeaderMap& headers, bool) -> void {
         EXPECT_EQ(headers.getContentLengthValue(), fmt::format("{}", strlen("large")));

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -672,11 +672,10 @@ TEST_F(RouterTest, AddCookie) {
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, true);
 
-  absl::string_view rc_details2 = "via_upstream";
-  EXPECT_CALL(callbacks_.stream_info_, setResponseCodeDetails(rc_details2));
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder->decodeHeaders(std::move(response_headers), true);
+  EXPECT_EQ(callbacks_.details_, "via_upstream");
   // When the router filter gets reset we should cancel the pool request.
   router_.onDestroy();
 }
@@ -943,8 +942,6 @@ TEST_F(RouterTest, ResponseCodeDetailsSetByUpstream) {
 
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "200"}});
-  absl::string_view rc_details = StreamInfo::ResponseCodeDetails::get().ViaUpstream;
-  EXPECT_CALL(callbacks_.stream_info_, setResponseCodeDetails(rc_details));
   response_decoder->decodeHeaders(std::move(response_headers), true);
   EXPECT_TRUE(verifyHostUpstreamStats(1, 0));
 }

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -87,7 +87,7 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
             if (modify_headers != nullptr) {
               modify_headers(*headers);
             }
-            encodeHeaders(std::move(headers), end_stream);
+            encodeHeaders(std::move(headers), end_stream, details_);
           },
           [this](Buffer::Instance& data, bool end_stream) -> void {
             encodeData(data, end_stream);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -164,7 +164,10 @@ public:
   void encode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override {
     encode100ContinueHeaders_(*headers);
   }
-  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) override {
+  void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
+                     absl::string_view details) override {
+    details_ = details;
+    stream_info_.setResponseCodeDetails(details);
     encodeHeaders_(*headers, end_stream);
   }
   void encodeTrailers(ResponseTrailerMapPtr&& trailers) override { encodeTrailers_(*trailers); }
@@ -195,6 +198,7 @@ public:
   testing::NiceMock<Tracing::MockSpan> active_span_;
   testing::NiceMock<Tracing::MockConfig> tracing_config_;
   testing::NiceMock<MockScopedTrackedObject> scope_;
+  // TODO(alyssawilk) remove this and use stream info consistently.
   std::string details_;
   bool is_grpc_request_{};
   bool is_head_request_{false};


### PR DESCRIPTION
Making sure that response code details are set for all HTTP/1 and HTTP/2 streams

This involves adding an argument to encodeHeaders (which could be optional in this PR and made mandatory in a follow-up if preferred)

Risk Level: Medium (header API change)
Testing: updated unit tests, all tests pass with new assert
Docs Changes: n/a
Release Notes: n/a