### PR TITLE
test: use test-only resource monitor in overload manager integration test

### DIFF
--- a/test/common/config/dummy_config.proto
+++ b/test/common/config/dummy_config.proto
@@ -1,4 +1,4 @@
-// Provides protos for testing source/common/config/config_provider_impl.{h,cc}.
+// Provides protos for testing.
 
 syntax = "proto3";
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1019,7 +1019,7 @@ envoy_cc_test(
     tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
-        "//source/extensions/resource_monitors/injected_resource:config",
+        "//test/common/config:dummy_config_proto_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/overload/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
Commit Message: remove overload manager integration test dependence on injected_resource monitor
Additional Description:
Remove the dependence on the injected_resource build target target that
can be disabled via the extension system.
Risk Level: low
Testing: ran integration test
Docs Changes: none
Release Notes: none