### PR TITLE
quiche: fix memory deallocation

### DIFF
--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
@@ -16,7 +16,7 @@ QuicMemSliceImpl::QuicMemSliceImpl(QuicUniqueBufferPtr buffer, size_t length)
     : fragment_(std::make_unique<Envoy::Buffer::BufferFragmentImpl>(
           buffer.release(), length,
           [](const void* p, size_t, const Envoy::Buffer::BufferFragmentImpl*) {
-            delete static_cast<const char*>(p);
+            delete[] static_cast<const char*>(p);
           })) {
   single_slice_buffer_.addBufferFragment(*fragment_);
   ASSERT(this->length() == length);


### PR DESCRIPTION
Commit Message: quiche: fix memory deallocation
Additional Description: When Envoy is linked with the new tcmalloc and compiled with gcc it crashes upon assert in tcmalloc because a buffer slice is allocated with `new []`, but deallocated with `delete`.
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
