### PR TITLE
backport to v1.15: Fix Kafka Repository Location

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -468,7 +468,7 @@ DEPENDENCY_REPOSITORIES = dict(
     kafka_server_binary = dict(
         sha256 = "b9582bab0c3e8d131953b1afa72d6885ca1caae0061c2623071e7f396f2ccfee",
         strip_prefix = "kafka_2.12-2.4.0",
-        urls = ["http://us.mirrors.quenda.co/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"],
+        urls = ["https://mirrors.gigenet.com/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"],
         use_category = ["test"],
     ),
     kafka_python_client = dict(


### PR DESCRIPTION
Commit Message:
Fix Kafka Repository Location

Update mirror used to fetch kafka dependency to a valid, working mirror.

Based on #13025

Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #13011
