### PR TITLE
filter: http: jwt: implement matching for HTTP CONNECT

### DIFF
--- a/source/extensions/filters/http/jwt_authn/matcher.cc
+++ b/source/extensions/filters/http/jwt_authn/matcher.cc
@@ -143,6 +143,22 @@ private:
   std::string regex_str_;
 };
 
+/**
+ * Perform a match against an HTTP CONNECT request.
+ */
+class ConnectMatcherImpl : public BaseMatcherImpl {
+public:
+  ConnectMatcherImpl(const RequirementRule& rule) : BaseMatcherImpl(rule) {}
+
+  bool matches(const Http::RequestHeaderMap& headers) const override {
+    if (Http::HeaderUtility::isConnect(headers) && BaseMatcherImpl::matchRoute(headers)) {
+      ENVOY_LOG(debug, "CONNECT requirement matched.");
+      return true;
+    }
+
+    return false;
+  }
+};
 } // namespace
 
 MatcherConstPtr Matcher::create(const RequirementRule& rule) {
@@ -155,10 +171,7 @@ MatcherConstPtr Matcher::create(const RequirementRule& rule) {
   case RouteMatch::PathSpecifierCase::kSafeRegex:
     return std::make_unique<RegexMatcherImpl>(rule);
   case RouteMatch::PathSpecifierCase::kConnectMatcher:
-    // TODO: When CONNECT match support is implemented, remove the manual clean-up of CONNECT
-    // matching in the filter fuzzer implementation:
-    // //test/extensions/filters/http/common/fuzz/uber_per_filter.cc
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    return std::make_unique<ConnectMatcherImpl>(rule);
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -76,16 +76,6 @@ void UberFilterFuzzer::guideAnyProtoType(test::fuzz::HttpData* mutable_data, uin
   mutable_any->set_type_url(type_url);
 }
 
-void removeConnectMatcher(Protobuf::Message* message) {
-  envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& config =
-      dynamic_cast<envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication&>(*message);
-  for (auto& rules : *config.mutable_rules()) {
-    if (rules.match().has_connect_matcher()) {
-      rules.mutable_match()->set_path("/");
-    }
-  }
-}
-
 void cleanAttachmentTemplate(Protobuf::Message* message) {
   envoy::extensions::filters::http::squash::v3::Squash& config =
       dynamic_cast<envoy::extensions::filters::http::squash::v3::Squash&>(*message);
@@ -137,10 +127,6 @@ void UberFilterFuzzer::cleanFuzzedConfig(absl::string_view filter_name,
   } else if (name == HttpFilterNames::get().Tap) {
     // TapDS oneof field and OutputSinkType StreamingGrpc not implemented
     cleanTapConfig(message);
-  }
-  if (filter_name == HttpFilterNames::get().JwtAuthn) {
-    // Remove when connect matcher is implemented for Jwt Authentication filter.
-    removeConnectMatcher(message);
   }
 }
 


### PR DESCRIPTION
Remove an existing TODO and implement the matcher, which mirrors the
behavior of the HTTP router, using the `RouteMatch` configuration to
determine whether the matcher should run for a given request.

This change allows JWT-based authentication for HTTP CONNECT requests.

Clean up a TODO in `uber_per_filter.cc` and remove some obsolete cleanup
code.

Additional Description: This is a follow-on from #13056.
Risk Level: Medium (minor extension to an existing feature).
Testing: Unit test cases added for matching.
Docs Changes: n/a
Release Notes: n/a