### PR TITLE
docs/ci: Publish docs build artifacts

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -64,6 +64,12 @@ jobs:
           GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
           GCS_ARTIFACT_BUCKET: $(GcsArtifactBucket)
 
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: "$(Build.SourcesDirectory)/generated/docs"
+          artifactName: docs
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+
       - task: InstallSSHKey@0
         inputs:
           hostName: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs/ci: Publish docs build artifacts
Additional Description:

see #13506 

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue] Partial fix for #13506 
[Optional Deprecated:]
