### PR TITLE
[Windows] Adds a native windows filesystem implementation

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -61,7 +61,7 @@ typedef ptrdiff_t ssize_t;
 typedef uint32_t mode_t;
 
 typedef SOCKET os_fd_t;
-typedef HANDLE os_h_t;
+using os_h_t = HANDLE;
 
 typedef unsigned int sa_family_t;
 
@@ -211,7 +211,7 @@ constexpr absl::string_view null_device_path{"NUL"};
 #endif
 
 typedef int os_fd_t;
-typedef int os_h_t;
+using os_h_t = int;
 
 #define INVALID_HANDLE -1
 #define INVALID_SOCKET -1

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -61,6 +61,7 @@ typedef ptrdiff_t ssize_t;
 typedef uint32_t mode_t;
 
 typedef SOCKET os_fd_t;
+typedef HANDLE os_h_t;
 
 typedef unsigned int sa_family_t;
 
@@ -116,6 +117,7 @@ struct msghdr {
 #define IPV6_RECVPKTINFO IPV6_PKTINFO
 #endif
 
+#define INVALID_HANDLE INVALID_HANDLE_VALUE
 #define SOCKET_VALID(sock) ((sock) != INVALID_SOCKET)
 #define SOCKET_INVALID(sock) ((sock) == INVALID_SOCKET)
 #define SOCKET_FAILURE(rc) ((rc) == SOCKET_ERROR)
@@ -142,6 +144,9 @@ struct msghdr {
 #define SOCKET_ERROR_ADDR_NOT_AVAIL WSAEADDRNOTAVAIL
 #define SOCKET_ERROR_INVAL WSAEINVAL
 #define SOCKET_ERROR_ADDR_IN_USE WSAEADDRINUSE
+
+#define HANDLE_ERROR_PERM ERROR_ACCESS_DENIED
+#define HANDLE_ERROR_INVALID ERROR_INVALID_HANDLE
 
 namespace Platform {
 constexpr absl::string_view null_device_path{"NUL"};
@@ -206,7 +211,9 @@ constexpr absl::string_view null_device_path{"NUL"};
 #endif
 
 typedef int os_fd_t;
+typedef int os_h_t;
 
+#define INVALID_HANDLE -1
 #define INVALID_SOCKET -1
 #define SOCKET_VALID(sock) ((sock) >= 0)
 #define SOCKET_INVALID(sock) ((sock) == -1)
@@ -230,6 +237,10 @@ typedef int os_fd_t;
 #define SOCKET_ERROR_ADDR_NOT_AVAIL EADDRNOTAVAIL
 #define SOCKET_ERROR_INVAL EINVAL
 #define SOCKET_ERROR_ADDR_IN_USE EADDRINUSE
+
+// Mapping POSIX file errors to common error names 
+#define HANDLE_ERROR_PERM EACCES
+#define HANDLE_ERROR_INVALID EBADF
 
 namespace Platform {
 constexpr absl::string_view null_device_path{"/dev/null"};

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -61,7 +61,7 @@ typedef ptrdiff_t ssize_t;
 typedef uint32_t mode_t;
 
 typedef SOCKET os_fd_t;
-using os_h_t = HANDLE;
+typedef HANDLE os_h_t;
 
 typedef unsigned int sa_family_t;
 
@@ -211,7 +211,7 @@ constexpr absl::string_view null_device_path{"NUL"};
 #endif
 
 typedef int os_fd_t;
-using os_h_t = int;
+typedef int os_h_t;
 
 #define INVALID_HANDLE -1
 #define INVALID_SOCKET -1

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -61,7 +61,7 @@ typedef ptrdiff_t ssize_t;
 typedef uint32_t mode_t;
 
 typedef SOCKET os_fd_t;
-typedef HANDLE os_h_t;
+typedef HANDLE filesystem_os_id_t; // NOLINT(modernize-use-using)
 
 typedef unsigned int sa_family_t;
 
@@ -211,7 +211,7 @@ constexpr absl::string_view null_device_path{"NUL"};
 #endif
 
 typedef int os_fd_t;
-typedef int os_h_t;
+typedef int filesystem_os_id_t; // NOLINT(modernize-use-using)
 
 #define INVALID_HANDLE -1
 #define INVALID_SOCKET -1

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -238,7 +238,7 @@ typedef int os_h_t;
 #define SOCKET_ERROR_INVAL EINVAL
 #define SOCKET_ERROR_ADDR_IN_USE EADDRINUSE
 
-// Mapping POSIX file errors to common error names 
+// Mapping POSIX file errors to common error names
 #define HANDLE_ERROR_PERM EACCES
 #define HANDLE_ERROR_INVALID EBADF
 

--- a/source/common/filesystem/file_shared_impl.cc
+++ b/source/common/filesystem/file_shared_impl.cc
@@ -1,43 +1,26 @@
 #include "common/filesystem/file_shared_impl.h"
-
-#include <cstring>
+#include "common/common/utility.h"
 
 namespace Envoy {
 namespace Filesystem {
 
-Api::IoError::IoErrorCode IoFileError::getErrorCode() const { return IoErrorCode::UnknownError; }
+Api::IoError::IoErrorCode IoFileError::getErrorCode() const { 
+  switch (errno_) {
+    case HANDLE_ERROR_PERM:
+      return IoErrorCode::Permission;
+    case HANDLE_ERROR_INVALID:
+      return IoErrorCode::BadFd;
+    default:
+      ENVOY_LOG_MISC(debug, "Unknown error code {} details {}", errno_, getErrorDetails());
+      return IoErrorCode::UnknownError;
+  }
+}
 
 std::string IoFileError::getErrorDetails() const {
-  // TODO(sunjayBhatia, wrowe): Disable clang-format until win32 implementation no longer uses POSIX
-  // subsystem, see https://github.com/envoyproxy/envoy/issues/11655
-  // clang-format off
-  return ::strerror(errno_);
-  // clang-format on
+  return errorDetails(errno_);
 }
 
-Api::IoCallBoolResult FileSharedImpl::open(FlagSet in) {
-  if (isOpen()) {
-    return resultSuccess<bool>(true);
-  }
-
-  openFile(in);
-  return fd_ != -1 ? resultSuccess<bool>(true) : resultFailure<bool>(false, errno);
-}
-
-Api::IoCallSizeResult FileSharedImpl::write(absl::string_view buffer) {
-  const ssize_t rc = writeFile(buffer);
-  return rc != -1 ? resultSuccess<ssize_t>(rc) : resultFailure<ssize_t>(rc, errno);
-};
-
-Api::IoCallBoolResult FileSharedImpl::close() {
-  ASSERT(isOpen());
-
-  bool success = closeFile();
-  fd_ = -1;
-  return success ? resultSuccess<bool>(true) : resultFailure<bool>(false, errno);
-}
-
-bool FileSharedImpl::isOpen() const { return fd_ != -1; };
+bool FileSharedImpl::isOpen() const { return fd_ != INVALID_HANDLE; };
 
 std::string FileSharedImpl::path() const { return path_; };
 

--- a/source/common/filesystem/file_shared_impl.cc
+++ b/source/common/filesystem/file_shared_impl.cc
@@ -1,24 +1,23 @@
 #include "common/filesystem/file_shared_impl.h"
+
 #include "common/common/utility.h"
 
 namespace Envoy {
 namespace Filesystem {
 
-Api::IoError::IoErrorCode IoFileError::getErrorCode() const { 
+Api::IoError::IoErrorCode IoFileError::getErrorCode() const {
   switch (errno_) {
-    case HANDLE_ERROR_PERM:
-      return IoErrorCode::Permission;
-    case HANDLE_ERROR_INVALID:
-      return IoErrorCode::BadFd;
-    default:
-      ENVOY_LOG_MISC(debug, "Unknown error code {} details {}", errno_, getErrorDetails());
-      return IoErrorCode::UnknownError;
+  case HANDLE_ERROR_PERM:
+    return IoErrorCode::Permission;
+  case HANDLE_ERROR_INVALID:
+    return IoErrorCode::BadFd;
+  default:
+    ENVOY_LOG_MISC(debug, "Unknown error code {} details {}", errno_, getErrorDetails());
+    return IoErrorCode::UnknownError;
   }
 }
 
-std::string IoFileError::getErrorDetails() const {
-  return errorDetails(errno_);
-}
+std::string IoFileError::getErrorDetails() const { return errorDetails(errno_); }
 
 bool FileSharedImpl::isOpen() const { return fd_ != INVALID_HANDLE; };
 

--- a/source/common/filesystem/file_shared_impl.h
+++ b/source/common/filesystem/file_shared_impl.h
@@ -37,23 +37,15 @@ template <typename T> Api::IoCallResult<T> resultSuccess(T result) {
 
 class FileSharedImpl : public File {
 public:
-  FileSharedImpl(std::string path) : fd_(-1), path_(std::move(path)) {}
+  FileSharedImpl(std::string path) : fd_(INVALID_HANDLE), path_(std::move(path)) {}
 
   ~FileSharedImpl() override = default;
 
-  // Filesystem::File
-  Api::IoCallBoolResult open(FlagSet flag) override;
-  Api::IoCallSizeResult write(absl::string_view buffer) override;
-  Api::IoCallBoolResult close() override;
   bool isOpen() const override;
   std::string path() const override;
 
 protected:
-  virtual void openFile(FlagSet in) PURE;
-  virtual ssize_t writeFile(absl::string_view buffer) PURE;
-  virtual bool closeFile() PURE;
-
-  int fd_;
+  os_h_t fd_;
   const std::string path_;
 };
 

--- a/source/common/filesystem/file_shared_impl.h
+++ b/source/common/filesystem/file_shared_impl.h
@@ -45,7 +45,7 @@ public:
   std::string path() const override;
 
 protected:
-  os_h_t fd_;
+  filesystem_os_id_t fd_;
   const std::string path_;
 };
 

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -21,11 +21,11 @@ protected:
     mode_t mode_ = 0;
   };
 
-  // Filesystem::FileSharedImpl
+  Api::IoCallBoolResult open(FlagSet flag) override;
+  Api::IoCallSizeResult write(absl::string_view buffer) override;
+  Api::IoCallBoolResult close() override;
+
   FlagsAndMode translateFlag(FlagSet in);
-  void openFile(FlagSet flags) override;
-  ssize_t writeFile(absl::string_view buffer) override;
-  bool closeFile() override;
 
 private:
   friend class FileSystemImplTest;

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -25,9 +25,8 @@ protected:
   Api::IoCallSizeResult write(absl::string_view buffer) override;
   Api::IoCallBoolResult close() override;
 
-  FlagsAndMode translateFlag(FlagSet in);
-
 private:
+  FlagsAndMode translateFlag(FlagSet in);
   friend class FileSystemImplTest;
 };
 

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -59,7 +59,6 @@ Api::IoCallBoolResult FileImplWin32::close() {
   return resultSuccess(true);
 }
 
-
 FileImplWin32::FlagsAndMode FileImplWin32::translateFlag(FlagSet in) {
   DWORD access = 0;
   DWORD creation = OPEN_EXISTING;
@@ -71,7 +70,7 @@ FileImplWin32::FlagsAndMode FileImplWin32::translateFlag(FlagSet in) {
   if (in.test(File::Operation::Write)) {
     access = GENERIC_WRITE;
   }
-  
+
   // Order of tests matter here. There reason for that
   // is that `FILE_APPEND_DATA` should not be used together
   // with `GENERIC_WRITE`. If both of them are used the file
@@ -105,7 +104,8 @@ bool InstanceImplWin32::directoryExists(const std::string& path) {
 }
 
 ssize_t InstanceImplWin32::fileSize(const std::string& path) {
-  auto fd = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, NULL, NULL);
+  auto fd =
+      CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, NULL, NULL);
   if (fd == INVALID_HANDLE) {
     return -1;
   }
@@ -113,7 +113,7 @@ ssize_t InstanceImplWin32::fileSize(const std::string& path) {
   LARGE_INTEGER lFileSize;
   BOOL bGetSize = GetFileSizeEx(fd, &lFileSize);
   CloseHandle(fd);
-  if(!bGetSize) {
+  if (!bGetSize) {
     return -1;
   }
   result += lFileSize.QuadPart;

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -32,7 +32,8 @@ Api::IoCallBoolResult FileImplWin32::open(FlagSet in) {
   }
 
   auto flags = translateFlag(in);
-  fd_ = CreateFileA(path_.c_str(), flags.access_, NULL, NULL, flags.creation_, NULL, NULL);
+  fd_ = CreateFileA(path_.c_str(), flags.access_, FILE_SHARE_READ | FILE_SHARE_WRITE, 0,
+                    flags.creation_, 0, NULL);
   if (fd_ == INVALID_HANDLE) {
     return resultFailure(false, ::GetLastError());
   }
@@ -104,8 +105,7 @@ bool InstanceImplWin32::directoryExists(const std::string& path) {
 }
 
 ssize_t InstanceImplWin32::fileSize(const std::string& path) {
-  auto fd =
-      CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, NULL, NULL);
+  auto fd = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, 0, NULL);
   if (fd == INVALID_HANDLE) {
     return -1;
   }

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -26,39 +26,66 @@ FileImplWin32::~FileImplWin32() {
   }
 }
 
-void FileImplWin32::openFile(FlagSet in) {
-  const auto flags_and_mode = translateFlag(in);
-  fd_ = ::open(path_.c_str(), flags_and_mode.flags_, flags_and_mode.pmode_);
+Api::IoCallBoolResult FileImplWin32::open(FlagSet in) {
+  if (isOpen()) {
+    return resultSuccess(true);
+  }
+
+  auto flags = translateFlag(in);
+  fd_ = CreateFileA(path_.c_str(), flags.access_, NULL, NULL, flags.creation_, NULL, NULL);
+  if (fd_ == INVALID_HANDLE) {
+    return resultFailure(false, ::GetLastError());
+  }
+  return resultSuccess(true);
 }
 
-ssize_t FileImplWin32::writeFile(absl::string_view buffer) {
-  return ::_write(fd_, buffer.data(), buffer.size());
+Api::IoCallSizeResult FileImplWin32::write(absl::string_view buffer) {
+  DWORD bytes_written;
+  BOOL result = WriteFile(fd_, buffer.data(), buffer.length(), &bytes_written, NULL);
+  if (result == 0) {
+    return resultFailure<ssize_t>(-1, ::GetLastError());
+  }
+  return resultSuccess<ssize_t>(bytes_written);
+};
+
+Api::IoCallBoolResult FileImplWin32::close() {
+  ASSERT(isOpen());
+
+  BOOL result = CloseHandle(fd_);
+  fd_ = INVALID_HANDLE;
+  if (result == 0) {
+    return resultFailure(false, ::GetLastError());
+  }
+  return resultSuccess(true);
 }
+
 
 FileImplWin32::FlagsAndMode FileImplWin32::translateFlag(FlagSet in) {
-  int out = 0;
-  int pmode = 0;
+  DWORD access = 0;
+  DWORD creation = OPEN_EXISTING;
+
   if (in.test(File::Operation::Create)) {
-    out |= _O_CREAT;
-    pmode |= _S_IREAD | _S_IWRITE;
+    creation = OPEN_ALWAYS;
   }
 
+  if (in.test(File::Operation::Write)) {
+    access = GENERIC_WRITE;
+  }
+  
+  // Order of tests matter here. There reason for that
+  // is that `FILE_APPEND_DATA` should not be used together
+  // with `GENERIC_WRITE`. If both of them are used the file
+  // is not opened in append mode.
   if (in.test(File::Operation::Append)) {
-    out |= _O_APPEND;
+    access = FILE_APPEND_DATA;
   }
 
-  if (in.test(File::Operation::Read) && in.test(File::Operation::Write)) {
-    out |= _O_RDWR;
-  } else if (in.test(File::Operation::Read)) {
-    out |= _O_RDONLY;
-  } else if (in.test(File::Operation::Write)) {
-    out |= _O_WRONLY;
+  if (in.test(File::Operation::Read)) {
+    access |= GENERIC_READ;
   }
 
-  return {out, pmode};
+  return {access, creation};
 }
-
-bool FileImplWin32::closeFile() { return ::_close(fd_) != -1; }
 
 FilePtr InstanceImplWin32::createFile(const std::string& path) {
   return std::make_unique<FileImplWin32>(path);
@@ -78,11 +105,19 @@ bool InstanceImplWin32::directoryExists(const std::string& path) {
 }
 
 ssize_t InstanceImplWin32::fileSize(const std::string& path) {
-  struct _stat info;
-  if (::_stat(path.c_str(), &info) != 0) {
+  auto fd = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, NULL, NULL);
+  if (fd == INVALID_HANDLE) {
     return -1;
   }
-  return info.st_size;
+  ssize_t result = 0;
+  LARGE_INTEGER lFileSize;
+  BOOL bGetSize = GetFileSizeEx(fd, &lFileSize);
+  CloseHandle(fd);
+  if(!bGetSize) {
+    return -1;
+  }
+  result += lFileSize.QuadPart;
+  return result;
 }
 
 std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -15,15 +15,15 @@ public:
 
 protected:
   struct FlagsAndMode {
-    int flags_ = 0;
-    int pmode_ = 0;
+    DWORD access_ = 0;
+    DWORD creation_ = 0;
   };
 
-  // Filesystem::FileSharedImpl
+  Api::IoCallBoolResult open(FlagSet flag) override;
+  Api::IoCallSizeResult write(absl::string_view buffer) override;
+  Api::IoCallBoolResult close() override;
+
   FlagsAndMode translateFlag(FlagSet in);
-  void openFile(FlagSet in) override;
-  ssize_t writeFile(absl::string_view buffer) override;
-  bool closeFile() override;
 
 private:
   friend class FileSystemImplTest;

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -14,13 +14,11 @@ public:
   ~FileImplWin32();
 
 protected:
-
   Api::IoCallBoolResult open(FlagSet flag) override;
   Api::IoCallSizeResult write(absl::string_view buffer) override;
   Api::IoCallBoolResult close() override;
 
 private:
-
   struct FlagsAndMode {
     DWORD access_ = 0;
     DWORD creation_ = 0;

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -14,18 +14,19 @@ public:
   ~FileImplWin32();
 
 protected:
-  struct FlagsAndMode {
-    DWORD access_ = 0;
-    DWORD creation_ = 0;
-  };
 
   Api::IoCallBoolResult open(FlagSet flag) override;
   Api::IoCallSizeResult write(absl::string_view buffer) override;
   Api::IoCallBoolResult close() override;
 
-  FlagsAndMode translateFlag(FlagSet in);
-
 private:
+
+  struct FlagsAndMode {
+    DWORD access_ = 0;
+    DWORD creation_ = 0;
+  };
+
+  FlagsAndMode translateFlag(FlagSet in);
   friend class FileSystemImplTest;
 };
 

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -231,6 +231,18 @@ TEST_F(FileSystemImplTest, Open) {
   EXPECT_TRUE(file->isOpen());
 }
 
+TEST_F(FileSystemImplTest, OpenReadOnly) {
+  const std::string new_file_path = TestEnvironment::temporaryPath("envoy_this_not_exist");
+  ::unlink(new_file_path.c_str());
+  static constexpr FlagSet ReadOnlyFlags{1 << Filesystem::File::Operation::Read |
+                                        1 << Filesystem::File::Operation::Create |
+                                        1 << Filesystem::File::Operation::Append};
+  FilePtr file = file_system_.createFile(new_file_path);
+  const Api::IoCallBoolResult result = file->open(ReadOnlyFlags);
+  EXPECT_TRUE(result.rc_);
+  EXPECT_TRUE(file->isOpen());
+}
+
 TEST_F(FileSystemImplTest, OpenTwice) {
   const std::string new_file_path = TestEnvironment::temporaryPath("envoy_this_not_exist");
   ::unlink(new_file_path.c_str());

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -351,19 +351,18 @@ TEST_F(FileSystemImplTest, ExistingReadOnlyFileAndWrite) {
   EXPECT_EQ("existing file", contents);
 }
 
-TEST(FileSystemImplTest, TestIoFileError) {
+TEST_F(FileSystemImplTest, TestIoFileError) {
   IoFileError error1(HANDLE_ERROR_PERM);
   EXPECT_EQ(IoFileError::IoErrorCode::Permission, error1.getErrorCode());
   EXPECT_EQ(errorDetails(HANDLE_ERROR_PERM), error1.getErrorDetails());
 
-
   IoFileError error2(HANDLE_ERROR_INVALID);
-  EXPECT_EQ(IoFileError::IoErrorCode::BadFd, error1.getErrorCode());
-  EXPECT_EQ(errorDetails(HANDLE_ERROR_PERM), error1.getErrorDetails());
+  EXPECT_EQ(IoFileError::IoErrorCode::BadFd, error2.getErrorCode());
+  EXPECT_EQ(errorDetails(HANDLE_ERROR_INVALID), error2.getErrorDetails());
 
   int not_known_error = 42;
   IoFileError error3(not_known_error);
-  EXPECT_EQ(IoFileError::IoErrorCode::UnknownError, error1.getErrorCode());
+  EXPECT_EQ(IoFileError::IoErrorCode::UnknownError, error3.getErrorCode());
 }
 
 } // namespace Filesystem

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -63,11 +63,7 @@ TEST_F(FileSystemImplTest, DirectoryExists) {
 }
 
 TEST_F(FileSystemImplTest, FileSize) {
-#ifdef WIN32
-  EXPECT_EQ(0, file_system_.fileSize("NUL"));
-#else
-  EXPECT_EQ(0, file_system_.fileSize("/dev/null"));
-#endif
+  EXPECT_EQ(0, file_system_.fileSize(std::string(Platform::null_device_path)));
   EXPECT_EQ(-1, file_system_.fileSize("/dev/blahblahblah"));
   const std::string data = "test string\ntest";
   const std::string file_path = TestEnvironment::writeStringToFileForTest("test_envoy", data);
@@ -353,6 +349,21 @@ TEST_F(FileSystemImplTest, ExistingReadOnlyFileAndWrite) {
 
   auto contents = TestEnvironment::readFileToStringForTest(file_path);
   EXPECT_EQ("existing file", contents);
+}
+
+TEST(FileSystemImplTest, TestIoFileError) {
+  IoFileError error1(HANDLE_ERROR_PERM);
+  EXPECT_EQ(IoFileError::IoErrorCode::Permission, error1.getErrorCode());
+  EXPECT_EQ(errorDetails(HANDLE_ERROR_PERM), error1.getErrorDetails());
+
+
+  IoFileError error2(HANDLE_ERROR_INVALID);
+  EXPECT_EQ(IoFileError::IoErrorCode::BadFd, error1.getErrorCode());
+  EXPECT_EQ(errorDetails(HANDLE_ERROR_PERM), error1.getErrorDetails());
+
+  int not_known_error = 42;
+  IoFileError error3(not_known_error);
+  EXPECT_EQ(IoFileError::IoErrorCode::UnknownError, error1.getErrorCode());
 }
 
 } // namespace Filesystem

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -19,7 +19,7 @@ static constexpr FlagSet DefaultFlags{
 
 class FileSystemImplTest : public testing::Test {
 protected:
-  os_h_t getFd(File* file) {
+  filesystem_os_id_t getFd(File* file) {
 #ifdef WIN32
     auto file_impl = dynamic_cast<FileImplWin32*>(file);
 #else
@@ -239,7 +239,7 @@ TEST_F(FileSystemImplTest, OpenTwice) {
   EXPECT_EQ(getFd(file.get()), INVALID_HANDLE);
 
   const Api::IoCallBoolResult result1 = file->open(DefaultFlags);
-  const os_h_t initial_fd = getFd(file.get());
+  const filesystem_os_id_t initial_fd = getFd(file.get());
   EXPECT_TRUE(result1.rc_);
   EXPECT_TRUE(file->isOpen());
 

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -235,8 +235,8 @@ TEST_F(FileSystemImplTest, OpenReadOnly) {
   const std::string new_file_path = TestEnvironment::temporaryPath("envoy_this_not_exist");
   ::unlink(new_file_path.c_str());
   static constexpr FlagSet ReadOnlyFlags{1 << Filesystem::File::Operation::Read |
-                                        1 << Filesystem::File::Operation::Create |
-                                        1 << Filesystem::File::Operation::Append};
+                                         1 << Filesystem::File::Operation::Create |
+                                         1 << Filesystem::File::Operation::Append};
   FilePtr file = file_system_.createFile(new_file_path);
   const Api::IoCallBoolResult result = file->open(ReadOnlyFlags);
   EXPECT_TRUE(result.rc_);


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Commit Message:

Refactor `filesystem_impl` to use win32 APIs instead of POSIX subsystem. Fixes issue #11655.

Additional Description:

For easier review the major changes are the following:

1. Adds a Win32 impl
1. Strips away the `file_shared_impl` because it relied on `errno` for error handling. This change cascades to the POSIX implementation
1. Adds a preliminary error mapping so we don't rely on error strings.

Risk Level: Low
Testing: Already tested in `filesystem_impl_test`
Docs Changes: N/A
Release Notes: N/A
