### PR TITLE
[fuzz] Added checks in health check fuzzing

### DIFF
--- a/test/common/upstream/health_check_corpus/custom_health_check
+++ b/test/common/upstream/health_check_corpus/custom_health_check
@@ -1,0 +1,62 @@
+health_check_config {
+  timeout {
+    seconds: 26624
+  }
+  interval {
+    seconds: 8960
+    nanos: 65530
+  }
+  interval_jitter {
+    seconds: 8960
+    nanos: 7
+  }
+  unhealthy_threshold {
+    value: 641007614
+  }
+  healthy_threshold {
+    value: 1024
+  }
+  alt_port {
+    value: 16777216
+  }
+  reuse_connection {
+    value: true
+  }
+  no_traffic_interval {
+    nanos: 2097152
+  }
+  custom_health_check {
+    name: "ssssssssssssssssssssssssssssssssssssssssss"
+  }
+  unhealthy_edge_interval {
+    seconds: 131072
+    nanos: 4104
+  }
+  healthy_edge_interval {
+    seconds: 131072
+    nanos: 128
+  }
+  event_log_path: "A("
+  interval_jitter_percent: 641007544
+  initial_jitter {
+    seconds: 8960
+    nanos: 7
+  }
+  tls_options {
+  }
+}
+actions {
+  raise_event: REMOTE_CLOSE
+}
+actions {
+  raise_event: REMOTE_CLOSE
+}
+actions {
+  trigger_interval_timer {
+  }
+}
+actions {
+  raise_event: CONNECTED
+}
+http_verify_cluster: true
+start_failed: true

--- a/test/common/upstream/health_check_corpus/http_out_of_range_status
+++ b/test/common/upstream/health_check_corpus/http_out_of_range_status
@@ -1,0 +1,47 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    no_traffic_interval {
+        seconds: 1
+    }
+    interval_jitter {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    http_health_check {
+        path: "/healthcheck"
+        service_name_matcher {
+            prefix: "locations"
+        }
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+            }
+            status: 1500
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+                
+            }
+        }
+    }
+}

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -496,8 +496,9 @@ void HealthCheckFuzz::initializeAndReplay(test::common::upstream::HealthCheckTes
       grpc_fuzz_test_->initialize(input);
       break;
     }
-    default:
-      break;
+    default: // Handles custom health checkers
+      ENVOY_LOG_MISC(trace, "Custom Health Checker currently unsupported, skipping");
+      return;
     }
   } catch (EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "EnvoyException: {}", e.what());

--- a/test/common/upstream/health_check_fuzz.proto
+++ b/test/common/upstream/health_check_fuzz.proto
@@ -9,7 +9,7 @@ import "google/protobuf/empty.proto";
 
 message HttpRespond {
   test.fuzz.Headers headers = 1;
-  uint64 status = 2;
+  uint64 status = 2 [(validate.rules).uint64.lt = 1000];
 }
 
 message TcpRespond {
@@ -25,7 +25,7 @@ enum ServingStatus {
 
 message GrpcRespondHeaders {
   test.fuzz.Headers headers = 1;
-  uint64 status = 2;
+  uint64 status = 2 [(validate.rules).uint64.lt = 1000];
 }
 
 message GrpcRespondUnstructuredBytes {

--- a/test/common/upstream/health_check_fuzz_test.cc
+++ b/test/common/upstream/health_check_fuzz_test.cc
@@ -15,6 +15,12 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::HealthCheckTestCase input) {
     return;
   }
 
+  if (input.health_check_config().health_checker_case() ==
+      envoy::config::core::v3::HealthCheck::kCustomHealthCheck) {
+    ENVOY_LOG_MISC(trace, "Fuzz engine created Custom Health Checker");
+    return;
+  }
+
   HealthCheckFuzz health_check_fuzz;
 
   health_check_fuzz.initializeAndReplay(input);

--- a/test/common/upstream/health_check_fuzz_test.cc
+++ b/test/common/upstream/health_check_fuzz_test.cc
@@ -15,12 +15,6 @@ DEFINE_PROTO_FUZZER(const test::common::upstream::HealthCheckTestCase input) {
     return;
   }
 
-  if (input.health_check_config().health_checker_case() ==
-      envoy::config::core::v3::HealthCheck::kCustomHealthCheck) {
-    ENVOY_LOG_MISC(trace, "Fuzz engine created Custom Health Checker");
-    return;
-  }
-
   HealthCheckFuzz health_check_fuzz;
 
   health_check_fuzz.initializeAndReplay(input);


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Added checks in health checks fuzzing
Additional Description: Added a validation to further constrain respond search space. Also added a check for custom health checker, which was throwing a crash in OSSFuzz.
Risk Level: Low
Testing:
Docs Changes:
Release Notes: