### PR TITLE
[WIP] Copying header matcher to envoy.type.v3.matcher

### DIFF
--- a/api/envoy/type/matcher/v3/header.proto
+++ b/api/envoy/type/matcher/v3/header.proto
@@ -39,12 +39,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //        }
 //     }
 //
-// .. attention::
-//   In the absence of any header match specifier, match will default to :ref:`present_match
-//   <envoy_api_field_type.matcher.v3.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
-//   <envoy_api_field_type.matcher.v3.HeaderMatcher.name>` header will match, regardless of the header's
-//   value.
-//
 message HeaderMatcher {
   // Specifies the name of the header in the request.
   string name = 1

--- a/api/envoy/type/matcher/v3/header.proto
+++ b/api/envoy/type/matcher/v3/header.proto
@@ -15,6 +15,10 @@ option java_outer_classname = "HeaderProto";
 option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
 // [#protodoc-title: Header matcher]
 
 // .. attention::

--- a/api/envoy/type/matcher/v3/header.proto
+++ b/api/envoy/type/matcher/v3/header.proto
@@ -2,8 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher.v3;
 
-import "envoy/type/matcher/v3/regex.proto";
-import "envoy/type/v3/range.proto";
+import "envoy/type/matcher/v3/string.proto";
 
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
@@ -35,7 +34,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 //     {
 //       "name": ":method",
-//       "exact_match": "POST"
+//       "pattern": {
+//          "exact_match": "POST"
+//        }
 //     }
 //
 // .. attention::
@@ -44,64 +45,13 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //   <envoy_api_field_type.matcher.v3.HeaderMatcher.name>` header will match, regardless of the header's
 //   value.
 //
-// [#next-free-field: 13]
 message HeaderMatcher {
   // Specifies the name of the header in the request.
   string name = 1
       [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
   // Specifies how the header match will be performed to route the request.
-  oneof header_match_specifier {
-    // If specified, header match will be performed based on the value of the header.
-    string exact_match = 4;
-
-    // If specified, this regex string is a regular expression rule which implies the entire request
-    // header value must match the regex. The rule will not match if only a subsequence of the
-    // request header value matches the regex.
-    RegexMatcher safe_regex_match = 11;
-
-    // If specified, header match will be performed based on range.
-    // The rule will match if the request header value is within this range.
-    // The entire request header value must represent an integer in base 10 notation: consisting of
-    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
-    // the header value does not represent an integer. Match will fail for empty values, floating
-    // point numbers or if only a subsequence of the header value is an integer.
-    //
-    // Examples:
-    //
-    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-    //   "-1somestring"
-    type.v3.Int64Range range_match = 6;
-
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
-    bool present_match = 7;
-
-    // If specified, header match will be performed based on the prefix of the header value.
-    // Note: empty prefix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
-    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on the suffix of the header value.
-    // Note: empty suffix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
-    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on whether the header value contains
-    // the given value or not.
-    // Note: empty contains match is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
-    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
-  }
+  StringMatcher pattern = 2;
 
   // If specified, the match result will be inverted before checking. Defaults to false.
   //
@@ -109,5 +59,5 @@ message HeaderMatcher {
   //
   // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
   // * The range [-10,0) will match the value -1, so it will not match when inverted.
-  bool invert_match = 8;
+  bool invert_match = 3;
 }

--- a/api/envoy/type/matcher/v3/header.proto
+++ b/api/envoy/type/matcher/v3/header.proto
@@ -1,0 +1,109 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v3;
+
+import "envoy/type/matcher/v3/regex.proto";
+import "envoy/type/v3/range.proto";
+
+import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v3";
+option java_outer_classname = "HeaderProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Header matcher]
+
+// .. attention::
+//
+//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+//
+// .. attention::
+//
+//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//
+//   .. code-block:: json
+//
+//     {
+//       "name": ":method",
+//       "exact_match": "POST"
+//     }
+//
+// .. attention::
+//   In the absence of any header match specifier, match will default to :ref:`present_match
+//   <envoy_api_field_type.matcher.v3.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
+//   <envoy_api_field_type.matcher.v3.HeaderMatcher.name>` header will match, regardless of the header's
+//   value.
+//
+// [#next-free-field: 13]
+message HeaderMatcher {
+  // Specifies the name of the header in the request.
+  string name = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // Specifies how the header match will be performed to route the request.
+  oneof header_match_specifier {
+    // If specified, header match will be performed based on the value of the header.
+    string exact_match = 4;
+
+    // If specified, this regex string is a regular expression rule which implies the entire request
+    // header value must match the regex. The rule will not match if only a subsequence of the
+    // request header value matches the regex.
+    RegexMatcher safe_regex_match = 11;
+
+    // If specified, header match will be performed based on range.
+    // The rule will match if the request header value is within this range.
+    // The entire request header value must represent an integer in base 10 notation: consisting of
+    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
+    // the header value does not represent an integer. Match will fail for empty values, floating
+    // point numbers or if only a subsequence of the header value is an integer.
+    //
+    // Examples:
+    //
+    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+    //   "-1somestring"
+    type.v3.Int64Range range_match = 6;
+
+    // If specified, header match will be performed based on whether the header is in the
+    // request.
+    bool present_match = 7;
+
+    // If specified, header match will be performed based on the prefix of the header value.
+    // Note: empty prefix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
+    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on the suffix of the header value.
+    // Note: empty suffix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
+    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on whether the header value contains
+    // the given value or not.
+    // Note: empty contains match is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
+    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
+  }
+
+  // If specified, the match result will be inverted before checking. Defaults to false.
+  //
+  // Examples:
+  //
+  // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
+  // * The range [-10,0) will match the value -1, so it will not match when inverted.
+  bool invert_match = 8;
+}

--- a/api/envoy/type/matcher/v3/matcher.proto
+++ b/api/envoy/type/matcher/v3/matcher.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v3;
+
+import "envoy/type/matcher/v3/header.proto";
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v3";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
+// [#protodoc-title: Logical Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 6]
+message MatchPredicate {
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_headers_match = 5;
+
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  // HTTP headers to match.
+  repeated type.matcher.v3.HeaderMatcher headers = 1;
+}

--- a/api/envoy/type/matcher/v3/matcher.proto
+++ b/api/envoy/type/matcher/v3/matcher.proto
@@ -49,12 +49,11 @@ message MatchPredicate {
 
     // HTTP response headers match configuration.
     HttpHeadersMatch http_headers_match = 5;
-
   }
 }
 
 // HTTP headers match configuration.
 message HttpHeadersMatch {
   // HTTP headers to match.
-  repeated type.matcher.v3.HeaderMatcher headers = 1;
+  repeated HeaderMatcher headers = 1;
 }

--- a/api/envoy/type/matcher/v4alpha/header.proto
+++ b/api/envoy/type/matcher/v4alpha/header.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v4alpha;
+
+import "envoy/type/matcher/v4alpha/regex.proto";
+import "envoy/type/v3/range.proto";
+
+import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v4alpha";
+option java_outer_classname = "HeaderProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Header matcher]
+
+// .. attention::
+//
+//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+//
+// .. attention::
+//
+//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//
+//   .. code-block:: json
+//
+//     {
+//       "name": ":method",
+//       "exact_match": "POST"
+//     }
+//
+// .. attention::
+//   In the absence of any header match specifier, match will default to :ref:`present_match
+//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
+//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.name>` header will match, regardless of the header's
+//   value.
+//
+// [#next-free-field: 13]
+message HeaderMatcher {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.type.matcher.v3.HeaderMatcher";
+
+  // Specifies the name of the header in the request.
+  string name = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // Specifies how the header match will be performed to route the request.
+  oneof header_match_specifier {
+    // If specified, header match will be performed based on the value of the header.
+    string exact_match = 4;
+
+    // If specified, this regex string is a regular expression rule which implies the entire request
+    // header value must match the regex. The rule will not match if only a subsequence of the
+    // request header value matches the regex.
+    RegexMatcher safe_regex_match = 11;
+
+    // If specified, header match will be performed based on range.
+    // The rule will match if the request header value is within this range.
+    // The entire request header value must represent an integer in base 10 notation: consisting of
+    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
+    // the header value does not represent an integer. Match will fail for empty values, floating
+    // point numbers or if only a subsequence of the header value is an integer.
+    //
+    // Examples:
+    //
+    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+    //   "-1somestring"
+    v3.Int64Range range_match = 6;
+
+    // If specified, header match will be performed based on whether the header is in the
+    // request.
+    bool present_match = 7;
+
+    // If specified, header match will be performed based on the prefix of the header value.
+    // Note: empty prefix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
+    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on the suffix of the header value.
+    // Note: empty suffix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
+    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on whether the header value contains
+    // the given value or not.
+    // Note: empty contains match is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
+    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
+  }
+
+  // If specified, the match result will be inverted before checking. Defaults to false.
+  //
+  // Examples:
+  //
+  // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
+  // * The range [-10,0) will match the value -1, so it will not match when inverted.
+  bool invert_match = 8;
+}

--- a/api/envoy/type/matcher/v4alpha/header.proto
+++ b/api/envoy/type/matcher/v4alpha/header.proto
@@ -39,12 +39,6 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //        }
 //     }
 //
-// .. attention::
-//   In the absence of any header match specifier, match will default to :ref:`present_match
-//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
-//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.name>` header will match, regardless of the header's
-//   value.
-//
 message HeaderMatcher {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.type.matcher.v3.HeaderMatcher";

--- a/api/envoy/type/matcher/v4alpha/header.proto
+++ b/api/envoy/type/matcher/v4alpha/header.proto
@@ -2,8 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher.v4alpha;
 
-import "envoy/type/matcher/v4alpha/regex.proto";
-import "envoy/type/v3/range.proto";
+import "envoy/type/matcher/v4alpha/string.proto";
 
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
@@ -35,7 +34,9 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //
 //     {
 //       "name": ":method",
-//       "exact_match": "POST"
+//       "pattern": {
+//          "exact_match": "POST"
+//        }
 //     }
 //
 // .. attention::
@@ -44,7 +45,6 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.name>` header will match, regardless of the header's
 //   value.
 //
-// [#next-free-field: 13]
 message HeaderMatcher {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.type.matcher.v3.HeaderMatcher";
@@ -54,57 +54,7 @@ message HeaderMatcher {
       [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
   // Specifies how the header match will be performed to route the request.
-  oneof header_match_specifier {
-    // If specified, header match will be performed based on the value of the header.
-    string exact_match = 4;
-
-    // If specified, this regex string is a regular expression rule which implies the entire request
-    // header value must match the regex. The rule will not match if only a subsequence of the
-    // request header value matches the regex.
-    RegexMatcher safe_regex_match = 11;
-
-    // If specified, header match will be performed based on range.
-    // The rule will match if the request header value is within this range.
-    // The entire request header value must represent an integer in base 10 notation: consisting of
-    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
-    // the header value does not represent an integer. Match will fail for empty values, floating
-    // point numbers or if only a subsequence of the header value is an integer.
-    //
-    // Examples:
-    //
-    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-    //   "-1somestring"
-    v3.Int64Range range_match = 6;
-
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
-    bool present_match = 7;
-
-    // If specified, header match will be performed based on the prefix of the header value.
-    // Note: empty prefix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
-    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on the suffix of the header value.
-    // Note: empty suffix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
-    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on whether the header value contains
-    // the given value or not.
-    // Note: empty contains match is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
-    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
-  }
+  StringMatcher pattern = 2;
 
   // If specified, the match result will be inverted before checking. Defaults to false.
   //
@@ -112,5 +62,5 @@ message HeaderMatcher {
   //
   // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
   // * The range [-10,0) will match the value -1, so it will not match when inverted.
-  bool invert_match = 8;
+  bool invert_match = 3;
 }

--- a/api/envoy/type/matcher/v4alpha/header.proto
+++ b/api/envoy/type/matcher/v4alpha/header.proto
@@ -15,6 +15,10 @@ option java_outer_classname = "HeaderProto";
 option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
 
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
 // [#protodoc-title: Header matcher]
 
 // .. attention::

--- a/api/envoy/type/matcher/v4alpha/matcher.proto
+++ b/api/envoy/type/matcher/v4alpha/matcher.proto
@@ -8,7 +8,7 @@ import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
-option java_package = "io.envoyproxy.envoy.config.common.matcher.v4alpha";
+option java_package = "io.envoyproxy.envoy.type.matcher.v4alpha";
 option java_outer_classname = "MatcherProto";
 option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
@@ -54,7 +54,6 @@ message MatchPredicate {
 
     // HTTP response headers match configuration.
     HttpHeadersMatch http_headers_match = 5;
-
   }
 }
 
@@ -64,5 +63,5 @@ message HttpHeadersMatch {
       "envoy.type.matcher.v3.HttpHeadersMatch";
 
   // HTTP headers to match.
-  repeated type.matcher.v4alpha.HeaderMatcher headers = 1;
+  repeated HeaderMatcher headers = 1;
 }

--- a/api/envoy/type/matcher/v4alpha/matcher.proto
+++ b/api/envoy/type/matcher/v4alpha/matcher.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v4alpha;
+
+import "envoy/type/matcher/v4alpha/header.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.common.matcher.v4alpha";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
+// [#protodoc-title: Logical Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 6]
+message MatchPredicate {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.type.matcher.v3.MatchPredicate";
+
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.type.matcher.v3.MatchPredicate.MatchSet";
+
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_headers_match = 5;
+
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.type.matcher.v3.HttpHeadersMatch";
+
+  // HTTP headers to match.
+  repeated type.matcher.v4alpha.HeaderMatcher headers = 1;
+}

--- a/generated_api_shadow/envoy/type/matcher/v3/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/header.proto
@@ -39,12 +39,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //        }
 //     }
 //
-// .. attention::
-//   In the absence of any header match specifier, match will default to :ref:`present_match
-//   <envoy_api_field_type.matcher.v3.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
-//   <envoy_api_field_type.matcher.v3.HeaderMatcher.name>` header will match, regardless of the header's
-//   value.
-//
 message HeaderMatcher {
   // Specifies the name of the header in the request.
   string name = 1

--- a/generated_api_shadow/envoy/type/matcher/v3/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/header.proto
@@ -15,6 +15,10 @@ option java_outer_classname = "HeaderProto";
 option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
 // [#protodoc-title: Header matcher]
 
 // .. attention::

--- a/generated_api_shadow/envoy/type/matcher/v3/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/header.proto
@@ -2,8 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher.v3;
 
-import "envoy/type/matcher/v3/regex.proto";
-import "envoy/type/v3/range.proto";
+import "envoy/type/matcher/v3/string.proto";
 
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
@@ -35,7 +34,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 //     {
 //       "name": ":method",
-//       "exact_match": "POST"
+//       "pattern": {
+//          "exact_match": "POST"
+//        }
 //     }
 //
 // .. attention::
@@ -44,64 +45,13 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //   <envoy_api_field_type.matcher.v3.HeaderMatcher.name>` header will match, regardless of the header's
 //   value.
 //
-// [#next-free-field: 13]
 message HeaderMatcher {
   // Specifies the name of the header in the request.
   string name = 1
       [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
   // Specifies how the header match will be performed to route the request.
-  oneof header_match_specifier {
-    // If specified, header match will be performed based on the value of the header.
-    string exact_match = 4;
-
-    // If specified, this regex string is a regular expression rule which implies the entire request
-    // header value must match the regex. The rule will not match if only a subsequence of the
-    // request header value matches the regex.
-    RegexMatcher safe_regex_match = 11;
-
-    // If specified, header match will be performed based on range.
-    // The rule will match if the request header value is within this range.
-    // The entire request header value must represent an integer in base 10 notation: consisting of
-    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
-    // the header value does not represent an integer. Match will fail for empty values, floating
-    // point numbers or if only a subsequence of the header value is an integer.
-    //
-    // Examples:
-    //
-    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-    //   "-1somestring"
-    type.v3.Int64Range range_match = 6;
-
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
-    bool present_match = 7;
-
-    // If specified, header match will be performed based on the prefix of the header value.
-    // Note: empty prefix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
-    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on the suffix of the header value.
-    // Note: empty suffix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
-    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on whether the header value contains
-    // the given value or not.
-    // Note: empty contains match is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
-    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
-  }
+  StringMatcher pattern = 2;
 
   // If specified, the match result will be inverted before checking. Defaults to false.
   //
@@ -109,5 +59,5 @@ message HeaderMatcher {
   //
   // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
   // * The range [-10,0) will match the value -1, so it will not match when inverted.
-  bool invert_match = 8;
+  bool invert_match = 3;
 }

--- a/generated_api_shadow/envoy/type/matcher/v3/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/header.proto
@@ -1,0 +1,109 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v3;
+
+import "envoy/type/matcher/v3/regex.proto";
+import "envoy/type/v3/range.proto";
+
+import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v3";
+option java_outer_classname = "HeaderProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Header matcher]
+
+// .. attention::
+//
+//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+//
+// .. attention::
+//
+//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//
+//   .. code-block:: json
+//
+//     {
+//       "name": ":method",
+//       "exact_match": "POST"
+//     }
+//
+// .. attention::
+//   In the absence of any header match specifier, match will default to :ref:`present_match
+//   <envoy_api_field_type.matcher.v3.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
+//   <envoy_api_field_type.matcher.v3.HeaderMatcher.name>` header will match, regardless of the header's
+//   value.
+//
+// [#next-free-field: 13]
+message HeaderMatcher {
+  // Specifies the name of the header in the request.
+  string name = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // Specifies how the header match will be performed to route the request.
+  oneof header_match_specifier {
+    // If specified, header match will be performed based on the value of the header.
+    string exact_match = 4;
+
+    // If specified, this regex string is a regular expression rule which implies the entire request
+    // header value must match the regex. The rule will not match if only a subsequence of the
+    // request header value matches the regex.
+    RegexMatcher safe_regex_match = 11;
+
+    // If specified, header match will be performed based on range.
+    // The rule will match if the request header value is within this range.
+    // The entire request header value must represent an integer in base 10 notation: consisting of
+    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
+    // the header value does not represent an integer. Match will fail for empty values, floating
+    // point numbers or if only a subsequence of the header value is an integer.
+    //
+    // Examples:
+    //
+    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+    //   "-1somestring"
+    type.v3.Int64Range range_match = 6;
+
+    // If specified, header match will be performed based on whether the header is in the
+    // request.
+    bool present_match = 7;
+
+    // If specified, header match will be performed based on the prefix of the header value.
+    // Note: empty prefix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
+    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on the suffix of the header value.
+    // Note: empty suffix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
+    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on whether the header value contains
+    // the given value or not.
+    // Note: empty contains match is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
+    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
+  }
+
+  // If specified, the match result will be inverted before checking. Defaults to false.
+  //
+  // Examples:
+  //
+  // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
+  // * The range [-10,0) will match the value -1, so it will not match when inverted.
+  bool invert_match = 8;
+}

--- a/generated_api_shadow/envoy/type/matcher/v3/matcher.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/matcher.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v3;
+
+import "envoy/type/matcher/v3/header.proto";
+
+import "udpa/annotations/migrate.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v3";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
+// [#protodoc-title: Logical Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 6]
+message MatchPredicate {
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_headers_match = 5;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  // HTTP headers to match.
+  repeated HeaderMatcher headers = 1;
+}

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v4alpha;
+
+import "envoy/type/matcher/v4alpha/regex.proto";
+import "envoy/type/v3/range.proto";
+
+import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v4alpha";
+option java_outer_classname = "HeaderProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Header matcher]
+
+// .. attention::
+//
+//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+//
+// .. attention::
+//
+//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//
+//   .. code-block:: json
+//
+//     {
+//       "name": ":method",
+//       "exact_match": "POST"
+//     }
+//
+// .. attention::
+//   In the absence of any header match specifier, match will default to :ref:`present_match
+//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
+//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.name>` header will match, regardless of the header's
+//   value.
+//
+// [#next-free-field: 13]
+message HeaderMatcher {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.type.matcher.v3.HeaderMatcher";
+
+  // Specifies the name of the header in the request.
+  string name = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // Specifies how the header match will be performed to route the request.
+  oneof header_match_specifier {
+    // If specified, header match will be performed based on the value of the header.
+    string exact_match = 4;
+
+    // If specified, this regex string is a regular expression rule which implies the entire request
+    // header value must match the regex. The rule will not match if only a subsequence of the
+    // request header value matches the regex.
+    RegexMatcher safe_regex_match = 11;
+
+    // If specified, header match will be performed based on range.
+    // The rule will match if the request header value is within this range.
+    // The entire request header value must represent an integer in base 10 notation: consisting of
+    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
+    // the header value does not represent an integer. Match will fail for empty values, floating
+    // point numbers or if only a subsequence of the header value is an integer.
+    //
+    // Examples:
+    //
+    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+    //   "-1somestring"
+    v3.Int64Range range_match = 6;
+
+    // If specified, header match will be performed based on whether the header is in the
+    // request.
+    bool present_match = 7;
+
+    // If specified, header match will be performed based on the prefix of the header value.
+    // Note: empty prefix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
+    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on the suffix of the header value.
+    // Note: empty suffix is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
+    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
+
+    // If specified, header match will be performed based on whether the header value contains
+    // the given value or not.
+    // Note: empty contains match is not allowed, please use present_match instead.
+    //
+    // Examples:
+    //
+    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
+    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
+  }
+
+  // If specified, the match result will be inverted before checking. Defaults to false.
+  //
+  // Examples:
+  //
+  // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
+  // * The range [-10,0) will match the value -1, so it will not match when inverted.
+  bool invert_match = 8;
+}

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
@@ -39,12 +39,6 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //        }
 //     }
 //
-// .. attention::
-//   In the absence of any header match specifier, match will default to :ref:`present_match
-//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
-//   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.name>` header will match, regardless of the header's
-//   value.
-//
 message HeaderMatcher {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.type.matcher.v3.HeaderMatcher";

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
@@ -2,8 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher.v4alpha;
 
-import "envoy/type/matcher/v4alpha/regex.proto";
-import "envoy/type/v3/range.proto";
+import "envoy/type/matcher/v4alpha/string.proto";
 
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
@@ -35,7 +34,9 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //
 //     {
 //       "name": ":method",
-//       "exact_match": "POST"
+//       "pattern": {
+//          "exact_match": "POST"
+//        }
 //     }
 //
 // .. attention::
@@ -44,7 +45,6 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //   <envoy_api_field_type.matcher.v4alpha.HeaderMatcher.name>` header will match, regardless of the header's
 //   value.
 //
-// [#next-free-field: 13]
 message HeaderMatcher {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.type.matcher.v3.HeaderMatcher";
@@ -54,57 +54,7 @@ message HeaderMatcher {
       [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
   // Specifies how the header match will be performed to route the request.
-  oneof header_match_specifier {
-    // If specified, header match will be performed based on the value of the header.
-    string exact_match = 4;
-
-    // If specified, this regex string is a regular expression rule which implies the entire request
-    // header value must match the regex. The rule will not match if only a subsequence of the
-    // request header value matches the regex.
-    RegexMatcher safe_regex_match = 11;
-
-    // If specified, header match will be performed based on range.
-    // The rule will match if the request header value is within this range.
-    // The entire request header value must represent an integer in base 10 notation: consisting of
-    // an optional plus or minus sign followed by a sequence of digits. The rule will not match if
-    // the header value does not represent an integer. Match will fail for empty values, floating
-    // point numbers or if only a subsequence of the header value is an integer.
-    //
-    // Examples:
-    //
-    // * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-    //   "-1somestring"
-    v3.Int64Range range_match = 6;
-
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
-    bool present_match = 7;
-
-    // If specified, header match will be performed based on the prefix of the header value.
-    // Note: empty prefix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The prefix *abcd* matches the value *abcdxyz*, but not for *abcxyz*.
-    string prefix_match = 9 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on the suffix of the header value.
-    // Note: empty suffix is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The suffix *abcd* matches the value *xyzabcd*, but not for *xyzbcd*.
-    string suffix_match = 10 [(validate.rules).string = {min_len: 1}];
-
-    // If specified, header match will be performed based on whether the header value contains
-    // the given value or not.
-    // Note: empty contains match is not allowed, please use present_match instead.
-    //
-    // Examples:
-    //
-    // * The value *abcd* matches the value *xyzabcdpqr*, but not for *xyzbcdpqr*.
-    string contains_match = 12 [(validate.rules).string = {min_len: 1}];
-  }
+  StringMatcher pattern = 2;
 
   // If specified, the match result will be inverted before checking. Defaults to false.
   //
@@ -112,5 +62,5 @@ message HeaderMatcher {
   //
   // * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
   // * The range [-10,0) will match the value -1, so it will not match when inverted.
-  bool invert_match = 8;
+  bool invert_match = 3;
 }

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/header.proto
@@ -15,6 +15,10 @@ option java_outer_classname = "HeaderProto";
 option java_multiple_files = true;
 option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
 
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
 // [#protodoc-title: Header matcher]
 
 // .. attention::

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/matcher.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/matcher.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package envoy.type.matcher.v4alpha;
+
+import "envoy/type/matcher/v4alpha/header.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.type.matcher.v4alpha";
+option java_outer_classname = "MatcherProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// TODO(shivanshu21): Once HeaderMatcher is deprecated in favor of StringMatcher,
+// this file will no longer be required as the dependency from
+// envoy.config.common.matcher to route.v3.HeaderMatcher will be broken.
+
+// [#protodoc-title: Logical Matcher API]
+
+// Match configuration. This is a recursive structure which allows complex nested match
+// configurations to be built using various logical operators.
+// [#next-free-field: 6]
+message MatchPredicate {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.type.matcher.v3.MatchPredicate";
+
+  // A set of match configurations used for logical operations.
+  message MatchSet {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.type.matcher.v3.MatchPredicate.MatchSet";
+
+    // The list of rules that make up the set.
+    repeated MatchPredicate rules = 1 [(validate.rules).repeated = {min_items: 2}];
+  }
+
+  oneof rule {
+    option (validate.required) = true;
+
+    // A set that describes a logical OR. If any member of the set matches, the match configuration
+    // matches.
+    MatchSet or_match = 1;
+
+    // A set that describes a logical AND. If all members of the set match, the match configuration
+    // matches.
+    MatchSet and_match = 2;
+
+    // A negation match. The match configuration will match if the negated match condition matches.
+    MatchPredicate not_match = 3;
+
+    // The match configuration will always match.
+    bool any_match = 4 [(validate.rules).bool = {const: true}];
+
+    // HTTP response headers match configuration.
+    HttpHeadersMatch http_headers_match = 5;
+  }
+}
+
+// HTTP headers match configuration.
+message HttpHeadersMatch {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.type.matcher.v3.HttpHeadersMatch";
+
+  // HTTP headers to match.
+  repeated HeaderMatcher headers = 1;
+}


### PR DESCRIPTION
Signed-off-by: Shivanshu Goswami <shigoswami@ebay.com>

Commit Message: Copying header matcher to envoy.type.v3.matcher
Additional Description: Needed to break dependency of config.common.matcher.v3.MatchPredicate on Route components so that route components can use match predicate
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
