### PR TITLE
[cdn_loop] Check that the cdn_id is a valid CDN identifier

### DIFF
--- a/source/extensions/filters/http/cdn_loop/BUILD
+++ b/source/extensions/filters/http/cdn_loop/BUILD
@@ -49,9 +49,11 @@ envoy_cc_extension(
     status = "alpha",
     deps = [
         ":filter_lib",
+        ":parser_lib",
         "//include/envoy/http:filter_interface",
         "//include/envoy/registry",
         "//include/envoy/server:factory_context_interface",
+        "//source/common/common:statusor_lib",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@envoy_api//envoy/extensions/filters/http/cdn_loop/v3alpha:pkg_cc_proto",

--- a/source/extensions/filters/http/cdn_loop/config.cc
+++ b/source/extensions/filters/http/cdn_loop/config.cc
@@ -2,21 +2,34 @@
 
 #include <memory>
 
+#include "envoy/common/exception.h"
 #include "envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.pb.h"
 #include "envoy/http/filter.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/factory_context.h"
 
+#include "common/common/statusor.h"
+
 #include "extensions/filters/http/cdn_loop/filter.h"
+#include "extensions/filters/http/cdn_loop/parser.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace CdnLoop {
 
+using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::parseCdnId;
+using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::ParseContext;
+using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::ParsedCdnId;
+
 Http::FilterFactoryCb CdnLoopFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cdn_loop::v3alpha::CdnLoopConfig& config,
     const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& /*context*/) {
+  StatusOr<ParsedCdnId> context = parseCdnId(ParseContext(config.cdn_id()));
+  if (!context.ok()) {
+    throw EnvoyException(fmt::format("Provided cdn_id \"{}\" is not a valid CDN identifier: {}",
+                                     config.cdn_id(), context.status()));
+  }
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(
         std::make_shared<CdnLoopFilter>(config.cdn_id(), config.max_allowed_occurrences()));

--- a/test/extensions/filters/http/cdn_loop/config_test.cc
+++ b/test/extensions/filters/http/cdn_loop/config_test.cc
@@ -40,7 +40,7 @@ TEST(CdnLoopFilterFactoryTest, BlankCdnIdThrows) {
   CdnLoopFilterFactory factory;
 
   EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
-                             EnvoyException, HasSubstr("value length must be at least"));
+                             ProtoValidationException, HasSubstr("value length must be at least"));
 }
 
 TEST(CdnLoopFilterFactoryTest, InvalidCdnId) {

--- a/test/extensions/filters/http/cdn_loop/config_test.cc
+++ b/test/extensions/filters/http/cdn_loop/config_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.pb.h"
 
 #include "extensions/filters/http/cdn_loop/config.h"
@@ -39,6 +41,28 @@ TEST(CdnLoopFilterFactoryTest, BlankCdnIdThrows) {
 
   EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
                              EnvoyException, HasSubstr("value length must be at least"));
+}
+
+TEST(CdnLoopFilterFactoryTest, InvalidCdnId) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
+  envoy::extensions::filters::http::cdn_loop::v3alpha::CdnLoopConfig config;
+  config.set_cdn_id("[not-token-or-ip");
+  CdnLoopFilterFactory factory;
+
+  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+                             EnvoyException, HasSubstr("is not a valid CDN identifier"));
+}
+
+TEST(CdnLoopFilterFactoryTest, InvalidCdnIdNonHeaderWhitespace) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
+  envoy::extensions::filters::http::cdn_loop::v3alpha::CdnLoopConfig config;
+  config.set_cdn_id("\r\n");
+  CdnLoopFilterFactory factory;
+
+  EXPECT_THAT_THROWS_MESSAGE(factory.createFilterFactoryFromProto(config, "stats", context),
+                             EnvoyException, HasSubstr("is not a valid CDN identifier"));
 }
 
 } // namespace CdnLoop


### PR DESCRIPTION
RFC 8586 requires that the cdn-id be a token or pseudonymn.  We
weren’t checking this before, so it was possible for someone to
configure the cdn_id field that would produce an invalid RFC 8586
CDN-Loop header.

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

Risk Level: Low
Testing: bazel test //test/extensions/filters/http/cdn_loop/...
Docs Changes: N/A
Release Notes: N/A (because the cdn_loop filter is new enough that it's still in the "New" section)