### PR TITLE
[fuzz] fix fuzz coverage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -275,6 +275,7 @@ build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
+build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
 
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb

--- a/.bazelrc
+++ b/.bazelrc
@@ -276,6 +276,7 @@ build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
 build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
+build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
 
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb

--- a/bazel/coverage/fuzz_coverage_wrapper.sh
+++ b/bazel/coverage/fuzz_coverage_wrapper.sh
@@ -12,6 +12,6 @@ mkdir -p fuzz_corpus/seed_corpus
 cp -r $@ fuzz_corpus/seed_corpus
 
 # TODO(asraa): When fuzz targets are stable, remove error suppression and run coverage while fuzzing.
-LLVM_PROFILE_FILE= ${TEST_BINARY} fuzz_corpus -seed=${FUZZ_CORPUS_SEED:-1} -max_total_time=${FUZZ_CORPUS_TIME:-60} -max_len=2048 -rss_limit_mb=8192 || true
+LLVM_PROFILE_FILE= ${TEST_BINARY} fuzz_corpus -seed=${FUZZ_CORPUS_SEED:-1} -max_total_time=${FUZZ_CORPUS_TIME:-60} -max_len=2048 -rss_limit_mb=8192 -timeout=30 || true
 
 ${TEST_BINARY} fuzz_corpus -rss_limit_mb=8192 -runs=0 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: fuzz coverage builds weren't instrumented for coverage so fuzzing wasn't running and reports were only against the corpus. this actually allows the 60 minutes of fuzzing time to happen, which increases total coverage by 3%
Risk Level: Low

New coverage report: https://storage.googleapis.com/envoy-pr/13113/fuzz_coverage/index.html
Old main coverage report: https://storage.googleapis.com/envoy-postsubmit/master/fuzz_coverage/index.html
