### PR TITLE
build: support ppc64le with wasm

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -2,12 +2,12 @@
 
 set -e
 
-# This works only on Linux-{x86_64,s390x,aarch64} and macOS-x86_64.
+# This works only on Linux-{x86_64,s390x,aarch64,ppc64le} and macOS-x86_64.
 case "$$(uname -s)-$$(uname -m)" in
-Linux-x86_64|Linux-s390x|Linux-aarch64|Darwin-x86_64)
+Linux-x86_64|Linux-s390x|Linux-aarch64|Linux-ppc64le|Darwin-x86_64)
   ;;
 *)
-  echo "ERROR: wee8 is currently supported only on Linux-{x86_64,s390x,aarch64} and macOS-x86_64." >&2
+  echo "ERROR: wee8 is currently supported only on Linux-{x86_64,s390x,aarch64,ppc64le} and macOS-x86_64." >&2
   exit 1
 esac
 
@@ -87,6 +87,11 @@ WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
 # Support Arm64
 if [[ `uname -m` == "aarch64" ]]; then
   WEE8_BUILD_ARGS+=" target_cpu=\"arm64\""
+fi
+# Support ppc64
+# Only tests with gn 5da62d5
+if [[ `uname -m` == "ppc64le" ]]; then
+  WEE8_BUILD_ARGS+=" target_cpu=\"ppc64\""
 fi
 
 # Build wee8.


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>


Commit Message: build: support ppc64le with wasm
Additional Description: The build has only been tested with gn git sha 5da62d5 as
recommended by ppc64 maintainers of the v8 runtime.
Risk Level: Low- Should only affect the ppc64 builds
Testing: Normal ppc64 static binary build with just this commit https://powerci.osuosl.org/job/build-envoy-static-branch/2/
Docs Changes: N/A
Release Notes: support ppc64 wasm extension
Platform Specific Features: N/A
Fixes #13593 
