### PR TITLE
[WIP] protos: Remove unused imports

### DIFF
--- a/api/envoy/config/filter/http/on_demand/v2/on_demand.proto
+++ b/api/envoy/config/filter/http/on_demand/v2/on_demand.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.http.on_demand.v2;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.on_demand.v2";
 option java_outer_classname = "OnDemandProto";

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -4,9 +4,7 @@ package envoy.extensions.compression.gzip.decompressor.v3;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.compression.gzip.decompressor.v3";

--- a/api/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
+++ b/api/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
@@ -5,12 +5,8 @@ package envoy.extensions.filters.http.admission_control.v3alpha;
 import "envoy/config/core/v3/base.proto";
 import "envoy/type/v3/range.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-import "google/rpc/status.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
+++ b/api/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.filters.http.cdn_loop.v3alpha;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.cdn_loop.v3alpha";

--- a/api/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -4,9 +4,7 @@ package envoy.extensions.filters.network.postgres_proxy.v3alpha;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.postgres_proxy.v3alpha";

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/redis_proxy/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";

--- a/api/envoy/service/extension/v3/config_discovery.proto
+++ b/api/envoy/service/extension/v3/config_discovery.proto
@@ -8,7 +8,6 @@ import "google/api/annotations.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.service.extension.v3";
 option java_outer_classname = "ConfigDiscoveryProto";

--- a/generated_api_shadow/envoy/config/filter/http/on_demand/v2/on_demand.proto
+++ b/generated_api_shadow/envoy/config/filter/http/on_demand/v2/on_demand.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.http.on_demand.v2;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.on_demand.v2";
 option java_outer_classname = "OnDemandProto";

--- a/generated_api_shadow/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -4,9 +4,7 @@ package envoy.extensions.compression.gzip.decompressor.v3;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.compression.gzip.decompressor.v3";

--- a/generated_api_shadow/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
@@ -5,12 +5,8 @@ package envoy.extensions.filters.http.admission_control.v3alpha;
 import "envoy/config/core/v3/base.proto";
 import "envoy/type/v3/range.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-import "google/rpc/status.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/generated_api_shadow/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.filters.http.cdn_loop.v3alpha;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.cdn_loop.v3alpha";

--- a/generated_api_shadow/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -4,9 +4,7 @@ package envoy.extensions.filters.network.postgres_proxy.v3alpha;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.postgres_proxy.v3alpha";

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/redis_proxy/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/service/extension/v3/config_discovery.proto
+++ b/generated_api_shadow/envoy/service/extension/v3/config_discovery.proto
@@ -8,7 +8,6 @@ import "google/api/annotations.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.service.extension.v3";
 option java_outer_classname = "ConfigDiscoveryProto";


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: protos: Remove unused imports
Additional Description:

not sure if these are safe to remove, but im noticing that unused (?) imports in proto files are emitting lots of warning across CI builds

one doubt i have is that some of the "unused" imports are `versioning` and `annotations` and im wondering if these need to be brought into the namespace for some reason to do with validation or custom compilation

i have just removed a few to see whether it had any effect in CI, i would be happy to remove the rest if this is wanted

Risk Level: ?
Testing: 
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
