### PR TITLE
wasm: flip the meaning of the "repository" in envoy_wasm_cc_binary().

### DIFF
--- a/bazel/wasm/wasm.bzl
+++ b/bazel/wasm/wasm.bzl
@@ -88,9 +88,9 @@ def wasm_cc_binary(name, tags = [], repository = "", **kwargs):
     kwargs.setdefault("additional_linker_inputs", ["@proxy_wasm_cpp_sdk//:jslib", "@envoy//source/extensions/common/wasm/ext:jslib"])
 
     if repository == "@envoy":
-        envoy_js = "--js-library source/extensions/common/wasm/ext/envoy_wasm_intrinsics.js"
-    else:
         envoy_js = "--js-library external/envoy/source/extensions/common/wasm/ext/envoy_wasm_intrinsics.js"
+    else:
+        envoy_js = "--js-library source/extensions/common/wasm/ext/envoy_wasm_intrinsics.js"
     kwargs.setdefault("linkopts", [
         envoy_js,
         "--js-library external/proxy_wasm_cpp_sdk/proxy_wasm_intrinsics.js",
@@ -112,7 +112,7 @@ def wasm_cc_binary(name, tags = [], repository = "", **kwargs):
     )
 
 def envoy_wasm_cc_binary(name, tags = [], **kwargs):
-    wasm_cc_binary(name, tags, repository = "@envoy", **kwargs)
+    wasm_cc_binary(name, tags, repository = "", **kwargs)
 
 def wasm_rust_binary(name, tags = [], **kwargs):
     wasm_name = "_wasm_" + name.replace(".", "_")


### PR DESCRIPTION
Change the meaning of the "repository" parameter to refer to an external
Bazel repository, instead of using "@envoy" in targets that are included
in the Envoy repository.

This aligns with other envoy_* rules.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>