### PR TITLE
repokitteh: enhance dependency-shepherds rules.

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -29,8 +29,9 @@ use(
     {
       "owner": "envoyproxy/dependency-shepherds!",
       "path":
-      "(bazel/.*repos.*\.bzl)|(bazel/dependency_imports\.bzl)|(api/bazel/.*\.bzl)|(.*/requirements\.txt)",
+      "(bazel/.*repos.*\.bzl)|(bazel/dependency_imports\.bzl)|(api/bazel/.*\.bzl)|(.*/requirements\.txt)|(.*\.patch)",
       "label": "deps",
+      "allow_global_approval": False,
       "github_status_label": "any dependency change",
     },
   ],


### PR DESCRIPTION
* Monitor all *.patch files; we want fewer of these for release update
  velocity reasons (with the resulting security win).

* Make dependency-shepherds check not subject to global approval. The
  dependency shepherds will need to perform an explicit "/lgtm deps" to
  prevent accidental merge. This extra steps establishes a checklist philosophy
  during dependency review.

Signed-off-by: Harvey Tuch <htuch@google.com>