### PR TITLE
fix an build error

### DIFF
--- a/source/common/init/manager_impl.cc
+++ b/source/common/init/manager_impl.cc
@@ -70,7 +70,7 @@ const absl::flat_hash_map<std::string, uint32_t>& ManagerImpl::unreadyTargets() 
 void ManagerImpl::dumpUnreadyTargets(envoy::admin::v3::UnreadyTargetsDumps& unready_targets_dumps) {
   auto& message = *unready_targets_dumps.mutable_unready_targets_dumps()->Add();
   message.set_name(name_);
-  for (const auto& [target_name, count] : target_names_count_) {
+  for (const auto& [target_name, _] : target_names_count_) {
     message.add_target_names(target_name);
   }
 }


### PR DESCRIPTION
Commit Message: 
fix build err with gcc 7.5 on ubuntu 18.04

Additional Description:

external/envoy/source/common/init/manager_impl.cc:73:39: error: unused variable 'count' [-Werror=unused-variable]
   for (const auto& [target_name, count] : target_names_count_) {
                                       ^
cc1plus: all warnings being treated as errors
Target //:envoy failed to build
Use --verbose_failures to see the command lines of failed build steps.

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
