### PR TITLE
api: Add is_local_server RouteAction option.

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -549,7 +549,7 @@ message CorsPolicy {
   core.v3.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -818,6 +818,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // [#not-implemented-hide:]
+    // Requests are handled locally in the xDS client itself, rather than using any cluster. This
+    // is used in xDS clients like the gRPC server that do not forward traffic to other servers.
+    bool is_local_server = 37;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -551,7 +551,7 @@ message CorsPolicy {
   core.v4alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RouteAction";
 
@@ -818,6 +818,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // [#not-implemented-hide:]
+    // Requests are handled locally in the xDS client itself, rather than using any cluster. This
+    // is used in xDS clients like the gRPC server that do not forward traffic to other servers.
+    bool is_local_server = 37;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -561,7 +561,7 @@ message CorsPolicy {
       [deprecated = true, (validate.rules).repeated = {items {string {max_bytes: 1024}}}];
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -827,6 +827,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // [#not-implemented-hide:]
+    // Requests are handled locally in the xDS client itself, rather than using any cluster. This
+    // is used in xDS clients like the gRPC server that do not forward traffic to other servers.
+    bool is_local_server = 37;
   }
 
   // The HTTP status code to use when configured cluster is not found.

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -551,7 +551,7 @@ message CorsPolicy {
   core.v4alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RouteAction";
 
@@ -826,6 +826,11 @@ message RouteAction {
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
     WeightedCluster weighted_clusters = 3;
+
+    // [#not-implemented-hide:]
+    // Requests are handled locally in the xDS client itself, rather than using any cluster. This
+    // is used in xDS clients like the gRPC server that do not forward traffic to other servers.
+    bool is_local_server = 37;
   }
 
   // The HTTP status code to use when configured cluster is not found.


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Add is_local_server RouteAction option.
Additional Description: This will be used on gRPC servers that get their configuration from xDS.  The gRPC server is not a proxy and will never forward requests to an external cluster, so this new field will be used to indicate that the request will be handled locally.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR.
Release Notes: N/A

I haven't actually discussed this with any of the xDS folks yet, so this PR is in the way of an initial proposal.  Feedback welcome.

CC @htuch @ejona86 @dfawley