### PR TITLE
api: rename grpc MaxStreamDuration fields for clarity

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -778,7 +778,7 @@ message RouteAction {
     // <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
     // *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
     // If set to 0, the `grpc-timeout` header is used without modification.
-    google.protobuf.Duration grpc_max_timeout = 2;
+    google.protobuf.Duration grpc_timeout_header_max = 2;
 
     // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
     // subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -786,7 +786,7 @@ message RouteAction {
     // makes it more likely that Envoy will handle the timeout instead of having the call canceled
     // by the client. If, after applying the offset, the resulting timeout is zero or negative,
     // the stream will timeout immediately.
-    google.protobuf.Duration grpc_timeout_offset = 3;
+    google.protobuf.Duration grpc_timeout_header_offset = 3;
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10;

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -777,7 +777,7 @@ message RouteAction {
     // <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
     // *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
     // If set to 0, the `grpc-timeout` header is used without modification.
-    google.protobuf.Duration grpc_max_timeout = 2;
+    google.protobuf.Duration grpc_timeout_header_max = 2;
 
     // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
     // subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -785,7 +785,7 @@ message RouteAction {
     // makes it more likely that Envoy will handle the timeout instead of having the call canceled
     // by the client. If, after applying the offset, the resulting timeout is zero or negative,
     // the stream will timeout immediately.
-    google.protobuf.Duration grpc_timeout_offset = 3;
+    google.protobuf.Duration grpc_timeout_header_offset = 3;
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10, 14, 26, 31;

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -789,7 +789,7 @@ message RouteAction {
     // <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
     // *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
     // If set to 0, the `grpc-timeout` header is used without modification.
-    google.protobuf.Duration grpc_max_timeout = 2;
+    google.protobuf.Duration grpc_timeout_header_max = 2;
 
     // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
     // subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -797,7 +797,7 @@ message RouteAction {
     // makes it more likely that Envoy will handle the timeout instead of having the call canceled
     // by the client. If, after applying the offset, the resulting timeout is zero or negative,
     // the stream will timeout immediately.
-    google.protobuf.Duration grpc_timeout_offset = 3;
+    google.protobuf.Duration grpc_timeout_header_offset = 3;
   }
 
   reserved 12, 18, 19, 16, 22, 21;

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -786,7 +786,7 @@ message RouteAction {
     // <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, use that value as the
     // *max_stream_duration*, but limit the applied timeout to the maximum value specified here.
     // If set to 0, the `grpc-timeout` header is used without modification.
-    google.protobuf.Duration grpc_max_timeout = 2;
+    google.protobuf.Duration grpc_timeout_header_max = 2;
 
     // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by
     // subtracting the provided duration from the header. This is useful for allowing Envoy to set
@@ -794,7 +794,7 @@ message RouteAction {
     // makes it more likely that Envoy will handle the timeout instead of having the call canceled
     // by the client. If, after applying the offset, the resulting timeout is zero or negative,
     // the stream will timeout immediately.
-    google.protobuf.Duration grpc_timeout_offset = 3;
+    google.protobuf.Duration grpc_timeout_header_offset = 3;
   }
 
   reserved 12, 18, 19, 16, 22, 21, 10;


### PR DESCRIPTION
Signed-off-by: Doug Fawley <dfawley@google.com>

Commit Message: Rename grpc_max_timeout and grpc_timeout_offset to grpc_timeout_header_max and grpc_timeout_header_offset.  This more clearly describes their function, as they do not act upon gRPC requests, but upon the grpc-timeout header.  Even though this is a breaking API change, this should be safe as the fields are only 9 days old, were never released, and should still be unused.
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

cc @alyssawilk @htuch @markdroth @ejona86
