### PR TITLE
xds: Clarify limitations of resource type instance version.

### DIFF
--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -286,7 +286,12 @@ given type from multiple xDS servers, each xDS server will have a different noti
 Note that the version for a resource type is not a property of an individual xDS stream but rather
 a property of the resources themselves. If the stream becomes broken and the client creates a new
 stream, the client's initial request on the new stream should indicate the most recent version
-seen by the client on the previous stream.
+seen by the client on the previous stream. Servers may decide to optimize by not resending
+resources that the client had already seen on the previous stream, but only if they know that the
+client is not subscribing to a new resource that it was not previously subscribed to. For example,
+it is generally safe for servers to do this optimization for wildcard LDS and CDS requests, and it
+is safe to do in environments where the clients will always subscribe to exactly the same set of
+resources.
 
 An example EDS request might be:
 


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: xds: Clarify limitations of resource type instance version.
Additional Description: Clarify that the server may not resend resources upon stream restart only if it has some way to know that the client is not subscribing to new resources that it wasn't previously subscribed to.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

Clarifies text added in #12580.  CC @htuch 