### PR TITLE
http2: Proactively disconnect connections flooded when encoding headers

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -176,6 +176,7 @@ void ConnectionImpl::StreamImpl::encodeHeadersBase(const std::vector<nghttp2_nv>
   // process termination from unhandled exception with the RELEASE_ASSERT.
   // Further work will replace this RELEASE_ASSERT with proper error handling.
   RELEASE_ASSERT(status.ok(), "sendPendingFrames() failure in non dispatching context");
+  parent_.checkProtocolConstraintViolation();
 }
 
 void ConnectionImpl::ClientStreamImpl::encodeHeaders(const RequestHeaderMap& headers,
@@ -488,7 +489,7 @@ void ConnectionImpl::StreamImpl::encodeDataHelper(Buffer::Instance& data, bool e
   auto status = parent_.sendPendingFrames();
   // See comment in the `encodeHeadersBase()` method about this RELEASE_ASSERT.
   RELEASE_ASSERT(status.ok(), "sendPendingFrames() failure in non dispatching context");
-  parent_.checkProtocolConstrainViolation();
+  parent_.checkProtocolConstraintViolation();
 
   if (local_end_stream_ && pending_send_data_.length() > 0) {
     createPendingFlushTimer();
@@ -1506,7 +1507,7 @@ ServerConnectionImpl::trackOutboundFrames(bool is_outbound_flood_monitored_contr
   return releasor;
 }
 
-void ServerConnectionImpl::checkProtocolConstrainViolation() {
+void ServerConnectionImpl::checkProtocolConstraintViolation() {
   if (!protocol_constraints_.checkOutboundFrameLimits().ok()) {
     scheduleProtocolConstraintViolationCallback();
   }

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -462,7 +462,7 @@ protected:
    * implementation in the ServerConnectionImpl schedules callback to terminate connection if the
    * protocol constraint was violated.
    */
-  virtual void checkProtocolConstrainViolation() PURE;
+  virtual void checkProtocolConstraintViolation() PURE;
 
   /**
    * Callback for terminating connection when protocol constrain has been violated
@@ -578,7 +578,7 @@ private:
     return ProtocolConstraints::ReleasorProc([]() {});
   }
   Status trackInboundFrames(const nghttp2_frame_hd*, uint32_t) override { return okStatus(); }
-  void checkProtocolConstrainViolation() override {}
+  void checkProtocolConstraintViolation() override {}
 
   Http::ConnectionCallbacks& callbacks_;
 };
@@ -610,7 +610,7 @@ private:
    * Check protocol constraint violations outside of the dispatching context.
    * This method ASSERTs if it is called in the dispatching context.
    */
-  void checkProtocolConstrainViolation() override;
+  void checkProtocolConstraintViolation() override;
 
   // Http::Connection
   // The reason for overriding the dispatch method is to do flood mitigation only when

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -169,6 +169,7 @@ void ConnectionImpl::StreamImpl::encodeHeadersBase(const std::vector<nghttp2_nv>
   local_end_stream_ = end_stream;
   submitHeaders(final_headers, end_stream ? nullptr : &provider);
   parent_.sendPendingFrames();
+  parent_.checkProtocolConstraintViolation();
 }
 
 void ConnectionImpl::ClientStreamImpl::encodeHeaders(const RequestHeaderMap& headers,
@@ -470,7 +471,7 @@ void ConnectionImpl::StreamImpl::encodeDataHelper(Buffer::Instance& data, bool e
   }
 
   parent_.sendPendingFrames();
-  parent_.checkProtocolConstrainViolation();
+  parent_.checkProtocolConstraintViolation();
 
   if (local_end_stream_ && pending_send_data_.length() > 0) {
     createPendingFlushTimer();
@@ -1457,7 +1458,7 @@ ServerConnectionImpl::trackOutboundFrames(bool is_outbound_flood_monitored_contr
   return releasor;
 }
 
-void ServerConnectionImpl::checkProtocolConstrainViolation() {
+void ServerConnectionImpl::checkProtocolConstraintViolation() {
   if (!protocol_constraints_.checkOutboundFrameLimits().ok()) {
     scheduleProtocolConstraintViolationCallback();
   }

--- a/source/common/http/http2/codec_impl_legacy.h
+++ b/source/common/http/http2/codec_impl_legacy.h
@@ -445,7 +445,7 @@ protected:
    * The implementation in the ServerConnectionImpl schedules callback to terminate connection if
    * the protocol constraint was violated.
    */
-  virtual void checkProtocolConstrainViolation() PURE;
+  virtual void checkProtocolConstraintViolation() PURE;
 
   /**
    * Callback for terminating connection when protocol constrain has been violated
@@ -556,7 +556,7 @@ private:
     return Envoy::Http::Http2::ProtocolConstraints::ReleasorProc([]() {});
   }
   bool trackInboundFrames(const nghttp2_frame_hd*, uint32_t) override { return true; }
-  void checkProtocolConstrainViolation() override {}
+  void checkProtocolConstraintViolation() override {}
 
   Http::ConnectionCallbacks& callbacks_;
 };
@@ -588,7 +588,7 @@ private:
    * Check protocol constraint violations outside of the dispatching context.
    * This method ASSERTs if it is called in the dispatching context.
    */
-  void checkProtocolConstrainViolation() override;
+  void checkProtocolConstraintViolation() override;
 
   // Http::Connection
   // The reason for overriding the dispatch method is to do flood mitigation only when

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -21,6 +21,7 @@ const char AutonomousStream::RESPONSE_SIZE_BYTES[] = "response_size_bytes";
 const char AutonomousStream::RESPONSE_DATA_BLOCKS[] = "response_data_blocks";
 const char AutonomousStream::EXPECT_REQUEST_SIZE_BYTES[] = "expect_request_size_bytes";
 const char AutonomousStream::RESET_AFTER_REQUEST[] = "reset_after_request";
+const char AutonomousStream::NO_TRAILERS[] = "no_trailers";
 
 AutonomousStream::AutonomousStream(FakeHttpConnection& parent, Http::ResponseEncoder& encoder,
                                    AutonomousUpstream& upstream, bool allow_incomplete_streams)
@@ -63,11 +64,17 @@ void AutonomousStream::sendResponse() {
   int32_t response_data_blocks = 1;
   HeaderToInt(RESPONSE_DATA_BLOCKS, response_data_blocks, headers);
 
-  encodeHeaders(upstream_.responseHeaders(), false);
-  for (int32_t i = 0; i < response_data_blocks; ++i) {
-    encodeData(response_body_length, false);
+  const bool send_trailers = headers.get_(NO_TRAILERS).empty();
+  const bool headers_only_response = !send_trailers && response_data_blocks == 0;
+  encodeHeaders(upstream_.responseHeaders(), headers_only_response);
+  if (!headers_only_response) {
+    for (int32_t i = 0; i < response_data_blocks; ++i) {
+      encodeData(response_body_length, i == (response_data_blocks - 1) && !send_trailers);
+    }
+    if (send_trailers) {
+      encodeTrailers(upstream_.responseTrailers());
+    }
   }
-  encodeTrailers(upstream_.responseTrailers());
 }
 
 AutonomousHttpConnection::AutonomousHttpConnection(AutonomousUpstream& autonomous_upstream,

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -21,6 +21,8 @@ public:
   // If set, the stream will reset when the request is complete, rather than
   // sending a response.
   static const char RESET_AFTER_REQUEST[];
+  // Prevents upstream from sending trailers.
+  static const char NO_TRAILERS[];
 
   AutonomousStream(FakeHttpConnection& parent, Http::ResponseEncoder& encoder,
                    AutonomousUpstream& upstream, bool allow_incomplete_streams);

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -138,5 +138,6 @@ protected:
 
   void setNetworkConnectionBufferSize();
   void beginSession() override;
+  void prefillOutboundDownstreamQueue(uint32_t data_frame_count);
 };
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
Proactively disconnect connections flooded when encoding headers

Additional Description:
This PR adds error handling and associated tests for flood triggered in the `ConnectionImpl::StreamImpl::encodeHeadersBase()` method. Previously connection stayed in the flooded state until downstream data was received.

Part of fixing #12280 

Risk Level: Medium, H/2 codec
Testing: Unit and integration tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
