### PR TITLE
ci: Add retry loop for brew commands

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -7,6 +7,9 @@
 # a list of pre-installed tools in the macOS image.
 
 export HOMEBREW_NO_AUTO_UPDATE=1
+HOMEBREW_RETRY_ATTEMPTS=10
+HOMEBREW_RETRY_INTERVAL=1
+
 
 function is_installed {
     brew ls --versions "$1" >/dev/null
@@ -20,7 +23,21 @@ function install {
     fi
 }
 
-if ! brew update; then
+function retry () {
+    local returns=1 i=1
+    while ((i<=HOMEBREW_RETRY_ATTEMPTS)); do
+	if "$@"; then
+	    returns=0
+	    break
+	else
+	    sleep "$HOMEBREW_RETRY_INTERVAL";
+	    ((i++))
+	fi
+    done
+    return "$returns"
+}
+
+if ! retry brew update; then
     echo "Failed to update homebrew"
     exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Add retry loop for brew commands
Additional Description:
the mac ci run has been failing frequently on `brew update`

i  tried adding `--retry 10`  but that only seems to work with `brew fetch`  - not sure if setting `HOMEBREW_CURL_RETRIES` would work (https://docs.brew.sh/Manpage)

im also not sure if there are other brew commands here that would benefit from a retry or if its just an issue with the update.

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
