### PR TITLE
[tls] Introduce HandshakerAndConnectionInfo interface.

### DIFF
--- a/include/envoy/ssl/handshaker.h
+++ b/include/envoy/ssl/handshaker.h
@@ -49,7 +49,7 @@ public:
 };
 
 /**
- * Base interface for a combined handshaker-and-connectioninfo class
+ * Base interface for a combined `handshaker-and-connectioninfo` class
  * which can both perform handshakes and provide connection-specific
  * information.
  */

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.h
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.h
@@ -37,7 +37,7 @@ private:
       Envoy::Ssl::ClientValidationStatus::NotValidated};
 };
 
-class SslHandshakerImpl : public Ssl::ConnectionInfo, public Ssl::Handshaker {
+class SslHandshakerImpl : public Ssl::HandshakerAndConnectionInfo {
 public:
   SslHandshakerImpl(bssl::UniquePtr<SSL> ssl, int ssl_extended_socket_info_index,
                     Ssl::HandshakeCallbacks* handshake_callbacks);
@@ -67,10 +67,11 @@ public:
   // Ssl::Handshaker
   Network::PostIoAction doHandshake() override;
 
-  Ssl::SocketState state() { return state_; }
-  void setState(Ssl::SocketState state) { state_ = state; }
-  SSL* ssl() const { return ssl_.get(); }
-  Ssl::HandshakeCallbacks* handshakeCallbacks() { return handshake_callbacks_; }
+  // Ssl::HandshakerAndConnectionInfo
+  Ssl::SocketState state() override { return state_; }
+  void setState(Ssl::SocketState state) override { state_ = state; }
+  SSL* ssl() const override { return ssl_.get(); }
+  Ssl::HandshakeCallbacks* handshakeCallbacks() override { return handshake_callbacks_; }
 
   bssl::UniquePtr<SSL> ssl_;
 
@@ -94,8 +95,6 @@ private:
   mutable std::string cached_tls_version_;
   mutable SslExtendedSocketInfoImpl extended_socket_info_;
 };
-
-using SslHandshakerImplSharedPtr = std::shared_ptr<SslHandshakerImpl>;
 
 class HandshakerFactoryContextImpl : public Ssl::HandshakerFactoryContext {
 public:

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -50,9 +50,8 @@ SslSocket::SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
                      Ssl::HandshakerFactoryCb handshaker_factory_cb)
     : transport_socket_options_(transport_socket_options),
       ctx_(std::dynamic_pointer_cast<ContextImpl>(ctx)),
-      info_(std::dynamic_pointer_cast<SslHandshakerImpl>(
-          handshaker_factory_cb(ctx_->newSsl(transport_socket_options_.get()),
-                                ctx_->sslExtendedSocketInfoIndex(), this))) {
+      info_(handshaker_factory_cb(ctx_->newSsl(transport_socket_options_.get()),
+                                  ctx_->sslExtendedSocketInfoIndex(), this)) {
   if (state == InitialState::Client) {
     SSL_set_connect_state(rawSsl());
   } else {

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -72,7 +72,7 @@ public:
   SSL* rawSslForTest() const { return rawSsl(); }
 
 protected:
-  SSL* rawSsl() const { return info_->ssl_.get(); }
+  SSL* rawSsl() const { return info_->ssl(); }
 
 private:
   struct ReadResult {
@@ -94,7 +94,7 @@ private:
   uint64_t bytes_to_retry_{};
   std::string failure_reason_;
 
-  SslHandshakerImplSharedPtr info_;
+  Ssl::HandshakerAndConnectionInfoSharedPtr info_;
 };
 
 class ClientSslSocketFactory : public Network::TransportSocketFactory,


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

Commit Message: Introduce HandshakerAndConnectionInfo interface.
Additional Description: @mattklein123 pointed out in https://github.com/envoyproxy/envoy/pull/12658#discussion_r487170205 that the current design of `dynamic_pointer_cast`-ing an extension impl only works if, as in the test, our custom impl extends the real impl. This PR introduces a new interface with the necessary method, which allows us to remove this unsafe cast.
Risk Level: Low
Testing: N/a
Docs Changes: N/a
Release Notes: N/a