### PR TITLE
Windows: bring back tests disabled by #13133

### DIFF
--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -63,8 +63,6 @@ envoy_cc_test(
     name = "main_common_test",
     srcs = ["main_common_test.cc"],
     data = ["//test/config/integration:google_com_proxy_port_0"],
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl fastbuild TIMEOUT flake
-    tags = ["flaky_on_windows"],
     deps = [
         "//source/common/api:api_lib",
         "//source/exe:main_common_lib",

--- a/test/extensions/filters/http/adaptive_concurrency/BUILD
+++ b/test/extensions/filters/http/adaptive_concurrency/BUILD
@@ -34,8 +34,6 @@ envoy_extension_cc_test(
         "adaptive_concurrency_filter_integration_test.h",
     ],
     extension_name = "envoy.filters.http.adaptive_concurrency",
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl build test failure
-    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/filters/http/adaptive_concurrency:config",
         "//source/extensions/filters/http/fault:config",

--- a/test/extensions/filters/http/common/compressor/BUILD
+++ b/test/extensions/filters/http/common/compressor/BUILD
@@ -49,6 +49,4 @@ envoy_cc_benchmark_binary(
 envoy_benchmark_test(
     name = "compressor_filter_speed_test_benchmark_test",
     benchmark_binary = "compressor_filter_speed_test",
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl build test failure
-    tags = ["fails_on_windows"],
 )

--- a/test/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/test/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -60,8 +60,6 @@ envoy_extension_cc_test(
         "//test/proto:bookstore_proto_descriptor",
     ],
     extension_name = "envoy.filters.http.grpc_json_transcoder",
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl build test failure
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/grpc:codec_lib",
         "//source/common/http:header_map_lib",

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -15,8 +15,6 @@ envoy_extension_cc_test(
     name = "lua_filter_test",
     srcs = ["lua_filter_test.cc"],
     extension_name = "envoy.filters.http.lua",
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl build test failure
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/http/lua:lua_filter_lib",

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/BUILD
@@ -33,8 +33,6 @@ envoy_extension_cc_test(
         "//test/config/integration/certs",
     ],
     extension_name = "envoy.filters.network.sni_dynamic_forward_proxy",
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl build test failure
-    tags = ["fails_on_windows"],
     deps = [
         "//source/extensions/clusters/dynamic_forward_proxy:cluster",
         "//source/extensions/filters/listener/tls_inspector:config",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -358,8 +358,6 @@ envoy_cc_test(
         ":server_test_data",
         ":static_validation_test_data",
     ],
-    # TODO(envoyproxy/windows-dev): diagnose clang-cl build test timeout
-    tags = ["fails_on_windows"],
     deps = [
         "//source/common/version:version_lib",
         "//source/extensions/access_loggers/file:config",


### PR DESCRIPTION
Commit Message: Windows: bring back tests disabled by #13133
Additional Description:
PR #13133 disabled various tests as they failed or flaked when compiled
with clang-cl. Given we have some significant other blockers to adding
clang-cl support and enabling as many tests to run in CI as possible is
important to progress to beta/GA support, we can un-skip these tests.

We could be "clever" and use a select to only tag tests to be skipped
when built with a specific compiler and compilation mode as well as an
alternative.

Risk Level: Low
Testing: Re-enables tests in the Windows pipeline
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A