### PR TITLE
grpc_stats: serializeAsString implementation

### DIFF
--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.h
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.h
@@ -24,6 +24,10 @@ struct GrpcStatsObject : public StreamInfo::FilterState::Object {
     msg->set_response_message_count(response_message_count);
     return msg;
   }
+
+  absl::optional<std::string> serializeAsString() const override {
+    return absl::StrCat(request_message_count, ",", response_message_count);
+  }
 };
 
 class GrpcStatsFilterConfigFactory

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -415,6 +415,7 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
           data.serializeAsProto().get());
   EXPECT_EQ(2U, filter_object.request_message_count());
   EXPECT_EQ(3U, filter_object.response_message_count());
+  EXPECT_EQ("2,3", data.serializeAsString().value());
 }
 
 TEST_F(GrpcStatsFilterConfigTest, UpstreamStats) {


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>
Commit Message: expose grpc_stats filter state as string to be used in Wasm ABI; protobuf is too heavy for this purpose.
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none

