### PR TITLE
[fuzz] Fixed Health Check Fuzz corpus syntax

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -680,7 +680,7 @@ envoy_proto_library(
 envoy_cc_fuzz_test(
     name = "health_check_fuzz_test",
     srcs = ["health_check_fuzz_test.cc"],
-    corpus = "//test/common/upstream:health_check_corpus",
+    corpus = "health_check_corpus",
     deps = [
         ":health_check_fuzz_lib",
         ":health_check_fuzz_proto_cc_proto",


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Fixed Health Check Fuzz corpus syntax
Additional Description: Full path name for corpus is disabled internally.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
