### PR TITLE
[tls] Add transportSocketCallbacks() to Ssl::HandshakeCallbacks

### DIFF
--- a/include/envoy/ssl/handshaker.h
+++ b/include/envoy/ssl/handshaker.h
@@ -30,6 +30,12 @@ public:
    * A callback which will be executed at most once upon handshake failure.
    */
   virtual void onFailure() PURE;
+
+  /**
+   * Returns a pointer to the transportSocketCallbacks struct, or nullptr if
+   * unset.
+   */
+  virtual Network::TransportSocketCallbacks* transportSocketCallbacks() PURE;
 };
 
 /**

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -68,6 +68,7 @@ public:
   Network::Connection& connection() const override;
   void onSuccess(SSL* ssl) override;
   void onFailure() override;
+  Network::TransportSocketCallbacks* transportSocketCallbacks() override { return callbacks_; }
 
   SSL* rawSslForTest() const { return rawSsl(); }
 

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -49,6 +49,7 @@ envoy_cc_test(
         "//test/mocks/buffer:buffer_mocks",
         "//test/mocks/init:init_mocks",
         "//test/mocks/local_info:local_info_mocks",
+        "//test/mocks/network:io_handle_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_mocks",

--- a/test/extensions/transport_sockets/tls/handshaker_test.cc
+++ b/test/extensions/transport_sockets/tls/handshaker_test.cc
@@ -45,6 +45,7 @@ public:
   MOCK_METHOD(Network::Connection&, connection, (), (const, override));
   MOCK_METHOD(void, onSuccess, (SSL*), (override));
   MOCK_METHOD(void, onFailure, (), (override));
+  MOCK_METHOD(Network::TransportSocketCallbacks*, transportSocketCallbacks, (), (override));
 };
 
 class HandshakerTest : public SslCertsTest {

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -37,6 +37,7 @@
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/init/mocks.h"
 #include "test/mocks/local_info/mocks.h"
+#include "test/mocks/network/io_handle.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/secret/mocks.h"
 #include "test/mocks/server/transport_socket_factory_context.h"
@@ -4501,6 +4502,38 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
   result = transport_socket->doWrite(buffer, true);
   EXPECT_EQ(Network::PostIoAction::Close, result.action_);
   EXPECT_EQ("TLS error: Secret is not supplied by SDS", transport_socket->failureReason());
+}
+
+TEST_P(SslSocketTest, TestTransportSocketCallback) {
+  // Make MockTransportSocketCallbacks.
+  Network::MockIoHandle io_handle;
+  NiceMock<Network::MockTransportSocketCallbacks> callbacks;
+  ON_CALL(callbacks, ioHandle()).WillByDefault(ReturnRef(io_handle));
+
+  // Make SslSocket.
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  Stats::TestUtil::TestStore stats_store;
+  ON_CALL(factory_context, stats()).WillByDefault(ReturnRef(stats_store));
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  ON_CALL(factory_context, localInfo()).WillByDefault(ReturnRef(local_info));
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context);
+
+  ContextManagerImpl manager(time_system_);
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
+
+  Network::TransportSocketPtr transport_socket =
+      client_ssl_socket_factory.createTransportSocket(nullptr);
+
+  SslSocket* ssl_socket = dynamic_cast<SslSocket*>(transport_socket.get());
+
+  // If no transport socket callbacks have been set, this method should return nullptr.
+  EXPECT_EQ(ssl_socket->transportSocketCallbacks(), nullptr);
+
+  // Otherwise, it should return a pointer to the set callbacks object.
+  ssl_socket->setTransportSocketCallbacks(callbacks);
+  EXPECT_EQ(ssl_socket->transportSocketCallbacks(), &callbacks);
 }
 
 class SslReadBufferLimitTest : public SslSocketTest {


### PR DESCRIPTION
Signed-off-by: James Buckland <jbuckland@google.com>

Commit Message: [tls] Add a transportSocketCallbacks() accessor to the Ssl::HandshakeCallbacks interface.
Additional Description: I think access to the suite of `TransportSocketCallbacks` is useful for custom Handshaker implementations. Rather than duplicate each callback as a member of `Ssl::HandshakeCallbacks`, adding an accessor seems like the natural fix. This lets custom handshaker implementations do things like read and flush buffers, raise events, inspect the `IoHandle`, modify the connection, etc.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
