### PR TITLE
Replace old MOCK_METHOD macros

### DIFF
--- a/test/extensions/filters/common/lua/lua_wrappers.h
+++ b/test/extensions/filters/common/lua/lua_wrappers.h
@@ -19,7 +19,7 @@ namespace Lua {
 // A helper to be called inside the registered closure.
 class Printer {
 public:
-  MOCK_CONST_METHOD1(testPrint, void(const std::string&));
+  MOCK_METHOD(void, testPrint, (const std::string&), (const));
 };
 
 const Printer& getPrinter() { CONSTRUCT_ON_FIRST_USE(Printer); }

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -264,9 +264,9 @@ public:
   MockTextReadout();
   ~MockTextReadout() override;
 
-  MOCK_METHOD1(set, void(absl::string_view value));
-  MOCK_CONST_METHOD0(used, bool());
-  MOCK_CONST_METHOD0(value, std::string());
+  MOCK_METHOD(void, set, (absl::string_view value), (override));
+  MOCK_METHOD(bool, used, (), (const, override));
+  MOCK_METHOD(std::string, value, (), (const, override));
 
   bool used_;
   std::string value_;


### PR DESCRIPTION
Commit Message: Replace old MOCK_METHOD macros
Additional Description: As recommended in https://github.com/google/googletest/blob/release-1.10.0/googlemock/docs/cook_book.md#old-style-mock_methodn-macros
Risk Level: Low
Testing: unit test
Docs Changes: N/A
Release Notes: N/A