### PR TITLE
perf: avoiding string view copies

### DIFF
--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier.cc
@@ -35,7 +35,7 @@ quic::QuicAsyncStatus EnvoyQuicProofVerifier::VerifyCertChain(
   std::unique_ptr<quic::CertificateView> cert_view =
       quic::CertificateView::ParseSingleCertificate(certs[0]);
   ASSERT(cert_view != nullptr);
-  for (const absl::string_view config_san : cert_view->subject_alt_name_domains()) {
+  for (const absl::string_view& config_san : cert_view->subject_alt_name_domains()) {
     if (Extensions::TransportSockets::Tls::ContextImpl::dnsNameMatch(hostname, config_san)) {
       return quic::QUIC_SUCCESS;
     }

--- a/test/extensions/filters/http/cdn_loop/parser_fuzz_test.cc
+++ b/test/extensions/filters/http/cdn_loop/parser_fuzz_test.cc
@@ -21,7 +21,7 @@ DEFINE_FUZZER(const uint8_t* buf, size_t len) {
     // If we successfully parse input, we should make sure that cdn_ids we find appear in the input
     // string in order.
     size_t start = 0;
-    for (const absl::string_view cdn_id : list->cdnIds()) {
+    for (const absl::string_view& cdn_id : list->cdnIds()) {
       size_t pos = input.find(cdn_id, start);
       FUZZ_ASSERT(pos != absl::string_view::npos);
       FUZZ_ASSERT(pos >= start);


### PR DESCRIPTION
Not that copying string views is expensive, but my clang's -Wrange-loop-analysis doesn't like them.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
