### PR TITLE
Add StatusString into JwtAuthn filter's rc_detail

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -28,7 +28,7 @@ bool isCorsPreflightRequest(const Http::RequestHeaderMap& headers) {
 }
 
 // The prefix used in the response code detail sent from jwt authn filter.
-constexpr char kRcDetailJwtAuthnPrefix[] = "jwt_authn_access_denied";
+constexpr absl::string_view kRcDetailJwtAuthnPrefix = "jwt_authn_access_denied";
 } // namespace
 
 Filter::Filter(FilterConfigSharedPtr config)

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -31,7 +31,6 @@ bool isCorsPreflightRequest(const Http::RequestHeaderMap& headers) {
 constexpr char kRcDetailJwtAuthnPrefix[] = "jwt_authn_access_denied";
 } // namespace
 
-
 Filter::Filter(FilterConfigSharedPtr config)
     : stats_(config->stats()), config_(std::move(config)) {}
 
@@ -93,8 +92,10 @@ void Filter::onComplete(const Status& status) {
     Http::Code code =
         status == Status::JwtAudienceNotAllowed ? Http::Code::Forbidden : Http::Code::Unauthorized;
     // return failure reason as message body
-    decoder_callbacks_->sendLocalReply(code, ::google::jwt_verify::getStatusString(status), nullptr,
-                                       absl::nullopt, absl::StrCat(kRcDetailJwtAuthnPrefix, "{", ::google::jwt_verify::getStatusString(status), "}"));
+    decoder_callbacks_->sendLocalReply(
+        code, ::google::jwt_verify::getStatusString(status), nullptr, absl::nullopt,
+        absl::StrCat(kRcDetailJwtAuthnPrefix, "{", ::google::jwt_verify::getStatusString(status),
+                     "}"));
     return;
   }
   stats_.allowed_.inc();

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -179,7 +179,7 @@ TEST_F(FilterTest, InlineUnauthorizedFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details());
+  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Jwt is not in the form of Header.Payload.Signature with two dots and 3 sections}");
 }
 
 // This test verifies Verifier::Callback is called inline with a failure(403 Forbidden) status.
@@ -200,7 +200,7 @@ TEST_F(FilterTest, InlineForbiddenFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ("jwt_authn_access_denied", filter_callbacks_.details());
+  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Audiences in Jwt are not allowed}");
 }
 
 // This test verifies Verifier::Callback is called with OK status after verify().

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -179,7 +179,8 @@ TEST_F(FilterTest, InlineUnauthorizedFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Jwt is not in the form of Header.Payload.Signature with two dots and 3 sections}");
+  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Jwt is not in the form of "
+                                         "Header.Payload.Signature with two dots and 3 sections}");
 }
 
 // This test verifies Verifier::Callback is called inline with a failure(403 Forbidden) status.
@@ -200,7 +201,8 @@ TEST_F(FilterTest, InlineForbiddenFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Audiences in Jwt are not allowed}");
+  EXPECT_EQ(filter_callbacks_.details(),
+            "jwt_authn_access_denied{Audiences in Jwt are not allowed}");
 }
 
 // This test verifies Verifier::Callback is called with OK status after verify().


### PR DESCRIPTION
Commit Message: Add the status string into the jwtAuthn filter's response code detail. The change is simply
`jwt_authn_access_denied` -> `jwt_authn_access_denied{#STATUS_STRING}`, ex. `jwt_authn_access_denied{Audiences in Jwt are not allowed}`. 

It provides more information why requests are rejected in the access log to the service provider, which is same as what the downstream see right now. It shouldn't break anything unless some automation depends on the static `jwt_authn_access_denied` %RESPONSE_CODE_DETAIL%, which is very unlikely.

Risk Level:low

Testing:included in the integration test