### PR TITLE
[test] Http2Frame support for client and general stream ids

### DIFF
--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -333,7 +333,7 @@ protected:
 
     // HTTP/2 codec does not send empty DATA frames with no END_STREAM flag.
     // To make this work, send raw bytes representing empty DATA frames bypassing client codec.
-    Http2Frame emptyDataFrame = Http2Frame::makeEmptyDataFrame(0);
+    Http2Frame emptyDataFrame = Http2Frame::makeEmptyDataFrame(Http2Frame::makeClientStreamId(0));
     constexpr uint32_t max_allowed =
         CommonUtility::OptionsLimits::DEFAULT_MAX_CONSECUTIVE_INBOUND_FRAMES_WITH_EMPTY_PAYLOAD;
     for (uint32_t i = 0; i < max_allowed + 1; ++i) {

--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -10,8 +10,8 @@
 
 namespace {
 
-// Make request stream ID in the network byte order
-uint32_t makeRequestStreamId(uint32_t stream_id) { return htonl((stream_id << 1) | 1); }
+// Converts stream ID to the network byte order.
+uint32_t makeStreamId(uint32_t stream_id) { return htonl(stream_id); }
 
 // All this templatized stuff is for the typesafe constexpr bitwise ORing of the "enum class" values
 template <typename First, typename... Rest> struct FirstArgType {
@@ -146,29 +146,27 @@ Http2Frame Http2Frame::makeEmptySettingsFrame(SettingsFlags flags) {
 
 Http2Frame Http2Frame::makeEmptyHeadersFrame(uint32_t stream_index, HeadersFlags flags) {
   Http2Frame frame;
-  frame.buildHeader(Type::Headers, 0, static_cast<uint8_t>(flags),
-                    makeRequestStreamId(stream_index));
+  frame.buildHeader(Type::Headers, 0, static_cast<uint8_t>(flags), makeStreamId(stream_index));
   return frame;
 }
 
 Http2Frame Http2Frame::makeEmptyContinuationFrame(uint32_t stream_index, HeadersFlags flags) {
   Http2Frame frame;
-  frame.buildHeader(Type::Continuation, 0, static_cast<uint8_t>(flags),
-                    makeRequestStreamId(stream_index));
+  frame.buildHeader(Type::Continuation, 0, static_cast<uint8_t>(flags), makeStreamId(stream_index));
   return frame;
 }
 
 Http2Frame Http2Frame::makeEmptyDataFrame(uint32_t stream_index, DataFlags flags) {
   Http2Frame frame;
-  frame.buildHeader(Type::Data, 0, static_cast<uint8_t>(flags), makeRequestStreamId(stream_index));
+  frame.buildHeader(Type::Data, 0, static_cast<uint8_t>(flags), makeStreamId(stream_index));
   return frame;
 }
 
 Http2Frame Http2Frame::makePriorityFrame(uint32_t stream_index, uint32_t dependent_index) {
   static constexpr size_t kPriorityPayloadSize = 5;
   Http2Frame frame;
-  frame.buildHeader(Type::Priority, kPriorityPayloadSize, 0, makeRequestStreamId(stream_index));
-  const uint32_t dependent_net = makeRequestStreamId(dependent_index);
+  frame.buildHeader(Type::Priority, kPriorityPayloadSize, 0, makeStreamId(stream_index));
+  const uint32_t dependent_net = makeStreamId(dependent_index);
   ASSERT(frame.data_.capacity() >= HeaderSize + sizeof(uint32_t));
   memcpy(&frame.data_[HeaderSize], reinterpret_cast<const void*>(&dependent_net), sizeof(uint32_t));
   return frame;
@@ -180,8 +178,8 @@ Http2Frame Http2Frame::makeEmptyPushPromiseFrame(uint32_t stream_index,
   static constexpr size_t kEmptyPushPromisePayloadSize = 4;
   Http2Frame frame;
   frame.buildHeader(Type::PushPromise, kEmptyPushPromisePayloadSize, static_cast<uint8_t>(flags),
-                    makeRequestStreamId(stream_index));
-  const uint32_t promised_stream_id = makeRequestStreamId(promised_stream_index);
+                    makeStreamId(stream_index));
+  const uint32_t promised_stream_id = makeStreamId(promised_stream_index);
   ASSERT(frame.data_.capacity() >= HeaderSize + sizeof(uint32_t));
   memcpy(&frame.data_[HeaderSize], reinterpret_cast<const void*>(&promised_stream_id),
          sizeof(uint32_t));
@@ -191,7 +189,7 @@ Http2Frame Http2Frame::makeEmptyPushPromiseFrame(uint32_t stream_index,
 Http2Frame Http2Frame::makeResetStreamFrame(uint32_t stream_index, ErrorCode error_code) {
   static constexpr size_t kResetStreamPayloadSize = 4;
   Http2Frame frame;
-  frame.buildHeader(Type::RstStream, kResetStreamPayloadSize, 0, makeRequestStreamId(stream_index));
+  frame.buildHeader(Type::RstStream, kResetStreamPayloadSize, 0, makeStreamId(stream_index));
   const uint32_t error = static_cast<uint32_t>(error_code);
   ASSERT(frame.data_.capacity() >= HeaderSize + sizeof(uint32_t));
   memcpy(&frame.data_[HeaderSize], reinterpret_cast<const void*>(&error), sizeof(uint32_t));
@@ -201,8 +199,8 @@ Http2Frame Http2Frame::makeResetStreamFrame(uint32_t stream_index, ErrorCode err
 Http2Frame Http2Frame::makeEmptyGoAwayFrame(uint32_t last_stream_index, ErrorCode error_code) {
   static constexpr size_t kEmptyGoAwayPayloadSize = 8;
   Http2Frame frame;
-  frame.buildHeader(Type::GoAway, kEmptyGoAwayPayloadSize, 0, makeRequestStreamId(0));
-  const uint32_t last_stream_id = makeRequestStreamId(last_stream_index);
+  frame.buildHeader(Type::GoAway, kEmptyGoAwayPayloadSize, 0);
+  const uint32_t last_stream_id = makeStreamId(last_stream_index);
   ASSERT(frame.data_.capacity() >= HeaderSize + 4 + sizeof(uint32_t));
   memcpy(&frame.data_[HeaderSize], reinterpret_cast<const void*>(&last_stream_id),
          sizeof(uint32_t));
@@ -214,8 +212,7 @@ Http2Frame Http2Frame::makeEmptyGoAwayFrame(uint32_t last_stream_index, ErrorCod
 Http2Frame Http2Frame::makeWindowUpdateFrame(uint32_t stream_index, uint32_t increment) {
   static constexpr size_t kWindowUpdatePayloadSize = 4;
   Http2Frame frame;
-  frame.buildHeader(Type::WindowUpdate, kWindowUpdatePayloadSize, 0,
-                    makeRequestStreamId(stream_index));
+  frame.buildHeader(Type::WindowUpdate, kWindowUpdatePayloadSize, 0, makeStreamId(stream_index));
   const uint32_t increment_net = htonl(increment);
   ASSERT(frame.data_.capacity() >= HeaderSize + sizeof(uint32_t));
   memcpy(&frame.data_[HeaderSize], reinterpret_cast<const void*>(&increment_net), sizeof(uint32_t));
@@ -251,7 +248,7 @@ Http2Frame Http2Frame::makeMetadataFrameFromMetadataMap(uint32_t stream_index,
 
   Http2Frame frame;
   frame.buildHeader(Type::Metadata, numberOfBytesInMetadataPayload, static_cast<uint8_t>(flags),
-                    makeRequestStreamId(stream_index));
+                    makeStreamId(stream_index));
   std::vector<uint8_t> bufferVector(buffer, buffer + numberOfBytesInMetadataPayload);
   frame.appendDataAfterHeaders(bufferVector);
   delete[] buffer;
@@ -262,7 +259,7 @@ Http2Frame Http2Frame::makeMetadataFrameFromMetadataMap(uint32_t stream_index,
 Http2Frame Http2Frame::makeMalformedRequest(uint32_t stream_index) {
   Http2Frame frame;
   frame.buildHeader(Type::Headers, 0, orFlags(HeadersFlags::EndStream, HeadersFlags::EndHeaders),
-                    makeRequestStreamId(stream_index));
+                    makeStreamId(stream_index));
   frame.appendStaticHeader(
       StaticHeaderIndex::Status200); // send :status as request header, which is invalid
   frame.adjustPayloadSize();
@@ -274,7 +271,7 @@ Http2Frame Http2Frame::makeMalformedRequestWithZerolenHeader(uint32_t stream_ind
                                                              absl::string_view path) {
   Http2Frame frame;
   frame.buildHeader(Type::Headers, 0, orFlags(HeadersFlags::EndStream, HeadersFlags::EndHeaders),
-                    makeRequestStreamId(stream_index));
+                    makeStreamId(stream_index));
   frame.appendStaticHeader(StaticHeaderIndex::MethodGet);
   frame.appendStaticHeader(StaticHeaderIndex::SchemeHttps);
   frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Path, path);
@@ -288,7 +285,7 @@ Http2Frame Http2Frame::makeRequest(uint32_t stream_index, absl::string_view host
                                    absl::string_view path) {
   Http2Frame frame;
   frame.buildHeader(Type::Headers, 0, orFlags(HeadersFlags::EndStream, HeadersFlags::EndHeaders),
-                    makeRequestStreamId(stream_index));
+                    makeStreamId(stream_index));
   frame.appendStaticHeader(StaticHeaderIndex::MethodGet);
   frame.appendStaticHeader(StaticHeaderIndex::SchemeHttps);
   frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Path, path);
@@ -312,7 +309,7 @@ Http2Frame Http2Frame::makePostRequest(uint32_t stream_index, absl::string_view 
                                        absl::string_view path) {
   Http2Frame frame;
   frame.buildHeader(Type::Headers, 0, orFlags(HeadersFlags::EndHeaders),
-                    makeRequestStreamId(stream_index));
+                    makeStreamId(stream_index));
   frame.appendStaticHeader(StaticHeaderIndex::MethodPost);
   frame.appendStaticHeader(StaticHeaderIndex::SchemeHttps);
   frame.appendHeaderWithoutIndexing(StaticHeaderIndex::Path, path);

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -99,7 +99,13 @@ public:
     std::string value_;
   };
 
-  // Make client request stream ID out of the given ID in the host byte order
+  /**
+   * Make client stream ID out of the given ID in the host byte order, ensuring that the stream id
+   * is odd as required by https://tools.ietf.org/html/rfc7540#section-5.1.1
+   * Use this function to create client stream ids for methods creating HTTP/2 frames.
+   * @param stream_id some stream id that will be used to create the client stream id.
+   * @return an odd number client stream id.
+   */
   static uint32_t makeClientStreamId(uint32_t stream_id) { return (stream_id << 1) | 1; }
 
   // Methods for creating HTTP2 frames

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -99,6 +99,9 @@ public:
     std::string value_;
   };
 
+  // Make client request stream ID out of the given ID in the host byte order
+  static uint32_t makeClientStreamId(uint32_t stream_id) { return (stream_id << 1) | 1; }
+
   // Methods for creating HTTP2 frames
   static Http2Frame makePingFrame(absl::string_view data = {});
   static Http2Frame makeEmptySettingsFrame(SettingsFlags flags = SettingsFlags::None);

--- a/test/common/http/http2/http2_frame_test.cc
+++ b/test/common/http/http2/http2_frame_test.cc
@@ -21,7 +21,7 @@ TEST(EqualityMetadataFrame, Http2FrameTest) {
   ASSERT_EQ(static_cast<int>(http2FrameFromUtility.type()), 0x4D); // type
   ASSERT_EQ(payloadFromHttp2Frame[4], 4);                          // flags
   ASSERT_EQ(std::to_string(payloadFromHttp2Frame[8]),
-            std::to_string(3)); // stream_id (extra bit at the end)
+            std::to_string(1)); // stream_id
 }
 } // namespace Http2
 } // namespace Http


### PR DESCRIPTION
Commit Message: Supporting both client and non-client stream ids in Http2Frame

Additional Description: Http2Frame supported only frames with an odd value (client stream id according to the [rfc](https://tools.ietf.org/html/rfc7540#section-5.1.1)), which means that frames with non-client stream ids (server or whole-connection) could not be created.
This PR introduces an explicit function that converts a given stream to an odd value client stream.

Risk Level: Low (test only).
Testing: Tests only code.
Docs Changes: None.
Release Notes: None.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
