### PR TITLE
dependencies: patch policy.

### DIFF
--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -93,6 +93,25 @@ basis:
 Where possible, we prefer the latest release version for external dependencies, rather than master
 branch GitHub SHA tarballs.
 
+## Dependency patches
+
+Occasionally it is necessary to introduce an Envoy-side patch to a dependency in a `.patch` file.
+These are typically applied in [bazel/repositories.bzl](bazel/repositories.bzl). Our policy on this
+is as follows:
+
+* Patch files impede dependency updates. They are expedient at creation time but are a maintenance
+  penalty. They reduce the velocity and increase the effort of upgrades in response to security
+  vulnerabilities in external dependencies.
+
+* No patch will be accepted without a sincere and sustained effort to upstream the patch to the
+  dependency's canonical repository.
+
+* There should exist a plan-of-record, filed as an issue in Envoy or the upstream GitHub tracking
+  elimination of the patch.
+
+* Every patch must have comments at its point-of-use in [bazel/repositories.bzl](bazel/repositories.bzl)
+  providing a rationale and detailing to the tracking issue.
+
 ## Policy exceptions
 
 The following dependencies are exempt from the policy:

--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -110,7 +110,7 @@ is as follows:
   elimination of the patch.
 
 * Every patch must have comments at its point-of-use in [bazel/repositories.bzl](bazel/repositories.bzl)
-  providing a rationale and detailing to the tracking issue.
+  providing a rationale and detailing the tracking issue.
 
 ## Policy exceptions
 


### PR DESCRIPTION
Clarify the conditions under which patches may be used on external deps.

Signed-off-by: Harvey Tuch <htuch@google.com>