### PR TITLE
config: Increase the connect timeout in example file

### DIFF
--- a/configs/google_com_proxy.v2.yaml
+++ b/configs/google_com_proxy.v2.yaml
@@ -34,7 +34,7 @@ static_resources:
           - name: envoy.filters.http.router
   clusters:
   - name: service_google
-    connect_timeout: 0.25s
+    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Increase the connect timeout in example file
Additional Description: **TLDR: bump the limit from 0.25s to 30s**, I'm fairly new to envoy proxy. So I try this tutorial from this link https://www.envoyproxy.io/docs/envoy/latest/start/start which use envoy-dev docker image that use [this config](https://github.com/envoyproxy/envoy/blob/a8b946e1c30618dfcab6c7e90333301c16b56a65/configs/google_com_proxy.v2.yaml), but after I start my envoy with this configuration it gives me this error message `upstream connect error or disconnect/reset before headers. reset reason: local reset` because of low connection timeout value, which in my opinion is confusing for a newcomer who expect things to work, so I made this PR to bump the limit from 0.25s to 30s with hope this will help another newcomer like me.
Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
