### PR TITLE
Watchdog: use abort action as a default

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -55,6 +55,7 @@ envoy_cc_library(
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/trace/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/watchdog/abort_action/v3alpha:pkg_cc_proto",
     ],
 )
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -182,13 +182,13 @@ WatchdogImpl::WatchdogImpl(const envoy::config::bootstrap::v3::Watchdog& watchdo
   abort_config.mutable_wait_duration()->set_seconds(1);
 
   if (kill_timeout > 0) {
-    auto abort_action_config = actions.Add();
+    envoy::config::bootstrap::v3::Watchdog::WatchdogAction* abort_action_config = actions.Add();
     abort_action_config->set_event(envoy::config::bootstrap::v3::Watchdog::WatchdogAction::KILL);
     abort_action_config->mutable_config()->mutable_typed_config()->PackFrom(abort_config);
   }
 
   if (multikill_timeout_.count() > 0) {
-    auto abort_action_config = actions.Add();
+    envoy::config::bootstrap::v3::Watchdog::WatchdogAction* abort_action_config = actions.Add();
     abort_action_config->set_event(
         envoy::config::bootstrap::v3::Watchdog::WatchdogAction::MULTIKILL);
     abort_action_config->mutable_config()->mutable_typed_config()->PackFrom(abort_config);


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

Commit Message: Watchdog: use abort action as a default if killing is enabled and we're on a supported platform.
Additional Description:
Risk Level: low
Testing: unit tests
Docs Changes: N/A
Release Notes: TBD
See https://github.com/envoyproxy/envoy/pull/12860#pullrequestreview-486072875 for comment chain about making this a default
