### PR TITLE
fix envoy build failed with unused variable factory_name

### DIFF
--- a/include/envoy/registry/registry.h
+++ b/include/envoy/registry/registry.h
@@ -345,7 +345,7 @@ private:
   static std::unique_ptr<absl::flat_hash_map<std::string, Base*>> buildFactoriesByType() {
     auto mapping = std::make_unique<absl::flat_hash_map<std::string, Base*>>();
 
-    for (const auto& [factory_name, factory] : factories()) {
+    for (const auto& [[[maybe_unused]]factory_name, factory] : factories()) {
       if (factory == nullptr) {
         continue;
       }


### PR DESCRIPTION
Commit Message: fix envoy build failed with unused variable factory_name
Additional Description:n/a
Risk Level:n/a
Testing:n/a
Docs Changes: n/a
Release Notes:n/a