### PR TITLE
backport to v1.14: Fix Kafka Repository Location

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -323,7 +323,7 @@ REPOSITORY_LOCATIONS = dict(
     kafka_server_binary = dict(
         sha256 = "b9582bab0c3e8d131953b1afa72d6885ca1caae0061c2623071e7f396f2ccfee",
         strip_prefix = "kafka_2.12-2.4.0",
-        urls = ["http://us.mirrors.quenda.co/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"],
+        urls = ["https://mirrors.gigenet.com/apache/kafka/2.4.0/kafka_2.12-2.4.0.tgz"],
     ),
     kafka_python_client = dict(
         sha256 = "454bf3aafef9348017192417b7f0828a347ec2eaf3efba59336f3a3b68f10094",


### PR DESCRIPTION
Commit Message:
Fix Kafka Repository Location

Update mirror used to fetch kafka dependency to a valid, working mirror.

Based on #13025

Additional Description:
Risk Level: n/a
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #13011 