### PR TITLE
async_client: minor refactor to response body handling

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -14,6 +14,7 @@ Minor Behavior Changes
 *Changes that may cause incompatibilities for some users, but should not for most*
 
 * adaptive concurrency: added a response body / grpc-message header for rejected requests.
+* async_client: minor change to handling header only responses more similar to header-with-empty-body responses.
 * build: an :ref:`Ubuntu based debug image <install_binaries>` is built and published in DockerHub.
 * build: the debug information will be generated separately to reduce target size and reduce compilation time when build in compilation mode `dbg` and `opt`. Users will need to build dwp file to debug with gdb.
 * compressor: always insert `Vary` headers for compressible resources even if it's decided not to compress a response due to incompatible `Accept-Encoding` value. The `Vary` header needs to be inserted to let a caching proxy in front of Envoy know that the requested resource still can be served with compression applied.

--- a/include/envoy/http/message.h
+++ b/include/envoy/http/message.h
@@ -22,10 +22,9 @@ public:
   virtual HeaderType& headers() PURE;
 
   /**
-   * @return Buffer::InstancePtr& the message body, if any. Callers are free to reallocate, remove,
-   *         etc. the body.
+   * @return Buffer::Instance the message body, if any. Callers are free to modify the body.
    */
-  virtual Buffer::InstancePtr& body() PURE;
+  virtual Buffer::Instance& body() PURE;
 
   /**
    * @return TrailerType* the message trailers, if any.

--- a/source/common/config/http_subscription_impl.cc
+++ b/source/common/config/http_subscription_impl.cc
@@ -70,10 +70,9 @@ void HttpSubscriptionImpl::createRequest(Http::RequestMessage& request) {
   stats_.update_attempt_.inc();
   request.headers().setReferenceMethod(Http::Headers::get().MethodValues.Post);
   request.headers().setPath(path_);
-  request.body() = std::make_unique<Buffer::OwnedImpl>(
-      VersionConverter::getJsonStringFromMessage(request_, transport_api_version_));
+  request.body().add(VersionConverter::getJsonStringFromMessage(request_, transport_api_version_));
   request.headers().setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
-  request.headers().setContentLength(request.body()->length());
+  request.headers().setContentLength(request.body().length());
 }
 
 void HttpSubscriptionImpl::parseResponse(const Http::ResponseMessage& response) {

--- a/source/common/config/remote_data_fetcher.cc
+++ b/source/common/config/remote_data_fetcher.cc
@@ -44,15 +44,15 @@ void RemoteDataFetcher::onSuccess(const Http::AsyncClient::Request&,
   const uint64_t status_code = Http::Utility::getResponseStatus(response->headers());
   if (status_code == enumToInt(Http::Code::OK)) {
     ENVOY_LOG(debug, "fetch remote data [uri = {}]: success", uri_.uri());
-    if (response->body()) {
+    if (response->body().length() > 0) {
       auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
-      const auto content_hash = Hex::encode(crypto_util.getSha256Digest(*response->body()));
+      const auto content_hash = Hex::encode(crypto_util.getSha256Digest(response->body()));
 
       if (content_hash_ != content_hash) {
         ENVOY_LOG(debug, "fetch remote data [uri = {}]: data is invalid", uri_.uri());
         callback_.onFailure(FailureReason::InvalidData);
       } else {
-        callback_.onSuccess(response->body()->toString());
+        callback_.onSuccess(response->bodyAsString());
       }
     } else {
       ENVOY_LOG(debug, "fetch remote data [uri = {}]: body is empty", uri_.uri());

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -459,7 +459,7 @@ private:
     // The request is already fully buffered. Note that this is only called via the async client's
     // internal use of the router filter which uses this function for buffering.
   }
-  const Buffer::Instance* decodingBuffer() override { return request_->body().get(); }
+  const Buffer::Instance* decodingBuffer() override { return &request_->body(); }
   void modifyDecodingBuffer(std::function<void(Buffer::Instance&)>) override {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }

--- a/source/common/http/message_impl.h
+++ b/source/common/http/message_impl.h
@@ -24,22 +24,16 @@ public:
 
   // Http::Message
   HeadersInterfaceType& headers() override { return *headers_; }
-  Buffer::InstancePtr& body() override { return body_; }
+  Buffer::Instance& body() override { return body_; }
   TrailersInterfaceType* trailers() override { return trailers_.get(); }
   void trailers(std::unique_ptr<TrailersInterfaceType>&& trailers) override {
     trailers_ = std::move(trailers);
   }
-  std::string bodyAsString() const override {
-    if (body_) {
-      return body_->toString();
-    } else {
-      return "";
-    }
-  }
+  std::string bodyAsString() const override { return body_.toString(); }
 
 private:
   std::unique_ptr<HeadersInterfaceType> headers_;
-  Buffer::InstancePtr body_;
+  Buffer::OwnedImpl body_;
   std::unique_ptr<TrailersInterfaceType> trailers_;
 };
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -739,7 +739,7 @@ void Filter::maybeDoShadowing() {
     Http::RequestMessagePtr request(new Http::RequestMessageImpl(
         Http::createHeaderMap<Http::RequestHeaderMapImpl>(*downstream_headers_)));
     if (callbacks_->decodingBuffer()) {
-      request->body() = std::make_unique<Buffer::OwnedImpl>(*callbacks_->decodingBuffer());
+      request->body().add(*callbacks_->decodingBuffer());
     }
     if (downstream_trailers_) {
       request->trailers(Http::createHeaderMap<Http::RequestTrailerMapImpl>(*downstream_trailers_));

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -82,8 +82,8 @@ std::string SignerImpl::createContentHash(Http::RequestMessage& message, bool si
     return SignatureConstants::get().HashedEmptyString;
   }
   auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
-  const auto content_hash = message.body()
-                                ? Hex::encode(crypto_util.getSha256Digest(*message.body()))
+  const auto content_hash = message.body().length() > 0
+                                ? Hex::encode(crypto_util.getSha256Digest(message.body()))
                                 : SignatureConstants::get().HashedEmptyString;
   return content_hash;
 }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -258,8 +258,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks, Event::Dispatcher& di
   Http::RequestMessagePtr message =
       std::make_unique<Envoy::Http::RequestMessageImpl>(std::move(headers));
   if (request_length > 0) {
-    message->body() =
-        std::make_unique<Buffer::OwnedImpl>(request.attributes().request().http().body());
+    message->body().add(request.attributes().request().http().body());
   }
 
   const std::string& cluster = config_->cluster();

--- a/source/extensions/filters/http/common/jwks_fetcher.cc
+++ b/source/extensions/filters/http/common/jwks_fetcher.cc
@@ -69,9 +69,8 @@ public:
     const uint64_t status_code = Http::Utility::getResponseStatus(response->headers());
     if (status_code == enumToInt(Http::Code::OK)) {
       ENVOY_LOG(debug, "{}: fetch pubkey [uri = {}]: success", __func__, uri_->uri());
-      if (response->body()) {
-        const auto len = response->body()->length();
-        const auto body = std::string(static_cast<char*>(response->body()->linearize(len)), len);
+      if (response->body().length() != 0) {
+        const auto body = response->bodyAsString();
         auto jwks =
             google::jwt_verify::Jwks::createFrom(body, google::jwt_verify::Jwks::Type::JWKS);
         if (jwks->getStatus() == google::jwt_verify::Status::Ok) {

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -135,7 +135,7 @@ Http::AsyncClient::Request* makeHttpCall(lua_State* state, Filter& filter,
   }
 
   if (body != nullptr) {
-    message->body() = std::make_unique<Buffer::OwnedImpl>(body, body_size);
+    message->body().add(body, body_size);
     message->headers().setContentLength(body_size);
   }
 
@@ -348,9 +348,9 @@ void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
   });
 
   // TODO(mattklein123): Avoid double copy here.
-  if (response->body() != nullptr) {
+  if (response->body().length() > 0) {
     lua_pushlstring(coroutine_.luaState(), response->bodyAsString().data(),
-                    response->body()->length());
+                    response->body().length());
   } else {
     lua_pushnil(coroutine_.luaState());
   }
@@ -385,7 +385,7 @@ void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
       new Http::ResponseMessageImpl(Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
           {{Http::Headers::get().Status,
             std::to_string(enumToInt(Http::Code::ServiceUnavailable))}})));
-  response_message->body() = std::make_unique<Buffer::OwnedImpl>("upstream failure");
+  response_message->body().add("upstream failure");
   onSuccess(request, std::move(response_message));
 }
 

--- a/source/extensions/filters/http/oauth2/oauth_client.cc
+++ b/source/extensions/filters/http/oauth2/oauth_client.cc
@@ -39,8 +39,6 @@ void OAuth2ClientImpl::asyncGetAccessToken(const std::string& auth_code,
   Http::RequestMessagePtr request = createPostRequest();
   const std::string body = fmt::format(GetAccessTokenBodyFormatString, auth_code, encoded_client_id,
                                        encoded_secret, encoded_cb_url);
-  request->body() = std::make_unique<Buffer::OwnedImpl>(body);
-
   ENVOY_LOG(debug, "Dispatching OAuth request for access token.");
   dispatchRequest(std::move(request));
 

--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -148,7 +148,7 @@ Http::FilterHeadersStatus SquashFilter::decodeHeaders(Http::RequestHeaderMap& he
   request->headers().setReferencePath(POST_ATTACHMENT_PATH);
   request->headers().setReferenceHost(SERVER_AUTHORITY);
   request->headers().setReferenceMethod(Http::Headers::get().MethodValues.Post);
-  request->body() = std::make_unique<Buffer::OwnedImpl>(config_->attachmentJson());
+  request->body().add(config_->attachmentJson());
 
   is_squashing_ = true;
   in_flight_request_ =

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -95,9 +95,7 @@ void TraceReporter::flushTraces() {
       message->headers().setReferenceKey(lower_case_headers_.at(h.first), h.second);
     }
 
-    Buffer::InstancePtr body(new Buffer::OwnedImpl());
-    body->add(encoder_->payload());
-    message->body() = std::move(body);
+    message->body().add(encoder_->payload());
     ENVOY_LOG(debug, "submitting {} trace(s) to {} with payload size {}", pendingTraces,
               encoder_->path(), encoder_->payload().size());
 

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -186,9 +186,7 @@ void ReporterImpl::flushSpans() {
             ? Http::Headers::get().ContentTypeValues.Protobuf
             : Http::Headers::get().ContentTypeValues.Json);
 
-    Buffer::InstancePtr body = std::make_unique<Buffer::OwnedImpl>();
-    body->add(request_body);
-    message->body() = std::move(body);
+    message->body().add(request_body);
 
     const uint64_t timeout =
         driver_.runtime().snapshot().getInteger("tracing.zipkin.request_timeout", 5000U);

--- a/test/common/config/datasource_test.cc
+++ b/test/common/config/datasource_test.cc
@@ -244,7 +244,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccessIncorrectSha256) {
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
     Http::ResponseMessagePtr response(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-    response->body() = std::make_unique<Buffer::OwnedImpl>(body);
+    response->body().add(body);
 
     callbacks.onSuccess(request_, std::move(response));
     return nullptr;
@@ -289,7 +289,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceSuccess) {
                  const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
     Http::ResponseMessagePtr response(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-    response->body() = std::make_unique<Buffer::OwnedImpl>(body);
+    response->body().add(body);
 
     callbacks.onSuccess(request_, std::move(response));
     return nullptr;
@@ -371,7 +371,7 @@ TEST_F(AsyncDataSourceTest, DatasourceReleasedBeforeFetchingData) {
                    const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
       Http::ResponseMessagePtr response(new Http::ResponseMessageImpl(
           Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-      response->body() = std::make_unique<Buffer::OwnedImpl>(body);
+      response->body().add(body);
 
       callbacks.onSuccess(request_, std::move(response));
       return nullptr;
@@ -446,7 +446,7 @@ TEST_F(AsyncDataSourceTest, LoadRemoteDataSourceWithRetry) {
                     Http::ResponseMessagePtr response(
                         new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                             new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-                    response->body() = std::make_unique<Buffer::OwnedImpl>(body);
+                    response->body().add(body);
 
                     callbacks.onSuccess(request_, std::move(response));
                     return nullptr;

--- a/test/common/config/http_subscription_impl_test.cc
+++ b/test/common/config/http_subscription_impl_test.cc
@@ -32,7 +32,7 @@ TEST_F(HttpSubscriptionImplTest, BadJsonRecovery) {
   Http::ResponseHeaderMapPtr response_headers{
       new Http::TestResponseHeaderMapImpl{{":status", "200"}}};
   Http::ResponseMessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
-  message->body() = std::make_unique<Buffer::OwnedImpl>(";!@#badjso n");
+  message->body().add(";!@#badjso n");
   EXPECT_CALL(random_gen_, random()).WillOnce(Return(0));
   EXPECT_CALL(*timer_, enableTimer(_, _));
   EXPECT_CALL(callbacks_,

--- a/test/common/config/http_subscription_test_harness.h
+++ b/test/common/config/http_subscription_test_harness.h
@@ -139,7 +139,7 @@ public:
     Http::ResponseHeaderMapPtr response_headers{
         new Http::TestResponseHeaderMapImpl{{":status", response_code}}};
     Http::ResponseMessagePtr message{new Http::ResponseMessageImpl(std::move(response_headers))};
-    message->body() = std::make_unique<Buffer::OwnedImpl>(response_json);
+    message->body().add(response_json);
     const auto decoded_resources =
         TestUtility::decodeResources<envoy::config::endpoint::v3::ClusterLoadAssignment>(
             response_pb, "cluster_name");

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -155,8 +155,8 @@ TEST_F(AsyncClientImplTest, BasicStream) {
 }
 
 TEST_F(AsyncClientImplTest, Basic) {
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -193,8 +193,8 @@ TEST_F(AsyncClientImplTest, Basic) {
 
 TEST_F(AsyncClientImplTracingTest, Basic) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -238,8 +238,8 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
 
 TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   Tracing::MockSpan* child_span{new Tracing::MockSpan()};
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -284,8 +284,8 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
 }
 
 TEST_F(AsyncClientImplTest, BasicHashPolicy) {
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -331,8 +331,8 @@ TEST_F(AsyncClientImplTest, Retry) {
       .WillByDefault(Return(true));
   RequestMessage* message_copy = message_.get();
 
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -484,8 +484,8 @@ TEST_F(AsyncClientImplTest, MultipleStreams) {
 
 TEST_F(AsyncClientImplTest, MultipleRequests) {
   // Send request 1
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -572,8 +572,8 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
 TEST_F(AsyncClientImplTest, StreamAndRequest) {
   // Send request
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -664,8 +664,8 @@ TEST_F(AsyncClientImplTest, StreamWithTrailers) {
 }
 
 TEST_F(AsyncClientImplTest, Trailers) {
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("test body");
-  Buffer::Instance& data = *message_->body();
+  message_->body().add("test body");
+  Buffer::Instance& data = message_->body();
 
   EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseDecoder& decoder,
@@ -1116,7 +1116,7 @@ TEST_F(AsyncClientImplTest, PoolFailureWithBody) {
         EXPECT_NE(nullptr, &request);
         EXPECT_EQ(503, Utility::getResponseStatus(response->headers()));
       }));
-  message_->body() = std::make_unique<Buffer::OwnedImpl>("hello");
+  message_->body().add("hello");
   EXPECT_EQ(nullptr, client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions()));
 
   EXPECT_EQ(

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4730,7 +4730,7 @@ TEST_F(RouterTest, Shadow) {
   EXPECT_CALL(*shadow_writer_, shadow_("foo", _, _))
       .WillOnce(Invoke([](const std::string&, Http::RequestMessagePtr& request,
                           const Http::AsyncClient::RequestOptions& options) -> void {
-        EXPECT_NE(nullptr, request->body());
+        EXPECT_NE(request->body().length(), 0);
         EXPECT_NE(nullptr, request->trailers());
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
         EXPECT_TRUE(options.sampled_);
@@ -4738,7 +4738,7 @@ TEST_F(RouterTest, Shadow) {
   EXPECT_CALL(*shadow_writer_, shadow_("fizz", _, _))
       .WillOnce(Invoke([](const std::string&, Http::RequestMessagePtr& request,
                           const Http::AsyncClient::RequestOptions& options) -> void {
-        EXPECT_NE(nullptr, request->body());
+        EXPECT_NE(request->body().length(), 0);
         EXPECT_NE(nullptr, request->trailers());
         EXPECT_EQ(absl::optional<std::chrono::milliseconds>(10), options.timeout);
         EXPECT_FALSE(options.sampled_);

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -37,9 +37,7 @@ public:
     message_->headers().addCopy(Http::LowerCaseString(key), value);
   }
 
-  void setBody(const std::string& body) {
-    message_->body() = std::make_unique<Buffer::OwnedImpl>(body);
-  }
+  void setBody(const std::string& body) { message_->body().add(body); }
 
   void expectSignHeaders(absl::string_view service_name, absl::string_view signature,
                          absl::string_view payload) {

--- a/test/extensions/filters/common/ext_authz/test_common.cc
+++ b/test/extensions/filters/common/ext_authz/test_common.cc
@@ -94,7 +94,7 @@ Http::ResponseMessagePtr TestCommon::makeMessageResponse(const HeaderValueOption
     response->headers().addCopy(Http::LowerCaseString(header.header().key()),
                                 header.header().value());
   }
-  response->body() = std::make_unique<Buffer::OwnedImpl>(body);
+  response->body().add(body);
   return response;
 };
 

--- a/test/extensions/filters/http/common/mock.cc
+++ b/test/extensions/filters/http/common/mock.cc
@@ -17,9 +17,9 @@ MockUpstream::MockUpstream(Upstream::MockClusterManager& mock_cm, const std::str
                 new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                     new Http::TestResponseHeaderMapImpl{{":status", status_}}}));
             if (response_body_.length()) {
-              response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
+              response_message->body().add(response_body_);
             } else {
-              response_message->body().reset(nullptr);
+              response_message->body().drain(response_message->body().length());
             }
             cb.onSuccess(request_, std::move(response_message));
             return &request_;

--- a/test/extensions/filters/http/jwt_authn/mock.h
+++ b/test/extensions/filters/http/jwt_authn/mock.h
@@ -72,7 +72,7 @@ public:
               Http::ResponseMessagePtr response_message(
                   new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
                       new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-              response_message->body() = std::make_unique<Buffer::OwnedImpl>(response_body_);
+              response_message->body().add(response_body_);
               cb.onSuccess(request_, std::move(response_message));
               called_count_++;
               return &request_;

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -832,7 +832,7 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   const char response[8] = {'r', 'e', 's', 'p', '\0', 'n', 's', 'e'};
-  response_message->body() = std::make_unique<Buffer::OwnedImpl>(response, 8);
+  response_message->body().add(response, 8);
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("8")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("resp")));
@@ -899,7 +899,7 @@ TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
 
   Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-  response_message->body() = std::make_unique<Buffer::OwnedImpl>("response");
+  response_message->body().add("response");
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
@@ -1018,7 +1018,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
 
   Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-  response_message->body() = std::make_unique<Buffer::OwnedImpl>("response");
+  response_message->body().add("response");
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(cluster_manager_, get(Eq("cluster2")));

--- a/test/extensions/filters/http/oauth2/oauth_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_test.cc
@@ -73,7 +73,7 @@ TEST_F(OAuth2ClientTest, RequestAccessTokenSuccess) {
   }};
   Http::ResponseMessagePtr mock_response(
       new Http::ResponseMessageImpl(std::move(mock_response_headers)));
-  mock_response->body() = std::make_unique<Buffer::OwnedImpl>(json);
+  mock_response->body().add(json);
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillRepeatedly(
@@ -104,7 +104,7 @@ TEST_F(OAuth2ClientTest, RequestAccessTokenIncompleteResponse) {
   }};
   Http::ResponseMessagePtr mock_response(
       new Http::ResponseMessageImpl(std::move(mock_response_headers)));
-  mock_response->body() = std::make_unique<Buffer::OwnedImpl>(json);
+  mock_response->body().add(json);
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillRepeatedly(
@@ -160,7 +160,7 @@ TEST_F(OAuth2ClientTest, RequestAccessTokenInvalidResponse) {
   }};
   Http::ResponseMessagePtr mock_response(
       new Http::ResponseMessageImpl(std::move(mock_response_headers)));
-  mock_response->body() = std::make_unique<Buffer::OwnedImpl>(json);
+  mock_response->body().add(json);
 
   EXPECT_CALL(cm_.async_client_, send_(_, _, _))
       .WillRepeatedly(

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -222,7 +222,7 @@ protected:
   void completeRequest(const std::string& status, const std::string& body) {
     Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
         Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", status}}}));
-    msg->body() = std::make_unique<Buffer::OwnedImpl>(body);
+    msg->body().add(body);
     popPendingCallback()->onSuccess(request_, std::move(msg));
   }
 

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -170,9 +170,8 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
   Http::ResponseMessagePtr message(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-  message->body() = std::make_unique<Buffer::OwnedImpl>(
-      api_->fileSystem().fileReadToEnd(TestEnvironment::runfilesPath(
-          "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
+  message->body().add(api_->fileSystem().fileReadToEnd(TestEnvironment::runfilesPath(
+      "test/extensions/filters/network/client_ssl_auth/test_data/vpn_response_1.json")));
   callbacks_->onSuccess(request_, std::move(message));
   EXPECT_EQ(1U,
             stats_store_
@@ -237,7 +236,7 @@ TEST_F(ClientSslAuthFilterTest, Ssl) {
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
   message = std::make_unique<Http::ResponseMessageImpl>(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}});
-  message->body() = std::make_unique<Buffer::OwnedImpl>("bad_json");
+  message->body().add("bad_json");
   callbacks_->onSuccess(request_, std::move(message));
 
   // Interval timer fires.

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -175,7 +175,6 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
 
   Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
-  msg->body() = std::make_unique<Buffer::OwnedImpl>("");
 
   callback->onSuccess(request, std::move(msg));
 

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -55,7 +55,7 @@ static Http::ResponseMessagePtr makeSuccessResponse() {
   std::unique_ptr<Protobuf::Message> collector_response =
       lightstep::Transporter::MakeCollectorResponse();
   EXPECT_NE(collector_response, nullptr);
-  msg->body() = Grpc::Common::serializeToGrpcFrame(*collector_response);
+  msg->body().add(*Grpc::Common::serializeToGrpcFrame(*collector_response));
   return msg;
 }
 


### PR DESCRIPTION
As a follow-up to https://github.com/envoyproxy/envoy/pull/13328, always creating a body buffer to avoid the pattern of null pointer derefs.

Risk Level: Medium
Testing: unit tests pass
Docs Changes: n/a
Release Notes: yes
