### PR TITLE
extensions: add explicit type annotation for absl::optional

### DIFF
--- a/source/extensions/transport_sockets/tls/ocsp/asn1_utility.cc
+++ b/source/extensions/transport_sockets/tls/ocsp/asn1_utility.cc
@@ -34,7 +34,7 @@ ParsingResult<absl::optional<CBS>> Asn1Utility::getOptional(CBS& cbs, unsigned t
     return "Failed to parse ASN.1 element tag";
   }
 
-  return is_present ? absl::optional(data) : absl::nullopt;
+  return is_present ? absl::optional<CBS>(data) : absl::nullopt;
 }
 
 ParsingResult<std::string> Asn1Utility::parseOid(CBS& cbs) {


### PR DESCRIPTION
When compiling Envoy Mobile locally, I was seeing the following error without this change:

```
external/envoy/source/extensions/transport_sockets/tls/ocsp/asn1_utility.cc:37:23: error: no viable constructor or deduction guide for deduction of template arguments of 'optional'
  return is_present ? absl::optional(data) : absl::nullopt;
```

Risk Level: Low
Testing: N/A
Docs Changes: N/A

Signed-off-by: Michael Rebello <me@michaelrebello.com>