### PR TITLE
docs: Copy examples to docs include folder

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -142,6 +142,13 @@ cp -f "${API_DIR}"/xds_protocol.rst "${GENERATED_RST_DIR}/api-docs/xds_protocol.
 mkdir -p "${GENERATED_RST_DIR}"/configuration/best_practices
 cp -f "${CONFIGS_DIR}"/google-vrp/envoy-edge.yaml "${GENERATED_RST_DIR}"/configuration/best_practices
 
+copy_example_configs () {
+    mkdir -p "${GENERATED_RST_DIR}/start/sandboxes/_include"
+    cp -a "${SRC_DIR}"/examples/* "${GENERATED_RST_DIR}/start/sandboxes/_include"
+}
+
+copy_example_configs
+
 rsync -rav  "${API_DIR}/diagrams" "${GENERATED_RST_DIR}/api-docs"
 
 rsync -av \


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>


Commit Message: docs: Copy examples to docs include folder
Additional Description:

copies the examples/ folder  into a docs include folder so that the configs can be shown/downloaded directly in the docs

it may want to be more selective about which files it copies, but the dir is not big

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Touch #13060 #13622 
[Optional Deprecated:]
