### PR TITLE
reverse bridge: use local reply instead of ContinueAndEndStream

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -26,6 +26,7 @@ Minor Behavior Changes
   This behavior can be reverted by setting runtime feature ``envoy.reloadable_features.ext_authz_measure_timeout_on_check_created`` to false. When enabled, a new `ext_authz.timeout` stat is counted when timeout occurs. See :ref:`stats
   // <config_http_filters_ext_authz_stats>`.
 * ext_authz_filter: added :ref:`disable_request_body_buffering <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.disable_request_body_buffering>` to disable request data buffering per-route.
+* grpc reverse bridge: upstream headers will no longer be propagated when the response is missing or contains an unexpected content-type.
 * http: added :ref:`contains <envoy_api_msg_type.matcher.StringMatcher>` a new string matcher type which matches if the value of the string has the substring mentioned in contains matcher.
 * http: added :ref:`contains <envoy_api_msg_route.HeaderMatcher>` a new header matcher type which matches if the value of the header has the substring mentioned in contains matcher.
 * http: added :ref:`headers_to_add <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.ResponseMapper.headers_to_add>` to :ref:`local reply mapper <config_http_conn_man_local_reply>` to allow its users to add/append/override response HTTP headers to local replies.


### PR DESCRIPTION
Instead of returning ContinueAndEndStream we can respond with a local
reply. This removes the only use case of ContinueAndEndStream in
non-test code.

Take two after https://github.com/envoyproxy/envoy/commit/fb7bdbe45cc04ef504b1092f037b45a45cad2714 has landed with the fix + regression test for this change.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Existing integration test, updated UTs
Docs Changes: n/a
Release Notes: Release note added
