### PR TITLE
[router] fix assert when encoding metadata

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -440,8 +440,6 @@ void UpstreamRequest::encodeBodyAndTrailers() {
                        downstream_metadata_map_vector_);
       upstream_->encodeMetadata(downstream_metadata_map_vector_);
       downstream_metadata_map_vector_.clear();
-
-      ASSERT(buffered_request_body_);
     }
 
     if (buffered_request_body_) {

--- a/test/integration/h2_corpus/buffered_body
+++ b/test/integration/h2_corpus/buffered_body
@@ -1,0 +1,61 @@
+events {
+  downstream_send_event {
+    h2_frames {
+      settings {
+      }
+    }
+    h2_frames {
+      request {
+        stream_index: 1
+        host: "host"
+        path: "/p?th/to/longo"
+      }
+    }
+  }
+}
+events {
+  downstream_send_event {
+    h2_frames {
+      metadata {
+        flags: END_HEADERS
+        stream_index: 1
+        metadata {
+          metadata {
+            key: ""
+            value: "@"
+          }
+          metadata {
+            key: "("
+            value: ""
+          }
+          metadata {
+            key: "Timeout Seconds"
+            value: "10"
+          }
+          metadata {
+            key: "tincoes"
+            value: "15"
+          }
+        }
+      }
+    }
+  }
+}
+events {
+  downstream_send_event {
+    h2_frames {
+      settings {
+        flags: ACK
+      }
+    }
+  }
+}
+events {
+  upstream_send_event {
+    h2_frames {
+      window_update {
+        stream_index: 2147483648
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Fix an invalid ASSERT when encoding metadata frames in the router.
Additional Description:
METADATA frames can't end stream, so there must be data, trailers, or a reset stream frame to end the stream. The ASSERT was meant to verify that there is data following METADATA frames to end the stream (for example, in the case a client sends headers only request and metadata is added). However, Trailers could also end the stream, or the client could send body later/never. The ASSERT is invalid. 

The PR removes the ASSERT. 

Open to suggestions to have an ASSERT, but I couldn't think of one that was worth it / could be detected here. "if we had a header only request before, ASSERT there is empty data", or "if there is no possibility of stream reset occurring at this stage, ASSERT there is data or trailers."

Risk Level: Low. This only affects the ASSERT, has no impact on traffic.
Testing: Integration test added as a regression. Fuzz testcase added.
Fixes:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26238