### PR TITLE
common: fix `-Wrange-loop-analysis` error on Envoy Mobile

### DIFF
--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -503,7 +503,7 @@ HeaderMap::NonConstGetResult HeaderMapImpl::getExisting(const LowerCaseString& k
     if (iter != headers_.mapEnd()) {
       const HeaderList::HeaderNodeVector& v = iter->second;
       ASSERT(!v.empty()); // It's impossible to have a map entry with an empty vector as its value.
-      for (const auto values_it : v) {
+      for (const auto& values_it : v) {
         // Convert the iterated value to a HeaderEntry*.
         ret.push_back(&(*values_it));
       }


### PR DESCRIPTION
Envoy Mobile is failing compilation with this error:

```
external/envoy/source/common/http/header_map_impl.cc:506:23: error: loop variable 'values_it' of type 'const std::__1::__list_iterator<Envoy::Http::HeaderMapImpl::HeaderEntryImpl, void *>' creates a copy from type 'const std::__1::__list_iterator<Envoy::Http::HeaderMapImpl::HeaderEntryImpl, void *>' [-Werror,-Wrange-loop-analysis]
      for (const auto values_it : v) {
                      ^
external/envoy/source/common/http/header_map_impl.cc:506:12: note: use reference type 'const std::__1::__list_iterator<Envoy::Http::HeaderMapImpl::HeaderEntryImpl, void *> &' to prevent copying
      for (const auto values_it : v) {
           ^~~~~~~~~~~~~~~~~~~~~~
                      &
```

This regression was introduced in https://github.com/envoyproxy/envoy/commit/442b3f168384f7a1a714d9478f1512e9152706c3.

We're tracking enabling this rule on Envoy builds in https://github.com/envoyproxy/envoy/issues/13154, but it's currently blocked.

Risk Level: Low
Testing: N/A
Docs Changes: N/A

Signed-off-by: Michael Rebello <me@michaelrebello.com>