### PR TITLE
api: update doc to clarify match_subject_alt_names is optional and fix a typo

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -297,8 +297,8 @@ message CertificateValidationContext {
   repeated string verify_certificate_hash = 2
       [(validate.rules).repeated = {items {string {min_len: 64 max_bytes: 95}}}];
 
-  // An optional list of Subject Alternative name matchers. Envoy will verify that the
-  // Subject Alternative Name of the presented certificate matches one of the specified matches.
+  // An optional list of Subject Alternative name matchers. If specified, Envoy will verify that the
+  // Subject Alternative Name of the presented certificate matches one of the specified matchers.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`.

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -299,8 +299,8 @@ message CertificateValidationContext {
   repeated string verify_certificate_hash = 2
       [(validate.rules).repeated = {items {string {min_len: 64 max_bytes: 95}}}];
 
-  // An optional list of Subject Alternative name matchers. Envoy will verify that the
-  // Subject Alternative Name of the presented certificate matches one of the specified matches.
+  // An optional list of Subject Alternative name matchers. If specified, Envoy will verify that the
+  // Subject Alternative Name of the presented certificate matches one of the specified matchers.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v4alpha.StringMatcher>`.

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -294,8 +294,8 @@ message CertificateValidationContext {
   repeated string verify_certificate_hash = 2
       [(validate.rules).repeated = {items {string {min_len: 64 max_bytes: 95}}}];
 
-  // An optional list of Subject Alternative name matchers. Envoy will verify that the
-  // Subject Alternative Name of the presented certificate matches one of the specified matches.
+  // An optional list of Subject Alternative name matchers. If specified, Envoy will verify that the
+  // Subject Alternative Name of the presented certificate matches one of the specified matchers.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v3.StringMatcher>`.

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -299,8 +299,8 @@ message CertificateValidationContext {
   repeated string verify_certificate_hash = 2
       [(validate.rules).repeated = {items {string {min_len: 64 max_bytes: 95}}}];
 
-  // An optional list of Subject Alternative name matchers. Envoy will verify that the
-  // Subject Alternative Name of the presented certificate matches one of the specified matches.
+  // An optional list of Subject Alternative name matchers. If specified, Envoy will verify that the
+  // Subject Alternative Name of the presented certificate matches one of the specified matchers.
   //
   // When a certificate has wildcard DNS SAN entries, to match a specific client, it should be
   // configured with exact match type in the :ref:`string matcher <envoy_api_msg_type.matcher.v4alpha.StringMatcher>`.


### PR DESCRIPTION
Signed-off-by: Sanjay Pujare <sanjaypujare@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: api: update doc to clarify match_subject_alt_names is optional and fix a typo
Additional Description: The comment in v3 version was missing the "If specified.." clause from the v2 version of that comment
Risk Level: low
Testing: Ran `./ci/run_envoy_docker.sh './ci/do_ci.sh fix_format'`
Docs Changes: comment in a proto file changed
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
