### PR TITLE
cleanup: Remove unused stats_prefix_

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/proxy.cc
+++ b/source/extensions/filters/network/mongo_proxy/proxy.cc
@@ -59,10 +59,9 @@ ProxyFilter::ProxyFilter(const std::string& stat_prefix, Stats::Scope& scope,
                          const Filters::Common::Fault::FaultDelayConfigSharedPtr& fault_config,
                          const Network::DrainDecision& drain_decision, TimeSource& time_source,
                          bool emit_dynamic_metadata, const MongoStatsSharedPtr& mongo_stats)
-    : stat_prefix_(stat_prefix), stats_(generateStats(stat_prefix, scope)), runtime_(runtime),
-      drain_decision_(drain_decision), access_log_(access_log), fault_config_(fault_config),
-      time_source_(time_source), emit_dynamic_metadata_(emit_dynamic_metadata),
-      mongo_stats_(mongo_stats) {
+    : stats_(generateStats(stat_prefix, scope)), runtime_(runtime), drain_decision_(drain_decision),
+      access_log_(access_log), fault_config_(fault_config), time_source_(time_source),
+      emit_dynamic_metadata_(emit_dynamic_metadata), mongo_stats_(mongo_stats) {
   if (!runtime_.snapshot().featureEnabled(MongoRuntimeConfig::get().ConnectionLoggingEnabled,
                                           100)) {
     // If we are not logging at the connection level, just release the shared pointer so that we

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -183,7 +183,6 @@ private:
   void tryInjectDelay();
 
   std::unique_ptr<Decoder> decoder_;
-  std::string stat_prefix_;
   MongoProxyStats stats_;
   Runtime::Loader& runtime_;
   const Network::DrainDecision& drain_decision_;

--- a/source/extensions/filters/network/mysql_proxy/mysql_filter.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_filter.cc
@@ -14,7 +14,7 @@ namespace NetworkFilters {
 namespace MySQLProxy {
 
 MySQLFilterConfig::MySQLFilterConfig(const std::string& stat_prefix, Stats::Scope& scope)
-    : scope_(scope), stat_prefix_(stat_prefix), stats_(generateStats(stat_prefix, scope)) {}
+    : scope_(scope), stats_(generateStats(stat_prefix, scope)) {}
 
 MySQLFilter::MySQLFilter(MySQLFilterConfigSharedPtr config) : config_(std::move(config)) {}
 

--- a/source/extensions/filters/network/mysql_proxy/mysql_filter.h
+++ b/source/extensions/filters/network/mysql_proxy/mysql_filter.h
@@ -54,7 +54,6 @@ public:
   const MySQLProxyStats& stats() { return stats_; }
 
   Stats::Scope& scope_;
-  const std::string stat_prefix_;
   MySQLProxyStats stats_;
 
 private:

--- a/source/extensions/filters/network/postgres_proxy/postgres_filter.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_filter.cc
@@ -13,8 +13,7 @@ namespace PostgresProxy {
 
 PostgresFilterConfig::PostgresFilterConfig(const std::string& stat_prefix, bool enable_sql_parsing,
                                            Stats::Scope& scope)
-    : stat_prefix_{stat_prefix},
-      enable_sql_parsing_(enable_sql_parsing), scope_{scope}, stats_{generateStats(stat_prefix,
+    : enable_sql_parsing_(enable_sql_parsing), scope_{scope}, stats_{generateStats(stat_prefix,
                                                                                    scope)} {}
 
 PostgresFilter::PostgresFilter(PostgresFilterConfigSharedPtr config) : config_{config} {

--- a/source/extensions/filters/network/postgres_proxy/postgres_filter.h
+++ b/source/extensions/filters/network/postgres_proxy/postgres_filter.h
@@ -65,7 +65,6 @@ public:
   PostgresFilterConfig(const std::string& stat_prefix, bool enable_sql_parsing,
                        Stats::Scope& scope);
 
-  const std::string stat_prefix_;
   bool enable_sql_parsing_{true};
   Stats::Scope& scope_;
   PostgresProxyStats stats_;


### PR DESCRIPTION
Commit Message: This removes unused stats_prefix_ variables.

Risk Level: N/A, removes unused vars.
Testing: Existing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>