### PR TITLE
ci: various improvements

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -70,7 +70,6 @@ stages:
             inputs:
               pathtoPublish: "$(Build.SourcesDirectory)/generated/docs"
               artifactName: docs
-            condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
           - task: InstallSSHKey@0
             inputs:
@@ -78,7 +77,7 @@ stages:
               sshPublicKey: "$(DocsPublicKey)"
               sshPassphrase: "$(SshDeployKeyPassphrase)"
               sshKeySecureFile: "$(DocsPrivateKey)"
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['PostSubmit'], true))
+            condition: and(succeeded(), eq(variables['PostSubmit'], true), ne(variables['NoSync'], true))
 
           - script: docs/publish.sh
             displayName: "Publish to GitHub"
@@ -86,7 +85,8 @@ stages:
             env:
               AZP_BRANCH: $(Build.SourceBranch)
               AZP_SHA1: $(Build.SourceVersion)
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['PostSubmit'], true))
+            condition: and(succeeded(), eq(variables['PostSubmit'], true), ne(variables['NoSync'], true))
+
       - job: dependencies
         dependsOn: [] # this removes the implicit dependency on previous stage and causes this to run in parallel.
         pool:
@@ -102,9 +102,8 @@ stages:
               GITHUB_TOKEN: $(GitHubPublicRepoOnlyAccessToken)
             displayName: "Verify dependency information"
 
-
   - stage: sync
-    condition: and(succeeded(), eq(variables['PostSubmit'], true))
+    condition: and(succeeded(), eq(variables['PostSubmit'], true), ne(variables['NoSync'], true))
     dependsOn: []
     jobs:
       - job: filter_example
@@ -145,6 +144,8 @@ stages:
 
       - job: go_control_plane
         dependsOn: []
+        pool:
+          vmImage: "ubuntu-18.04"
         steps:
           - task: InstallSSHKey@0
             inputs:
@@ -167,12 +168,11 @@ stages:
 
   - stage: linux_x64
     dependsOn: ["precheck"]
-    # For master builds, continue even if precheck fails
-    condition: and(not(canceled()), or(succeeded(), ne(variables['Build.Reason'], 'PullRequest')))
+    # For post-submit builds, continue even if precheck fails
+    condition: and(not(canceled()), or(succeeded(), eq(variables['PostSubmit'], true)))
     jobs:
       - job: release
-        # For master builds, continue even if format fails
-        timeoutInMinutes: 360
+        timeoutInMinutes: 120
         pool:
           vmImage: "ubuntu-18.04"
         steps:
@@ -182,11 +182,11 @@ stages:
 
   - stage: linux_arm64
     dependsOn: ["precheck"]
-    # For master builds, continue even if precheck fails
-    condition: and(not(canceled()), or(succeeded(), ne(variables['Build.Reason'], 'PullRequest')))
+    # For post-submit builds, continue even if precheck fails
+    condition: and(not(canceled()), or(succeeded(), eq(variables['PostSubmit'], true)))
     jobs:
       - job: release
-        timeoutInMinutes: 360
+        timeoutInMinutes: 120
         pool: "arm-large"
         steps:
           - template: bazel.yml
@@ -218,7 +218,7 @@ stages:
               CI_TARGET: "bazel.tsan"
             compile_time_options:
               CI_TARGET: "bazel.compile_time_options"
-        timeoutInMinutes: 360
+        timeoutInMinutes: 120
         pool:
           vmImage: "ubuntu-18.04"
         steps:
@@ -229,7 +229,7 @@ stages:
       - job: coverage
         displayName: "linux_x64"
         dependsOn: []
-        timeoutInMinutes: 360
+        timeoutInMinutes: 120
         pool: "x64-large"
         strategy:
           maxParallel: 2
@@ -328,7 +328,7 @@ stages:
     dependsOn: ["precheck"]
     jobs:
       - job: test
-        timeoutInMinutes: 360
+        timeoutInMinutes: 180
         pool:
           vmImage: "macos-latest"
         steps:
@@ -362,7 +362,7 @@ stages:
     dependsOn: ["precheck"]
     jobs:
       - job: release
-        timeoutInMinutes: 360
+        timeoutInMinutes: 120
         pool:
           vmImage: "windows-latest"
         steps:
@@ -383,7 +383,7 @@ stages:
 
       - job: docker
         dependsOn: ["release"]
-        timeoutInMinutes: 360
+        timeoutInMinutes: 120
         pool:
           vmImage: "windows-latest"
         steps:


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

CI Improvements before backport:
- shorten timeout to 120 minutes for RBE builds (early catch RBE hangs) and 180 minutes for macOS.
- use NoSync to control sync jobs (for private fork not to sync)