### PR TITLE
tests: Move configuration file count to constant

### DIFF
--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -24,6 +24,7 @@ envoy_cc_test(
     ],
     deps = [
         ":config_test_lib",
+        "//source/common/filesystem:filesystem_lib",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
     ],

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -8,8 +8,10 @@
 
 namespace Envoy {
 
+#if defined(__APPLE__) || defined(WIN32)
 // freebind/freebind.yaml is not supported on macOS or Windows and is disabled via Bazel.
 constexpr uint64_t LinuxOnlyConfigFileTestCount = 1UL;
+#endif
 
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -8,11 +8,6 @@
 
 namespace Envoy {
 
-#if defined(__APPLE__) || defined(WIN32)
-// freebind/freebind.yaml is not supported on macOS or Windows and is disabled via Bazel.
-constexpr uint64_t LinuxOnlyConfigFileTestCount = 1UL;
-#endif
-
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
@@ -36,11 +31,7 @@ TEST(ExampleConfigsTest, All) {
   RELEASE_ASSERT(::getcwd(cwd, sizeof(cwd)) != nullptr, "");
   RELEASE_ASSERT(::chdir(directory.c_str()) == 0, "");
 
-#if defined(__APPLE__) || defined(WIN32)
-  EXPECT_EQ(config_file_count - LinuxOnlyConfigFileTestCount, ConfigTest::run(directory));
-#else
   EXPECT_EQ(config_file_count, ConfigTest::run(directory));
-#endif
 
   ConfigTest::testMerge();
 

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -5,6 +5,10 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
+
+// The total number of available configuration files under the examples directory.
+constexpr uint64_t NumberOfConfigurationFiles = 38UL;
+
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
@@ -21,9 +25,9 @@ TEST(ExampleConfigsTest, All) {
 
 #if defined(__APPLE__) || defined(WIN32)
   // freebind/freebind.yaml is not supported on macOS or Windows and is disabled via Bazel.
-  EXPECT_EQ(37UL, ConfigTest::run(directory));
+  EXPECT_EQ(NumberOfConfigurationFiles - 1, ConfigTest::run(directory));
 #else
-  EXPECT_EQ(38UL, ConfigTest::run(directory));
+  EXPECT_EQ(NumberOfConfigurationFiles, ConfigTest::run(directory));
 #endif
 
   ConfigTest::testMerge();

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -1,17 +1,27 @@
 #include "test/config_test/config_test.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
+#include "common/filesystem/filesystem_impl.h"
 
 #include "gtest/gtest.h"
 
 namespace Envoy {
 
-// The total number of available configuration files under the examples directory.
-constexpr uint64_t NumberOfConfigurationFiles = 38UL;
+// freebind/freebind.yaml is not supported on macOS or Windows and is disabled via Bazel.
+constexpr uint64_t LinuxOnlyConfigFileTestCount = 1UL;
 
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
+
+#ifdef WIN32
+  Filesystem::InstanceImplWin32 file_system;
+#else
+  Filesystem::InstanceImplPosix file_system;
+#endif
+
+  const auto config_file_count = std::stoi(
+      file_system.fileReadToEnd(TestEnvironment::temporaryDirectory() + "/config-file-count.txt"));
 
   // Change working directory, otherwise we won't be able to read files using relative paths.
 #ifdef PATH_MAX
@@ -24,10 +34,9 @@ TEST(ExampleConfigsTest, All) {
   RELEASE_ASSERT(::chdir(directory.c_str()) == 0, "");
 
 #if defined(__APPLE__) || defined(WIN32)
-  // freebind/freebind.yaml is not supported on macOS or Windows and is disabled via Bazel.
-  EXPECT_EQ(NumberOfConfigurationFiles - 1, ConfigTest::run(directory));
+  EXPECT_EQ(config_file_count - LinuxOnlyConfigFileTestCount, ConfigTest::run(directory));
 #else
-  EXPECT_EQ(NumberOfConfigurationFiles, ConfigTest::run(directory));
+  EXPECT_EQ(config_file_count, ConfigTest::run(directory));
 #endif
 
   ConfigTest::testMerge();

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -1,7 +1,8 @@
+#include "common/filesystem/filesystem_impl.h"
+
 #include "test/config_test/config_test.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
-#include "common/filesystem/filesystem_impl.h"
 
 #include "gtest/gtest.h"
 

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -6,5 +6,5 @@ DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
 tar -xvf "$TEST_SRCDIR"/envoy/configs/example_configs.tar -C "$DIR"
 
-# find uses full path to prevent using windows find on windows
+# find uses full path to prevent using Windows find on Windows.
 /usr/bin/find "$DIR" -type f | grep -c .yaml > "$TEST_TMPDIR"/config-file-count.txt

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -5,3 +5,6 @@ set -e
 DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
 tar -xvf "$TEST_SRCDIR"/envoy/configs/example_configs.tar -C "$DIR"
+
+CONFIG_FILE_COUNT=$(find "$DIR" -type f | grep .yaml | wc -l)
+echo "$CONFIG_FILE_COUNT" > "$TEST_TMPDIR"/config-file-count.txt

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -6,4 +6,5 @@ DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
 tar -xvf "$TEST_SRCDIR"/envoy/configs/example_configs.tar -C "$DIR"
 
-find "$DIR" -type f | grep -c .yaml > "$TEST_TMPDIR"/config-file-count.txt
+# find uses full path to prevent using windows find on windows
+/usr/bin/find "$DIR" -type f | grep -c .yaml > "$TEST_TMPDIR"/config-file-count.txt

--- a/test/config_test/example_configs_test_setup.sh
+++ b/test/config_test/example_configs_test_setup.sh
@@ -6,5 +6,4 @@ DIR="$TEST_TMPDIR"/test/config_test
 mkdir -p "$DIR"
 tar -xvf "$TEST_SRCDIR"/envoy/configs/example_configs.tar -C "$DIR"
 
-CONFIG_FILE_COUNT=$(find "$DIR" -type f | grep .yaml | wc -l)
-echo "$CONFIG_FILE_COUNT" > "$TEST_TMPDIR"/config-file-count.txt
+find "$DIR" -type f | grep -c .yaml > "$TEST_TMPDIR"/config-file-count.txt


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: tests: Move configuration file count to constant
Additional Description: 

This makes it easier to update/document new sandboxes.

Ideally we set the var dynamically - possibly by setting the constant from an env var -  ~and maybe updating `verify_examples.sh` to get  the expected count of files~

One bit of complexity ~not (yet)~ dealt with here is that it hardcodes `-1` when running on windows or mac - we may want to somehow account for this dynamically too (*...update; if its safe to just use the count of bundled yaml file we can remove this decrement*)

See https://github.com/envoyproxy/envoy/pull/13200#discussion_r491994317 for discussion with @dio on reasoning for this

Risk Level: low
Testing: yep
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]  touch #13200 
[Optional Deprecated:]
