### PR TITLE
router: extend HTTP CONNECT route matching criteria

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1056,9 +1056,10 @@ void ConnectRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
 }
 
 RouteConstSharedPtr ConnectRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
-                                                   const StreamInfo::StreamInfo&,
+                                                   const StreamInfo::StreamInfo& stream_info,
                                                    uint64_t random_value) const {
-  if (Http::HeaderUtility::isConnect(headers)) {
+  if (Http::HeaderUtility::isConnect(headers) &&
+      RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
     return clusterEntry(headers, random_value);
   }
   return nullptr;


### PR DESCRIPTION
Currently, using `ConnectMatcher` as a `RouteMatch` will match only on
an HTTP `:method` header of `CONNECT`.

Extend the matching functionality to allow for use of the additional
match criteria in `RouteMatch` - i.e. header matching, path matching,
etc. - mimicking the existing behavior of the other matchers (prefix,
path, etc.).

Closes #13042.

Risk Level: Medium (minor extension to an existing feature).
Testing: Unit test cases added for header matching.
Docs Changes: n/a
Release Notes: n/a