### PR TITLE
ext_authz: Add matchers to skip buffering based on request headers

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/ext_authz/v2:pkg",
+        "//envoy/config/route/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -6,6 +6,7 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/core/v3/http_uri.proto";
+import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
@@ -158,6 +159,9 @@ message BufferSettings {
   // body<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
   // with UTF-8 string request body.
   bool pack_as_bytes = 3;
+
+  // Any request that matches any of the provided matchers will skip request body buffering.
+  repeated config.route.v3.HeaderMatcher skip_buffering_matchers = 4;
 }
 
 // HttpService is used for raw HTTP communication between the filter and the authorization service.

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/core/v4alpha:pkg",
+        "//envoy/config/route/v4alpha:pkg",
         "//envoy/extensions/filters/http/ext_authz/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -6,6 +6,7 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/core/v4alpha/grpc_service.proto";
 import "envoy/config/core/v4alpha/http_uri.proto";
+import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 import "envoy/type/v3/http_status.proto";
 
@@ -158,6 +159,9 @@ message BufferSettings {
   // body<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
   // with UTF-8 string request body.
   bool pack_as_bytes = 3;
+
+  // Any request that matches any of the provided matchers will skip request body buffering.
+  repeated config.route.v4alpha.HeaderMatcher skip_buffering_matchers = 4;
 }
 
 // HttpService is used for raw HTTP communication between the filter and the authorization service.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -26,6 +26,7 @@ Minor Behavior Changes
   This behavior can be reverted by setting runtime feature ``envoy.reloadable_features.ext_authz_measure_timeout_on_check_created`` to false. When enabled, a new `ext_authz.timeout` stat is counted when timeout occurs. See :ref:`stats
   // <config_http_filters_ext_authz_stats>`.
 * ext_authz_filter: added :ref:`disable_request_body_buffering <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>` to disable request data buffering per-route.
+* ext_authz_filter: added :ref:`skip_buffering_matchers <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.BufferSettings.skip_buffering_matchers>` to disable request data buffering based on request headers matching.
 * http: added :ref:`contains <envoy_api_msg_type.matcher.StringMatcher>` a new string matcher type which matches if the value of the string has the substring mentioned in contains matcher.
 * http: added :ref:`contains <envoy_api_msg_route.HeaderMatcher>` a new header matcher type which matches if the value of the header has the substring mentioned in contains matcher.
 * http: added :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to local replies.

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/BUILD
@@ -9,6 +9,7 @@ api_proto_package(
         "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/http/ext_authz/v2:pkg",
+        "//envoy/config/route/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -6,6 +6,7 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 import "envoy/config/core/v3/http_uri.proto";
+import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/http_status.proto";
 
@@ -157,6 +158,9 @@ message BufferSettings {
   // body<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
   // with UTF-8 string request body.
   bool pack_as_bytes = 3;
+
+  // Any request that matches any of the provided matchers will skip request body buffering.
+  repeated config.route.v3.HeaderMatcher skip_buffering_matchers = 4;
 }
 
 // HttpService is used for raw HTTP communication between the filter and the authorization service.

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/core/v4alpha:pkg",
+        "//envoy/config/route/v4alpha:pkg",
         "//envoy/extensions/filters/http/ext_authz/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -6,6 +6,7 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/core/v4alpha/config_source.proto";
 import "envoy/config/core/v4alpha/grpc_service.proto";
 import "envoy/config/core/v4alpha/http_uri.proto";
+import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 import "envoy/type/v3/http_status.proto";
 
@@ -158,6 +159,9 @@ message BufferSettings {
   // body<envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.body>` will be filled
   // with UTF-8 string request body.
   bool pack_as_bytes = 3;
+
+  // Any request that matches any of the provided matchers will skip request body buffering.
+  repeated config.route.v4alpha.HeaderMatcher skip_buffering_matchers = 4;
 }
 
 // HttpService is used for raw HTTP communication between the filter and the authorization service.

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -185,6 +185,21 @@ public:
    * @brief Remove the port part from host/authority header if it is equal to provided port
    */
   static void stripPortFromHost(RequestHeaderMap& headers, uint32_t listener_port);
+
+  /**
+   * Builds a list of header matchers from matcher protos.
+   * @param matcher_protos the matcher protos.
+   * @return std::vector<Http::HeaderUtility::HeaderData> a list of header matchers.
+   */
+  template <class T>
+  static std::vector<Http::HeaderUtility::HeaderData> buildHeaderMatchers(const T& matcher_protos) {
+    std::vector<Http::HeaderUtility::HeaderData> matchers;
+    matchers.reserve(matcher_protos.size());
+    for (const auto& proto : matcher_protos) {
+      matchers.emplace_back(proto);
+    }
+    return matchers;
+  }
 };
 } // namespace Http
 } // namespace Envoy

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -41,7 +41,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/filters/http/dynamic_forward_proxy:94.9"
 "source/extensions/filters/http/ip_tagging:91.2"
 "source/extensions/filters/http/grpc_json_transcoder:93.3"
-"source/extensions/filters/http/oauth2:96.5"
+"source/extensions/filters/http/oauth2:96.4"
 "source/extensions/filters/listener:96.0"
 "source/extensions/filters/listener/tls_inspector:92.4"
 "source/extensions/filters/listener/http_inspector:93.3"


### PR DESCRIPTION
Commit Message: This patch adds the `skip_buffering_matchers` field to BufferSettings to skip request body buffering controlled by request headers matching. A sample use-case for this is to skip request body buffering when uploading data, which content-type is `multipart/form-data`.
Additional description: https://github.com/envoyproxy/envoy/issues/9822#issuecomment-696785057 cc. @klarose 

Risk Level: Low
Testing: Added
Docs Changes: Updated
Release Notes: Added

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>

