### PR TITLE
[http] swap codec implementations to default new

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -282,7 +282,7 @@ elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
     "--define" "wasm=disabled"
     "--define" "path_normalization_by_default=true"
     "--define" "deprecated_features=disabled"
-    "--define" "use_new_codecs_in_integration_tests=true"
+    "--define" "use_new_codecs_in_integration_tests=false"
     "--define" "tcmalloc=gperftools"
     "--define" "zlib=ng")
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -22,6 +22,7 @@ Removed Config or Runtime
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
 * ext_authz: removed auto ignore case in HTTP-based `ext_authz` header matching and the runtime guard `envoy.reloadable_features.ext_authz_http_service_enable_case_sensitive_string_matcher`. To ignore case, set the :ref:`ignore_case <envoy_api_field_type.matcher.StringMatcher.ignore_case>` field to true.
+* http: flip default HTTP/1 and HTTP/2 server codec implementations to new codecs that remove the use of exceptions for control flow. To revert to old codec behavior, set the runtime feature `envoy.reloadable_features.new_codec_behavior` to false.
 * http: removed `envoy.reloadable_features.http1_flood_protection` and legacy code path for turning flood protection off.
 
 New Features

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -167,17 +167,10 @@ CodecClientProd::CodecClientProd(Type type, Network::ClientConnectionPtr&& conne
     break;
   }
   case Type::HTTP2: {
-    if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.new_codec_behavior")) {
-      codec_ = std::make_unique<Http2::ClientConnectionImpl>(
-          *connection_, *this, host->cluster().http2CodecStats(), random_generator,
-          host->cluster().http2Options(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-          host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
-    } else {
-      codec_ = std::make_unique<Http2::ClientConnectionImpl>(
-          *connection_, *this, host->cluster().http2CodecStats(), random_generator,
-          host->cluster().http2Options(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-          host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
-    }
+    codec_ = std::make_unique<Http2::ClientConnectionImpl>(
+        *connection_, *this, host->cluster().http2CodecStats(), random_generator,
+        host->cluster().http2Options(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
+        host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
     break;
   }
   case Type::HTTP3: {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -79,6 +79,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.http_transport_failure_reason_in_body",
     "envoy.reloadable_features.http2_skip_encoding_empty_trailers",
     "envoy.reloadable_features.listener_in_place_filterchain_update",
+    "envoy.reloadable_features.new_codec_behavior",
     "envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2",
     "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing",
     "envoy.reloadable_features.preserve_query_string_in_path_redirects",
@@ -103,8 +104,6 @@ constexpr const char* disabled_runtime_features[] = {
     // Allow Envoy to upgrade or downgrade version of type url, should be removed when support for
     // v2 url is removed from codebase.
     "envoy.reloadable_features.enable_type_url_downgrade_and_upgrade",
-    // TODO(asraa) flip this feature after codec errors are handled
-    "envoy.reloadable_features.new_codec_behavior",
     // TODO(alyssawilk) flip true after the release.
     "envoy.reloadable_features.new_tcp_connection_pool",
     // Sentinel and test flag.

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -40,10 +40,6 @@ CODEC_TEST_DEPS = [
 envoy_cc_test(
     name = "codec_impl_test",
     srcs = ["codec_impl_test.cc"],
-    # The default codec is the legacy codec. Override runtime flag for testing new codec.
-    args = [
-        "--runtime-feature-override-for-tests=envoy.reloadable_features.new_codec_behavior",
-    ],
     shard_count = 5,
     deps = CODEC_TEST_DEPS,
 )
@@ -51,7 +47,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "codec_impl_legacy_test",
     srcs = ["codec_impl_test.cc"],
-    # The default codec is the legacy codec. Verify the runtime flag for the new codec is disabled.
+    # The default codec is the new codec. Disable runtime flag for testing old codec.
     args = [
         "--runtime-feature-disable-for-tests=envoy.reloadable_features.new_codec_behavior",
     ],


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Swaps default codec implementation flag to new. It is possible to revert to old behavior by setting `envoy.reloadable_features.new_codec_behavior` to false.
Risk Level: Medium-high
Testing: Verified that integration tests also default to new codec, and old behavior is testing in compile_time_options with/without asan. Also verified H/2 codec args correspond to expected.
Release Notes: Added

