### PR TITLE
typos: fix a couple 'enovy' mispellings

### DIFF
--- a/source/extensions/filters/network/rocketmq_proxy/active_message.cc
+++ b/source/extensions/filters/network/rocketmq_proxy/active_message.cc
@@ -153,7 +153,7 @@ void ActiveMessage::onQueryTopicRoute() {
     cluster = cluster_manager.get(cluster_name);
   }
   if (cluster) {
-    ENVOY_LOG(trace, "Enovy has an operating cluster {} for topic {}", cluster_name, topic_name);
+    ENVOY_LOG(trace, "Envoy has an operating cluster {} for topic {}", cluster_name, topic_name);
     std::vector<QueueData> queue_data_list;
     std::vector<BrokerData> broker_data_list;
     for (auto& host_set : cluster->prioritySet().hostSetsPerPriority()) {

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # For this test we use a slightly modiified test binary, based on
-# source/exe/enovy-static. If this starts failing to run or build, ensure that
+# source/exe/envoy-static. If this starts failing to run or build, ensure that
 # source/exe/main.cc and ./hotrestart_main.cc have not diverged except for
 # adding the new gauge.
 export ENVOY_BIN="${TEST_SRCDIR}"/envoy/test/integration/hotrestart_main


### PR DESCRIPTION
Commit Message: typos: fix a couple 'enovy' mispellings
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
