### PR TITLE
[fuzz] Added validation for required enum in health check fuzzer

### DIFF
--- a/test/common/upstream/health_check_corpus/clusterfuzz-testcase-minimized-health_check_fuzz_test-5748071634567168
+++ b/test/common/upstream/health_check_corpus/clusterfuzz-testcase-minimized-health_check_fuzz_test-5748071634567168
@@ -1,0 +1,24 @@
+health_check_config {
+  timeout {
+    nanos: 9
+  }
+  interval {
+    seconds: 32768
+    nanos: 426
+  }
+  unhealthy_threshold {
+    value: 491516
+  }
+  healthy_threshold {
+    value: 524284
+  }
+  http_health_check {
+    path: "("
+  }
+  event_log_path: "("
+}
+actions {
+  raise_event: 355888746
+}
+http_verify_cluster: true
+start_failed: true

--- a/test/common/upstream/health_check_fuzz.proto
+++ b/test/common/upstream/health_check_fuzz.proto
@@ -34,7 +34,7 @@ message Action {
     google.protobuf.Empty trigger_interval_timer = 2;
     //TODO: respondBody, respondTrailers
     google.protobuf.Empty trigger_timeout_timer = 3;
-    RaiseEvent raise_event = 4;
+    RaiseEvent raise_event = 4 [(validate.rules).enum.defined_only = true];
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Added validation for required enum in health check fuzzer
Additional Description: Fuzz engine was generating enums out of range, which was hitting a not reached macro.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A