### PR TITLE
docs: upstream_rq_per_try_timeout with hedged requests

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -70,7 +70,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_maintenance_mode, Counter, Total requests that resulted in an immediate 503 due to :ref:`maintenance mode<config_http_filters_router_runtime_maintenance_mode>`
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
   upstream_rq_max_duration_reached, Counter, Total requests closed due to max duration reached
-  upstream_rq_per_try_timeout, Counter, Total requests that hit the per try timeout
+  upstream_rq_per_try_timeout, Counter, Total requests that hit the per try timeout, except when request hedging is enabled
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely
   upstream_rq_tx_reset, Counter, Total requests that were reset locally
   upstream_rq_retry, Counter, Total request retries

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -70,7 +70,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_rq_maintenance_mode, Counter, Total requests that resulted in an immediate 503 due to :ref:`maintenance mode<config_http_filters_router_runtime_maintenance_mode>`
   upstream_rq_timeout, Counter, Total requests that timed out waiting for a response
   upstream_rq_max_duration_reached, Counter, Total requests closed due to max duration reached
-  upstream_rq_per_try_timeout, Counter, Total requests that hit the per try timeout, except when request hedging is enabled
+  upstream_rq_per_try_timeout, Counter, Total requests that hit the per try timeout (except when request hedging is enabled)
   upstream_rq_rx_reset, Counter, Total requests that were reset remotely
   upstream_rq_tx_reset, Counter, Total requests that were reset locally
   upstream_rq_retry, Counter, Total request retries


### PR DESCRIPTION
Per
https://github.com/envoyproxy/envoy/blob/5fd73ca889aa12618c626c96bb33fde4707f8bf0/source/common/router/router.cc#L869-L874
upstream_rq_per_try_timeout is not incremented for hedged requests.