### PR TITLE
http2: Proactively disconnect connections flooded in read resumption

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -280,6 +280,7 @@ void ConnectionImpl::StreamImpl::readDisable(bool disable) {
       auto status = parent_.sendPendingFrames();
       // See comment in the `encodeHeadersBase()` method about this RELEASE_ASSERT.
       RELEASE_ASSERT(status.ok(), "sendPendingFrames() failure in non dispatching context");
+      parent_.checkProtocolConstraintViolation();
     }
   }
 }

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -277,6 +277,12 @@ protected:
     int32_t stream_id_{-1};
     uint32_t unconsumed_bytes_{0};
     uint32_t read_disable_count_{0};
+
+    // Note that in current implementation the watermark callbacks of the pending_recv_data_ are
+    // never called. The watermark value is set to the size of the stream window. As a result this
+    // watermark can never overflow because the peer can never send more bytes than the stream
+    // window without triggering protocol error and this buffer is drained after each DATA frame was
+    // dispatched through the filter chain. See source/docs/flow_control.md for more information.
     Buffer::WatermarkBuffer pending_recv_data_{
         [this]() -> void { this->pendingRecvBufferLowWatermark(); },
         [this]() -> void { this->pendingRecvBufferHighWatermark(); },

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -267,6 +267,7 @@ void ConnectionImpl::StreamImpl::readDisable(bool disable) {
       nghttp2_session_consume(parent_.session_, stream_id_, unconsumed_bytes_);
       unconsumed_bytes_ = 0;
       parent_.sendPendingFrames();
+      parent_.checkProtocolConstraintViolation();
     }
   }
 }

--- a/source/common/http/http2/codec_impl_legacy.h
+++ b/source/common/http/http2/codec_impl_legacy.h
@@ -277,6 +277,12 @@ protected:
     int32_t stream_id_{-1};
     uint32_t unconsumed_bytes_{0};
     uint32_t read_disable_count_{0};
+
+    // Note that in current implementation the watermark callbacks of the pending_recv_data_ are
+    // never called. The watermark value is set to the size of the stream window. As a result this
+    // watermark can never overflow because the peer can never send more bytes than the stream
+    // window without triggering protocol error and this buffer is drained after each DATA frame was
+    // dispatched through the filter chain. See source/docs/flow_control.md for more information.
     Buffer::WatermarkBuffer pending_recv_data_{
         [this]() -> void { this->pendingRecvBufferLowWatermark(); },
         [this]() -> void { this->pendingRecvBufferHighWatermark(); },

--- a/test/common/http/http2/http2_frame.cc
+++ b/test/common/http/http2/http2_frame.cc
@@ -324,6 +324,18 @@ Http2Frame Http2Frame::makePostRequest(uint32_t stream_index, absl::string_view 
   return frame;
 }
 
+Http2Frame Http2Frame::makePostRequest(uint32_t stream_index, absl::string_view host,
+                                       absl::string_view path,
+                                       const std::vector<Header> extra_headers) {
+
+  auto frame = makePostRequest(stream_index, host, path);
+  for (const auto& header : extra_headers) {
+    frame.appendHeaderWithoutIndexing(header);
+  }
+  frame.adjustPayloadSize();
+  return frame;
+}
+
 Http2Frame Http2Frame::makeGenericFrame(absl::string_view contents) {
   Http2Frame frame;
   frame.appendData(contents);
@@ -333,6 +345,16 @@ Http2Frame Http2Frame::makeGenericFrame(absl::string_view contents) {
 Http2Frame Http2Frame::makeGenericFrameFromHexDump(absl::string_view contents) {
   Http2Frame frame;
   frame.appendData(Hex::decode(std::string(contents)));
+  return frame;
+}
+
+Http2Frame Http2Frame::makeDataFrame(uint32_t stream_index, absl::string_view data,
+                                     DataFlags flags) {
+  Http2Frame frame;
+  frame.buildHeader(Type::Data, 0, static_cast<uint8_t>(flags),
+                    makeNetworkOrderStreamId(stream_index));
+  frame.appendData(data);
+  frame.adjustPayloadSize();
   return frame;
 }
 

--- a/test/common/http/http2/http2_frame.h
+++ b/test/common/http/http2/http2_frame.h
@@ -138,6 +138,12 @@ public:
                                 absl::string_view path, const std::vector<Header> extra_headers);
   static Http2Frame makePostRequest(uint32_t stream_index, absl::string_view host,
                                     absl::string_view path);
+  static Http2Frame makePostRequest(uint32_t stream_index, absl::string_view host,
+                                    absl::string_view path,
+                                    const std::vector<Header> extra_headers);
+  static Http2Frame makeDataFrame(uint32_t stream_index, absl::string_view data,
+                                  DataFlags flags = DataFlags::None);
+
   /**
    * Creates a frame with the given contents. This frame can be
    * malformed/invalid depending on the given contents.

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -328,6 +328,7 @@ envoy_cc_test(
         "//source/extensions/filters/http/buffer:config",
         "//source/extensions/filters/http/health_check:config",
         "//test/common/http/http2:http2_frame",
+        "//test/integration/filters:backpressure_filter_config_lib",
         "//test/integration/filters:metadata_stop_all_filter_config_lib",
         "//test/integration/filters:request_metadata_filter_config_lib",
         "//test/integration/filters:response_metadata_filter_config_lib",


### PR DESCRIPTION
Commit Message:
Proactively disconnect connections flooded in read resumption

Additional Description:
This PR adds error handling and associated tests for flood triggered in the ConnectionImpl::readDisable() method. Previously connection stayed in the flooded state until downstream data was received.

Part of fixing #12280

Risk Level: Medium, H/2 codec
Testing: Unit and integration tests
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
