### PR TITLE
ci: enable CVE scanner on AZP.

### DIFF
--- a/.azure-pipelines/cve_scan.yml
+++ b/.azure-pipelines/cve_scan.yml
@@ -1,0 +1,22 @@
+# Pipeline for running Envoy's CVE scanner on an hourly basis.
+
+# This pipeline only uses scheduled triggers.
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 * * * *"
+  displayName: Hourly CVE scan
+  branches:
+    include:
+    - master
+  always: true
+
+pool:
+  vmImage: "ubuntu-18.04"
+steps:
+  - script: ci/run_envoy_docker.sh 'ci/do_ci.sh cve_scan'
+    workingDirectory: $(Build.SourcesDirectory)
+    env:
+      ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+    displayName: "Scan for CVEs in dependencies"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -419,9 +419,16 @@ elif [[ "$CI_TARGET" == "deps" ]]; then
   # Validate dependency relationships between core/extensions and external deps.
   ./tools/dependency/validate_test.py
   ./tools/dependency/validate.py
-  # Validate the CVE scanner works.
+  # Validate the CVE scanner works. We do it here as well as in cve_scan, since this blocks
+  # presubmits, but cve_scan only runs async.
   python3.8 tools/dependency/cve_scan_test.py
+  # Validate repository metadata.
   ./ci/check_repository_locations.sh
+  exit 0
+elif [[ "$CI_TARGET" == "cve_scan" ]]; then
+  echo "scanning for CVEs in dependencies..."
+  python3.8 tools/dependency/cve_scan_test.py
+  python3.8 tools/dependency/cve_scan.py
   exit 0
 elif [[ "$CI_TARGET" == "verify_examples" ]]; then
   echo "verify examples..."

--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -193,11 +193,9 @@ def CpeMatch(cpe, dep_metadata):
   # An exact version match is a hit.
   if cpe.version == dep_version:
     return True
-  # Allow the 'last_updated' dependency metadata to substitute for date.
-  # TODO(htuch): Make a finer grained distinction between Envoy update date and dependency
-  # release date in 'last_updated'.
+  # Allow the 'release_date' dependency metadata to substitute for date.
   # TODO(htuch): Consider fuzzier date ranges.
-  if cpe.version == dep_metadata['last_updated']:
+  if cpe.version == dep_metadata['release_date']:
     return True
   # Try a fuzzy date match to deal with versions like fips-20190304 in dependency version.
   if RegexGroupsMatch(FUZZY_DATE_RE, dep_version, cpe.version):
@@ -234,7 +232,7 @@ def CveMatch(cve, dep_metadata):
   if wildcard_version_match:
     # If the CVE was published after the dependency was last updated, it's a
     # potential match.
-    last_dep_update = dt.date.fromisoformat(dep_metadata['last_updated'])
+    last_dep_update = dt.date.fromisoformat(dep_metadata['release_date'])
     if last_dep_update <= cve.published_date:
       return True
   return False

--- a/tools/dependency/cve_scan_test.py
+++ b/tools/dependency/cve_scan_test.py
@@ -122,12 +122,12 @@ class CveScanTest(unittest.TestCase):
   def BuildCpe(self, cpe_str):
     return cve_scan.Cpe.FromString(cpe_str)
 
-  def BuildDep(self, cpe_str, version=None, last_updated=None):
-    return {'cpe': cpe_str, 'version': version, 'last_updated': last_updated}
+  def BuildDep(self, cpe_str, version=None, release_date=None):
+    return {'cpe': cpe_str, 'version': version, 'release_date': release_date}
 
-  def CpeMatch(self, cpe_str, dep_cpe_str, version=None, last_updated=None):
+  def CpeMatch(self, cpe_str, dep_cpe_str, version=None, release_date=None):
     return cve_scan.CpeMatch(self.BuildCpe(cpe_str),
-                             self.BuildDep(dep_cpe_str, version=version, last_updated=last_updated))
+                             self.BuildDep(dep_cpe_str, version=version, release_date=release_date))
 
   def test_cpe_match(self):
     # Mismatched part
@@ -147,7 +147,7 @@ class CveScanTest(unittest.TestCase):
     self.assertTrue(
         self.CpeMatch('cpe:2.3:a:foo:bar:2020-03-05',
                       'cpe:2.3:a:foo:bar:*',
-                      last_updated='2020-03-05'))
+                      release_date='2020-03-05'))
     fuzzy_version_matches = [
         ('2020-03-05', '2020-03-05'),
         ('2020-03-05', '20200305'),
@@ -186,9 +186,9 @@ class CveScanTest(unittest.TestCase):
                         published_date=dt.date.fromisoformat(published_date),
                         last_modified_date=None)
 
-  def CveMatch(self, cve_id, cpes, published_date, dep_cpe_str, version=None, last_updated=None):
+  def CveMatch(self, cve_id, cpes, published_date, dep_cpe_str, version=None, release_date=None):
     return cve_scan.CveMatch(self.BuildCve(cve_id, cpes=cpes, published_date=published_date),
-                             self.BuildDep(dep_cpe_str, version=version, last_updated=last_updated))
+                             self.BuildDep(dep_cpe_str, version=version, release_date=release_date))
 
   def test_cve_match(self):
     # Empty CPEs, no match
@@ -199,20 +199,20 @@ class CveScanTest(unittest.TestCase):
                       set([self.BuildCpe('cpe:2.3:a:foo:bar:*')]),
                       '2020-05-03',
                       'cpe:2.3:a:foo:bar:*',
-                      last_updated='2020-05-02'))
+                      release_date='2020-05-02'))
     self.assertTrue(
         self.CveMatch('CVE-2020-123',
                       set([self.BuildCpe('cpe:2.3:a:foo:bar:*')]),
                       '2020-05-03',
                       'cpe:2.3:a:foo:bar:*',
-                      last_updated='2020-05-03'))
+                      release_date='2020-05-03'))
     # Wildcard version, recently updated
     self.assertFalse(
         self.CveMatch('CVE-2020-123',
                       set([self.BuildCpe('cpe:2.3:a:foo:bar:*')]),
                       '2020-05-03',
                       'cpe:2.3:a:foo:bar:*',
-                      last_updated='2020-05-04'))
+                      release_date='2020-05-04'))
     # Version match
     self.assertTrue(
         self.CveMatch('CVE-2020-123',
@@ -227,7 +227,7 @@ class CveScanTest(unittest.TestCase):
                       '2020-05-03',
                       'cpe:2.3:a:foo:bar:*',
                       version='1.2.4',
-                      last_updated='2020-05-02'))
+                      release_date='2020-05-02'))
     # Multiple CPEs, match first, don't match later.
     self.assertTrue(
         self.CveMatch('CVE-2020-123',


### PR DESCRIPTION
This runs on a cron schedule every hour. Notifications will be
configured to e-mail envoy-security@googlegroups.com on failure.

A separate pipeline is used to isolate only the CVE scanner and avoid
interfering with normal builds.

Signed-off-by: Harvey Tuch <htuch@google.com>