### PR TITLE
governance: clean up release instructions

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -137,10 +137,7 @@ Deprecated
 ----------
 ```
 * Run the deprecate_versions.py script (e.g. `sh tools/deprecate_version/deprecate_version.sh`)
-  to file tracking issues for code which can be removed.
-* Run the deprecate_features.py script (e.g. `sh tools/deprecate_features/deprecate_features.sh`)
-  to make the last release's deprecated features fatal-by-default. Submit the resultant PR and send
-  an email to envoy-announce.
+  to file tracking issues for runtime guarded code which can be removed.
 * Check source/common/runtime/runtime_features.cc and see if any runtime guards in
   disabled_runtime_features should be reassessed, and ping on the relevant issues.
 


### PR DESCRIPTION
Removing a deprecated (see what I did there?) step.

Risk Level: n/a
Testing: n/a
Docs Changes: yes
Release Notes: no
