### PR TITLE
ci: stop building alpine-debug images in favor of ubuntu-based debug image

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -250,6 +250,10 @@ stages:
         steps:
           - bash: .azure-pipelines/cleanup.sh
             displayName: "Removing tools from agent"
+          - bash: |
+              echo "disk space at beginning of build:"
+              df -h
+            displayName: "Check disk space at beginning"
           - task: DownloadBuildArtifacts@0
             inputs:
               buildType: current
@@ -275,6 +279,11 @@ stages:
               AZP_SHA1: $(Build.SourceVersion)
               DOCKERHUB_USERNAME: $(DockerUsername)
               DOCKERHUB_PASSWORD: $(DockerPassword)
+          - bash: |
+              echo "disk space at end of build:"
+              df -h
+            displayName: "Check disk space at end"
+            condition: always()
           - task: PublishBuildArtifacts@1
             inputs:
               pathtoPublish: "$(Build.StagingDirectory)/build_images"

--- a/ci/README.md
+++ b/ci/README.md
@@ -15,7 +15,7 @@ binary built from the latest tip of master that passed tests.
 
 ## Alpine Envoy image
 
-Minimal images based on Alpine Linux allow for quicker deployment of Envoy. The Alpine base image are only built with symbol stripped.
+Minimal images based on Alpine Linux allow for quicker deployment of Envoy. The Alpine base image is only built with symbols stripped.
 To get the binary with symbols, use the corresponding Ubuntu based debug image. The image is pushed with two different tags:
 `<hash>` and `latest`. Parallel to the Ubuntu images above, `<hash>` corresponds to the
 master commit at which the binary was compiled, and `latest` corresponds to a binary built from the latest tip of master that passed tests.

--- a/ci/README.md
+++ b/ci/README.md
@@ -15,9 +15,9 @@ binary built from the latest tip of master that passed tests.
 
 ## Alpine Envoy image
 
-Minimal images based on Alpine Linux allow for quicker deployment of Envoy. Two Alpine based images are built,
-one with an Envoy binary with debug (`envoyproxy/envoy-alpine-debug`) symbols and one stripped of them (`envoyproxy/envoy-alpine`).
-Both images are pushed with two different tags: `<hash>` and `latest`. Parallel to the Ubuntu images above, `<hash>` corresponds to the
+Minimal images based on Alpine Linux allow for quicker deployment of Envoy. The Alpine base image are only built with symbol stripped.
+To get the binary with symbols, use the corresponding Ubuntu based debug image. The image is pushed with two different tags:
+`<hash>` and `latest`. Parallel to the Ubuntu images above, `<hash>` corresponds to the
 master commit at which the binary was compiled, and `latest` corresponds to a binary built from the latest tip of master that passed tests.
 
 ## Windows 2019 Envoy image

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -125,7 +125,7 @@ if is_windows; then
   BUILD_COMMAND=("build")
 else
   # "-google-vrp" must come afer "" to ensure we rebuild the local base image dependency.
-  BUILD_TYPES=("" "-debug" "-alpine" "-alpine-debug" "-google-vrp")
+  BUILD_TYPES=("" "-debug" "-alpine" "-google-vrp")
 
   # Configure docker-buildx tools
   BUILD_COMMAND=("buildx" "build")

--- a/docs/root/start/building.rst
+++ b/docs/root/start/building.rst
@@ -42,9 +42,6 @@ be found in the following repositories:
   binary with debug symbols on top of an Ubuntu Bionic base.
 * `envoyproxy/envoy-alpine <https://hub.docker.com/r/envoyproxy/envoy-alpine/tags/>`_: Release
   binary with symbols stripped on top of a **glibc** alpine base.
-* `envoyproxy/envoy-alpine-debug <https://hub.docker.com/r/envoyproxy/envoy-alpine-debug/tags/>`_:
-  *Deprecated in favor of envoyproxy/envoy-debug.* Release binary with debug symbols on top of a
-  Release binary with debug symbols on top of a **glibc** alpine base.
 
 .. note::
 
@@ -59,9 +56,6 @@ be found in the following repositories:
   binary with debug symbols on top of an Ubuntu Bionic base.
 * `envoyproxy/envoy-alpine-dev <https://hub.docker.com/r/envoyproxy/envoy-alpine-dev/tags/>`_: Release
   binary with symbols stripped on top of a **glibc** alpine base.
-* `envoyproxy/envoy-alpine-debug-dev <https://hub.docker.com/r/envoyproxy/envoy-alpine-debug-dev/tags/>`_:
-  *Deprecated in favor of envoyproxy/envoy-debug-dev.* Release binary with debug symbols on top of a
-  **glibc** alpine base.
 
 In the above *dev* repositories, the *latest* tag points to the last Envoy SHA in master that passed
 tests.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,6 +9,7 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* build: the Alpine based debug images are no longer built in CI, use Ubuntu based images instead.
 * ext_authz filter: the deprecated field :ref:`use_alpha <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.use_alpha>` is no longer supported and cannot be set anymore.
 
 Bug Fixes


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

Additional Description:
Stop building the deprecated image for CI speed up and space saving.
Risk Level: Low
Testing:
Docs Changes: Done
Release Notes: