### PR TITLE
[VHDS]  fix vhds DELTA_GRPC check which can not support Ads 

### DIFF
--- a/include/envoy/config/grpc_mux.h
+++ b/include/envoy/config/grpc_mux.h
@@ -15,6 +15,10 @@ namespace Config {
 
 using ScopedResume = std::unique_ptr<Cleanup>;
 /**
+ * Support parameterizing over state-of-the-world xDS vs delta xDS.
+ */
+enum class SotwOrDelta { Sotw, Delta };
+/**
  * All control plane related stats. @see stats_macros.h
  */
 #define ALL_CONTROL_PLANE_STATS(COUNTER, GAUGE, TEXT_READOUT)                                      \
@@ -59,6 +63,11 @@ public:
    * Initiate stream with management server.
    */
   virtual void start() PURE;
+
+  /**
+   * Indicate this GrpcMux is delta or SotW.
+   */
+  virtual SotwOrDelta sotwOrDelta() PURE;
 
   /**
    * Pause discovery requests for a given API type. This is useful when we're processing an update

--- a/source/common/config/new_grpc_mux_impl.h
+++ b/source/common/config/new_grpc_mux_impl.h
@@ -45,7 +45,8 @@ public:
 
   void requestOnDemandUpdate(const std::string& type_url,
                              const std::set<std::string>& for_update) override;
-
+  // GrpcMux
+  SotwOrDelta sotwOrDelta() override { return SotwOrDelta::Delta; }
   ScopedResume pause(const std::string& type_url) override;
   ScopedResume pause(const std::vector<std::string> type_urls) override;
 

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -338,7 +338,9 @@ ClusterManagerImpl::ClusterManagerImpl(
           bootstrap.dynamic_resources().ads_config().set_node_on_first_message_only());
     }
   } else {
-    ads_mux_ = std::make_unique<Config::NullGrpcMuxImpl>();
+    ads_mux_ =
+        std::make_unique<Config::NullGrpcMuxImpl<envoy::service::discovery::v3::DiscoveryResponse>>(
+            Envoy::Config::SotwOrDelta::Sotw);
   }
 
   // After ADS is initialized, load EDS static clusters as EDS config may potentially need ADS.

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -113,7 +113,10 @@ class ScopedRdsTest : public ScopedRoutesTestBase {
 protected:
   void setup() {
     ON_CALL(server_factory_context_.cluster_manager_, adsMux())
-        .WillByDefault(Return(std::make_shared<::Envoy::Config::NullGrpcMuxImpl>()));
+        .WillByDefault(Return(
+            std::make_shared<
+                ::Envoy::Config::NullGrpcMuxImpl<envoy::service::discovery::v3::DiscoveryResponse>>(
+                Envoy::Config::SotwOrDelta::Sotw)));
 
     InSequence s;
     // Since server_factory_context_.cluster_manager_.subscription_factory_.callbacks_ is taken by

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -102,6 +102,7 @@ public:
   ~MockGrpcMux() override;
 
   MOCK_METHOD(void, start, (), (override));
+  MOCK_METHOD(SotwOrDelta, sotwOrDelta, (), (override));
   MOCK_METHOD(ScopedResume, pause, (const std::string& type_url), (override));
   MOCK_METHOD(ScopedResume, pause, (const std::vector<std::string> type_urls), (override));
 


### PR DESCRIPTION
Commit Message:
Fix VHDS DELTA_GRPC check which can not support Ads 
Additional Description:
 VHDS can not use Ads config, like below:
            config_source:
              resource_api_version: V3
              ads: {}
the error msg is:

envoy.config.route.v3.RouteConfiguration rejected: vhds: only 'DELTA_GRPC' is supported as an api_type

this PR let vhds can use ads config.

Risk Level:
Low
Testing:
Yes

