### PR TITLE
ci: bring BAZEL_BUILD_OPTIONS back for format and docs

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -369,6 +369,8 @@ elif [[ "$CI_TARGET" == "bazel.fuzz" ]]; then
 elif [[ "$CI_TARGET" == "fix_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
+
+  export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}"
   echo "fix_format..."
   ./tools/code_format/check_format.py fix
   ./tools/code_format/format_python_tools.sh fix
@@ -377,6 +379,8 @@ elif [[ "$CI_TARGET" == "fix_format" ]]; then
 elif [[ "$CI_TARGET" == "check_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
+
+  export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}"
   echo "check_format_test..."
   ./tools/code_format/check_format_test_helper.sh --log=WARN
   echo "check_format..."
@@ -411,7 +415,7 @@ elif [[ "$CI_TARGET" == "docs" ]]; then
   tools/dependency/validate_test.py
   tools/dependency/validate.py
   # Build docs.
-  docs/build.sh
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" docs/build.sh
   exit 0
 elif [[ "$CI_TARGET" == "verify_examples" ]]; then
   echo "verify examples..."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -370,26 +370,22 @@ elif [[ "$CI_TARGET" == "fix_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
 
-  # shellcheck disable=SC2178
-  export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}"
   echo "fix_format..."
   ./tools/code_format/check_format.py fix
   ./tools/code_format/format_python_tools.sh fix
-  ./tools/proto_format/proto_format.sh fix --test
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" ./tools/proto_format/proto_format.sh fix --test
   exit 0
 elif [[ "$CI_TARGET" == "check_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
 
-  # shellcheck disable=SC2178
-  export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}"
   echo "check_format_test..."
   ./tools/code_format/check_format_test_helper.sh --log=WARN
   echo "check_format..."
   ./tools/code_format/check_shellcheck_format.sh
   ./tools/code_format/check_format.py check
   ./tools/code_format/format_python_tools.sh check
-  ./tools/proto_format/proto_format.sh check --test
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" ./tools/proto_format/proto_format.sh check --test
   exit 0
 elif [[ "$CI_TARGET" == "check_repositories" ]]; then
   echo "check_repositories..."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -370,6 +370,7 @@ elif [[ "$CI_TARGET" == "fix_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
 
+  # shellcheck disable=SC2178
   export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}"
   echo "fix_format..."
   ./tools/code_format/check_format.py fix
@@ -380,6 +381,7 @@ elif [[ "$CI_TARGET" == "check_format" ]]; then
   # proto_format.sh needs to build protobuf.
   setup_clang_toolchain
 
+  # shellcheck disable=SC2178
   export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}"
   echo "check_format_test..."
   ./tools/code_format/check_format_test_helper.sh --log=WARN


### PR DESCRIPTION
Commit Message:
They got lost in #13169, and we no longer has repository cache for format since then.