### PR TITLE
Add Platform Specific Feature guidance to PR template

### DIFF
--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -70,6 +70,16 @@ current version. Please include any relevant links. Each release note should be 
 relevant subsystem in **alphabetical order** (see existing examples as a guide) and include links
 to relevant parts of the documentation. Thank you! Please write in N/A if there are no release notes.
 
+### <a name="platform_specific_features"></a>Platform Specific Features
+
+If this change involves any platform specific features (e.g. utilizing OS-specific socket options)
+or only implements new features for a limited set of platforms (e.g. Linux amd64 only), please
+include an explanation that addresses the reasoning behind this. Please also open a new tracking
+issue for each platform this change is not implemented on (and link them in the PR) to enable
+maintainers and contributors to triage. Reviewers will look for the change to avoid
+`#ifdef <OSNAME>` and rather prefer feature guards to not enable the change on a given platform
+using the build system.
+
 ### <a name="runtime_guard"></a>Runtime guard
 
 If this PR has a user-visible behavioral change, or otherwise falls under the

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ Risk Level:
 Testing:
 Docs Changes:
 Release Notes:
+Platform Specific Features:
 [Optional Runtime guard:]
 [Optional Fixes #Issue]
 [Optional Deprecated:]


### PR DESCRIPTION
Commit Message: Add Platform Specific Feature guidance to PR template
Additional Description: The intent of this change is to ensure platform specific features or features that a contributor PRs without for example Windows support fully implemented get a tracking issue and specific consideration from that fact from reviewers. This will help some of the platform-specific contributor groups to discover the gaps that need to be filled on a given platform without having to follow each PR.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
