### PR TITLE
Fix unused proto import warnings in api

### DIFF
--- a/api/envoy/admin/v3/BUILD
+++ b/api/envoy/admin/v3/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/admin/v2alpha:pkg",
-        "//envoy/annotations:pkg",
         "//envoy/config/bootstrap/v3:pkg",
         "//envoy/config/cluster/v3:pkg",
         "//envoy/config/core/v3:pkg",

--- a/api/envoy/admin/v3/init_dump.proto
+++ b/api/envoy/admin/v3/init_dump.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.admin.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.admin.v3";
 option java_outer_classname = "InitDumpProto";

--- a/api/envoy/admin/v3/server_info.proto
+++ b/api/envoy/admin/v3/server_info.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/base.proto";
 
 import "google/protobuf/duration.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/api/envoy/admin/v4alpha/BUILD
+++ b/api/envoy/admin/v4alpha/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/admin/v3:pkg",
-        "//envoy/annotations:pkg",
         "//envoy/config/bootstrap/v4alpha:pkg",
         "//envoy/config/cluster/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",

--- a/api/envoy/admin/v4alpha/server_info.proto
+++ b/api/envoy/admin/v4alpha/server_info.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/base.proto";
 
 import "google/protobuf/duration.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/api/envoy/api/v2/auth/cert.proto
+++ b/api/envoy/api/v2/auth/cert.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.api.v2.auth;
 
 import "udpa/annotations/migrate.proto";
-import "udpa/annotations/status.proto";
 
 import public "envoy/api/v2/auth/common.proto";
 import public "envoy/api/v2/auth/secret.proto";

--- a/api/envoy/api/v2/core/base.proto
+++ b/api/envoy/api/v2/core/base.proto
@@ -9,7 +9,6 @@ import "envoy/type/percent.proto";
 import "envoy/type/semantic_version.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/api/v2/eds.proto
+++ b/api/envoy/api/v2/eds.proto
@@ -5,13 +5,10 @@ package envoy.api.v2;
 import "envoy/api/v2/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 import public "envoy/api/v2/endpoint.proto";
 

--- a/api/envoy/api/v2/endpoint.proto
+++ b/api/envoy/api/v2/endpoint.proto
@@ -5,7 +5,6 @@ package envoy.api.v2;
 import "envoy/api/v2/endpoint/endpoint_components.proto";
 import "envoy/type/percent.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/api/v2/endpoint/endpoint.proto
+++ b/api/envoy/api/v2/endpoint/endpoint.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.endpoint;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/api/v2/endpoint/endpoint_components.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";

--- a/api/envoy/api/v2/lds.proto
+++ b/api/envoy/api/v2/lds.proto
@@ -5,13 +5,10 @@ package envoy.api.v2;
 import "envoy/api/v2/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 import public "envoy/api/v2/listener.proto";
 

--- a/api/envoy/api/v2/listener.proto
+++ b/api/envoy/api/v2/listener.proto
@@ -10,7 +10,6 @@ import "envoy/api/v2/listener/udp_listener_config.proto";
 import "envoy/config/filter/accesslog/v2/accesslog.proto";
 import "envoy/config/listener/v2/api_listener.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/api/v2/listener/listener.proto
+++ b/api/envoy/api/v2/listener/listener.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.listener;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/api/v2/listener/listener_components.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.listener";

--- a/api/envoy/api/v2/rds.proto
+++ b/api/envoy/api/v2/rds.proto
@@ -5,12 +5,10 @@ package envoy.api.v2;
 import "envoy/api/v2/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 import public "envoy/api/v2/route.proto";
 

--- a/api/envoy/api/v2/route/route.proto
+++ b/api/envoy/api/v2/route/route.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.route;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/api/v2/route/route_components.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.route";

--- a/api/envoy/config/accesslog/v3/accesslog.proto
+++ b/api/envoy/config/accesslog/v3/accesslog.proto
@@ -8,7 +8,6 @@ import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/api/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -8,7 +8,6 @@ import "envoy/type/matcher/v4alpha/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/bootstrap/v3/BUILD
+++ b/api/envoy/config/bootstrap/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/bootstrap/v2:pkg",
         "//envoy/config/cluster/v3:pkg",
         "//envoy/config/core/v3:pkg",

--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -20,7 +20,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/bootstrap/v4alpha/BUILD
+++ b/api/envoy/config/bootstrap/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/bootstrap/v3:pkg",
         "//envoy/config/cluster/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",

--- a/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -19,7 +19,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/cluster/v3/BUILD
+++ b/api/envoy/config/cluster/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/api/v2:pkg",
         "//envoy/api/v2/cluster:pkg",
         "//envoy/config/core/v3:pkg",

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -21,8 +21,6 @@ import "google/protobuf/wrappers.proto";
 
 import "xds/core/v3/collection_entry.proto";
 
-import "envoy/annotations/deprecation.proto";
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/cluster/v4alpha/BUILD
+++ b/api/envoy/config/cluster/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/cluster/v3:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/endpoint/v3:pkg",

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -20,7 +20,6 @@ import "google/protobuf/wrappers.proto";
 
 import "xds/core/v3/collection_entry.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/common/matcher/v3/matcher.proto
+++ b/api/envoy/config/common/matcher/v3/matcher.proto
@@ -6,9 +6,7 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.common.matcher.v3";

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -9,7 +9,6 @@ import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/semantic_version.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/config/core/v3/health_check.proto
+++ b/api/envoy/config/core/v3/health_check.proto
@@ -13,7 +13,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/config/core/v3/proxy_protocol.proto
+++ b/api/envoy/config/core/v3/proxy_protocol.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.core.v3;
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ProxyProtocolProto";

--- a/api/envoy/config/core/v3/substitution_format_string.proto
+++ b/api/envoy/config/core/v3/substitution_format_string.proto
@@ -5,7 +5,6 @@ package envoy.config.core.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/core/v4alpha/base.proto
+++ b/api/envoy/config/core/v4alpha/base.proto
@@ -8,7 +8,6 @@ import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/semantic_version.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/config/core/v4alpha/health_check.proto
+++ b/api/envoy/config/core/v4alpha/health_check.proto
@@ -13,7 +13,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/config/core/v4alpha/proxy_protocol.proto
+++ b/api/envoy/config/core/v4alpha/proxy_protocol.proto
@@ -4,7 +4,6 @@ package envoy.config.core.v4alpha;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
 option java_outer_classname = "ProxyProtocolProto";

--- a/api/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/api/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -5,7 +5,6 @@ package envoy.config.core.v4alpha;
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/endpoint/v3/endpoint.proto
+++ b/api/envoy/config/endpoint/v3/endpoint.proto
@@ -5,7 +5,6 @@ package envoy.config.endpoint.v3;
 import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "envoy/type/v3/percent.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.proto
+++ b/api/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.proto
@@ -5,7 +5,6 @@ package envoy.config.filter.http.adaptive_concurrency.v2alpha;
 import "envoy/api/v2/core/base.proto";
 import "envoy/type/percent.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
@@ -8,7 +8,6 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.grpc_stats.v2alpha";
 option java_outer_classname = "ConfigProto";

--- a/api/envoy/config/filter/http/on_demand/v2/on_demand.proto
+++ b/api/envoy/config/filter/http/on_demand/v2/on_demand.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.http.on_demand.v2;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.on_demand.v2";
 option java_outer_classname = "OnDemandProto";

--- a/api/envoy/config/filter/http/original_src/v2alpha1/original_src.proto
+++ b/api/envoy/config/filter/http/original_src/v2alpha1/original_src.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.http.original_src.v2alpha1;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.original_src.v2alpha1";
 option java_outer_classname = "OriginalSrcProto";

--- a/api/envoy/config/filter/http/rbac/v2/rbac.proto
+++ b/api/envoy/config/filter/http/rbac/v2/rbac.proto
@@ -6,7 +6,6 @@ import "envoy/config/rbac/v2/rbac.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.rbac.v2";
 option java_outer_classname = "RbacProto";

--- a/api/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto
+++ b/api/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.listener.original_src.v2alpha1;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.listener.original_src.v2alpha1";
 option java_outer_classname = "OriginalSrcProto";

--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -11,7 +11,6 @@ import "envoy/config/listener/v3/api_listener.proto";
 import "envoy/config/listener/v3/listener_components.proto";
 import "envoy/config/listener/v3/udp_listener_config.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/config/listener/v3/listener_components.proto
+++ b/api/envoy/config/listener/v3/listener_components.proto
@@ -9,7 +9,6 @@ import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/listener/v3/udp_default_writer_config.proto
+++ b/api/envoy/config/listener/v3/udp_default_writer_config.proto
@@ -2,11 +2,7 @@ syntax = "proto3";
 
 package envoy.config.listener.v3;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "UdpDefaultWriterConfigProto";

--- a/api/envoy/config/listener/v3/udp_gso_batch_writer_config.proto
+++ b/api/envoy/config/listener/v3/udp_gso_batch_writer_config.proto
@@ -2,11 +2,7 @@ syntax = "proto3";
 
 package envoy.config.listener.v3;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "UdpGsoBatchWriterConfigProto";

--- a/api/envoy/config/listener/v3/udp_listener_config.proto
+++ b/api/envoy/config/listener/v3/udp_listener_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.listener.v3;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/listener/v4alpha/listener.proto
+++ b/api/envoy/config/listener/v4alpha/listener.proto
@@ -11,7 +11,6 @@ import "envoy/config/listener/v4alpha/api_listener.proto";
 import "envoy/config/listener/v4alpha/listener_components.proto";
 import "envoy/config/listener/v4alpha/udp_listener_config.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/config/listener/v4alpha/listener_components.proto
+++ b/api/envoy/config/listener/v4alpha/listener_components.proto
@@ -9,7 +9,6 @@ import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/listener/v4alpha/udp_default_writer_config.proto
+++ b/api/envoy/config/listener/v4alpha/udp_default_writer_config.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package envoy.config.listener.v4alpha;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/api/envoy/config/listener/v4alpha/udp_gso_batch_writer_config.proto
+++ b/api/envoy/config/listener/v4alpha/udp_gso_batch_writer_config.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package envoy.config.listener.v4alpha;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/api/envoy/config/listener/v4alpha/udp_listener_config.proto
+++ b/api/envoy/config/listener/v4alpha/udp_listener_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.listener.v4alpha;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/metrics/v3/stats.proto
+++ b/api/envoy/config/metrics/v3/stats.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/address.proto";
 import "envoy/type/matcher/v3/string.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/metrics/v4alpha/stats.proto
+++ b/api/envoy/config/metrics/v4alpha/stats.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/address.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/config/overload/v3/overload.proto
+++ b/api/envoy/config/overload/v3/overload.proto
@@ -6,7 +6,6 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -14,7 +14,6 @@ import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -14,7 +14,6 @@ import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";

--- a/api/envoy/config/trace/v2/opencensus.proto
+++ b/api/envoy/config/trace/v2/opencensus.proto
@@ -7,7 +7,6 @@ import "envoy/api/v2/core/grpc_service.proto";
 import "opencensus/proto/trace/v1/trace_config.proto";
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "OpencensusProto";

--- a/api/envoy/config/trace/v2/trace.proto
+++ b/api/envoy/config/trace/v2/trace.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.config.trace.v2;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/config/trace/v2/datadog.proto";
 import public "envoy/config/trace/v2/dynamic_ot.proto";
 import public "envoy/config/trace/v2/http_tracer.proto";

--- a/api/envoy/config/trace/v3/http_tracer.proto
+++ b/api/envoy/config/trace/v3/http_tracer.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.trace.v3;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/config/trace/v3/opencensus.proto
+++ b/api/envoy/config/trace/v3/opencensus.proto
@@ -9,7 +9,6 @@ import "opencensus/proto/trace/v1/trace_config.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "OpencensusProto";

--- a/api/envoy/config/trace/v3/skywalking.proto
+++ b/api/envoy/config/trace/v3/skywalking.proto
@@ -9,7 +9,6 @@ import "google/protobuf/wrappers.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";

--- a/api/envoy/config/trace/v3/trace.proto
+++ b/api/envoy/config/trace/v3/trace.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.config.trace.v3;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/config/trace/v3/datadog.proto";
 import public "envoy/config/trace/v3/dynamic_ot.proto";
 import public "envoy/config/trace/v3/http_tracer.proto";

--- a/api/envoy/config/trace/v4alpha/http_tracer.proto
+++ b/api/envoy/config/trace/v4alpha/http_tracer.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.trace.v4alpha;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/extensions/access_loggers/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/access_loggers/wasm/v3/wasm.proto
@@ -5,7 +5,6 @@ package envoy.extensions.access_loggers.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.access_loggers.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/api/envoy/extensions/common/matching/v3/extension_matcher.proto
+++ b/api/envoy/extensions/common/matching/v3/extension_matcher.proto
@@ -5,7 +5,6 @@ package envoy.extensions.common.matching.v3;
 import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/common/tap/v3/common.proto
+++ b/api/envoy/extensions/common/tap/v3/common.proto
@@ -4,7 +4,6 @@ package envoy.extensions.common.tap.v3;
 
 import "envoy/config/tap/v3/common.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/extensions/compression/gzip/compressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/compressor/v3/gzip.proto
@@ -5,7 +5,6 @@ package envoy.extensions.compression.gzip.compressor.v3;
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.compression.gzip.compressor.v3";

--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -4,9 +4,7 @@ package envoy.extensions.compression.gzip.decompressor.v3;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.compression.gzip.decompressor.v3";

--- a/api/envoy/extensions/filters/common/dependency/v3/dependency.proto
+++ b/api/envoy/extensions/filters/common/dependency/v3/dependency.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.filters.common.dependency.v3;
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/filters/common/fault/v3/BUILD
+++ b/api/envoy/extensions/filters/common/fault/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/filter/fault/v2:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -6,7 +6,6 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/duration.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/extensions/filters/common/matcher/action/v3/skip_action.proto
+++ b/api/envoy/extensions/filters/common/matcher/action/v3/skip_action.proto
@@ -2,10 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.filters.common.matcher.action.v3;
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.common.matcher.action.v3";
 option java_outer_classname = "SkipActionProto";

--- a/api/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
+++ b/api/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
@@ -5,12 +5,8 @@ package envoy.extensions.filters.http.admission_control.v3alpha;
 import "envoy/config/core/v3/base.proto";
 import "envoy/type/v3/range.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-import "google/rpc/status.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/api/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
+++ b/api/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.filters.http.cdn_loop.v3alpha;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.cdn_loop.v3alpha";

--- a/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -5,12 +5,10 @@ package envoy.extensions.filters.http.compressor.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.compressor.v3";
 option java_outer_classname = "CompressorProto";

--- a/api/envoy/extensions/filters/http/compressor/v4alpha/compressor.proto
+++ b/api/envoy/extensions/filters/http/compressor/v4alpha/compressor.proto
@@ -5,12 +5,10 @@ package envoy.extensions.filters.http.compressor.v4alpha;
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.compressor.v4alpha";
 option java_outer_classname = "CompressorProto";

--- a/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
+++ b/api/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
@@ -5,12 +5,9 @@ package envoy.extensions.filters.http.decompressor.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.decompressor.v3";

--- a/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/ext_authz/v2:pkg",
         "//envoy/type/matcher/v3:pkg",

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -10,7 +10,6 @@ import "envoy/type/matcher/v3/metadata.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/extensions/filters/http/ext_authz/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -10,7 +10,6 @@ import "envoy/type/matcher/v4alpha/metadata.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 import "envoy/type/v3/http_status.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -8,7 +8,6 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.grpc_stats.v3";
 option java_outer_classname = "ConfigProto";

--- a/api/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
+++ b/api/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
@@ -8,7 +8,6 @@ import "envoy/type/v3/http_status.proto";
 import "envoy/type/v3/token_bucket.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.local_ratelimit.v3";

--- a/api/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
@@ -7,10 +7,7 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "envoy/type/matcher/v3/path.proto";
 
-import "google/protobuf/duration.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.oauth2.v3alpha";

--- a/api/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
@@ -7,8 +7,6 @@ import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/secret.proto";
 import "envoy/type/matcher/v4alpha/path.proto";
 
-import "google/protobuf/duration.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
+++ b/api/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.http.on_demand.v3;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.on_demand.v3";
 option java_outer_classname = "OnDemandProto";

--- a/api/envoy/extensions/filters/http/original_src/v3/original_src.proto
+++ b/api/envoy/extensions/filters/http/original_src/v3/original_src.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.http.original_src.v3;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.original_src.v3";
 option java_outer_classname = "OriginalSrcProto";

--- a/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -6,7 +6,6 @@ import "envoy/config/rbac/v3/rbac.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v3";
 option java_outer_classname = "RbacProto";

--- a/api/envoy/extensions/filters/http/rbac/v4alpha/rbac.proto
+++ b/api/envoy/extensions/filters/http/rbac/v4alpha/rbac.proto
@@ -6,7 +6,6 @@ import "envoy/config/rbac/v4alpha/rbac.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v4alpha";
 option java_outer_classname = "RbacProto";

--- a/api/envoy/extensions/filters/http/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/filters/http/wasm/v3/wasm.proto
@@ -5,8 +5,6 @@ package envoy.extensions.filters.http.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/api/envoy/extensions/filters/listener/original_src/v3/original_src.proto
+++ b/api/envoy/extensions/filters/listener/original_src/v3/original_src.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.listener.original_src.v3;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.listener.original_src.v3";
 option java_outer_classname = "OriginalSrcProto";

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v3:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/http_connection_manager/v2:pkg",

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -16,10 +16,8 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -16,10 +16,8 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -4,9 +4,7 @@ package envoy.extensions.filters.network.postgres_proxy.v3alpha;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.postgres_proxy.v3alpha";

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/redis_proxy/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
@@ -4,11 +4,9 @@ package envoy.extensions.filters.network.rocketmq_proxy.v3;
 
 import "envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
@@ -7,7 +7,6 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.network.rocketmq_proxy.v4alpha;
 
 import "envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
+++ b/api/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
@@ -5,7 +5,6 @@ package envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3alpha;
 import "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3alpha";

--- a/api/envoy/extensions/filters/network/thrift_proxy/v3/thrift_proxy.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v3/thrift_proxy.proto
@@ -5,7 +5,6 @@ package envoy.extensions.filters.network.thrift_proxy.v3;
 import "envoy/extensions/filters/network/thrift_proxy/v3/route.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/thrift_proxy.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/thrift_proxy.proto
@@ -5,7 +5,6 @@ package envoy.extensions.filters.network.thrift_proxy.v4alpha;
 import "envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/extensions/filters/network/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/filters/network/wasm/v3/wasm.proto
@@ -5,8 +5,6 @@ package envoy.extensions.filters.network.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/api/envoy/extensions/internal_redirect/allow_listed_routes/v3/allow_listed_routes_config.proto
+++ b/api/envoy/extensions/internal_redirect/allow_listed_routes/v3/allow_listed_routes_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.internal_redirect.allow_listed_routes.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.internal_redirect.allow_listed_routes.v3";

--- a/api/envoy/extensions/internal_redirect/previous_routes/v3/previous_routes_config.proto
+++ b/api/envoy/extensions/internal_redirect/previous_routes/v3/previous_routes_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.internal_redirect.previous_routes.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.internal_redirect.previous_routes.v3";
 option java_outer_classname = "PreviousRoutesConfigProto";

--- a/api/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
+++ b/api/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package envoy.extensions.internal_redirect.safe_cross_scheme.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.internal_redirect.safe_cross_scheme.v3";
 option java_outer_classname = "SafeCrossSchemeConfigProto";

--- a/api/envoy/extensions/stat_sinks/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/stat_sinks/wasm/v3/wasm.proto
@@ -5,8 +5,6 @@ package envoy.extensions.stat_sinks.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.stat_sinks.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/api/envoy/extensions/tracers/opencensus/v4alpha/opencensus.proto
+++ b/api/envoy/extensions/tracers/opencensus/v4alpha/opencensus.proto
@@ -8,7 +8,6 @@ import "opencensus/proto/trace/v1/trace_config.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.tracers.opencensus.v4alpha";
 option java_outer_classname = "OpencensusProto";

--- a/api/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
+++ b/api/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
@@ -5,7 +5,6 @@ package envoy.extensions.transport_sockets.quic.v3;
 import "envoy/extensions/transport_sockets/tls/v3/tls.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.quic.v3";

--- a/api/envoy/extensions/transport_sockets/starttls/v3/starttls.proto
+++ b/api/envoy/extensions/transport_sockets/starttls/v3/starttls.proto
@@ -5,10 +5,7 @@ package envoy.extensions.transport_sockets.starttls.v3;
 import "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.proto";
 import "envoy/extensions/transport_sockets/tls/v3/tls.proto";
 
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.starttls.v3";

--- a/api/envoy/extensions/transport_sockets/starttls/v4alpha/starttls.proto
+++ b/api/envoy/extensions/transport_sockets/starttls/v4alpha/starttls.proto
@@ -5,8 +5,6 @@ package envoy.extensions.transport_sockets.starttls.v4alpha;
 import "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/tls.proto";
 
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.transport_sockets.tls.v3;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/extensions/transport_sockets/tls/v3/common.proto";
 import public "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import public "envoy/extensions/transport_sockets/tls/v3/tls.proto";

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/type/matcher/v3/string.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/sensitive.proto";

--- a/api/envoy/extensions/transport_sockets/tls/v3/secret.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/secret.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/sensitive.proto";

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/common.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/secret.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/any.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.wasm.v3";

--- a/api/envoy/extensions/watchdog/profile_action/v3alpha/profile_action.proto
+++ b/api/envoy/extensions/watchdog/profile_action/v3alpha/profile_action.proto
@@ -5,7 +5,6 @@ package envoy.extensions.watchdog.profile_action.v3alpha;
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.watchdog.profile_action.v3alpha";

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -8,7 +8,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/api/envoy/service/endpoint/v3/eds.proto
+++ b/api/envoy/service/endpoint/v3/eds.proto
@@ -5,13 +5,10 @@ package envoy.service.endpoint.v3;
 import "envoy/service/discovery/v3/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.endpoint.v3";
 option java_outer_classname = "EdsProto";

--- a/api/envoy/service/extension/v3/config_discovery.proto
+++ b/api/envoy/service/extension/v3/config_discovery.proto
@@ -8,7 +8,6 @@ import "google/api/annotations.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.service.extension.v3";
 option java_outer_classname = "ConfigDiscoveryProto";

--- a/api/envoy/service/health/v3/hds.proto
+++ b/api/envoy/service/health/v3/hds.proto
@@ -10,7 +10,6 @@ import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/api/envoy/service/listener/v3/lds.proto
+++ b/api/envoy/service/listener/v3/lds.proto
@@ -5,13 +5,10 @@ package envoy.service.listener.v3;
 import "envoy/service/discovery/v3/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.listener.v3";
 option java_outer_classname = "LdsProto";

--- a/api/envoy/service/load_stats/v2/lrs.proto
+++ b/api/envoy/service/load_stats/v2/lrs.proto
@@ -8,7 +8,6 @@ import "envoy/api/v2/endpoint/load_report.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.load_stats.v2";
 option java_outer_classname = "LrsProto";

--- a/api/envoy/service/load_stats/v3/lrs.proto
+++ b/api/envoy/service/load_stats/v3/lrs.proto
@@ -9,7 +9,6 @@ import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.load_stats.v3";
 option java_outer_classname = "LrsProto";

--- a/api/envoy/service/load_stats/v4alpha/lrs.proto
+++ b/api/envoy/service/load_stats/v4alpha/lrs.proto
@@ -9,7 +9,6 @@ import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.load_stats.v4alpha";
 option java_outer_classname = "LrsProto";

--- a/api/envoy/service/ratelimit/v2/rls.proto
+++ b/api/envoy/service/ratelimit/v2/rls.proto
@@ -7,7 +7,6 @@ import "envoy/api/v2/ratelimit/ratelimit.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.ratelimit.v2";
 option java_outer_classname = "RlsProto";

--- a/api/envoy/service/ratelimit/v3/rls.proto
+++ b/api/envoy/service/ratelimit/v3/rls.proto
@@ -10,7 +10,6 @@ import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.ratelimit.v3";
 option java_outer_classname = "RlsProto";

--- a/api/envoy/service/route/v3/rds.proto
+++ b/api/envoy/service/route/v3/rds.proto
@@ -5,12 +5,10 @@ package envoy.service.route.v3;
 import "envoy/service/discovery/v3/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.route.v3";
 option java_outer_classname = "RdsProto";

--- a/api/envoy/service/status/v2/csds.proto
+++ b/api/envoy/service/status/v2/csds.proto
@@ -7,7 +7,6 @@ import "envoy/api/v2/core/base.proto";
 import "envoy/type/matcher/node.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 

--- a/api/envoy/service/status/v3/csds.proto
+++ b/api/envoy/service/status/v3/csds.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/type/matcher/v3/node.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";

--- a/api/envoy/service/status/v4alpha/csds.proto
+++ b/api/envoy/service/status/v4alpha/csds.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/type/matcher/v4alpha/node.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/api/envoy/service/trace/v2/trace_service.proto
+++ b/api/envoy/service/trace/v2/trace_service.proto
@@ -4,8 +4,6 @@ package envoy.service.trace.v2;
 
 import "envoy/api/v2/core/base.proto";
 
-import "google/api/annotations.proto";
-
 import "opencensus/proto/trace/v1/trace.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/service/trace/v3/trace_service.proto
+++ b/api/envoy/service/trace/v3/trace_service.proto
@@ -4,8 +4,6 @@ package envoy.service.trace.v3;
 
 import "envoy/config/core/v3/base.proto";
 
-import "google/api/annotations.proto";
-
 import "opencensus/proto/trace/v1/trace.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/service/trace/v4alpha/trace_service.proto
+++ b/api/envoy/service/trace/v4alpha/trace_service.proto
@@ -4,8 +4,6 @@ package envoy.service.trace.v4alpha;
 
 import "envoy/config/core/v4alpha/base.proto";
 
-import "google/api/annotations.proto";
-
 import "opencensus/proto/trace/v1/trace.proto";
 
 import "udpa/annotations/status.proto";

--- a/api/envoy/type/matcher/v3/BUILD
+++ b/api/envoy/type/matcher/v3/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/type/matcher:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/type/matcher/v3/http_inputs.proto
+++ b/api/envoy/type/matcher/v3/http_inputs.proto
@@ -2,10 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher.v3;
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "HttpInputsProto";

--- a/api/envoy/type/matcher/v3/string.proto
+++ b/api/envoy/type/matcher/v3/string.proto
@@ -4,7 +4,6 @@ package envoy.type.matcher.v3;
 
 import "envoy/type/matcher/v3/regex.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/type/matcher/v4alpha/BUILD
+++ b/api/envoy/type/matcher/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/type/matcher/v4alpha/http_inputs.proto
+++ b/api/envoy/type/matcher/v4alpha/http_inputs.proto
@@ -4,7 +4,6 @@ package envoy.type.matcher.v4alpha;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher.v4alpha";
 option java_outer_classname = "HttpInputsProto";

--- a/api/envoy/type/matcher/v4alpha/string.proto
+++ b/api/envoy/type/matcher/v4alpha/string.proto
@@ -4,7 +4,6 @@ package envoy.type.matcher.v4alpha;
 
 import "envoy/type/matcher/v4alpha/regex.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/api/envoy/watchdog/v3alpha/abort_action.proto
+++ b/api/envoy/watchdog/v3alpha/abort_action.proto
@@ -5,8 +5,6 @@ package envoy.watchdog.v3alpha;
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.watchdog.v3alpha";
 option java_outer_classname = "AbortActionProto";

--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -146,6 +146,7 @@ proto_library(
         "//envoy/config/retry/omit_canary_hosts/v2:pkg",
         "//envoy/config/retry/omit_canary_hosts/v3:pkg",
         "//envoy/config/retry/previous_hosts/v2:pkg",
+        "//envoy/config/retry/previous_hosts/v3:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/config/tap/v3:pkg",
         "//envoy/config/trace/v3:pkg",

--- a/generated_api_shadow/envoy/admin/v3/init_dump.proto
+++ b/generated_api_shadow/envoy/admin/v3/init_dump.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.admin.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.admin.v3";
 option java_outer_classname = "InitDumpProto";

--- a/generated_api_shadow/envoy/admin/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/admin/v4alpha/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/admin/v3:pkg",
-        "//envoy/annotations:pkg",
         "//envoy/config/bootstrap/v4alpha:pkg",
         "//envoy/config/cluster/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",

--- a/generated_api_shadow/envoy/admin/v4alpha/server_info.proto
+++ b/generated_api_shadow/envoy/admin/v4alpha/server_info.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/base.proto";
 
 import "google/protobuf/duration.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/generated_api_shadow/envoy/api/v2/auth/cert.proto
+++ b/generated_api_shadow/envoy/api/v2/auth/cert.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.api.v2.auth;
 
 import "udpa/annotations/migrate.proto";
-import "udpa/annotations/status.proto";
 
 import public "envoy/api/v2/auth/common.proto";
 import public "envoy/api/v2/auth/secret.proto";

--- a/generated_api_shadow/envoy/api/v2/core/base.proto
+++ b/generated_api_shadow/envoy/api/v2/core/base.proto
@@ -9,7 +9,6 @@ import "envoy/type/percent.proto";
 import "envoy/type/semantic_version.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/api/v2/eds.proto
+++ b/generated_api_shadow/envoy/api/v2/eds.proto
@@ -5,13 +5,10 @@ package envoy.api.v2;
 import "envoy/api/v2/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 import public "envoy/api/v2/endpoint.proto";
 

--- a/generated_api_shadow/envoy/api/v2/endpoint.proto
+++ b/generated_api_shadow/envoy/api/v2/endpoint.proto
@@ -5,7 +5,6 @@ package envoy.api.v2;
 import "envoy/api/v2/endpoint/endpoint_components.proto";
 import "envoy/type/percent.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/api/v2/endpoint/endpoint.proto
+++ b/generated_api_shadow/envoy/api/v2/endpoint/endpoint.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.endpoint;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/api/v2/endpoint/endpoint_components.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.endpoint";

--- a/generated_api_shadow/envoy/api/v2/lds.proto
+++ b/generated_api_shadow/envoy/api/v2/lds.proto
@@ -5,13 +5,10 @@ package envoy.api.v2;
 import "envoy/api/v2/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 import public "envoy/api/v2/listener.proto";
 

--- a/generated_api_shadow/envoy/api/v2/listener.proto
+++ b/generated_api_shadow/envoy/api/v2/listener.proto
@@ -10,7 +10,6 @@ import "envoy/api/v2/listener/udp_listener_config.proto";
 import "envoy/config/filter/accesslog/v2/accesslog.proto";
 import "envoy/config/listener/v2/api_listener.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/api/v2/listener/listener.proto
+++ b/generated_api_shadow/envoy/api/v2/listener/listener.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.listener;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/api/v2/listener/listener_components.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.listener";

--- a/generated_api_shadow/envoy/api/v2/rds.proto
+++ b/generated_api_shadow/envoy/api/v2/rds.proto
@@ -5,12 +5,10 @@ package envoy.api.v2;
 import "envoy/api/v2/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 import public "envoy/api/v2/route.proto";
 

--- a/generated_api_shadow/envoy/api/v2/route/route.proto
+++ b/generated_api_shadow/envoy/api/v2/route/route.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.api.v2.route;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/api/v2/route/route_components.proto";
 
 option java_package = "io.envoyproxy.envoy.api.v2.route";

--- a/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v4alpha/accesslog.proto
@@ -8,7 +8,6 @@ import "envoy/type/matcher/v4alpha/metadata.proto";
 import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/bootstrap/v3:pkg",
         "//envoy/config/cluster/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -20,7 +20,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -23,7 +23,6 @@ import "google/protobuf/wrappers.proto";
 import "xds/core/v3/collection_entry.proto";
 
 import "envoy/annotations/deprecation.proto";
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/cluster/v3:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/endpoint/v3:pkg",

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -21,7 +21,6 @@ import "google/protobuf/wrappers.proto";
 
 import "xds/core/v3/collection_entry.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
@@ -6,9 +6,7 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.common.matcher.v3";

--- a/generated_api_shadow/envoy/config/core/v3/base.proto
+++ b/generated_api_shadow/envoy/config/core/v3/base.proto
@@ -9,7 +9,6 @@ import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/semantic_version.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/config/core/v3/proxy_protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v3/proxy_protocol.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.core.v3;
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v3";
 option java_outer_classname = "ProxyProtocolProto";

--- a/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v3/substitution_format_string.proto
@@ -5,7 +5,6 @@ package envoy.config.core.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/config/core/v4alpha/base.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/base.proto
@@ -9,7 +9,6 @@ import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/semantic_version.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/config/core/v4alpha/health_check.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/health_check.proto
@@ -13,7 +13,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/generated_api_shadow/envoy/config/core/v4alpha/proxy_protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/proxy_protocol.proto
@@ -4,7 +4,6 @@ package envoy.config.core.v4alpha;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
 option java_outer_classname = "ProxyProtocolProto";

--- a/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/substitution_format_string.proto
@@ -5,7 +5,6 @@ package envoy.config.core.v4alpha;
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
+++ b/generated_api_shadow/envoy/config/endpoint/v3/endpoint.proto
@@ -5,7 +5,6 @@ package envoy.config.endpoint.v3;
 import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "envoy/type/v3/percent.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.proto
+++ b/generated_api_shadow/envoy/config/filter/http/adaptive_concurrency/v2alpha/adaptive_concurrency.proto
@@ -5,7 +5,6 @@ package envoy.config.filter.http.adaptive_concurrency.v2alpha;
 import "envoy/api/v2/core/base.proto";
 import "envoy/type/percent.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
+++ b/generated_api_shadow/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
@@ -8,7 +8,6 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.grpc_stats.v2alpha";
 option java_outer_classname = "ConfigProto";

--- a/generated_api_shadow/envoy/config/filter/http/on_demand/v2/on_demand.proto
+++ b/generated_api_shadow/envoy/config/filter/http/on_demand/v2/on_demand.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.http.on_demand.v2;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.on_demand.v2";
 option java_outer_classname = "OnDemandProto";

--- a/generated_api_shadow/envoy/config/filter/http/original_src/v2alpha1/original_src.proto
+++ b/generated_api_shadow/envoy/config/filter/http/original_src/v2alpha1/original_src.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.http.original_src.v2alpha1;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.original_src.v2alpha1";
 option java_outer_classname = "OriginalSrcProto";

--- a/generated_api_shadow/envoy/config/filter/http/rbac/v2/rbac.proto
+++ b/generated_api_shadow/envoy/config/filter/http/rbac/v2/rbac.proto
@@ -6,7 +6,6 @@ import "envoy/config/rbac/v2/rbac.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.http.rbac.v2";
 option java_outer_classname = "RbacProto";

--- a/generated_api_shadow/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto
+++ b/generated_api_shadow/envoy/config/filter/listener/original_src/v2alpha1/original_src.proto
@@ -4,7 +4,6 @@ package envoy.config.filter.listener.original_src.v2alpha1;
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.filter.listener.original_src.v2alpha1";
 option java_outer_classname = "OriginalSrcProto";

--- a/generated_api_shadow/envoy/config/listener/v3/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/listener.proto
@@ -11,7 +11,6 @@ import "envoy/config/listener/v3/api_listener.proto";
 import "envoy/config/listener/v3/listener_components.proto";
 import "envoy/config/listener/v3/udp_listener_config.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/config/listener/v3/udp_default_writer_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/udp_default_writer_config.proto
@@ -2,11 +2,7 @@ syntax = "proto3";
 
 package envoy.config.listener.v3;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "UdpDefaultWriterConfigProto";

--- a/generated_api_shadow/envoy/config/listener/v3/udp_gso_batch_writer_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/udp_gso_batch_writer_config.proto
@@ -2,11 +2,7 @@ syntax = "proto3";
 
 package envoy.config.listener.v3;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.config.listener.v3";
 option java_outer_classname = "UdpGsoBatchWriterConfigProto";

--- a/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
@@ -11,7 +11,6 @@ import "envoy/config/listener/v4alpha/api_listener.proto";
 import "envoy/config/listener/v4alpha/listener_components.proto";
 import "envoy/config/listener/v4alpha/udp_listener_config.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/config/listener/v4alpha/listener_components.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/listener_components.proto
@@ -9,7 +9,6 @@ import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/config/listener/v4alpha/udp_default_writer_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/udp_default_writer_config.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package envoy.config.listener.v4alpha;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/generated_api_shadow/envoy/config/listener/v4alpha/udp_gso_batch_writer_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/udp_gso_batch_writer_config.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 package envoy.config.listener.v4alpha;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/generated_api_shadow/envoy/config/listener/v4alpha/udp_listener_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/udp_listener_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.listener.v4alpha;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/config/metrics/v4alpha/stats.proto
+++ b/generated_api_shadow/envoy/config/metrics/v4alpha/stats.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/address.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -14,7 +14,6 @@ import "envoy/type/v3/range.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";

--- a/generated_api_shadow/envoy/config/trace/v2/opencensus.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/opencensus.proto
@@ -7,7 +7,6 @@ import "envoy/api/v2/core/grpc_service.proto";
 import "opencensus/proto/trace/v1/trace_config.proto";
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v2";
 option java_outer_classname = "OpencensusProto";

--- a/generated_api_shadow/envoy/config/trace/v2/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v2/trace.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.config.trace.v2;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/config/trace/v2/datadog.proto";
 import public "envoy/config/trace/v2/dynamic_ot.proto";
 import public "envoy/config/trace/v2/http_tracer.proto";

--- a/generated_api_shadow/envoy/config/trace/v3/opencensus.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/opencensus.proto
@@ -9,7 +9,6 @@ import "opencensus/proto/trace/v1/trace_config.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";
 option java_outer_classname = "OpencensusProto";

--- a/generated_api_shadow/envoy/config/trace/v3/skywalking.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/skywalking.proto
@@ -9,7 +9,6 @@ import "google/protobuf/wrappers.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.config.trace.v3";

--- a/generated_api_shadow/envoy/config/trace/v3/trace.proto
+++ b/generated_api_shadow/envoy/config/trace/v3/trace.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.config.trace.v3;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/config/trace/v3/datadog.proto";
 import public "envoy/config/trace/v3/dynamic_ot.proto";
 import public "envoy/config/trace/v3/http_tracer.proto";

--- a/generated_api_shadow/envoy/config/trace/v4alpha/http_tracer.proto
+++ b/generated_api_shadow/envoy/config/trace/v4alpha/http_tracer.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.config.trace.v4alpha;
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/extensions/access_loggers/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/wasm/v3/wasm.proto
@@ -5,7 +5,6 @@ package envoy.extensions.access_loggers.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.access_loggers.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/generated_api_shadow/envoy/extensions/common/matching/v3/extension_matcher.proto
+++ b/generated_api_shadow/envoy/extensions/common/matching/v3/extension_matcher.proto
@@ -5,7 +5,6 @@ package envoy.extensions.common.matching.v3;
 import "envoy/config/common/matcher/v3/matcher.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/generated_api_shadow/envoy/extensions/common/tap/v3/common.proto
+++ b/generated_api_shadow/envoy/extensions/common/tap/v3/common.proto
@@ -4,7 +4,6 @@ package envoy.extensions.common.tap.v3;
 
 import "envoy/config/tap/v3/common.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/generated_api_shadow/envoy/extensions/compression/gzip/compressor/v3/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/compression/gzip/compressor/v3/gzip.proto
@@ -5,7 +5,6 @@ package envoy.extensions.compression.gzip.compressor.v3;
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.compression.gzip.compressor.v3";

--- a/generated_api_shadow/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -4,9 +4,7 @@ package envoy.extensions.compression.gzip.decompressor.v3;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.compression.gzip.decompressor.v3";

--- a/generated_api_shadow/envoy/extensions/filters/common/dependency/v3/dependency.proto
+++ b/generated_api_shadow/envoy/extensions/filters/common/dependency/v3/dependency.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.filters.common.dependency.v3;
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/generated_api_shadow/envoy/extensions/filters/common/matcher/action/v3/skip_action.proto
+++ b/generated_api_shadow/envoy/extensions/filters/common/matcher/action/v3/skip_action.proto
@@ -2,10 +2,7 @@ syntax = "proto3";
 
 package envoy.extensions.filters.common.matcher.action.v3;
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.common.matcher.action.v3";
 option java_outer_classname = "SkipActionProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/admission_control/v3alpha/admission_control.proto
@@ -5,12 +5,8 @@ package envoy.extensions.filters.http.admission_control.v3alpha;
 import "envoy/config/core/v3/base.proto";
 import "envoy/type/v3/range.proto";
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
-import "google/rpc/status.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/generated_api_shadow/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/cdn_loop/v3alpha/cdn_loop.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.filters.http.cdn_loop.v3alpha;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.cdn_loop.v3alpha";

--- a/generated_api_shadow/envoy/extensions/filters/http/compressor/v3/compressor.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/compressor/v3/compressor.proto
@@ -5,12 +5,10 @@ package envoy.extensions.filters.http.compressor.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.compressor.v3";
 option java_outer_classname = "CompressorProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/compressor/v4alpha/compressor.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/compressor/v4alpha/compressor.proto
@@ -5,12 +5,10 @@ package envoy.extensions.filters.http.compressor.v4alpha;
 import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.compressor.v4alpha";
 option java_outer_classname = "CompressorProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/decompressor/v3/decompressor.proto
@@ -5,12 +5,9 @@ package envoy.extensions.filters.http.decompressor.v3;
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.decompressor.v3";

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/extensions/filters/http/ext_authz/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -10,7 +10,6 @@ import "envoy/type/matcher/v4alpha/metadata.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 import "envoy/type/v3/http_status.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -8,7 +8,6 @@ import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.grpc_stats.v3";
 option java_outer_classname = "ConfigProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto
@@ -8,7 +8,6 @@ import "envoy/type/v3/http_status.proto";
 import "envoy/type/v3/token_bucket.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.local_ratelimit.v3";

--- a/generated_api_shadow/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
@@ -7,10 +7,7 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "envoy/type/matcher/v3/path.proto";
 
-import "google/protobuf/duration.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.oauth2.v3alpha";

--- a/generated_api_shadow/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
@@ -7,8 +7,6 @@ import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/secret.proto";
 import "envoy/type/matcher/v4alpha/path.proto";
 
-import "google/protobuf/duration.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/generated_api_shadow/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/on_demand/v3/on_demand.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.http.on_demand.v3;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.on_demand.v3";
 option java_outer_classname = "OnDemandProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/original_src/v3/original_src.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/original_src/v3/original_src.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.http.original_src.v3;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.original_src.v3";
 option java_outer_classname = "OriginalSrcProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/rbac/v3/rbac.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/rbac/v3/rbac.proto
@@ -6,7 +6,6 @@ import "envoy/config/rbac/v3/rbac.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v3";
 option java_outer_classname = "RbacProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/rbac/v4alpha/rbac.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/rbac/v4alpha/rbac.proto
@@ -6,7 +6,6 @@ import "envoy/config/rbac/v4alpha/rbac.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.rbac.v4alpha";
 option java_outer_classname = "RbacProto";

--- a/generated_api_shadow/envoy/extensions/filters/http/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/wasm/v3/wasm.proto
@@ -5,8 +5,6 @@ package envoy.extensions.filters.http.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/generated_api_shadow/envoy/extensions/filters/listener/original_src/v3/original_src.proto
+++ b/generated_api_shadow/envoy/extensions/filters/listener/original_src/v3/original_src.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.listener.original_src.v3;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.listener.original_src.v3";
 option java_outer_classname = "OriginalSrcProto";

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v4alpha:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/config/route/v4alpha:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -16,10 +16,8 @@ import "envoy/type/v3/percent.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/security.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -4,9 +4,7 @@ package envoy.extensions.filters.network.postgres_proxy.v3alpha;
 
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.postgres_proxy.v3alpha";

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.proto
@@ -4,11 +4,9 @@ package envoy.extensions.filters.network.rocketmq_proxy.v3;
 
 import "envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
@@ -7,7 +7,6 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.rocketmq_proxy.v3";

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/rocketmq_proxy.proto
@@ -4,7 +4,6 @@ package envoy.extensions.filters.network.rocketmq_proxy.v4alpha;
 
 import "envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
@@ -5,7 +5,6 @@ package envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3alpha;
 import "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3alpha";

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/thrift_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/thrift_proxy.proto
@@ -5,7 +5,6 @@ package envoy.extensions.filters.network.thrift_proxy.v4alpha;
 import "envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/extensions/filters/network/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/wasm/v3/wasm.proto
@@ -5,8 +5,6 @@ package envoy.extensions.filters.network.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.filters.network.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/generated_api_shadow/envoy/extensions/internal_redirect/allow_listed_routes/v3/allow_listed_routes_config.proto
+++ b/generated_api_shadow/envoy/extensions/internal_redirect/allow_listed_routes/v3/allow_listed_routes_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.internal_redirect.allow_listed_routes.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.internal_redirect.allow_listed_routes.v3";

--- a/generated_api_shadow/envoy/extensions/internal_redirect/previous_routes/v3/previous_routes_config.proto
+++ b/generated_api_shadow/envoy/extensions/internal_redirect/previous_routes/v3/previous_routes_config.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package envoy.extensions.internal_redirect.previous_routes.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.internal_redirect.previous_routes.v3";
 option java_outer_classname = "PreviousRoutesConfigProto";

--- a/generated_api_shadow/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
+++ b/generated_api_shadow/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 package envoy.extensions.internal_redirect.safe_cross_scheme.v3;
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.internal_redirect.safe_cross_scheme.v3";
 option java_outer_classname = "SafeCrossSchemeConfigProto";

--- a/generated_api_shadow/envoy/extensions/stat_sinks/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/stat_sinks/wasm/v3/wasm.proto
@@ -5,8 +5,6 @@ package envoy.extensions.stat_sinks.wasm.v3;
 import "envoy/extensions/wasm/v3/wasm.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.stat_sinks.wasm.v3";
 option java_outer_classname = "WasmProto";

--- a/generated_api_shadow/envoy/extensions/tracers/opencensus/v4alpha/opencensus.proto
+++ b/generated_api_shadow/envoy/extensions/tracers/opencensus/v4alpha/opencensus.proto
@@ -8,7 +8,6 @@ import "opencensus/proto/trace/v1/trace_config.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.tracers.opencensus.v4alpha";
 option java_outer_classname = "OpencensusProto";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
@@ -5,7 +5,6 @@ package envoy.extensions.transport_sockets.quic.v3;
 import "envoy/extensions/transport_sockets/tls/v3/tls.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.quic.v3";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/starttls/v3/starttls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/starttls/v3/starttls.proto
@@ -5,10 +5,7 @@ package envoy.extensions.transport_sockets.starttls.v3;
 import "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.proto";
 import "envoy/extensions/transport_sockets/tls/v3/tls.proto";
 
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.transport_sockets.starttls.v3";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/starttls/v4alpha/starttls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/starttls/v4alpha/starttls.proto
@@ -5,8 +5,6 @@ package envoy.extensions.transport_sockets.starttls.v4alpha;
 import "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/tls.proto";
 
-import "google/protobuf/wrappers.proto";
-
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/cert.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package envoy.extensions.transport_sockets.tls.v3;
 
-import "udpa/annotations/status.proto";
-
 import public "envoy/extensions/transport_sockets/tls/v3/common.proto";
 import public "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import public "envoy/extensions/transport_sockets/tls/v3/tls.proto";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/secret.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/secret.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v3/extension.proto";
 import "envoy/extensions/transport_sockets/tls/v3/common.proto";
 import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 
 import "google/protobuf/any.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "udpa/annotations/sensitive.proto";

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -6,7 +6,6 @@ import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/common.proto";
 import "envoy/extensions/transport_sockets/tls/v4alpha/secret.proto";
 
-import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/any.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.wasm.v3";

--- a/generated_api_shadow/envoy/extensions/watchdog/profile_action/v3alpha/profile_action.proto
+++ b/generated_api_shadow/envoy/extensions/watchdog/profile_action/v3alpha/profile_action.proto
@@ -5,7 +5,6 @@ package envoy.extensions.watchdog.profile_action.v3alpha;
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.watchdog.profile_action.v3alpha";

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -8,7 +8,6 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/rpc/status.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/generated_api_shadow/envoy/service/endpoint/v3/eds.proto
+++ b/generated_api_shadow/envoy/service/endpoint/v3/eds.proto
@@ -5,13 +5,10 @@ package envoy.service.endpoint.v3;
 import "envoy/service/discovery/v3/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.endpoint.v3";
 option java_outer_classname = "EdsProto";

--- a/generated_api_shadow/envoy/service/extension/v3/config_discovery.proto
+++ b/generated_api_shadow/envoy/service/extension/v3/config_discovery.proto
@@ -8,7 +8,6 @@ import "google/api/annotations.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
 
 option java_package = "io.envoyproxy.envoy.service.extension.v3";
 option java_outer_classname = "ConfigDiscoveryProto";

--- a/generated_api_shadow/envoy/service/health/v3/hds.proto
+++ b/generated_api_shadow/envoy/service/health/v3/hds.proto
@@ -10,7 +10,6 @@ import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 

--- a/generated_api_shadow/envoy/service/listener/v3/lds.proto
+++ b/generated_api_shadow/envoy/service/listener/v3/lds.proto
@@ -5,13 +5,10 @@ package envoy.service.listener.v3;
 import "envoy/service/discovery/v3/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.listener.v3";
 option java_outer_classname = "LdsProto";

--- a/generated_api_shadow/envoy/service/load_stats/v2/lrs.proto
+++ b/generated_api_shadow/envoy/service/load_stats/v2/lrs.proto
@@ -8,7 +8,6 @@ import "envoy/api/v2/endpoint/load_report.proto";
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.load_stats.v2";
 option java_outer_classname = "LrsProto";

--- a/generated_api_shadow/envoy/service/load_stats/v3/lrs.proto
+++ b/generated_api_shadow/envoy/service/load_stats/v3/lrs.proto
@@ -9,7 +9,6 @@ import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.load_stats.v3";
 option java_outer_classname = "LrsProto";

--- a/generated_api_shadow/envoy/service/load_stats/v4alpha/lrs.proto
+++ b/generated_api_shadow/envoy/service/load_stats/v4alpha/lrs.proto
@@ -9,7 +9,6 @@ import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.load_stats.v4alpha";
 option java_outer_classname = "LrsProto";

--- a/generated_api_shadow/envoy/service/ratelimit/v2/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v2/rls.proto
@@ -7,7 +7,6 @@ import "envoy/api/v2/ratelimit/ratelimit.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.ratelimit.v2";
 option java_outer_classname = "RlsProto";

--- a/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
+++ b/generated_api_shadow/envoy/service/ratelimit/v3/rls.proto
@@ -10,7 +10,6 @@ import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.ratelimit.v3";
 option java_outer_classname = "RlsProto";

--- a/generated_api_shadow/envoy/service/route/v3/rds.proto
+++ b/generated_api_shadow/envoy/service/route/v3/rds.proto
@@ -5,12 +5,10 @@ package envoy.service.route.v3;
 import "envoy/service/discovery/v3/discovery.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/resource.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.service.route.v3";
 option java_outer_classname = "RdsProto";

--- a/generated_api_shadow/envoy/service/status/v2/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v2/csds.proto
@@ -7,7 +7,6 @@ import "envoy/api/v2/core/base.proto";
 import "envoy/type/matcher/node.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 

--- a/generated_api_shadow/envoy/service/status/v3/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v3/csds.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/type/matcher/v3/node.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
+++ b/generated_api_shadow/envoy/service/status/v4alpha/csds.proto
@@ -7,7 +7,6 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/type/matcher/v4alpha/node.proto";
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";

--- a/generated_api_shadow/envoy/service/trace/v2/trace_service.proto
+++ b/generated_api_shadow/envoy/service/trace/v2/trace_service.proto
@@ -4,8 +4,6 @@ package envoy.service.trace.v2;
 
 import "envoy/api/v2/core/base.proto";
 
-import "google/api/annotations.proto";
-
 import "opencensus/proto/trace/v1/trace.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/service/trace/v3/trace_service.proto
+++ b/generated_api_shadow/envoy/service/trace/v3/trace_service.proto
@@ -4,8 +4,6 @@ package envoy.service.trace.v3;
 
 import "envoy/config/core/v3/base.proto";
 
-import "google/api/annotations.proto";
-
 import "opencensus/proto/trace/v1/trace.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/service/trace/v4alpha/trace_service.proto
+++ b/generated_api_shadow/envoy/service/trace/v4alpha/trace_service.proto
@@ -4,8 +4,6 @@ package envoy.service.trace.v4alpha;
 
 import "envoy/config/core/v4alpha/base.proto";
 
-import "google/api/annotations.proto";
-
 import "opencensus/proto/trace/v1/trace.proto";
 
 import "udpa/annotations/status.proto";

--- a/generated_api_shadow/envoy/type/matcher/v3/http_inputs.proto
+++ b/generated_api_shadow/envoy/type/matcher/v3/http_inputs.proto
@@ -2,10 +2,7 @@ syntax = "proto3";
 
 package envoy.type.matcher.v3;
 
-import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher.v3";
 option java_outer_classname = "HttpInputsProto";

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/BUILD
@@ -6,7 +6,6 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
-        "//envoy/annotations:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/http_inputs.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/http_inputs.proto
@@ -4,7 +4,6 @@ package envoy.type.matcher.v4alpha;
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.type.matcher.v4alpha";
 option java_outer_classname = "HttpInputsProto";

--- a/generated_api_shadow/envoy/type/matcher/v4alpha/string.proto
+++ b/generated_api_shadow/envoy/type/matcher/v4alpha/string.proto
@@ -4,7 +4,6 @@ package envoy.type.matcher.v4alpha;
 
 import "envoy/type/matcher/v4alpha/regex.proto";
 
-import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";

--- a/generated_api_shadow/envoy/watchdog/v3alpha/abort_action.proto
+++ b/generated_api_shadow/envoy/watchdog/v3alpha/abort_action.proto
@@ -5,8 +5,6 @@ package envoy.watchdog.v3alpha;
 import "google/protobuf/duration.proto";
 
 import "udpa/annotations/status.proto";
-import "udpa/annotations/versioning.proto";
-import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.watchdog.v3alpha";
 option java_outer_classname = "AbortActionProto";

--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
         "//source/common/http:headers_lib",
         "//source/common/protobuf",
         "//source/extensions/filters/http:well_known_names",
+        "@com_google_googleapis//google/api:http_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -13,6 +13,7 @@
 
 #include "extensions/filters/http/grpc_json_transcoder/transcoder_input_stream_impl.h"
 
+#include "google/api/http.pb.h"
 #include "grpc_transcoding/path_matcher.h"
 #include "grpc_transcoding/request_message_translator.h"
 #include "grpc_transcoding/transcoder.h"

--- a/tools/proto_format/proto_format.sh
+++ b/tools/proto_format/proto_format.sh
@@ -58,7 +58,7 @@ export PYTHONPATH="$TOOLS"
 # Build protoprint and merge_active_shadow_tools for use in proto_sync.py.
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/protoxform:protoprint //tools/protoxform:merge_active_shadow
 
-# Copy back the FileDescriptorProtos that protoxform emittted to the source tree. This involves
+# Copy back the FileDescriptorProtos that protoxform emitted to the source tree. This involves
 # pretty-printing to format with protoprint and potentially merging active/shadow versions of protos
 # with merge_active_shadow.
 ./tools/proto_format/proto_sync.py "--mode=${PROTO_SYNC_CMD}" "${PROTO_TARGETS[@]}"

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -3,7 +3,7 @@
 # 1. Take protoxform artifacts from Bazel cache and pretty-print with protoprint.py.
 # 2. In the case where we are generating an Envoy internal shadow, it may be
 #    necessary to combine the current active proto, subject to hand editing, with
-#    shadow artifacts from the previous verion; this is done via
+#    shadow artifacts from the previous version; this is done via
 #    merge_active_shadow.py.
 # 3. Diff or copy resulting artifacts to the source tree.
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: api: fix unused proto import warnings
Additional Description:  Fixing "warning: Import ... but not used" warnings from protoc
Risk Level: Low
Testing: manually built protos
Docs Changes: None
Release Notes: None
