### PR TITLE
tls: fix SslSocket read resumption after readDisable when processing the SSL record that contains the last bytes of the HTTP message

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -58,6 +58,7 @@ Bug Fixes
 * listener: fixed crash at listener inplace update when connetion load balancer is set.
 * rocketmq_proxy network-level filter: fixed an issue involving incorrect header lengths. In debug mode it causes crash and in release mode it causes underflow.
 * thrift_proxy: fixed crashing bug on request overflow.
+* tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
 * udp_proxy: fixed a crash due to UDP packets being processed after listener removal.
 
 Removed Config or Runtime

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.h
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.h
@@ -36,8 +36,6 @@ protected:
   // Set this true to debug SSL handshake issues with openssl s_client. The
   // verbose trace will be in the logs, openssl must be installed separately.
   bool debug_with_s_client_{false};
-
-private:
   std::unique_ptr<ContextManager> context_manager_;
 };
 

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -12,6 +12,7 @@
 #include "common/event/dispatcher_impl.h"
 #include "common/json/json_loader.h"
 #include "common/network/address_impl.h"
+#include "common/network/connection_impl.h"
 #include "common/network/listen_socket_impl.h"
 #include "common/network/transport_socket_options_impl.h"
 #include "common/network/utility.h"
@@ -4567,8 +4568,10 @@ protected:
     read_filter_ = std::make_shared<Network::MockReadFilter>();
   }
 
-  void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t expected_chunk_size,
-                           uint32_t write_size, uint32_t num_writes, bool reserve_write_space) {
+  void readBufferLimitTest(uint32_t read_buffer_limit, uint32_t min_expected_chunk_size,
+                           uint32_t max_expected_chunk_size, uint32_t write_size,
+                           uint32_t num_writes, bool reserve_write_space,
+                           bool bypass_client_connection) {
     initialize();
 
     EXPECT_CALL(listener_callbacks_, onAccept_(_))
@@ -4592,7 +4595,8 @@ protected:
     EXPECT_CALL(*read_filter_, onNewConnection());
     EXPECT_CALL(*read_filter_, onData(_, _))
         .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> Network::FilterStatus {
-          EXPECT_GE(expected_chunk_size, data.length());
+          EXPECT_LE(min_expected_chunk_size, data.length());
+          EXPECT_GE(max_expected_chunk_size, data.length());
           filter_seen += data.length();
           data.drain(data.length());
           if (filter_seen == (write_size * num_writes)) {
@@ -4619,7 +4623,15 @@ protected:
         data.commit(iovecs, 2);
       }
 
-      client_connection_->write(data, false);
+      if (bypass_client_connection) {
+        auto result = client_transport_socket_->doWrite(data, false);
+        ASSERT_EQ(Network::PostIoAction::KeepOpen, result.action_);
+        ASSERT_EQ(write_size, result.bytes_processed_);
+        ASSERT_FALSE(result.end_stream_read_);
+      } else {
+        client_connection_->write(data, false);
+        dynamic_cast<Network::ConnectionImpl*>(client_connection_.get())->flushWriteBuffer();
+      }
     }
 
     dispatcher_->run(Event::Dispatcher::RunType::Block);
@@ -4741,17 +4753,23 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, SslReadBufferLimitTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(SslReadBufferLimitTest, NoLimit) {
-  readBufferLimitTest(0, 256 * 1024, 256 * 1024, 1, false);
+  readBufferLimitTest(0, 1, 256 * 1024, 256 * 1024, 1, false, false);
 }
 
-TEST_P(SslReadBufferLimitTest, NoLimitReserveSpace) { readBufferLimitTest(0, 512, 512, 1, true); }
+TEST_P(SslReadBufferLimitTest, NoLimitReserveSpace) {
+  readBufferLimitTest(0, 512, 512, 512, 1, true, false);
+}
 
 TEST_P(SslReadBufferLimitTest, NoLimitSmallWrites) {
-  readBufferLimitTest(0, 256 * 1024, 1, 256 * 1024, false);
+  readBufferLimitTest(0, 1, 256 * 1024, 1, 256 * 1024, false, false);
 }
 
 TEST_P(SslReadBufferLimitTest, SomeLimit) {
-  readBufferLimitTest(32 * 1024, 32 * 1024, 256 * 1024, 1, false);
+  readBufferLimitTest(32 * 1024, 32 * 1024, 32 * 1024, 256 * 1024, 1, false, false);
+}
+
+TEST_P(SslReadBufferLimitTest, DrainToSslRecordBoundary) {
+  readBufferLimitTest(16 * 1024, 20 * 1024, 20 * 1024, 10 * 1024, 10, false, true);
 }
 
 TEST_P(SslReadBufferLimitTest, WritesSmallerThanBufferLimit) { singleWriteTest(5 * 1024, 1024); }

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -289,6 +289,22 @@ public:
                                                  *dispatcher_);
   }
 
+  /**
+   * Helper to create ConnectionDriver.
+   *
+   * @param port the port to connect to.
+   * @param write_request_cb callback used to send data.
+   * @param data_callback the callback on the received data.
+   * @param transport_socket transport socket to use for the client connection
+   **/
+  std::unique_ptr<RawConnectionDriver> createConnectionDriver(
+      uint32_t port, RawConnectionDriver::DoWriteCallback write_request_cb,
+      std::function<void(Network::ClientConnection&, const Buffer::Instance&)>&& data_callback,
+      Network::TransportSocketPtr transport_socket = nullptr) {
+    return std::make_unique<RawConnectionDriver>(port, write_request_cb, data_callback, version_,
+                                                 *dispatcher_, std::move(transport_socket));
+  }
+
 protected:
   bool initialized() const { return initialized_; }
 

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -27,6 +27,21 @@
 #include "absl/strings/match.h"
 
 namespace Envoy {
+namespace {
+
+RawConnectionDriver::DoWriteCallback writeBufferCallback(Buffer::Instance& data) {
+  auto shared_data = std::make_shared<Buffer::OwnedImpl>();
+  shared_data->move(data);
+  return [shared_data](Network::ClientConnection& client) {
+    if (shared_data->length() > 0) {
+      client.write(*shared_data, false);
+      shared_data->drain(shared_data->length());
+    }
+  };
+}
+
+} // namespace
+
 void BufferingStreamDecoder::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!complete_);
   complete_ = end_stream;
@@ -112,15 +127,24 @@ IntegrationUtil::makeSingleRequest(uint32_t port, const std::string& method, con
   return makeSingleRequest(addr, method, url, body, type, host, content_type);
 }
 
-RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data,
-                                         ReadCallback data_callback,
+RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& request_data,
+                                         ReadCallback response_data_callback,
+                                         Network::Address::IpVersion version,
+                                         Event::Dispatcher& dispatcher,
+                                         Network::TransportSocketPtr transport_socket)
+    : RawConnectionDriver(port, writeBufferCallback(request_data), response_data_callback, version,
+                          dispatcher, std::move(transport_socket)) {}
+
+RawConnectionDriver::RawConnectionDriver(uint32_t port, DoWriteCallback write_request_callback,
+                                         ReadCallback response_data_callback,
                                          Network::Address::IpVersion version,
                                          Event::Dispatcher& dispatcher,
                                          Network::TransportSocketPtr transport_socket)
     : dispatcher_(dispatcher) {
   api_ = Api::createApiForTest(stats_store_);
   Event::GlobalTimeSystem time_system;
-  callbacks_ = std::make_unique<ConnectionCallbacks>();
+  callbacks_ = std::make_unique<ConnectionCallbacks>(
+      [this, write_request_callback]() { write_request_callback(*client_); });
 
   if (transport_socket == nullptr) {
     transport_socket = Network::Test::createRawBufferSocket();
@@ -130,9 +154,13 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, Buffer::Instance& initia
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
       Network::Address::InstanceConstSharedPtr(), std::move(transport_socket), nullptr);
+  // ConnectionCallbacks will call write_request_callback from the connect and low-watermark
+  // callbacks. Set a small buffer limit so high-watermark is triggered after every write and
+  // low-watermark is triggered every time the buffer is drained.
+  client_->setBufferLimits(1);
   client_->addConnectionCallbacks(*callbacks_);
-  client_->addReadFilter(Network::ReadFilterSharedPtr{new ForwardingFilter(*this, data_callback)});
-  client_->write(initial_data, false);
+  client_->addReadFilter(
+      Network::ReadFilterSharedPtr{new ForwardingFilter(*this, response_data_callback)});
   client_->connect();
 }
 

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -121,11 +121,8 @@ private:
                   event == Network::ConnectionEvent::LocalClose);
       connected_ |= (event == Network::ConnectionEvent::Connected);
     }
-    void onAboveWriteBufferHighWatermark() override { high_watermark_triggered_ = true; }
-    void onBelowWriteBufferLowWatermark() override {
-      high_watermark_triggered_ = false;
-      write_cb_();
-    }
+    void onAboveWriteBufferHighWatermark() override {}
+    void onBelowWriteBufferLowWatermark() override { write_cb_(); }
 
     Network::ConnectionEvent last_connection_event_;
 
@@ -133,7 +130,6 @@ private:
     WriteCb write_cb_;
     bool connected_{false};
     bool closed_{false};
-    bool high_watermark_triggered_{false};
   };
 
   Stats::IsolatedStoreImpl stats_store_;

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -63,10 +63,17 @@ using BufferingStreamDecoderPtr = std::unique_ptr<BufferingStreamDecoder>;
  */
 class RawConnectionDriver {
 public:
+  using DoWriteCallback = std::function<void(Network::ClientConnection&)>;
   using ReadCallback = std::function<void(Network::ClientConnection&, const Buffer::Instance&)>;
 
-  RawConnectionDriver(uint32_t port, Buffer::Instance& initial_data, ReadCallback data_callback,
-                      Network::Address::IpVersion version, Event::Dispatcher& dispatcher,
+  RawConnectionDriver(uint32_t port, DoWriteCallback write_request_callback,
+                      ReadCallback response_data_callback, Network::Address::IpVersion version,
+                      Event::Dispatcher& dispatcher,
+                      Network::TransportSocketPtr transport_socket = nullptr);
+  // Similar to the constructor above but accepts the request as a constructor argument.
+  RawConnectionDriver(uint32_t port, Buffer::Instance& request_data,
+                      ReadCallback response_data_callback, Network::Address::IpVersion version,
+                      Event::Dispatcher& dispatcher,
                       Network::TransportSocketPtr transport_socket = nullptr);
   ~RawConnectionDriver();
   const Network::Connection& connection() { return *client_; }
@@ -83,39 +90,50 @@ public:
 private:
   struct ForwardingFilter : public Network::ReadFilterBaseImpl {
     ForwardingFilter(RawConnectionDriver& parent, ReadCallback cb)
-        : parent_(parent), data_callback_(cb) {}
+        : parent_(parent), response_data_callback_(cb) {}
 
     // Network::ReadFilter
     Network::FilterStatus onData(Buffer::Instance& data, bool) override {
-      data_callback_(*parent_.client_, data);
+      response_data_callback_(*parent_.client_, data);
       data.drain(data.length());
       return Network::FilterStatus::StopIteration;
     }
 
     RawConnectionDriver& parent_;
-    ReadCallback data_callback_;
+    ReadCallback response_data_callback_;
   };
 
   struct ConnectionCallbacks : public Network::ConnectionCallbacks {
+    using WriteCb = std::function<void()>;
 
+    ConnectionCallbacks(WriteCb write_cb) : write_cb_(write_cb) {}
     bool connected() const { return connected_; }
     bool closed() const { return closed_; }
 
     // Network::ConnectionCallbacks
     void onEvent(Network::ConnectionEvent event) override {
+      if (!connected_ && event == Network::ConnectionEvent::Connected) {
+        write_cb_();
+      }
+
       last_connection_event_ = event;
       closed_ |= (event == Network::ConnectionEvent::RemoteClose ||
                   event == Network::ConnectionEvent::LocalClose);
       connected_ |= (event == Network::ConnectionEvent::Connected);
     }
-    void onAboveWriteBufferHighWatermark() override {}
-    void onBelowWriteBufferLowWatermark() override {}
+    void onAboveWriteBufferHighWatermark() override { high_watermark_triggered_ = true; }
+    void onBelowWriteBufferLowWatermark() override {
+      high_watermark_triggered_ = false;
+      write_cb_();
+    }
 
     Network::ConnectionEvent last_connection_event_;
 
   private:
+    WriteCb write_cb_;
     bool connected_{false};
     bool closed_{false};
+    bool high_watermark_triggered_{false};
   };
 
   Stats::IsolatedStoreImpl stats_store_;


### PR DESCRIPTION
Commit Message:
tls: fix SslSocket read resumption after readDisable when processing the SSL record that contains the last bytes of the HTTP message

Drain SSL_pending additional bytes from RawSSL after hitting buffer high watermark to avoid read resumption error when all remaining bytes of an HTTP message are trapped in SSL internal buffers.
Additional Description:
Risk Level: medium, small localized fixed to IO resumption.
Testing: new unit and integration tests
Docs Changes: n/a
Release Notes: added
Fixes #12304