### PR TITLE
wasm: envoy specific ABI to add tags to active span

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -308,6 +308,18 @@ void Context::onStatsUpdate(Envoy::Stats::MetricSnapshot& snapshot) {
   wasm()->on_stats_update_(this, id_, counter_block_size + gauge_block_size);
 }
 
+// Tracing
+WasmResult Context::activeSpanSetTag(absl::string_view key, absl::string_view value) {
+  if (decoder_callbacks_) {
+    Tracing::Span& span = decoder_callbacks_->activeSpan();
+    span.setTag(key, value);
+  } else if (encoder_callbacks_) {
+    Tracing::Span& span = encoder_callbacks_->activeSpan();
+    span.setTag(key, value);
+  }
+  return WasmResult::Ok;
+}
+
 // Native serializer carrying over bit representation from CEL value to the extension.
 // This implementation assumes that the value type is static and known to the consumer.
 WasmResult serializeValue(Filters::Common::Expr::CelValue value, std::string* result) {

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -276,6 +276,7 @@ public:
                     std::list<Envoy::Network::DnsResponse>&& response);
 
   void onStatsUpdate(Envoy::Stats::MetricSnapshot& snapshot);
+  WasmResult activeSpanSetTag(absl::string_view key, absl::string_view value);
 
   // CEL evaluation
   std::vector<const google::api::expr::runtime::CelFunction*>

--- a/source/extensions/common/wasm/ext/envoy_null_plugin.h
+++ b/source/extensions/common/wasm/ext/envoy_null_plugin.h
@@ -18,6 +18,10 @@ namespace Wasm {
 proxy_wasm::Word resolve_dns(void* raw_context, proxy_wasm::Word dns_address,
                              proxy_wasm::Word dns_address_size, proxy_wasm::Word token_ptr);
 
+proxy_wasm::Word set_active_span_tag(void* raw_context, proxy_wasm::Word key_ptr,
+                                     proxy_wasm::Word key_size, proxy_wasm::Word value_ptr,
+                                     proxy_wasm::Word value_size);
+
 } // namespace Wasm
 } // namespace Common
 } // namespace Extensions
@@ -38,6 +42,14 @@ inline WasmResult envoy_resolve_dns(const char* dns_address, size_t dns_address_
   return static_cast<WasmResult>(
       ::Envoy::Extensions::Common::Wasm::resolve_dns(proxy_wasm::current_context_, WR(dns_address),
                                                      WS(dns_address_size), WR(token))
+          .u64_);
+}
+
+inline WasmResult envoy_set_active_span_tag(const char* key_ptr, size_t key_size,
+                                            const char* value_ptr, size_t value_size) {
+  return static_cast<WasmResult>(
+      ::Envoy::Extensions::Common::Wasm::set_active_span_tag(
+          proxy_wasm::current_context_, WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size))
           .u64_);
 }
 

--- a/source/extensions/common/wasm/ext/envoy_null_plugin.h
+++ b/source/extensions/common/wasm/ext/envoy_null_plugin.h
@@ -53,6 +53,7 @@ inline WasmResult envoy_set_active_span_tag(const char* key_ptr, size_t key_size
           .u64_);
 }
 
+
 #undef WS
 #undef WR
 

--- a/source/extensions/common/wasm/ext/envoy_proxy_wasm_api.h
+++ b/source/extensions/common/wasm/ext/envoy_proxy_wasm_api.h
@@ -129,3 +129,6 @@ inline StatResult parseStatResults(std::string_view data) {
 }
 
 extern "C" WasmResult envoy_resolve_dns(const char* address, size_t address_size, uint32_t* token);
+// Tracing
+extern "C" WasmResult envoy_set_active_span_tag(const char* key_ptr, size_t key_size,
+                                                const char* value_ptr, size_t value_size);

--- a/source/extensions/common/wasm/ext/envoy_wasm_intrinsics.js
+++ b/source/extensions/common/wasm/ext/envoy_wasm_intrinsics.js
@@ -1,3 +1,4 @@
 mergeInto(LibraryManager.library, {
   envoy_resolve_dns: function() {},
+  envoy_set_active_span_tag: function () {},
 });

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -204,6 +204,19 @@ Word resolve_dns(void* raw_context, Word dns_address_ptr, Word dns_address_size,
   return WasmResult::Ok;
 }
 
+// // NOLINTNEXTLINE(readability-identifier-naming)
+Word set_active_span_tag(void* raw_context, Word key_ptr, Word key_size, Word value_ptr,
+                         Word value_size) {
+  auto context = WASM_CONTEXT(raw_context);
+  auto key = context->wasmVm()->getMemory(key_ptr.u64_, key_size.u64_);
+  auto value = context->wasmVm()->getMemory(value_ptr.u64_, value_size.u64_);
+  if (!key || !value) {
+    return WasmResult::InvalidMemoryAccess;
+  }
+  context->activeSpanSetTag(key.value(), value.value());
+  return WasmResult::Ok;
+}
+
 void Wasm::registerCallbacks() {
   WasmBase::registerCallbacks();
 #define _REGISTER(_fn)                                                                             \
@@ -211,6 +224,7 @@ void Wasm::registerCallbacks() {
       "env", "envoy_" #_fn, &_fn,                                                                  \
       &proxy_wasm::ConvertFunctionWordToUint32<decltype(_fn), _fn>::convertFunctionWordToUint32)
   _REGISTER(resolve_dns);
+  _REGISTER(set_active_span_tag);
 #undef _REGISTER
 }
 

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -257,6 +257,11 @@ FilterHeadersStatus TestContext::onRequestHeaders(uint32_t, bool) {
     }
 
     return FilterHeadersStatus::Continue;
+  }  else if (test == "tracing") {
+    std::string tag_key = "tag_1";
+    std::string tag_value = "tag_value_1";
+    envoy_set_active_span_tag(tag_key.c_str(), tag_key.size(), tag_value.c_str(), tag_value.size());
+    return FilterHeadersStatus::Continue;
   }
   return FilterHeadersStatus::Continue;
 }

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/mocks/network/connection.h"
 #include "test/mocks/router/mocks.h"
+#include "test/mocks/tracing/mocks.h"
 #include "test/test_common/wasm_base.h"
 
 using testing::Eq;
@@ -83,6 +84,7 @@ public:
     setupBase(std::get<0>(GetParam()), code, createContextFn(), root_id, vm_configuration);
   }
   void setupFilter(const std::string root_id = "") { setupFilterBase<TestFilter>(root_id); }
+  NiceMock<Tracing::MockSpan> active_span_;
 
   void setupGrpcStreamTest(Grpc::RawAsyncStreamCallbacks*& callbacks);
 
@@ -1436,6 +1438,21 @@ TEST_P(WasmHttpFilterTest, RootId2) {
   setupFilter("context2");
   EXPECT_CALL(filter(), log_(spdlog::level::debug, Eq(absl::string_view("onRequestHeaders2 2"))));
   Http::TestRequestHeaderMapImpl request_headers;
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
+}
+
+// Verifies if the tag have been added correctly.
+TEST_P(WasmHttpFilterTest, AddTagToActiveSpans) {
+  if (std::get<1>(GetParam()) == "rust") {
+    // Tracing ABI not added in rust SDK yet.
+    return;
+  }
+  setupTest("", "tracing");
+  setupFilter();
+
+  EXPECT_CALL(decoder_callbacks_, activeSpan).WillRepeatedly(ReturnRef(active_span_));
+  EXPECT_CALL(active_span_, setTag(Eq("tag_1"), Eq("tag_value_1")));
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
 }
 


### PR DESCRIPTION
Added an envoy specific wasm ABI: envoy_set_active_span_tag.
This ABI can be used for adding tag informations for an active
span while request processing in a WASM filter.

Signed-off-by: Mohit Agarwal <mohit@traceable.ai>

Risk Level: Low
Testing: Added test cases.
Docs Changes: Not sure. Will have to see how to add documentation for this.
