### PR TITLE
overload: use symbol table for overload action names

### DIFF
--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -75,21 +75,28 @@ private:
  */
 class ThreadLocalOverloadStateImpl : public ThreadLocalOverloadState {
 public:
+  ThreadLocalOverloadStateImpl(const NamedOverloadActionSymbolTable& action_symbol_table)
+      : action_symbol_table_(action_symbol_table),
+        actions_(action_symbol_table.size(), OverloadActionState(0)) {}
+
   const OverloadActionState& getState(const std::string& action) override {
-    auto it = actions_.find(action);
-    if (it == actions_.end()) {
-      it = actions_.insert(std::make_pair(action, OverloadActionState::inactive())).first;
+    if (auto symbol = action_symbol_table_.find(action); symbol != absl::nullopt) {
+      return actions_[symbol->index()];
     }
-    return it->second;
+    return always_inactive_;
   }
 
-  void setState(const std::string& action, OverloadActionState state) {
-    actions_.insert_or_assign(action, state);
+  void setState(NamedOverloadActionSymbolTable::Symbol action, OverloadActionState state) {
+    actions_[action.index()] = state;
   }
 
 private:
-  absl::node_hash_map<std::string, OverloadActionState> actions_;
+  static const OverloadActionState always_inactive_;
+  const NamedOverloadActionSymbolTable& action_symbol_table_;
+  std::vector<OverloadActionState> actions_;
 };
+
+const OverloadActionState ThreadLocalOverloadStateImpl::always_inactive_{0.0};
 
 Stats::Counter& makeCounter(Stats::Scope& scope, absl::string_view a, absl::string_view b) {
   Stats::StatNameManagedStorage stat_name(absl::StrCat("overload.", a, ".", b),
@@ -105,6 +112,37 @@ Stats::Gauge& makeGauge(Stats::Scope& scope, absl::string_view a, absl::string_v
 }
 
 } // namespace
+
+NamedOverloadActionSymbolTable::Symbol
+NamedOverloadActionSymbolTable::get(absl::string_view string) {
+  if (auto it = table_.find(string); it != table_.end()) {
+    return Symbol(it->second);
+  }
+
+  size_t index = table_.size();
+
+  names_.emplace_back(string);
+  table_.emplace(std::make_pair(string, index));
+
+  return Symbol(index);
+}
+
+absl::optional<NamedOverloadActionSymbolTable::Symbol>
+NamedOverloadActionSymbolTable::find(absl::string_view string) const {
+  if (auto it = table_.find(string); it != table_.end()) {
+    return Symbol(it->second);
+  }
+  return absl::nullopt;
+}
+
+const std::string& NamedOverloadActionSymbolTable::name(Symbol symbol) const {
+  return names_.at(symbol.index());
+}
+
+bool operator==(const NamedOverloadActionSymbolTable::Symbol& lhs,
+                const NamedOverloadActionSymbolTable::Symbol& rhs) {
+  return lhs.index() == rhs.index();
+}
 
 OverloadAction::OverloadAction(const envoy::config::overload::v3::OverloadAction& config,
                                Stats::Scope& stats_scope)
@@ -191,13 +229,14 @@ OverloadManagerImpl::OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::S
 
   for (const auto& action : config.actions()) {
     const auto& name = action.name();
+    const auto symbol = action_symbol_table_.get(name);
     ENVOY_LOG(debug, "Adding overload action {}", name);
     // TODO: use in place construction once https://github.com/abseil/abseil-cpp/issues/388 is
     // addressed
     // We cannot currently use in place construction as the OverloadAction constructor may throw,
     // causing an inconsistent internal state of the actions_ map, which on destruction results in
     // an invalid free.
-    auto result = actions_.try_emplace(name, OverloadAction(action, stats_scope));
+    auto result = actions_.try_emplace(symbol, OverloadAction(action, stats_scope));
     if (!result.second) {
       throw EnvoyException(absl::StrCat("Duplicate overload action ", name));
     }
@@ -210,7 +249,7 @@ OverloadManagerImpl::OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::S
             fmt::format("Unknown trigger resource {} for overload action {}", resource, name));
       }
 
-      resource_to_actions_.insert(std::make_pair(resource, name));
+      resource_to_actions_.insert(std::make_pair(resource, symbol));
     }
   }
 }
@@ -219,8 +258,8 @@ void OverloadManagerImpl::start() {
   ASSERT(!started_);
   started_ = true;
 
-  tls_->set([](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    return std::make_shared<ThreadLocalOverloadStateImpl>();
+  tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    return std::make_shared<ThreadLocalOverloadStateImpl>(action_symbol_table_);
   });
 
   if (resources_.empty()) {
@@ -259,13 +298,14 @@ bool OverloadManagerImpl::registerForAction(const std::string& action,
                                             Event::Dispatcher& dispatcher,
                                             OverloadActionCb callback) {
   ASSERT(!started_);
+  const auto symbol = action_symbol_table_.get(action);
 
-  if (actions_.find(action) == actions_.end()) {
+  if (actions_.find(symbol) == actions_.end()) {
     ENVOY_LOG(debug, "No overload action is configured for {}.", action);
     return false;
   }
 
-  action_to_callbacks_.emplace(std::piecewise_construct, std::forward_as_tuple(action),
+  action_to_callbacks_.emplace(std::piecewise_construct, std::forward_as_tuple(symbol),
                                std::forward_as_tuple(dispatcher, callback));
   return true;
 }
@@ -279,7 +319,7 @@ void OverloadManagerImpl::updateResourcePressure(const std::string& resource, do
   auto [start, end] = resource_to_actions_.equal_range(resource);
 
   std::for_each(start, end, [&](ResourceToActionMap::value_type& entry) {
-    const std::string& action = entry.second;
+    const NamedOverloadActionSymbolTable::Symbol action = entry.second;
     auto action_it = actions_.find(action);
     ASSERT(action_it != actions_.end());
     const OverloadActionState old_state = action_it->second.getState();
@@ -287,7 +327,7 @@ void OverloadManagerImpl::updateResourcePressure(const std::string& resource, do
       const auto state = action_it->second.getState();
 
       if (old_state.isSaturated() != state.isSaturated()) {
-        ENVOY_LOG(debug, "Overload action {} became {}", action,
+        ENVOY_LOG(debug, "Overload action {} became {}", action_symbol_table_.name(action),
                   (state.isSaturated() ? "saturated" : "scaling"));
       }
 
@@ -320,7 +360,8 @@ void OverloadManagerImpl::updateResourcePressure(const std::string& resource, do
 
 void OverloadManagerImpl::flushResourceUpdates() {
   if (!state_updates_to_flush_.empty()) {
-    auto shared_updates = std::make_shared<absl::flat_hash_map<std::string, OverloadActionState>>();
+    auto shared_updates = std::make_shared<
+        absl::flat_hash_map<NamedOverloadActionSymbolTable::Symbol, OverloadActionState>>();
     std::swap(*shared_updates, state_updates_to_flush_);
 
     tls_->runOnAllThreads(

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -135,7 +135,7 @@ NamedOverloadActionSymbolTable::lookup(absl::string_view string) const {
   return absl::nullopt;
 }
 
-const std::string& NamedOverloadActionSymbolTable::name(Symbol symbol) const {
+const absl::string_view NamedOverloadActionSymbolTable::name(Symbol symbol) const {
   return names_.at(symbol.index());
 }
 

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -80,7 +80,7 @@ public:
         actions_(action_symbol_table.size(), OverloadActionState(0)) {}
 
   const OverloadActionState& getState(const std::string& action) override {
-    if (auto symbol = action_symbol_table_.find(action); symbol != absl::nullopt) {
+    if (const auto symbol = action_symbol_table_.lookup(action); symbol != absl::nullopt) {
       return actions_[symbol->index()];
     }
     return always_inactive_;
@@ -128,7 +128,7 @@ NamedOverloadActionSymbolTable::get(absl::string_view string) {
 }
 
 absl::optional<NamedOverloadActionSymbolTable::Symbol>
-NamedOverloadActionSymbolTable::find(absl::string_view string) const {
+NamedOverloadActionSymbolTable::lookup(absl::string_view string) const {
   if (auto it = table_.find(string); it != table_.end()) {
     return Symbol(it->second);
   }

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -52,6 +52,49 @@ private:
   Stats::Gauge& scale_percent_gauge_;
 };
 
+// Simple table that converts strings into Symbol instances. Symbols are guaranteed to start at 0
+// and be indexed sequentially.
+class NamedOverloadActionSymbolTable {
+public:
+  class Symbol {
+  public:
+    // Allow copy construction everywhere.
+    Symbol(const Symbol&) = default;
+
+    // Returns the index of the symbol in the table.
+    size_t index() const { return index_; }
+
+    // Support use as a map key.
+    bool operator==(const Symbol other) { return other.index_ == index_; }
+    template <typename H> friend H AbslHashValue(H h, const Symbol& s) {
+      return H::combine(std::move(h), s.index_);
+    }
+
+  private:
+    friend class NamedOverloadActionSymbolTable;
+    // Only the symbol table class can create Symbol instanes from indicies.
+    explicit Symbol(size_t index) : index_(index) {}
+
+    size_t index_;
+  };
+
+  // Finds an existing or adds a new entry for the given name.
+  Symbol get(absl::string_view name);
+
+  // Returns the symbol for the name if there is one, otherwise nullopt.
+  absl::optional<Symbol> find(absl::string_view string) const;
+
+  // Translates a symbol back into a name.
+  const std::string& name(Symbol symbol) const;
+
+  // Returns the number of symbols in the table. All symbols are guaranteed to have an index less
+  // than size().
+  size_t size() const { return table_.size(); }
+
+  absl::flat_hash_map<std::string, size_t> table_;
+  std::vector<std::string> names_;
+};
+
 class OverloadManagerImpl : Logger::Loggable<Logger::Id::main>, public OverloadManager {
 public:
   OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::Scope& stats_scope,
@@ -109,20 +152,25 @@ private:
   bool started_;
   Event::Dispatcher& dispatcher_;
   ThreadLocal::SlotPtr tls_;
+  NamedOverloadActionSymbolTable action_symbol_table_;
   const std::chrono::milliseconds refresh_interval_;
   Event::TimerPtr timer_;
   absl::node_hash_map<std::string, Resource> resources_;
-  absl::node_hash_map<std::string, OverloadAction> actions_;
+  absl::node_hash_map<NamedOverloadActionSymbolTable::Symbol, OverloadAction> actions_;
 
-  absl::flat_hash_map<std::string, OverloadActionState> state_updates_to_flush_;
+  absl::flat_hash_map<NamedOverloadActionSymbolTable::Symbol, OverloadActionState>
+      state_updates_to_flush_;
   absl::flat_hash_map<ActionCallback*, OverloadActionState> callbacks_to_flush_;
   FlushEpochId flush_epoch_ = 0;
   uint64_t flush_awaiting_updates_ = 0;
 
-  using ResourceToActionMap = std::unordered_multimap<std::string, std::string>;
+  using ResourceToActionMap =
+      std::unordered_multimap<std::string, NamedOverloadActionSymbolTable::Symbol>;
   ResourceToActionMap resource_to_actions_;
 
-  using ActionToCallbackMap = std::unordered_multimap<std::string, ActionCallback>;
+  using ActionToCallbackMap =
+      std::unordered_multimap<NamedOverloadActionSymbolTable::Symbol, ActionCallback,
+                              absl::Hash<NamedOverloadActionSymbolTable::Symbol>>;
   ActionToCallbackMap action_to_callbacks_;
 };
 

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -82,7 +82,7 @@ public:
   Symbol get(absl::string_view name);
 
   // Returns the symbol for the name if there is one, otherwise nullopt.
-  absl::optional<Symbol> find(absl::string_view string) const;
+  absl::optional<Symbol> lookup(absl::string_view string) const;
 
   // Translates a symbol back into a name.
   const std::string& name(Symbol symbol) const;

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -72,7 +72,7 @@ public:
 
   private:
     friend class NamedOverloadActionSymbolTable;
-    // Only the symbol table class can create Symbol instances from indicies.
+    // Only the symbol table class can create Symbol instances from indices.
     explicit Symbol(size_t index) : index_(index) {}
 
     size_t index_;

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -88,12 +88,13 @@ public:
   absl::optional<Symbol> lookup(absl::string_view string) const;
 
   // Translates a symbol back into a name.
-  const std::string& name(Symbol symbol) const;
+  const absl::string_view name(Symbol symbol) const;
 
   // Returns the number of symbols in the table. All symbols are guaranteed to have an index less
   // than size().
   size_t size() const { return table_.size(); }
 
+private:
   absl::flat_hash_map<std::string, size_t> table_;
   std::vector<std::string> names_;
 };

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -72,7 +72,7 @@ public:
 
   private:
     friend class NamedOverloadActionSymbolTable;
-    // Only the symbol table class can create Symbol instanes from indicies.
+    // Only the symbol table class can create Symbol instances from indicies.
     explicit Symbol(size_t index) : index_(index) {}
 
     size_t index_;

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -66,7 +66,10 @@ public:
 
     // Support use as a map key.
     bool operator==(const Symbol other) { return other.index_ == index_; }
-    template <typename H> friend H AbslHashValue(H h, const Symbol& s) {
+
+    // Support absl::Hash.
+    template <typename H>
+    friend H AbslHashValue(H h, const Symbol& s) { // NOLINT(readability-identifier-naming)
       return H::combine(std::move(h), s.index_);
     }
 


### PR DESCRIPTION
Commit Message: Use symbol table for overload action names
Additional Description:
Flushing resource updates requires looking up actions by names in a map.
With this change, the map lookups are done once at initialization time
and action names are resolved to symbols. The symbols are 0-indexed so
map lookup by string becomes indexing into a vector.

Risk Level: low
Testing: ran affected tests
Docs Changes: n/a
Release Notes: n/a

/cc @eziskind
