### PR TITLE
test: trivial fix for deprecated runtime feature test.

### DIFF
--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -859,8 +859,8 @@ TEST_P(ServerInstanceImplTest, BootstrapRtdsThroughAdsViaEdsFails) {
 
 TEST_P(ServerInstanceImplTest, DEPRECATED_FEATURE_TEST(InvalidLegacyBootstrapRuntime)) {
   EXPECT_THROW_WITH_MESSAGE(
-      initialize("test/server/test_data/server/invalid_legacy_runtime_bootstrap.yaml"), EnvoyException,
-      "Invalid runtime entry value for foo");
+      initialize("test/server/test_data/server/invalid_legacy_runtime_bootstrap.yaml"),
+      EnvoyException, "Invalid runtime entry value for foo");
 }
 
 // Validate invalid runtime in bootstrap is rejected.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -859,7 +859,7 @@ TEST_P(ServerInstanceImplTest, BootstrapRtdsThroughAdsViaEdsFails) {
 
 TEST_P(ServerInstanceImplTest, DEPRECATED_FEATURE_TEST(InvalidLegacyBootstrapRuntime)) {
   EXPECT_THROW_WITH_MESSAGE(
-      initialize("test/server/test_data/server/invalid_runtime_bootstrap.yaml"), EnvoyException,
+      initialize("test/server/test_data/server/invalid_legacy_runtime_bootstrap.yaml"), EnvoyException,
       "Invalid runtime entry value for foo");
 }
 


### PR DESCRIPTION
Noticed this while I was verifying that deprecated_by_default is handled
consistently across proto binary/pb_text/JSON/YAML.

Signed-off-by: Harvey Tuch <htuch@google.com>