### PR TITLE
ext_authz: Add per-route flag to skip request body buffering 

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -267,17 +267,19 @@ message ExtAuthzPerRoute {
   }
 }
 
-// Extra settings for the check request. You can use this to provide extra context for the
-// external authorization server on specific virtual hosts \ routes. For example, adding a context
-// extension on the virtual host level can give the ext-authz server information on what virtual
-// host is used without needing to parse the host header. If CheckSettings is specified in multiple
-// per-filter-configs, they will be merged in order, and the result will be used.
+// Extra settings for the check request.
 message CheckSettings {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.CheckSettings";
 
   // Context extensions to set on the CheckRequest's
   // :ref:`AttributeContext.context_extensions<envoy_api_field_service.auth.v3.AttributeContext.context_extensions>`
+  //
+  // You can use this to provide extra context for the external authorization server on specific
+  // virtual hosts/routes. For example, adding a context extension on the virtual host level can
+  // give the ext-authz server information on what virtual host is used without needing to parse the
+  // host header. If CheckSettings is specified in multiple per-filter-configs, they will be merged
+  // in order, and the result will be used.
   //
   // Merge semantics for this field are such that keys from more specific configs override.
   //
@@ -286,4 +288,8 @@ message CheckSettings {
   //   These settings are only applied to a filter configured with a
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
+
+  // When set to true, bypass the configured :ref:`with_request_body
+  // <envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` for a route.
+  bool bypass_buffering_request_body = 2;
 }

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -289,7 +289,7 @@ message CheckSettings {
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
 
-  // When set to true, bypass the configured :ref:`with_request_body
+  // When set to true, disable the configured :ref:`with_request_body
   // <envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` for a route.
-  bool bypass_buffering_request_body = 2;
+  bool disable_request_body_buffering = 2;
 }

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -267,17 +267,19 @@ message ExtAuthzPerRoute {
   }
 }
 
-// Extra settings for the check request. You can use this to provide extra context for the
-// external authorization server on specific virtual hosts \ routes. For example, adding a context
-// extension on the virtual host level can give the ext-authz server information on what virtual
-// host is used without needing to parse the host header. If CheckSettings is specified in multiple
-// per-filter-configs, they will be merged in order, and the result will be used.
+// Extra settings for the check request.
 message CheckSettings {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.ext_authz.v3.CheckSettings";
 
   // Context extensions to set on the CheckRequest's
   // :ref:`AttributeContext.context_extensions<envoy_api_field_service.auth.v4alpha.AttributeContext.context_extensions>`
+  //
+  // You can use this to provide extra context for the external authorization server on specific
+  // virtual hosts/routes. For example, adding a context extension on the virtual host level can
+  // give the ext-authz server information on what virtual host is used without needing to parse the
+  // host header. If CheckSettings is specified in multiple per-filter-configs, they will be merged
+  // in order, and the result will be used.
   //
   // Merge semantics for this field are such that keys from more specific configs override.
   //
@@ -286,4 +288,8 @@ message CheckSettings {
   //   These settings are only applied to a filter configured with a
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
+
+  // When set to true, bypass the configured :ref:`with_request_body
+  // <envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.with_request_body>` for a route.
+  bool bypass_buffering_request_body = 2;
 }

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -289,7 +289,7 @@ message CheckSettings {
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
 
-  // When set to true, bypass the configured :ref:`with_request_body
+  // When set to true, disable the configured :ref:`with_request_body
   // <envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.with_request_body>` for a route.
-  bool bypass_buffering_request_body = 2;
+  bool disable_request_body_buffering = 2;
 }

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,7 +25,7 @@ Minor Behavior Changes
 * ext_authz filter: request timeout will now count from the time the check request is created, instead of when it becomes active. This makes sure that the timeout is enforced even if the ext_authz cluster's circuit breaker is engaged.
   This behavior can be reverted by setting runtime feature ``envoy.reloadable_features.ext_authz_measure_timeout_on_check_created`` to false. When enabled, a new `ext_authz.timeout` stat is counted when timeout occurs. See :ref:`stats
   // <config_http_filters_ext_authz_stats>`.
-* ext_authz_filter: added :ref:`bypass_buffering_request_body <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.bypass_buffering_request_body>` to bypass buffering request data per-route.
+* ext_authz_filter: added :ref:`disable_request_body_buffering <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>` to disable request data buffering per-route.
 * http: added :ref:`contains <envoy_api_msg_type.matcher.StringMatcher>` a new string matcher type which matches if the value of the string has the substring mentioned in contains matcher.
 * http: added :ref:`contains <envoy_api_msg_route.HeaderMatcher>` a new header matcher type which matches if the value of the header has the substring mentioned in contains matcher.
 * http: added :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to local replies.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,6 +25,7 @@ Minor Behavior Changes
 * ext_authz filter: request timeout will now count from the time the check request is created, instead of when it becomes active. This makes sure that the timeout is enforced even if the ext_authz cluster's circuit breaker is engaged.
   This behavior can be reverted by setting runtime feature ``envoy.reloadable_features.ext_authz_measure_timeout_on_check_created`` to false. When enabled, a new `ext_authz.timeout` stat is counted when timeout occurs. See :ref:`stats
   // <config_http_filters_ext_authz_stats>`.
+* ext_authz_filter: added :ref:`bypass_buffering_request_body <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.bypass_buffering_request_body>` to bypass buffering request data per-route.
 * http: added :ref:`contains <envoy_api_msg_type.matcher.StringMatcher>` a new string matcher type which matches if the value of the string has the substring mentioned in contains matcher.
 * http: added :ref:`contains <envoy_api_msg_route.HeaderMatcher>` a new header matcher type which matches if the value of the header has the substring mentioned in contains matcher.
 * http: added :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to local replies.

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -288,7 +288,7 @@ message CheckSettings {
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
 
-  // When set to true, bypass the configured :ref:`with_request_body
+  // When set to true, disable the configured :ref:`with_request_body
   // <envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` for a route.
-  bool bypass_buffering_request_body = 2;
+  bool disable_request_body_buffering = 2;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -266,17 +266,19 @@ message ExtAuthzPerRoute {
   }
 }
 
-// Extra settings for the check request. You can use this to provide extra context for the
-// external authorization server on specific virtual hosts \ routes. For example, adding a context
-// extension on the virtual host level can give the ext-authz server information on what virtual
-// host is used without needing to parse the host header. If CheckSettings is specified in multiple
-// per-filter-configs, they will be merged in order, and the result will be used.
+// Extra settings for the check request.
 message CheckSettings {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.CheckSettings";
 
   // Context extensions to set on the CheckRequest's
   // :ref:`AttributeContext.context_extensions<envoy_api_field_service.auth.v3.AttributeContext.context_extensions>`
+  //
+  // You can use this to provide extra context for the external authorization server on specific
+  // virtual hosts/routes. For example, adding a context extension on the virtual host level can
+  // give the ext-authz server information on what virtual host is used without needing to parse the
+  // host header. If CheckSettings is specified in multiple per-filter-configs, they will be merged
+  // in order, and the result will be used.
   //
   // Merge semantics for this field are such that keys from more specific configs override.
   //
@@ -285,4 +287,8 @@ message CheckSettings {
   //   These settings are only applied to a filter configured with a
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
+
+  // When set to true, bypass the configured :ref:`with_request_body
+  // <envoy_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` for a route.
+  bool bypass_buffering_request_body = 2;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -267,17 +267,19 @@ message ExtAuthzPerRoute {
   }
 }
 
-// Extra settings for the check request. You can use this to provide extra context for the
-// external authorization server on specific virtual hosts \ routes. For example, adding a context
-// extension on the virtual host level can give the ext-authz server information on what virtual
-// host is used without needing to parse the host header. If CheckSettings is specified in multiple
-// per-filter-configs, they will be merged in order, and the result will be used.
+// Extra settings for the check request.
 message CheckSettings {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.ext_authz.v3.CheckSettings";
 
   // Context extensions to set on the CheckRequest's
   // :ref:`AttributeContext.context_extensions<envoy_api_field_service.auth.v4alpha.AttributeContext.context_extensions>`
+  //
+  // You can use this to provide extra context for the external authorization server on specific
+  // virtual hosts/routes. For example, adding a context extension on the virtual host level can
+  // give the ext-authz server information on what virtual host is used without needing to parse the
+  // host header. If CheckSettings is specified in multiple per-filter-configs, they will be merged
+  // in order, and the result will be used.
   //
   // Merge semantics for this field are such that keys from more specific configs override.
   //
@@ -286,4 +288,8 @@ message CheckSettings {
   //   These settings are only applied to a filter configured with a
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
+
+  // When set to true, bypass the configured :ref:`with_request_body
+  // <envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.with_request_body>` for a route.
+  bool bypass_buffering_request_body = 2;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -289,7 +289,7 @@ message CheckSettings {
   //   :ref:`grpc_service<envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.grpc_service>`.
   map<string, string> context_extensions = 1;
 
-  // When set to true, bypass the configured :ref:`with_request_body
+  // When set to true, disable the configured :ref:`with_request_body
   // <envoy_api_field_extensions.filters.http.ext_authz.v4alpha.ExtAuthz.with_request_body>` for a route.
-  bool bypass_buffering_request_body = 2;
+  bool disable_request_body_buffering = 2;
 }

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -330,18 +330,18 @@ void Filter::continueDecoding() {
 
 Filter::PerRouteFlags Filter::getPerRouteFlags(const Router::RouteConstSharedPtr& route) const {
   if (route == nullptr || route->routeEntry() == nullptr) {
-    return Filter::PerRouteFlags{true /*skip_check_*/, false /*skip_request_body_buffering_*/};
+    return PerRouteFlags{true /*skip_check_*/, false /*skip_request_body_buffering_*/};
   }
 
   const auto* specific_per_route_config =
       Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfigPerRoute>(
           HttpFilterNames::get().ExtAuthorization, route);
   if (specific_per_route_config != nullptr) {
-    return Filter::PerRouteFlags{specific_per_route_config->disabled(),
-                                 specific_per_route_config->disableRequestBodyBuffering()};
+    return PerRouteFlags{specific_per_route_config->disabled(),
+                         specific_per_route_config->disableRequestBodyBuffering()};
   }
 
-  return Filter::PerRouteFlags{false /*skip_check_*/, false /*skip_request_body_buffering_*/};
+  return PerRouteFlags{false /*skip_check_*/, false /*skip_request_body_buffering_*/};
 }
 
 } // namespace ExtAuthz

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -338,7 +338,7 @@ bool Filter::skipCheckForRoute(const Router::RouteConstSharedPtr& route) const {
 
 bool Filter::shouldBufferRequestBody(Http::RequestHeaderMap& headers, bool end_stream) const {
   return config_->withRequestBody() &&
-         !(per_route_config_ && per_route_config_->bypassBufferingRequestBody()) &&
+         !(per_route_config_ && per_route_config_->disableRequestBodyBuffering()) &&
          !(end_stream || Http::Utility::isWebSocketUpgradeRequest(headers) ||
            Http::Utility::isH2UpgradeRequest(headers));
 }

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -23,7 +23,8 @@ struct RcDetailsValues {
 using RcDetails = ConstSingleton<RcDetailsValues>;
 
 void FilterConfigPerRoute::merge(const FilterConfigPerRoute& other) {
-  disabled_ = other.disabled_;
+  // We only merge context extensions here, and leave boolean flags untouched since those flags are
+  // not used from the merged config.
   auto begin_it = other.context_extensions_.begin();
   auto end_it = other.context_extensions_.end();
   for (auto it = begin_it; it != end_it; ++it) {
@@ -77,9 +78,7 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers,
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
   Router::RouteConstSharedPtr route = callbacks_->route();
-
   const auto per_route_flags = getPerRouteFlags(route);
-
   skip_check_ = per_route_flags.skip_check_;
 
   if (!config_->filterEnabled() || skip_check_) {

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -246,8 +246,13 @@ private:
                     const Router::RouteConstSharedPtr& route);
   void continueDecoding();
   bool isBufferFull() const;
-  bool skipCheckForRoute(const Router::RouteConstSharedPtr& route) const;
-  bool shouldBufferRequestBody(Http::RequestHeaderMap& headers, bool end_stream) const;
+
+  // This holds a set of flags defined in per-route configuration.
+  struct PerRouteFlags {
+    const bool skip_check_;
+    const bool skip_request_body_buffering_;
+  };
+  PerRouteFlags getPerRouteFlags(const Router::RouteConstSharedPtr& route) const;
 
   // State of this filter's communication with the external authorization service.
   // The filter has either not started calling the external service, in the middle of calling
@@ -275,7 +280,6 @@ private:
   bool buffer_data_{};
   bool skip_check_{false};
   envoy::service::auth::v3::CheckRequest check_request_{};
-  mutable const FilterConfigPerRoute* per_route_config_{nullptr};
 };
 
 } // namespace ExtAuthz

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -191,8 +191,8 @@ public:
       : context_extensions_(config.has_check_settings()
                                 ? config.check_settings().context_extensions()
                                 : ContextExtensionsMap()),
-        bypass_buffering_request_body_(config.has_check_settings() &&
-                                       config.check_settings().bypass_buffering_request_body()),
+        disable_request_body_buffering_(config.has_check_settings() &&
+                                        config.check_settings().disable_request_body_buffering()),
         disabled_(config.disabled()) {}
 
   void merge(const FilterConfigPerRoute& other);
@@ -206,13 +206,13 @@ public:
 
   bool disabled() const { return disabled_; }
 
-  bool bypassBufferingRequestBody() const { return bypass_buffering_request_body_; }
+  bool disableRequestBodyBuffering() const { return disable_request_body_buffering_; }
 
 private:
   // We save the context extensions as a protobuf map instead of an std::map as this allows us to
   // move it to the CheckRequest, thus avoiding a copy that would incur by converting it.
   ContextExtensionsMap context_extensions_;
-  bool bypass_buffering_request_body_;
+  bool disable_request_body_buffering_;
   bool disabled_;
 };
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -155,7 +155,6 @@ TEST_F(HttpFilterTest, MergeConfig) {
   base_config.merge(disabled_config);
 
   // Make sure all values were merged:
-  EXPECT_TRUE(base_config.disabled());
   auto&& merged_extensions = base_config.contextExtensions();
   EXPECT_EQ("base_value", merged_extensions.at("base_key"));
   EXPECT_EQ("value", merged_extensions.at("merged_key"));


### PR DESCRIPTION
Commit Message: This patch adds per-route flag to bypass the request body buffering.
Additional Description: I'm preparing another patch to skip request body buffering via a list of `config.route.v3.HeaderMatcher`. Hence skipping request body buffering, for example, can be done to a specific request with a certain "content-type".

Risk Level: Low
Testing: Added.
Docs Changes: Updated.
Release Notes: Added.
Fixes #13285

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>