### PR TITLE
jwt_authn: add debug log for jwt parsing

### DIFF
--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -140,6 +140,7 @@ void AuthenticatorImpl::startVerify() {
   tokens_.pop_back();
 
   jwt_ = std::make_unique<::google::jwt_verify::Jwt>();
+  ENVOY_LOG(debug, "{}: Parse Jwt {}", name(), curr_token_->token());
   const Status status = jwt_->parseFromString(curr_token_->token());
   if (status != Status::Ok) {
     doneWithStatus(status);

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -83,7 +83,7 @@ void Filter::setPayload(const ProtobufWkt::Struct& payload) {
 }
 
 void Filter::onComplete(const Status& status) {
-  ENVOY_LOG(debug, "Called Filter : check complete {}",
+  ENVOY_LOG(debug, "Jwt authentication completed with: {}",
             ::google::jwt_verify::getStatusString(status));
   // This stream has been reset, abort the callback.
   if (state_ == Responded) {


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Add a line of debug log to log the JWT is about to be parsed.
Just debugged a jwt parsing [issue](https://github.com/GoogleCloudPlatform/esp-v2/issues/342) with padding "=".
If there were this debug log, it would have been much easier to debug.

Commit Message:
Additional Description:
Risk Level: None
Testing: None
Docs Changes: None
Release Notes: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
