### PR TITLE
wasm: support list lookup in get_property

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -615,7 +615,7 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
       }
     } else if (value.IsList()) {
       auto& list = *value.ListOrDie();
-      int64_t idx = 0;
+      int idx = 0;
       if (!absl::SimpleAtoi(part, &idx)) {
         return WasmResult::NotFound;
       }

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -613,6 +613,16 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
           return WasmResult::InternalFailure;
         }
       }
+    } else if (value.IsList()) {
+      auto& list = *value.ListOrDie();
+      int64_t idx = 0;
+      if (!absl::SimpleAtoi(part, &idx)) {
+        return WasmResult::NotFound;
+      }
+      if (idx < 0 || idx >= list.size()) {
+        return WasmResult::NotFound;
+      }
+      value = list[idx];
     } else {
       return WasmResult::NotFound;
     }

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -578,6 +578,20 @@ void TestRootContext::onTick() {
       logDebug("missing node metadata");
     }
     logDebug(std::string("onTick ") + value);
+
+    std::string list_value;
+    if (!getValue({"node", "metadata", "wasm_node_list_key", "0"}, &list_value)) {
+      logDebug("missing node metadata list value");
+    }
+    if (list_value != "wasm_node_get_value") {
+      logWarn("unexpected list value: " + list_value);
+    }
+    if (getValue({"node", "metadata", "wasm_node_list_key", "bad_key"}, &list_value)) {
+      logDebug("unexpected list value for a bad_key");
+    }
+    if (getValue({"node", "metadata", "wasm_node_list_key", "1"}, &list_value)) {
+      logDebug("unexpected list value outside the range");
+    }
   } else if (test_ == "property") {
     uint64_t t;
     if (WasmResult::Ok != proxy_get_current_time_nanoseconds(&t)) {

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1216,6 +1216,8 @@ TEST_P(WasmHttpFilterTest, Metadata) {
   ProtobufWkt::Value node_val;
   node_val.set_string_value("wasm_node_get_value");
   (*node_data.mutable_metadata()->mutable_fields())["wasm_node_get_key"] = node_val;
+  (*node_data.mutable_metadata()->mutable_fields())["wasm_node_list_key"] =
+      ValueUtil::listValue({node_val});
   EXPECT_CALL(local_info_, node()).WillRepeatedly(ReturnRef(node_data));
   EXPECT_CALL(rootContext(),
               log_(spdlog::level::debug, Eq(absl::string_view("onTick wasm_node_get_value"))));


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Add traversal by decimal index in a list
Additional Description:
Risk Level: low
Testing: unit
Docs Changes: none
Release Notes: none