### PR TITLE
ext_authz: disable envoy.reloadable_features.ext_authz_measure_timeout_on_check_created by default

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -11,7 +11,7 @@ Minor Behavior Changes
 
 * build: the Alpine based debug images are no longer built in CI, use Ubuntu based images instead.
 * ext_authz filter: the deprecated field :ref:`use_alpha <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.use_alpha>` is no longer supported and cannot be set anymore.
-* 'ext_authz filter: Disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default.
+* ext_authz filter: Disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default.
 * watchdog: the watchdog action :ref:`abort_action <envoy_v3_api_msg_watchdog.v3alpha.AbortActionConfig>` is now the default action to terminate the process if watchdog kill / multikill is enabled.
 
 Bug Fixes

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -10,8 +10,8 @@ Minor Behavior Changes
 *Changes that may cause incompatibilities for some users, but should not for most*
 
 * build: the Alpine based debug images are no longer built in CI, use Ubuntu based images instead.
+* ext_authz filter: disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default.
 * ext_authz filter: the deprecated field :ref:`use_alpha <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.use_alpha>` is no longer supported and cannot be set anymore.
-* ext_authz filter: Disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default.
 * watchdog: the watchdog action :ref:`abort_action <envoy_v3_api_msg_watchdog.v3alpha.AbortActionConfig>` is now the default action to terminate the process if watchdog kill / multikill is enabled.
 
 Bug Fixes

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -11,6 +11,7 @@ Minor Behavior Changes
 
 * build: the Alpine based debug images are no longer built in CI, use Ubuntu based images instead.
 * ext_authz filter: the deprecated field :ref:`use_alpha <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.use_alpha>` is no longer supported and cannot be set anymore.
+* 'ext_authz filter: Disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default.
 * watchdog: the watchdog action :ref:`abort_action <envoy_v3_api_msg_watchdog.v3alpha.AbortActionConfig>` is now the default action to terminate the process if watchdog kill / multikill is enabled.
 
 Bug Fixes

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -68,7 +68,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.early_errors_via_hcm",
     "envoy.reloadable_features.enable_deprecated_v2_api_warning",
     "envoy.reloadable_features.enable_dns_cache_circuit_breakers",
-    "envoy.reloadable_features.ext_authz_measure_timeout_on_check_created",
     "envoy.reloadable_features.fix_upgrade_response",
     "envoy.reloadable_features.fix_wildcard_matching",
     "envoy.reloadable_features.fixed_connection_close",
@@ -108,6 +107,9 @@ constexpr const char* disabled_runtime_features[] = {
     "envoy.reloadable_features.new_tcp_connection_pool",
     // Sentinel and test flag.
     "envoy.reloadable_features.test_feature_false",
+    // gRPC Timeout header is missing (#13580)
+    "envoy.reloadable_features.ext_authz_measure_timeout_on_check_created",
+
 };
 
 RuntimeFeatures::RuntimeFeatures() {

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -285,11 +285,6 @@ TEST_F(ExtAuthzHttpClientTest, AllowedRequestHeadersPrefix) {
 
 // Verify client response when authorization server returns a 200 OK.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationOk) {
-  NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timer, enableTimer(_, _));
-  bool timer_destroyed = false;
-  timer->timer_destroyed_ = &timer_destroyed;
-
   const auto expected_headers = TestCommon::makeHeaderValueOption({{":status", "200", false}});
   const auto authz_response = TestCommon::makeAuthzResponse(CheckStatus::OK);
   auto check_response = TestCommon::makeMessageResponse(expected_headers);
@@ -299,8 +294,6 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationOk) {
   EXPECT_CALL(request_callbacks_,
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzOkResponse(authz_response))));
   client_->onSuccess(async_request_, std::move(check_response));
-  // make sure the internal timeout timer is destroyed
-  EXPECT_EQ(timer_destroyed, true);
 }
 
 using HeaderValuePair = std::pair<const Http::LowerCaseString, const std::string>;
@@ -484,11 +477,6 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationDeniedAndAllowedClientHeaders) {
 
 // Test the client when an unknown error occurs.
 TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
-  NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timer, enableTimer(_, _));
-  bool timer_destroyed = false;
-  timer->timer_destroyed_ = &timer_destroyed;
-
   envoy::service::auth::v3::CheckRequest request;
 
   client_->check(request_callbacks_, dispatcher_, request, parent_span_, stream_info_);
@@ -496,8 +484,6 @@ TEST_F(ExtAuthzHttpClientTest, AuthorizationRequestError) {
   EXPECT_CALL(request_callbacks_,
               onComplete_(WhenDynamicCastTo<ResponsePtr&>(AuthzErrorResponse(CheckStatus::Error))));
   client_->onFailure(async_request_, Http::AsyncClient::FailureReason::Reset);
-  // make sure the internal timeout timer is destroyed
-  // EXPECT_EQ(timer_destroyed, true);
 }
 
 // Test the client when a call to authorization server returns a 5xx error status.


### PR DESCRIPTION
Commit Message:
Disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default, due to an issue where the grpc timeout headder is missing when enabled.
Additional Description:
Risk Level: Low
Release Notes: Added
Runtime guard: envoy.reloadable_features.ext_authz_measure_timeout_on_check_created
Relates to https://github.com/envoyproxy/envoy/issues/13580
