### PR TITLE
http3: add shutdown notification support

### DIFF
--- a/source/extensions/quic_listeners/quiche/codec_impl.cc
+++ b/source/extensions/quic_listeners/quiche/codec_impl.cc
@@ -55,7 +55,7 @@ void QuicHttpServerConnectionImpl::shutdownNotice() {
   if (quic::VersionUsesHttp3(quic_server_session_.transport_version())) {
     quic_server_session_.SendHttp3Shutdown();
   } else {
-    ENVOY_CONN_LOG(error, "Shutdown notice is not propagated to QUIC.", quic_server_session_);
+    ENVOY_CONN_LOG(debug, "Shutdown notice is not propagated to QUIC.", quic_server_session_);
   }
 }
 

--- a/source/extensions/quic_listeners/quiche/codec_impl.cc
+++ b/source/extensions/quic_listeners/quiche/codec_impl.cc
@@ -51,6 +51,14 @@ void QuicHttpServerConnectionImpl::onUnderlyingConnectionBelowWriteBufferLowWate
   runWatermarkCallbacksForEachStream(quic_server_session_.stream_map(), false);
 }
 
+void QuicHttpServerConnectionImpl::shutdownNotice() {
+  if (quic::VersionUsesHttp3(quic_server_session_.transport_version())) {
+    quic_server_session_.SendHttp3Shutdown();
+  } else {
+    ENVOY_CONN_LOG(error, "Shutdown notice is not propagated to QUIC.", quic_server_session_);
+  }
+}
+
 void QuicHttpServerConnectionImpl::goAway() {
   if (quic::VersionUsesHttp3(quic_server_session_.transport_version())) {
     quic_server_session_.SendHttp3GoAway();

--- a/source/extensions/quic_listeners/quiche/codec_impl.h
+++ b/source/extensions/quic_listeners/quiche/codec_impl.h
@@ -47,10 +47,7 @@ public:
 
   // Http::Connection
   void goAway() override;
-  void shutdownNotice() override {
-    // TODO(danzh): Add double-GOAWAY support in QUIC.
-    ENVOY_CONN_LOG(error, "Shutdown notice is not propagated to QUIC.", quic_server_session_);
-  }
+  void shutdownNotice() override;
   void onUnderlyingConnectionAboveWriteBufferHighWatermark() override;
   void onUnderlyingConnectionBelowWriteBufferLowWatermark() override;
 


### PR DESCRIPTION
Commit Message: Add shutdown notification support for HTTP3
Additional Description:
Use the newly-added quiche support for sending an advisory GOAWAY frame
on HTTP3 connections when an Envoy starts draining a connection.

Risk Level: low
Testing: ran quiche codec and integration tests
Docs Changes: none
Release Notes: none