### PR TITLE
rbac: expose filter state

### DIFF
--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -90,6 +90,7 @@ The following attributes are exposed to the language runtime:
    destination.address, string, Downstream connection local address
    destination.port, int, Downstream connection local port
    metadata, :ref:`Metadata<envoy_api_msg_core.Metadata>`, Dynamic metadata
+   filter_state, map string to bytes, Filter state mapping data names to their serialized string value
    connection.mtls, bool, Indicates whether TLS is applied to the downstream connection and the peer ceritificate is presented
    connection.requested_server_name, string, Requested server name in the downstream TLS connection
    connection.tls_version, string, TLS version of the downstream TLS connection

--- a/include/envoy/stream_info/filter_state.h
+++ b/include/envoy/stream_info/filter_state.h
@@ -102,6 +102,13 @@ public:
   }
 
   /**
+   * @param data_name the name of the data being looked up (mutable/readonly).
+   * @return a const reference to the stored data.
+   * An exception will be thrown if the data does not exist.
+   */
+  virtual const Object* getDataReadOnlyGeneric(absl::string_view data_name) const PURE;
+
+  /**
    * @param data_name the name of the data being looked up (mutable only).
    * @return a non-const reference to the stored data if and only if the
    * underlying data is mutable.
@@ -154,7 +161,6 @@ public:
   virtual FilterStateSharedPtr parent() const PURE;
 
 protected:
-  virtual const Object* getDataReadOnlyGeneric(absl::string_view data_name) const PURE;
   virtual Object* getDataMutableGeneric(absl::string_view data_name) PURE;
 };
 

--- a/source/common/router/string_accessor_impl.h
+++ b/source/common/router/string_accessor_impl.h
@@ -19,6 +19,8 @@ public:
     return message;
   }
 
+  absl::optional<std::string> serializeAsString() const override { return value_; }
+
 private:
   std::string value_;
 };

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -233,6 +233,22 @@ absl::optional<CelValue> PeerWrapper::operator[](CelValue key) const {
   return {};
 }
 
+absl::optional<CelValue> FilterStateWrapper::operator[](CelValue key) const {
+  if (!key.IsString()) {
+    return {};
+  }
+  auto value = key.StringOrDie().value();
+  if (filter_state_.hasDataWithName(value)) {
+    const StreamInfo::FilterState::Object* object = filter_state_.getDataReadOnlyGeneric(value);
+    absl::optional<std::string> serialized = object->serializeAsString();
+    if (serialized.has_value()) {
+      std::string* out = ProtobufWkt::Arena::Create<std::string>(arena_, serialized.value());
+      return CelValue::CreateBytes(out);
+    }
+  }
+  return {};
+}
+
 } // namespace Expr
 } // namespace Common
 } // namespace Filters

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -25,6 +25,8 @@ ActivationPtr createActivation(const StreamInfo::StreamInfo& info,
   activation->InsertValueProducer(Destination, std::make_unique<PeerWrapper>(info, true));
   activation->InsertValueProducer(Metadata,
                                   std::make_unique<MetadataProducer>(info.dynamicMetadata()));
+  activation->InsertValueProducer(FilterState,
+                                  std::make_unique<FilterStateWrapper>(info.filterState()));
   return activation;
 }
 

--- a/test/extensions/filters/common/expr/BUILD
+++ b/test/extensions/filters/common/expr/BUILD
@@ -18,6 +18,8 @@ envoy_extension_cc_test(
     srcs = ["context_test.cc"],
     extension_name = "envoy.filters.http.rbac",
     deps = [
+        "//source/common/router:string_accessor_lib",
+        "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/common/expr:context_lib",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stream_info:stream_info_mocks",

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -614,9 +614,9 @@ TEST(Context, FilterStateAttributes) {
   ProtobufWkt::Arena arena;
   wrapper.Produce(&arena);
 
-  const auto key = "filter_state_key";
-  const auto serialized = "filter_state_value";
-  const auto missing = "missing_key";
+  const std::string key = "filter_state_key";
+  const std::string serialized = "filter_state_value";
+  const std::string missing = "missing_key";
 
   auto accessor = std::make_shared<Envoy::Router::StringAccessorImpl>(serialized);
   filter_state.setData(key, accessor, StreamInfo::FilterState::StateType::ReadOnly);


### PR DESCRIPTION
Commit Message: expose filter state values to CEL context. This uses string serialization due to better efficiency.
Risk Level: low (opt-in)
Testing: unit
Docs Changes: yes
Release Notes: no