### PR TITLE
ci/build: Add .dockerignore to limit build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+/*
+!/ci
+!/configs/google-vrp
+!/configs/*yaml
+!/linux/amd64/build_release*
+!/linux/arm64/build_release*
+!/local
+!/test/config/integration/certs
+!/windows


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci/build: Add .dockerignore to limit build context
Additional Description:

This is a ~workaround~ fix for #13613 that limits the context that is sent to the Docker daemon when building

It doesnt make much difference to CI (windows build may be a little quicker) but it does improve experience for end users building locally

by default it excludes everything and then lists paths to include. I have added the `local/` dir  as a path  to allow adding local artifacts into a build - i will document this as part of #13490 (or once this has landed)

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #13613 
[Optional Deprecated:]
