### PR TITLE
Wait for SDS secrets to load before starting health checks.

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -17,6 +17,8 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* active health checks: health checks using a TLS transport socket and secrets delivered via :ref:`SDS <config_secret_discovery_service>` will now wait until secrets are loaded before the first health check attempt. This should improve startup times by not having to wait for the :ref:`no_traffic_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_interval>` until the next attempt.
+
 * http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
 
 Removed Config or Runtime

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -226,6 +226,13 @@ public:
    */
   virtual TransportSocketPtr
   createTransportSocket(TransportSocketOptionsSharedPtr options) const PURE;
+
+  /**
+   * @param a callback to be invoked when the secrets required by the created transport
+   * sockets are ready. Will be invoked immediately if no secrets are required or if they
+   * are already loaded.
+   */
+  virtual void addReadyCb(std::function<void()> callback) PURE;
 };
 
 using TransportSocketFactoryPtr = std::unique_ptr<TransportSocketFactory>;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -113,6 +113,15 @@ public:
                               const envoy::config::core::v3::Metadata* metadata) const PURE;
 
   /**
+   * Register a callback to be invoked when secrets are ready for the transport socket that
+   * corresponds to the provided metadata.
+   * @param callback supplies the callback to be invoked.
+   * @param metadata supplies the metadata to be used for resolving transport socket matches.
+   */
+  virtual void addReadyCb(std::function<void()> callback,
+                          const envoy::config::core::v3::Metadata* metadata) const PURE;
+
+  /**
    * @return host specific gauges.
    */
   virtual std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>>

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -32,6 +32,7 @@ public:
   // Network::TransportSocketFactory
   TransportSocketPtr createTransportSocket(TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  void addReadyCb(std::function<void()> callback) override { callback(); }
 };
 
 } // namespace Network

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -384,6 +384,14 @@ void HealthCheckerImplBase::ActiveHealthCheckSession::onTimeoutBase() {
   handleFailure(envoy::data::core::v3::NETWORK);
 }
 
+void HealthCheckerImplBase::ActiveHealthCheckSession::start() {
+  // Start health checks only after secrets are ready for the transport socket
+  // that health checks will be performed on. If health checks start
+  // immediately, they may fail with "network" errors due to TLS credentials
+  // not yet being loaded, which can result in long startup times.
+  host_->addReadyCb([this] { onInitialInterval(); }, parent_.transportSocketMatchMetadata().get());
+}
+
 void HealthCheckerImplBase::ActiveHealthCheckSession::onInitialInterval() {
   if (parent_.initial_jitter_.count() == 0) {
     onIntervalBase();

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -77,7 +77,7 @@ protected:
     ~ActiveHealthCheckSession() override;
     HealthTransition setUnhealthy(envoy::data::core::v3::HealthCheckFailureType type);
     void onDeferredDeleteBase();
-    void start() { onInitialInterval(); }
+    void start();
 
   protected:
     ActiveHealthCheckSession(HealthCheckerImplBase& parent, HostSharedPtr host);

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -356,6 +356,14 @@ HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& clu
   return connection;
 }
 
+void HostImpl::addReadyCb(std::function<void()> callback,
+                          const envoy::config::core::v3::Metadata* metadata) const {
+  Network::TransportSocketFactory& factory =
+      (metadata != nullptr) ? cluster_->transportSocketMatcher().resolve(metadata).factory_
+                            : socket_factory_;
+  factory.addReadyCb(callback);
+}
+
 void HostImpl::weight(uint32_t new_weight) { weight_ = std::max(1U, new_weight); }
 
 std::vector<HostsPerLocalityConstSharedPtr> HostsPerLocalityImpl::filter(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -189,6 +189,8 @@ public:
   createHealthCheckConnection(Event::Dispatcher& dispatcher,
                               Network::TransportSocketOptionsSharedPtr transport_socket_options,
                               const envoy::config::core::v3::Metadata* metadata) const override;
+  void addReadyCb(std::function<void()> callback,
+                  const envoy::config::core::v3::Metadata* metadata) const override;
 
   std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>>
   gauges() const override {

--- a/source/extensions/quic_listeners/quiche/quic_transport_socket_factory.h
+++ b/source/extensions/quic_listeners/quiche/quic_transport_socket_factory.h
@@ -24,6 +24,9 @@ public:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
   bool implementsSecureTransport() const override { return true; }
+
+  // TODO(mpuncel) only invoke callback() once secrets are ready.
+  void addReadyCb(std::function<void()> callback) override { callback(); };
 };
 
 // TODO(danzh): when implement ProofSource, examine of it's necessary to

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -101,6 +101,9 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
 
+  // TODO(mpuncel) only invoke callback() once secrets are ready.
+  void addReadyCb(std::function<void()> callback) override { callback(); };
+
 private:
   HandshakerFactory handshaker_factory_;
   HandshakeValidator handshake_validator_;

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
@@ -49,6 +49,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  void addReadyCb(std::function<void()> callback) override { callback(); };
 
 private:
   Network::TransportSocketFactoryPtr transport_socket_factory_;

--- a/source/extensions/transport_sockets/tap/tap.h
+++ b/source/extensions/transport_sockets/tap/tap.h
@@ -41,6 +41,8 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  // TODO(mpuncel) only invoke callback() once secrets are ready.
+  void addReadyCb(std::function<void()> callback) override { callback(); };
 
 private:
   Network::TransportSocketFactoryPtr transport_socket_factory_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -355,11 +355,37 @@ bool ClientSslSocketFactory::implementsSecureTransport() const { return true; }
 
 void ClientSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
+  bool should_run_callbacks = false;
   {
     absl::WriterMutexLock l(&ssl_ctx_mu_);
     ssl_ctx_ = manager_.createSslClientContext(stats_scope_, *config_);
+    if (ssl_ctx_) {
+      should_run_callbacks = true;
+    }
+  }
+  if (should_run_callbacks) {
+    for (const auto& cb : secrets_ready_callbacks_) {
+      cb();
+    }
+    secrets_ready_callbacks_.clear();
   }
   stats_.ssl_context_update_by_sds_.inc();
+}
+
+void ClientSslSocketFactory::addReadyCb(std::function<void()> callback) {
+  bool immediately_run_callback = false;
+  {
+    absl::ReaderMutexLock l(&ssl_ctx_mu_);
+    if (ssl_ctx_) {
+      immediately_run_callback = true;
+    }
+  }
+
+  if (immediately_run_callback) {
+    callback();
+  } else {
+    secrets_ready_callbacks_.push_back(callback);
+  }
 }
 
 ServerSslSocketFactory::ServerSslSocketFactory(Envoy::Ssl::ServerContextConfigPtr config,
@@ -396,11 +422,37 @@ bool ServerSslSocketFactory::implementsSecureTransport() const { return true; }
 
 void ServerSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
+  bool should_run_callbacks = false;
   {
     absl::WriterMutexLock l(&ssl_ctx_mu_);
     ssl_ctx_ = manager_.createSslServerContext(stats_scope_, *config_, server_names_);
+
+    if (ssl_ctx_) {
+      should_run_callbacks = true;
+    }
+  }
+  if (should_run_callbacks) {
+    for (const auto& cb : secrets_ready_callbacks_) {
+      cb();
+    }
+    secrets_ready_callbacks_.clear();
   }
   stats_.ssl_context_update_by_sds_.inc();
+}
+
+void ServerSslSocketFactory::addReadyCb(std::function<void()> callback) {
+  bool immediately_run_callback = false;
+  {
+    absl::ReaderMutexLock l(&ssl_ctx_mu_);
+    if (ssl_ctx_) {
+      immediately_run_callback = true;
+    }
+  }
+  if (immediately_run_callback) {
+    callback();
+  } else {
+    secrets_ready_callbacks_.push_back(callback);
+  }
 }
 
 } // namespace Tls

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -378,13 +378,13 @@ void ClientSslSocketFactory::addReadyCb(std::function<void()> callback) {
     absl::ReaderMutexLock l(&ssl_ctx_mu_);
     if (ssl_ctx_) {
       immediately_run_callback = true;
+    } else {
+      secrets_ready_callbacks_.push_back(callback);
     }
   }
 
   if (immediately_run_callback) {
     callback();
-  } else {
-    secrets_ready_callbacks_.push_back(callback);
   }
 }
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -446,12 +446,12 @@ void ServerSslSocketFactory::addReadyCb(std::function<void()> callback) {
     absl::ReaderMutexLock l(&ssl_ctx_mu_);
     if (ssl_ctx_) {
       immediately_run_callback = true;
+    } else {
+      secrets_ready_callbacks_.push_back(callback);
     }
   }
   if (immediately_run_callback) {
     callback();
-  } else {
-    secrets_ready_callbacks_.push_back(callback);
   }
 }
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -109,6 +109,8 @@ public:
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
 
+  void addReadyCb(std::function<void()> callback) override;
+
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;
 
@@ -119,6 +121,7 @@ private:
   Envoy::Ssl::ClientContextConfigPtr config_;
   mutable absl::Mutex ssl_ctx_mu_;
   Envoy::Ssl::ClientContextSharedPtr ssl_ctx_ ABSL_GUARDED_BY(ssl_ctx_mu_);
+  std::list<std::function<void()>> secrets_ready_callbacks_;
 };
 
 class ServerSslSocketFactory : public Network::TransportSocketFactory,
@@ -133,6 +136,8 @@ public:
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
 
+  void addReadyCb(std::function<void()> callback) override;
+
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;
 
@@ -144,6 +149,7 @@ private:
   const std::vector<std::string> server_names_;
   mutable absl::Mutex ssl_ctx_mu_;
   Envoy::Ssl::ServerContextSharedPtr ssl_ctx_ ABSL_GUARDED_BY(ssl_ctx_mu_);
+  std::list<std::function<void()>> secrets_ready_callbacks_;
 };
 
 } // namespace Tls

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -942,6 +942,8 @@ TEST_F(HttpHealthCheckerImplTest, TlsOptions) {
       Network::TransportSocketFactoryPtr(socket_factory));
   cluster_->info_->transport_socket_matcher_.reset(transport_socket_match);
 
+  EXPECT_CALL(*socket_factory, addReadyCb(_))
+      .WillOnce(Invoke([&](std::function<void()> callback) -> void { callback(); }));
   EXPECT_CALL(*socket_factory, createTransportSocket(ApplicationProtocolListEq("http1")));
 
   allocHealthChecker(yaml);
@@ -2429,13 +2431,19 @@ TEST_F(HttpHealthCheckerImplTest, TransportSocketMatchCriteria) {
       ALL_TRANSPORT_SOCKET_MATCH_STATS(POOL_COUNTER_PREFIX(stats_store, "test"))};
   auto health_check_only_socket_factory = std::make_unique<Network::MockTransportSocketFactory>();
 
-  // We expect resolve() to be called twice, once for endpoint socket matching (with no metadata in
-  // this test) and once for health check socket matching. In the latter we expect metadata that
-  // matches the above object.
+  // We expect resolve() to be called 3 times, once for endpoint socket matching (with no metadata
+  // in this test) and twice for health check socket matching (once for checking if secrets are
+  // ready on the transport socket, and again for actually getting the health check transport socket
+  // to create a connection). In the latter 2 calls, we expect metadata that matches the above
+  // object.
   EXPECT_CALL(*transport_socket_match, resolve(nullptr));
   EXPECT_CALL(*transport_socket_match, resolve(MetadataEq(metadata)))
-      .WillOnce(Return(TransportSocketMatcher::MatchData(
-          *health_check_only_socket_factory, health_transport_socket_stats, "health_check_only")));
+      .Times(2)
+      .WillRepeatedly(Return(TransportSocketMatcher::MatchData(
+          *health_check_only_socket_factory, health_transport_socket_stats, "health_check_only")))
+      .RetiresOnSaturation();
+  EXPECT_CALL(*health_check_only_socket_factory, addReadyCb(_))
+      .WillOnce(Invoke([&](std::function<void()> callback) -> void { callback(); }));
   // The health_check_only_socket_factory should be used to create a transport socket for the health
   // check connection.
   EXPECT_CALL(*health_check_only_socket_factory, createTransportSocket(_));
@@ -2471,6 +2479,9 @@ TEST_F(HttpHealthCheckerImplTest, NoTransportSocketMatchCriteria) {
     )EOF";
 
   auto default_socket_factory = std::make_unique<Network::MockTransportSocketFactory>();
+
+  EXPECT_CALL(*default_socket_factory, addReadyCb(_))
+      .WillOnce(Invoke([&](std::function<void()> callback) -> void { callback(); }));
   // The default_socket_factory should be used to create a transport socket for the health check
   // connection.
   EXPECT_CALL(*default_socket_factory, createTransportSocket(_));

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -33,6 +33,7 @@ public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsSharedPtr), (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>));
   FakeTransportSocketFactory(std::string id) : id_(std::move(id)) {}
   std::string id() const { return id_; }
 
@@ -48,6 +49,7 @@ public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsSharedPtr), (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>));
 
   Network::TransportSocketFactoryPtr
   createTransportSocketFactory(const Protobuf::Message& proto,

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -59,6 +59,7 @@ using testing::ContainsRegex;
 using testing::DoAll;
 using testing::InSequence;
 using testing::Invoke;
+using testing::MockFunction;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
@@ -4490,6 +4491,12 @@ TEST_P(SslSocketTest, DownstreamNotReadySslSocket) {
   ContextManagerImpl manager(time_system_);
   ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), manager, stats_store,
                                                    std::vector<std::string>{});
+
+  // Add a secrets ready callback that should not be invoked.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  server_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
   auto transport_socket = server_ssl_socket_factory.createTransportSocket(nullptr);
   EXPECT_EQ(EMPTY_STRING, transport_socket->protocol());
   EXPECT_EQ(nullptr, transport_socket->ssl());
@@ -4525,6 +4532,12 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
 
   ContextManagerImpl manager(time_system_);
   ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), manager, stats_store);
+
+  // Add a secrets ready callback that should not be invoked.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  client_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
   auto transport_socket = client_ssl_socket_factory.createTransportSocket(nullptr);
   EXPECT_EQ(EMPTY_STRING, transport_socket->protocol());
   EXPECT_EQ(nullptr, transport_socket->ssl());
@@ -4534,6 +4547,97 @@ TEST_P(SslSocketTest, UpstreamNotReadySslSocket) {
   result = transport_socket->doWrite(buffer, true);
   EXPECT_EQ(Network::PostIoAction::Close, result.action_);
   EXPECT_EQ("TLS error: Secret is not supplied by SDS", transport_socket->failureReason());
+}
+
+// Validate that secrets callbacks are invoked when secrets become ready.
+TEST_P(SslSocketTest, ClientAddSecretsReadyCallback) {
+  Stats::TestUtil::TestStore stats_store;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(factory_context, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(factory_context, stats()).WillOnce(ReturnRef(stats_store));
+  EXPECT_CALL(factory_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(factory_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  auto sds_secret_configs =
+      tls_context.mutable_common_tls_context()->mutable_tls_certificate_sds_secret_configs()->Add();
+  sds_secret_configs->set_name("abc.com");
+  sds_secret_configs->mutable_sds_config();
+  auto client_cfg = std::make_unique<ClientContextConfigImpl>(tls_context, factory_context);
+  EXPECT_TRUE(client_cfg->tlsCertificates().empty());
+  EXPECT_FALSE(client_cfg->isReady());
+
+  NiceMock<Ssl::MockContextManager> context_manager;
+  ClientSslSocketFactory client_ssl_socket_factory(std::move(client_cfg), context_manager,
+                                                   stats_store);
+
+  // Add a secrets ready callback. It should not be invoked until onAddOrUpdateSecret() is called.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  client_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
+  // Call onAddOrUpdateSecret, but return a null ssl_ctx. This should not invoke the callback.
+  EXPECT_CALL(context_manager, createSslClientContext(_, _)).WillOnce(Return(nullptr));
+  client_ssl_socket_factory.onAddOrUpdateSecret();
+
+  EXPECT_CALL(mock_callback_, Call());
+  Ssl::ClientContextSharedPtr mock_context = std::make_shared<Ssl::MockClientContext>();
+  EXPECT_CALL(context_manager, createSslClientContext(_, _)).WillOnce(Return(mock_context));
+  client_ssl_socket_factory.onAddOrUpdateSecret();
+
+  // Add another callback, it should be invoked immediately.
+  MockFunction<void()> second_callback_;
+  EXPECT_CALL(second_callback_, Call());
+  client_ssl_socket_factory.addReadyCb(second_callback_.AsStdFunction());
+}
+
+// Validate that secrets callbacks are invoked when secrets become ready.
+TEST_P(SslSocketTest, ServerAddSecretsReadyCallback) {
+  Stats::TestUtil::TestStore stats_store;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
+  NiceMock<Init::MockManager> init_manager;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  EXPECT_CALL(factory_context, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(factory_context, stats()).WillOnce(ReturnRef(stats_store));
+  EXPECT_CALL(factory_context, initManager()).WillRepeatedly(ReturnRef(init_manager));
+  EXPECT_CALL(factory_context, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  auto sds_secret_configs =
+      tls_context.mutable_common_tls_context()->mutable_tls_certificate_sds_secret_configs()->Add();
+  sds_secret_configs->set_name("abc.com");
+  sds_secret_configs->mutable_sds_config();
+  auto server_cfg = std::make_unique<ServerContextConfigImpl>(tls_context, factory_context);
+  EXPECT_TRUE(server_cfg->tlsCertificates().empty());
+  EXPECT_FALSE(server_cfg->isReady());
+
+  NiceMock<Ssl::MockContextManager> context_manager;
+  ServerSslSocketFactory server_ssl_socket_factory(std::move(server_cfg), context_manager,
+                                                   stats_store, std::vector<std::string>{});
+
+  // Add a secrets ready callback. It should not be invoked until onAddOrUpdateSecret() is called.
+  MockFunction<void()> mock_callback_;
+  EXPECT_CALL(mock_callback_, Call()).Times(0);
+  server_ssl_socket_factory.addReadyCb(mock_callback_.AsStdFunction());
+
+  // Call onAddOrUpdateSecret, but return a null ssl_ctx. This should not invoke the callback.
+  EXPECT_CALL(context_manager, createSslServerContext(_, _, _)).WillOnce(Return(nullptr));
+  server_ssl_socket_factory.onAddOrUpdateSecret();
+
+  // Now return a ssl context which should result in the callback being invoked.
+  EXPECT_CALL(mock_callback_, Call());
+  Ssl::ServerContextSharedPtr mock_context = std::make_shared<Ssl::MockServerContext>();
+  EXPECT_CALL(context_manager, createSslServerContext(_, _, _)).WillOnce(Return(mock_context));
+  server_ssl_socket_factory.onAddOrUpdateSecret();
+
+  // Add another callback, it should be invoked immediately.
+  MockFunction<void()> second_callback_;
+  EXPECT_CALL(second_callback_, Call());
+  server_ssl_socket_factory.addReadyCb(second_callback_.AsStdFunction());
 }
 
 TEST_P(SslSocketTest, TestTransportSocketCallback) {

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -38,6 +38,7 @@ public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(TransportSocketPtr, createTransportSocket, (TransportSocketOptionsSharedPtr),
               (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>));
 };
 
 } // namespace Network

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -15,6 +15,9 @@ MockClientContext::~MockClientContext() = default;
 MockClientContextConfig::MockClientContextConfig() = default;
 MockClientContextConfig::~MockClientContextConfig() = default;
 
+MockServerContext::MockServerContext() = default;
+MockServerContext::~MockServerContext() = default;
+
 MockServerContextConfig::MockServerContextConfig() = default;
 MockServerContextConfig::~MockServerContextConfig() = default;
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -97,6 +97,17 @@ public:
   MOCK_METHOD(const std::string&, signingAlgorithmsForTest, (), (const));
 };
 
+class MockServerContext : public ServerContext {
+public:
+  MockServerContext();
+  ~MockServerContext() override;
+
+  MOCK_METHOD(size_t, daysUntilFirstCertExpires, (), (const));
+  MOCK_METHOD(absl::optional<uint64_t>, secondsUntilFirstOcspResponseExpires, (), (const));
+  MOCK_METHOD(CertificateDetailsPtr, getCaCertInformation, (), (const));
+  MOCK_METHOD(std::vector<CertificateDetailsPtr>, getCertChainInformation, (), (const));
+};
+
 class MockServerContextConfig : public ServerContextConfig {
 public:
   MockServerContextConfig();

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -192,6 +192,8 @@ public:
   MOCK_METHOD(uint32_t, priority, (), (const));
   MOCK_METHOD(void, priority, (uint32_t));
   MOCK_METHOD(bool, warmed, (), (const));
+  MOCK_METHOD(void, addReadyCb, (std::function<void()>, const envoy::config::core::v3::Metadata*),
+              (const));
 
   testing::NiceMock<MockClusterInfo> cluster_;
   Network::TransportSocketFactoryPtr socket_factory_;


### PR DESCRIPTION
DO NOT MERGE: This is a revert-of-a-revert and then an unverified fix. I'm opening the PR as a place to discuss how to add an integration test that would have caught this bug.

Commit Message:
Wait for SDS secrets to load before starting health checks on TLS transport sockets.

This fixes a common case where a health check might fail due to secrets not being loaded, and the next check would be performed after `no_traffic_interval` which defaults to 60 seconds, resulting in a slow Envoy bootup time.
Additional Description:
Risk Level: Medium - core behavior change, bugs could cause Envoy to fail to initialize.
Testing: Needs integration test.
Docs Changes: N/A
Release Notes: included
Fixes #12389
