### PR TITLE
Split verify_examples tests

### DIFF
--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -E
 
-TESTFILTER="${1:-*}"
+TESTCOMMAND="${1:-}"
+TESTFILTER="${2:-*}"
 FAILED=()
 SRCDIR="${SRCDIR:-$(pwd)}"
 EXCLUDED_BUILD_CONFIGS=${EXCLUDED_BUILD_CONFIGS:-"^./cache/responses.yaml|^./jaeger-native-tracing|docker-compose"}
@@ -54,9 +55,23 @@ verify_build_configs () {
     fi
 }
 
-verify_build_configs
-run_examples
-
+case "$TESTCOMMAND" in
+    build_config)
+	echo "Running build_configs test"
+	verify_build_configs
+	;;
+    sandbox)
+	echo "Running sandbox test"
+	run_examples
+	;;
+    "")
+	echo "Running all tests"
+	verify_build_configs
+	run_examples
+	;;
+    *)
+	echo "Usage ./ci/verify_examples.sh [build_config|sandbox] [<test_filter>]"
+esac
 
 if [[ "${#FAILED[@]}" -ne "0" ]]; then
     echo "TESTS FAILED:"

--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -64,7 +64,7 @@ case "$TESTCOMMAND" in
 	echo "Running sandbox test"
 	run_examples
 	;;
-    "")
+    ""|all)
 	echo "Running all tests"
 	verify_build_configs
 	run_examples

--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -70,7 +70,7 @@ case "$TESTCOMMAND" in
 	run_examples
 	;;
     *)
-	echo "Usage ./ci/verify_examples.sh [build_config|sandbox] [<test_filter>]"
+	echo "Usage: ./ci/verify_examples.sh [build_config|sandbox|all] [<test_filter>]"
 esac
 
 if [[ "${#FAILED[@]}" -ne "0" ]]; then


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: examples/ci: spit verify_examples tests
Additional Description:
This allows you to run `verify_build_configs` and `run_examples` independently,
making it easier to verify an added sandbox locally.

Risk Level: low
Testing: yep
Docs Changes: to follow
Release Notes:
[Optional Runtime guard:] touch #13084 
[Optional Fixes #Issue]
[Optional Deprecated:]
