### PR TITLE
[WIP] docs/ci: Add link redirect checker to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
      steps:
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
        - checkout
-       - run: ci/do_circle_ci.sh docs
+       - run: |
+           ci/do_circle_ci.sh docs-redirects
+           ci/do_circle_ci.sh docs
        - add_ssh_keys:
            fingerprints:
              - "44:c7:a1:9e:f4:9e:a5:33:11:f1:0e:79:e1:55:c9:04"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -412,6 +412,11 @@ elif [[ "$CI_TARGET" == "docs" ]]; then
   # Build docs.
   docs/build.sh
   exit 0
+elif [[ "$CI_TARGET" == "docs-redirects" ]]; then
+  echo "checking redirects in docs..."
+  export SPHINX_BUILDER=rediraffecheckdiff
+  docs/build.sh
+  exit 0
 elif [[ "$CI_TARGET" == "verify_examples" ]]; then
   echo "verify examples..."
   docker load < "$ENVOY_DOCKER_BUILD_DIR/docker/envoy-docker-images.tar.xz"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SPHINX_BUILDER="${SPHINX_BUILDER:-html}"
+
 # set SPHINX_SKIP_CONFIG_VALIDATION environment variable to true to skip
 # validation of configuration examples
 
@@ -149,4 +151,4 @@ rsync -av \
 # To speed up validate_fragment invocations in validating_code_block
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/config_validation:validate_fragment
 
-sphinx-build -W --keep-going -b html "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"
+sphinx-build -W --keep-going -b "${SPHINX_BUILDER}" "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -276,7 +276,5 @@ html_style = 'css/envoy.css'
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'envoydoc'
 
-# TODO(phlax): add redirect diff (`rediraffe_branch` setting)
-#  - not sure how diffing will work with master merging in PRs - might need
-#    to be injected dynamically, somehow
 rediraffe_redirects = "redirects.txt"
+rediraffe_branch = "master~1"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs/ci: Add link redirect checker to CI
Additional Description:

Now that we have added sphinxext-rediraffe we can use its tool to detect if a page has been moved in docs, without adding a redirect link for it

Risk Level: low
Testing: yep
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] touch #13436 
[Optional Deprecated:]
