### PR TITLE
build: always build test binaries dynamically

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,12 +71,12 @@ build:clang-asan --linkopt -fuse-ld=lld
 
 # macOS ASAN/UBSAN
 build:macos --cxxopt=-std=c++17
+# Workaround, see https://github.com/bazelbuild/bazel/issues/4341
+build:macos --copt -DGRPC_BAZEL_BUILD
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932
 build:macos-asan --copt -Wno-macro-redefined
 build:macos-asan --copt -D_FORTIFY_SOURCE=0
-# Workaround, see https://github.com/bazelbuild/bazel/issues/4341
-build:macos-asan --copt -DGRPC_BAZEL_BUILD
 # Dynamic link cause issues like: `dyld: malformed mach-o: load commands size (59272) > 32768`
 build:macos-asan --dynamic_mode=off
 
@@ -129,7 +129,6 @@ build:coverage --action_env=GCOV=llvm-profdata
 build:coverage --copt=-DNDEBUG
 # 1.5x original timeout + 300s for trace merger in all categories
 build:coverage --test_timeout=390,750,1500,5700
-build:coverage --define=dynamic_link_tests=true
 build:coverage --define=ENVOY_CONFIG_COVERAGE=1
 build:coverage --cxxopt="-DENVOY_CONFIG_COVERAGE=1"
 build:coverage --coverage_support=@envoy//bazel/coverage:coverage_support

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -139,13 +139,6 @@ config_setting(
 )
 
 config_setting(
-    name = "dynamic_link_tests",
-    values = {
-        "define": "dynamic_link_tests=true",
-    },
-)
-
-config_setting(
     name = "disable_tcmalloc",
     values = {"define": "tcmalloc=disabled"},
 )

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -91,8 +91,8 @@ def envoy_external_dep_path(dep):
 
 def envoy_linkstatic():
     return select({
-        "@envoy//bazel:dynamic_link_tests": 0,
-        "//conditions:default": 1,
+        "@envoy//bazel:asan_build": 1,
+        "//conditions:default": 0,
     })
 
 def envoy_select_force_libcpp(if_libcpp, default = None):

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -176,7 +176,7 @@ def envoy_cc_test(
         data = data,
         copts = envoy_copts(repository, test = True) + copts,
         linkopts = _envoy_test_linkopts(),
-        linkstatic = False,
+        linkstatic = envoy_linkstatic(),
         malloc = tcmalloc_external_dep(repository),
         deps = envoy_stdlib_deps() + deps + [envoy_external_dep_path(dep) for dep in external_deps + ["googletest"]] + [
             repository + "//test:main",

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -176,7 +176,7 @@ def envoy_cc_test(
         data = data,
         copts = envoy_copts(repository, test = True) + copts,
         linkopts = _envoy_test_linkopts(),
-        linkstatic = envoy_linkstatic(),
+        linkstatic = False,
         malloc = tcmalloc_external_dep(repository),
         deps = envoy_stdlib_deps() + deps + [envoy_external_dep_path(dep) for dep in external_deps + ["googletest"]] + [
             repository + "//test:main",


### PR DESCRIPTION
Commit Message: Always build test binaries dynamically
Additional Description:
Defaulting to linkstatic=1 results in bloated binaries that contain duplicated code
instead of leaving it in shared objects that can be loaded dynamically and
shared among multiple binaries.

Risk Level: low
Testing: built and ran tests
Docs Changes: none
Release Notes: none