### PR TITLE
ci: Increase brew retry interval

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -11,7 +11,7 @@ brew uninstall openssl@1.0.2t
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 HOMEBREW_RETRY_ATTEMPTS=10
-HOMEBREW_RETRY_INTERVAL=1
+HOMEBREW_RETRY_INTERVAL=3
 
 
 function is_installed {


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Increase brew retry interval
Additional Description:

im still seeing `brew update` timeout issues in ci, increasing the interval will spread the retries over 30 seconds, which might help

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
