### PR TITLE
Windows: Enable wasm vm test

### DIFF
--- a/test/extensions/common/wasm/BUILD
+++ b/test/extensions/common/wasm/BUILD
@@ -19,10 +19,6 @@ envoy_cc_test(
     data = envoy_select_wasm([
         "//test/extensions/common/wasm/test_data:test_rust.wasm",
     ]),
-    tags = [
-        # wasm (wee v8 etc) will not compile on Windows
-        "skip_on_windows",
-    ],
     deps = [
         "//source/extensions/common/wasm:wasm_lib",
         "//test/test_common:environment_lib",


### PR DESCRIPTION
Commit Message:
Windows: Enable wasm vm test

Does not rely on wee8/compile tool, only runs v8 tests if ENVOY_WASM_V8 is defined
Additional Description: N/A
Risk Level: Low
Testing: Test run in RBE on Windows
Docs Changes: N/A
Release Notes: N/A