### PR TITLE
dependencies: enforce dependency shepherd sign-off via RepoKitteh.

### DIFF
--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -50,8 +50,8 @@ Dependency declarations must:
 * CPEs are compulsory for all dependencies that are not purely build/test.
   [CPEs](https://en.wikipedia.org/wiki/Common_Platform_Enumeration) provide metadata that allow us
   to correlate with related CVEs in dashboards and other tooling, and also provide a machine
-  consumable join key. You can consult the latest [CPE
-  dictionary](https://nvd.nist.gov/products/cpe) to find a CPE for a dependency.`"N/A"` should only
+  consumable join key. You can consult [CPE
+  search](https://nvd.nist.gov/products/cpe/search) to find a CPE for a dependency.`"N/A"` should only
   be used if no CPE for the project is available in the CPE database. CPEs should be _versionless_
   with a `:*` suffix, since the version can be computed from `version`.
 
@@ -96,6 +96,14 @@ basis:
 
 Where possible, we prefer the latest release version for external dependencies, rather than master
 branch GitHub SHA tarballs.
+
+## Dependency shepherds
+
+Sign-off from the [dependency
+shepherds](https://github.com/orgs/envoyproxy/teams/dependency-shepherds) is
+required for every PR that modifies external dependencies. The shepherds will
+look to see that the policy in this document is enforced and that metadata is
+kept up-to-date.
 
 ## Dependency patches
 

--- a/repokitteh.star
+++ b/repokitteh.star
@@ -28,9 +28,11 @@ use(
       "path": "api/envoy/",
     },
     {
-      "owner": "envoyproxy/dependency-watchers",
+      "owner": "envoyproxy/dependency-shepherds!",
       "path":
-      "(bazel/repository_locations\.bzl)|(api/bazel/repository_locations\.bzl)|(.*/requirements\.txt)",
+      "(bazel/.*repos.*\.bzl)|(bazel/dependency_imports\.bzl)|(api/bazel/.*\.bzl)|(.*/requirements\.txt)",
+      "label": "deps",
+      "github_status_label": "any dependency change",
     },
   ],
 )


### PR DESCRIPTION
We now have envoyproxy/dependency-shepherds who will be needed to
sign-off on all PRs involving changes to external dependencies.
The dependency shepherds are responsible for enforcing
DEPENDENCY_POLICY.md and ensuring that dependency metadata is kept
up-to-date.

Signed-off-by: Harvey Tuch <htuch@google.com>
