### PR TITLE
test: working around a workaround

### DIFF
--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -133,6 +133,7 @@ protected:
     listener_ =
         dispatcher_->createListener(socket_, listener_callbacks_, true, ENVOY_TCP_BACKLOG_SIZE);
 #if defined(__clang__) && defined(__has_feature) && __has_feature(address_sanitizer)
+    // TODO(PiotrSikora, Lizan) sort this out.
     // There is a bug in clang with AddressSanitizer on the CI such that the code below reports:
     //
     //   runtime error: constructor call on address 0x6190000b4a80 with insufficient space for
@@ -147,7 +148,7 @@ protected:
     //   CorrectSize(p, size, tcmalloc::DefaultAlignPolicy())
     //
     // so we only use it for clang with AddressSanitizer builds.
-    auto x = malloc(sizeof(TestClientConnectionImpl) + 1024);
+    auto x = ::operator new(sizeof(TestClientConnectionImpl));
     new (x) TestClientConnectionImpl(*dispatcher_, socket_->localAddress(), source_address_,
                                      Network::Test::createRawBufferSocket(), socket_options_);
     client_connection_.reset(reinterpret_cast<TestClientConnectionImpl*>(x));


### PR DESCRIPTION
Our upstream asan gets cranky about  alloc-dealloc-mismatch (malloc vs operator delete) on 0x61d00003ca80
Also adding in a TODO for the wasm owners to fix this - I'm not sure what changes in the WASM pr made this necessary but it'd be good to clean it up.

Risk Level: n/a (test only)
Testing: local asan, docker asan, downstream asan
Docs Changes: n/a
Release Notes: n/a
