### PR TITLE
overload: scale selected timers in response to load

### DIFF
--- a/api/envoy/config/overload/v3/BUILD
+++ b/api/envoy/config/overload/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/overload/v2alpha:pkg",
+        "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/api/envoy/config/overload/v3/overload.proto
+++ b/api/envoy/config/overload/v3/overload.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.overload.v3;
 
+import "envoy/type/v3/percent.proto";
+
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -80,6 +82,28 @@ message Trigger {
   }
 }
 
+message ScaleTimersOverloadActionConfig {
+  enum TimerType { UNSPECIFIED = 0; }
+
+  message ScaleTimer {
+    // The type of timer this minimum applies to.
+    TimerType timer = 1;
+
+    oneof overload_adjust {
+      option (validate.required) = true;
+
+      // Sets the minimum duration as an absolute value.
+      google.protobuf.Duration min_timeout = 2;
+
+      // Sets the minimum duration as a percentage of the maximum value.
+      type.v3.Percent min_scale = 3;
+    }
+  }
+
+  // A set of timer scaling rules to be applied.
+  repeated ScaleTimer timer_scale_factors = 1;
+}
+
 message OverloadAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.overload.v2alpha.OverloadAction";
@@ -88,6 +112,9 @@ message OverloadAction {
   // use for registering callbacks. Custom overload actions should be named using reverse
   // DNS to ensure uniqueness.
   string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Configuration for the action being instantiated.
+  google.protobuf.Any typed_config = 3;
 
   // A set of triggers for this action. The state of the action is the maximum
   // state of all triggers, which can be scaling between 0 and 1 or saturated. Listeners

--- a/api/envoy/config/overload/v3/overload.proto
+++ b/api/envoy/config/overload/v3/overload.proto
@@ -83,7 +83,10 @@ message Trigger {
 }
 
 message ScaleTimersOverloadActionConfig {
-  enum TimerType { UNSPECIFIED = 0; }
+  enum TimerType {
+    // Adjusts the idle timer for downstream HTTP connections that takes effect when there are no active streams.
+    HTTP_DOWNSTREAM_CONNECTION_IDLE = 0;
+  }
 
   message ScaleTimer {
     // The type of timer this minimum applies to.
@@ -101,7 +104,7 @@ message ScaleTimersOverloadActionConfig {
   }
 
   // A set of timer scaling rules to be applied.
-  repeated ScaleTimer timer_scale_factors = 1;
+  repeated ScaleTimer timer_scale_factors = 1 [(validate.rules).repeated = {min_items: 1}];
 }
 
 message OverloadAction {

--- a/generated_api_shadow/envoy/config/overload/v3/BUILD
+++ b/generated_api_shadow/envoy/config/overload/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/config/overload/v2alpha:pkg",
+        "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/overload/v3/overload.proto
+++ b/generated_api_shadow/envoy/config/overload/v3/overload.proto
@@ -81,7 +81,10 @@ message Trigger {
 }
 
 message ScaleTimersOverloadActionConfig {
-  enum TimerType { UNSPECIFIED = 0; }
+  enum TimerType {
+    // Adjusts the idle timer for downstream HTTP connections that takes effect when there are no active streams.
+    HTTP_DOWNSTREAM_CONNECTION_IDLE = 0;
+  }
 
   message ScaleTimer {
     // The type of timer this minimum applies to.
@@ -99,7 +102,7 @@ message ScaleTimersOverloadActionConfig {
   }
 
   // A set of timer scaling rules to be applied.
-  repeated ScaleTimer timer_scale_factors = 1;
+  repeated ScaleTimer timer_scale_factors = 1 [(validate.rules).repeated = {min_items: 1}];
 }
 
 message OverloadAction {

--- a/generated_api_shadow/envoy/config/overload/v3/overload.proto
+++ b/generated_api_shadow/envoy/config/overload/v3/overload.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.config.overload.v3;
 
+import "envoy/type/v3/percent.proto";
+
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
@@ -78,6 +80,28 @@ message Trigger {
   }
 }
 
+message ScaleTimersOverloadActionConfig {
+  enum TimerType { UNSPECIFIED = 0; }
+
+  message ScaleTimer {
+    // The type of timer this minimum applies to.
+    TimerType timer = 1;
+
+    oneof overload_adjust {
+      option (validate.required) = true;
+
+      // Sets the minimum duration as an absolute value.
+      google.protobuf.Duration min_timeout = 2;
+
+      // Sets the minimum duration as a percentage of the maximum value.
+      type.v3.Percent min_scale = 3;
+    }
+  }
+
+  // A set of timer scaling rules to be applied.
+  repeated ScaleTimer timer_scale_factors = 1;
+}
+
 message OverloadAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.overload.v2alpha.OverloadAction";
@@ -86,6 +110,9 @@ message OverloadAction {
   // use for registering callbacks. Custom overload actions should be named using reverse
   // DNS to ensure uniqueness.
   string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Configuration for the action being instantiated.
+  google.protobuf.Any typed_config = 3;
 
   // A set of triggers for this action. The state of the action is the maximum
   // state of all triggers, which can be scaling between 0 and 1 or saturated. Listeners

--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -50,6 +50,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "scaled_range_timer_manager_interface",
+    hdrs = ["scaled_range_timer_manager.h"],
+    deps = [
+        ":range_timer_interface",
+        ":timer_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "schedulable_cb_interface",
     hdrs = ["schedulable_cb.h"],
 )

--- a/include/envoy/event/scaled_range_timer_manager.h
+++ b/include/envoy/event/scaled_range_timer_manager.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "envoy/common/pure.h"
+#include "envoy/event/range_timer.h"
+#include "envoy/event/timer.h"
+
+namespace Envoy {
+namespace Event {
+
+/**
+ * Class for creating RangeTimer objects that can be adjusted towards either the minimum or maximum
+ * of their range by the owner of the manager object. Users of this class can call createTimer() to
+ * receive a new RangeTimer object that they can then enable or disable at will (but only on the
+ * same dispatcher), and setScaleFactor() to change the scaling factor. The current scale factor is
+ * applied to all timers, including those that are created later.
+ */
+class ScaledRangeTimerManager {
+public:
+  virtual ~ScaledRangeTimerManager() = default;
+
+  /**
+   * Creates a new range timer backed by the manager. The returned timer will be subject to the
+   * current and future scale factor values set on the manager. All returned timers must be deleted
+   * before the manager.
+   */
+  virtual RangeTimerPtr createTimer(TimerCb callback) PURE;
+
+  /**
+   * Sets the scale factor for all timers created through this manager. The value should be between
+   * 0 and 1, inclusive. The scale factor affects the amount of time timers spend in their target
+   * range. The RangeTimers returned by createTimer will fire after (min + (max - min) *
+   * scale_factor). This means that a scale factor of 0 causes timers to fire immediately at the min
+   * duration, a factor of 0.5 causes firing halfway between min and max, and a factor of 1 causes
+   * firing at max.
+   */
+  virtual void setScaleFactor(double scale_factor) PURE;
+};
+
+using ScaledRangeTimerManagerPtr = std::unique_ptr<ScaledRangeTimerManager>;
+
+} // namespace Event
+} // namespace Envoy

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -307,6 +307,7 @@ envoy_cc_library(
     name = "overload_manager_interface",
     hdrs = ["overload_manager.h"],
     deps = [
+        "//include/envoy/event:timer_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/singleton:const_singleton",
     ],

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "envoy/common/pure.h"
+#include "envoy/event/timer.h"
 #include "envoy/thread_local/thread_local.h"
 
 #include "common/common/macros.h"
@@ -39,6 +40,11 @@ private:
  */
 using OverloadActionCb = std::function<void(OverloadActionState)>;
 
+enum class OverloadTimerType {
+  // Timers created with this type will never be scaled. This should only be used for testing.
+  UnscaledRealTimer,
+};
+
 /**
  * Thread-local copy of the state of each configured overload action.
  */
@@ -46,6 +52,9 @@ class ThreadLocalOverloadState : public ThreadLocal::ThreadLocalObject {
 public:
   // Get a thread-local reference to the value for the given action key.
   virtual const OverloadActionState& getState(const std::string& action) PURE;
+
+  virtual Event::TimerPtr createScaledTimer(OverloadTimerType timer_type,
+                                            Event::TimerCb callback) PURE;
 };
 
 /**
@@ -64,6 +73,9 @@ public:
 
   // Overload action to try to shrink the heap by releasing free memory.
   const std::string ShrinkHeap = "envoy.overload_actions.shrink_heap";
+
+  // Overload action to reduce some subset of configured timeouts.
+  const std::string ReduceTimeouts = "envoy.overload_actions.reduce_timeouts";
 };
 
 using OverloadActionNames = ConstSingleton<OverloadActionNameValues>;

--- a/include/envoy/server/overload_manager.h
+++ b/include/envoy/server/overload_manager.h
@@ -43,6 +43,8 @@ using OverloadActionCb = std::function<void(OverloadActionState)>;
 enum class OverloadTimerType {
   // Timers created with this type will never be scaled. This should only be used for testing.
   UnscaledRealTimer,
+  // The amount of time an HTTP connection to a downstream client can remain idle (no streams).
+  HttpDownstreamIdleConnectionTimeout,
 };
 
 /**

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -154,12 +154,13 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "scaled_range_timer_manager",
-    srcs = ["scaled_range_timer_manager.cc"],
-    hdrs = ["scaled_range_timer_manager.h"],
+    name = "scaled_range_timer_manager_lib",
+    srcs = ["scaled_range_timer_manager_impl.cc"],
+    hdrs = ["scaled_range_timer_manager_impl.h"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:range_timer_interface",
+        "//include/envoy/event:scaled_range_timer_manager_interface",
         "//source/common/common:scope_tracker",
     ],
 )

--- a/source/common/event/scaled_range_timer_manager_impl.h
+++ b/source/common/event/scaled_range_timer_manager_impl.h
@@ -3,6 +3,7 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/range_timer.h"
+#include "envoy/event/scaled_range_timer_manager.h"
 #include "envoy/event/timer.h"
 
 #include "absl/container/flat_hash_map.h"
@@ -11,30 +12,25 @@ namespace Envoy {
 namespace Event {
 
 /**
- * Class for creating RangeTimer objects that can be adjusted towards either the minimum or maximum
- * of their range by the owner of the manager object. Users of this class can call createTimer() to
- * receive a new RangeTimer object that they can then enable or disable at will (but only on the
- * same dispatcher), and setScaleFactor() to change the scaling factor. The current scale factor is
- * applied to all timers, including those that are created later.
- *
- * Internally, the manager uses a set of queues to track timers. When an enabled timer reaches its
- * min duration, it adds a tracker object to the queue corresponding to the duration (max - min).
- * Each queue tracks timers of only a single duration, and uses a real Timer object to schedule the
- * expiration of the first timer in the queue. The expectation is that the number of (max - min)
- * values used to enable timers is small, so the number of queues is tightly bounded. The
- * queue-based implementation depends on that expectation for efficient operation.
+ * Implementation class for ScaledRangeTimerManager. Internally, this uses a set of queues to track
+ * timers. When an enabled timer reaches its min duration, it adds a tracker object to the queue
+ * corresponding to the duration (max - min). Each queue tracks timers of only a single duration,
+ * and uses a real Timer object to schedule the expiration of the first timer in the queue. The
+ * expectation is that the number of (max - min) values used to enable timers is small, so the
+ * number of queues is tightly bounded. The queue-based implementation depends on that expectation
+ * for efficient operation.
  */
-class ScaledRangeTimerManager {
+class ScaledRangeTimerManagerImpl : public ScaledRangeTimerManager {
 public:
-  explicit ScaledRangeTimerManager(Dispatcher& dispatcher);
-  ~ScaledRangeTimerManager();
+  explicit ScaledRangeTimerManagerImpl(Dispatcher& dispatcher);
+  ~ScaledRangeTimerManagerImpl();
 
   /**
    * Creates a new range timer backed by the manager. The returned timer will be subject to the
    * current and future scale factor values set on the manager. All returned timers must be deleted
    * before the manager.
    */
-  RangeTimerPtr createTimer(TimerCb callback);
+  RangeTimerPtr createTimer(TimerCb callback) override;
 
   /**
    * Sets the scale factor for all timers created through this manager. The value should be between
@@ -44,7 +40,7 @@ public:
    * duration, a factor of 0.5 causes firing halfway between min and max, and a factor of 1 causes
    * firing at max.
    */
-  void setScaleFactor(double scale_factor);
+  void setScaleFactor(double scale_factor) override;
 
 private:
   class RangeTimerImpl;
@@ -62,7 +58,7 @@ private:
     // Typedef for convenience.
     using Iterator = std::list<Item>::iterator;
 
-    Queue(std::chrono::milliseconds duration, ScaledRangeTimerManager& manager,
+    Queue(std::chrono::milliseconds duration, ScaledRangeTimerManagerImpl& manager,
           Dispatcher& dispatcher);
 
     // The (max - min) value for all timers in range_timers_.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -85,10 +85,11 @@ ConnectionManagerImpl::ConnectionManagerImpl(ConnectionManagerConfig& config,
       random_generator_(random_generator), http_context_(http_context), runtime_(runtime),
       local_info_(local_info), cluster_manager_(cluster_manager),
       listener_stats_(config_.listenerStats()),
-      overload_stop_accepting_requests_ref_(overload_manager.getThreadLocalOverloadState().getState(
-          Server::OverloadActionNames::get().StopAcceptingRequests)),
-      overload_disable_keepalive_ref_(overload_manager.getThreadLocalOverloadState().getState(
-          Server::OverloadActionNames::get().DisableHttpKeepAlive)),
+      overload_state_(overload_manager.getThreadLocalOverloadState()),
+      overload_stop_accepting_requests_ref_(
+          overload_state_.getState(Server::OverloadActionNames::get().StopAcceptingRequests)),
+      overload_disable_keepalive_ref_(
+          overload_state_.getState(Server::OverloadActionNames::get().DisableHttpKeepAlive)),
       time_source_(time_source) {}
 
 const ResponseHeaderMap& ConnectionManagerImpl::continueHeader() {
@@ -109,7 +110,8 @@ void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCal
   read_callbacks_->connection().addConnectionCallbacks(*this);
 
   if (config_.idleTimeout()) {
-    connection_idle_timer_ = read_callbacks_->connection().dispatcher().createTimer(
+    connection_idle_timer_ = overload_state_.createScaledTimer(
+        Server::OverloadTimerType::HttpDownstreamIdleConnectionTimeout,
         [this]() -> void { onIdleTimeout(); });
     connection_idle_timer_->enableTimer(config_.idleTimeout().value());
   }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -427,6 +427,7 @@ private:
   Upstream::ClusterManager& cluster_manager_;
   Network::ReadFilterCallbacks* read_callbacks_{};
   ConnectionManagerListenerStats& listener_stats_;
+  Server::ThreadLocalOverloadState& overload_state_;
   // References into the overload manager thread local state map. Using these lets us avoid a
   // map lookup in the hot path of processing each request.
   const Server::OverloadActionState& overload_stop_accepting_requests_ref_;

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -251,11 +251,13 @@ envoy_cc_library(
     srcs = ["overload_manager_impl.cc"],
     hdrs = ["overload_manager_impl.h"],
     deps = [
+        "//include/envoy/event:range_timer_interface",
         "//include/envoy/server:overload_manager_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:logger_lib",
         "//source/common/config:utility_lib",
+        "//source/common/event:scaled_range_timer_manager_lib",
         "//source/common/stats:symbol_table_lib",
         "//source/server:resource_monitor_config_lib",
         "@envoy_api//envoy/config/overload/v3:pkg_cc_proto",

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -1,11 +1,17 @@
 #include "server/overload_manager_impl.h"
 
+#include <chrono>
+
 #include "envoy/common/exception.h"
 #include "envoy/config/overload/v3/overload.pb.h"
+#include "envoy/config/overload/v3/overload.pb.validate.h"
+#include "envoy/event/range_timer.h"
+#include "envoy/server/overload_manager.h"
 #include "envoy/stats/scope.h"
 
 #include "common/common/fmt.h"
 #include "common/config/utility.h"
+#include "common/event/scaled_range_timer_manager_impl.h"
 #include "common/protobuf/utility.h"
 #include "common/stats/symbol_table_impl.h"
 
@@ -70,14 +76,44 @@ private:
   OverloadActionState state_;
 };
 
+class FixedMinimumScaledTimer : public Event::Timer {
+public:
+  FixedMinimumScaledTimer(Event::RangeTimerPtr range_timer, ScaledTimerMinimum minimum)
+      : minimum_(minimum), range_timer_(std::move(range_timer)) {}
+
+  void enableTimer(std::chrono::milliseconds ms,
+                   const ScopeTrackedObject* object = nullptr) override {
+    range_timer_->enableTimer(minimum_.compute(ms), ms, object);
+  }
+
+  void enableHRTimer(std::chrono::microseconds us,
+                     const ScopeTrackedObject* object = nullptr) override {
+    enableTimer(std::chrono::duration_cast<std::chrono::milliseconds>(us), object);
+  }
+
+  void disableTimer() override { range_timer_->disableTimer(); }
+
+  bool enabled() override { return range_timer_->enabled(); }
+
+private:
+  const ScaledTimerMinimum minimum_;
+  const Event::RangeTimerPtr range_timer_;
+};
+
 /**
  * Thread-local copy of the state of each configured overload action.
  */
 class ThreadLocalOverloadStateImpl : public ThreadLocalOverloadState {
 public:
-  ThreadLocalOverloadStateImpl(const NamedOverloadActionSymbolTable& action_symbol_table)
+  ThreadLocalOverloadStateImpl(
+      Event::ScaledRangeTimerManagerPtr scaled_timer_manager_,
+      const NamedOverloadActionSymbolTable& action_symbol_table,
+      const absl::flat_hash_map<OverloadTimerType, ScaledTimerMinimum>& timer_minimums)
       : action_symbol_table_(action_symbol_table),
-        actions_(action_symbol_table.size(), OverloadActionState(0)) {}
+        timer_minimums_(timer_minimums),
+        actions_(action_symbol_table.size(), OverloadActionState(0)),
+        scaled_timer_action_(action_symbol_table.lookup(OverloadActionNames::get().ReduceTimeouts)),
+        scaled_timer_manager_(std::move(scaled_timer_manager_)) {}
 
   const OverloadActionState& getState(const std::string& action) override {
     if (const auto symbol = action_symbol_table_.lookup(action); symbol != absl::nullopt) {
@@ -86,14 +122,29 @@ public:
     return always_inactive_;
   }
 
+  Event::TimerPtr createScaledTimer(OverloadTimerType timer_type,
+                                    Event::TimerCb callback) override {
+    auto minimum_it = timer_minimums_.find(timer_type);
+    ScaledTimerMinimum minimum =
+        minimum_it != timer_minimums_.end() ? minimum_it->second : ScaledTimerMinimum(1.0);
+    return std::make_unique<FixedMinimumScaledTimer>(
+        scaled_timer_manager_->createTimer(std::move(callback)), minimum);
+  }
+
   void setState(NamedOverloadActionSymbolTable::Symbol action, OverloadActionState state) {
     actions_[action.index()] = state;
+    if (scaled_timer_action_.has_value() && scaled_timer_action_.value() == action) {
+      scaled_timer_manager_->setScaleFactor(1 - state.value());
+    }
   }
 
 private:
   static const OverloadActionState always_inactive_;
   const NamedOverloadActionSymbolTable& action_symbol_table_;
+  const absl::flat_hash_map<OverloadTimerType, ScaledTimerMinimum>& timer_minimums_;
   std::vector<OverloadActionState> actions_;
+  absl::optional<NamedOverloadActionSymbolTable::Symbol> scaled_timer_action_;
+  const Event::ScaledRangeTimerManagerPtr scaled_timer_manager_;
 };
 
 const OverloadActionState ThreadLocalOverloadStateImpl::always_inactive_{0.0};
@@ -109,6 +160,41 @@ Stats::Gauge& makeGauge(Stats::Scope& scope, absl::string_view a, absl::string_v
   Stats::StatNameManagedStorage stat_name(absl::StrCat("overload.", a, ".", b),
                                           scope.symbolTable());
   return scope.gaugeFromStatName(stat_name.statName(), import_mode);
+}
+
+OverloadTimerType parseTimerType(
+    envoy::config::overload::v3::ScaleTimersOverloadActionConfig::TimerType config_timer_type) {
+  switch (config_timer_type) {
+  default:
+    throw EnvoyException(fmt::format("Unknown timer type {}", config_timer_type));
+  }
+}
+
+absl::flat_hash_map<OverloadTimerType, ScaledTimerMinimum>
+parseTimerMinimums(const ProtobufWkt::Any& typed_config,
+                   ProtobufMessage::ValidationVisitor& validation_visitor) {
+  using Config = envoy::config::overload::v3::ScaleTimersOverloadActionConfig;
+  const Config action_config =
+      MessageUtil::anyConvertAndValidate<Config>(typed_config, validation_visitor);
+
+  absl::flat_hash_map<OverloadTimerType, ScaledTimerMinimum> timer_map;
+
+  for (const auto& scale_timer : action_config.timer_scale_factors()) {
+    const OverloadTimerType timer_type = parseTimerType(scale_timer.timer());
+
+    const ScaledTimerMinimum minimum =
+        scale_timer.has_min_timeout()
+            ? ScaledTimerMinimum(DurationUtil::durationToMilliseconds(scale_timer.min_timeout()))
+            : ScaledTimerMinimum(scale_timer.min_scale().value() / 100);
+
+    auto [_, inserted] = timer_map.insert(std::make_pair(timer_type, minimum));
+    if (!inserted) {
+      throw EnvoyException(fmt::format("Found duplicate entry for timer type {}",
+                                       Config::TimerType_Name(scale_timer.timer())));
+    }
+  }
+
+  return timer_map;
 }
 
 } // namespace
@@ -142,6 +228,14 @@ const absl::string_view NamedOverloadActionSymbolTable::name(Symbol symbol) cons
 bool operator==(const NamedOverloadActionSymbolTable::Symbol& lhs,
                 const NamedOverloadActionSymbolTable::Symbol& rhs) {
   return lhs.index() == rhs.index();
+}
+
+ScaledTimerMinimum::ScaledTimerMinimum(double scale_factor) : value_(ScaleFactor(scale_factor)) {}
+ScaledTimerMinimum::ScaledTimerMinimum(std::chrono::milliseconds absolute_duration)
+    : value_(AbsoluteValue(absolute_duration)) {}
+
+std::chrono::milliseconds ScaledTimerMinimum::compute(std::chrono::milliseconds ms) const {
+  return absl::visit([ms](auto value) { return value.compute(ms); }, value_);
 }
 
 OverloadAction::OverloadAction(const envoy::config::overload::v3::OverloadAction& config,
@@ -241,6 +335,13 @@ OverloadManagerImpl::OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::S
       throw EnvoyException(absl::StrCat("Duplicate overload action ", name));
     }
 
+    if (name == OverloadActionNames::get().ReduceTimeouts) {
+      timer_minimums_ = parseTimerMinimums(action.typed_config(), validation_visitor);
+    } else if (action.has_typed_config()) {
+      throw EnvoyException(fmt::format(
+          "Overload action \"{}\" has an unexpected value for the typed_config field", name));
+    }
+
     for (const auto& trigger : action.triggers()) {
       const std::string& resource = trigger.name();
 
@@ -258,8 +359,9 @@ void OverloadManagerImpl::start() {
   ASSERT(!started_);
   started_ = true;
 
-  tls_->set([this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    return std::make_shared<ThreadLocalOverloadStateImpl>(action_symbol_table_);
+  tls_->set([this](Event::Dispatcher& dispatcher) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+    return std::make_shared<ThreadLocalOverloadStateImpl>(createScaledRangeTimerManager(dispatcher),
+                                                          action_symbol_table_, timer_minimums_);
   });
 
   if (resources_.empty()) {
@@ -312,6 +414,11 @@ bool OverloadManagerImpl::registerForAction(const std::string& action,
 
 ThreadLocalOverloadState& OverloadManagerImpl::getThreadLocalOverloadState() {
   return tls_->getTyped<ThreadLocalOverloadStateImpl>();
+}
+
+Event::ScaledRangeTimerManagerPtr
+OverloadManagerImpl::createScaledRangeTimerManager(Event::Dispatcher& dispatcher) const {
+  return std::make_unique<Event::ScaledRangeTimerManagerImpl>(dispatcher);
 }
 
 void OverloadManagerImpl::updateResourcePressure(const std::string& resource, double pressure,

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -43,10 +43,10 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
-    name = "scaled_range_timer_manager_test",
-    srcs = ["scaled_range_timer_manager_test.cc"],
+    name = "scaled_range_timer_manager_impl_test",
+    srcs = ["scaled_range_timer_manager_impl_test.cc"],
     deps = [
-        "//source/common/event:scaled_range_timer_manager",
+        "//source/common/event:scaled_range_timer_manager_lib",
         "//test/mocks/event:wrapped_dispatcher",
         "//test/test_common:simulated_time_system_lib",
     ],

--- a/test/common/event/scaled_range_timer_manager_impl_test.cc
+++ b/test/common/event/scaled_range_timer_manager_impl_test.cc
@@ -3,7 +3,7 @@
 #include "envoy/event/timer.h"
 
 #include "common/event/dispatcher_impl.h"
-#include "common/event/scaled_range_timer_manager.h"
+#include "common/event/scaled_range_timer_manager_impl.h"
 
 #include "test/mocks/common.h"
 #include "test/mocks/event/wrapped_dispatcher.h"
@@ -47,7 +47,7 @@ public:
 };
 
 struct TrackedTimer {
-  explicit TrackedTimer(ScaledRangeTimerManager& manager, TimeSystem& time_system)
+  explicit TrackedTimer(ScaledRangeTimerManagerImpl& manager, TimeSystem& time_system)
       : timer(manager.createTimer([trigger_times = trigger_times.get(), &time_system] {
           trigger_times->push_back(time_system.monotonicTime());
         })) {}
@@ -57,11 +57,11 @@ struct TrackedTimer {
 };
 
 TEST_F(ScaledRangeTimerManagerTest, CreateAndDestroy) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 }
 
 TEST_F(ScaledRangeTimerManagerTest, CreateAndDestroyTimer) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   {
     MockFunction<TimerCb> callback;
@@ -70,7 +70,7 @@ TEST_F(ScaledRangeTimerManagerTest, CreateAndDestroyTimer) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, CreateSingleScaledTimer) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -87,7 +87,7 @@ TEST_F(ScaledRangeTimerManagerTest, CreateSingleScaledTimer) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, EnableAndDisableTimer) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -105,7 +105,7 @@ TEST_F(ScaledRangeTimerManagerTest, EnableAndDisableTimer) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, DisableWhileDisabled) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -117,7 +117,7 @@ TEST_F(ScaledRangeTimerManagerTest, DisableWhileDisabled) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, DisableWhileWaitingForMin) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -129,7 +129,7 @@ TEST_F(ScaledRangeTimerManagerTest, DisableWhileWaitingForMin) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, DisableWhileScalingMax) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -148,7 +148,7 @@ TEST_F(ScaledRangeTimerManagerTest, DisableWhileScalingMax) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, DisableWithZeroMinTime) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -165,7 +165,7 @@ TEST_F(ScaledRangeTimerManagerTest, DisableWithZeroMinTime) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, TriggerWithZeroMinTime) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -178,7 +178,7 @@ TEST_F(ScaledRangeTimerManagerTest, TriggerWithZeroMinTime) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, DisableFrontScalingMaxTimer) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback1, callback2;
   auto timer1 = manager.createTimer(callback1.AsStdFunction());
@@ -204,7 +204,7 @@ TEST_F(ScaledRangeTimerManagerTest, DisableFrontScalingMaxTimer) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, DisableLaterScalingMaxTimer) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback1, callback2;
   auto timer1 = manager.createTimer(callback1.AsStdFunction());
@@ -234,7 +234,7 @@ public:
 };
 
 TEST_P(ScaledRangeTimerManagerTestWithScope, ReRegisterOnCallback) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -265,7 +265,7 @@ TEST_P(ScaledRangeTimerManagerTestWithScope, ReRegisterOnCallback) {
 };
 
 TEST_P(ScaledRangeTimerManagerTestWithScope, ScheduleWithScalingFactorZero) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -282,7 +282,7 @@ INSTANTIATE_TEST_SUITE_P(WithAndWithoutScope, ScaledRangeTimerManagerTestWithSco
                          testing::Bool());
 
 TEST_F(ScaledRangeTimerManagerTest, SingleTimerTriggeredNoScaling) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   bool triggered = false;
 
   MockFunction<TimerCb> callback;
@@ -304,7 +304,7 @@ TEST_F(ScaledRangeTimerManagerTest, SingleTimerTriggeredNoScaling) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, SingleTimerSameMinMax) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback;
   auto timer = manager.createTimer(callback.AsStdFunction());
@@ -317,7 +317,7 @@ TEST_F(ScaledRangeTimerManagerTest, SingleTimerSameMinMax) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, MultipleTimersNoScaling) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   std::vector<TrackedTimer> timers;
   timers.reserve(3);
 
@@ -340,7 +340,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersNoScaling) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithScaling) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   std::vector<TrackedTimer> timers;
   timers.reserve(3);
 
@@ -381,7 +381,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithScaling) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, MultipleTimersSameTimes) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   std::vector<TrackedTimer> timers;
   timers.reserve(3);
 
@@ -402,7 +402,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersSameTimes) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, MultipleTimersSameTimesFastClock) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   std::vector<TrackedTimer> timers;
   timers.reserve(3);
 
@@ -423,7 +423,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersSameTimesFastClock) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, ScheduledWithScalingFactorZero) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   manager.setScaleFactor(0);
 
   TrackedTimer timer(manager, simTime());
@@ -442,7 +442,7 @@ TEST_F(ScaledRangeTimerManagerTest, ScheduledWithScalingFactorZero) {
 TEST_F(ScaledRangeTimerManagerTest, ScheduledWithMaxBeforeMin) {
   // When max < min, the timer behaves the same as if max == min. This ensures that min is always
   // respected, and max is respected as much as possible.
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   TrackedTimer timer(manager, simTime());
 
@@ -457,7 +457,7 @@ TEST_F(ScaledRangeTimerManagerTest, ScheduledWithMaxBeforeMin) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, MultipleTimersTriggeredInTheSameEventLoopIteration) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
 
   MockFunction<TimerCb> callback1, callback2, callback3;
   auto timer1 = manager.createTimer(callback1.AsStdFunction());
@@ -510,7 +510,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersTriggeredInTheSameEventLoopIte
 }
 
 TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithChangeInScalingFactor) {
-  ScaledRangeTimerManager manager(dispatcher_);
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
   const MonotonicTime start = simTime().monotonicTime();
 
   std::vector<TrackedTimer> timers;

--- a/test/mocks/event/BUILD
+++ b/test/mocks/event/BUILD
@@ -17,6 +17,7 @@ envoy_cc_mock(
         "//include/envoy/event:deferred_deletable",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:file_event_interface",
+        "//include/envoy/event:scaled_range_timer_manager_interface",
         "//include/envoy/event:signal_interface",
         "//include/envoy/event:timer_interface",
         "//include/envoy/network:connection_handler_interface",

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -55,6 +55,10 @@ MockTimer::~MockTimer() {
   }
 }
 
+MockRangeTimer::MockRangeTimer(MockScaledRangeTimerManager* manager) {
+  EXPECT_CALL(*manager, createTimer_).WillOnce(DoAll(SaveArg<0>(&callback_), Return(this)));
+}
+
 MockSchedulableCallback::~MockSchedulableCallback() = default;
 
 MockSchedulableCallback::MockSchedulableCallback(MockDispatcher* dispatcher)

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -119,62 +119,12 @@ protected:
 
   envoy::config::overload::v3::OverloadManager parseConfig(const std::string& config) {
     envoy::config::overload::v3::OverloadManager proto;
-    bool success = Protobuf::TextFormat::ParseFromString(config, &proto);
-    ASSERT(success);
+    TestUtility::loadFromYaml(config, proto);
     return proto;
   }
 
-  std::string getConfig() {
-    return R"EOF(
-      refresh_interval {
-        seconds: 1
-      }
-      resource_monitors {
-        name: "envoy.resource_monitors.fake_resource1"
-      }
-      resource_monitors {
-        name: "envoy.resource_monitors.fake_resource2"
-      }
-      resource_monitors {
-        name: "envoy.resource_monitors.fake_resource3"
-      }
-      resource_monitors {
-        name: "envoy.resource_monitors.fake_resource4"
-      }
-      actions {
-        name: "envoy.overload_actions.dummy_action"
-        triggers {
-          name: "envoy.resource_monitors.fake_resource1"
-          threshold {
-            value: 0.9
-          }
-        }
-        triggers {
-          name: "envoy.resource_monitors.fake_resource2"
-          threshold {
-            value: 0.8
-          }
-        }
-        triggers {
-          name: "envoy.resource_monitors.fake_resource3"
-          scaled {
-            scaling_threshold: 0.5
-            saturation_threshold: 0.8
-          }
-        }
-        triggers {
-          name: "envoy.resource_monitors.fake_resource4"
-          scaled {
-            scaling_threshold: 0.5
-            saturation_threshold: 0.8
-          }
-        }
-      }
-    )EOF";
-  }
-
-  std::unique_ptr<OverloadManagerImpl> createOverloadManager(const std::string& config) {
-    return std::make_unique<OverloadManagerImpl>(dispatcher_, stats_, thread_local_,
+  std::unique_ptr<TestOverloadManager> createOverloadManager(const std::string& config) {
+    return std::make_unique<TestOverloadManager>(dispatcher_, stats_, thread_local_,
                                                  parseConfig(config), validation_visitor_, *api_);
   }
 
@@ -195,10 +145,37 @@ protected:
   Api::ApiPtr api_;
 };
 
+constexpr char kRegularStateConfig[] = R"YAML(
+  refresh_interval:
+    seconds: 1
+  resource_monitors:
+    - name: envoy.resource_monitors.fake_resource1
+    - name: envoy.resource_monitors.fake_resource2
+    - name: envoy.resource_monitors.fake_resource3
+    - name: envoy.resource_monitors.fake_resource4
+  actions:
+    - name: envoy.overload_actions.dummy_action
+      triggers:
+        - name: envoy.resource_monitors.fake_resource1
+          threshold:
+            value: 0.9
+        - name: envoy.resource_monitors.fake_resource2
+          threshold:
+            value: 0.8
+        - name: envoy.resource_monitors.fake_resource3
+          scaled:
+            scaling_threshold: 0.5
+            saturation_threshold: 0.8
+        - name: envoy.resource_monitors.fake_resource4
+          scaled:
+            scaling_threshold: 0.5
+            saturation_threshold: 0.8
+)YAML";
+
 TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   setDispatcherExpectation();
 
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   bool is_active = false;
   int cb_count = 0;
   manager->registerForAction("envoy.overload_actions.dummy_action", dispatcher_,
@@ -306,7 +283,7 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
 TEST_F(OverloadManagerImplTest, ScaledTrigger) {
   setDispatcherExpectation();
 
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
   const auto& action_state =
       manager->getThreadLocalOverloadState().getState("envoy.overload_actions.dummy_action");
@@ -350,7 +327,7 @@ TEST_F(OverloadManagerImplTest, ScaledTrigger) {
 
 TEST_F(OverloadManagerImplTest, FailedUpdates) {
   setDispatcherExpectation();
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
   Stats::Counter& failed_updates =
       stats_.counter("overload.envoy.resource_monitors.fake_resource1.failed_updates");
@@ -366,7 +343,7 @@ TEST_F(OverloadManagerImplTest, FailedUpdates) {
 
 TEST_F(OverloadManagerImplTest, AggregatesMultipleResourceUpdates) {
   setDispatcherExpectation();
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
 
   const OverloadActionState& action_state =
@@ -388,7 +365,7 @@ TEST_F(OverloadManagerImplTest, AggregatesMultipleResourceUpdates) {
 
 TEST_F(OverloadManagerImplTest, DelayedUpdatesAreCoalesced) {
   setDispatcherExpectation();
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
 
   const OverloadActionState& action_state =
@@ -412,7 +389,7 @@ TEST_F(OverloadManagerImplTest, DelayedUpdatesAreCoalesced) {
 
 TEST_F(OverloadManagerImplTest, FlushesUpdatesEvenWithOneUnresponsive) {
   setDispatcherExpectation();
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
 
   const OverloadActionState& action_state =
@@ -436,7 +413,7 @@ TEST_F(OverloadManagerImplTest, FlushesUpdatesEvenWithOneUnresponsive) {
 TEST_F(OverloadManagerImplTest, SkippedUpdates) {
   setDispatcherExpectation();
 
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
   Stats::Counter& skipped_updates =
       stats_.counter("overload.envoy.resource_monitors.fake_resource1.skipped_updates");
@@ -466,12 +443,9 @@ TEST_F(OverloadManagerImplTest, SkippedUpdates) {
 
 TEST_F(OverloadManagerImplTest, DuplicateResourceMonitor) {
   const std::string config = R"EOF(
-    resource_monitors {
-      name: "envoy.resource_monitors.fake_resource1"
-    }
-    resource_monitors {
-      name: "envoy.resource_monitors.fake_resource1"
-    }
+    resource_monitors:
+      - name: "envoy.resource_monitors.fake_resource1"
+      - name: "envoy.resource_monitors.fake_resource1"
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
@@ -480,34 +454,73 @@ TEST_F(OverloadManagerImplTest, DuplicateResourceMonitor) {
 
 TEST_F(OverloadManagerImplTest, DuplicateOverloadAction) {
   const std::string config = R"EOF(
-    actions {
-      name: "envoy.overload_actions.dummy_action"
-    }
-    actions {
-      name: "envoy.overload_actions.dummy_action"
-    }
+    actions:
+      - name: "envoy.overload_actions.dummy_action"
+      - name: "envoy.overload_actions.dummy_action"
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
                           "Duplicate overload action .*");
 }
 
+TEST_F(OverloadManagerImplTest, ActionWithUnexpectedTypedConfig) {
+  const std::string config = R"EOF(
+    actions:
+      - name: "envoy.overload_actions.dummy_action"
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Empty
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
+                          ".* unexpected .* typed_config .*");
+}
+
+TEST_F(OverloadManagerImplTest, ReduceTimeoutsWithoutAction) {
+  const std::string config = R"EOF(
+    actions:
+      - name: "envoy.overload_actions.reduce_timeouts"
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
+                          "Unable to unpack as .*ScaleTimersOverloadActionConfig");
+}
+
+TEST_F(OverloadManagerImplTest, ReduceTimeoutsWithWrongTypedConfigMessage) {
+  const std::string config = R"EOF(
+    actions:
+      - name: "envoy.overload_actions.reduce_timeouts"
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Empty
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
+                          "Unable to unpack as .*ScaleTimersOverloadActionConfig");
+}
+
+TEST_F(OverloadManagerImplTest, ReduceTimeoutsWithNoTimersSpecified) {
+  const std::string config = R"EOF(
+    actions:
+      - name: "envoy.overload_actions.reduce_timeouts"
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.overload.v3.ScaleTimersOverloadActionConfig
+  )EOF";
+
+  EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
+                          ".* constraint validation failed.*");
+}
+
 // A scaled trigger action's thresholds must conform to scaling < saturation.
 TEST_F(OverloadManagerImplTest, ScaledTriggerSaturationLessThanScalingThreshold) {
   const std::string config = R"EOF(
-    resource_monitors {
-      name: "envoy.resource_monitors.fake_resource1"
-    }
-    actions {
-      name: "envoy.overload_actions.dummy_action"
-      triggers {
-        name: "envoy.resource_monitors.fake_resource1"
-        scaled {
-          scaling_threshold: 0.9
-          saturation_threshold: 0.8
-        }
-      }
-    }
+    resource_monitors:
+      - name: "envoy.resource_monitors.fake_resource1"
+    actions:
+      - name: "envoy.overload_actions.dummy_action"
+        triggers:
+          - name: "envoy.resource_monitors.fake_resource1"
+            scaled:
+              scaling_threshold: 0.9
+              saturation_threshold: 0.8
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
@@ -517,19 +530,15 @@ TEST_F(OverloadManagerImplTest, ScaledTriggerSaturationLessThanScalingThreshold)
 // A scaled trigger action can't have threshold values that are equal.
 TEST_F(OverloadManagerImplTest, ScaledTriggerThresholdsEqual) {
   const std::string config = R"EOF(
-    resource_monitors {
-      name: "envoy.resource_monitors.fake_resource1"
-    }
-    actions {
-      name: "envoy.overload_actions.dummy_action"
-      triggers {
-        name: "envoy.resource_monitors.fake_resource1"
-        scaled {
-          scaling_threshold: 0.9
-          saturation_threshold: 0.9
-        }
-      }
-    }
+    resource_monitors:
+      - name: "envoy.resource_monitors.fake_resource1"
+    actions:
+      - name: "envoy.overload_actions.dummy_action"
+        triggers:
+          - name: "envoy.resource_monitors.fake_resource1"
+            scaled:
+              scaling_threshold: 0.9
+              saturation_threshold: 0.9
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
@@ -538,15 +547,12 @@ TEST_F(OverloadManagerImplTest, ScaledTriggerThresholdsEqual) {
 
 TEST_F(OverloadManagerImplTest, UnknownTrigger) {
   const std::string config = R"EOF(
-    actions {
-      name: "envoy.overload_actions.dummy_action"
-      triggers {
-        name: "envoy.resource_monitors.fake_resource1"
-        threshold {
-          value: 0.9
-        }
-      }
-    }
+    actions:
+      - name: "envoy.overload_actions.dummy_action"
+        triggers:
+          - name: "envoy.resource_monitors.fake_resource1"
+            threshold:
+              value: 0.9
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException,
@@ -555,24 +561,17 @@ TEST_F(OverloadManagerImplTest, UnknownTrigger) {
 
 TEST_F(OverloadManagerImplTest, DuplicateTrigger) {
   const std::string config = R"EOF(
-    resource_monitors {
-      name: "envoy.resource_monitors.fake_resource1"
-    }
-    actions {
-      name: "envoy.overload_actions.dummy_action"
-      triggers {
-        name: "envoy.resource_monitors.fake_resource1"
-        threshold {
-          value: 0.9
-        }
-      }
-      triggers {
-        name: "envoy.resource_monitors.fake_resource1"
-        threshold {
-          value: 0.8
-        }
-      }
-    }
+    resource_monitors:
+      - name: "envoy.resource_monitors.fake_resource1"
+    actions:
+      - name: "envoy.overload_actions.dummy_action"
+        triggers:
+          - name: "envoy.resource_monitors.fake_resource1"
+            threshold:
+              value: 0.9
+          - name: "envoy.resource_monitors.fake_resource1"
+            threshold:
+              value: 0.8
   )EOF";
 
   EXPECT_THROW_WITH_REGEX(createOverloadManager(config), EnvoyException, "Duplicate trigger .*");
@@ -581,7 +580,7 @@ TEST_F(OverloadManagerImplTest, DuplicateTrigger) {
 TEST_F(OverloadManagerImplTest, Shutdown) {
   setDispatcherExpectation();
 
-  auto manager(createOverloadManager(getConfig()));
+  auto manager(createOverloadManager(kRegularStateConfig));
   manager->start();
 
   EXPECT_CALL(*timer_, disableTimer());


### PR DESCRIPTION
Commit Message: Scale timers in response to overload state
Additional Description:
Add a new overload action and use the new typed_config field to adjust timers based on resource pressure.
Risk Level: low - everything is disabled by default
Testing: ran unit and integration tests
Docs Changes: TBD
Release Notes: TBD

Towards #11427