### PR TITLE
[DO-NOT-REVIEW] add matcher API in HTTP filter level (Just for asking questions, not for review)

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v3:pkg",
+        "//envoy/config/common/matcher/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",
         "//envoy/config/route/v3:pkg",

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.network.http_connection_manager.v3;
 
 import "envoy/config/accesslog/v3/accesslog.proto";
+import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/extension.proto";
@@ -797,7 +798,7 @@ message ScopedRds {
       [(validate.rules).message = {required: true}];
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message HttpFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpFilter";
@@ -810,6 +811,10 @@ message HttpFilter {
   // select an extension if the type of the configuration proto is not
   // sufficient. It also serves as a resource name in ExtensionConfigDS.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // If specified, the http filter will be enabled only if match evaluates to true.
+  // Just an example matcher object.
+  config.common.matcher.v3.MatchPredicate match = 6;
 
   // Filter specific configuration which depends on the filter being instantiated. See the supported
   // filters for further documentation.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v4alpha:pkg",
+        "//envoy/config/common/matcher/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
         "//envoy/config/trace/v4alpha:pkg",

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.network.http_connection_manager.v4alpha;
 
 import "envoy/config/accesslog/v4alpha/accesslog.proto";
+import "envoy/config/common/matcher/v4alpha/matcher.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/core/v4alpha/extension.proto";
@@ -803,7 +804,7 @@ message ScopedRds {
       [(validate.rules).message = {required: true}];
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message HttpFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter";
@@ -816,6 +817,9 @@ message HttpFilter {
   // select an extension if the type of the configuration proto is not
   // sufficient. It also serves as a resource name in ExtensionConfigDS.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // If specified, the http filter will be enabled only if match evaluates to true.
+  config.common.matcher.v4alpha.MatchPredicate match = 6;
 
   // Filter specific configuration which depends on the filter being instantiated. See the supported
   // filters for further documentation.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v3:pkg",
+        "//envoy/config/common/matcher/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",
         "//envoy/config/route/v3:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.network.http_connection_manager.v3;
 
 import "envoy/config/accesslog/v3/accesslog.proto";
+import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/extension.proto";
@@ -802,7 +803,7 @@ message ScopedRds {
       [(validate.rules).message = {required: true}];
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message HttpFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpFilter";
@@ -813,6 +814,9 @@ message HttpFilter {
   // select an extension if the type of the configuration proto is not
   // sufficient. It also serves as a resource name in ExtensionConfigDS.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // If specified, the http filter will be enabled only if match evaluates to true.
+  config.common.matcher.v3.MatchPredicate match = 6;
 
   // Filter specific configuration which depends on the filter being instantiated. See the supported
   // filters for further documentation.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v4alpha:pkg",
+        "//envoy/config/common/matcher/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",
         "//envoy/config/trace/v4alpha:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.network.http_connection_manager.v4alpha;
 
 import "envoy/config/accesslog/v4alpha/accesslog.proto";
+import "envoy/config/common/matcher/v4alpha/matcher.proto";
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/core/v4alpha/extension.proto";
@@ -803,7 +804,7 @@ message ScopedRds {
       [(validate.rules).message = {required: true}];
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message HttpFilter {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter";
@@ -816,6 +817,9 @@ message HttpFilter {
   // select an extension if the type of the configuration proto is not
   // sufficient. It also serves as a resource name in ExtensionConfigDS.
   string name = 1 [(validate.rules).string = {min_bytes: 1}];
+
+  // If specified, the http filter will be enabled only if match evaluates to true.
+  config.common.matcher.v4alpha.MatchPredicate match = 6;
 
   // Filter specific configuration which depends on the filter being instantiated. See the supported
   // filters for further documentation.

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/config/common/matcher/v3/matcher.pb.h"
 #include "envoy/access_log/access_log.h"
 #include "envoy/common/scope_tracker.h"
 #include "envoy/event/dispatcher.h"
@@ -890,6 +891,12 @@ public:
   virtual bool createUpgradeFilterChain(absl::string_view upgrade,
                                         const UpgradeMap* per_route_upgrade_map,
                                         FilterChainFactoryCallbacks& callbacks) PURE;
+
+  /**
+   * Idea 2, called by FilterManager to get the matcher object by index of the http_filters field.
+   */
+  virtual absl::optional<envoy::config::common::matcher::v3::MatchPredicate>
+  getFilterMatchPredicate(std::size_t index) PURE;
 };
 
 } // namespace Http

--- a/source/extensions/filters/http/rbac/config.cc
+++ b/source/extensions/filters/http/rbac/config.cc
@@ -19,6 +19,8 @@ Http::FilterFactoryCb RoleBasedAccessControlFilterConfigFactory::createFilterFac
                                                                      context.scope());
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    // Idea 1, pass the matcher object as well.
+    // Just an idea, seems practically impossible because every filter needs to change its code.
     callbacks.addStreamDecoderFilter(std::make_shared<RoleBasedAccessControlFilter>(config));
   };
 }

--- a/source/extensions/filters/network/http_connection_manager/BUILD
+++ b/source/extensions/filters/network/http_connection_manager/BUILD
@@ -54,6 +54,7 @@ envoy_cc_extension(
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
+        "@envoy_api//envoy/config/common/matcher/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/tracing/v3:pkg_cc_proto",

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -447,6 +447,9 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
   const auto& filters = config.http_filters();
   for (int32_t i = 0; i < filters.size(); i++) {
     processFilter(filters[i], i, "http", filter_factories_, "http", i == filters.size() - 1);
+    // Idea 2, Store the matcher object in a vector and returns to FilterManager later.
+    matchers_.push_back(filters[i].has_match() ? absl::optional(filters[i].match())
+                                               : absl::nullopt);
   }
 
   for (const auto& upgrade_config : config.upgrade_configs()) {

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 
+#include "envoy/config/common/matcher/v3/matcher.pb.h"
 #include "envoy/config/config_provider_manager.h"
 #include "envoy/config/core/v3/extension.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
@@ -103,6 +104,11 @@ public:
   bool createUpgradeFilterChain(absl::string_view upgrade_type,
                                 const Http::FilterChainFactory::UpgradeMap* per_route_upgrade_map,
                                 Http::FilterChainFactoryCallbacks& callbacks) override;
+  // Idea 2.
+  absl::optional<envoy::config::common::matcher::v3::MatchPredicate>
+  getFilterMatchPredicate(std::size_t index) override {
+    return index < matchers_.size() ? matchers_[index] : absl::nullopt;
+  }
 
   // Http::ConnectionManagerConfig
   Http::RequestIDExtensionSharedPtr requestIDExtension() override { return request_id_extension_; }
@@ -255,6 +261,8 @@ private:
   static const uint64_t StreamIdleTimeoutMs = 5 * 60 * 1000;
   // request timeout is disabled by default
   static const uint64_t RequestTimeoutMs = 0;
+
+  std::vector<absl::optional<envoy::config::common::matcher::v3::MatchPredicate>> matchers_;
 };
 
 /**

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -65,6 +65,7 @@ envoy_cc_library(
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/access_loggers/file:file_access_log_lib",
         "//source/server:listener_manager_lib",
+        "@envoy_api//envoy/config/common/matcher/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "envoy/config/common/matcher/v3/matcher.pb.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/request_id_extension.h"
 #include "envoy/network/filter.h"
@@ -112,6 +113,8 @@ public:
                                 Http::FilterChainFactoryCallbacks&) override {
     return false;
   }
+  absl::optional<envoy::config::common::matcher::v3::MatchPredicate>
+  getFilterMatchPredicate(std::size_t) override { return absl::nullopt; }
 
   // Http::ConnectionManagerConfig
   Http::RequestIDExtensionSharedPtr requestIDExtension() override { return request_id_extension_; }

--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -56,6 +56,7 @@ envoy_cc_mock(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:host_mocks",
+        "@envoy_api//envoy/config/common/matcher/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "envoy/access_log/access_log.h"
+#include "envoy/config/common/matcher/v3/matcher.pb.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/conn_pool.h"
@@ -114,6 +115,8 @@ public:
   MOCK_METHOD(bool, createUpgradeFilterChain,
               (absl::string_view upgrade_type, const FilterChainFactory::UpgradeMap* upgrade_map,
                FilterChainFactoryCallbacks& callbacks));
+  MOCK_METHOD(absl::optional<envoy::config::common::matcher::v3::MatchPredicate>,
+              getFilterMatchPredicate, (std::size_t index));
 };
 
 class MockStreamFilterCallbacksBase {


### PR DESCRIPTION
Just created the PR for asking questions, not for review.

"conceptually i think you would just store a matcher object alongside each ActiveStreamFilter in the FM and call it during decodeHeaders to do the matching -> either skip or invoke callback for each filter"

Questions:
1. In FilterManager, the ActiveStreamFilter is created in addStreamFilter() which is called by each filter via the std::function() callback
   To store the matcher object alongside the ActiveStreamFilter, it seems like the actual filter needs to pass it to addStreamFilter() when calling from the std::function() callback
   And this seems very infesible because it requires every filter to change its code

2. If instead, the HttpConnectionManagerConfig somehow provide a callback to FilterManager to allow it to get the matcher object separately, some big issues with this idea:
   1) FilterManager needs a way to tell HttpConnectionManagerConfig which matcher object it wants. This actually seems hard to do because HttpConnectionManagerConfig
      doesn't know the mapping between the StreamDecodeFilterSharedPtr (StreamEncodeFilterSharedPtr) and the matcher object
   2) Cannot use index because the filter may not be added inside the std::function() callback.


Signed-off-by: Yangmin Zhu <ymzhu@google.com>
