### PR TITLE
test: cleaning up mocks

### DIFF
--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -459,7 +459,7 @@ TEST_F(RouterTest, RouteNotFound) {
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
-  EXPECT_EQ(callbacks_.details_, "route_not_found");
+  EXPECT_EQ(callbacks_.details(), "route_not_found");
 }
 
 TEST_F(RouterTest, ClusterNotFound) {
@@ -473,7 +473,7 @@ TEST_F(RouterTest, ClusterNotFound) {
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
-  EXPECT_EQ(callbacks_.details_, "cluster_not_found");
+  EXPECT_EQ(callbacks_.details(), "cluster_not_found");
 }
 
 TEST_F(RouterTest, PoolFailureWithPriority) {
@@ -506,7 +506,7 @@ TEST_F(RouterTest, PoolFailureWithPriority) {
   // Pool failure, so upstream request was not initiated.
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
-  EXPECT_EQ(callbacks_.details_,
+  EXPECT_EQ(callbacks_.details(),
             "upstream_reset_before_response_started{connection failure,tls version mismatch}");
 }
 
@@ -675,7 +675,7 @@ TEST_F(RouterTest, AddCookie) {
   Http::ResponseHeaderMapPtr response_headers(
       new Http::TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder->decodeHeaders(std::move(response_headers), true);
-  EXPECT_EQ(callbacks_.details_, "via_upstream");
+  EXPECT_EQ(callbacks_.details(), "via_upstream");
   // When the router filter gets reset we should cancel the pool request.
   router_.onDestroy();
 }
@@ -877,7 +877,7 @@ TEST_F(RouterTest, NoHost) {
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
-  EXPECT_EQ(callbacks_.details_, "no_healthy_upstream");
+  EXPECT_EQ(callbacks_.details(), "no_healthy_upstream");
 }
 
 TEST_F(RouterTest, MaintenanceMode) {
@@ -904,7 +904,7 @@ TEST_F(RouterTest, MaintenanceMode) {
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->load_report_stats_store_
                     .counter("upstream_rq_dropped")
                     .value());
-  EXPECT_EQ(callbacks_.details_, "maintenance_mode");
+  EXPECT_EQ(callbacks_.details(), "maintenance_mode");
 }
 
 // Validate that we don't set x-envoy-overloaded when Envoy header suppression
@@ -1138,7 +1138,7 @@ TEST_F(RouterTest, EnvoyAttemptCountInResponsePresentWithLocalReply) {
   EXPECT_EQ(0U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
-  EXPECT_EQ(callbacks_.details_, "upstream_reset_before_response_started{connection failure}");
+  EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{connection failure}");
 }
 
 // Validate that the x-envoy-attempt-count header in the downstream response reflects the number of
@@ -3116,7 +3116,7 @@ TEST_F(RouterTest, RetryRequestDuringBodyBufferLimitExceeded) {
   Buffer::OwnedImpl buf2(body2);
   router_.decodeData(buf2, false);
 
-  EXPECT_EQ(callbacks_.details_, "request_payload_exceeded_retry_buffer_limit");
+  EXPECT_EQ(callbacks_.details(), "request_payload_exceeded_retry_buffer_limit");
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("retry_or_shadow_abandoned")
                     .value());
@@ -6218,7 +6218,7 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
-  EXPECT_EQ(callbacks_.details_, "upstream_reset_before_response_started{remote reset}");
+  EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{remote reset}");
 }
 
 class RouterTestChildSpan : public RouterTestBase {
@@ -6495,7 +6495,7 @@ TEST_P(RouterTestStrictCheckOneHeader, SingleInvalidHeader) {
       }));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, router_.decodeHeaders(req_headers, true));
-  EXPECT_EQ(callbacks_.details_,
+  EXPECT_EQ(callbacks_.details(),
             fmt::format("request_headers_failed_strict_check{{{}}}", checked_header));
 }
 
@@ -6563,7 +6563,7 @@ TEST_P(RouterTestStrictCheckAllHeaders, MultipleInvalidHeaders) {
       }));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, router_.decodeHeaders(headers, true));
-  EXPECT_THAT(callbacks_.details_,
+  EXPECT_THAT(callbacks_.details(),
               StartsWith(fmt::format("request_headers_failed_strict_check{{")));
   router_.onDestroy();
 }

--- a/test/extensions/filters/http/csrf/csrf_filter_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_test.cc
@@ -156,7 +156,7 @@ TEST_F(CsrfFilterTest, RequestWithInvalidOrigin) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
-  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details_);
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestWithInvalidOriginDifferentNonStandardPorts) {
@@ -180,7 +180,7 @@ TEST_F(CsrfFilterTest, RequestWithInvalidOriginDifferentNonStandardPorts) {
   EXPECT_EQ(0U, config_->stats().missing_source_origin_.value());
   EXPECT_EQ(1U, config_->stats().request_invalid_.value());
   EXPECT_EQ(0U, config_->stats().request_valid_.value());
-  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details_);
+  EXPECT_EQ("csrf_origin_mismatch", decoder_callbacks_.details());
 }
 
 TEST_F(CsrfFilterTest, RequestWithValidOrigin) {

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -238,7 +238,7 @@ TEST_F(HttpFilterTest, ErrorCustomStatusCode) {
       1U,
       filter_callbacks_.clusterInfo()->statsScope().counterFromString("ext_authz.error").value());
   EXPECT_EQ(1U, config_->stats().error_.value());
-  EXPECT_EQ("ext_authz_error", filter_callbacks_.details_);
+  EXPECT_EQ("ext_authz_error", filter_callbacks_.details());
 }
 
 // Test when failure_mode_allow is set and the response from the authorization service is Error that
@@ -793,7 +793,7 @@ TEST_F(HttpFilterTest, NoClearCacheRouteDeniedResponse) {
   EXPECT_EQ(
       1U,
       filter_callbacks_.clusterInfo()->statsScope().counterFromString("ext_authz.denied").value());
-  EXPECT_EQ("ext_authz_denied", filter_callbacks_.details_);
+  EXPECT_EQ("ext_authz_denied", filter_callbacks_.details());
 }
 
 // Verifies that specified metadata is passed along in the check request

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -277,7 +277,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
-  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
 }
 
 TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
@@ -324,7 +324,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
   EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
-  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
 }
 
 TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
@@ -377,7 +377,7 @@ TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
   EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
-  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
 }
 
 TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
@@ -427,7 +427,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
   EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
-  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
 }
 
 TEST_F(FaultFilterTest, HeaderAbortWithHttpAndGrpcStatus) {
@@ -477,7 +477,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpAndGrpcStatus) {
   EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
   EXPECT_EQ(0UL, config_->stats().active_faults_.value());
-  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details());
 }
 
 TEST_F(FaultFilterTest, FixedDelayZeroDuration) {

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -77,7 +77,7 @@ TEST_F(ReverseBridgeTest, InvalidGrpcRequest) {
                                 Http::Utility::PercentEncoding::encode("invalid request body")));
     }));
     EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer, false));
-    EXPECT_EQ(decoder_callbacks_.details_, "grpc_bridge_data_too_small");
+    EXPECT_EQ(decoder_callbacks_.details(), "grpc_bridge_data_too_small");
   }
 }
 

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -657,7 +657,7 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryError) {
 
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_.decodeData(request_data, true));
   EXPECT_EQ(0, request_data.length());
-  EXPECT_EQ(decoder_callbacks_.details_, "grpc_json_transcode_failure{INVALID_ARGUMENT}");
+  EXPECT_EQ(decoder_callbacks_.details(), "grpc_json_transcode_failure{INVALID_ARGUMENT}");
 }
 
 TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryTimeout) {

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -177,7 +177,7 @@ TEST_F(GrpcWebFilterTest, InvalidBase64) {
   request_buffer.add(&INVALID_B64_MESSAGE, INVALID_B64_MESSAGE_SIZE);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
             filter_.decodeData(request_buffer, true));
-  EXPECT_EQ(decoder_callbacks_.details_, "grpc_base_64_decode_failed");
+  EXPECT_EQ(decoder_callbacks_.details(), "grpc_base_64_decode_failed");
 }
 
 TEST_F(GrpcWebFilterTest, Base64NoPadding) {
@@ -192,7 +192,7 @@ TEST_F(GrpcWebFilterTest, Base64NoPadding) {
   request_buffer.add(&B64_MESSAGE_NO_PADDING, B64_MESSAGE_NO_PADDING_SIZE);
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
             filter_.decodeData(request_buffer, true));
-  EXPECT_EQ(decoder_callbacks_.details_, "grpc_base_64_decode_failed_bad_size");
+  EXPECT_EQ(decoder_callbacks_.details(), "grpc_base_64_decode_failed_bad_size");
 }
 
 TEST_P(GrpcWebFilterTest, StatsNoCluster) {

--- a/test/extensions/filters/http/health_check/health_check_test.cc
+++ b/test/extensions/filters/http/health_check/health_check_test.cc
@@ -127,7 +127,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_ok", callbacks_.details_);
+    EXPECT_EQ("health_check_ok", callbacks_.details());
   }
   {
     Http::TestResponseHeaderMapImpl health_check_response{{":status", "503"}};
@@ -135,7 +135,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_failed", callbacks_.details_);
+    EXPECT_EQ("health_check_failed", callbacks_.details());
   }
 
   // Test non-pass-through health checks with upstream cluster minimum health specified.
@@ -154,7 +154,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_ok_cluster_healthy", callbacks_.details_);
+    EXPECT_EQ("health_check_ok_cluster_healthy", callbacks_.details());
   }
   {
     // This should fail, because one upstream cluster has too few healthy servers.
@@ -168,7 +168,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_failed_cluster_unhealthy", callbacks_.details_);
+    EXPECT_EQ("health_check_failed_cluster_unhealthy", callbacks_.details());
   }
   {
     // This should fail, because one upstream cluster has no servers at all.
@@ -182,7 +182,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_failed_cluster_empty", callbacks_.details_);
+    EXPECT_EQ("health_check_failed_cluster_empty", callbacks_.details());
   }
   // Test the cases where an upstream cluster is empty, or has no healthy servers, but
   // the minimum required percent healthy is zero. The health check should return a 200.
@@ -199,7 +199,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_ok_cluster_healthy", callbacks_.details_);
+    EXPECT_EQ("health_check_ok_cluster_healthy", callbacks_.details());
   }
   {
     // This should succeed, because each cluster has degraded + healthy hosts greater than the
@@ -214,7 +214,7 @@ TEST_F(HealthCheckFilterNoPassThroughTest, ComputedHealth) {
     EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&health_check_response), true));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers_, true));
-    EXPECT_EQ("health_check_ok_cluster_healthy", callbacks_.details_);
+    EXPECT_EQ("health_check_ok_cluster_healthy", callbacks_.details());
   }
 }
 
@@ -325,7 +325,7 @@ TEST_F(HealthCheckFilterCachingTest, CachedOkCallbackNotCalled) {
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, true));
-  EXPECT_EQ("health_check_cached", callbacks_.details_);
+  EXPECT_EQ("health_check_cached", callbacks_.details());
 }
 
 TEST_F(HealthCheckFilterCachingTest, All) {

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -179,7 +179,7 @@ TEST_F(FilterTest, InlineUnauthorizedFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details_);
+  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details());
 }
 
 // This test verifies Verifier::Callback is called inline with a failure(403 Forbidden) status.
@@ -200,7 +200,7 @@ TEST_F(FilterTest, InlineForbiddenFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details_);
+  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details());
 }
 
 // This test verifies Verifier::Callback is called with OK status after verify().

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -485,7 +485,7 @@ TEST_F(HttpRateLimitFilterTest, ErrorResponseWithFailureModeAllowOff) {
                     ->statsScope()
                     .counterFromStatName(ratelimit_failure_mode_allowed_)
                     .value());
-  EXPECT_EQ("rate_limiter_error", filter_callbacks_.details_);
+  EXPECT_EQ("rate_limiter_error", filter_callbacks_.details());
 }
 
 TEST_F(HttpRateLimitFilterTest, LimitResponse) {
@@ -525,7 +525,7 @@ TEST_F(HttpRateLimitFilterTest, LimitResponse) {
   EXPECT_EQ(
       1U,
       filter_callbacks_.clusterInfo()->statsScope().counterFromStatName(upstream_rq_429_).value());
-  EXPECT_EQ("request_rate_limited", filter_callbacks_.details_);
+  EXPECT_EQ("request_rate_limited", filter_callbacks_.details());
 }
 
 TEST_F(HttpRateLimitFilterTest, LimitResponseWithHeaders) {

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -186,7 +186,7 @@ TEST_F(RoleBasedAccessControlFilterTest, Denied) {
   auto filter_meta = req_info_.dynamicMetadata().filter_metadata().at(HttpFilterNames::get().Rbac);
   EXPECT_EQ("allowed", filter_meta.fields().at("shadow_engine_result").string_value());
   EXPECT_EQ("bar", filter_meta.fields().at("shadow_effective_policy_id").string_value());
-  EXPECT_EQ("rbac_access_denied", callbacks_.details_);
+  EXPECT_EQ("rbac_access_denied", callbacks_.details());
   checkAccessLogMetadata(LogResult::Undecided);
 }
 

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -78,16 +78,15 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
     Code code, absl::string_view body,
     std::function<void(ResponseHeaderMap& headers)> modify_headers,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
-  details_ = std::string(details);
   Utility::sendLocalReply(
       stream_destroyed_,
       Utility::EncodeFunctions{
           nullptr, nullptr,
-          [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
+          [this, modify_headers, details](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
             if (modify_headers != nullptr) {
               modify_headers(*headers);
             }
-            encodeHeaders(std::move(headers), end_stream, details_);
+            encodeHeaders(std::move(headers), end_stream, details);
           },
           [this](Buffer::Instance& data, bool end_stream) -> void {
             encodeData(data, end_stream);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -166,13 +166,18 @@ public:
   }
   void encodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream,
                      absl::string_view details) override {
-    details_ = details;
     stream_info_.setResponseCodeDetails(details);
     encodeHeaders_(*headers, end_stream);
   }
   void encodeTrailers(ResponseTrailerMapPtr&& trailers) override { encodeTrailers_(*trailers); }
   void encodeMetadata(MetadataMapPtr&& metadata_map) override {
     encodeMetadata_(std::move(metadata_map));
+  }
+  absl::string_view details() {
+    if (stream_info_.responseCodeDetails()) {
+      return stream_info_.responseCodeDetails().value();
+    }
+    return "";
   }
 
   MOCK_METHOD(void, continueDecoding, ());
@@ -198,8 +203,6 @@ public:
   testing::NiceMock<Tracing::MockSpan> active_span_;
   testing::NiceMock<Tracing::MockConfig> tracing_config_;
   testing::NiceMock<MockScopedTrackedObject> scope_;
-  // TODO(alyssawilk) remove this and use stream info consistently.
-  std::string details_;
   bool is_grpc_request_{};
   bool is_head_request_{false};
   bool stream_destroyed_{};


### PR DESCRIPTION
Cleaning up redundant details_ object in test mocks.

Risk Level: n/a (test only) 
Testing: unit tests pass
Docs Changes: n/a
Release Notes: n/a