### PR TITLE
api: Add UDPA resource names to SotW API, RouteAction, and ClusterStats

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -13,6 +13,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -132,7 +134,7 @@ message Extension {
 // Identifies a specific Envoy instance. The node identifier is presented to the
 // management server, which may use this identifier to distinguish per Envoy
 // configuration for serving.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message Node {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.Node";
 
@@ -160,7 +162,11 @@ message Node {
   // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
   // <arch_overview_tracing>`, either in this message or via
   // :option:`--service-cluster`.
-  string cluster = 2;
+  string cluster = 2 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 12
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // Opaque metadata extending the node identifier. Envoy will pass this
   // directly to the management server.

--- a/api/envoy/config/core/v3/grpc_service.proto
+++ b/api/envoy/config/core/v3/grpc_service.proto
@@ -10,6 +10,9 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -35,7 +38,14 @@ message GrpcService {
     // The name of the upstream gRPC cluster. SSL credentials will be supplied
     // in the :ref:`Cluster <envoy_api_msg_config.cluster.v3.Cluster>` :ref:`transport_socket
     // <envoy_api_field_config.cluster.v3.Cluster.transport_socket>`.
-    string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+    string cluster_name = 1 [
+      (validate.rules).string = {min_len: 1},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // The `:authority` header in the grpc request. If this field is not set, the authority header value will be `cluster_name`.
     // Note that this authority does not override the SNI. The SNI is provided by the transport socket of the cluster.

--- a/api/envoy/config/core/v3/http_uri.proto
+++ b/api/envoy/config/core/v3/http_uri.proto
@@ -4,6 +4,8 @@ package envoy.config.core.v3;
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -46,6 +48,9 @@ message HttpUri {
     //    cluster: jwks_cluster
     //
     string cluster = 2 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.

--- a/api/envoy/config/core/v4alpha/base.proto
+++ b/api/envoy/config/core/v4alpha/base.proto
@@ -12,6 +12,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -130,7 +132,7 @@ message Extension {
 // Identifies a specific Envoy instance. The node identifier is presented to the
 // management server, which may use this identifier to distinguish per Envoy
 // configuration for serving.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message Node {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.core.v3.Node";
 
@@ -146,19 +148,24 @@ message Node {
   // :option:`--service-node`.
   string id = 1;
 
-  // Defines the local service cluster name where Envoy is running. Though
-  // optional, it should be set if any of the following features are used:
-  // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
-  // verification
-  // <envoy_api_field_config.core.v4alpha.HealthCheck.HttpHealthCheck.service_name_matcher>`,
-  // :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v4alpha.Runtime>`,
-  // :ref:`user agent addition
-  // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.add_user_agent>`,
-  // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
-  // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-  // <arch_overview_tracing>`, either in this message or via
-  // :option:`--service-cluster`.
-  string cluster = 2;
+  oneof cluster_specifier {
+    // Defines the local service cluster name where Envoy is running. Though
+    // optional, it should be set if any of the following features are used:
+    // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+    // verification
+    // <envoy_api_field_config.core.v4alpha.HealthCheck.HttpHealthCheck.service_name_matcher>`,
+    // :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v4alpha.Runtime>`,
+    // :ref:`user agent addition
+    // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.add_user_agent>`,
+    // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+    // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+    // <arch_overview_tracing>`, either in this message or via
+    // :option:`--service-cluster`.
+    string cluster = 2;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 12;
+  }
 
   // Opaque metadata extending the node identifier. Envoy will pass this
   // directly to the management server.

--- a/api/envoy/config/core/v4alpha/grpc_service.proto
+++ b/api/envoy/config/core/v4alpha/grpc_service.proto
@@ -10,6 +10,8 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -32,10 +34,15 @@ message GrpcService {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.core.v3.GrpcService.EnvoyGrpc";
 
-    // The name of the upstream gRPC cluster. SSL credentials will be supplied
-    // in the :ref:`Cluster <envoy_api_msg_config.cluster.v4alpha.Cluster>` :ref:`transport_socket
-    // <envoy_api_field_config.cluster.v4alpha.Cluster.transport_socket>`.
-    string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      // The name of the upstream gRPC cluster. SSL credentials will be supplied
+      // in the :ref:`Cluster <envoy_api_msg_config.cluster.v4alpha.Cluster>` :ref:`transport_socket
+      // <envoy_api_field_config.cluster.v4alpha.Cluster.transport_socket>`.
+      string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
+    }
 
     // The `:authority` header in the grpc request. If this field is not set, the authority header value will be `cluster_name`.
     // Note that this authority does not override the SNI. The SNI is provided by the transport socket of the cluster.

--- a/api/envoy/config/core/v4alpha/http_uri.proto
+++ b/api/envoy/config/core/v4alpha/http_uri.proto
@@ -4,6 +4,8 @@ package envoy.config.core.v4alpha;
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -46,6 +48,9 @@ message HttpUri {
     //    cluster: jwks_cluster
     //
     string cluster = 2 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.

--- a/api/envoy/config/endpoint/v3/BUILD
+++ b/api/envoy/config/endpoint/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/endpoint/v3/load_report.proto
+++ b/api/envoy/config/endpoint/v3/load_report.proto
@@ -8,6 +8,9 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
+import "udpa/core/v1/resource_name.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -119,8 +122,7 @@ message EndpointLoadMetricStats {
 
 // Per cluster load stats. Envoy reports these stats a management server in a
 // :ref:`LoadStatsRequest<envoy_api_msg_service.load_stats.v3.LoadStatsRequest>`
-// Next ID: 7
-// [#next-free-field: 7]
+// [#next-free-field: 9]
 message ClusterStats {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.endpoint.ClusterStats";
 
@@ -136,12 +138,24 @@ message ClusterStats {
   }
 
   // The name of the cluster.
-  string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+  string cluster_name = 1 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceName cluster_resource_name = 7
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // The eds_cluster_config service_name of the cluster.
   // It's possible that two clusters send the same service_name to EDS,
   // in that case, the management server is supposed to do aggregation on the load reports.
-  string cluster_service_name = 6;
+  string cluster_service_name = 6
+      [(udpa.annotations.field_migrate).oneof_promotion = "eds_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceName eds_resource_name = 8
+      [(udpa.annotations.field_migrate).oneof_promotion = "eds_specifier"];
 
   // Need at least one.
   repeated UpstreamLocalityStats upstream_locality_stats = 2

--- a/api/envoy/config/route/v3/BUILD
+++ b/api/envoy/config/route/v3/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -8,6 +8,8 @@ import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -113,4 +115,7 @@ message Vhds {
 
   // Configuration source specifier for VHDS.
   core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator resource_locator = 2;
 }

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -17,6 +17,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
@@ -549,7 +551,7 @@ message CorsPolicy {
   core.v3.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -799,6 +801,9 @@ message RouteAction {
     // Indicates the upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 37;
 
     // Envoy will determine the cluster to route to by reading the value of the
     // HTTP header named by cluster_header from the request headers. If the

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -302,7 +302,7 @@ message Route {
 message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.WeightedCluster";
 
-  // [#next-free-field: 11]
+  // [#next-free-field: 12]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.WeightedCluster.ClusterWeight";
@@ -313,7 +313,14 @@ message WeightedCluster {
 
     // Name of the upstream cluster. The cluster must exist in the
     // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string = {min_len: 1}];
+    string name = 1 [
+      (validate.rules).string = {min_len: 1},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 11
+        [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // An integer between 0 and :ref:`total_weight
     // <envoy_api_field_config.route.v3.WeightedCluster.total_weight>`. When a request matches the route,

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -590,6 +590,7 @@ message RouteAction {
   // .. note::
   //
   //   Shadowing will not be triggered if the primary cluster does not exist.
+  // [#next-free-field: 6]
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";
@@ -600,7 +601,14 @@ message RouteAction {
 
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.
-    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+    string cluster = 1 [
+      (validate.rules).string = {min_len: 1},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 5
+        [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // If not specified, all requests to the target cluster will be mirrored.
     //

--- a/api/envoy/config/route/v4alpha/BUILD
+++ b/api/envoy/config/route/v4alpha/BUILD
@@ -14,5 +14,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/config/route/v4alpha/route.proto
+++ b/api/envoy/config/route/v4alpha/route.proto
@@ -8,6 +8,8 @@ import "envoy/config/route/v4alpha/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -114,4 +116,7 @@ message Vhds {
 
   // Configuration source specifier for VHDS.
   core.v4alpha.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator resource_locator = 2;
 }

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -302,7 +302,7 @@ message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.route.v3.WeightedCluster";
 
-  // [#next-free-field: 11]
+  // [#next-free-field: 12]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.WeightedCluster.ClusterWeight";
@@ -311,9 +311,14 @@ message WeightedCluster {
 
     reserved "per_filter_config";
 
-    // Name of the upstream cluster. The cluster must exist in the
-    // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      // Name of the upstream cluster. The cluster must exist in the
+      // :ref:`cluster manager configuration <config_cluster_manager>`.
+      string name = 1 [(validate.rules).string = {min_len: 1}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 11;
+    }
 
     // An integer between 0 and :ref:`total_weight
     // <envoy_api_field_config.route.v4alpha.WeightedCluster.total_weight>`. When a request matches the route,

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -581,6 +581,7 @@ message RouteAction {
   // .. note::
   //
   //   Shadowing will not be triggered if the primary cluster does not exist.
+  // [#next-free-field: 6]
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.RequestMirrorPolicy";
@@ -589,9 +590,14 @@ message RouteAction {
 
     reserved "runtime_key";
 
-    // Specifies the cluster that requests will be mirrored to. The cluster must
-    // exist in the cluster manager configuration.
-    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      // Specifies the cluster that requests will be mirrored to. The cluster must
+      // exist in the cluster manager configuration.
+      string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
+    }
 
     // If not specified, all requests to the target cluster will be mirrored.
     //

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -17,6 +17,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -551,7 +553,7 @@ message CorsPolicy {
   core.v4alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RouteAction";
 
@@ -799,6 +801,9 @@ message RouteAction {
     // Indicates the upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 37;
 
     // Envoy will determine the cluster to route to by reading the value of the
     // HTTP header named by cluster_header from the request headers. If the

--- a/api/envoy/data/cluster/v3/BUILD
+++ b/api/envoy/data/cluster/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/data/cluster/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/data/cluster/v3/outlier_detection_event.proto
+++ b/api/envoy/data/cluster/v3/outlier_detection_event.proto
@@ -5,6 +5,9 @@ package envoy.data.cluster.v3;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -73,7 +76,7 @@ enum Action {
   UNEJECT = 1;
 }
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message OutlierDetectionEvent {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.data.cluster.v2alpha.OutlierDetectionEvent";
@@ -88,7 +91,14 @@ message OutlierDetectionEvent {
   google.protobuf.UInt64Value secs_since_last_action = 3;
 
   // The :ref:`cluster <envoy_api_msg_config.cluster.v3.Cluster>` that owns the ejected host.
-  string cluster_name = 4 [(validate.rules).string = {min_len: 1}];
+  string cluster_name = 4 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 12
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // The URL of the ejected host. E.g., ``tcp://1.2.3.4:80``.
   string upstream_url = 5 [(validate.rules).string = {min_len: 1}];

--- a/api/envoy/data/core/v3/BUILD
+++ b/api/envoy/data/core/v3/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/data/core/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/data/core/v3/health_check_event.proto
+++ b/api/envoy/data/core/v3/health_check_event.proto
@@ -6,6 +6,9 @@ import "envoy/config/core/v3/address.proto";
 
 import "google/protobuf/timestamp.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -31,7 +34,7 @@ enum HealthCheckerType {
   REDIS = 3;
 }
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message HealthCheckEvent {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.data.core.v2alpha.HealthCheckEvent";
@@ -40,7 +43,14 @@ message HealthCheckEvent {
 
   config.core.v3.Address host = 2;
 
-  string cluster_name = 3 [(validate.rules).string = {min_len: 1}];
+  string cluster_name = 3 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 10
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   oneof event {
     option (validate.required) = true;

--- a/api/envoy/data/dns/v3/BUILD
+++ b/api/envoy/data/dns/v3/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/data/dns/v2alpha:pkg",
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/data/dns/v3/dns_table.proto
+++ b/api/envoy/data/dns/v3/dns_table.proto
@@ -6,6 +6,8 @@ import "envoy/type/matcher/v3/string.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -56,7 +58,7 @@ message DnsTable {
   }
 
   // Specify the target for a given DNS service
-  // [#next-free-field: 6]
+  // [#next-free-field: 7]
   message DnsServiceTarget {
     // Specify the name of the endpoint for the Service. The name is a hostname or a cluster
     oneof endpoint_type {
@@ -69,6 +71,9 @@ message DnsTable {
       // Use a cluster name as the endpoint for a service.
       string cluster_name = 2
           [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 6;
     }
 
     // The priority of the service record target
@@ -116,6 +121,9 @@ message DnsTable {
 
       // Define a cluster whose addresses are returned for the specified endpoint
       string cluster_name = 2;
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
 
       // Define a DNS Service List for the specified endpoint
       DnsServiceList service_list = 3;

--- a/api/envoy/data/dns/v4alpha/BUILD
+++ b/api/envoy/data/dns/v4alpha/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/data/dns/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/data/dns/v4alpha/dns_table.proto
+++ b/api/envoy/data/dns/v4alpha/dns_table.proto
@@ -6,6 +6,8 @@ import "envoy/type/matcher/v4alpha/string.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -59,7 +61,7 @@ message DnsTable {
   }
 
   // Specify the target for a given DNS service
-  // [#next-free-field: 6]
+  // [#next-free-field: 7]
   message DnsServiceTarget {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.data.dns.v3.DnsTable.DnsServiceTarget";
@@ -75,6 +77,9 @@ message DnsTable {
       // Use a cluster name as the endpoint for a service.
       string cluster_name = 2
           [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 6;
     }
 
     // The priority of the service record target
@@ -128,6 +133,9 @@ message DnsTable {
 
       // Define a cluster whose addresses are returned for the specified endpoint
       string cluster_name = 2;
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
 
       // Define a DNS Service List for the specified endpoint
       DnsServiceList service_list = 3;

--- a/api/envoy/extensions/clusters/aggregate/v3/BUILD
+++ b/api/envoy/extensions/clusters/aggregate/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/config/cluster/aggregate/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/aggregate/v3/cluster.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package envoy.extensions.clusters.aggregate.v3;
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -22,5 +25,12 @@ message ClusterConfig {
 
   // Load balancing clusters in aggregate cluster. Clusters are prioritized based on the order they
   // appear in this list.
-  repeated string clusters = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated string clusters = 1 [
+    (validate.rules).repeated = {min_items: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator cluster_resource_locator = 2
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 }

--- a/api/envoy/extensions/filters/http/squash/v3/BUILD
+++ b/api/envoy/extensions/filters/http/squash/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/config/filter/http/squash/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/squash/v3/squash.proto
+++ b/api/envoy/extensions/filters/http/squash/v3/squash.proto
@@ -5,6 +5,9 @@ package envoy.extensions.filters.http.squash.v3;
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -18,13 +21,20 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Squash :ref:`configuration overview <config_http_filters_squash>`.
 // [#extension: envoy.filters.http.squash]
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Squash {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.squash.v2.Squash";
 
   // The name of the cluster that hosts the Squash server.
-  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  string cluster = 1 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 6
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // When the filter requests the Squash server to create a DebugAttachment, it will use this
   // structure as template for the body of the request. It can contain reference to environment

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
@@ -6,6 +6,8 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/range.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,9 @@ message RouteAction {
 
     // Indicates the upstream cluster to which the request should be routed.
     string cluster = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
@@ -6,6 +6,8 @@ import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 import "envoy/type/v3/range.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,9 @@ message RouteAction {
 
     // Indicates the upstream cluster to which the request should be routed.
     string cluster = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/redis_proxy/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -7,6 +7,8 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
@@ -125,6 +127,7 @@ message RedisProxy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes";
 
+    // [#next-free-field: 6]
     message Route {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.Route";
@@ -140,7 +143,14 @@ message RedisProxy {
 
         // Specifies the cluster that requests will be mirrored to. The cluster must
         // exist in the cluster manager configuration.
-        string cluster = 1 [(validate.rules).string = {min_len: 1}];
+        string cluster = 1 [
+          (validate.rules).string = {min_len: 1},
+          (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+        ];
+
+        // [#not-implemented-hide:]
+        udpa.core.v1.ResourceLocator cluster_resource_locator = 4
+            [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
         // If not specified or the runtime key is not present, all requests to the target cluster
         // will be mirrored.
@@ -162,7 +172,14 @@ message RedisProxy {
       bool remove_prefix = 2;
 
       // Upstream cluster to forward the command to.
-      string cluster = 3 [(validate.rules).string = {min_len: 1}];
+      string cluster = 3 [
+        (validate.rules).string = {min_len: 1},
+        (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+      ];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 5
+          [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
       // Indicates that the route has a request mirroring policy.
       repeated RequestMirrorPolicy request_mirror_policy = 4;

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/route/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
@@ -6,6 +6,9 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -48,7 +51,14 @@ message RouteMatch {
 
 message RouteAction {
   // Indicates the upstream cluster to which the request should be routed.
-  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  string cluster = 1 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // Optional endpoint metadata match criteria used by the subset load balancer.
   config.core.v3.Metadata metadata_match = 2;

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/extensions/filters/network/rocketmq_proxy/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto
+++ b/api/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto
@@ -6,6 +6,8 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -59,8 +61,13 @@ message RouteAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.rocketmq_proxy.v3.RouteAction";
 
-  // Indicates the upstream cluster to which the request should be routed.
-  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  oneof cluster_specifier {
+    // Indicates the upstream cluster to which the request should be routed.
+    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
+  }
 
   // Optional endpoint metadata match criteria used by the subset load balancer.
   config.core.v4alpha.Metadata metadata_match = 2;

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/filter/network/tcp_proxy/v2:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -9,6 +9,8 @@ import "envoy/type/v3/hash_policy.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -22,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";
@@ -83,6 +85,9 @@ message TcpProxy {
 
     // The upstream cluster to connect to.
     string cluster = 2;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 14;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/extensions/filters/network/tcp_proxy/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
@@ -9,6 +9,8 @@ import "envoy/type/v3/hash_policy.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -22,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy";
@@ -83,6 +85,9 @@ message TcpProxy {
 
     // The upstream cluster to connect to.
     string cluster = 2;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 14;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/extensions/filters/network/thrift_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/filter/network/thrift_proxy/v2alpha1:pkg",
         "//envoy/config/route/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
@@ -7,6 +7,8 @@ import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -81,7 +83,7 @@ message RouteMatch {
   repeated config.route.v3.HeaderMatcher headers = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.thrift_proxy.v2alpha1.RouteAction";
@@ -92,6 +94,9 @@ message RouteAction {
     // Indicates a single upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 7;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/BUILD
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/route/v4alpha:pkg",
         "//envoy/extensions/filters/network/thrift_proxy/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
+++ b/api/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
@@ -7,6 +7,8 @@ import "envoy/config/route/v4alpha/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -81,7 +83,7 @@ message RouteMatch {
   repeated config.route.v4alpha.HeaderMatcher headers = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.thrift_proxy.v3.RouteAction";
@@ -92,6 +94,9 @@ message RouteAction {
     // Indicates a single upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 7;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/config/filter/udp/udp_proxy/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -4,6 +4,8 @@ package envoy.extensions.filters.udp.udp_proxy.v3;
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -18,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.udp_listener.udp_proxy]
 
 // Configuration for the UDP proxy filter.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message UdpProxyConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.udp.udp_proxy.v2alpha.UdpProxyConfig";
@@ -42,6 +44,9 @@ message UdpProxyConfig {
 
     // The upstream cluster to connect to.
     string cluster = 2 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 6;
   }
 
   // The idle timeout for sessions. Idle is defined as no datagrams between received or sent by

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DiscoveryRequest";
 
@@ -46,6 +46,9 @@ message DiscoveryRequest {
   // will then imply a number of resources that need to be fetched via EDS/RDS,
   // which will be explicitly enumerated in resource_names.
   repeated string resource_names = 3;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resource_names = 7;
 
   // Type of the resource that is being requested, e.g.
   // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.DiscoveryRequest";
@@ -46,6 +46,9 @@ message DiscoveryRequest {
   // will then imply a number of resources that need to be fetched via EDS/RDS,
   // which will be explicitly enumerated in resource_names.
   repeated string resource_names = 3;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resource_names = 7;
 
   // Type of the resource that is being requested, e.g.
   // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit

--- a/api/envoy/service/health/v3/BUILD
+++ b/api/envoy/service/health/v3/BUILD
@@ -12,5 +12,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/discovery/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/service/health/v3/hds.proto
+++ b/api/envoy/service/health/v3/hds.proto
@@ -10,6 +10,8 @@ import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -120,7 +122,11 @@ message LocalityEndpointsHealth {
 // The health status of endpoints in a cluster. The cluster name and locality
 // should match the corresponding fields in ClusterHealthCheck message.
 message ClusterEndpointsHealth {
-  string cluster_name = 1;
+  string cluster_name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   repeated LocalityEndpointsHealth locality_endpoints_health = 2;
 }
@@ -160,11 +166,16 @@ message LocalityEndpoints {
 // health checks to support statistics reporting, logging and debugging by the
 // Envoy instance (outside of HDS). For maximum usefulness, it should match the
 // same cluster structure as that provided by EDS.
+// [#next-free-field: 6]
 message ClusterHealthCheck {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v2.ClusterHealthCheck";
 
-  string cluster_name = 1;
+  string cluster_name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 5
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   repeated config.core.v3.HealthCheck health_checks = 2;
 

--- a/api/envoy/service/health/v4alpha/BUILD
+++ b/api/envoy/service/health/v4alpha/BUILD
@@ -12,5 +12,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/health/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/service/health/v4alpha/hds.proto
+++ b/api/envoy/service/health/v4alpha/hds.proto
@@ -10,6 +10,8 @@ import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 
@@ -124,7 +126,12 @@ message ClusterEndpointsHealth {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.health.v3.ClusterEndpointsHealth";
 
-  string cluster_name = 1;
+  oneof cluster_specifier {
+    string cluster_name = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
+  }
 
   repeated LocalityEndpointsHealth locality_endpoints_health = 2;
 }
@@ -165,11 +172,17 @@ message LocalityEndpoints {
 // health checks to support statistics reporting, logging and debugging by the
 // Envoy instance (outside of HDS). For maximum usefulness, it should match the
 // same cluster structure as that provided by EDS.
+// [#next-free-field: 6]
 message ClusterHealthCheck {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.health.v3.ClusterHealthCheck";
 
-  string cluster_name = 1;
+  oneof cluster_specifier {
+    string cluster_name = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
+  }
 
   repeated config.core.v4alpha.HealthCheck health_checks = 2;
 

--- a/api/envoy/service/load_stats/v3/BUILD
+++ b/api/envoy/service/load_stats/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/load_stats/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/service/load_stats/v3/lrs.proto
+++ b/api/envoy/service/load_stats/v3/lrs.proto
@@ -7,6 +7,8 @@ import "envoy/config/endpoint/v3/load_report.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,7 @@ message LoadStatsRequest {
 
 // The management server sends envoy a LoadStatsResponse with all clusters it
 // is interested in learning load stats about.
+// [#next-free-field: 6]
 message LoadStatsResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.load_stats.v2.LoadStatsResponse";
@@ -81,6 +84,9 @@ message LoadStatsResponse {
   // Clusters to report stats for.
   // Not populated if *send_all_clusters* is true.
   repeated string clusters = 1;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
 
   // If true, the client should send all clusters it knows about.
   // Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their

--- a/api/envoy/service/load_stats/v4alpha/BUILD
+++ b/api/envoy/service/load_stats/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/load_stats/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/api/envoy/service/load_stats/v4alpha/lrs.proto
+++ b/api/envoy/service/load_stats/v4alpha/lrs.proto
@@ -7,6 +7,8 @@ import "envoy/config/endpoint/v3/load_report.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,7 @@ message LoadStatsRequest {
 
 // The management server sends envoy a LoadStatsResponse with all clusters it
 // is interested in learning load stats about.
+// [#next-free-field: 6]
 message LoadStatsResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.load_stats.v3.LoadStatsResponse";
@@ -81,6 +84,9 @@ message LoadStatsResponse {
   // Clusters to report stats for.
   // Not populated if *send_all_clusters* is true.
   repeated string clusters = 1;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
 
   // If true, the client should send all clusters it knows about.
   // Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their

--- a/generated_api_shadow/envoy/config/core/v3/base.proto
+++ b/generated_api_shadow/envoy/config/core/v3/base.proto
@@ -13,6 +13,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -132,7 +134,7 @@ message Extension {
 // Identifies a specific Envoy instance. The node identifier is presented to the
 // management server, which may use this identifier to distinguish per Envoy
 // configuration for serving.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message Node {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.Node";
 
@@ -156,7 +158,11 @@ message Node {
   // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
   // <arch_overview_tracing>`, either in this message or via
   // :option:`--service-cluster`.
-  string cluster = 2;
+  string cluster = 2 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 12
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // Opaque metadata extending the node identifier. Envoy will pass this
   // directly to the management server.

--- a/generated_api_shadow/envoy/config/core/v3/grpc_service.proto
+++ b/generated_api_shadow/envoy/config/core/v3/grpc_service.proto
@@ -10,6 +10,9 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -35,7 +38,14 @@ message GrpcService {
     // The name of the upstream gRPC cluster. SSL credentials will be supplied
     // in the :ref:`Cluster <envoy_api_msg_config.cluster.v3.Cluster>` :ref:`transport_socket
     // <envoy_api_field_config.cluster.v3.Cluster.transport_socket>`.
-    string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+    string cluster_name = 1 [
+      (validate.rules).string = {min_len: 1},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3
+        [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // The `:authority` header in the grpc request. If this field is not set, the authority header value will be `cluster_name`.
     // Note that this authority does not override the SNI. The SNI is provided by the transport socket of the cluster.

--- a/generated_api_shadow/envoy/config/core/v3/http_uri.proto
+++ b/generated_api_shadow/envoy/config/core/v3/http_uri.proto
@@ -4,6 +4,8 @@ package envoy.config.core.v3;
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -46,6 +48,9 @@ message HttpUri {
     //    cluster: jwks_cluster
     //
     string cluster = 2 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.

--- a/generated_api_shadow/envoy/config/core/v4alpha/base.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/base.proto
@@ -13,6 +13,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -131,7 +133,7 @@ message Extension {
 // Identifies a specific Envoy instance. The node identifier is presented to the
 // management server, which may use this identifier to distinguish per Envoy
 // configuration for serving.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message Node {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.core.v3.Node";
 
@@ -147,19 +149,24 @@ message Node {
   // :option:`--service-node`.
   string id = 1;
 
-  // Defines the local service cluster name where Envoy is running. Though
-  // optional, it should be set if any of the following features are used:
-  // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
-  // verification
-  // <envoy_api_field_config.core.v4alpha.HealthCheck.HttpHealthCheck.service_name_matcher>`,
-  // :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v4alpha.Runtime>`,
-  // :ref:`user agent addition
-  // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.add_user_agent>`,
-  // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
-  // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
-  // <arch_overview_tracing>`, either in this message or via
-  // :option:`--service-cluster`.
-  string cluster = 2;
+  oneof cluster_specifier {
+    // Defines the local service cluster name where Envoy is running. Though
+    // optional, it should be set if any of the following features are used:
+    // :ref:`statsd <arch_overview_statistics>`, :ref:`health check cluster
+    // verification
+    // <envoy_api_field_config.core.v4alpha.HealthCheck.HttpHealthCheck.service_name_matcher>`,
+    // :ref:`runtime override directory <envoy_api_msg_config.bootstrap.v4alpha.Runtime>`,
+    // :ref:`user agent addition
+    // <envoy_api_field_extensions.filters.network.http_connection_manager.v4alpha.HttpConnectionManager.add_user_agent>`,
+    // :ref:`HTTP global rate limiting <config_http_filters_rate_limit>`,
+    // :ref:`CDS <config_cluster_manager_cds>`, and :ref:`HTTP tracing
+    // <arch_overview_tracing>`, either in this message or via
+    // :option:`--service-cluster`.
+    string cluster = 2;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 12;
+  }
 
   // Opaque metadata extending the node identifier. Envoy will pass this
   // directly to the management server.

--- a/generated_api_shadow/envoy/config/core/v4alpha/grpc_service.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/grpc_service.proto
@@ -10,6 +10,8 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -32,10 +34,15 @@ message GrpcService {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.core.v3.GrpcService.EnvoyGrpc";
 
-    // The name of the upstream gRPC cluster. SSL credentials will be supplied
-    // in the :ref:`Cluster <envoy_api_msg_config.cluster.v4alpha.Cluster>` :ref:`transport_socket
-    // <envoy_api_field_config.cluster.v4alpha.Cluster.transport_socket>`.
-    string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      // The name of the upstream gRPC cluster. SSL credentials will be supplied
+      // in the :ref:`Cluster <envoy_api_msg_config.cluster.v4alpha.Cluster>` :ref:`transport_socket
+      // <envoy_api_field_config.cluster.v4alpha.Cluster.transport_socket>`.
+      string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
+    }
 
     // The `:authority` header in the grpc request. If this field is not set, the authority header value will be `cluster_name`.
     // Note that this authority does not override the SNI. The SNI is provided by the transport socket of the cluster.

--- a/generated_api_shadow/envoy/config/core/v4alpha/http_uri.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/http_uri.proto
@@ -4,6 +4,8 @@ package envoy.config.core.v4alpha;
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -46,6 +48,9 @@ message HttpUri {
     //    cluster: jwks_cluster
     //
     string cluster = 2 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
   }
 
   // Sets the maximum duration in milliseconds that a response can take to arrive upon request.

--- a/generated_api_shadow/envoy/config/endpoint/v3/BUILD
+++ b/generated_api_shadow/envoy/config/endpoint/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/endpoint/v3/load_report.proto
+++ b/generated_api_shadow/envoy/config/endpoint/v3/load_report.proto
@@ -8,6 +8,9 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
+import "udpa/core/v1/resource_name.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -119,8 +122,7 @@ message EndpointLoadMetricStats {
 
 // Per cluster load stats. Envoy reports these stats a management server in a
 // :ref:`LoadStatsRequest<envoy_api_msg_service.load_stats.v3.LoadStatsRequest>`
-// Next ID: 7
-// [#next-free-field: 7]
+// [#next-free-field: 9]
 message ClusterStats {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.endpoint.ClusterStats";
 
@@ -136,12 +138,24 @@ message ClusterStats {
   }
 
   // The name of the cluster.
-  string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
+  string cluster_name = 1 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceName cluster_resource_name = 7
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // The eds_cluster_config service_name of the cluster.
   // It's possible that two clusters send the same service_name to EDS,
   // in that case, the management server is supposed to do aggregation on the load reports.
-  string cluster_service_name = 6;
+  string cluster_service_name = 6
+      [(udpa.annotations.field_migrate).oneof_promotion = "eds_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceName eds_resource_name = 8
+      [(udpa.annotations.field_migrate).oneof_promotion = "eds_specifier"];
 
   // Need at least one.
   repeated UpstreamLocalityStats upstream_locality_stats = 2

--- a/generated_api_shadow/envoy/config/route/v3/BUILD
+++ b/generated_api_shadow/envoy/config/route/v3/BUILD
@@ -15,5 +15,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/route/v3/route.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route.proto
@@ -8,6 +8,8 @@ import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -113,4 +115,7 @@ message Vhds {
 
   // Configuration source specifier for VHDS.
   core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator resource_locator = 2;
 }

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -17,6 +17,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
@@ -561,7 +563,7 @@ message CorsPolicy {
       [deprecated = true, (validate.rules).repeated = {items {string {max_bytes: 1024}}}];
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.RouteAction";
 
@@ -808,6 +810,9 @@ message RouteAction {
     // Indicates the upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 37;
 
     // Envoy will determine the cluster to route to by reading the value of the
     // HTTP header named by cluster_header from the request headers. If the

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -304,7 +304,7 @@ message Route {
 message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.WeightedCluster";
 
-  // [#next-free-field: 11]
+  // [#next-free-field: 12]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.WeightedCluster.ClusterWeight";
@@ -313,7 +313,14 @@ message WeightedCluster {
 
     // Name of the upstream cluster. The cluster must exist in the
     // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string = {min_len: 1}];
+    string name = 1 [
+      (validate.rules).string = {min_len: 1},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 11
+        [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // An integer between 0 and :ref:`total_weight
     // <envoy_api_field_config.route.v3.WeightedCluster.total_weight>`. When a request matches the route,

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -602,13 +602,21 @@ message RouteAction {
   // .. note::
   //
   //   Shadowing will not be triggered if the primary cluster does not exist.
+  // [#next-free-field: 6]
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.api.v2.route.RouteAction.RequestMirrorPolicy";
 
     // Specifies the cluster that requests will be mirrored to. The cluster must
     // exist in the cluster manager configuration.
-    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+    string cluster = 1 [
+      (validate.rules).string = {min_len: 1},
+      (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+    ];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 5
+        [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // If not specified, all requests to the target cluster will be mirrored.
     //

--- a/generated_api_shadow/envoy/config/route/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/config/route/v4alpha/BUILD
@@ -14,5 +14,6 @@ api_proto_package(
         "//envoy/type/tracing/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/config/route/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route.proto
@@ -8,6 +8,8 @@ import "envoy/config/route/v4alpha/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -114,4 +116,7 @@ message Vhds {
 
   // Configuration source specifier for VHDS.
   core.v4alpha.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator resource_locator = 2;
 }

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -17,6 +17,8 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -551,7 +553,7 @@ message CorsPolicy {
   core.v4alpha.RuntimeFractionalPercent shadow_enabled = 10;
 }
 
-// [#next-free-field: 37]
+// [#next-free-field: 38]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.RouteAction";
 
@@ -807,6 +809,9 @@ message RouteAction {
     // Indicates the upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 37;
 
     // Envoy will determine the cluster to route to by reading the value of the
     // HTTP header named by cluster_header from the request headers. If the

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -590,6 +590,7 @@ message RouteAction {
   // .. note::
   //
   //   Shadowing will not be triggered if the primary cluster does not exist.
+  // [#next-free-field: 6]
   message RequestMirrorPolicy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.RouteAction.RequestMirrorPolicy";
@@ -598,9 +599,14 @@ message RouteAction {
 
     reserved "runtime_key";
 
-    // Specifies the cluster that requests will be mirrored to. The cluster must
-    // exist in the cluster manager configuration.
-    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      // Specifies the cluster that requests will be mirrored to. The cluster must
+      // exist in the cluster manager configuration.
+      string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
+    }
 
     // If not specified, all requests to the target cluster will be mirrored.
     //

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -302,7 +302,7 @@ message WeightedCluster {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.route.v3.WeightedCluster";
 
-  // [#next-free-field: 11]
+  // [#next-free-field: 12]
   message ClusterWeight {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.route.v3.WeightedCluster.ClusterWeight";
@@ -311,9 +311,14 @@ message WeightedCluster {
 
     reserved "per_filter_config";
 
-    // Name of the upstream cluster. The cluster must exist in the
-    // :ref:`cluster manager configuration <config_cluster_manager>`.
-    string name = 1 [(validate.rules).string = {min_len: 1}];
+    oneof cluster_specifier {
+      // Name of the upstream cluster. The cluster must exist in the
+      // :ref:`cluster manager configuration <config_cluster_manager>`.
+      string name = 1 [(validate.rules).string = {min_len: 1}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 11;
+    }
 
     // An integer between 0 and :ref:`total_weight
     // <envoy_api_field_config.route.v4alpha.WeightedCluster.total_weight>`. When a request matches the route,

--- a/generated_api_shadow/envoy/data/cluster/v3/BUILD
+++ b/generated_api_shadow/envoy/data/cluster/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/data/cluster/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/data/cluster/v3/outlier_detection_event.proto
+++ b/generated_api_shadow/envoy/data/cluster/v3/outlier_detection_event.proto
@@ -5,6 +5,9 @@ package envoy.data.cluster.v3;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -73,7 +76,7 @@ enum Action {
   UNEJECT = 1;
 }
 
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message OutlierDetectionEvent {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.data.cluster.v2alpha.OutlierDetectionEvent";
@@ -88,7 +91,14 @@ message OutlierDetectionEvent {
   google.protobuf.UInt64Value secs_since_last_action = 3;
 
   // The :ref:`cluster <envoy_api_msg_config.cluster.v3.Cluster>` that owns the ejected host.
-  string cluster_name = 4 [(validate.rules).string = {min_len: 1}];
+  string cluster_name = 4 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 12
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // The URL of the ejected host. E.g., ``tcp://1.2.3.4:80``.
   string upstream_url = 5 [(validate.rules).string = {min_len: 1}];

--- a/generated_api_shadow/envoy/data/core/v3/BUILD
+++ b/generated_api_shadow/envoy/data/core/v3/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/data/core/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/data/core/v3/health_check_event.proto
+++ b/generated_api_shadow/envoy/data/core/v3/health_check_event.proto
@@ -6,6 +6,9 @@ import "envoy/config/core/v3/address.proto";
 
 import "google/protobuf/timestamp.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -31,7 +34,7 @@ enum HealthCheckerType {
   REDIS = 3;
 }
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message HealthCheckEvent {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.data.core.v2alpha.HealthCheckEvent";
@@ -40,7 +43,14 @@ message HealthCheckEvent {
 
   config.core.v3.Address host = 2;
 
-  string cluster_name = 3 [(validate.rules).string = {min_len: 1}];
+  string cluster_name = 3 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 10
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   oneof event {
     option (validate.required) = true;

--- a/generated_api_shadow/envoy/data/dns/v3/BUILD
+++ b/generated_api_shadow/envoy/data/dns/v3/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/data/dns/v2alpha:pkg",
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/data/dns/v3/dns_table.proto
+++ b/generated_api_shadow/envoy/data/dns/v3/dns_table.proto
@@ -6,6 +6,8 @@ import "envoy/type/matcher/v3/string.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -56,7 +58,7 @@ message DnsTable {
   }
 
   // Specify the target for a given DNS service
-  // [#next-free-field: 6]
+  // [#next-free-field: 7]
   message DnsServiceTarget {
     // Specify the name of the endpoint for the Service. The name is a hostname or a cluster
     oneof endpoint_type {
@@ -69,6 +71,9 @@ message DnsTable {
       // Use a cluster name as the endpoint for a service.
       string cluster_name = 2
           [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 6;
     }
 
     // The priority of the service record target
@@ -116,6 +121,9 @@ message DnsTable {
 
       // Define a cluster whose addresses are returned for the specified endpoint
       string cluster_name = 2;
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
 
       // Define a DNS Service List for the specified endpoint
       DnsServiceList service_list = 3;

--- a/generated_api_shadow/envoy/data/dns/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/data/dns/v4alpha/BUILD
@@ -9,5 +9,6 @@ api_proto_package(
         "//envoy/data/dns/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/data/dns/v4alpha/dns_table.proto
+++ b/generated_api_shadow/envoy/data/dns/v4alpha/dns_table.proto
@@ -6,6 +6,8 @@ import "envoy/type/matcher/v4alpha/string.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -59,7 +61,7 @@ message DnsTable {
   }
 
   // Specify the target for a given DNS service
-  // [#next-free-field: 6]
+  // [#next-free-field: 7]
   message DnsServiceTarget {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.data.dns.v3.DnsTable.DnsServiceTarget";
@@ -75,6 +77,9 @@ message DnsTable {
       // Use a cluster name as the endpoint for a service.
       string cluster_name = 2
           [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME}];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 6;
     }
 
     // The priority of the service record target
@@ -128,6 +133,9 @@ message DnsTable {
 
       // Define a cluster whose addresses are returned for the specified endpoint
       string cluster_name = 2;
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 4;
 
       // Define a DNS Service List for the specified endpoint
       DnsServiceList service_list = 3;

--- a/generated_api_shadow/envoy/extensions/clusters/aggregate/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/clusters/aggregate/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/config/cluster/aggregate/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/clusters/aggregate/v3/cluster.proto
+++ b/generated_api_shadow/envoy/extensions/clusters/aggregate/v3/cluster.proto
@@ -2,6 +2,9 @@ syntax = "proto3";
 
 package envoy.extensions.clusters.aggregate.v3;
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -22,5 +25,12 @@ message ClusterConfig {
 
   // Load balancing clusters in aggregate cluster. Clusters are prioritized based on the order they
   // appear in this list.
-  repeated string clusters = 1 [(validate.rules).repeated = {min_items: 1}];
+  repeated string clusters = 1 [
+    (validate.rules).repeated = {min_items: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator cluster_resource_locator = 2
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/squash/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/http/squash/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/config/filter/http/squash/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/http/squash/v3/squash.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/squash/v3/squash.proto
@@ -5,6 +5,9 @@ package envoy.extensions.filters.http.squash.v3;
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -18,13 +21,20 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Squash :ref:`configuration overview <config_http_filters_squash>`.
 // [#extension: envoy.filters.http.squash]
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Squash {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.squash.v2.Squash";
 
   // The name of the cluster that hosts the Squash server.
-  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  string cluster = 1 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 6
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // When the filter requests the Squash server to create a DebugAttachment, it will use this
   // structure as template for the body of the request. It can contain reference to environment

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
@@ -6,6 +6,8 @@ import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/type/v3/range.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,9 @@ message RouteAction {
 
     // Indicates the upstream cluster to which the request should be routed.
     string cluster = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/type/matcher/v4alpha:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
@@ -6,6 +6,8 @@ import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 import "envoy/type/v3/range.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,9 @@ message RouteAction {
 
     // Indicates the upstream cluster to which the request should be routed.
     string cluster = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/network/redis_proxy/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -7,6 +7,8 @@ import "envoy/config/core/v3/base.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
@@ -125,6 +127,7 @@ message RedisProxy {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes";
 
+    // [#next-free-field: 6]
     message Route {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.filter.network.redis_proxy.v2.RedisProxy.PrefixRoutes.Route";
@@ -140,7 +143,14 @@ message RedisProxy {
 
         // Specifies the cluster that requests will be mirrored to. The cluster must
         // exist in the cluster manager configuration.
-        string cluster = 1 [(validate.rules).string = {min_len: 1}];
+        string cluster = 1 [
+          (validate.rules).string = {min_len: 1},
+          (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+        ];
+
+        // [#not-implemented-hide:]
+        udpa.core.v1.ResourceLocator cluster_resource_locator = 4
+            [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
         // If not specified or the runtime key is not present, all requests to the target cluster
         // will be mirrored.
@@ -162,7 +172,14 @@ message RedisProxy {
       bool remove_prefix = 2;
 
       // Upstream cluster to forward the command to.
-      string cluster = 3 [(validate.rules).string = {min_len: 1}];
+      string cluster = 3 [
+        (validate.rules).string = {min_len: 1},
+        (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+      ];
+
+      // [#not-implemented-hide:]
+      udpa.core.v1.ResourceLocator cluster_resource_locator = 5
+          [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
       // Indicates that the route has a request mirroring policy.
       repeated RequestMirrorPolicy request_mirror_policy = 4;

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/route/v3:pkg",
         "//envoy/type/matcher/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v3/route.proto
@@ -6,6 +6,9 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -48,7 +51,14 @@ message RouteMatch {
 
 message RouteAction {
   // Indicates the upstream cluster to which the request should be routed.
-  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  string cluster = 1 [
+    (validate.rules).string = {min_len: 1},
+    (udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"
+  ];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   // Optional endpoint metadata match criteria used by the subset load balancer.
   config.core.v3.Metadata metadata_match = 2;

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/extensions/filters/network/rocketmq_proxy/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/rocketmq_proxy/v4alpha/route.proto
@@ -6,6 +6,8 @@ import "envoy/config/core/v4alpha/base.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
 import "envoy/type/matcher/v4alpha/string.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -59,8 +61,13 @@ message RouteAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.rocketmq_proxy.v3.RouteAction";
 
-  // Indicates the upstream cluster to which the request should be routed.
-  string cluster = 1 [(validate.rules).string = {min_len: 1}];
+  oneof cluster_specifier {
+    // Indicates the upstream cluster to which the request should be routed.
+    string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
+  }
 
   // Optional endpoint metadata match criteria used by the subset load balancer.
   config.core.v4alpha.Metadata metadata_match = 2;

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/filter/network/tcp_proxy/v2:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -10,6 +10,8 @@ import "envoy/type/v3/hash_policy.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -23,7 +25,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";
@@ -104,6 +106,9 @@ message TcpProxy {
 
     // The upstream cluster to connect to.
     string cluster = 2;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 14;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/extensions/filters/network/tcp_proxy/v3:pkg",
         "//envoy/type/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
@@ -9,6 +9,8 @@ import "envoy/type/v3/hash_policy.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -22,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy";
@@ -83,6 +85,9 @@ message TcpProxy {
 
     // The upstream cluster to connect to.
     string cluster = 2;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 14;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v3/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/filter/network/thrift_proxy/v2alpha1:pkg",
         "//envoy/config/route/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v3/route.proto
@@ -7,6 +7,8 @@ import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -81,7 +83,7 @@ message RouteMatch {
   repeated config.route.v3.HeaderMatcher headers = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.thrift_proxy.v2alpha1.RouteAction";
@@ -92,6 +94,9 @@ message RouteAction {
     // Indicates a single upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 7;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/BUILD
@@ -10,5 +10,6 @@ api_proto_package(
         "//envoy/config/route/v4alpha:pkg",
         "//envoy/extensions/filters/network/thrift_proxy/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/thrift_proxy/v4alpha/route.proto
@@ -7,6 +7,8 @@ import "envoy/config/route/v4alpha/route_components.proto";
 
 import "google/protobuf/wrappers.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -81,7 +83,7 @@ message RouteMatch {
   repeated config.route.v4alpha.HeaderMatcher headers = 4;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RouteAction {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.thrift_proxy.v3.RouteAction";
@@ -92,6 +94,9 @@ message RouteAction {
     // Indicates a single upstream cluster to which the request should be routed
     // to.
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 7;
 
     // Multiple upstream clusters can be specified for a given route. The
     // request is routed to one of the upstream clusters based on weights

--- a/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
@@ -8,5 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/config/filter/udp/udp_proxy/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -4,6 +4,8 @@ package envoy.extensions.filters.udp.udp_proxy.v3;
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -18,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.filters.udp_listener.udp_proxy]
 
 // Configuration for the UDP proxy filter.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message UdpProxyConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.udp.udp_proxy.v2alpha.UdpProxyConfig";
@@ -42,6 +44,9 @@ message UdpProxyConfig {
 
     // The upstream cluster to connect to.
     string cluster = 2 [(validate.rules).string = {min_len: 1}];
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 6;
   }
 
   // The idle timeout for sessions. Idle is defined as no datagrams between received or sent by

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DiscoveryRequest";
 
@@ -46,6 +46,9 @@ message DiscoveryRequest {
   // will then imply a number of resources that need to be fetched via EDS/RDS,
   // which will be explicitly enumerated in resource_names.
   repeated string resource_names = 3;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resource_names = 7;
 
   // Type of the resource that is being requested, e.g.
   // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.DiscoveryRequest";
@@ -46,6 +46,9 @@ message DiscoveryRequest {
   // will then imply a number of resources that need to be fetched via EDS/RDS,
   // which will be explicitly enumerated in resource_names.
   repeated string resource_names = 3;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator udpa_resource_names = 7;
 
   // Type of the resource that is being requested, e.g.
   // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit

--- a/generated_api_shadow/envoy/service/health/v3/BUILD
+++ b/generated_api_shadow/envoy/service/health/v3/BUILD
@@ -12,5 +12,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/discovery/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/health/v3/hds.proto
+++ b/generated_api_shadow/envoy/service/health/v3/hds.proto
@@ -10,6 +10,8 @@ import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -120,7 +122,11 @@ message LocalityEndpointsHealth {
 // The health status of endpoints in a cluster. The cluster name and locality
 // should match the corresponding fields in ClusterHealthCheck message.
 message ClusterEndpointsHealth {
-  string cluster_name = 1;
+  string cluster_name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 3
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   repeated LocalityEndpointsHealth locality_endpoints_health = 2;
 }
@@ -160,11 +166,16 @@ message LocalityEndpoints {
 // health checks to support statistics reporting, logging and debugging by the
 // Envoy instance (outside of HDS). For maximum usefulness, it should match the
 // same cluster structure as that provided by EDS.
+// [#next-free-field: 6]
 message ClusterHealthCheck {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v2.ClusterHealthCheck";
 
-  string cluster_name = 1;
+  string cluster_name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
+
+  // [#not-implemented-hide:]
+  udpa.core.v1.ResourceLocator cluster_resource_locator = 5
+      [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
   repeated config.core.v3.HealthCheck health_checks = 2;
 

--- a/generated_api_shadow/envoy/service/health/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/health/v4alpha/BUILD
@@ -12,5 +12,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/health/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/health/v4alpha/hds.proto
+++ b/generated_api_shadow/envoy/service/health/v4alpha/hds.proto
@@ -10,6 +10,8 @@ import "envoy/config/endpoint/v3/endpoint_components.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 
@@ -124,7 +126,12 @@ message ClusterEndpointsHealth {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.health.v3.ClusterEndpointsHealth";
 
-  string cluster_name = 1;
+  oneof cluster_specifier {
+    string cluster_name = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 3;
+  }
 
   repeated LocalityEndpointsHealth locality_endpoints_health = 2;
 }
@@ -164,11 +171,17 @@ message LocalityEndpoints {
 // health checks to support statistics reporting, logging and debugging by the
 // Envoy instance (outside of HDS). For maximum usefulness, it should match the
 // same cluster structure as that provided by EDS.
+// [#next-free-field: 6]
 message ClusterHealthCheck {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.health.v3.ClusterHealthCheck";
 
-  string cluster_name = 1;
+  oneof cluster_specifier {
+    string cluster_name = 1;
+
+    // [#not-implemented-hide:]
+    udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
+  }
 
   repeated config.core.v4alpha.HealthCheck health_checks = 2;
 

--- a/generated_api_shadow/envoy/service/load_stats/v3/BUILD
+++ b/generated_api_shadow/envoy/service/load_stats/v3/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/load_stats/v2:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/load_stats/v3/lrs.proto
+++ b/generated_api_shadow/envoy/service/load_stats/v3/lrs.proto
@@ -7,6 +7,8 @@ import "envoy/config/endpoint/v3/load_report.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,7 @@ message LoadStatsRequest {
 
 // The management server sends envoy a LoadStatsResponse with all clusters it
 // is interested in learning load stats about.
+// [#next-free-field: 6]
 message LoadStatsResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.load_stats.v2.LoadStatsResponse";
@@ -81,6 +84,9 @@ message LoadStatsResponse {
   // Clusters to report stats for.
   // Not populated if *send_all_clusters* is true.
   repeated string clusters = 1;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
 
   // If true, the client should send all clusters it knows about.
   // Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their

--- a/generated_api_shadow/envoy/service/load_stats/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/service/load_stats/v4alpha/BUILD
@@ -11,5 +11,6 @@ api_proto_package(
         "//envoy/config/endpoint/v3:pkg",
         "//envoy/service/load_stats/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
+        "@com_github_cncf_udpa//udpa/core/v1:pkg",
     ],
 )

--- a/generated_api_shadow/envoy/service/load_stats/v4alpha/lrs.proto
+++ b/generated_api_shadow/envoy/service/load_stats/v4alpha/lrs.proto
@@ -7,6 +7,8 @@ import "envoy/config/endpoint/v3/load_report.proto";
 
 import "google/protobuf/duration.proto";
 
+import "udpa/core/v1/resource_locator.proto";
+
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -74,6 +76,7 @@ message LoadStatsRequest {
 
 // The management server sends envoy a LoadStatsResponse with all clusters it
 // is interested in learning load stats about.
+// [#next-free-field: 6]
 message LoadStatsResponse {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.load_stats.v3.LoadStatsResponse";
@@ -81,6 +84,9 @@ message LoadStatsResponse {
   // Clusters to report stats for.
   // Not populated if *send_all_clusters* is true.
   repeated string clusters = 1;
+
+  // [#not-implemented-hide:]
+  repeated udpa.core.v1.ResourceLocator cluster_resource_locator = 5;
 
   // If true, the client should send all clusters it knows about.
   // Only clients that advertise the "envoy.lrs.supports_send_all_clusters" capability in their


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Add UDPA resource names to SotW API, RouteAction, and ClusterStats
Additional Description: Adds the new UdpaResourceName and UdpaResourceLocator fields to various additional places where it's needed in the API.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A

Use of UdpaResourceLocator in the SotW API will require using the client feature to tell the server to wrap the returned resources in the `Resource` message, as discussed in #13201.

The changes in RouteAction and ClusterStats are necessary to allow us to refer to a cluster that has a new-style name.

CC @htuch 