### PR TITLE
docs: Add sphinxext.rediraffe redirection plugin

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -139,7 +139,12 @@ cp -f "${CONFIGS_DIR}"/google-vrp/envoy-edge.yaml "${GENERATED_RST_DIR}"/configu
 
 rsync -rav  "${API_DIR}/diagrams" "${GENERATED_RST_DIR}/api-docs"
 
-rsync -av "${SCRIPT_DIR}"/root/ "${SCRIPT_DIR}"/conf.py "${SCRIPT_DIR}"/_ext "${GENERATED_RST_DIR}"
+rsync -av \
+      "${SCRIPT_DIR}"/root/ \
+      "${SCRIPT_DIR}"/conf.py \
+      "${SCRIPT_DIR}"/redirects.txt \
+      "${SCRIPT_DIR}"/_ext \
+      "${GENERATED_RST_DIR}"
 
 # To speed up validate_fragment invocations in validating_code_block
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/config_validation:validate_fragment

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ sys.path.append(os.path.abspath("./_ext"))
 
 extensions = [
     'sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig', 'sphinx_tabs.tabs',
-    'sphinx_copybutton', 'validating_code_block'
+    'sphinx_copybutton', 'validating_code_block', 'sphinxext.rediraffe'
 ]
 extlinks = {
     'repo': ('https://github.com/envoyproxy/envoy/blob/{}/%s'.format(blob_sha), ''),
@@ -275,3 +275,8 @@ html_style = 'css/envoy.css'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'envoydoc'
+
+# TODO(phlax): add redirect diff (`rediraffe_branch` setting)
+#  - not sure how diffing will work with master merging in PRs - might need
+#    to be injected dynamically, somehow
+rediraffe_redirects = "redirects.txt"

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,2 @@
+intro/arch_overview/http/websocket.rst intro/arch_overview/http/upgrades.rst
+configuration/observability/access_log.rst intro/arch_overview/observability/access_logging.rst

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -116,6 +116,9 @@ sphinxcontrib-jsmath==1.0.1 \
 sphinxcontrib-qthelp==1.0.3 \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6
+sphinxext-rediraffe==0.2.3 \
+    --hash=sha256:3abc7f8c6c1fecb38e6613ffc1bfb7b0025e9cbb3929ed8aea6b20709571a69d \
+    --hash=sha256:38e21589607c3149135fd94b87cdd28924fe3857e2755ff70ded948b4da26711
 sphinxcontrib-serializinghtml==1.1.4 \
     --hash=sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc \
     --hash=sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Add sphinxext.rediraffe redirection plugin
Additional Description:

Adds a Sphinx extension that allows redirecting pages that have been moved, to ensure that old published links continue to work when docs change

Also has a tool for diffing against commit/branch to figure out which redirects should be added. This could potentially be added as part of CI, but i have not done so in this PR, as just fixing the links and adding the redirects seemed a greater priority.

Of the options i looked at this extension seemed to have the most active dev, and has the bonus feature of the diff tool

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #11068 touch #13386 
[Optional Deprecated:]

### refs

- https://github.com/wpilibsuite/sphinxext-rediraffe
- https://pypi.org/project/sphinxext-rediraffe/