### PR TITLE
docs: Updating DNS Filter sample to correct whitespace and fields

### DIFF
--- a/docs/root/configuration/listeners/udp_filters/dns_filter.rst
+++ b/docs/root/configuration/listeners/udp_filters/dns_filter.rst
@@ -56,12 +56,12 @@ Example Configuration
           - suffix: "domain4.com"
           - suffix: "domain5.com"
           virtual_domains:
-           - name: "www.domain1.com"
-             endpoint:
-               address_list:
-                 address:
-                 - 10.0.0.1
-                 - 10.0.0.2
+            - name: "www.domain1.com"
+              endpoint:
+                address_list:
+                  address:
+                  - 10.0.0.1
+                  - 10.0.0.2
             - name: "www.domain2.com"
               endpoint:
                 address_list:
@@ -83,15 +83,15 @@ Example Configuration
                       protocol: { number: 6 }
                       ttl: 86400s
                       targets:
-                      - name: { host_name: "primary.voip.domain5.com" }
+                      - host_name: "primary.voip.domain5.com"
                         priority: 10
                         weight: 30
                         port: 5060
-                      - name: { host_name: "secondary.voip.domain5.com" }
+                      - host_name: "secondary.voip.domain5.com"
                         priority: 10
                         weight: 20
                         port: 5060
-                      - name: { host_name: "backup.voip.domain5.com" }
+                      - host_name: "backup.voip.domain5.com"
                         priority: 10
                         weight: 10
                         port: 5060


### PR DESCRIPTION
Commit Message:  Correcting malformed DNS Filter config.  Remove non-existent field from DNSServiceTarget
Additional Description:  DnsServiceTarget does not have a `name`.  Correcting to only include `host_name`. 
https://www.envoyproxy.io/docs/envoy/latest/api-v3/data/dns/v3/dns_table.proto#envoy-v3-api-msg-data-dns-v3-dnstable-dnsservicetarget
Risk Level: None
Testing: None
Docs Changes:  No changes to code.  Just doc changes.

