### PR TITLE
Added DurationTimeout as response flag for HCM.

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -464,13 +464,13 @@ void ConnectionManagerImpl::onIdleTimeout() {
   }
 }
 
-// TODO(#13142): Add DurationTimeout response flag for HCM.
 void ConnectionManagerImpl::onConnectionDurationTimeout() {
   ENVOY_CONN_LOG(debug, "max connection duration reached", read_callbacks_->connection());
   stats_.named_.downstream_cx_max_duration_reached_.inc();
   if (!codec_) {
     // Attempt to write out buffered data one last time and issue a local close if successful.
-    doConnectionClose(Network::ConnectionCloseType::FlushWrite, absl::nullopt,
+    doConnectionClose(Network::ConnectionCloseType::FlushWrite,
+                      StreamInfo::ResponseFlag::DurationTimeout,
                       StreamInfo::ResponseCodeDetails::get().DurationTimeout);
   } else if (drain_state_ == DrainState::NotDraining) {
     startDrainSequence();


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>

Commit Message: Added DurationTimeout as a response flag for HCM.
Additional Description: In #12495, "DurationTimeout" as a response flag produced at the TCP connection timeout. The timeout flag should have the same behavior for TCP and HTTP connection-level.   
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Fixes #13142 