### PR TITLE
Adds block property to socket io results

### DIFF
--- a/include/envoy/event/file_event.h
+++ b/include/envoy/event/file_event.h
@@ -53,6 +53,11 @@ public:
    * registered events and fire callbacks when they are active.
    */
   virtual void setEnabled(uint32_t events) PURE;
+
+  /**
+   * Gets the currently enabled events.
+   */
+  virtual uint32_t getEnabled() PURE;
 };
 
 using FileEventPtr = std::unique_ptr<FileEvent>;

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -33,6 +33,11 @@ struct IoResult {
    * can only be true for read operations.
    */
   bool end_stream_read_;
+
+  /**
+   * True if the I/O call blocked.
+   */
+  bool didBlock_;
 };
 
 /**

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -35,9 +35,9 @@ struct IoResult {
   bool end_stream_read_;
 
   /**
-   * True if the I/O call blocked.
+   * True if the I/O call would block.
    */
-  bool didBlock_;
+  bool would_block;
 };
 
 /**

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -13,7 +13,7 @@ namespace Event {
 
 FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, os_fd_t fd, FileReadyCb cb,
                              FileTriggerType trigger, uint32_t events)
-    : cb_(cb), fd_(fd), trigger_(trigger),
+    : cb_(cb), fd_(fd), trigger_(trigger), events_(events),
       activate_fd_events_next_event_loop_(
           // Only read the runtime feature if the runtime loader singleton has already been created.
           // Attempts to access runtime features too early in the initialization sequence triggers
@@ -122,6 +122,7 @@ void FileEventImpl::setEnabled(uint32_t events) {
   event_del(&raw_event_);
   assignEvents(events, base);
   event_add(&raw_event_, nullptr);
+  events_ = events;
 }
 
 void FileEventImpl::mergeInjectedEventsAndRunCb(uint32_t events) {

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -22,6 +22,7 @@ public:
   // Event::FileEvent
   void activate(uint32_t events) override;
   void setEnabled(uint32_t events) override;
+  uint32_t getEnabled() override { return events_; }
 
 private:
   void assignEvents(uint32_t events, event_base* base);
@@ -30,6 +31,8 @@ private:
   FileReadyCb cb_;
   os_fd_t fd_;
   FileTriggerType trigger_;
+  // Enabled events for this fd.
+  uint32_t events_;
 
   // Injected FileReadyType events that were scheduled by recent calls to activate() and are pending
   // delivery.

--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -16,7 +16,7 @@ void RawBufferSocket::setTransportSocketCallbacks(TransportSocketCallbacks& call
 IoResult RawBufferSocket::doRead(Buffer::Instance& buffer) {
   PostIoAction action = PostIoAction::KeepOpen;
   uint64_t bytes_read = 0;
-  bool didBlock = true;
+  bool didBlock = false;
   bool end_stream = false;
   do {
     // 16K read is arbitrary. TODO(mattklein123) PERF: Tune the read size.

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -34,7 +34,8 @@ Network::IoResult UpstreamProxyProtocolSocket::doWrite(Buffer::Instance& buffer,
     auto header_res = writeHeader();
     if (header_buffer_.length() == 0 && header_res.action_ == Network::PostIoAction::KeepOpen) {
       auto inner_res = transport_socket_->doWrite(buffer, end_stream);
-      return {inner_res.action_, header_res.bytes_processed_ + inner_res.bytes_processed_, false, false};
+      return {inner_res.action_, header_res.bytes_processed_ + inner_res.bytes_processed_, false,
+              false};
     }
     return header_res;
   } else {

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -94,6 +94,7 @@ Network::IoResult UpstreamProxyProtocolSocket::writeHeader() {
                      result.err_->getErrorDetails());
       if (result.err_->getErrorCode() != Api::IoError::IoErrorCode::Again) {
         action = Network::PostIoAction::Close;
+      } else {
         didBlock = true;
       }
       break;

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -78,7 +78,7 @@ void UpstreamProxyProtocolSocket::generateHeaderV2() {
 Network::IoResult UpstreamProxyProtocolSocket::writeHeader() {
   Network::PostIoAction action = Network::PostIoAction::KeepOpen;
   uint64_t bytes_written = 0;
-  bool didBlock = false;
+  bool wouldBlock = false;
   do {
     if (header_buffer_.length() == 0) {
       break;
@@ -95,13 +95,13 @@ Network::IoResult UpstreamProxyProtocolSocket::writeHeader() {
       if (result.err_->getErrorCode() != Api::IoError::IoErrorCode::Again) {
         action = Network::PostIoAction::Close;
       } else {
-        didBlock = true;
+        wouldBlock = true;
       }
       break;
     }
   } while (true);
 
-  return {action, bytes_written, false, didBlock};
+  return {action, bytes_written, false, wouldBlock};
 }
 
 } // namespace ProxyProtocol

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -149,6 +149,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
         case SSL_ERROR_WANT_WRITE:
           // Renegotiation has started. We don't handle renegotiation so just fall through.
           wouldBlock = true;
+          break;
         default:
           drainErrorQueue();
           action = PostIoAction::Close;
@@ -268,9 +269,10 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       case SSL_ERROR_WANT_READ:
         // Renegotiation has started. We don't handle renegotiation so just fall through.
         wouldBlock = true;
+        break;
       default:
         drainErrorQueue();
-        return {PostIoAction::Close, total_bytes_written, false, false};
+        return {PostIoAction::Close, total_bytes_written, false, wouldBlock};
       }
 
       break;

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -322,15 +322,19 @@ TEST_F(FileEventImplTest, SetEnabled) {
       trigger, FileReadyType::Read | FileReadyType::Write);
 
   file_event->setEnabled(FileReadyType::Read);
+  EXPECT_EQUAL(file_event->getEnabled(), FileReadyType::Read);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file_event->setEnabled(FileReadyType::Write);
+  EXPECT_EQUAL(file_event->getEnabled(), FileReadyType::Write);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file_event->setEnabled(0);
+  EXPECT_EQUAL(file_event->getEnabled(), 0);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file_event->setEnabled(FileReadyType::Read | FileReadyType::Write);
+  EXPECT_EQUAL(file_event->getEnabled(), FileReadyType::Read | FileReadyType::Write);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 }
 

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -322,19 +322,19 @@ TEST_F(FileEventImplTest, SetEnabled) {
       trigger, FileReadyType::Read | FileReadyType::Write);
 
   file_event->setEnabled(FileReadyType::Read);
-  EXPECT_EQUAL(file_event->getEnabled(), FileReadyType::Read);
+  EXPECT_TRUE(file_event->getEnabled() == FileReadyType::Read);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file_event->setEnabled(FileReadyType::Write);
-  EXPECT_EQUAL(file_event->getEnabled(), FileReadyType::Write);
+  EXPECT_TRUE(file_event->getEnabled() == FileReadyType::Write);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file_event->setEnabled(0);
-  EXPECT_EQUAL(file_event->getEnabled(), 0);
+  EXPECT_TRUE(file_event->getEnabled() == 0);
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 
   file_event->setEnabled(FileReadyType::Read | FileReadyType::Write);
-  EXPECT_EQUAL(file_event->getEnabled(), FileReadyType::Read | FileReadyType::Write);
+  EXPECT_TRUE(file_event->getEnabled() == (FileReadyType::Read | FileReadyType::Write));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
 }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1744,7 +1744,7 @@ public:
 
   // This may be invoked for doWrite() on the transport to simulate all the data
   // being written.
-  static IoResult SimulateSuccessfulWrite(Buffer::Instance& buffer, bool) {
+  static IoResult simulateSuccessfulWrite(Buffer::Instance& buffer, bool) {
     uint64_t size = buffer.length();
     buffer.drain(size);
     return {PostIoAction::KeepOpen, size, false, false};
@@ -1862,7 +1862,7 @@ TEST_F(MockTransportConnectionImplTest, FullCloseWrite) {
   Buffer::OwnedImpl buffer(val);
   EXPECT_CALL(*file_event_, activate(Event::FileReadyType::Write)).WillOnce(Invoke(file_ready_cb_));
   EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
-      .WillOnce(Invoke(SimulateSuccessfulWrite));
+      .WillOnce(Invoke(simulateSuccessfulWrite));
   connection_->write(buffer, false);
 }
 
@@ -1875,10 +1875,10 @@ TEST_F(MockTransportConnectionImplTest, HalfCloseWrite) {
   const std::string val("some data");
   Buffer::OwnedImpl buffer(val);
   EXPECT_CALL(*transport_socket_, doWrite(BufferStringEqual(val), false))
-      .WillOnce(Invoke(SimulateSuccessfulWrite));
+      .WillOnce(Invoke(simulateSuccessfulWrite));
   connection_->write(buffer, false);
 
-  EXPECT_CALL(*transport_socket_, doWrite(_, true)).WillOnce(Invoke(SimulateSuccessfulWrite));
+  EXPECT_CALL(*transport_socket_, doWrite(_, true)).WillOnce(Invoke(simulateSuccessfulWrite));
   connection_->write(buffer, true);
 }
 
@@ -1951,7 +1951,7 @@ TEST_F(MockTransportConnectionImplTest, BothHalfCloseWritesNotFlushedWriteFirst)
   file_ready_cb_(Event::FileReadyType::Read);
 
   EXPECT_CALL(callbacks_, onEvent(ConnectionEvent::LocalClose));
-  EXPECT_CALL(*transport_socket_, doWrite(_, true)).WillOnce(Invoke(SimulateSuccessfulWrite));
+  EXPECT_CALL(*transport_socket_, doWrite(_, true)).WillOnce(Invoke(simulateSuccessfulWrite));
   file_ready_cb_(Event::FileReadyType::Write);
 }
 

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -41,6 +41,7 @@ public:
 class FastMockFileEvent : public Event::FileEvent {
   void activate(uint32_t) override {}
   void setEnabled(uint32_t) override {}
+  uint32_t getEnabled() override { return 0; }
 };
 
 class FastMockDispatcher : public Event::MockDispatcher {

--- a/test/extensions/transport_sockets/alts/tsi_socket_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_socket_test.cc
@@ -64,26 +64,28 @@ protected:
 
     ON_CALL(*client_.raw_socket_, doWrite(_, _))
         .WillByDefault(Invoke([&](Buffer::Instance& buffer, bool) {
-          Network::IoResult result = {Network::PostIoAction::KeepOpen, buffer.length(), false};
+          Network::IoResult result = {Network::PostIoAction::KeepOpen, buffer.length(), false,
+                                      false};
           client_to_server_.move(buffer);
           return result;
         }));
     ON_CALL(*server_.raw_socket_, doWrite(_, _))
         .WillByDefault(Invoke([&](Buffer::Instance& buffer, bool) {
-          Network::IoResult result = {Network::PostIoAction::KeepOpen, buffer.length(), false};
+          Network::IoResult result = {Network::PostIoAction::KeepOpen, buffer.length(), false,
+                                      false};
           server_to_client_.move(buffer);
           return result;
         }));
 
     ON_CALL(*client_.raw_socket_, doRead(_)).WillByDefault(Invoke([&](Buffer::Instance& buffer) {
       Network::IoResult result = {Network::PostIoAction::KeepOpen, server_to_client_.length(),
-                                  false};
+                                  false, false};
       buffer.move(server_to_client_);
       return result;
     }));
     ON_CALL(*server_.raw_socket_, doRead(_)).WillByDefault(Invoke([&](Buffer::Instance& buffer) {
       Network::IoResult result = {Network::PostIoAction::KeepOpen, client_to_server_.length(),
-                                  false};
+                                  false, false};
       buffer.move(client_to_server_);
       return result;
     }));
@@ -118,13 +120,13 @@ protected:
   void doFakeInitHandshake() {
     EXPECT_CALL(*client_.raw_socket_, doWrite(_, false));
     client_.tsi_socket_->onConnected();
-    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                    client_.tsi_socket_->doWrite(client_.write_buffer_, false));
     EXPECT_EQ(makeFakeTsiFrame("CLIENT_INIT"), client_to_server_.toString());
 
     EXPECT_CALL(*server_.raw_socket_, doRead(_));
     EXPECT_CALL(*server_.raw_socket_, doWrite(_, false));
-    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                    server_.tsi_socket_->doRead(server_.read_buffer_));
     EXPECT_EQ(makeFakeTsiFrame("SERVER_INIT"), server_to_client_.toString());
     EXPECT_EQ(0L, server_.read_buffer_.length());
@@ -135,7 +137,7 @@ protected:
 
     EXPECT_CALL(*client_.raw_socket_, doRead(_));
     EXPECT_CALL(*client_.raw_socket_, doWrite(_, false));
-    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                    client_.tsi_socket_->doRead(client_.read_buffer_));
     EXPECT_EQ(makeFakeTsiFrame("CLIENT_FINISHED"), client_to_server_.toString());
     EXPECT_EQ(0L, client_.read_buffer_.length());
@@ -143,13 +145,13 @@ protected:
     EXPECT_CALL(*server_.raw_socket_, doRead(_));
     EXPECT_CALL(*server_.raw_socket_, doWrite(_, false));
     EXPECT_CALL(server_.callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
-    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                    server_.tsi_socket_->doRead(server_.read_buffer_));
     EXPECT_EQ(makeFakeTsiFrame("SERVER_FINISHED"), server_to_client_.toString());
 
     EXPECT_CALL(*client_.raw_socket_, doRead(_));
     EXPECT_CALL(client_.callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
-    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                    client_.tsi_socket_->doRead(client_.read_buffer_));
   }
 
@@ -161,12 +163,12 @@ protected:
     EXPECT_EQ("", client_.tsi_socket_->protocol());
 
     EXPECT_CALL(*client_.raw_socket_, doWrite(_, false));
-    expectIoResult({Network::PostIoAction::KeepOpen, 21UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 21UL, false, false},
                    client_.tsi_socket_->doWrite(client_.write_buffer_, false));
     EXPECT_EQ(makeFakeTsiFrame(data), client_to_server_.toString());
 
     EXPECT_CALL(*server_.raw_socket_, doRead(_));
-    expectIoResult({Network::PostIoAction::KeepOpen, 21UL, false},
+    expectIoResult({Network::PostIoAction::KeepOpen, 21UL, false, false},
                    server_.tsi_socket_->doRead(server_.read_buffer_));
     EXPECT_EQ(data, server_.read_buffer_.toString());
   }
@@ -229,7 +231,7 @@ TEST_F(TsiSocketTest, HandshakeValidationFail) {
 
   EXPECT_CALL(*client_.raw_socket_, doRead(_));
   EXPECT_CALL(*client_.raw_socket_, doWrite(_, false));
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
   EXPECT_EQ(makeFakeTsiFrame("CLIENT_FINISHED"), client_to_server_.toString());
   EXPECT_EQ(0L, client_.read_buffer_.length());
@@ -237,7 +239,7 @@ TEST_F(TsiSocketTest, HandshakeValidationFail) {
   EXPECT_CALL(*server_.raw_socket_, doRead(_));
   EXPECT_CALL(server_.callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   // doRead won't immediately fail, but it will result connection close.
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  server_.tsi_socket_->doRead(server_.read_buffer_));
   EXPECT_EQ(0, server_to_client_.length());
 }
@@ -252,13 +254,13 @@ TEST_F(TsiSocketTest, HandshakerCreationFail) {
   EXPECT_CALL(*client_.raw_socket_, doWrite(_, _)).Times(0);
   EXPECT_CALL(client_.callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   client_.tsi_socket_->onConnected();
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doWrite(client_.write_buffer_, false));
   EXPECT_EQ("", client_to_server_.toString());
 
   EXPECT_CALL(*server_.raw_socket_, doRead(_));
   EXPECT_CALL(*server_.raw_socket_, doWrite(_, _)).Times(0);
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  server_.tsi_socket_->doRead(server_.read_buffer_));
   EXPECT_EQ("", server_to_client_.toString());
 }
@@ -269,7 +271,7 @@ TEST_F(TsiSocketTest, HandshakeWithUnusedData) {
   doFakeInitHandshake();
   EXPECT_CALL(*client_.raw_socket_, doRead(_));
   EXPECT_CALL(*client_.raw_socket_, doWrite(_, false));
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
   EXPECT_EQ(makeFakeTsiFrame("CLIENT_FINISHED"), client_to_server_.toString());
   EXPECT_EQ(0L, client_.read_buffer_.length());
@@ -280,14 +282,14 @@ TEST_F(TsiSocketTest, HandshakeWithUnusedData) {
   EXPECT_CALL(*server_.raw_socket_, doRead(_));
   EXPECT_CALL(*server_.raw_socket_, doWrite(_, false));
   EXPECT_CALL(server_.callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
-  expectIoResult({Network::PostIoAction::KeepOpen, 21UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 21UL, false, false},
                  server_.tsi_socket_->doRead(server_.read_buffer_));
   EXPECT_EQ(makeFakeTsiFrame("SERVER_FINISHED"), server_to_client_.toString());
   EXPECT_EQ(ClientToServerData, server_.read_buffer_.toString());
 
   EXPECT_CALL(*client_.raw_socket_, doRead(_));
   EXPECT_CALL(client_.callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
 }
 
@@ -297,7 +299,7 @@ TEST_F(TsiSocketTest, HandshakeWithUnusedDataAndEndOfStream) {
   doFakeInitHandshake();
   EXPECT_CALL(*client_.raw_socket_, doRead(_));
   EXPECT_CALL(*client_.raw_socket_, doWrite(_, false));
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
   EXPECT_EQ(makeFakeTsiFrame("CLIENT_FINISHED"), client_to_server_.toString());
   EXPECT_EQ(0L, client_.read_buffer_.length());
@@ -306,20 +308,21 @@ TEST_F(TsiSocketTest, HandshakeWithUnusedDataAndEndOfStream) {
   client_to_server_.add(makeFakeTsiFrame(ClientToServerData));
 
   EXPECT_CALL(*server_.raw_socket_, doRead(_)).WillOnce(Invoke([&](Buffer::Instance& buffer) {
-    Network::IoResult result = {Network::PostIoAction::KeepOpen, client_to_server_.length(), true};
+    Network::IoResult result = {Network::PostIoAction::KeepOpen, client_to_server_.length(), true,
+                                false};
     buffer.move(client_to_server_);
     return result;
   }));
   EXPECT_CALL(*server_.raw_socket_, doWrite(_, false));
   EXPECT_CALL(server_.callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
-  expectIoResult({Network::PostIoAction::KeepOpen, 21UL, true},
+  expectIoResult({Network::PostIoAction::KeepOpen, 21UL, true, false},
                  server_.tsi_socket_->doRead(server_.read_buffer_));
   EXPECT_EQ(makeFakeTsiFrame("SERVER_FINISHED"), server_to_client_.toString());
   EXPECT_EQ(ClientToServerData, server_.read_buffer_.toString());
 
   EXPECT_CALL(*client_.raw_socket_, doRead(_));
   EXPECT_CALL(client_.callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
 }
 
@@ -327,12 +330,13 @@ TEST_F(TsiSocketTest, HandshakeWithImmediateReadError) {
   initialize(nullptr, nullptr);
 
   EXPECT_CALL(*client_.raw_socket_, doRead(_)).WillOnce(Invoke([&](Buffer::Instance& buffer) {
-    Network::IoResult result = {Network::PostIoAction::Close, server_to_client_.length(), false};
+    Network::IoResult result = {Network::PostIoAction::Close, server_to_client_.length(), false,
+                                false};
     buffer.move(server_to_client_);
     return result;
   }));
   EXPECT_CALL(*client_.raw_socket_, doWrite(_, false)).Times(0);
-  expectIoResult({Network::PostIoAction::Close, 0UL, false},
+  expectIoResult({Network::PostIoAction::Close, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
   EXPECT_EQ("", client_to_server_.toString());
   EXPECT_EQ(0L, client_.read_buffer_.length());
@@ -344,13 +348,14 @@ TEST_F(TsiSocketTest, HandshakeWithReadError) {
   doFakeInitHandshake();
 
   EXPECT_CALL(*client_.raw_socket_, doRead(_)).WillOnce(Invoke([&](Buffer::Instance& buffer) {
-    Network::IoResult result = {Network::PostIoAction::Close, server_to_client_.length(), false};
+    Network::IoResult result = {Network::PostIoAction::Close, server_to_client_.length(), false,
+                                false};
     buffer.move(server_to_client_);
     return result;
   }));
   EXPECT_CALL(*client_.raw_socket_, doWrite(_, false)).Times(0);
   EXPECT_CALL(client_.callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
-  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false},
+  expectIoResult({Network::PostIoAction::KeepOpen, 0UL, false, false},
                  client_.tsi_socket_->doRead(client_.read_buffer_));
   EXPECT_EQ("", client_to_server_.toString());
   EXPECT_EQ(0L, client_.read_buffer_.length());

--- a/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_test.cc
@@ -97,9 +97,11 @@ TEST_F(ProxyProtocolTest, BytesProcessedIncludesProxyProtocolHeader) {
   {
     InSequence s;
     EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false))
-        .WillOnce(Return(Network::IoResult{Network::PostIoAction::KeepOpen, msg.length(), false}));
+        .WillOnce(
+            Return(Network::IoResult{Network::PostIoAction::KeepOpen, msg.length(), false, false}));
     EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg2), false))
-        .WillOnce(Return(Network::IoResult{Network::PostIoAction::KeepOpen, msg2.length(), false}));
+        .WillOnce(Return(
+            Network::IoResult{Network::PostIoAction::KeepOpen, msg2.length(), false, false}));
   }
 
   auto resp = proxy_protocol_socket_->doWrite(msg, false);
@@ -131,7 +133,8 @@ TEST_F(ProxyProtocolTest, ReturnsKeepOpenWhenWriteErrorIsAgain) {
         .WillOnce(Return(testing::ByMove(Api::IoCallUint64Result(
             expected_buff.length(), Api::IoErrorPtr(nullptr, [](Api::IoError*) {})))));
     EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false))
-        .WillOnce(Return(Network::IoResult{Network::PostIoAction::KeepOpen, msg.length(), false}));
+        .WillOnce(
+            Return(Network::IoResult{Network::PostIoAction::KeepOpen, msg.length(), false, false}));
   }
 
   auto resp = proxy_protocol_socket_->doWrite(msg, false);

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -216,6 +216,7 @@ public:
 
   MOCK_METHOD(void, activate, (uint32_t events));
   MOCK_METHOD(void, setEnabled, (uint32_t events));
+  MOCK_METHOD(uint32_t, getEnabled, ());
 };
 
 } // namespace Event


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

In preparation for #13189 we add the following functionality to the internal API:
1. `getEnabled ` to `file_event.h` which returns the active events in a file event. This is useful to 
2. `didBlock` to `IoResult` to know if the last I/O call blocked.

Risk Level: Low
Testing: Tests
Docs Changes: N/A
Release Notes: N/A
