### PR TITLE
local rate limit: fix docs

### DIFF
--- a/docs/root/configuration/listeners/network_filters/local_rate_limit_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/local_rate_limit_filter.rst
@@ -25,7 +25,7 @@ processed by the filter utilizes a single token, and if no tokens are available,
 be immediately closed without further filter iteration.
 
 .. note::
-  In the current implementation each filter and filter chain has an independent rate limit.
+  In the current implementation each filter chain has an independent rate limit.
 
 .. _config_network_filters_local_rate_limit_stats:
 


### PR DESCRIPTION
For the L4 local rate limit filter, the rate limit is per filter chain
though shared across filters (each connection) within that filter chain.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
