### PR TITLE
router: Make direct response body size configurable

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1385,6 +1385,7 @@ message RedirectAction {
   bool strip_query = 6;
 }
 
+// [#next-free-field: 19]
 message DirectResponseAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.route.DirectResponseAction";
@@ -1401,6 +1402,17 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
   core.v3.DataSource body = 2;
+
+  // The maximum bytes of the response :ref:`body
+  // <envoy_api_field_config.route.v3.DirectResponseAction.body>` size. If not specified the default
+  // is 4096.
+  //
+  // .. warning::
+  //
+  //   The content of :ref:`body <envoy_api_field_config.route.v3.DirectResponseAction.body>`
+  //   will be held in memory.
+  //
+  google.protobuf.UInt32Value max_body_size_bytes = 18;
 }
 
 message Decorator {

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1333,6 +1333,7 @@ message RedirectAction {
   bool strip_query = 6;
 }
 
+// [#next-free-field: 19]
 message DirectResponseAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.route.v3.DirectResponseAction";
@@ -1349,6 +1350,17 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v4alpha.Route`, :ref:`envoy_api_msg_config.route.v4alpha.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v4alpha.VirtualHost`.
   core.v4alpha.DataSource body = 2;
+
+  // The maximum bytes of the response :ref:`body
+  // <envoy_api_field_config.route.v4alpha.DirectResponseAction.body>` size. If not specified the default
+  // is 4096.
+  //
+  // .. warning::
+  //
+  //   The content of :ref:`body <envoy_api_field_config.route.v4alpha.DirectResponseAction.body>`
+  //   will be held in memory.
+  //
+  google.protobuf.UInt32Value max_body_size_bytes = 18;
 }
 
 message Decorator {

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -22,6 +22,7 @@ Removed Config or Runtime
 New Features
 ------------
 * grpc: implemented header value syntax support when defining :ref:`initial metadata <envoy_v3_api_field_config.core.v3.GrpcService.initial_metadata>` for gRPC-based `ext_authz` :ref:`HTTP <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.grpc_service>` and :ref:`network <envoy_v3_api_field_extensions.filters.network.ext_authz.v3.ExtAuthz.grpc_service>` filters, and :ref:`ratelimit <envoy_v3_api_field_config.ratelimit.v3.RateLimitServiceConfig.grpc_service>` filters.
+* router: added :ref:`max_body_size_bytes <envoy_v3_api_field_config.route.v3.DirectResponseAction.max_body_size_bytes>` to set the maximum bytes of the direct response :ref:`body <envoy_v3_api_field_config.route.v3.DirectResponseAction.body>` size.
 
 Deprecated
 ----------

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1392,6 +1392,7 @@ message RedirectAction {
   bool strip_query = 6;
 }
 
+// [#next-free-field: 19]
 message DirectResponseAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.route.DirectResponseAction";
@@ -1408,6 +1409,17 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
   core.v3.DataSource body = 2;
+
+  // The maximum bytes of the response :ref:`body
+  // <envoy_api_field_config.route.v3.DirectResponseAction.body>` size. If not specified the default
+  // is 4096.
+  //
+  // .. warning::
+  //
+  //   The content of :ref:`body <envoy_api_field_config.route.v3.DirectResponseAction.body>`
+  //   will be held in memory.
+  //
+  google.protobuf.UInt32Value max_body_size_bytes = 18;
 }
 
 message Decorator {

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1400,6 +1400,7 @@ message RedirectAction {
   bool strip_query = 6;
 }
 
+// [#next-free-field: 19]
 message DirectResponseAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.route.v3.DirectResponseAction";
@@ -1416,6 +1417,17 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v4alpha.Route`, :ref:`envoy_api_msg_config.route.v4alpha.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v4alpha.VirtualHost`.
   core.v4alpha.DataSource body = 2;
+
+  // The maximum bytes of the response :ref:`body
+  // <envoy_api_field_config.route.v4alpha.DirectResponseAction.body>` size. If not specified the default
+  // is 4096.
+  //
+  // .. warning::
+  //
+  //   The content of :ref:`body <envoy_api_field_config.route.v4alpha.DirectResponseAction.body>`
+  //   will be held in memory.
+  //
+  google.protobuf.UInt32Value max_body_size_bytes = 18;
 }
 
 message Decorator {

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -124,6 +124,8 @@ std::string ConfigUtility::parseDirectResponseBody(const envoy::config::route::v
     return EMPTY_STRING;
   }
   const auto& body = route.direct_response().body();
+  const uint32_t maxBodySize =
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.direct_response(), max_body_size_bytes, MaxBodySize);
   const std::string& filename = body.filename();
   if (!filename.empty()) {
     if (!api.fileSystem().fileExists(filename)) {
@@ -133,17 +135,17 @@ std::string ConfigUtility::parseDirectResponseBody(const envoy::config::route::v
     if (size < 0) {
       throw EnvoyException(absl::StrCat("cannot determine size of response body file ", filename));
     }
-    if (size > MaxBodySize) {
+    if (size > maxBodySize) {
       throw EnvoyException(fmt::format("response body file {} size is {} bytes; maximum is {}",
-                                       filename, size, MaxBodySize));
+                                       filename, size, maxBodySize));
     }
     return api.fileSystem().fileReadToEnd(filename);
   }
   const std::string inline_body(body.inline_bytes().empty() ? body.inline_string()
                                                             : body.inline_bytes());
-  if (inline_body.length() > MaxBodySize) {
+  if (inline_body.length() > maxBodySize) {
     throw EnvoyException(fmt::format("response body size is {} bytes; maximum is {}",
-                                     inline_body.length(), MaxBodySize));
+                                     inline_body.length(), maxBodySize));
   }
   return inline_body;
 }

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -124,7 +124,7 @@ std::string ConfigUtility::parseDirectResponseBody(const envoy::config::route::v
     return EMPTY_STRING;
   }
   const auto& body = route.direct_response().body();
-  const uint32_t maxBodySize =
+  const uint32_t max_body_size =
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(route.direct_response(), max_body_size_bytes, MaxBodySize);
   const std::string& filename = body.filename();
   if (!filename.empty()) {
@@ -135,17 +135,17 @@ std::string ConfigUtility::parseDirectResponseBody(const envoy::config::route::v
     if (size < 0) {
       throw EnvoyException(absl::StrCat("cannot determine size of response body file ", filename));
     }
-    if (size > maxBodySize) {
+    if (size > max_body_size) {
       throw EnvoyException(fmt::format("response body file {} size is {} bytes; maximum is {}",
-                                       filename, size, maxBodySize));
+                                       filename, size, max_body_size));
     }
     return api.fileSystem().fileReadToEnd(filename);
   }
   const std::string inline_body(body.inline_bytes().empty() ? body.inline_string()
                                                             : body.inline_bytes());
-  if (inline_body.length() > maxBodySize) {
+  if (inline_body.length() > max_body_size) {
     throw EnvoyException(fmt::format("response body size is {} bytes; maximum is {}",
-                                     inline_body.length(), maxBodySize));
+                                     inline_body.length(), max_body_size));
   }
   return inline_body;
 }


### PR DESCRIPTION
Commit Message: This patch adds `max_body_size_bytes` to set the maximum bytes of the direct response body size.
Risk Level: Low, since the default behavior is preserved.
Testing: Updated to test the newly introduced config.
Docs Changes: Updated.
Release Notes: Added.
Fixes #13422

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>


