### PR TITLE
http: using CONNECT_ERROR for HTTP/2

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -15,6 +15,8 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
+
 Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -251,7 +251,9 @@ enum class StreamResetReason {
   // If the stream was locally reset due to connection termination.
   ConnectionTermination,
   // The stream was reset because of a resource overflow.
-  Overflow
+  Overflow,
+  // Either there was an early TCP error for a CONNECT request or the peer reset with CONNECT_ERROR
+  ConnectError
 };
 
 /**

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -993,11 +993,12 @@ int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
         if (error_code == NGHTTP2_REFUSED_STREAM) {
           reason = StreamResetReason::RemoteRefusedStreamReset;
           stream->setDetails(Http2ResponseCodeDetails::get().remote_refused);
-        } else if (error_code == NGHTTP2_CONNECT_ERROR) {
-          reason = StreamResetReason::ConnectError;
-          stream->setDetails(Http2ResponseCodeDetails::get().remote_reset);
         } else {
-          reason = StreamResetReason::RemoteReset;
+          if (error_code == NGHTTP2_CONNECT_ERROR) {
+            reason = StreamResetReason::ConnectError;
+          } else {
+            reason = StreamResetReason::RemoteReset;
+          }
           stream->setDetails(Http2ResponseCodeDetails::get().remote_reset);
         }
       }

--- a/source/common/http/http2/codec_impl_legacy.cc
+++ b/source/common/http/http2/codec_impl_legacy.cc
@@ -63,6 +63,17 @@ public:
   }
 };
 
+int reasonToReset(StreamResetReason reason) {
+  switch (reason) {
+  case StreamResetReason::LocalRefusedStreamReset:
+    return NGHTTP2_REFUSED_STREAM;
+  case StreamResetReason::ConnectError:
+    return NGHTTP2_CONNECT_ERROR;
+  default:
+    return NGHTTP2_NO_ERROR;
+  }
+}
+
 using Http2ResponseCodeDetails = ConstSingleton<Http2ResponseCodeDetailValues>;
 using Http::Http2::CodecStats;
 using Http::Http2::MetadataDecoder;
@@ -505,9 +516,7 @@ void ConnectionImpl::StreamImpl::resetStream(StreamResetReason reason) {
 
 void ConnectionImpl::StreamImpl::resetStreamWorker(StreamResetReason reason) {
   int rc = nghttp2_submit_rst_stream(parent_.session_, NGHTTP2_FLAG_NONE, stream_id_,
-                                     reason == StreamResetReason::LocalRefusedStreamReset
-                                         ? NGHTTP2_REFUSED_STREAM
-                                         : NGHTTP2_NO_ERROR);
+                                     reasonToReset(reason));
   ASSERT(rc == 0);
 }
 
@@ -953,6 +962,9 @@ int ConnectionImpl::onStreamClose(int32_t stream_id, uint32_t error_code) {
         if (error_code == NGHTTP2_REFUSED_STREAM) {
           reason = StreamResetReason::RemoteRefusedStreamReset;
           stream->setDetails(Http2ResponseCodeDetails::get().remote_refused);
+        } else if (error_code == NGHTTP2_CONNECT_ERROR) {
+          reason = StreamResetReason::ConnectError;
+          stream->setDetails(Http2ResponseCodeDetails::get().remote_reset);
         } else {
           reason = StreamResetReason::RemoteReset;
           stream->setDetails(Http2ResponseCodeDetails::get().remote_reset);

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -819,6 +819,8 @@ const std::string Utility::resetReasonToString(const Http::StreamResetReason res
     return "remote reset";
   case Http::StreamResetReason::RemoteRefusedStreamReset:
     return "remote refused stream reset";
+  case Http::StreamResetReason::ConnectError:
+    return "remote error with CONNECT request";
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2621,6 +2621,10 @@ TEST_P(Http2CodecImplTest, ConnectTest) {
   expected_headers.setReferenceKey(Headers::get().Protocol, "bytestream");
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
   request_encoder_->encodeHeaders(request_headers, false);
+
+  EXPECT_CALL(callbacks, onResetStream(StreamResetReason::ConnectError, _));
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(StreamResetReason::ConnectError, _));
+  response_encoder_->getStream().resetStream(StreamResetReason::ConnectError);
 }
 
 template <typename, typename> class TestNghttp2SessionFactory;

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -790,6 +790,8 @@ TEST(HttpUtility, ResetReasonToString) {
   EXPECT_EQ("remote reset", Utility::resetReasonToString(Http::StreamResetReason::RemoteReset));
   EXPECT_EQ("remote refused stream reset",
             Utility::resetReasonToString(Http::StreamResetReason::RemoteRefusedStreamReset));
+  EXPECT_EQ("remote error with CONNECT request",
+            Utility::resetReasonToString(Http::StreamResetReason::ConnectError));
 }
 
 // Verify that it resolveMostSpecificPerFilterConfigGeneric works with nil routes.

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -2330,9 +2330,9 @@ TEST_F(RouterTest, UpstreamPerTryTimeoutExcludesNewStream) {
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginTimeout, _));
   EXPECT_CALL(*per_try_timeout_, disableTimer());
-  EXPECT_CALL(*response_timeout_, disableTimer());
   EXPECT_CALL(callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::UpstreamRequestTimeout));
+  EXPECT_CALL(*response_timeout_, disableTimer());
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "504"}, {"content-length", "24"}, {"content-type", "text/plain"}};
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -208,7 +208,7 @@ TEST_P(WebsocketIntegrationTest, WebSocketConnectionUpstreamDisconnect) {
   // Verify both the data and the disconnect went through.
   response_->waitForBodyData(5);
   EXPECT_EQ("world", response_->body());
-  waitForClientDisconnectOrReset();
+  waitForClientDisconnectOrReset(Http::StreamResetReason::ConnectError);
 }
 
 TEST_P(WebsocketIntegrationTest, EarlyData) {

--- a/test/integration/websocket_integration_test.h
+++ b/test/integration/websocket_integration_test.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/http/codec.h"
+
 #include "test/integration/http_protocol_integration.h"
 
 #include "gtest/gtest.h"
@@ -35,9 +37,11 @@ protected:
     }
   }
 
-  void waitForClientDisconnectOrReset() {
+  void waitForClientDisconnectOrReset(
+      Http::StreamResetReason reason = Http::StreamResetReason::RemoteReset) {
     if (downstreamProtocol() != Http::CodecClient::Type::HTTP1) {
       response_->waitForReset();
+      ASSERT_EQ(reason, response_->resetReason());
     } else {
       ASSERT_TRUE(codec_client_->waitForDisconnect());
     }


### PR DESCRIPTION
Commit Message: http: using CONNECT_ERROR for HTTP/2
Risk Level: Low (changing rst code on the wire)
Testing: new unit, integration tests
Docs Changes: n/a
Release Notes: inline
Fixes #13055
