### PR TITLE
[ci] try to fix the fuzz coverage failure

### DIFF
--- a/bazel/coverage/fuzz_coverage_wrapper.sh
+++ b/bazel/coverage/fuzz_coverage_wrapper.sh
@@ -15,5 +15,5 @@ cp -r $@ fuzz_corpus/seed_corpus
 LLVM_PROFILE_FILE= ${TEST_BINARY} fuzz_corpus -seed=${FUZZ_CORPUS_SEED:-1} -max_total_time=${FUZZ_CORPUS_TIME:-60} -max_len=2048 -rss_limit_mb=8192 -timeout=30 || true
 
 # Passing files instead of a directory will run fuzzing as a regression test.
-# TODO(asraa): Add a manual `|| true`, but this shouldn't be necessary. 
-${TEST_BINARY} $(find fuzz_corpus -type f) -rss_limit_mb=8192
+# TODO(asraa): Remove manual `|| true`, but this shouldn't be necessary. 
+${TEST_BINARY} $(find fuzz_corpus -type f) -rss_limit_mb=8192 || true

--- a/bazel/coverage/fuzz_coverage_wrapper.sh
+++ b/bazel/coverage/fuzz_coverage_wrapper.sh
@@ -16,4 +16,4 @@ LLVM_PROFILE_FILE= ${TEST_BINARY} fuzz_corpus -seed=${FUZZ_CORPUS_SEED:-1} -max_
 
 # Passing files instead of a directory will run fuzzing as a regression test.
 # TODO(asraa): Add a manual `|| true`, but this shouldn't be necessary. 
-${TEST_BINARY} $(find fuzz_corpus -type f)
+${TEST_BINARY} $(find fuzz_corpus -type f) -rss_limit_mb=8192

--- a/bazel/coverage/fuzz_coverage_wrapper.sh
+++ b/bazel/coverage/fuzz_coverage_wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -ex
 
 TEST_BINARY=$1
 shift
@@ -14,4 +14,6 @@ cp -r $@ fuzz_corpus/seed_corpus
 # TODO(asraa): When fuzz targets are stable, remove error suppression and run coverage while fuzzing.
 LLVM_PROFILE_FILE= ${TEST_BINARY} fuzz_corpus -seed=${FUZZ_CORPUS_SEED:-1} -max_total_time=${FUZZ_CORPUS_TIME:-60} -max_len=2048 -rss_limit_mb=8192 -timeout=30 || true
 
-${TEST_BINARY} fuzz_corpus -rss_limit_mb=8192 -runs=0 
+# Passing files instead of a directory will run fuzzing as a regression test.
+# TODO(asraa): Add a manual `|| true`, but this shouldn't be necessary. 
+${TEST_BINARY} fuzz_corpus/* 

--- a/bazel/coverage/fuzz_coverage_wrapper.sh
+++ b/bazel/coverage/fuzz_coverage_wrapper.sh
@@ -16,4 +16,4 @@ LLVM_PROFILE_FILE= ${TEST_BINARY} fuzz_corpus -seed=${FUZZ_CORPUS_SEED:-1} -max_
 
 # Passing files instead of a directory will run fuzzing as a regression test.
 # TODO(asraa): Add a manual `|| true`, but this shouldn't be necessary. 
-${TEST_BINARY} fuzz_corpus/* 
+${TEST_BINARY} $(find fuzz_corpus -type f)


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Attempt to fix https://github.com/envoyproxy/envoy/issues/13171
I made used the actual regression testing process (using a list of files as args) instead of running with -runs=0 which seems to be doing some (preliminary?) fuzzing process. This seems to avoid catching bugs while capturing coverage.

Even then, sometimes there are flakes (memory corruption), particularly in `network_readfilter_fuzz_test` (see below). Added a workaround to always pass.
```
2020-09-18T20:30:05.1746225Z UndefinedBehaviorSanitizer:DEADLYSIGNAL
2020-09-18T20:30:05.1747002Z ==27421==ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000000000 bp 0x7fffbf9fe9e0 sp 0x7fffbf9fe7f8 T27421)
2020-09-18T20:30:05.1747878Z ==27421==Hint: pc points to the zero page.
2020-09-18T20:30:05.1748440Z ==27421==The signal is caused by a READ memory access.
2020-09-18T20:30:05.1748996Z ==27421==Hint: address points to the zero page.
2020-09-18T20:30:05.1749664Z     #0 0x0  (<unknown module>)
2020-09-18T20:30:05.1751543Z     #1 0x41ff2a  (/build/tmp/_bazel_envoybuild/b570b5ccd0454dc9af9f65ab1833764d/execroot/envoy/bazel-out/k8-fastbuild/bin/test/extensions/filters/network/common/fuzz/network_readfilter_fuzz_test+0x41ff2a)
2020-09-18T20:30:05.1753115Z     #2 0x7fb8c3c7489f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1289f)
2020-09-18T20:30:05.1753581Z 
2020-09-18T20:30:05.1754055Z UndefinedBehaviorSanitizer can not provide additional info.
2020-09-18T20:30:05.1754706Z SUMMARY: UndefinedBehaviorSanitizer: SEGV (<unknown module>) 
2020-09-18T20:30:05.1755253Z ==27421==ABORTING
```