### PR TITLE
dispatcher: Do not change the registration of schedulable callbacks that are already enabled.

### DIFF
--- a/source/common/event/schedulable_cb_impl.cc
+++ b/source/common/event/schedulable_cb_impl.cc
@@ -21,12 +21,18 @@ SchedulableCallbackImpl::SchedulableCallbackImpl(Libevent::BasePtr& libevent,
 }
 
 void SchedulableCallbackImpl::scheduleCallbackCurrentIteration() {
+  if (enabled()) {
+    return;
+  }
   // event_active directly adds the event to the end of the work queue so it executes in the current
   // iteration of the event loop.
   event_active(&raw_event_, EV_TIMEOUT, 0);
 }
 
 void SchedulableCallbackImpl::scheduleCallbackNextIteration() {
+  if (enabled()) {
+    return;
+  }
   // libevent computes the list of timers to move to the work list after polling for fd events, but
   // iteration through the work list starts. Zero delay timers added while iterating through the
   // work list execute on the next iteration of the event loop.


### PR DESCRIPTION
Commit Message: dispatcher: Do not change the registration of schedulable callbacks that are already enabled.
Additional Description:
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a