### PR TITLE
lb: Use index based consistent hashing

### DIFF
--- a/api/envoy/api/v2/cluster.proto
+++ b/api/envoy/api/v2/cluster.proto
@@ -392,9 +392,9 @@ message Cluster {
 
     // Common Configuration for all consistent hashing load balancers (MaglevLb, RingHashLb, etc.)
     message ConsistentHashingLbConfig {
-      // If set to `true`, the cluster will use hostname instead of the resolved
-      // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
-      bool use_hostname_for_hashing = 1;
+      // If set to `true`, the cluster will use the array index of the endpoints
+      // as the key to consistently hash to an upstream host
+      bool use_index_for_hashing = 1;
     }
 
     // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.

--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -487,9 +487,9 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
-      // If set to `true`, the cluster will use hostname instead of the resolved
-      // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
-      bool use_hostname_for_hashing = 1;
+      // If set to `true`, the cluster will use the array index of the endpoints
+      // as the key to consistently hash to an upstream host
+      bool use_index_for_hashing = 1;
 
       // Configures percentage of average cluster load to bound per upstream host. For example, with a value of 150
       // no upstream host will get a load more than 1.5 times the average load of all the hosts in the cluster.

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -493,9 +493,9 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.cluster.v3.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
-      // If set to `true`, the cluster will use hostname instead of the resolved
-      // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
-      bool use_hostname_for_hashing = 1;
+      // If set to `true`, the cluster will use the array index of the endpoints
+      // as the key to consistently hash to an upstream host
+      bool use_index_for_hashing = 1;
 
       // Configures percentage of average cluster load to bound per upstream host. For example, with a value of 150
       // no upstream host will get a load more than 1.5 times the average load of all the hosts in the cluster.

--- a/generated_api_shadow/envoy/api/v2/cluster.proto
+++ b/generated_api_shadow/envoy/api/v2/cluster.proto
@@ -392,9 +392,9 @@ message Cluster {
 
     // Common Configuration for all consistent hashing load balancers (MaglevLb, RingHashLb, etc.)
     message ConsistentHashingLbConfig {
-      // If set to `true`, the cluster will use hostname instead of the resolved
-      // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
-      bool use_hostname_for_hashing = 1;
+      // If set to `true`, the cluster will use the array index of the endpoints
+      // as the key to consistently hash to an upstream host
+      bool use_index_for_hashing = 1;
     }
 
     // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -487,9 +487,9 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
-      // If set to `true`, the cluster will use hostname instead of the resolved
-      // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
-      bool use_hostname_for_hashing = 1;
+      // If set to `true`, the cluster will use the array index of the endpoints
+      // as the key to consistently hash to an upstream host
+      bool use_index_for_hashing = 1;
 
       // Configures percentage of average cluster load to bound per upstream host. For example, with a value of 150
       // no upstream host will get a load more than 1.5 times the average load of all the hosts in the cluster.

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -493,9 +493,9 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.cluster.v3.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
-      // If set to `true`, the cluster will use hostname instead of the resolved
-      // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
-      bool use_hostname_for_hashing = 1;
+      // If set to `true`, the cluster will use the array index of the endpoints
+      // as the key to consistently hash to an upstream host
+      bool use_index_for_hashing = 1;
 
       // Configures percentage of average cluster load to bound per upstream host. For example, with a value of 150
       // no upstream host will get a load more than 1.5 times the average load of all the hosts in the cluster.

--- a/source/common/upstream/cluster_factory_impl.cc
+++ b/source/common/upstream/cluster_factory_impl.cc
@@ -57,13 +57,6 @@ std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr> ClusterFactoryImplBase::
     cluster_type = cluster.cluster_type().name();
   }
 
-  if (cluster.common_lb_config().has_consistent_hashing_lb_config() &&
-      cluster.common_lb_config().consistent_hashing_lb_config().use_hostname_for_hashing() &&
-      cluster.type() != envoy::config::cluster::v3::Cluster::STRICT_DNS) {
-    throw EnvoyException(fmt::format(
-        "Cannot use hostname for consistent hashing loadbalancing for cluster of type: '{}'",
-        cluster_type));
-  }
   ClusterFactory* factory = Registry::FactoryRegistry<ClusterFactory>::getFactory(cluster_type);
 
   if (factory == nullptr) {

--- a/source/common/upstream/maglev_lb.h
+++ b/source/common/upstream/maglev_lb.h
@@ -35,7 +35,7 @@ class MaglevTable : public ThreadAwareLoadBalancerBase::HashingLoadBalancer,
                     Logger::Loggable<Logger::Id::upstream> {
 public:
   MaglevTable(const NormalizedHostWeightVector& normalized_host_weights,
-              double max_normalized_weight, uint64_t table_size, bool use_hostname_for_hashing,
+              double max_normalized_weight, uint64_t table_size, bool use_index_for_hashing,
               MaglevLoadBalancerStats& stats);
 
   // ThreadAwareLoadBalancerBase::HashingLoadBalancer
@@ -87,7 +87,7 @@ private:
                      double /* min_normalized_weight */, double max_normalized_weight) override {
     HashingLoadBalancerSharedPtr maglev_lb =
         std::make_shared<MaglevTable>(normalized_host_weights, max_normalized_weight, table_size_,
-                                      use_hostname_for_hashing_, stats_);
+                                      use_index_for_hashing_, stats_);
 
     if (hash_balance_factor_ == 0) {
       return maglev_lb;
@@ -102,7 +102,7 @@ private:
   Stats::ScopePtr scope_;
   MaglevLoadBalancerStats stats_;
   const uint64_t table_size_;
-  const bool use_hostname_for_hashing_;
+  const bool use_index_for_hashing_;
   const uint32_t hash_balance_factor_;
 };
 

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -59,7 +59,7 @@ private:
   struct Ring : public HashingLoadBalancer {
     Ring(const NormalizedHostWeightVector& normalized_host_weights, double min_normalized_weight,
          uint64_t min_ring_size, uint64_t max_ring_size, HashFunction hash_function,
-         bool use_hostname_for_hashing, RingHashLoadBalancerStats& stats);
+         bool use_index_for_hashing, RingHashLoadBalancerStats& stats);
 
     // ThreadAwareLoadBalancerBase::HashingLoadBalancer
     HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
@@ -76,7 +76,7 @@ private:
                      double min_normalized_weight, double /* max_normalized_weight */) override {
     HashingLoadBalancerSharedPtr ring_hash_lb =
         std::make_shared<Ring>(normalized_host_weights, min_normalized_weight, min_ring_size_,
-                               max_ring_size_, hash_function_, use_hostname_for_hashing_, stats_);
+                               max_ring_size_, hash_function_, use_index_for_hashing_, stats_);
     if (hash_balance_factor_ == 0) {
       return ring_hash_lb;
     }
@@ -95,7 +95,7 @@ private:
   const uint64_t min_ring_size_;
   const uint64_t max_ring_size_;
   const HashFunction hash_function_;
-  const bool use_hostname_for_hashing_;
+  const bool use_index_for_hashing_;
   const uint32_t hash_balance_factor_;
 };
 

--- a/test/common/upstream/cluster_factory_impl_test.cc
+++ b/test/common/upstream/cluster_factory_impl_test.cc
@@ -235,40 +235,6 @@ TEST_F(TestStaticClusterImplTest, UnsupportedClusterType) {
       "Didn't find a registered cluster factory implementation for name: "
       "'envoy.clusters.bad_cluster_name'");
 }
-
-TEST_F(TestStaticClusterImplTest, HostnameWithoutDNS) {
-  const std::string yaml = R"EOF(
-      name: staticcluster
-      connect_timeout: 0.25s
-      lb_policy: ROUND_ROBIN
-      common_lb_config:
-        consistent_hashing_lb_config:
-          use_hostname_for_hashing: true
-      load_assignment:
-        endpoints:
-          - lb_endpoints:
-            - endpoint:
-                address:
-                  socket_address:
-                    address: 10.0.0.1
-                    port_value: 443
-      cluster_type:
-        name: envoy.clusters.test_static
-    )EOF";
-
-  EXPECT_THROW_WITH_MESSAGE(
-      {
-        const envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
-        ClusterFactoryImplBase::create(
-            cluster_config, cm_, stats_, tls_, dns_resolver_, ssl_context_manager_, runtime_,
-            dispatcher_, log_manager_, local_info_, admin_, singleton_manager_,
-            std::move(outlier_event_logger_), false, validation_visitor_, *api_);
-      },
-      EnvoyException,
-      "Cannot use hostname for consistent hashing loadbalancing for cluster of type: "
-      "'envoy.clusters.test_static'");
-}
-
 } // namespace
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -124,8 +124,8 @@ TEST_F(MaglevLoadBalancerTest, Basic) {
   }
 }
 
-// Basic with hostname.
-TEST_F(MaglevLoadBalancerTest, BasicWithHostName) {
+// Basic with index based hashing.
+TEST_F(MaglevLoadBalancerTest, BasicWithIndexHashing) {
   host_set_.hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90"),
                       makeTestHost(info_, "91", "tcp://127.0.0.1:91"),
                       makeTestHost(info_, "92", "tcp://127.0.0.1:92"),
@@ -136,7 +136,7 @@ TEST_F(MaglevLoadBalancerTest, BasicWithHostName) {
   host_set_.runCallbacks({}, {});
   common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
   auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
-  chc.set_use_hostname_for_hashing(true);
+  chc.set_use_index_for_hashing(true);
   common_config_.set_allocated_consistent_hashing_lb_config(&chc);
   init(7);
   common_config_.release_consistent_hashing_lb_config();
@@ -146,15 +146,15 @@ TEST_F(MaglevLoadBalancerTest, BasicWithHostName) {
   EXPECT_EQ(1, lb_->stats().min_entries_per_host_.value());
   EXPECT_EQ(2, lb_->stats().max_entries_per_host_.value());
 
-  // maglev: i=0 host=92
-  // maglev: i=1 host=95
+  // maglev: i=0 host=93
+  // maglev: i=1 host=90
   // maglev: i=2 host=90
-  // maglev: i=3 host=93
+  // maglev: i=3 host=91
   // maglev: i=4 host=94
-  // maglev: i=5 host=91
-  // maglev: i=6 host=90
+  // maglev: i=5 host=92
+  // maglev: i=6 host=95
   LoadBalancerPtr lb = lb_->factory()->create();
-  const std::vector<uint32_t> expected_assignments{2, 5, 0, 3, 4, 1, 0};
+  const std::vector<uint32_t> expected_assignments{3, 0, 0, 1, 4, 2, 5};
   for (uint32_t i = 0; i < 3 * expected_assignments.size(); ++i) {
     TestLoadBalancerContext context(i);
     EXPECT_EQ(host_set_.hosts_[expected_assignments[i % expected_assignments.size()]],

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -263,8 +263,8 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMurmur2) {
   EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
 }
 
-// Expect reasonable results with hostname.
-TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
+// Expect reasonable results with index based hashing.
+TEST_P(RingHashLoadBalancerTest, BasicWithIndexHashing) {
   hostSet().hosts_ = {makeTestHost(info_, "90", "tcp://127.0.0.1:90"),
                       makeTestHost(info_, "91", "tcp://127.0.0.1:91"),
                       makeTestHost(info_, "92", "tcp://127.0.0.1:92"),
@@ -279,7 +279,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
 
   common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
   auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
-  chc.set_use_hostname_for_hashing(true);
+  chc.set_use_index_for_hashing(true);
   common_config_.set_allocated_consistent_hashing_lb_config(&chc);
 
   init();
@@ -295,37 +295,37 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
   // hash ring:
   // host | position
   // ---------------------------
-  // 95 | 1975508444536362413
-  // 95 | 2376063919839173711
-  // 93 | 2386806903309390596
-  // 94 | 6749904478991551885
-  // 93 | 6803900775736438537
-  // 92 | 7225015537174310577
-  // 90 | 8787465352164086522
-  // 92 | 11282020843382717940
-  // 91 | 13723418369486627818
-  // 90 | 13776502110861797421
-  // 91 | 14338313586354474791
-  // 94 | 15364271037087512980
+  // 91 | 623620434812591335
+  // 91 | 1291284742260624308
+  // 93 | 2240678485176585483
+  // 90 | 7336049725490893212
+  // 95 | 11067797875844516204
+  // 94 | 11152906599107103836
+  // 90 | 11180626175924339903
+  // 95 | 11880846191933415469
+  // 94 | 11940626933830197904
+  // 92 | 13159892096342920361
+  // 92 | 17241333882518980491
+  // 93 | 18330096856982668041
 
   LoadBalancerPtr lb = lb_->factory()->create();
   {
     TestLoadBalancerContext context(0);
-    EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
+    EXPECT_EQ(hostSet().hosts_[1], lb->chooseHost(&context));
   }
   {
     TestLoadBalancerContext context(std::numeric_limits<uint64_t>::max());
-    EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
+    EXPECT_EQ(hostSet().hosts_[1], lb->chooseHost(&context));
   }
   {
-    TestLoadBalancerContext context(7225015537174310577);
-    EXPECT_EQ(hostSet().hosts_[2], lb->chooseHost(&context));
-  }
-  {
-    TestLoadBalancerContext context(6803900775736438537);
+    TestLoadBalancerContext context(2240678485176585483);
     EXPECT_EQ(hostSet().hosts_[3], lb->chooseHost(&context));
   }
-  { EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(nullptr)); }
+  {
+    TestLoadBalancerContext context(7336049725490893212);
+    EXPECT_EQ(hostSet().hosts_[0], lb->chooseHost(&context));
+  }
+  { EXPECT_EQ(hostSet().hosts_[1], lb->chooseHost(nullptr)); }
   EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
 
   hostSet().healthy_hosts_.clear();
@@ -333,7 +333,7 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
   lb = lb_->factory()->create();
   {
     TestLoadBalancerContext context(0);
-    EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
+    EXPECT_EQ(hostSet().hosts_[1], lb->chooseHost(&context));
   }
   EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
 }


### PR DESCRIPTION
When I proposed https://github.com/envoyproxy/envoy/issues/9074 and solved it by using the host's hostname instead with https://github.com/envoyproxy/envoy/pull/10233, it only partially fixed the underlying problem. The core problem is the need to consistently hash to semantically and logically equal hosts that could have different addresses. My original solution just moved the problem one step further without really fixing it.

We ran into this when we had to migrate our workloads/clusters inplace. In these cases even the hostnames change and we end up with inconsistent hashing. The solution to this seems to be to use the index in your endpoints array as the hash key as done in [mcrouter](https://github.com/facebook/mcrouter) e.g.

So instead of doing it based on the hostname which can still change,  I've used the array index in the list of hosts instead.

I haven't handled the deprecation of the old config partly because I'm not sure how we want to do this and what the considerations are. I don't think the previous option was used much and with this feature it is probably not very useful so it seems like it should be deprecated. However, if there are existing uses then this scheme will change the hash so it isn't a direct swap. So perhaps we need to keep both around? But that seems like carrying dead code. If we keep both then perhaps this config needs to become an enum with different schemes for the `hash_key`.

cc @mattklein123 

Additional Description:
Risk Level: Medium
Testing: unit
Docs Changes: yes
Release Notes: 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
Deprecated: use_hostname_for_hashing
Fixes https://github.com/envoyproxy/envoy/issues/9074