### PR TITLE
ci: fix python version used in mac virtual env

### DIFF
--- a/ci/flaky_test/run_process_xml_mac.sh
+++ b/ci/flaky_test/run_process_xml_mac.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-pip3 install slackclient
-./ci/flaky_test/process_xml.py
+# shellcheck source=tools/shell_utils.sh
+. "${ENVOY_SRCDIR}"/tools/shell_utils.sh
+
+python_venv process_xml "$1"

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 # Installs the dependencies required for a macOS build via homebrew.
 # Tools are not upgraded to new versions.

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -64,5 +64,3 @@ if ! brew link --overwrite bazelisk; then
 fi
 
 bazel version
-
-pip3 install slackclient

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 # Installs the dependencies required for a macOS build via homebrew.
 # Tools are not upgraded to new versions.

--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-EXCLUDED_SHELLFILES=${EXCLUDED_SHELLFILES:-"^.github|.rst$|.md$"}
+EXCLUDED_SHELLFILES=${EXCLUDED_SHELLFILES:-"^.github|.rst$|.md$|shell_utils.sh"}
 
 
 find_shell_files () {

--- a/tools/shell_utils.sh
+++ b/tools/shell_utils.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 source_venv() {
   VENV_DIR=$1
@@ -21,11 +22,11 @@ python_venv() {
   VENV_DIR="${BUILD_DIR}/${PY_NAME}"
 
   source_venv "${VENV_DIR}"
-  which pip
+  which pip # debug, temporary
   pip install -r "${SCRIPT_DIR}"/requirements.txt
 
-  pip list
+  pip list # debug, temporary
   shift
-  which python3
+  which python3 # debug, temporary
   python3 "${SCRIPT_DIR}/${PY_NAME}.py" "$*"
 }

--- a/tools/shell_utils.sh
+++ b/tools/shell_utils.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 
 source_venv() {
   VENV_DIR=$1
@@ -22,11 +21,11 @@ python_venv() {
   VENV_DIR="${BUILD_DIR}/${PY_NAME}"
 
   source_venv "${VENV_DIR}"
-  which pip # debug, temporary
+  which pip
   pip install -r "${SCRIPT_DIR}"/requirements.txt
 
-  pip list # debug, temporary
+  pip list
   shift
-  which python3 # debug, temporary
+  which python3
   python3 "${SCRIPT_DIR}/${PY_NAME}.py" "$*"
 }

--- a/tools/shell_utils.sh
+++ b/tools/shell_utils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 
 source_venv() {
   VENV_DIR=$1
@@ -22,8 +22,11 @@ python_venv() {
   VENV_DIR="${BUILD_DIR}/${PY_NAME}"
 
   source_venv "${VENV_DIR}"
+  which pip # debug, temporary
   pip install -r "${SCRIPT_DIR}"/requirements.txt
 
+  pip list # debug, temporary
   shift
+  which python3 # debug, temporary
   python3 "${SCRIPT_DIR}/${PY_NAME}.py" "$*"
 }

--- a/tools/shell_utils.sh
+++ b/tools/shell_utils.sh
@@ -5,7 +5,7 @@ source_venv() {
   VENV_DIR=$1
   if [[ "${VIRTUAL_ENV}" == "" ]]; then
     if [[ ! -d "${VENV_DIR}"/venv ]]; then
-      virtualenv "${VENV_DIR}"/venv --python=python3
+      virtualenv "${VENV_DIR}"/venv --python=python3.8
     fi
     # shellcheck disable=SC1090
     source "${VENV_DIR}/venv/bin/activate"


### PR DESCRIPTION
Commit Message: pin python for mac virtualenv
Additional Description: pin python to 3.8; remove superfluous pip install of slackclient, outside virtualenv
Risk Level: low
Testing: manual
Docs Changes: N/A
Release Notes: N/A
