### PR TITLE
connect: example instructions

### DIFF
--- a/configs/encapsulate_in_connect.yaml
+++ b/configs/encapsulate_in_connect.yaml
@@ -1,3 +1,8 @@
+# This configuration takes incoming data on port 10000 and encapsulates it in a CONNECT
+# request which is sent upstream port 10001.
+# It can be used to test TCP tunneling as described in docs/root/intro/arch_overview/http/upgrades.rst
+# and running `curl --x 127.0.0.1:10000 https://www.google.com`
+
 admin:
   access_log_path: /tmp/admin_access.log
   address:

--- a/configs/terminate_connect.yaml
+++ b/configs/terminate_connect.yaml
@@ -59,4 +59,4 @@ static_resources:
             address:
               socket_address:
                 address: www.google.com
-                port_value: 80
+                port_value: 443

--- a/configs/terminate_connect.yaml
+++ b/configs/terminate_connect.yaml
@@ -1,3 +1,6 @@
+# This configuration terminates a CONNECT request and sends the CONNECT payload upstream.
+# It can be used to test TCP tunneling as described in docs/root/intro/arch_overview/http/upgrades.rst
+# or used to test CONNECT directly, by running `curl -k -v -x 127.0.0.1:10001 https://www.google.com`
 admin:
   access_log_path: /tmp/admin_access.log
   address:
@@ -56,9 +59,4 @@ static_resources:
             address:
               socket_address:
                 address: www.google.com
-                port_value: 443
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        sni: www.google.com
+                port_value: 80


### PR DESCRIPTION
Tweaking connect example so it works both for tunneling and direct CONNECT.
Manually verified instructions in docs/root/intro/arch_overview/http/upgrades.rst still work and the new curl instructions do as well.