### PR TITLE
Add TestScopedInjectableLoader to swap InjectableSingleton during unit tests

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -335,6 +335,7 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/upstream:retry_priority_factory_mocks",
         "//test/mocks/upstream:retry_priority_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
         "@com_google_absl//absl/synchronization",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1592,10 +1592,8 @@ const uint32_t ControlFrameFloodLimit = 100;
 const uint32_t AllFrameFloodLimit = 1000;
 } // namespace
 
-Http2FloodMitigationTest::Http2FloodMitigationTest() {
-  Envoy::Network::SocketInterfaceSingleton::clear();
-  test_socket_interface_loader_ = std::make_unique<Envoy::Network::SocketInterfaceLoader>(
-      std::make_unique<Envoy::Network::TestSocketInterface>(
+Http2FloodMitigationTest::Http2FloodMitigationTest()
+    : test_socket_interface_loader_(std::make_unique<Envoy::Network::TestSocketInterface>(
           [writev_matcher = writev_matcher_](Envoy::Network::TestIoSocketHandle* io_handle,
                                              const Buffer::RawSlice*,
                                              uint64_t) -> absl::optional<Api::IoCallUint64Result> {
@@ -1605,15 +1603,10 @@ Http2FloodMitigationTest::Http2FloodMitigationTest() {
                                      Network::IoSocketError::deleteIoError));
             }
             return absl::nullopt;
-          }));
+          })) {
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) { hcm.mutable_delayed_close_timeout()->set_seconds(1); });
-}
-
-Http2FloodMitigationTest::~Http2FloodMitigationTest() {
-  test_socket_interface_loader_.reset();
-  Envoy::Network::SocketInterfaceSingleton::initialize(previous_socket_interface_);
 }
 
 void Http2FloodMitigationTest::setNetworkConnectionBufferSize() {

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -8,6 +8,7 @@
 #include "test/common/http/http2/http2_frame.h"
 #include "test/integration/filters/test_socket_interface.h"
 #include "test/integration/http_integration.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
 
 #include "absl/synchronization/mutex.h"
 #include "gtest/gtest.h"
@@ -88,7 +89,6 @@ protected:
 class Http2FloodMitigationTest : public Http2FrameIntegrationTest {
 public:
   Http2FloodMitigationTest();
-  ~Http2FloodMitigationTest() override;
 
 protected:
   // Object of this class hold the state determining the IoHandle which
@@ -123,9 +123,7 @@ protected:
   void setNetworkConnectionBufferSize();
   void beginSession() override;
 
-  Envoy::Network::SocketInterface* const previous_socket_interface_{
-      Envoy::Network::SocketInterfaceSingleton::getExisting()};
   std::shared_ptr<IoHandleMatcher> writev_matcher_{std::make_shared<IoHandleMatcher>()};
-  std::unique_ptr<Envoy::Network::SocketInterfaceLoader> test_socket_interface_loader_;
+  TestScopedInjectableLoader<Network::SocketInterface> test_socket_interface_loader_;
 };
 } // namespace Envoy

--- a/test/test_common/threadsafe_singleton_injector.h
+++ b/test/test_common/threadsafe_singleton_injector.h
@@ -17,4 +17,24 @@ private:
   T* latched_instance_;
 };
 
+// Note this class is not thread-safe, and should be called exceedingly carefully.
+template <class T> class TestScopedInjectableLoader {
+public:
+  TestScopedInjectableLoader(std::unique_ptr<T>&& instance)
+      : instance_(std::move(instance)), previous_instance_(InjectableSingleton<T>::getExisting()) {
+    InjectableSingleton<T>::clear();
+    InjectableSingleton<T>::initialize(instance_.get());
+  }
+  ~TestScopedInjectableLoader() {
+    InjectableSingleton<T>::clear();
+    if (previous_instance_) {
+      InjectableSingleton<T>::initialize(previous_instance_);
+    }
+  }
+
+private:
+  std::unique_ptr<T> instance_;
+  T* const previous_instance_;
+};
+
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
Add TestScopedInjectableLoader to swap InjectableSingleton during unit tests

Additional Description:
Class similar to the TestThreadsafeSingletonInjector but for the InjectableSingleton

Risk Level: Low, test only
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
