### PR TITLE
stats: add more headroom in integration tests to reduce flakiness with new tcmalloc

### DIFF
--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -288,7 +288,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSize) {
     // https://github.com/envoyproxy/envoy/issues/12209
     // EXPECT_MEMORY_EQ(m_per_cluster, 37061);
   }
-  EXPECT_MEMORY_LE(m_per_cluster, 39350); // Round up to allow platform variations.
+  EXPECT_MEMORY_LE(m_per_cluster, 40000); // Round up to allow platform variations.
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
@@ -334,7 +334,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
     // https://github.com/envoyproxy/envoy/issues/12209
     // EXPECT_MEMORY_EQ(m_per_host, 1380);
   }
-  EXPECT_MEMORY_LE(m_per_host, 1800); // Round up to allow platform variations.
+  EXPECT_MEMORY_LE(m_per_host, 2000); // Round up to allow platform variations.
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: With the new tcmalloc there's more variation in the amount of memory consumed from run to run. This PR just gives a little more headroom to try to avoid flakes.
Additional Description:
Risk Level: low
Testing: //test/integration:stats_integration_test, with optimization, many iterations
Docs Changes: n/a
Release Notes: n/a

