### PR TITLE
ext_authz: Remove envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,6 +19,8 @@ Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
+* ext_authz: removed auto ignore case in HTTP-based `ext_authz` header matching and the runtime guard `envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher`. To ignore case, set the :ref:`ignore_case <envoy_api_field_type.matcher.StringMatcher.ignore_case>` field to true.
+
 New Features
 ------------
 * grpc: implemented header value syntax support when defining :ref:`initial metadata <envoy_v3_api_field_config.core.v3.GrpcService.initial_metadata>` for gRPC-based `ext_authz` :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>` and :ref:`network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.grpc_service>` filters, and :ref:`ratelimit <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.grpc_service>` filters.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -69,7 +69,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.early_errors_via_hcm",
     "envoy.reloadable_features.enable_deprecated_v2_api_warning",
     "envoy.reloadable_features.enable_dns_cache_circuit_breakers",
-    "envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher",
     "envoy.reloadable_features.ext_authz_measure_timeout_on_check_created",
     "envoy.reloadable_features.fix_upgrade_response",
     "envoy.reloadable_features.fix_wildcard_matching",

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -75,40 +75,11 @@ struct SuccessResponse {
   ResponsePtr response_;
 };
 
-envoy::type::matcher::v3::StringMatcher
-ignoreCaseStringMatcher(const envoy::type::matcher::v3::StringMatcher& matcher) {
-  const auto& match_pattern_case = matcher.match_pattern_case();
-  if (match_pattern_case == envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kSafeRegex ||
-      match_pattern_case ==
-          envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kHiddenEnvoyDeprecatedRegex) {
-    return matcher;
-  }
-
-  envoy::type::matcher::v3::StringMatcher ignore_case;
-  ignore_case.set_ignore_case(true);
-  switch (matcher.match_pattern_case()) {
-  case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact:
-    ignore_case.set_exact(matcher.exact());
-    break;
-  case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kPrefix:
-    ignore_case.set_prefix(matcher.prefix());
-    break;
-  case envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kSuffix:
-    ignore_case.set_suffix(matcher.suffix());
-    break;
-  default:
-    NOT_REACHED_GCOVR_EXCL_LINE;
-  }
-  return ignore_case;
-}
-
 std::vector<Matchers::StringMatcherPtr>
-createStringMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
-                     const bool disable_lowercase_string_matcher) {
+createStringMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
   std::vector<Matchers::StringMatcherPtr> matchers;
   for (const auto& matcher : list.patterns()) {
-    matchers.push_back(std::make_unique<Matchers::StringMatcherImpl>(
-        disable_lowercase_string_matcher ? matcher : ignoreCaseStringMatcher(matcher)));
+    matchers.push_back(std::make_unique<Matchers::StringMatcherImpl>(matcher));
   }
   return matchers;
 }
@@ -132,20 +103,14 @@ bool NotHeaderKeyMatcher::matches(absl::string_view key) const { return !matcher
 // Config
 ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& config,
                            uint32_t timeout, absl::string_view path_prefix)
-    : enable_case_sensitive_string_matcher_(Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher")),
-      request_header_matchers_(
-          toRequestMatchers(config.http_service().authorization_request().allowed_headers(),
-                            enable_case_sensitive_string_matcher_)),
-      client_header_matchers_(
-          toClientMatchers(config.http_service().authorization_response().allowed_client_headers(),
-                           enable_case_sensitive_string_matcher_)),
+    : request_header_matchers_(
+          toRequestMatchers(config.http_service().authorization_request().allowed_headers())),
+      client_header_matchers_(toClientMatchers(
+          config.http_service().authorization_response().allowed_client_headers())),
       upstream_header_matchers_(toUpstreamMatchers(
-          config.http_service().authorization_response().allowed_upstream_headers(),
-          enable_case_sensitive_string_matcher_)),
+          config.http_service().authorization_response().allowed_upstream_headers())),
       upstream_header_to_append_matchers_(toUpstreamMatchers(
-          config.http_service().authorization_response().allowed_upstream_headers_to_append(),
-          enable_case_sensitive_string_matcher_)),
+          config.http_service().authorization_response().allowed_upstream_headers_to_append())),
       cluster_name_(config.http_service().server_uri().cluster()), timeout_(timeout),
       path_prefix_(path_prefix),
       tracing_name_(fmt::format("async {} egress", config.http_service().server_uri().cluster())),
@@ -153,14 +118,12 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
           config.http_service().authorization_request().headers_to_add(), false)) {}
 
 MatcherSharedPtr
-ClientConfig::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
-                                const bool disable_lowercase_string_matcher) {
+ClientConfig::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
   const std::vector<Http::LowerCaseString> keys{
       {Http::CustomHeaders::get().Authorization, Http::Headers::get().Method,
        Http::Headers::get().Path, Http::Headers::get().Host}};
 
-  std::vector<Matchers::StringMatcherPtr> matchers(
-      createStringMatchers(list, disable_lowercase_string_matcher));
+  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
   for (const auto& key : keys) {
     envoy::type::matcher::v3::StringMatcher matcher;
     matcher.set_exact(key.get());
@@ -171,10 +134,8 @@ ClientConfig::toRequestMatchers(const envoy::type::matcher::v3::ListStringMatche
 }
 
 MatcherSharedPtr
-ClientConfig::toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
-                               const bool disable_lowercase_string_matcher) {
-  std::vector<Matchers::StringMatcherPtr> matchers(
-      createStringMatchers(list, disable_lowercase_string_matcher));
+ClientConfig::toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
+  std::vector<Matchers::StringMatcherPtr> matchers(createStringMatchers(list));
 
   // If list is empty, all authorization response headers, except Host, should be added to
   // the client response.
@@ -202,10 +163,8 @@ ClientConfig::toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher
 }
 
 MatcherSharedPtr
-ClientConfig::toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
-                                 const bool disable_lowercase_string_matcher) {
-  return std::make_unique<HeaderKeyMatcher>(
-      createStringMatchers(list, disable_lowercase_string_matcher));
+ClientConfig::toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& list) {
+  return std::make_unique<HeaderKeyMatcher>(createStringMatchers(list));
 }
 
 RawHttpClientImpl::RawHttpClientImpl(Upstream::ClusterManager& cm, ClientConfigSharedPtr config)

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -119,16 +119,12 @@ public:
 
 private:
   static MatcherSharedPtr
-  toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& matcher,
-                    bool enable_case_sensitive_string_matcher);
+  toRequestMatchers(const envoy::type::matcher::v3::ListStringMatcher& matcher);
   static MatcherSharedPtr
-  toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& matcher,
-                   bool enable_case_sensitive_string_matcher);
+  toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& matcher);
   static MatcherSharedPtr
-  toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& matcher,
-                     bool enable_case_sensitive_string_matcher);
+  toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatcher& matcher);
 
-  const bool enable_case_sensitive_string_matcher_;
   const MatcherSharedPtr request_header_matchers_;
   const MatcherSharedPtr client_header_matchers_;
   const MatcherSharedPtr upstream_header_matchers_;

--- a/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_integration_test.cc
@@ -509,12 +509,8 @@ public:
     });
   }
 
-  void setupWithDisabledCaseSensitiveStringMatcher(bool disable_case_sensitive_matcher) {
+  void setup() {
     initializeConfig();
-
-    if (disable_case_sensitive_matcher) {
-      disableCaseSensitiveStringMatcher();
-    }
 
     HttpIntegrationTest::initialize();
 
@@ -691,19 +687,9 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ExtAuthzHttpIntegrationTest,
 
 // Verifies that by default HTTP service uses the case-sensitive string matcher.
 TEST_P(ExtAuthzHttpIntegrationTest, DefaultCaseSensitiveStringMatcher) {
-  setupWithDisabledCaseSensitiveStringMatcher(false);
+  setup();
   const auto* header_entry = ext_authz_request_->headers().get(case_sensitive_header_name_);
   ASSERT_EQ(header_entry, nullptr);
-}
-
-// Verifies that by setting "false" to
-// envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher, the string
-// matcher used by HTTP service will be case-insensitive.
-TEST_P(ExtAuthzHttpIntegrationTest, DisableCaseSensitiveStringMatcher) {
-  setupWithDisabledCaseSensitiveStringMatcher(true);
-  const auto* header_entry = ext_authz_request_->headers().get(case_sensitive_header_name_);
-  ASSERT_NE(header_entry, nullptr);
-  EXPECT_EQ(case_sensitive_header_value_, header_entry->value().getStringView());
 }
 
 TEST_P(ExtAuthzHttpIntegrationTest, CheckTimesOutLegacy) { expectCheckRequestTimedout(false); }


### PR DESCRIPTION
Commit Message: This patch removes
`envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher`
runtime flag.
Risk Level: Low, runtime flag removal after 6 months.
Testing: Updated existing tests to accommodate runtime flag removal.
Docs Changes: N/A.
Release Notes: Added.
Fixes #13446

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>