### PR TITLE
network: pass buffer to io handle for reading

### DIFF
--- a/include/envoy/buffer/buffer.h
+++ b/include/envoy/buffer/buffer.h
@@ -194,15 +194,6 @@ public:
   virtual void move(Instance& rhs, uint64_t length) PURE;
 
   /**
-   * Read from a file descriptor directly into the buffer.
-   * @param io_handle supplies the io handle to read from.
-   * @param max_length supplies the maximum length to read.
-   * @return a IoCallUint64Result with err_ = nullptr and rc_ = the number of bytes
-   * read if successful, or err_ = some IoError for failure. If call failed, rc_ shouldn't be used.
-   */
-  virtual Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) PURE;
-
-  /**
    * Reserve space in the buffer.
    * @param length supplies the amount of space to reserve.
    * @param iovecs supplies the slices to fill with reserved memory.

--- a/include/envoy/network/io_handle.h
+++ b/include/envoy/network/io_handle.h
@@ -14,6 +14,7 @@
 namespace Envoy {
 namespace Buffer {
 struct RawSlice;
+class Instance;
 } // namespace Buffer
 
 namespace Event {
@@ -64,6 +65,15 @@ public:
    */
   virtual Api::IoCallUint64Result readv(uint64_t max_length, Buffer::RawSlice* slices,
                                         uint64_t num_slice) PURE;
+
+  /**
+   * Read from a io handle directly into buffer.
+   * @param buffer supplies the buffer to read into.
+   * @param max_length supplies the maximum length to read.
+   * @return a IoCallUint64Result with err_ = nullptr and rc_ = the number of bytes
+   * read if successful, or err_ = some IoError for failure. If call failed, rc_ shouldn't be used.
+   */
+  virtual Api::IoCallUint64Result read(Buffer::Instance& buffer, uint64_t max_length) PURE;
 
   /**
    * Write the data in slices out.

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -327,24 +327,6 @@ void OwnedImpl::move(Instance& rhs, uint64_t length) {
   other.postProcess();
 }
 
-Api::IoCallUint64Result OwnedImpl::read(Network::IoHandle& io_handle, uint64_t max_length) {
-  if (max_length == 0) {
-    return Api::ioCallUint64ResultNoError();
-  }
-  constexpr uint64_t MaxSlices = 2;
-  RawSlice slices[MaxSlices];
-  const uint64_t num_slices = reserve(max_length, slices, MaxSlices);
-  Api::IoCallUint64Result result = io_handle.readv(max_length, slices, num_slices);
-  uint64_t bytes_to_commit = result.ok() ? result.rc_ : 0;
-  ASSERT(bytes_to_commit <= max_length);
-  for (uint64_t i = 0; i < num_slices; i++) {
-    slices[i].len_ = std::min(slices[i].len_, static_cast<size_t>(bytes_to_commit));
-    bytes_to_commit -= slices[i].len_;
-  }
-  commit(slices, num_slices);
-  return result;
-}
-
 uint64_t OwnedImpl::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) {
   if (num_iovecs == 0 || length == 0) {
     return 0;

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -570,7 +570,6 @@ public:
   void* linearize(uint32_t size) override;
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
-  Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   ssize_t search(const void* data, uint64_t size, size_t start, size_t length) const override;
   bool startsWith(absl::string_view data) const override;

--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -57,12 +57,6 @@ SliceDataPtr WatermarkBuffer::extractMutableFrontSlice() {
   return result;
 }
 
-Api::IoCallUint64Result WatermarkBuffer::read(Network::IoHandle& io_handle, uint64_t max_length) {
-  Api::IoCallUint64Result result = OwnedImpl::read(io_handle, max_length);
-  checkHighAndOverflowWatermarks();
-  return result;
-}
-
 uint64_t WatermarkBuffer::reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) {
   uint64_t bytes_reserved = OwnedImpl::reserve(length, iovecs, num_iovecs);
   checkHighAndOverflowWatermarks();

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -35,7 +35,6 @@ public:
   void move(Instance& rhs) override;
   void move(Instance& rhs, uint64_t length) override;
   SliceDataPtr extractMutableFrontSlice() override;
-  Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override;
   uint64_t reserve(uint64_t length, RawSlice* iovecs, uint64_t num_iovecs) override;
   Api::IoCallUint64Result write(Network::IoHandle& io_handle) override;
   void postProcess() override { checkLowWatermark(); }

--- a/source/common/network/io_socket_handle_impl.cc
+++ b/source/common/network/io_socket_handle_impl.cc
@@ -48,6 +48,24 @@ Api::IoCallUint64Result IoSocketHandleImpl::readv(uint64_t max_length, Buffer::R
       fd_, iov.begin(), static_cast<int>(num_slices_to_read)));
 }
 
+Api::IoCallUint64Result IoSocketHandleImpl::read(Buffer::Instance& buffer, uint64_t max_length) {
+  if (max_length == 0) {
+    return Api::ioCallUint64ResultNoError();
+  }
+  constexpr uint64_t MaxSlices = 2;
+  Buffer::RawSlice slices[MaxSlices];
+  const uint64_t num_slices = buffer.reserve(max_length, slices, MaxSlices);
+  Api::IoCallUint64Result result = readv(max_length, slices, num_slices);
+  uint64_t bytes_to_commit = result.ok() ? result.rc_ : 0;
+  ASSERT(bytes_to_commit <= max_length);
+  for (uint64_t i = 0; i < num_slices; i++) {
+    slices[i].len_ = std::min(slices[i].len_, static_cast<size_t>(bytes_to_commit));
+    bytes_to_commit -= slices[i].len_;
+  }
+  buffer.commit(slices, num_slices);
+  return result;
+}
+
 Api::IoCallUint64Result IoSocketHandleImpl::writev(const Buffer::RawSlice* slices,
                                                    uint64_t num_slice) {
   absl::FixedArray<iovec> iov(num_slice);

--- a/source/common/network/io_socket_handle_impl.h
+++ b/source/common/network/io_socket_handle_impl.h
@@ -32,6 +32,7 @@ public:
 
   Api::IoCallUint64Result readv(uint64_t max_length, Buffer::RawSlice* slices,
                                 uint64_t num_slice) override;
+  Api::IoCallUint64Result read(Buffer::Instance& buffer, uint64_t max_length) override;
 
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
 

--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -19,7 +19,7 @@ IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
   bool end_stream = false;
   do {
     // 16K read is arbitrary. TODO(mattklein123) PERF: Tune the read size.
-    Api::IoCallUint64Result result = buffer.read(callbacks_->ioHandle(), 16384);
+    Api::IoCallUint64Result result = callbacks_->ioHandle().read(buffer, 16384);
 
     if (result.ok()) {
       ENVOY_CONN_LOG(trace, "read returns: {}", callbacks_->connection(), result.rc_);

--- a/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
+++ b/source/extensions/quic_listeners/quiche/quic_io_handle_wrapper.h
@@ -28,6 +28,13 @@ public:
     }
     return io_handle_.readv(max_length, slices, num_slice);
   }
+  Api::IoCallUint64Result read(Buffer::Instance& buffer, uint64_t max_length) override {
+    if (closed_) {
+      return Api::IoCallUint64Result(0, Api::IoErrorPtr(new Network::IoSocketError(EBADF),
+                                                        Network::IoSocketError::deleteIoError));
+    }
+    return io_handle_.read(buffer, max_length);
+  }
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override {
     if (closed_) {
       return Api::IoCallUint64Result(0, Api::IoErrorPtr(new Network::IoSocketError(EBADF),

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -144,15 +144,6 @@ public:
     src.size_ -= length;
   }
 
-  Api::IoCallUint64Result read(Network::IoHandle& io_handle, uint64_t max_length) override {
-    FUZZ_ASSERT(start_ + size_ + max_length <= data_.size());
-    Buffer::RawSlice slice{mutableEnd(), max_length};
-    Api::IoCallUint64Result result = io_handle.readv(max_length, &slice, 1);
-    FUZZ_ASSERT(result.ok() && result.rc_ > 0);
-    size_ += result.rc_;
-    return result;
-  }
-
   uint64_t reserve(uint64_t length, Buffer::RawSlice* iovecs, uint64_t num_iovecs) override {
     FUZZ_ASSERT(num_iovecs > 0);
     FUZZ_ASSERT(start_ + size_ + length <= data_.size());
@@ -355,7 +346,7 @@ uint32_t bufferAction(Context& ctxt, char insert_value, uint32_t max_alloc, Buff
     std::string data(max_length, insert_value);
     const ssize_t rc = ::write(pipe_fds[1], data.data(), max_length);
     FUZZ_ASSERT(rc > 0);
-    Api::IoCallUint64Result result = target_buffer.read(io_handle, max_length);
+    Api::IoCallUint64Result result = io_handle.read(target_buffer, max_length);
     FUZZ_ASSERT(result.rc_ == static_cast<uint64_t>(rc));
     FUZZ_ASSERT(::close(pipe_fds[1]) == 0);
     break;

--- a/test/common/buffer/owned_impl_test.cc
+++ b/test/common/buffer/owned_impl_test.cc
@@ -319,14 +319,14 @@ TEST_F(OwnedImplTest, Read) {
   Buffer::OwnedImpl buffer;
   Network::IoSocketHandleImpl io_handle;
   EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{0, 0}));
-  Api::IoCallUint64Result result = buffer.read(io_handle, 100);
+  Api::IoCallUint64Result result = io_handle.read(buffer, 100);
   EXPECT_TRUE(result.ok());
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
   EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
 
   EXPECT_CALL(os_sys_calls, readv(_, _, _)).WillOnce(Return(Api::SysCallSizeResult{-1, 0}));
-  result = buffer.read(io_handle, 100);
+  result = io_handle.read(buffer, 100);
   EXPECT_EQ(Api::IoError::IoErrorCode::UnknownError, result.err_->getErrorCode());
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
@@ -334,14 +334,14 @@ TEST_F(OwnedImplTest, Read) {
 
   EXPECT_CALL(os_sys_calls, readv(_, _, _))
       .WillOnce(Return(Api::SysCallSizeResult{-1, SOCKET_ERROR_AGAIN}));
-  result = buffer.read(io_handle, 100);
+  result = io_handle.read(buffer, 100);
   EXPECT_EQ(Api::IoError::IoErrorCode::Again, result.err_->getErrorCode());
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
   EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
 
   EXPECT_CALL(os_sys_calls, readv(_, _, _)).Times(0);
-  result = buffer.read(io_handle, 0);
+  result = io_handle.read(buffer, 0);
   EXPECT_EQ(0, result.rc_);
   EXPECT_EQ(0, buffer.length());
   EXPECT_THAT(buffer.describeSlicesForTest(), testing::IsEmpty());
@@ -1161,7 +1161,7 @@ TEST_F(OwnedImplTest, ReserveZeroCommit) {
   const ssize_t rc = os_sys_calls.write(pipe_fds[1], data.data(), max_length).rc_;
   ASSERT_GT(rc, 0);
   const uint32_t previous_length = buf.length();
-  Api::IoCallUint64Result result = buf.read(io_handle, max_length);
+  Api::IoCallUint64Result result = io_handle.read(buf, max_length);
   ASSERT_EQ(result.rc_, static_cast<uint64_t>(rc));
   ASSERT_EQ(os_sys_calls.close(pipe_fds[1]).rc_, 0);
   ASSERT_EQ(previous_length, buf.search(data.data(), rc, previous_length, 0));
@@ -1189,7 +1189,7 @@ TEST_F(OwnedImplTest, ReadReserveAndCommit) {
   std::string data = "e";
   const ssize_t rc = os_sys_calls.write(pipe_fds[1], data.data(), data.size()).rc_;
   ASSERT_GT(rc, 0);
-  Api::IoCallUint64Result result = buf.read(io_handle, read_length);
+  Api::IoCallUint64Result result = io_handle.read(buf, read_length);
   ASSERT_EQ(result.rc_, static_cast<uint64_t>(rc));
   ASSERT_EQ(os_sys_calls.close(pipe_fds[1]).rc_, 0);
   EXPECT_EQ("bbbbbe", buf.toString());

--- a/test/common/buffer/watermark_buffer_test.cc
+++ b/test/common/buffer/watermark_buffer_test.cc
@@ -267,7 +267,7 @@ TEST_F(WatermarkBufferTest, WatermarkFdFunctions) {
   int bytes_read_total = 0;
   Network::IoSocketHandleImpl io_handle2(pipe_fds[0]);
   while (bytes_read_total < 20) {
-    Api::IoCallUint64Result result = buffer_.read(io_handle2, 20);
+    Api::IoCallUint64Result result = io_handle2.read(buffer_, 20);
     bytes_read_total += result.rc_;
   }
   EXPECT_EQ(2, times_high_watermark_called_);

--- a/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
+++ b/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
@@ -211,7 +211,7 @@ protected:
 
       do {
         Api::IoCallUint64Result result =
-            result_buffer->read(client_socket->ioHandle(), bytes_to_read - bytes_read);
+            client_socket->ioHandle().read(*result_buffer, bytes_to_read - bytes_read);
 
         if (result.ok()) {
           bytes_read += result.rc_;

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -70,7 +70,7 @@ TEST(UdpOverUdsStatsdSinkTest, InitWithPipeAddress) {
   // Do the flush which should have somewhere to write now.
   sink.flush(snapshot);
   Buffer::OwnedImpl receive_buffer;
-  receive_buffer.read(sock.ioHandle(), 32);
+  sock.ioHandle().read(receive_buffer, 32);
   EXPECT_EQ("envoy.test_counter:1|c", receive_buffer.toString());
 }
 #endif

--- a/test/mocks/network/io_handle.h
+++ b/test/mocks/network/io_handle.h
@@ -24,6 +24,7 @@ public:
   MOCK_METHOD(bool, isOpen, (), (const));
   MOCK_METHOD(Api::IoCallUint64Result, readv,
               (uint64_t max_length, Buffer::RawSlice* slices, uint64_t num_slice));
+  MOCK_METHOD(Api::IoCallUint64Result, read, (Buffer::Instance & buffer, uint64_t max_length));
   MOCK_METHOD(Api::IoCallUint64Result, writev,
               (const Buffer::RawSlice* slices, uint64_t num_slice));
   MOCK_METHOD(Api::IoCallUint64Result, sendmsg,


### PR DESCRIPTION
This provides to io handles control over how data is added to
buffers.

Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a