### PR TITLE
mac ci: try ignoring update failure

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -41,8 +41,9 @@ function retry () {
 }
 
 if ! retry brew update; then
-    echo "Failed to update homebrew"
-    exit 1
+  echo "Failed to update homebrew"
+  # Temporarily disable early exit if update fails.
+  # exit 1
 fi
 
 DEPS="automake cmake coreutils go libtool wget ninja"

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -41,9 +41,8 @@ function retry () {
 }
 
 if ! retry brew update; then
+  # Do not exit early if update fails.
   echo "Failed to update homebrew"
-  # Temporarily disable early exit if update fails.
-  # exit 1
 fi
 
 DEPS="automake cmake coreutils go libtool wget ninja"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Ignore update failures in mac CI.
