### PR TITLE
overload: prevent segfault when disabling listener

### DIFF
--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -423,6 +423,18 @@ void ConnectionHandlerImpl::ActiveTcpListener::onAcceptWorker(
   }
 }
 
+void ConnectionHandlerImpl::ActiveTcpListener::pauseListening() {
+  if (listener_ != nullptr) {
+    listener_->disable();
+  }
+}
+
+void ConnectionHandlerImpl::ActiveTcpListener::resumeListening() {
+  if (listener_ != nullptr) {
+    listener_->enable();
+  }
+}
+
 void ConnectionHandlerImpl::ActiveTcpListener::newConnection(
     Network::ConnectionSocketPtr&& socket, std::unique_ptr<StreamInfo::StreamInfo> stream_info) {
   // Find matching filter chain.

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -137,8 +137,8 @@ private:
 
     // ActiveListenerImplBase
     Network::Listener* listener() override { return listener_.get(); }
-    void pauseListening() override { listener_->disable(); }
-    void resumeListening() override { listener_->enable(); }
+    void pauseListening() override;
+    void resumeListening() override;
     void shutdownListener() override { listener_.reset(); }
 
     // Network::BalancedConnectionHandler

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -451,6 +451,22 @@ TEST_F(ConnectionHandlerTest, AddDisabledListener) {
   handler_->addListener(absl::nullopt, *test_listener);
 }
 
+TEST_F(ConnectionHandlerTest, DisableListenerAfterStop) {
+  InSequence s;
+
+  Network::TcpListenerCallbacks* listener_callbacks;
+  auto listener = new NiceMock<Network::MockListener>();
+  TestListener* test_listener =
+      addListener(1, false, false, "test_listener", listener, &listener_callbacks);
+  EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
+  handler_->addListener(absl::nullopt, *test_listener);
+
+  EXPECT_CALL(*listener, onDestroy());
+
+  handler_->stopListeners();
+  handler_->disableListeners();
+}
+
 TEST_F(ConnectionHandlerTest, DestroyCloseConnections) {
   InSequence s;
 


### PR DESCRIPTION
Commit Message: Prevent segfault when disabling listener due to overload
Additional Description:
This prevents the stop_listening overload action from causing
segmentation faults that can occur if the action is enabled after the
listener has already shut down.

Risk Level: low
Testing: ran unit tests
Docs Changes: none
Release Notes: none
Fixes #13514
