### PR TITLE
docs: Update build instructions for docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Building documentation locally
 
+There are two methods to build the documentation, described below.
+
+In both cases, the generated output can be found in `generated/docs`.
+
 ## Building in an existing Envoy development environment
 
 If you have an existing Envoy development environment, you should have the necessary dependencies
@@ -8,8 +12,6 @@ and requirements and be able to build the documentation directly.
 ```bash
 ./docs/build.sh
 ```
-
-The output can be found in `generated/docs`.
 
 By default configuration examples are going to be validated during build. To disable validation,
 set `SPHINX_SKIP_CONFIG_VALIDATION` environment variable to `true`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,10 @@ and requirements and be able to build the documentation directly.
 ./docs/build.sh
 ```
 
-The output can be found in `generated/docs`. By default configuration examples are going to be validated during build.
-To disable validation, set `SPHINX_SKIP_CONFIG_VALIDATION` environment variable to `true`:
+The output can be found in `generated/docs`.
+
+By default configuration examples are going to be validated during build. To disable validation,
+set `SPHINX_SKIP_CONFIG_VALIDATION` environment variable to `true`:
 
 ```bash
 SPHINX_SKIP_CONFIG_VALIDATION=true docs/build.sh
@@ -27,7 +29,7 @@ This can be done as follows:
 ./ci/run_envoy_docker.sh 'ci/do_ci.sh docs'
 ```
 
-To use this method you will need a minimum of 4-5GB of disk space available to accomodate the build image.
+To use this method you will need a minimum of 4-5GB of disk space available to accommodate the build image.
 
 # Creating a Pull Request with documentation changes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ To use this method you will need a minimum of 4-5GB of disk space available to a
 
 When you create a Pull Request the documentation is rendered by CircleCI.
 
-This can be viewed by clicking "Details" in "ci/circleci: docs" check. From there click "ARTIFACTS", and then
+This can be viewed by clicking "Details" in the "ci/circleci: docs" check. From there click "ARTIFACTS", and then
 "generated/docs/index.html".
 
 You should be able to see your changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,7 @@ In both cases, the generated output can be found in `generated/docs`.
 
 ## Building in an existing Envoy development environment
 
-If you have an existing Envoy development environment, you should have the necessary dependencies
-and requirements and be able to build the documentation directly.
+If you have an [existing Envoy development environment](https://github.com/envoyproxy/envoy/tree/master/bazel#quick-start-bazel-build-for-developers), you should have the necessary dependencies and requirements and be able to build the documentation directly.
 
 ```bash
 ./docs/build.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,42 @@
-# Developer-local docs build
+# Building documentation locally
+
+## Building in an existing envoy development environment
+
+If you have an existing envoy development environment, you should have the necessary dependencies
+and requirements and be able to build the documentation directly.
 
 ```bash
 ./docs/build.sh
 ```
 
-The output can be found in `generated/docs`. By default configuration examples are going to be validated during build. 
+The output can be found in `generated/docs`. By default configuration examples are going to be validated during build.
 To disable validation, set `SPHINX_SKIP_CONFIG_VALIDATION` environment variable to `true`:
 
 ```bash
 SPHINX_SKIP_CONFIG_VALIDATION=true docs/build.sh
 ```
 
+## Using the Docker build container to build the documentation
+
+If you *do not* have an existing development environment, you may wish to use the Docker build
+image that is used in continuous integration.
+
+This can be done as follows:
+
+```
+./ci/run_envoy_docker.sh 'ci/do_ci.sh docs'
+```
+
+To use this method you will need a minimum of 4-5GB of disk space available to accomodate the build image.
+
+# Creating a Pull Request with documentation changes
+
+When you create a Pull Request the documentation is rendered by CircleCI.
+
+This can be viewed by clicking "Details" in "ci/circleci: docs" check. From there click "ARTIFACTS", and then
+"generated/docs/index.html".
+
+You should be able to see your changes.
 
 # How the Envoy website and docs are updated
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ image that is used in continuous integration.
 This can be done as follows:
 
 ```
-./ci/run_envoy_docker.sh 'ci/do_ci.sh docs'
+./ci/run_envoy_docker.sh 'docs/build.sh'
 ```
 
 To use this method you will need a minimum of 4-5GB of disk space available to accommodate the build image.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,10 +37,13 @@ To use this method you will need a minimum of 4-5GB of disk space available to a
 
 When you create a Pull Request the documentation is rendered by CircleCI.
 
-This can be viewed by clicking "Details" in the "ci/circleci: docs" check. From there click "ARTIFACTS", and then
-"generated/docs/index.html".
+If you are logged in to CircleCI (it is possible to authenticate using your Github account), you can view
+the rendered changes.
 
-You should be able to see your changes.
+To do this:
+- click `Details` in the `ci/circleci: docs` check at the bottom of the Pull Request.
+- click `ARTIFACTS` in the CircleCI dashboard
+- browse to the documentation root at `generated/docs/index.html`.
 
 # How the Envoy website and docs are updated
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Building documentation locally
 
-## Building in an existing envoy development environment
+## Building in an existing Envoy development environment
 
-If you have an existing envoy development environment, you should have the necessary dependencies
+If you have an existing Envoy development environment, you should have the necessary dependencies
 and requirements and be able to build the documentation directly.
 
 ```bash


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Update build instructions for docs
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Partial fix for #13229 
[Optional Deprecated:]
