### PR TITLE
Fix runtime feature variable name

### DIFF
--- a/docs/root/version_history/v1.12.7.rst
+++ b/docs/root/version_history/v1.12.7.rst
@@ -6,7 +6,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,4 +17,4 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.

--- a/docs/root/version_history/v1.13.5.rst
+++ b/docs/root/version_history/v1.13.5.rst
@@ -6,7 +6,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,7 +17,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/root/version_history/v1.14.5.rst
+++ b/docs/root/version_history/v1.14.5.rst
@@ -6,7 +6,7 @@ Changes
   This patch changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,7 +17,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/root/version_history/v1.15.1.rst
+++ b/docs/root/version_history/v1.15.1.rst
@@ -7,7 +7,7 @@ Changes
   headers. This patch changes the default behavior to always logically match on all headers.
   Multiple individual headers will be logically concatenated with ',' similar to what is done with
   inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-  reverted by setting the runtime value "envoy.reloadable_features.header_match_on_all_headers" to
+  reverted by setting the runtime value "envoy.reloadable_features.http_match_on_all_headers" to
   "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
@@ -19,7 +19,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which


### PR DESCRIPTION
- change the runtime feature var name from `envoy.reloadable_features.header_match_on_all_headers` to `envoy.reloadable_features.http_match_on_all_headers` as this is the actual variable name defined in https://github.com/envoyproxy/envoy/blob/master/source/common/runtime/runtime_features.cc .


Risk Level: Low
Testing: N/A
Docs Changes: N/A, this is a docs change.
Release Notes: N/A

Signed-off-by: Denis Zaitcev <denis@tetrate.io>