### PR TITLE
stats: hist_mutex_ needs to outlive deleted_histograms_

### DIFF
--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
 #include <cstring>
 #include <functional>
 #include <memory>
@@ -19,12 +20,24 @@ namespace Thread {
  */
 class MutexBasicLockable : public BasicLockable {
 public:
+#ifndef NDEBBUG
+  ~MutexBasicLockable() override { destroyed_ = true; }
+#endif
+
   // BasicLockable
-  void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() override { mutex_.Lock(); }
+  void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() override {
+#ifndef NDEBUG
+    assert(!destroyed_);
+#endif
+    mutex_.Lock();
+  }
   bool tryLock() ABSL_EXCLUSIVE_TRYLOCK_FUNCTION(true) override { return mutex_.TryLock(); }
   void unlock() ABSL_UNLOCK_FUNCTION() override { mutex_.Unlock(); }
 
 private:
+#ifndef NDEBUG
+  bool destroyed_{false};
+#endif
   friend class CondVar;
   absl::Mutex mutex_;
 };

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -498,6 +498,9 @@ private:
   NullHistogramImpl null_histogram_;
   NullTextReadoutImpl null_text_readout_;
 
+  mutable Thread::MutexBasicLockable hist_mutex_;
+  StatSet<ParentHistogramImpl> histogram_set_ ABSL_GUARDED_BY(hist_mutex_);
+
   // Retain storage for deleted stats; these are no longer in maps because the
   // matcher-pattern was established after they were created. Since the stats
   // are held by reference in code that expects them to be there, we can't
@@ -516,9 +519,6 @@ private:
   uint64_t next_histogram_id_ ABSL_GUARDED_BY(hist_mutex_) = 0;
 
   StatNameSetPtr well_known_tags_;
-
-  mutable Thread::MutexBasicLockable hist_mutex_;
-  StatSet<ParentHistogramImpl> histogram_set_ ABSL_GUARDED_BY(hist_mutex_);
 };
 
 using ThreadLocalStoreImplPtr = std::unique_ptr<ThreadLocalStoreImpl>;


### PR DESCRIPTION
Commit Message: There was a destruction-order issue in ThreadLocalStore between `hist_mutex_` and `deleted_histograms_` thay did not manifest in clang, but showed up in gcc as a pure virtual function call. It also does not show up in gcc when optimizing, and this might be because gcc with optimization, and clang always, optimize around that virtual call because at the call-site with the error, the concrete type is visible to the compiler. 

You can make this show up in clang as well, by adding a `destroyed_` bit in `MutexBasicLockable`. So this PR both fixes the bug found by gcc and also adds that bit under `#ifndef NDEBUG` so other latent issues of a similar nature can be caught more quickly.

Note that there was not an ordering issue with `histogram_set_` as that was not referenced during shutdown anyway. It was only the mutex. But the fix moves the `histogram_set_` declaration too, to keep it close to its mutex.

Additional Description:
Risk Level: low
Testing: //test/common/stats:thread_local_store_test. for now
Docs Changes: n/a
Release Notes: n/a

