### PR TITLE
WIP hcm: ensure that empty data frame is propagated during metadata decoding

### DIFF
--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -510,19 +510,20 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
       // Metadata frame doesn't carry end of stream bit. We need an empty data frame to end the
       // stream.
       addDecodedData(*((*entry).get()), empty_data, true);
+
       // At this point we're no longer going to be decoding a headers only request, so reset this
       // flag. This is propagated to subsequent filters which will allow all of these to decode the
       // data.
       (*entry)->decoding_headers_only_ = false;
-      // Unmark end_stream_ for this filter so that it can receive the data when continue is called.
-      (*entry)->end_stream_ = false;
+
+      // This ensures that when we continue the data we set end_stream = true.
       maybeEndDecode(true);
 
+      // We do this check here in addition to below since we've cleared the entries that would mark this filter
+      // as the last filter.
       if (continue_data_entry == decoder_filters_.end()) {
         continue_data_entry = entry;
       }
-
-      (*entry)->iteration_state_ = ActiveStreamDecoderFilter::IterationState::Continue;
     }
 
     if (!continue_iteration && std::next(entry) != decoder_filters_.end()) {

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -519,8 +519,8 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
       // This ensures that when we continue the data we set end_stream = true.
       maybeEndDecode(true);
 
-      // We do this check here in addition to below since we've cleared the entries that would mark this filter
-      // as the last filter.
+      // We do this check here in addition to below since we've cleared the entries that would mark
+      // this filter as the last filter.
       if (continue_data_entry == decoder_filters_.end()) {
         continue_data_entry = entry;
       }

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -448,13 +448,14 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
     ASSERT(!(state_.filter_call_state_ & FilterCallState::DecodeHeaders));
     state_.filter_call_state_ |= FilterCallState::DecodeHeaders;
 
-    // If the previous filter is decoding headers only, so are we unless we start adding data during this filter.
-    // We propagate the decoding_headers_only_ flag forward to further filters, allowing filters to override thie value
-    // for itself and subsequent filters.
-    const auto decoding_headers_only = entry == decoder_filters_.begin() ? false : (*std::prev(entry))->decoding_headers_only_;
+    // If the previous filter is decoding headers only, so are we unless we start adding data during
+    // this filter. We propagate the decoding_headers_only_ flag forward to further filters,
+    // allowing filters to override thie value for itself and subsequent filters.
+    const auto decoding_headers_only =
+        entry == decoder_filters_.begin() ? false : (*std::prev(entry))->decoding_headers_only_;
     (*entry)->decoding_headers_only_ = decoding_headers_only;
-    (*entry)->end_stream_ = decoding_headers_only ||
-                            (end_stream && continue_data_entry == decoder_filters_.end());
+    (*entry)->end_stream_ =
+        decoding_headers_only || (end_stream && continue_data_entry == decoder_filters_.end());
     FilterHeadersStatus status = (*entry)->decodeHeaders(headers, (*entry)->end_stream_);
 
     ASSERT(!(status == FilterHeadersStatus::ContinueAndEndStream && (*entry)->end_stream_),
@@ -508,7 +509,8 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
 
     // Here we handle the case where we have a header only request, but a filter adds a body
     // to it. We need to not raise end_stream = true to further filters during inline iteration.
-    if ((end_stream || (*entry)->decoding_headers_only_) && buffered_request_data_ && continue_data_entry == decoder_filters_.end()) {
+    if ((end_stream || (*entry)->decoding_headers_only_) && buffered_request_data_ &&
+        continue_data_entry == decoder_filters_.end()) {
       continue_data_entry = entry;
     }
   }
@@ -948,13 +950,14 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
     ASSERT(!(state_.filter_call_state_ & FilterCallState::EncodeHeaders));
     state_.filter_call_state_ |= FilterCallState::EncodeHeaders;
 
-    // If the previous filter is encoding headers only, so are we unless we start adding data during this filter.
-    // We propagate the encoding_headers_only_ flag forward to further filters, allowing filters to override thie value
-    // for itself and subsequent filters.
-    const auto encoding_headers_only = entry == encoder_filters_.begin() ? false : (*std::prev(entry))->encoding_headers_only_;
+    // If the previous filter is encoding headers only, so are we unless we start adding data during
+    // this filter. We propagate the encoding_headers_only_ flag forward to further filters,
+    // allowing filters to override thie value for itself and subsequent filters.
+    const auto encoding_headers_only =
+        entry == encoder_filters_.begin() ? false : (*std::prev(entry))->encoding_headers_only_;
     (*entry)->encoding_headers_only_ = encoding_headers_only;
-    (*entry)->end_stream_ = encoding_headers_only ||
-                            (end_stream && continue_data_entry == encoder_filters_.end());
+    (*entry)->end_stream_ =
+        encoding_headers_only || (end_stream && continue_data_entry == encoder_filters_.end());
     FilterHeadersStatus status = (*entry)->handle_->encodeHeaders(headers, (*entry)->end_stream_);
 
     ASSERT(!(status == FilterHeadersStatus::ContinueAndEndStream && (*entry)->end_stream_),
@@ -994,12 +997,14 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
 
     // Here we handle the case where we have a header only response, but a filter adds a body
     // to it. We need to not raise end_stream = true to further filters during inline iteration.
-    if ((end_stream || (*entry)->encoding_headers_only_) && buffered_response_data_ && continue_data_entry == encoder_filters_.end()) {
+    if ((end_stream || (*entry)->encoding_headers_only_) && buffered_response_data_ &&
+        continue_data_entry == encoder_filters_.end()) {
       continue_data_entry = entry;
     }
   }
 
-  const bool encoding_headers_only = encoder_filters_.empty() ? false : encoder_filters_.back()->encoding_headers_only_;
+  const bool encoding_headers_only =
+      encoder_filters_.empty() ? false : encoder_filters_.back()->encoding_headers_only_;
   const bool modified_end_stream =
       encoding_headers_only || (end_stream && continue_data_entry == encoder_filters_.end());
   state_.non_100_response_headers_encoded_ = true;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -450,7 +450,7 @@ void FilterManager::decodeHeaders(ActiveStreamDecoderFilter* filter, RequestHead
 
     // If the previous filter is decoding headers only, so are we unless we start adding data during
     // this filter. We propagate the decoding_headers_only_ flag forward to further filters,
-    // allowing filters to override thie value for itself and subsequent filters.
+    // allowing filters to override this value for itself and subsequent filters.
     const auto decoding_headers_only =
         entry == decoder_filters_.begin() ? false : (*std::prev(entry))->decoding_headers_only_;
     (*entry)->decoding_headers_only_ = decoding_headers_only;
@@ -952,7 +952,7 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
 
     // If the previous filter is encoding headers only, so are we unless we start adding data during
     // this filter. We propagate the encoding_headers_only_ flag forward to further filters,
-    // allowing filters to override thie value for itself and subsequent filters.
+    // allowing filters to override this value for itself and subsequent filters.
     const auto encoding_headers_only =
         entry == encoder_filters_.begin() ? false : (*std::prev(entry))->encoding_headers_only_;
     (*entry)->encoding_headers_only_ = encoding_headers_only;

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -812,8 +812,7 @@ private:
     State()
         : remote_complete_(false), local_complete_(false), has_continue_headers_(false),
           created_filter_chain_(false), is_head_request_(false), is_grpc_request_(false),
-          non_100_response_headers_encoded_(false), ignore_downstream_data_(false),
-          ignore_downstream_trailers_(false) {}
+          non_100_response_headers_encoded_(false) {}
 
     uint32_t filter_call_state_{0};
 
@@ -831,8 +830,8 @@ private:
     bool is_grpc_request_ : 1;
     // Tracks if headers other than 100-Continue have been encoded to the codec.
     bool non_100_response_headers_encoded_ : 1;
-    bool ignore_downstream_data_;
-    bool ignore_downstream_trailers_;
+    bool ignore_downstream_data_{};
+    bool ignore_downstream_trailers_{};
 
     // The following 3 members are booleans rather than part of the space-saving bitfield as they
     // are passed as arguments to functions expecting bools. Extend State using the bitfield

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -504,8 +504,10 @@ public:
   // ScopeTrackedObject
   void dumpState(std::ostream& os, int indent_level = 0) const override {
     const char* spaces = spacesForLevel(indent_level);
-    os << spaces << "FilterManager " << this << DUMP_MEMBER(state_.has_continue_headers_)
-      //  << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_)
+    os << spaces << "FilterManager " << this
+       << DUMP_MEMBER(state_.has_continue_headers_)
+       //  << DUMP_MEMBER(state_.decoding_headers_only_) <<
+       //  DUMP_MEMBER(state_.encoding_headers_only_)
        << "\n";
 
     DUMP_OPT_REF_DETAILS(filter_manager_callbacks_.requestHeaders());

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -579,6 +579,10 @@ public:
    * @param end_stream whether this data is the end of the request.
    */
   void decodeData(Buffer::Instance& data, bool end_stream) {
+    if (state_.ignore_downstream_data_) {
+      return;
+    }
+
     decodeData(nullptr, data, end_stream, FilterIterationStartState::CanStartFromCurrent);
   }
 
@@ -808,7 +812,8 @@ private:
     State()
         : remote_complete_(false), local_complete_(false), has_continue_headers_(false),
           created_filter_chain_(false), is_head_request_(false), is_grpc_request_(false),
-          non_100_response_headers_encoded_(false) {}
+          non_100_response_headers_encoded_(false), ignore_downstream_data_(false),
+          ignore_downstream_trailers_(false) {}
 
     uint32_t filter_call_state_{0};
 
@@ -826,6 +831,8 @@ private:
     bool is_grpc_request_ : 1;
     // Tracks if headers other than 100-Continue have been encoded to the codec.
     bool non_100_response_headers_encoded_ : 1;
+    bool ignore_downstream_data_;
+    bool ignore_downstream_trailers_;
 
     // The following 3 members are booleans rather than part of the space-saving bitfield as they
     // are passed as arguments to functions expecting bools. Extend State using the bitfield

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -125,6 +125,12 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   const bool dual_filter_ : 1;
   bool decode_headers_called_ : 1;
   bool encode_headers_called_ : 1;
+  // Whether a filter has indicated that the response should be treated as a headers only
+  // response.
+  bool encoding_headers_only_{false};
+  // Whether a filter has indicated that the request should be treated as a headers only
+  // request.
+  bool decoding_headers_only_{false};
 };
 
 /**
@@ -499,7 +505,7 @@ public:
   void dumpState(std::ostream& os, int indent_level = 0) const override {
     const char* spaces = spacesForLevel(indent_level);
     os << spaces << "FilterManager " << this << DUMP_MEMBER(state_.has_continue_headers_)
-       << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_)
+      //  << DUMP_MEMBER(state_.decoding_headers_only_) << DUMP_MEMBER(state_.encoding_headers_only_)
        << "\n";
 
     DUMP_OPT_REF_DETAILS(filter_manager_callbacks_.requestHeaders());
@@ -825,12 +831,6 @@ private:
     bool encoder_filters_streaming_{true};
     bool decoder_filters_streaming_{true};
     bool destroyed_{false};
-    // Whether a filter has indicated that the response should be treated as a headers only
-    // response.
-    bool encoding_headers_only_{false};
-    // Whether a filter has indicated that the request should be treated as a headers only
-    // request.
-    bool decoding_headers_only_{false};
 
     // Used to track which filter is the latest filter that has received data.
     ActiveStreamEncoderFilter* latest_data_encoding_filter_{};

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -440,10 +440,6 @@ void UpstreamRequest::encodeBodyAndTrailers() {
                        downstream_metadata_map_vector_);
       upstream_->encodeMetadata(downstream_metadata_map_vector_);
       downstream_metadata_map_vector_.clear();
-      if (shouldSendEndStream()) {
-        Buffer::OwnedImpl empty_data("");
-        upstream_->encodeData(empty_data, true);
-      }
     }
 
     if (buffered_request_body_) {

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -690,7 +690,6 @@ void Http2MetadataIntegrationTest::verifyHeadersOnlyTest() {
   // Verifies a headers metadata added.
   std::set<std::string> expected_metadata_keys = {"headers"};
   expected_metadata_keys.insert("metadata");
-  expected_metadata_keys.insert("data");
   verifyExpectedMetadata(upstream_request_->metadataMap(), expected_metadata_keys);
 
   // Verifies zero length data received, and end_stream is true.

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -690,6 +690,7 @@ void Http2MetadataIntegrationTest::verifyHeadersOnlyTest() {
   // Verifies a headers metadata added.
   std::set<std::string> expected_metadata_keys = {"headers"};
   expected_metadata_keys.insert("metadata");
+  expected_metadata_keys.insert("data");
   verifyExpectedMetadata(upstream_request_->metadataMap(), expected_metadata_keys);
 
   // Verifies zero length data received, and end_stream is true.


### PR DESCRIPTION
    The HCM attempts to inject an empty DATA frame when processing METADATA
    frames within a header only request. These frames were never actually
    making it to the router filter, but was instead handled in
    UpstreamRequest. This fix this by making the encoding/decoding
    headers only a per filter property, which allows us to transform a
    filter chain that has been made header only back into a header + data
    when data has been injected for METADATA frames.

Risk Level: High
Testing:
Docs Changes:
Release Notes:
