### PR TITLE
gzip: disable envoy.extensions.filters.http.gzip by default

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -40,4 +40,5 @@ New Features
 
 Deprecated
 ----------
+* gzip: :ref:`HTTP Gzip filter <config_http_filters_gzip>` is rejected now unless explicitly allowed with :ref:`runtime override <config_runtime_deprecation>` `envoy.deprecated_features.allow_deprecated_gzip_http_filter` set to `true`.
 * ratelimit: the :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` action is deprecated in favor of the more generic :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` action.

--- a/source/extensions/filters/http/gzip/config.cc
+++ b/source/extensions/filters/http/gzip/config.cc
@@ -10,8 +10,8 @@ namespace Gzip {
 Http::FilterFactoryCb GzipFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::gzip::v3::Gzip& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  // This will flip to false eventually.
-  const bool runtime_feature_default = true;
+  // The current deprecation phase is fail-by-default.
+  const bool runtime_feature_default = false;
   const char runtime_key[] = "envoy.deprecated_features.allow_deprecated_gzip_http_filter";
   const std::string warn_message =
       "Using deprecated extension 'envoy.extensions.filters.http.gzip'. This "

--- a/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
+++ b/test/extensions/filters/http/gzip/gzip_filter_integration_test.cc
@@ -21,6 +21,8 @@ public:
 
   void initializeFilter(const std::string& config) {
     config_helper_.addFilter(config);
+    config_helper_.addRuntimeOverride("envoy.deprecated_features.allow_deprecated_gzip_http_filter",
+                                      "true");
     initialize();
     codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   }


### PR DESCRIPTION
Commit Message: gzip: disable envoy.extensions.filters.http.gzip by default
Additional Description: Move envoy.extensions.filters.http.gzip to the second deprecation phase.
Risk Level: Low
Testing: run unit tests
Docs Changes: N/A
Release Notes: mentioned further deprecation in current.rst
Platform Specific Features: N/A
