### PR TITLE
[fuzz] Fixed divide by zero bug

### DIFF
--- a/source/extensions/filters/http/admission_control/admission_control.cc
+++ b/source/extensions/filters/http/admission_control/admission_control.cc
@@ -52,11 +52,6 @@ double AdmissionControlFilterConfig::aggression() const {
 
 double AdmissionControlFilterConfig::successRateThreshold() const {
   const double pct = sr_threshold_ ? sr_threshold_->value() : defaultSuccessRateThreshold;
-  // The threshold value should not be 0. Since you cannot add a validation on a widely used Runtime
-  // percent value, simply map a 0 percent for the field to the default success rate threshold.
-  if (pct == 0) {
-    return defaultSuccessRateThreshold / 100.0;
-  }
   return std::min<double>(pct, 100.0) / 100.0;
 }
 

--- a/source/extensions/filters/http/admission_control/admission_control.cc
+++ b/source/extensions/filters/http/admission_control/admission_control.cc
@@ -52,6 +52,11 @@ double AdmissionControlFilterConfig::aggression() const {
 
 double AdmissionControlFilterConfig::successRateThreshold() const {
   const double pct = sr_threshold_ ? sr_threshold_->value() : defaultSuccessRateThreshold;
+  // The threshold value should not be 0. Since you cannot add a validation on a widely used Runtime
+  // percent value, simply map a 0 percent for the field to the default success rate threshold.
+  if (pct == 0) {
+    return defaultSuccessRateThreshold;
+  }
   return std::min<double>(pct, 100.0) / 100.0;
 }
 

--- a/source/extensions/filters/http/admission_control/admission_control.cc
+++ b/source/extensions/filters/http/admission_control/admission_control.cc
@@ -55,7 +55,7 @@ double AdmissionControlFilterConfig::successRateThreshold() const {
   // The threshold value should not be 0. Since you cannot add a validation on a widely used Runtime
   // percent value, simply map a 0 percent for the field to the default success rate threshold.
   if (pct == 0) {
-    return defaultSuccessRateThreshold;
+    return defaultSuccessRateThreshold / 100.0;
   }
   return std::min<double>(pct, 100.0) / 100.0;
 }

--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/http/admission_control/config.h"
 
+#include "envoy/common/exception.h"
 #include "envoy/extensions/filters/http/admission_control/v3alpha/admission_control.pb.h"
 #include "envoy/extensions/filters/http/admission_control/v3alpha/admission_control.pb.validate.h"
 #include "envoy/registry/registry.h"
@@ -20,6 +21,10 @@ static constexpr std::chrono::seconds defaultSamplingWindow{30};
 Http::FilterFactoryCb AdmissionControlFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::admission_control::v3alpha::AdmissionControl& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+
+  if (config.has_sr_threshold() && config.sr_threshold().default_value().value() == 0) {
+    throw EnvoyException("Success Rate Threshold cannot be zero percent");
+  }
 
   const std::string prefix = stats_prefix + "admission_control.";
 

--- a/test/extensions/filters/http/admission_control/BUILD
+++ b/test/extensions/filters/http/admission_control/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test(
         "//source/common/http:header_map_lib",
         "//source/common/http:headers_lib",
         "//source/extensions/filters/http/admission_control:admission_control_filter_lib",
+        "//source/extensions/filters/http/admission_control:config",
         "//test/mocks/http:http_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/thread_local:thread_local_mocks",

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -6,6 +6,7 @@
 #include "common/stats/isolated_store_impl.h"
 
 #include "extensions/filters/http/admission_control/admission_control.h"
+#include "extensions/filters/http/admission_control/config.h"
 #include "extensions/filters/http/admission_control/evaluators/success_criteria_evaluator.h"
 
 #include "test/mocks/runtime/mocks.h"
@@ -45,6 +46,36 @@ protected:
   Stats::IsolatedStoreImpl scope_;
   NiceMock<Random::MockRandomGenerator> random_;
 };
+
+// Ensure the filter ingest throws an exception if it is passed a config with a default value of 0
+// for sr_threshold If exception was not thrown, a default value of 0 for sr_threshold induces a
+// divide by zero error
+TEST_F(AdmissionControlConfigTest, ZeroSuccessRateThreshold) {
+  AdmissionControlFilterFactory admission_control_filter_factory;
+  const std::string yaml = R"EOF(
+enabled:
+  default_value: false
+  runtime_key: "foo.enabled"
+sampling_window: 1337s
+sr_threshold:
+  default_value:
+    value: 0
+  runtime_key: "foo.sr_threshold"
+aggression:
+  default_value: 4.2
+  runtime_key: "foo.aggression"
+success_criteria:
+  http_criteria:
+  grpc_criteria:
+)EOF";
+
+  AdmissionControlProto proto;
+  TestUtility::loadFromYamlAndValidate(yaml, proto);
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context;
+  EXPECT_THROW_WITH_MESSAGE(admission_control_filter_factory.createFilterFactoryFromProtoTyped(
+                                proto, "whatever", factory_context),
+                            EnvoyException, "Success Rate Threshold cannot be zero percent");
+}
 
 // Verify the configuration when all fields are set.
 TEST_F(AdmissionControlConfigTest, BasicTestAllConfigured) {

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-filter_fuzz_test-5914972389113856
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-filter_fuzz_test-5914972389113856
@@ -1,0 +1,12 @@
+config {
+  name: "envoy.filters.http.admission_control"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.admission_control.v3alpha.AdmissionControl"
+    value: "\022\000\032\000*\003\022\001$"
+  }
+}
+data {
+  http_body {
+    data: "\022\000"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Fixed divide by zero bug in admission control filter for HTTP.
Additional Description: Fixes issues: https://oss-fuzz.com/testcase-detail/5914972389113856
Risk Level: Low
Testing: Added regression test
Docs Changes: N/A
Release Notes: N/A