### PR TITLE
docs: Fix REQ command operator usage example

### DIFF
--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -23,15 +23,17 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // For example, setting ``text_format`` like below,
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    // .. code-block:: yaml
     //
-    // The following plain text will be created:
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
-    // .. code-block::
+    // generates plain text similar to:
     //
-    //   upstream connect error:204:path=/foo
+    // .. code-block:: text
+    //
+    //   upstream connect error:503:path=/foo
     //
     string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -41,11 +43,11 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -70,7 +72,7 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -25,7 +25,8 @@ message SubstitutionFormatString {
     //
     // For example, setting ``text_format`` like below,
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
     //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
@@ -43,11 +44,12 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
-    //  json_format:
-    //    status: "%RESPONSE_CODE%"
-    //    message: "%LOCAL_REPLY_BODY%"
+    //   json_format:
+    //     status: "%RESPONSE_CODE%"
+    //     message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -72,7 +74,8 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -29,7 +29,8 @@ message SubstitutionFormatString {
     //
     // For example, setting ``text_format`` like below,
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
     //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
@@ -47,11 +48,12 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
-    //  json_format:
-    //    status: "%RESPONSE_CODE%"
-    //    message: "%LOCAL_REPLY_BODY%"
+    //   json_format:
+    //     status: "%RESPONSE_CODE%"
+    //     message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -76,7 +78,8 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -27,15 +27,17 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // For example, setting ``text_format`` like below,
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    // .. code-block:: yaml
     //
-    // The following plain text will be created:
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
-    // .. code-block::
+    // generates plain text similar to:
     //
-    //   upstream connect error:204:path=/foo
+    // .. code-block:: text
+    //
+    //   upstream connect error:503:path=/foo
     //
     string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -45,11 +47,11 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -74,7 +76,7 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -571,27 +571,27 @@ message LocalReplyConfig {
   // The configuration to form response body from the :ref:`command operators <config_access_log_command_operators>`
   // and to specify response content type as one of: plain/text or application/json.
   //
-  // Example one: plain/text body_format.
+  // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
-  // The following response body in `plain/text` format will be generated for a request with
+  // The following response body in "plain/text" format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: text
   //
   //   upstream connect error:503:path=/foo
   //
-  //  Example two: application/json body_format.
+  // Example two: "application/json" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -573,7 +573,8 @@ message LocalReplyConfig {
   //
   // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
@@ -586,12 +587,13 @@ message LocalReplyConfig {
   //
   // Example two: "application/json" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
-  //  json_format:
-  //    status: "%RESPONSE_CODE%"
-  //    message: "%LOCAL_REPLY_BODY%"
-  //    path: "$REQ(:path)%"
+  //   json_format:
+  //     status: "%RESPONSE_CODE%"
+  //     message: "%LOCAL_REPLY_BODY%"
+  //     path: "%REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -575,7 +575,8 @@ message LocalReplyConfig {
   //
   // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
@@ -588,12 +589,13 @@ message LocalReplyConfig {
   //
   // Example two: "application/json" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
-  //  json_format:
-  //    status: "%RESPONSE_CODE%"
-  //    message: "%LOCAL_REPLY_BODY%"
-  //    path: "$REQ(:path)%"
+  //   json_format:
+  //     status: "%RESPONSE_CODE%"
+  //     message: "%LOCAL_REPLY_BODY%"
+  //     path: "%REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -573,27 +573,27 @@ message LocalReplyConfig {
   // The configuration to form response body from the :ref:`command operators <config_access_log_command_operators>`
   // and to specify response content type as one of: plain/text or application/json.
   //
-  // Example one: plain/text body_format.
+  // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
-  // The following response body in `plain/text` format will be generated for a request with
+  // The following response body in "plain/text" format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: text
   //
   //   upstream connect error:503:path=/foo
   //
-  //  Example two: application/json body_format.
+  // Example two: "application/json" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -23,15 +23,17 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // For example, setting ``text_format`` like below,
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    // .. code-block:: yaml
     //
-    // The following plain text will be created:
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
-    // .. code-block::
+    // generates plain text similar to:
     //
-    //   upstream connect error:204:path=/foo
+    // .. code-block:: text
+    //
+    //   upstream connect error:503:path=/foo
     //
     string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -41,11 +43,11 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -70,7 +72,7 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -25,7 +25,8 @@ message SubstitutionFormatString {
     //
     // For example, setting ``text_format`` like below,
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
     //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
@@ -43,11 +44,12 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
-    //  json_format:
-    //    status: "%RESPONSE_CODE%"
-    //    message: "%LOCAL_REPLY_BODY%"
+    //   json_format:
+    //     status: "%RESPONSE_CODE%"
+    //     message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -72,7 +74,8 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -29,7 +29,8 @@ message SubstitutionFormatString {
     //
     // For example, setting ``text_format`` like below,
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
     //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
@@ -47,11 +48,12 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block:: yaml
+    // .. validated-code-block:: yaml
+    //   :type-name: envoy.config.core.v3.SubstitutionFormatString
     //
-    //  json_format:
-    //    status: "%RESPONSE_CODE%"
-    //    message: "%LOCAL_REPLY_BODY%"
+    //   json_format:
+    //     status: "%RESPONSE_CODE%"
+    //     message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -76,7 +78,8 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -27,15 +27,17 @@ message SubstitutionFormatString {
     // Specify a format with command operators to form a text string.
     // Its details is described in :ref:`format string<config_access_log_format_strings>`.
     //
-    // .. code-block::
+    // For example, setting ``text_format`` like below,
     //
-    //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+    // .. code-block:: yaml
     //
-    // The following plain text will be created:
+    //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
     //
-    // .. code-block::
+    // generates plain text similar to:
     //
-    //   upstream connect error:204:path=/foo
+    // .. code-block:: text
+    //
+    //   upstream connect error:503:path=/foo
     //
     string text_format = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -45,11 +47,11 @@ message SubstitutionFormatString {
     // Nested JSON objects may be produced by some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).
     // See the documentation for a specific command operator for details.
     //
-    // .. code-block::
+    // .. code-block:: yaml
     //
     //  json_format:
-    //    status: %RESPONSE_CODE%
-    //    message: %LOCAL_REPLY_BODY%
+    //    status: "%RESPONSE_CODE%"
+    //    message: "%LOCAL_REPLY_BODY%"
     //
     // The following JSON object would be created:
     //
@@ -74,7 +76,7 @@ message SubstitutionFormatString {
   // If this field is not set then ``text/plain`` is used for *text_format* and
   // ``application/json`` is used for *json_format*.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //   content_type: "text/html; charset=UTF-8"
   //

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -576,27 +576,27 @@ message LocalReplyConfig {
   // The configuration to form response body from the :ref:`command operators <config_access_log_command_operators>`
   // and to specify response content type as one of: plain/text or application/json.
   //
-  // Example one: plain/text body_format.
+  // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
-  // The following response body in `plain/text` format will be generated for a request with
+  // The following response body in "plain/text" format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: text
   //
   //   upstream connect error:503:path=/foo
   //
-  //  Example two: application/json body_format.
+  // Example two: "application/json" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -578,7 +578,8 @@ message LocalReplyConfig {
   //
   // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
@@ -591,12 +592,13 @@ message LocalReplyConfig {
   //
   // Example two: "application/json" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
-  //  json_format:
-  //    status: "%RESPONSE_CODE%"
-  //    message: "%LOCAL_REPLY_BODY%"
-  //    path: "$REQ(:path)%"
+  //   json_format:
+  //     status: "%RESPONSE_CODE%"
+  //     message: "%LOCAL_REPLY_BODY%"
+  //     path: "%REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -575,7 +575,8 @@ message LocalReplyConfig {
   //
   // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
   //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
@@ -588,12 +589,13 @@ message LocalReplyConfig {
   //
   // Example two: "application/json" ``body_format``.
   //
-  // .. code-block:: yaml
+  // .. validated-code-block:: yaml
+  //   :type-name: envoy.config.core.v3.SubstitutionFormatString
   //
-  //  json_format:
-  //    status: "%RESPONSE_CODE%"
-  //    message: "%LOCAL_REPLY_BODY%"
-  //    path: "$REQ(:path)%"
+  //   json_format:
+  //     status: "%RESPONSE_CODE%"
+  //     message: "%LOCAL_REPLY_BODY%"
+  //     path: "%REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -573,27 +573,27 @@ message LocalReplyConfig {
   // The configuration to form response body from the :ref:`command operators <config_access_log_command_operators>`
   // and to specify response content type as one of: plain/text or application/json.
   //
-  // Example one: plain/text body_format.
+  // Example one: "plain/text" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
-  //   text_format: %LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=$REQ(:path)%
+  //   text_format: "%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\n"
   //
-  // The following response body in `plain/text` format will be generated for a request with
+  // The following response body in "plain/text" format will be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.
   //
-  // .. code-block::
+  // .. code-block:: text
   //
   //   upstream connect error:503:path=/foo
   //
-  //  Example two: application/json body_format.
+  // Example two: "application/json" ``body_format``.
   //
-  // .. code-block::
+  // .. code-block:: yaml
   //
   //  json_format:
-  //    status: %RESPONSE_CODE%
-  //    message: %LOCAL_REPLY_BODY%
-  //    path: $REQ(:path)%
+  //    status: "%RESPONSE_CODE%"
+  //    message: "%LOCAL_REPLY_BODY%"
+  //    path: "$REQ(:path)%"
   //
   // The following response body in "application/json" format would be generated for a request with
   // local reply body of "upstream connection error", response_code=503 and path=/foo.


### PR DESCRIPTION
Commit Message: This fixes the docs for `REQ` command operator usage example in `LocalReplyConfig` and `SubstitutionFormatString` protos. `$REQ(:path)%` is an invalid command operator, it should be `%REQ(:path)%`.

Risk Level: N/A
Testing: N/A
Docs Changes: This is a docs change.
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>