### PR TITLE
ci: Update shellcheck and build image hashes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -227,7 +227,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:1526786b8f5cfce7a40829a0c527b5a27570889c
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:325803575903766a631b6e2fde79c6cbedb92985
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.bazelrc
+++ b/.bazelrc
@@ -227,7 +227,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:325803575903766a631b6e2fde79c6cbedb92985
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:b480535e8423b5fd7c102fd30c92f4785519e33a
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     description: "A regular build executor based on ubuntu image"
     docker:
       # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-      - image: envoyproxy/envoy-build-ubuntu:1526786b8f5cfce7a40829a0c527b5a27570889c
+      - image: envoyproxy/envoy-build-ubuntu:325803575903766a631b6e2fde79c6cbedb92985
     resource_class: xlarge
     working_directory: /source
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     description: "A regular build executor based on ubuntu image"
     docker:
       # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/master/toolchains/rbe_toolchains_config.bzl#L8
-      - image: envoyproxy/envoy-build-ubuntu:325803575903766a631b6e2fde79c6cbedb92985
+      - image: envoyproxy/envoy-build-ubuntu:b480535e8423b5fd7c102fd30c92f4785519e33a
     resource_class: xlarge
     working_directory: /source
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/envoy-ci/envoy-build:325803575903766a631b6e2fde79c6cbedb92985
+FROM gcr.io/envoy-ci/envoy-build:b480535e8423b5fd7c102fd30c92f4785519e33a
 
 ARG USERNAME=vscode
 ARG USER_UID=501

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/envoy-ci/envoy-build:1526786b8f5cfce7a40829a0c527b5a27570889c
+FROM gcr.io/envoy-ci/envoy-build:325803575903766a631b6e2fde79c6cbedb92985
 
 ARG USERNAME=vscode
 ARG USER_UID=501

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -40,9 +40,9 @@ fi
 # Environment setup.
 export TEST_TMPDIR=${BUILD_DIR}/tmp
 
-[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=--nocache_test_results
+[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
 
-BAZEL_STARTUP_OPTIONS+=--output_base=c:/_eb
+BAZEL_STARTUP_OPTIONS+=("--output_base=c:/_eb")
 BAZEL_BUILD_OPTIONS=(
     -c opt
     --show_task_finish

--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -19,8 +19,7 @@ run_shellcheck_on () {
     local file
     file="$1"
     echo "Shellcheck: ${file}"
-    # TODO: add -f diff when shellcheck version allows (ubuntu > bionic)
-    shellcheck -x "$file"
+    shellcheck -f diff -x "$file"
 }
 
 run_shellchecks () {


### PR DESCRIPTION
Commit Message: ci: Update shellcheck and build image hashes
Additional Description:

some shellcheck cleanups that are required once shellcheck is updated

this pr needs to /wait until envoyproxy/envoy-build-tools#103 lands and to have the new build image hashes added

Risk Level: low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fixes #13228 
[Optional Deprecated:]
