### PR TITLE
grpc: implementing new duration API fields.

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -763,7 +763,6 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
-  // [#not-implemented-hide:]
   message MaxStreamDuration {
     // Specifies the maximum duration allowed for streams on the route. If not specified, the value
     // from the :ref:`max_stream_duration
@@ -1017,8 +1016,7 @@ message RouteAction {
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
 
-  // Deprecated by :ref:`grpc_timeout_header_max
-  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
+  // Deprecated by :ref:`grpc_timeout_header_max <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the
   // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
   // or its default value (infinity) instead of
@@ -1040,8 +1038,7 @@ message RouteAction {
   //    :ref:`retry overview <arch_overview_http_routing_retry>`.
   google.protobuf.Duration max_grpc_timeout = 23 [deprecated = true];
 
-  // Deprecated by :ref:`grpc_timeout_header_offset
-  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`
+  // Deprecated by :ref:`grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
   // timeout to be less than that of the deadline imposed by the calling client, which makes it more
@@ -1083,7 +1080,6 @@ message RouteAction {
   HedgePolicy hedge_policy = 27;
 
   // Specifies the maximum stream duration for this route.
-  // [#not-implemented-hide:]
   MaxStreamDuration max_stream_duration = 36;
 }
 

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -769,7 +769,9 @@ message RouteAction {
     // <envoy_api_field_config.core.v3.HttpProtocolOptions.max_stream_duration>` field in
     // :ref:`HttpConnectionManager.common_http_protocol_options
     // <envoy_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.common_http_protocol_options>`
-    // is used.
+    // is used. If this field is set explicitly to zero, any
+    // HttpConnectionManager max_stream_duration timeout will be disabled for
+    // this route.
     google.protobuf.Duration max_stream_duration = 1;
 
     // If present, and the request contains a `grpc-timeout header

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1017,6 +1017,8 @@ message RouteAction {
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
 
+  // Deprecated by :ref:`grpc_timeout_header_max
+  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the
   // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
   // or its default value (infinity) instead of
@@ -1036,8 +1038,10 @@ message RouteAction {
   //    :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
   //    :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //    :ref:`retry overview <arch_overview_http_routing_retry>`.
-  google.protobuf.Duration max_grpc_timeout = 23;
+  google.protobuf.Duration max_grpc_timeout = 23 [deprecated = true];
 
+  // Deprecated by :ref:`grpc_timeout_header_offset
+  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
   // timeout to be less than that of the deadline imposed by the calling client, which makes it more
@@ -1045,7 +1049,7 @@ message RouteAction {
   // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
   // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
   // infinity).
-  google.protobuf.Duration grpc_timeout_offset = 28;
+  google.protobuf.Duration grpc_timeout_offset = 28 [deprecated = true];
 
   repeated UpgradeConfig upgrade_configs = 25;
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -787,10 +787,10 @@ message RouteAction {
     google.protobuf.Duration grpc_timeout_header_offset = 3;
   }
 
-  reserved 12, 18, 19, 16, 22, 21, 10, 14, 26, 31;
+  reserved 12, 18, 19, 16, 22, 21, 10, 14, 23, 28, 26, 31;
 
-  reserved "request_mirror_policy", "include_vh_rate_limits", "internal_redirect_action",
-      "max_internal_redirects";
+  reserved "request_mirror_policy", "include_vh_rate_limits", "max_grpc_timeout",
+      "grpc_timeout_offset", "internal_redirect_action", "max_internal_redirects";
 
   oneof cluster_specifier {
     option (validate.required) = true;
@@ -1008,36 +1008,6 @@ message RouteAction {
 
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
-
-  // If present, and the request is a gRPC request, use the
-  // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
-  // or its default value (infinity) instead of
-  // :ref:`timeout <envoy_api_field_config.route.v4alpha.RouteAction.timeout>`, but limit the applied timeout
-  // to the maximum value specified here. If configured as 0, the maximum allowed timeout for
-  // gRPC requests is infinity. If not configured at all, the `grpc-timeout` header is not used
-  // and gRPC requests time out like any other requests using
-  // :ref:`timeout <envoy_api_field_config.route.v4alpha.RouteAction.timeout>` or its default.
-  // This can be used to prevent unexpected upstream request timeouts due to potentially long
-  // time gaps between gRPC request and response in gRPC streaming mode.
-  //
-  // .. note::
-  //
-  //    If a timeout is specified using :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`, it takes
-  //    precedence over `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, when
-  //    both are present. See also
-  //    :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
-  //    :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
-  //    :ref:`retry overview <arch_overview_http_routing_retry>`.
-  google.protobuf.Duration max_grpc_timeout = 23;
-
-  // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
-  // the provided duration from the header. This is useful in allowing Envoy to set its global
-  // timeout to be less than that of the deadline imposed by the calling client, which makes it more
-  // likely that Envoy will handle the timeout instead of having the call canceled by the client.
-  // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
-  // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
-  // infinity).
-  google.protobuf.Duration grpc_timeout_offset = 28;
 
   repeated UpgradeConfig upgrade_configs = 25;
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -759,7 +759,6 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
-  // [#not-implemented-hide:]
   message MaxStreamDuration {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.MaxStreamDuration";
@@ -1023,7 +1022,6 @@ message RouteAction {
   HedgePolicy hedge_policy = 27;
 
   // Specifies the maximum stream duration for this route.
-  // [#not-implemented-hide:]
   MaxStreamDuration max_stream_duration = 36;
 }
 

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -768,7 +768,9 @@ message RouteAction {
     // <envoy_api_field_config.core.v4alpha.HttpProtocolOptions.max_stream_duration>` field in
     // :ref:`HttpConnectionManager.common_http_protocol_options
     // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.common_http_protocol_options>`
-    // is used.
+    // is used. If this field is set explicitly to zero, any
+    // HttpConnectionManager max_stream_duration timeout will be disabled for
+    // this route.
     google.protobuf.Duration max_stream_duration = 1;
 
     // If present, and the request contains a `grpc-timeout header

--- a/docs/root/faq/configuration/timeouts.rst
+++ b/docs/root/faq/configuration/timeouts.rst
@@ -88,6 +88,10 @@ stream timeouts already introduced above.
   is sent to the downstream, which normally happens after the upstream has sent response headers.
   This timeout can be used with streaming endpoints to retry if the upstream fails to begin a
   response within the timeout.
+* The route :ref:`MaxStreamDuration proto <envoy_v3_api_msg_config.route.v3.RouteAction.MaxStreamDuration>`
+  can be used to override the HttpConnectionManager's
+  :ref:`max_stream_duration <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_stream_duration>`
+  for individual routes as well as setting both limits and a fixed time offset on grpc-timeout headers.
 
 TCP
 ---

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -93,7 +93,7 @@ New Features
 * http: added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_http_conn_man_headers_custom_request_headers>` as custom header.
 * http: added :ref:`allow_chunked_length <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.allow_chunked_length>` configuration option for HTTP/1 codec to allow processing requests/responses with both Content-Length and Transfer-Encoding: chunked headers. If such message is served and option is enabled - per RFC Content-Length is ignored and removed.
 * http: added :ref:`CDN Loop filter <envoy_v3_api_msg_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig>` and :ref:`documentation <config_http_filters_cdn_loop>`.
-* http: added :ref:`MaxStreamDuration proto <grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration>` for configuring per-route downstream duration timeouts.
+* http: added :ref:`MaxStreamDuration proto <envoy_v3_api_msg_config.route.v3.RouteAction.MaxStreamDuration>` for configuring per-route downstream duration timeouts.
 * http: introduced new HTTP/1 and HTTP/2 codec implementations that will remove the use of exceptions for control flow due to high risk factors and instead use error statuses. The old behavior is used by default, but the new codecs can be enabled for testing by setting the runtime feature `envoy.reloadable_features.new_codec_behavior` to true. The new codecs will be in development for one month, and then enabled by default while the old codecs are deprecated.
 * load balancer: added :ref:`RingHashLbConfig<envoy_v3_api_msg_config.cluster.v3.Cluster.MaglevLbConfig>` to configure the table size of Maglev consistent hash.
 * load balancer: added a :ref:`configuration<envoy_v3_api_msg_config.cluster.v3.Cluster.LeastRequestLbConfig>` option to specify the active request bias used by the least request load balancer.
@@ -152,8 +152,8 @@ Deprecated
   field has been deprecated in favor of :ref:`cluster_endpoints_health <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.cluster_endpoints_health>` to maintain
   grouping by cluster and locality.
 * router: the :ref:`include_vh_rate_limits <envoy_v3_api_field_config.route.v3.RouteAction.include_vh_rate_limits>` field has been deprecated in favor of :ref:`vh_rate_limits <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.vh_rate_limits>`.
-* router: the :ref:`<envoy_v3_api_field_config.route.v3.RouteAction.max_grpc_timeout>` field has been deprecated in favor of :ref:`grpc_timeout_header_max <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`.
-* router: the :ref:`<envoy_v3_api_field_config.route.v3.RouteAction.grpc_timeout_offset` field has been deprecated in favor of :ref:`<grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
+* router: the :ref:`max_grpc_timeout <envoy_v3_api_field_config.route.v3.RouteAction.max_grpc_timeout>` field has been deprecated in favor of :ref:`grpc_timeout_header_max <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`.
+* router: the :ref:`grpc_timeout_offset <envoy_v3_api_field_config.route.v3.RouteAction.grpc_timeout_offset>` field has been deprecated in favor of :ref:`grpc_timeout_header_offset <envoy_v3_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
 * tap: the :ref:`match_config <envoy_v3_api_field_config.tap.v3.TapConfig.match_config>` field has been deprecated in favor of
   :ref:`match <envoy_v3_api_field_config.tap.v3.TapConfig.match>` field.
 * ext_authz: the :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.OkHttpResponse.dynamic_metadata>` field in :ref:`OkHttpResponse <envoy_v3_api_msg_service.auth.v3.OkHttpResponse>`

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -93,6 +93,7 @@ New Features
 * http: added support for :ref:`%DOWNSTREAM_PEER_FINGERPRINT_1% <config_http_conn_man_headers_custom_request_headers>` as custom header.
 * http: added :ref:`allow_chunked_length <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.allow_chunked_length>` configuration option for HTTP/1 codec to allow processing requests/responses with both Content-Length and Transfer-Encoding: chunked headers. If such message is served and option is enabled - per RFC Content-Length is ignored and removed.
 * http: added :ref:`CDN Loop filter <envoy_v3_api_msg_extensions.filters.http.cdn_loop.v3alpha.CdnLoopConfig>` and :ref:`documentation <config_http_filters_cdn_loop>`.
+* http: added :ref:`MaxStreamDuration proto <grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration>` for configuring per-route downstream duration timeouts.
 * http: introduced new HTTP/1 and HTTP/2 codec implementations that will remove the use of exceptions for control flow due to high risk factors and instead use error statuses. The old behavior is used by default, but the new codecs can be enabled for testing by setting the runtime feature `envoy.reloadable_features.new_codec_behavior` to true. The new codecs will be in development for one month, and then enabled by default while the old codecs are deprecated.
 * load balancer: added :ref:`RingHashLbConfig<envoy_v3_api_msg_config.cluster.v3.Cluster.MaglevLbConfig>` to configure the table size of Maglev consistent hash.
 * load balancer: added a :ref:`configuration<envoy_v3_api_msg_config.cluster.v3.Cluster.LeastRequestLbConfig>` option to specify the active request bias used by the least request load balancer.
@@ -151,6 +152,8 @@ Deprecated
   field has been deprecated in favor of :ref:`cluster_endpoints_health <envoy_v3_api_field_service.health.v3.EndpointHealthResponse.cluster_endpoints_health>` to maintain
   grouping by cluster and locality.
 * router: the :ref:`include_vh_rate_limits <envoy_v3_api_field_config.route.v3.RouteAction.include_vh_rate_limits>` field has been deprecated in favor of :ref:`vh_rate_limits <envoy_v3_api_field_extensions.filters.http.ratelimit.v3.RateLimitPerRoute.vh_rate_limits>`.
+* router: the :ref:`<envoy_v3_api_field_config.route.v3.RouteAction.max_grpc_timeout>` field has been deprecated in favor of :ref:`grpc_timeout_header_max <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`.
+* router: the :ref:`<envoy_v3_api_field_config.route.v3.RouteAction.grpc_timeout_offset` field has been deprecated in favor of :ref:`<grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
 * tap: the :ref:`match_config <envoy_v3_api_field_config.tap.v3.TapConfig.match_config>` field has been deprecated in favor of
   :ref:`match <envoy_v3_api_field_config.tap.v3.TapConfig.match>` field.
 * ext_authz: the :ref:`dynamic metadata <envoy_v3_api_field_service.auth.v3.OkHttpResponse.dynamic_metadata>` field in :ref:`OkHttpResponse <envoy_v3_api_msg_service.auth.v3.OkHttpResponse>`

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1026,6 +1026,8 @@ message RouteAction {
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
 
+  // Deprecated by :ref:`grpc_timeout_header_max
+  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the
   // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
   // or its default value (infinity) instead of
@@ -1045,8 +1047,10 @@ message RouteAction {
   //    :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
   //    :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //    :ref:`retry overview <arch_overview_http_routing_retry>`.
-  google.protobuf.Duration max_grpc_timeout = 23;
+  google.protobuf.Duration max_grpc_timeout = 23 [deprecated = true];
 
+  // Deprecated by :ref:`grpc_timeout_header_offset
+  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
   // timeout to be less than that of the deadline imposed by the calling client, which makes it more
@@ -1054,7 +1058,7 @@ message RouteAction {
   // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
   // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
   // infinity).
-  google.protobuf.Duration grpc_timeout_offset = 28;
+  google.protobuf.Duration grpc_timeout_offset = 28 [deprecated = true];
 
   repeated UpgradeConfig upgrade_configs = 25;
 

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -780,7 +780,9 @@ message RouteAction {
     // <envoy_api_field_config.core.v3.HttpProtocolOptions.max_stream_duration>` field in
     // :ref:`HttpConnectionManager.common_http_protocol_options
     // <envoy_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.common_http_protocol_options>`
-    // is used.
+    // is used. If this field is set explicitly to zero, any
+    // HttpConnectionManager max_stream_duration timeout will be disabled for
+    // this route.
     google.protobuf.Duration max_stream_duration = 1;
 
     // If present, and the request contains a `grpc-timeout header

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -774,7 +774,6 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
-  // [#not-implemented-hide:]
   message MaxStreamDuration {
     // Specifies the maximum duration allowed for streams on the route. If not specified, the value
     // from the :ref:`max_stream_duration
@@ -1026,8 +1025,7 @@ message RouteAction {
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
 
-  // Deprecated by :ref:`grpc_timeout_header_max
-  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
+  // Deprecated by :ref:`grpc_timeout_header_max <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the
   // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
   // or its default value (infinity) instead of
@@ -1049,8 +1047,7 @@ message RouteAction {
   //    :ref:`retry overview <arch_overview_http_routing_retry>`.
   google.protobuf.Duration max_grpc_timeout = 23 [deprecated = true];
 
-  // Deprecated by :ref:`grpc_timeout_header_offset
-  // <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`
+  // Deprecated by :ref:`grpc_timeout_header_offset <envoy_api_field_config.route.v3.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
   // timeout to be less than that of the deadline imposed by the calling client, which makes it more
@@ -1092,7 +1089,6 @@ message RouteAction {
   HedgePolicy hedge_policy = 27;
 
   // Specifies the maximum stream duration for this route.
-  // [#not-implemented-hide:]
   MaxStreamDuration max_stream_duration = 36;
 
   RequestMirrorPolicy hidden_envoy_deprecated_request_mirror_policy = 10 [deprecated = true];

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1025,6 +1025,8 @@ message RouteAction {
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
 
+  // Deprecated by :ref:`grpc_timeout_header_max
+  // <envoy_api_field_config.route.v4alpha.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the
   // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
   // or its default value (infinity) instead of
@@ -1044,8 +1046,10 @@ message RouteAction {
   //    :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
   //    :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //    :ref:`retry overview <arch_overview_http_routing_retry>`.
-  google.protobuf.Duration max_grpc_timeout = 23;
+  google.protobuf.Duration hidden_envoy_deprecated_max_grpc_timeout = 23 [deprecated = true];
 
+  // Deprecated by :ref:`grpc_timeout_header_offset
+  // <envoy_api_field_config.route.v4alpha.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
   // timeout to be less than that of the deadline imposed by the calling client, which makes it more
@@ -1053,7 +1057,7 @@ message RouteAction {
   // The offset will only be applied if the provided grpc_timeout is greater than the offset. This
   // ensures that the offset will only ever decrease the timeout and never set it to 0 (meaning
   // infinity).
-  google.protobuf.Duration grpc_timeout_offset = 28;
+  google.protobuf.Duration hidden_envoy_deprecated_grpc_timeout_offset = 28 [deprecated = true];
 
   repeated UpgradeConfig upgrade_configs = 25;
 

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -777,7 +777,9 @@ message RouteAction {
     // <envoy_api_field_config.core.v4alpha.HttpProtocolOptions.max_stream_duration>` field in
     // :ref:`HttpConnectionManager.common_http_protocol_options
     // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.common_http_protocol_options>`
-    // is used.
+    // is used. If this field is set explicitly to zero, any
+    // HttpConnectionManager max_stream_duration timeout will be disabled for
+    // this route.
     google.protobuf.Duration max_stream_duration = 1;
 
     // If present, and the request contains a `grpc-timeout header

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -768,7 +768,6 @@ message RouteAction {
     ConnectConfig connect_config = 3;
   }
 
-  // [#not-implemented-hide:]
   message MaxStreamDuration {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.MaxStreamDuration";
@@ -1025,8 +1024,7 @@ message RouteAction {
   // Indicates that the route has a CORS policy.
   CorsPolicy cors = 17;
 
-  // Deprecated by :ref:`grpc_timeout_header_max
-  // <envoy_api_field_config.route.v4alpha.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
+  // Deprecated by :ref:`grpc_timeout_header_max <envoy_api_field_config.route.v4alpha.RouteAction.MaxStreamDuration.grpc_timeout_header_max>`
   // If present, and the request is a gRPC request, use the
   // `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_,
   // or its default value (infinity) instead of
@@ -1048,8 +1046,7 @@ message RouteAction {
   //    :ref:`retry overview <arch_overview_http_routing_retry>`.
   google.protobuf.Duration hidden_envoy_deprecated_max_grpc_timeout = 23 [deprecated = true];
 
-  // Deprecated by :ref:`grpc_timeout_header_offset
-  // <envoy_api_field_config.route.v4alpha.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`
+  // Deprecated by :ref:`grpc_timeout_header_offset <envoy_api_field_config.route.v4alpha.RouteAction.MaxStreamDuration.grpc_timeout_header_offset>`.
   // If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
   // the provided duration from the header. This is useful in allowing Envoy to set its global
   // timeout to be less than that of the deadline imposed by the calling client, which makes it more
@@ -1092,7 +1089,6 @@ message RouteAction {
   HedgePolicy hedge_policy = 27;
 
   // Specifies the maximum stream duration for this route.
-  // [#not-implemented-hide:]
   MaxStreamDuration max_stream_duration = 36;
 }
 

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -796,18 +796,18 @@ public:
   virtual absl::optional<std::chrono::milliseconds> idleTimeout() const PURE;
 
   /**
-   *    * @return optional<std::chrono::milliseconds> the route's maximum stream duration.
+   * @return optional<std::chrono::milliseconds> the route's maximum stream duration.
    */
   virtual absl::optional<std::chrono::milliseconds> maxStreamDuration() const PURE;
 
   /**
-   *    * @return optional<std::chrono::milliseconds> the max grpc-timeout this route will allow.
+   * @return optional<std::chrono::milliseconds> the max grpc-timeout this route will allow.
    */
   virtual absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const PURE;
 
   /**
-   *    * @return optional<std::chrono::milliseconds> the delta between grpc-timeout and enforced
-   * grpc timeout.
+   * @return optional<std::chrono::milliseconds> the delta between grpc-timeout and enforced grpc
+   *         timeout.
    */
   virtual absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const PURE;
 

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -796,6 +796,22 @@ public:
   virtual absl::optional<std::chrono::milliseconds> idleTimeout() const PURE;
 
   /**
+   *    * @return optional<std::chrono::milliseconds> the route's maximum stream duration.
+   */
+  virtual absl::optional<std::chrono::milliseconds> maxStreamDuration() const PURE;
+
+  /**
+   *    * @return optional<std::chrono::milliseconds> the max grpc-timeout this route will allow.
+   */
+  virtual absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const PURE;
+
+  /**
+   *    * @return optional<std::chrono::milliseconds> the delta between grpc-timeout and enforced
+   * grpc timeout.
+   */
+  virtual absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const PURE;
+
+  /**
    * @return absl::optional<std::chrono::milliseconds> the maximum allowed timeout value derived
    * from 'grpc-timeout' header of a gRPC request. Non-present value disables use of 'grpc-timeout'
    * header, while 0 represents infinity.

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -98,10 +98,11 @@ public:
    * @param request_headers the header map from which to extract the value of 'grpc-timeout' header.
    *        If this header is missing the timeout corresponds to infinity. The header is encoded in
    *        maximum of 8 decimal digits and a char for the unit.
-   * @return std::chrono::milliseconds the duration in milliseconds. A zero value corresponding to
-   *         infinity is returned if 'grpc-timeout' is missing or malformed.
+   * @return absl::optional<std::chrono::milliseconds> the duration in milliseconds. absl::nullopt
+   *         is returned if 'grpc-timeout' is missing or malformed.
    */
-  static std::chrono::milliseconds getGrpcTimeout(const Http::RequestHeaderMap& request_headers);
+  static absl::optional<std::chrono::milliseconds>
+  getGrpcTimeout(const Http::RequestHeaderMap& request_headers);
 
   /**
    * Encode 'timeout' into 'grpc-timeout' format in the grpc-timeout header.

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -255,6 +255,15 @@ private:
       }
     }
     absl::optional<std::chrono::milliseconds> idleTimeout() const override { return absl::nullopt; }
+    absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
+      return absl::nullopt;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const override {
+      return absl::nullopt;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const override {
+      return absl::nullopt;
+    }
     absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override {
       return absl::nullopt;
     }

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -711,10 +711,11 @@ void ConnectionManagerImpl::ActiveStream::onStreamMaxDurationReached() {
   ENVOY_STREAM_LOG(debug, "Stream max duration time reached", *this);
   connection_manager_.stats_.named_.downstream_rq_max_duration_reached_.inc();
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_response_for_timeout")) {
-    sendLocalReply(
-        request_headers_ != nullptr && Grpc::Common::isGrpcRequestHeaders(*request_headers_),
-        Http::Code::RequestTimeout, "downstream duration timeout", nullptr,
-        4 /* deadline exceeded */, StreamInfo::ResponseCodeDetails::get().MaxDurationTimeout);
+    sendLocalReply(request_headers_ != nullptr &&
+                       Grpc::Common::isGrpcRequestHeaders(*request_headers_),
+                   Http::Code::RequestTimeout, "downstream duration timeout", nullptr,
+                   Grpc::Status::WellKnownGrpcStatus::DeadlineExceeded,
+                   StreamInfo::ResponseCodeDetails::get().MaxDurationTimeout);
   } else {
     filter_manager_.streamInfo().setResponseCodeDetails(
         StreamInfo::ResponseCodeDetails::get().MaxDurationTimeout);

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -290,6 +290,7 @@ private:
         Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) override;
 
     void refreshCachedTracingCustomTags();
+    void refreshDurationTimeout();
 
     // All state for the stream. Put here for readability.
     struct State {

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -316,6 +316,12 @@ RouteEntryImplBase::RouteEntryImplBase(const VirtualHostImpl& vhost,
           route.route().cluster_not_found_response_code())),
       timeout_(PROTOBUF_GET_MS_OR_DEFAULT(route.route(), timeout, DEFAULT_ROUTE_TIMEOUT_MS)),
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), idle_timeout)),
+      max_stream_duration_(
+          PROTOBUF_GET_OPTIONAL_MS(route.route().max_stream_duration(), max_stream_duration)),
+      grpc_timeout_header_max_(
+          PROTOBUF_GET_OPTIONAL_MS(route.route().max_stream_duration(), grpc_timeout_header_max)),
+      grpc_timeout_header_offset_(PROTOBUF_GET_OPTIONAL_MS(route.route().max_stream_duration(),
+                                                           grpc_timeout_header_offset)),
       max_grpc_timeout_(PROTOBUF_GET_OPTIONAL_MS(route.route(), max_grpc_timeout)),
       grpc_timeout_offset_(PROTOBUF_GET_OPTIONAL_MS(route.route(), grpc_timeout_offset)),
       loader_(factory_context.runtime()), runtime_(loadRuntimeData(route.match())),

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -498,6 +498,15 @@ public:
   }
   std::chrono::milliseconds timeout() const override { return timeout_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
+  absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
+    return max_stream_duration_;
+  }
+  absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const override {
+    return grpc_timeout_header_max_;
+  }
+  absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const override {
+    return grpc_timeout_header_offset_;
+  }
   absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override {
     return max_grpc_timeout_;
   }
@@ -603,6 +612,15 @@ private:
     std::chrono::milliseconds timeout() const override { return parent_->timeout(); }
     absl::optional<std::chrono::milliseconds> idleTimeout() const override {
       return parent_->idleTimeout();
+    }
+    absl::optional<std::chrono::milliseconds> maxStreamDuration() const override {
+      return parent_->max_stream_duration_;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderMax() const override {
+      return parent_->grpc_timeout_header_max_;
+    }
+    absl::optional<std::chrono::milliseconds> grpcTimeoutHeaderOffset() const override {
+      return parent_->grpc_timeout_header_offset_;
     }
     absl::optional<std::chrono::milliseconds> maxGrpcTimeout() const override {
       return parent_->maxGrpcTimeout();
@@ -758,6 +776,9 @@ private:
   const Http::Code cluster_not_found_response_code_;
   const std::chrono::milliseconds timeout_;
   const absl::optional<std::chrono::milliseconds> idle_timeout_;
+  const absl::optional<std::chrono::milliseconds> max_stream_duration_;
+  const absl::optional<std::chrono::milliseconds> grpc_timeout_header_max_;
+  const absl::optional<std::chrono::milliseconds> grpc_timeout_header_offset_;
   const absl::optional<std::chrono::milliseconds> max_grpc_timeout_;
   const absl::optional<std::chrono::milliseconds> grpc_timeout_offset_;
   Runtime::Loader& loader_;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -118,7 +118,9 @@ FilterUtility::finalTimeout(const RouteEntry& route, Http::RequestHeaderMap& req
   TimeoutData timeout;
   if (grpc_request && route.maxGrpcTimeout()) {
     const std::chrono::milliseconds max_grpc_timeout = route.maxGrpcTimeout().value();
-    std::chrono::milliseconds grpc_timeout = Grpc::Common::getGrpcTimeout(request_headers);
+    auto header_timeout = Grpc::Common::getGrpcTimeout(request_headers);
+    std::chrono::milliseconds grpc_timeout =
+        header_timeout ? header_timeout.value() : std::chrono::milliseconds(0);
     if (route.grpcTimeoutOffset()) {
       // We only apply the offset if it won't result in grpc_timeout hitting 0 or below, as
       // setting it to 0 means infinity and a negative timeout makes no sense.

--- a/test/common/grpc/common_test.cc
+++ b/test/common/grpc/common_test.cc
@@ -70,19 +70,22 @@ TEST(GrpcContextTest, GetGrpcMessage) {
 
 TEST(GrpcContextTest, GetGrpcTimeout) {
   Http::TestRequestHeaderMapImpl empty_headers;
-  EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(empty_headers));
+  EXPECT_EQ(absl::nullopt, Common::getGrpcTimeout(empty_headers));
 
   Http::TestRequestHeaderMapImpl empty_grpc_timeout{{"grpc-timeout", ""}};
-  EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(empty_grpc_timeout));
+  EXPECT_EQ(absl::nullopt, Common::getGrpcTimeout(empty_grpc_timeout));
 
   Http::TestRequestHeaderMapImpl missing_unit{{"grpc-timeout", "123"}};
-  EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(missing_unit));
+  EXPECT_EQ(absl::nullopt, Common::getGrpcTimeout(missing_unit));
 
   Http::TestRequestHeaderMapImpl illegal_unit{{"grpc-timeout", "123F"}};
-  EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(illegal_unit));
+  EXPECT_EQ(absl::nullopt, Common::getGrpcTimeout(illegal_unit));
 
-  Http::TestRequestHeaderMapImpl unit_hours{{"grpc-timeout", "1H"}};
-  EXPECT_EQ(std::chrono::milliseconds(60 * 60 * 1000), Common::getGrpcTimeout(unit_hours));
+  Http::TestRequestHeaderMapImpl unit_hours{{"grpc-timeout", "0H"}};
+  EXPECT_EQ(std::chrono::milliseconds(0), Common::getGrpcTimeout(unit_hours));
+
+  Http::TestRequestHeaderMapImpl zero_hours{{"grpc-timeout", "1H"}};
+  EXPECT_EQ(std::chrono::milliseconds(60 * 60 * 1000), Common::getGrpcTimeout(zero_hours));
 
   Http::TestRequestHeaderMapImpl unit_minutes{{"grpc-timeout", "1M"}};
   EXPECT_EQ(std::chrono::milliseconds(60 * 1000), Common::getGrpcTimeout(unit_minutes));

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2064,6 +2064,175 @@ TEST_F(HttpConnectionManagerImplTest, TestStreamIdleAccessLog) {
   EXPECT_EQ(1U, stats_.named_.downstream_rq_idle_timeout_.value());
 }
 
+// Test timeout variants.
+TEST_F(HttpConnectionManagerImplTest, DurationTimeout) {
+  stream_idle_timeout_ = std::chrono::milliseconds(10);
+  setup(false, "");
+  setupFilterChain(1, 0);
+  RequestHeaderMap* latched_headers = nullptr;
+
+  EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+
+  // Create the stream.
+  EXPECT_CALL(*codec_, dispatch(_))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& data) -> Http::Status {
+        Event::MockTimer* idle_timer = setUpTimer();
+        EXPECT_CALL(*idle_timer, enableTimer(_, _));
+        RequestDecoder* decoder = &conn_manager_->newStream(response_encoder_);
+        EXPECT_CALL(*idle_timer, enableTimer(_, _));
+        EXPECT_CALL(*idle_timer, disableTimer());
+        RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{
+            {":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
+        latched_headers = headers.get();
+        decoder->decodeHeaders(std::move(headers), false);
+
+        data.drain(4);
+        return Http::okStatus();
+      }));
+  Buffer::OwnedImpl fake_input("1234");
+  conn_manager_->onData(fake_input, false);
+
+  // Clear and refresh the route cache (checking clusterInfo refreshes the route cache)
+  decoder_filters_[0]->callbacks_->clearRouteCache();
+  decoder_filters_[0]->callbacks_->clusterInfo();
+
+  Event::MockTimer* timer = setUpTimer();
+
+  // Set a max duration of 30ms and make sure a 30ms timer is set.
+  {
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(30), _));
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, maxStreamDuration())
+        .Times(2)
+        .WillRepeatedly(Return(std::chrono::milliseconds(30)));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // Clear the timeout and make sure the timer is disabled.
+  {
+    EXPECT_CALL(*timer, disableTimer());
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, maxStreamDuration())
+        .Times(1)
+        .WillRepeatedly(Return(absl::nullopt));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // Add a gRPC header, but not a gRPC timeout and verify the timer is unchanged.
+  latched_headers->setGrpcTimeout("1M");
+  {
+    EXPECT_CALL(*timer, disableTimer());
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, maxStreamDuration())
+        .Times(1)
+        .WillRepeatedly(Return(absl::nullopt));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a gRPC header of 1M and a gRPC header max of 0, respect the gRPC header.
+  {
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(0)));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(60000), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a gRPC header and a larger gRPC header cap, respect the gRPC header.
+  {
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(20000000)));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(60000), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a gRPC header and a small gRPC header cap, use the cap.
+  {
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(20)));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(20), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  latched_headers->setGrpcTimeout("0m");
+  // With a gRPC header of 0 (infinite), use the cap.
+  {
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(20)));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(20), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a gRPC header of 0 (infinite), and no cap, disable the timer.
+  {
+    EXPECT_CALL(*timer, disableTimer());
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(0)));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a timeout of 20ms and an offset of 10ms, set a timeout for 10ms.
+  {
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(20)));
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_,
+                grpcTimeoutHeaderOffset())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(10)));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(10), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a gRPC timeout of 20ms, and 5ms used already when the route was
+  // refreshed, set a timer for 15ms.
+  {
+    test_time_.timeSystem().setMonotonicTime(MonotonicTime(std::chrono::milliseconds(5)));
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(20)));
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_,
+                grpcTimeoutHeaderOffset())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(absl::nullopt));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(15), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // With a gRPC timeout of 20ms, and 25ms used already when the route was
+  // refreshed, set a timer for now (0ms)
+  {
+    test_time_.timeSystem().setMonotonicTime(MonotonicTime(std::chrono::milliseconds(25)));
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_, grpcTimeoutHeaderMax())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(std::chrono::milliseconds(20)));
+    EXPECT_CALL(route_config_provider_.route_config_->route_->route_entry_,
+                grpcTimeoutHeaderOffset())
+        .Times(AnyNumber())
+        .WillRepeatedly(Return(absl::nullopt));
+    EXPECT_CALL(*timer, enableTimer(std::chrono::milliseconds(0), _));
+    decoder_filters_[0]->callbacks_->clearRouteCache();
+    decoder_filters_[0]->callbacks_->clusterInfo();
+  }
+
+  // Cleanup.
+  EXPECT_CALL(*timer, disableTimer());
+  EXPECT_CALL(*decoder_filters_[0], onDestroy());
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
 // Per-route timeouts override the global stream idle timeout.
 TEST_F(HttpConnectionManagerImplTest, PerStreamIdleTimeoutRouteOverride) {
   stream_idle_timeout_ = std::chrono::milliseconds(10);

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -3726,7 +3726,7 @@ public:
           EXPECT_NE(nullptr, headers.Method());
           EXPECT_EQ(expected_host, headers.getHostValue());
           EXPECT_EQ(std::chrono::milliseconds(1000).count(),
-                    Envoy::Grpc::Common::getGrpcTimeout(headers).count());
+                    Envoy::Grpc::Common::getGrpcTimeout(headers).value().count());
         }));
     EXPECT_CALL(test_sessions_[0]->request_encoder_, encodeData(_, true))
         .WillOnce(Invoke([&](Buffer::Instance& data, bool) {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -365,6 +365,9 @@ public:
   MOCK_METHOD(const std::vector<ShadowPolicyPtr>&, shadowPolicies, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, timeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderMax, (), (const));
+  MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderOffset, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxGrpcTimeout, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, grpcTimeoutOffset, (), (const));
   MOCK_METHOD(const VirtualCluster*, virtualCluster, (const Http::HeaderMap& headers), (const));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -89,6 +89,10 @@ public:
   MOCK_METHOD(bool, addedViaApi, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, connectTimeout, (), (const));
   MOCK_METHOD(const absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
+  MOCK_METHOD(const absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
+  MOCK_METHOD(const absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderMax, (), (const));
+  MOCK_METHOD(const absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderOffset, (),
+              (const));
   MOCK_METHOD(float, perUpstreamPrefetchRatio, (), (const));
   MOCK_METHOD(float, peekaheadRatio, (), (const));
   MOCK_METHOD(uint32_t, perConnectionBufferLimitBytes, (), (const));


### PR DESCRIPTION
Commit Message: Implementing the new stream duration fields, and deprecating the old ones.
This does change the gRPC status code (to the correct code) for prior HCM duration timeouts.  It's behind an existing guard but the status code change is not separately guarded.

Risk Level: low - config guarded with the exception of the gRPC status code change.
Testing: new unit tests, updated integration tests
Docs Changes: n/a
Release Notes: deprecation notes include new fields.

