### PR TITLE
dependencies: CVE scanner for repository_locations.bzl metadata.

### DIFF
--- a/api/bazel/external_deps.bzl
+++ b/api/bazel/external_deps.bzl
@@ -101,8 +101,8 @@ def load_repository_locations(repository_locations_spec):
             # Starlark doesn't have regexes.
             cpe_components = len(cpe.split(":"))
 
-            # We allow cpe:2.3:a:foo:* and cpe:2.3.:a:foo:bar:* only.
-            cpe_components_valid = cpe_components in [5, 6]
+            # We allow cpe:2.3:a:foo:*:* and cpe:2.3.:a:foo:bar:* only.
+            cpe_components_valid = (cpe_components == 6)
             cpe_matches = (cpe == "N/A" or (cpe.startswith("cpe:2.3:a:") and cpe.endswith(":*") and cpe_components_valid))
             if not cpe_matches:
                 fail("CPE must match cpe:2.3:a:<facet>:<facet>:*: " + cpe)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -268,7 +268,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "nghttp2-{version}",
         urls = ["https://github.com/nghttp2/nghttp2/releases/download/v{version}/nghttp2-{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        last_updated = "2020-06-02",
+        last_updated = "2020-06-03",
         cpe = "cpe:2.3:a:nghttp2:nghttp2:*",
     ),
     io_opentracing_cpp = dict(
@@ -586,7 +586,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.filters.network.wasm",
             "envoy.stat_sinks.wasm",
         ],
-        cpe = "cpe:2.3:a:llvm:*",
+        cpe = "cpe:2.3:a:llvm:*:*",
     ),
     com_github_wavm_wavm = dict(
         project_name = "WAVM",

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -413,7 +413,7 @@ elif [[ "$CI_TARGET" == "docs" ]]; then
   tools/dependency/validate_test.py
   tools/dependency/validate.py
   # Validate the CVE scanner works. TODO(htuch): create a dedicated tools CI target.
-  tools/dependency/cve_scan_test.py
+  python3.8 tools/dependency/cve_scan_test.py
   # Build docs.
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" docs/build.sh
   exit 0

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -412,6 +412,8 @@ elif [[ "$CI_TARGET" == "docs" ]]; then
   # Validate dependency relationships between core/extensions and external deps.
   tools/dependency/validate_test.py
   tools/dependency/validate.py
+  # Validate the CVE scanner works. TODO(htuch): create a dedicated tools CI target.
+  tools/dependency/cve_scan_test.py
   # Build docs.
   BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS[*]}" docs/build.sh
   exit 0

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -81,7 +81,7 @@ mkdir -p "${GENERATED_RST_DIR}"/intro/arch_overview/security
 ./docs/generate_extension_rst.py "${EXTENSION_DB_PATH}" "${GENERATED_RST_DIR}"/intro/arch_overview/security
 
 # Generate RST for external dependency docs in intro/arch_overview/security.
-./docs/generate_external_dep_rst.py "${GENERATED_RST_DIR}"/intro/arch_overview/security
+PYTHONPATH=. ./docs/generate_external_dep_rst.py "${GENERATED_RST_DIR}"/intro/arch_overview/security
 
 function generate_api_rst() {
   local proto_target

--- a/generated_api_shadow/bazel/external_deps.bzl
+++ b/generated_api_shadow/bazel/external_deps.bzl
@@ -101,8 +101,8 @@ def load_repository_locations(repository_locations_spec):
             # Starlark doesn't have regexes.
             cpe_components = len(cpe.split(":"))
 
-            # We allow cpe:2.3:a:foo:* and cpe:2.3.:a:foo:bar:* only.
-            cpe_components_valid = cpe_components in [5, 6]
+            # We allow cpe:2.3:a:foo:*:* and cpe:2.3.:a:foo:bar:* only.
+            cpe_components_valid = (cpe_components == 6)
             cpe_matches = (cpe == "N/A" or (cpe.startswith("cpe:2.3:a:") and cpe.endswith(":*") and cpe_components_valid))
             if not cpe_matches:
                 fail("CPE must match cpe:2.3:a:<facet>:<facet>:*: " + cpe)

--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -145,7 +145,7 @@ def RegexGroupsMatch(regex, lhs, rhs):
   '''Do two strings match modulo a regular expression?
 
   Args:
-    regex: regular expresison
+    regex: regular expression
     lhs: LHS string
     rhs: RHS string
   Returns:
@@ -193,7 +193,7 @@ def CpeMatch(cpe, dep_metadata):
   # An exact version match is a hit.
   if cpe.version == dep_version:
     return True
-  # Allow the 'last_updated' dependency metadata to substitue for date.
+  # Allow the 'last_updated' dependency metadata to substitute for date.
   # TODO(htuch): Make a finer grained distinction between Envoy update date and dependency
   # release date in 'last_updated'.
   # TODO(htuch): Consider fuzzier date ranges.

--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+
+# Scan for any external dependencies that were last updated before known CVEs
+# (and near relatives). We also try a fuzzy match on version information.
+
+from collections import defaultdict, namedtuple
+import datetime as dt
+import gzip
+import json
+import re
+import sys
+import textwrap
+import urllib.request
+
+import utils as dep_utils
+
+# These CVEs are false positives for the match heuristics. An explanation is
+# required when adding a new entry to this list as a comment.
+IGNORES_CVES = set([
+    # Node.js issue unrelated to http-parser (napi_ API implementation).
+    'CVE-2020-8174',
+    # Node.js HTTP desync attack. Request smuggling due to CR and hyphen
+    # conflation in llhttp
+    # (https://github.com/nodejs/llhttp/commit/9d9da1d0f18599ceddd8f484df5a5ad694d23361).
+    # This was a result of using llparse's toLowerUnsafe() for header keys.
+    # http-parser uses a TOKEN method that doesn't have the same issue for
+    # header fields.
+    'CVE-2020-8201',
+    # Node.js issue unrelated to http-parser. This is a DoS due to a lack of
+    # request/connection timeouts, see
+    # https://github.com/nodejs/node/commit/753f3b247a.
+    'CVE-2020-8251',
+    # Node.js issue unrelated to http-parser (libuv).
+    'CVE-2020-8252',
+    # Fixed via the nghttp2 1.41.0 bump in Envoy 8b6ea4.
+    'CVE-2020-11080',
+])
+
+# Subset of CVE fields that are useful below.
+Cve = namedtuple(
+    'Cve',
+    ['id', 'description', 'cpes', 'score', 'severity', 'published_date', 'last_modified_date'])
+
+
+class Cpe(namedtuple('CPE', ['part', 'vendor', 'product', 'version'])):
+  '''Model a subset of CPE fields that are used in CPE matching.'''
+
+  @classmethod
+  def FromString(cls, cpe_str):
+    assert (cpe_str.startswith('cpe:2.3:'))
+    components = cpe_str.split(':')
+    assert (len(components) >= 6)
+    return cls(*components[2:6])
+
+  def __str__(self):
+    return f'cpe:2.3:{self.part}:{self.vendor}:{self.product}:{self.version}'
+
+  def VendorNormalized(self):
+    '''Return a normalized CPE where only part and vendor are significant.'''
+    return Cpe(self.part, self.vendor, '*', '*')
+
+
+def ParseCveJson(cve_json, cves, cpe_revmap):
+  '''Parse CVE JSON dictionary.
+
+  Args:
+    cve_json: a NIST CVE JSON dictionary.
+    cves: dictionary mapping CVE ID string to Cve object (output).
+    cpe_revmap: a reverse map from vendor normalized CPE to CVE ID string.
+  '''
+
+  # This provides an over-approximation of possible CPEs affected by CVE nodes
+  # metadata; it traverses the entire AND-OR tree and just gathers every CPE
+  # observed. Generally we expect that most of Envoy's CVE-CPE matches to be
+  # simple, plus it's interesting to consumers of this data to understand when a
+  # CPE pops up, even in a conditional setting.
+  def GatherCpes(nodes, cpe_set):
+    for node in nodes:
+      for cpe_match in node.get('cpe_match', []):
+        cpe_set.add(Cpe.FromString(cpe_match['cpe23Uri']))
+      GatherCpes(node.get('children', []), cpe_set)
+
+  for cve in cve_json['CVE_Items']:
+    cve_id = cve['cve']['CVE_data_meta']['ID']
+    description = cve['cve']['description']['description_data'][0]['value']
+    cpe_set = set()
+    GatherCpes(cve['configurations']['nodes'], cpe_set)
+    if len(cpe_set) == 0:
+      continue
+    cvss_v3_score = cve['impact']['baseMetricV3']['cvssV3']['baseScore']
+    cvss_v3_severity = cve['impact']['baseMetricV3']['cvssV3']['baseSeverity']
+
+    def ParseCveDate(date_str):
+      assert (date_str.endswith('Z'))
+      return dt.date.fromisoformat(date_str.split('T')[0])
+
+    published_date = ParseCveDate(cve['publishedDate'])
+    last_modified_date = ParseCveDate(cve['lastModifiedDate'])
+    cves[cve_id] = Cve(cve_id, description, cpe_set, cvss_v3_score, cvss_v3_severity,
+                       published_date, last_modified_date)
+    for cpe in cpe_set:
+      cpe_revmap[str(cpe.VendorNormalized())].add(cve_id)
+  return cves, cpe_revmap
+
+
+def DownloadCveData(urls):
+  '''Download NIST CVE JSON databases from given URLs and parse.
+
+  Args:
+    urls: a list of URLs.
+  Returns:
+    cves: dictionary mapping CVE ID string to Cve object (output).
+    cpe_revmap: a reverse map from vendor normalized CPE to CVE ID string.
+  '''
+  cves = {}
+  cpe_revmap = defaultdict(set)
+  for url in urls:
+    print(f'Loading NIST CVE database from {url}...')
+    with urllib.request.urlopen(url) as request:
+      with gzip.GzipFile(fileobj=request) as json_data:
+        ParseCveJson(json.loads(json_data.read()), cves, cpe_revmap)
+  return cves, cpe_revmap
+
+
+def FormatCveDetails(cve, deps):
+  formatted_deps = ', '.join(sorted(deps))
+  wrapped_description = '\n  '.join(textwrap.wrap(cve.description))
+  return f'''
+  CVE ID: {cve.id}
+  CVSS v3 score: {cve.score}
+  Severity: {cve.severity}
+  Published date: {cve.published_date}
+  Last modified date: {cve.last_modified_date}
+  Dependencies: {formatted_deps}
+  Description: {wrapped_description}
+  Affected CPEs:
+  ''' + '\n  '.join(f'- {cpe}' for cpe in cve.cpes)
+
+
+FUZZY_DATE_RE = re.compile('(\d{4}).?(\d{2}).?(\d{2})')
+FUZZY_SEMVER_RE = re.compile('(\d+)[:\.\-_](\d+)[:\.\-_](\d+)')
+
+
+def RegexGroupsMatch(regex, lhs, rhs):
+  '''Do two strings match modulo a regular expression?
+
+  Args:
+    regex: regular expresison
+    lhs: LHS string
+    rhs: RHS string
+  Returns:
+    A boolean indicating match.
+  '''
+  lhs_match = regex.search(lhs)
+  if lhs_match:
+    rhs_match = regex.search(rhs)
+    if rhs_match and lhs_match.groups() == rhs_match.groups():
+      return True
+  return False
+
+
+def CpeMatch(cpe, dep_metadata):
+  '''Heuristically match dependency metadata against CPE.
+
+  We have a number of rules below that should are easy to compute without having
+  to look at the dependency metadata. In the future, with additional access to
+  repository information we could do the following:
+  - For dependencies at a non-release version, walk back through git history to
+    the last known release version and attempt a match with this.
+  - For dependencies at a non-release version, use the commit date to look for a
+    version match where version is YYYY-MM-DD.
+
+  Args:
+    cpe: Cpe object to match against.
+    dep_metadata: dependency metadata dictionary.
+  Returns:
+    A boolean indicating a match.
+  '''
+  dep_cpe = Cpe.FromString(dep_metadata['cpe'])
+  dep_version = dep_metadata['version']
+  # The 'part' and 'vendor' must be an exact match.
+  if cpe.part != dep_cpe.part:
+    return False
+  if cpe.vendor != dep_cpe.vendor:
+    return False
+  # We allow Envoy dependency CPEs to wildcard the 'product', this is useful for
+  # LLVM where multiple product need to be covered.
+  if dep_cpe.product != '*' and cpe.product != dep_cpe.product:
+    return False
+  # Wildcard versions always match.
+  if cpe.version == '*':
+    return True
+  # An exact version match is a hit.
+  if cpe.version == dep_version:
+    return True
+  # Allow the 'last_updated' dependency metadata to substitue for date.
+  # TODO(htuch): Make a finer grained distinction between Envoy update date and dependency
+  # release date in 'last_updated'.
+  # TODO(htuch): Consider fuzzier date ranges.
+  if cpe.version == dep_metadata['last_updated']:
+    return True
+  # Try a fuzzy date match to deal with versions like fips-20190304 in dependency version.
+  if RegexGroupsMatch(FUZZY_DATE_RE, dep_version, cpe.version):
+    return True
+  # Try a fuzzy semver match to deal with things like 2.1.0-beta3.
+  if RegexGroupsMatch(FUZZY_SEMVER_RE, dep_version, cpe.version):
+    return True
+  # Fall-thru.
+  return False
+
+
+def CveMatch(cve, dep_metadata):
+  '''Heuristically match dependency metadata against CVE.
+
+  In general, we allow false positives but want to keep the noise low, to avoid
+  the toil around having to populate IGNORES_CVES.
+
+  Args:
+    cve: Cve object to match against.
+    dep_metadata: dependency metadata dictionary.
+  Returns:
+    A boolean indicating a match.
+  '''
+  wildcard_version_match = False
+  # Consider each CPE attached to the CVE for a match against the dependency CPE.
+  for cpe in cve.cpes:
+    if CpeMatch(cpe, dep_metadata):
+      # Wildcard version matches need additional heuristics unrelated to CPE to
+      # qualify, e.g. last updated date.
+      if cpe.version == '*':
+        wildcard_version_match = True
+      else:
+        return True
+  if wildcard_version_match:
+    # If the CVE was published after the dependency was last updated, it's a
+    # potential match.
+    last_dep_update = dt.date.fromisoformat(dep_metadata['last_updated'])
+    if last_dep_update <= cve.published_date:
+      return True
+  return False
+
+
+def CveScan(cves, cpe_revmap, cve_allowlist, repository_locations):
+  '''Scan for CVEs in a parsed NIST CVE database.
+
+  Args:
+    cves: CVE dictionary as provided by DownloadCveData().
+    cve_revmap: CPE-CVE reverse map as provided by DownloadCveData().
+    cve_allowlist: an allowlist of CVE IDs to ignore.
+    repository_locations: a dictionary of dependency metadata in the format
+      described in api/bazel/external_deps.bzl.
+  Returns:
+    possible_cves: a dictionary mapping CVE IDs to Cve objects.
+    cve_deps: a dictionary mapping CVE IDs to dependency names.
+  '''
+  possible_cves = {}
+  cve_deps = defaultdict(list)
+  for dep, metadata in repository_locations.items():
+    cpe = metadata.get('cpe', 'N/A')
+    if cpe == 'N/A':
+      continue
+    candidate_cve_ids = cpe_revmap.get(str(Cpe.FromString(cpe).VendorNormalized()), [])
+    for cve_id in candidate_cve_ids:
+      cve = cves[cve_id]
+      if cve.id in cve_allowlist:
+        continue
+      if CveMatch(cve, metadata):
+        possible_cves[cve_id] = cve
+        cve_deps[cve_id].append(dep)
+  return possible_cves, cve_deps
+
+
+if __name__ == '__main__':
+  # Allow local overrides for NIST CVE database URLs via args.
+  urls = sys.argv[1:]
+  if not urls:
+    # We only look back a few years, since we shouldn't have any ancient deps.
+    current_year = dt.datetime.now().year
+    scan_years = range(2018, current_year + 1)
+    urls = [
+        f'https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{year}.json.gz' for year in scan_years
+    ]
+  cves, cpe_revmap = DownloadCveData(urls)
+  possible_cves, cve_deps = CveScan(cves, cpe_revmap, IGNORES_CVES, dep_utils.RepositoryLocations())
+  if possible_cves:
+    print('\nBased on heuristic matching with the NIST CVE database, Envoy may be vulnerable to:')
+    for cve_id in sorted(possible_cves):
+      print(f'{FormatCveDetails(possible_cves[cve_id], cve_deps[cve_id])}')
+    sys.exit(1)

--- a/tools/dependency/cve_scan_test.py
+++ b/tools/dependency/cve_scan_test.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Tests for cve_scan."""
+
+from collections import defaultdict
+import datetime as dt
+import unittest
+
+import cve_scan
+
+
+class CveScanTest(unittest.TestCase):
+
+  def test_parse_cve_json(self):
+    cve_json = {
+        'CVE_Items': [
+            {
+                'cve': {
+                    'CVE_data_meta': {
+                        'ID': 'CVE-2020-1234'
+                    },
+                    'description': {
+                        'description_data': [{
+                            'value': 'foo'
+                        }]
+                    }
+                },
+                'configurations': {
+                    'nodes': [{
+                        'cpe_match': [{
+                            'cpe23Uri': 'cpe:2.3:a:foo:bar:1.2.3'
+                        }],
+                    }],
+                },
+                'impact': {
+                    'baseMetricV3': {
+                        'cvssV3': {
+                            'baseScore': 3.4,
+                            'baseSeverity': 'LOW'
+                        }
+                    }
+                },
+                'publishedDate': '2020-03-17T00:59Z',
+                'lastModifiedDate': '2020-04-17T00:59Z'
+            },
+            {
+                'cve': {
+                    'CVE_data_meta': {
+                        'ID': 'CVE-2020-1235'
+                    },
+                    'description': {
+                        'description_data': [{
+                            'value': 'bar'
+                        }]
+                    }
+                },
+                'configurations': {
+                    'nodes': [{
+                        'cpe_match': [{
+                            'cpe23Uri': 'cpe:2.3:a:foo:bar:1.2.3'
+                        }],
+                        'children': [
+                            {
+                                'cpe_match': [{
+                                    'cpe23Uri': 'cpe:2.3:a:foo:baz:3.2.3'
+                                }]
+                            },
+                            {
+                                'cpe_match': [{
+                                    'cpe23Uri': 'cpe:2.3:a:foo:*:*'
+                                }, {
+                                    'cpe23Uri': 'cpe:2.3:a:wat:bar:1.2.3'
+                                }]
+                            },
+                        ],
+                    }],
+                },
+                'impact': {
+                    'baseMetricV3': {
+                        'cvssV3': {
+                            'baseScore': 9.9,
+                            'baseSeverity': 'HIGH'
+                        }
+                    }
+                },
+                'publishedDate': '2020-03-18T00:59Z',
+                'lastModifiedDate': '2020-04-18T00:59Z'
+            },
+        ]
+    }
+    cves = {}
+    cpe_revmap = defaultdict(set)
+    cve_scan.ParseCveJson(cve_json, cves, cpe_revmap)
+    self.maxDiff = None
+    self.assertDictEqual(
+        cves, {
+            'CVE-2020-1234':
+                cve_scan.Cve(id='CVE-2020-1234',
+                             description='foo',
+                             cpes=set([self.BuildCpe('cpe:2.3:a:foo:bar:1.2.3')]),
+                             score=3.4,
+                             severity='LOW',
+                             published_date=dt.date(2020, 3, 17),
+                             last_modified_date=dt.date(2020, 4, 17)),
+            'CVE-2020-1235':
+                cve_scan.Cve(id='CVE-2020-1235',
+                             description='bar',
+                             cpes=set(
+                                 map(self.BuildCpe, [
+                                     'cpe:2.3:a:foo:bar:1.2.3', 'cpe:2.3:a:foo:baz:3.2.3',
+                                     'cpe:2.3:a:foo:*:*', 'cpe:2.3:a:wat:bar:1.2.3'
+                                 ])),
+                             score=9.9,
+                             severity='HIGH',
+                             published_date=dt.date(2020, 3, 18),
+                             last_modified_date=dt.date(2020, 4, 18))
+        })
+    self.assertDictEqual(cpe_revmap, {
+        'cpe:2.3:a:foo:*:*': {'CVE-2020-1234', 'CVE-2020-1235'},
+        'cpe:2.3:a:wat:*:*': {'CVE-2020-1235'}
+    })
+
+  def BuildCpe(self, cpe_str):
+    return cve_scan.Cpe.FromString(cpe_str)
+
+  def BuildDep(self, cpe_str, version=None, last_updated=None):
+    return {'cpe': cpe_str, 'version': version, 'last_updated': last_updated}
+
+  def CpeMatch(self, cpe_str, dep_cpe_str, version=None, last_updated=None):
+    return cve_scan.CpeMatch(self.BuildCpe(cpe_str),
+                             self.BuildDep(dep_cpe_str, version=version, last_updated=last_updated))
+
+  def test_cpe_match(self):
+    # Mismatched part
+    self.assertFalse(self.CpeMatch('cpe:2.3:o:foo:bar:*', 'cpe:2.3:a:foo:bar:*'))
+    # Mismatched vendor
+    self.assertFalse(self.CpeMatch('cpe:2.3:a:foo:bar:*', 'cpe:2.3:a:foz:bar:*'))
+    # Mismatched product
+    self.assertFalse(self.CpeMatch('cpe:2.3:a:foo:bar:*', 'cpe:2.3:a:foo:baz:*'))
+    # Wildcard product
+    self.assertTrue(self.CpeMatch('cpe:2.3:a:foo:bar:*', 'cpe:2.3:a:foo:*:*'))
+    # Wildcard version match
+    self.assertTrue(self.CpeMatch('cpe:2.3:a:foo:bar:*', 'cpe:2.3:a:foo:bar:*'))
+    # Exact version match
+    self.assertTrue(self.CpeMatch('cpe:2.3:a:foo:bar:1.2.3', 'cpe:2.3:a:foo:bar:*',
+                                  version='1.2.3'))
+    # Date version match
+    self.assertTrue(
+        self.CpeMatch('cpe:2.3:a:foo:bar:2020-03-05',
+                      'cpe:2.3:a:foo:bar:*',
+                      last_updated='2020-03-05'))
+    fuzzy_version_matches = [
+        ('2020-03-05', '2020-03-05'),
+        ('2020-03-05', '20200305'),
+        ('2020-03-05', 'foo-20200305-bar'),
+        ('2020-03-05', 'foo-2020_03_05-bar'),
+        ('2020-03-05', 'foo-2020-03-05-bar'),
+        ('1.2.3', '1.2.3'),
+        ('1.2.3', '1-2-3'),
+        ('1.2.3', '1_2_3'),
+        ('1.2.3', '1:2:3'),
+        ('1.2.3', 'foo-1-2-3-bar'),
+    ]
+    for cpe_version, dep_version in fuzzy_version_matches:
+      self.assertTrue(
+          self.CpeMatch(f'cpe:2.3:a:foo:bar:{cpe_version}',
+                        'cpe:2.3:a:foo:bar:*',
+                        version=dep_version))
+    fuzzy_version_no_matches = [
+        ('2020-03-05', '2020-3.5'),
+        ('2020-03-05', '2020--03-05'),
+        ('1.2.3', '1@2@3'),
+        ('1.2.3', '1..2.3'),
+    ]
+    for cpe_version, dep_version in fuzzy_version_no_matches:
+      self.assertFalse(
+          self.CpeMatch(f'cpe:2.3:a:foo:bar:{cpe_version}',
+                        'cpe:2.3:a:foo:bar:*',
+                        version=dep_version))
+
+  def BuildCve(self, cve_id, cpes, published_date):
+    return cve_scan.Cve(cve_id,
+                        description=None,
+                        cpes=cpes,
+                        score=None,
+                        severity=None,
+                        published_date=dt.date.fromisoformat(published_date),
+                        last_modified_date=None)
+
+  def CveMatch(self, cve_id, cpes, published_date, dep_cpe_str, version=None, last_updated=None):
+    return cve_scan.CveMatch(self.BuildCve(cve_id, cpes=cpes, published_date=published_date),
+                             self.BuildDep(dep_cpe_str, version=version, last_updated=last_updated))
+
+  def test_cve_match(self):
+    # Empty CPEs, no match
+    self.assertFalse(self.CveMatch('CVE-2020-123', set(), '2020-05-03', 'cpe:2.3:a:foo:bar:*'))
+    # Wildcard version, stale dependency match
+    self.assertTrue(
+        self.CveMatch('CVE-2020-123',
+                      set([self.BuildCpe('cpe:2.3:a:foo:bar:*')]),
+                      '2020-05-03',
+                      'cpe:2.3:a:foo:bar:*',
+                      last_updated='2020-05-02'))
+    self.assertTrue(
+        self.CveMatch('CVE-2020-123',
+                      set([self.BuildCpe('cpe:2.3:a:foo:bar:*')]),
+                      '2020-05-03',
+                      'cpe:2.3:a:foo:bar:*',
+                      last_updated='2020-05-03'))
+    # Wildcard version, recently updated
+    self.assertFalse(
+        self.CveMatch('CVE-2020-123',
+                      set([self.BuildCpe('cpe:2.3:a:foo:bar:*')]),
+                      '2020-05-03',
+                      'cpe:2.3:a:foo:bar:*',
+                      last_updated='2020-05-04'))
+    # Version match
+    self.assertTrue(
+        self.CveMatch('CVE-2020-123',
+                      set([self.BuildCpe('cpe:2.3:a:foo:bar:1.2.3')]),
+                      '2020-05-03',
+                      'cpe:2.3:a:foo:bar:*',
+                      version='1.2.3'))
+    # Version mismatch
+    self.assertFalse(
+        self.CveMatch('CVE-2020-123',
+                      set([self.BuildCpe('cpe:2.3:a:foo:bar:1.2.3')]),
+                      '2020-05-03',
+                      'cpe:2.3:a:foo:bar:*',
+                      version='1.2.4',
+                      last_updated='2020-05-02'))
+    # Multiple CPEs, match first, don't match later.
+    self.assertTrue(
+        self.CveMatch('CVE-2020-123',
+                      set([
+                          self.BuildCpe('cpe:2.3:a:foo:bar:1.2.3'),
+                          self.BuildCpe('cpe:2.3:a:foo:baz:3.2.1')
+                      ]),
+                      '2020-05-03',
+                      'cpe:2.3:a:foo:bar:*',
+                      version='1.2.3'))
+
+  def test_cve_scan(self):
+    cves = {
+        'CVE-2020-1234':
+            self.BuildCve(
+                'CVE-2020-1234',
+                set([
+                    self.BuildCpe('cpe:2.3:a:foo:bar:1.2.3'),
+                    self.BuildCpe('cpe:2.3:a:foo:baz:3.2.1')
+                ]), '2020-05-03'),
+        'CVE-2020-1235':
+            self.BuildCve(
+                'CVE-2020-1235',
+                set([
+                    self.BuildCpe('cpe:2.3:a:foo:bar:1.2.3'),
+                    self.BuildCpe('cpe:2.3:a:foo:baz:3.2.1')
+                ]), '2020-05-03'),
+        'CVE-2020-1236':
+            self.BuildCve('CVE-2020-1236', set([
+                self.BuildCpe('cpe:2.3:a:foo:wat:1.2.3'),
+            ]), '2020-05-03'),
+    }
+    cpe_revmap = {
+        'cpe:2.3:a:foo:*:*': ['CVE-2020-1234', 'CVE-2020-1235', 'CVE-2020-1236'],
+    }
+    cve_allowlist = ['CVE-2020-1235']
+    repository_locations = {
+        'bar': self.BuildDep('cpe:2.3:a:foo:bar:*', version='1.2.3'),
+        'baz': self.BuildDep('cpe:2.3:a:foo:baz:*', version='3.2.1'),
+        'foo': self.BuildDep('cpe:2.3:a:foo:*:*', version='1.2.3'),
+        'blah': self.BuildDep('N/A'),
+    }
+    possible_cves, cve_deps = cve_scan.CveScan(cves, cpe_revmap, cve_allowlist,
+                                               repository_locations)
+    self.assertListEqual(sorted(possible_cves.keys()), ['CVE-2020-1234', 'CVE-2020-1236'])
+    self.assertDictEqual(cve_deps, {
+        'CVE-2020-1234': ['bar', 'baz', 'foo'],
+        'CVE-2020-1236': ['foo']
+    })
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tools/dependency/utils.py
+++ b/tools/dependency/utils.py
@@ -1,0 +1,28 @@
+# Utilities for reasoning about dependencies.
+
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader
+
+
+# Shared Starlark/Python files must have a .bzl suffix for Starlark import, so
+# we are forced to do this workaround.
+def LoadModule(name, path):
+  spec = spec_from_loader(name, SourceFileLoader(name, path))
+  module = module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+envoy_repository_locations = LoadModule('envoy_repository_locations',
+                                        'bazel/repository_locations.bzl')
+api_repository_locations = LoadModule('api_repository_locations',
+                                      'api/bazel/repository_locations.bzl')
+repository_locations_utils = LoadModule('repository_locations_utils',
+                                        'api/bazel/repository_locations_utils.bzl')
+
+
+def RepositoryLocations():
+  spec_loader = repository_locations_utils.load_repository_locations_spec
+  locations = spec_loader(envoy_repository_locations.REPOSITORY_LOCATIONS_SPEC)
+  locations.update(spec_loader(api_repository_locations.REPOSITORY_LOCATIONS_SPEC))
+  return locations


### PR DESCRIPTION
This is a custom CVE scanner that consumes the NIST CVE database and
heuristically matches against the CPEs, versions and last update stamps
in repository_locations.bzl.

Future PRs will create a CI job that runs this on a periodic basis
(every few hours) to provide a CVE early warning system.

Example output:

Based on heuristic matching with the NIST CVE database, Envoy may be vulnerable to:

  CVE ID: CVE-2019-19391
  CVSS v3 score: 9.1
  Severity: CRITICAL
  Published date: 2019-11-29
  Last modified date: 2019-12-19
  Dependencies: com_github_luajit_luajit
  Description: ** DISPUTED ** In LuaJIT through 2.0.5, as used in Moonjit before
  2.1.2 and other products, debug.getinfo has a type confusion issue
  that leads to arbitrary memory write or read operations, because
  certain cases involving valid stack levels and > options are
  mishandled. NOTE: The LuaJIT project owner states that the debug
  libary is unsafe by definition and that this is not a vulnerability.
  When LuaJIT was originally developed, the expectation was that the
  entire debug library had no security guarantees and thus it made no
  sense to assign CVEs. However, not all users of later LuaJIT
  derivatives share this perspective.
  Affected CPEs:
  - cpe:2.3:a:moonjit_project:moonjit:*
  - cpe:2.3:a:luajit:luajit:*

Risk level: Low
Testing: cve_scan_test.py unit tests, manual.

Signed-off-by: Harvey Tuch <htuch@google.com>