### PR TITLE
stream_info: Build replacement map on first use

### DIFF
--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -19,6 +19,17 @@
 namespace Envoy {
 namespace StreamInfo {
 
+namespace {
+using ReplacementMap = absl::flat_hash_map<std::string, std::string>;
+
+const ReplacementMap& emptySpaceReplacement() {
+  CONSTRUCT_ON_FIRST_USE(
+      ReplacementMap,
+      ReplacementMap{{" ", "_"}, {"\t", "_"}, {"\f", "_"}, {"\v", "_"}, {"\n", "_"}, {"\r", "_"}});
+}
+
+} // namespace
+
 struct StreamInfoImpl : public StreamInfo {
   StreamInfoImpl(TimeSource& time_source,
                  FilterState::LifeSpan life_span = FilterState::LifeSpan::FilterChain)
@@ -120,9 +131,7 @@ struct StreamInfoImpl : public StreamInfo {
   }
 
   void setResponseCodeDetails(absl::string_view rc_details) override {
-    const absl::flat_hash_map<std::string, std::string> replacement{
-        {" ", "_"}, {"\t", "_"}, {"\f", "_"}, {"\v", "_"}, {"\n", "_"}, {"\r", "_"}};
-    response_code_details_.emplace(absl::StrReplaceAll(rc_details, replacement));
+    response_code_details_.emplace(absl::StrReplaceAll(rc_details, emptySpaceReplacement()));
   }
 
   const absl::optional<std::string>& connectionTerminationDetails() const override {

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -20,6 +20,7 @@ namespace Envoy {
 namespace StreamInfo {
 
 namespace {
+
 using ReplacementMap = absl::flat_hash_map<std::string, std::string>;
 
 const ReplacementMap& emptySpaceReplacement() {


### PR DESCRIPTION
Commit Message: This is a follow up (performance nit) after #13423. This builds the replacement map on the first use. 
Additional Description: https://github.com/envoyproxy/envoy/pull/13423#discussion_r501898998
Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
