### PR TITLE
Change StreamFilterCallbacks::tracingConfig() to return a pointer

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -244,9 +244,9 @@ public:
   virtual Tracing::Span& activeSpan() PURE;
 
   /**
-   * @return tracing configuration.
+   * @return tracing configuration. May be nullptr if there's no tracing configuration.
    */
-  virtual const Tracing::Config& tracingConfig() PURE;
+  virtual const Tracing::Config* tracingConfig() PURE;
 
   /**
    * @return the ScopeTrackedObject for this stream.

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -186,7 +186,7 @@ public:
   /**
    * Start driver specific span.
    */
-  virtual SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  virtual SpanPtr startSpan(const Config* config, Http::RequestHeaderMap& request_headers,
                             const std::string& operation_name, SystemTime start_time,
                             const Tracing::Decision tracing_decision) PURE;
 };
@@ -201,7 +201,7 @@ class HttpTracer {
 public:
   virtual ~HttpTracer() = default;
 
-  virtual SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  virtual SpanPtr startSpan(const Config* config, Http::RequestHeaderMap& request_headers,
                             const StreamInfo::StreamInfo& stream_info,
                             const Tracing::Decision tracing_decision) PURE;
 };

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -354,7 +354,7 @@ private:
   void clearRouteCache() override {}
   uint64_t streamId() const override { return stream_id_; }
   Tracing::Span& activeSpan() override { return active_span_; }
-  const Tracing::Config& tracingConfig() override { return tracing_config_; }
+  const Tracing::Config* tracingConfig() override { return tracing_config_; }
   void continueDecoding() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   RequestTrailerMap& addDecodedTrailers() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
   void addDecodedData(Buffer::Instance&, bool) override {
@@ -428,7 +428,7 @@ private:
   Router::ProdFilter router_;
   StreamInfo::StreamInfoImpl stream_info_;
   Tracing::NullSpan active_span_;
-  const Tracing::Config& tracing_config_;
+  const Tracing::Config* tracing_config_;
   std::shared_ptr<RouteImpl> route_;
   uint32_t high_watermark_calls_{};
   bool local_closed_{};

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -120,7 +120,7 @@ struct ConnectionManagerTracingStats {
  * Http Tracing can be enabled/disabled on a per connection manager basis.
  * Here we specify some specific for connection manager settings.
  */
-struct TracingConnectionManagerConfig {
+struct TracingConnectionManagerConfig : public Tracing::Config {
   Tracing::OperationName operation_name_;
   Tracing::CustomTagMap custom_tags_;
   envoy::type::v3::FractionalPercent client_sampling_;
@@ -128,6 +128,23 @@ struct TracingConnectionManagerConfig {
   envoy::type::v3::FractionalPercent overall_sampling_;
   bool verbose_;
   uint32_t max_path_tag_length_;
+
+  TracingConnectionManagerConfig(Tracing::OperationName operation_name,
+                                 const Tracing::CustomTagMap& custom_tags,
+                                 envoy::type::v3::FractionalPercent client_sampling,
+                                 envoy::type::v3::FractionalPercent random_sampling,
+                                 envoy::type::v3::FractionalPercent overall_sampling, bool verbose,
+                                 uint32_t max_path_tag_length)
+      : operation_name_(operation_name), custom_tags_(custom_tags),
+        client_sampling_(client_sampling), random_sampling_(random_sampling),
+        overall_sampling_(overall_sampling), verbose_(verbose),
+        max_path_tag_length_(max_path_tag_length) {}
+
+  TracingConnectionManagerConfig() {}
+  Tracing::OperationName operationName() const override { return operation_name_; }
+  const Tracing::CustomTagMap* customTags() const override { return &custom_tags_; }
+  bool verbose() const override { return verbose_; }
+  uint32_t maxPathTagLength() const override { return max_path_tag_length_; }
 };
 
 using TracingConnectionManagerConfigPtr = std::unique_ptr<TracingConnectionManagerConfig>;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -152,7 +152,6 @@ private:
                         public Event::DeferredDeletable,
                         public StreamCallbacks,
                         public RequestDecoder,
-                        public Tracing::Config,
                         public ScopeTrackedObject,
                         public FilterManagerCallbacks {
     ActiveStream(ConnectionManagerImpl& connection_manager, uint32_t buffer_limit);
@@ -190,12 +189,6 @@ private:
     // Http::RequestDecoder
     void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override;
     void decodeTrailers(RequestTrailerMapPtr&& trailers) override;
-
-    // Tracing::TracingConfig
-    Tracing::OperationName operationName() const override;
-    const Tracing::CustomTagMap* customTags() const override;
-    bool verbose() const override;
-    uint32_t maxPathTagLength() const override;
 
     // ScopeTrackedObject
     void dumpState(std::ostream& os, int indent_level = 0) const override {
@@ -275,7 +268,7 @@ private:
     void onRequestDataTooLarge() override;
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
     void onLocalReply(Code code) override;
-    Tracing::Config& tracingConfig() override;
+    Tracing::Config* tracingConfig() override;
     const ScopeTrackedObject& scope() override;
 
     void traceRequest();

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -223,7 +223,7 @@ const ScopeTrackedObject& ActiveStreamFilterBase::scope() {
   return parent_.filter_manager_callbacks_.scope();
 }
 
-Tracing::Config& ActiveStreamFilterBase::tracingConfig() {
+Tracing::Config* ActiveStreamFilterBase::tracingConfig() {
   return parent_.filter_manager_callbacks_.tracingConfig();
 }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -69,7 +69,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   uint64_t streamId() const override;
   StreamInfo::StreamInfo& streamInfo() override;
   Tracing::Span& activeSpan() override;
-  Tracing::Config& tracingConfig() override;
+  Tracing::Config* tracingConfig() override;
   const ScopeTrackedObject& scope() override;
 
   // Functions to set or get iteration state.
@@ -471,7 +471,7 @@ public:
   /**
    * Returns the tracing configuration to use for this stream.
    */
-  virtual Tracing::Config& tracingConfig() PURE;
+  virtual Tracing::Config* tracingConfig() PURE;
 
   /**
    * Returns the tracked scope to use for this stream.

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -354,6 +354,7 @@ void MessageUtil::loadFromJson(const std::string& json, Protobuf::Message& messa
       throw EnvoyException("Unable to parse JSON as proto (" + relaxed_status.ToString() +
                            "): " + json);
     }
+
     // We know it's an unknown field at this point. If we're at the latest
     // version, then it's definitely an unknown field, otherwise we try to
     // load again at a later version.

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -53,7 +53,7 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
       record_timeout_budget_(parent_.cluster()->timeoutBudgetStats().has_value()) {
   if (parent_.config().start_child_span_) {
     span_ = parent_.callbacks()->activeSpan().spawnChild(
-        parent_.callbacks()->tracingConfig(), "router " + parent.cluster()->name() + " egress",
+        *parent_.callbacks()->tracingConfig(), "router " + parent.cluster()->name() + " egress",
         parent.timeSource().systemTime());
     if (parent.attemptCount() != 1) {
       // This is a retry request, add this metadata to span.
@@ -71,7 +71,7 @@ UpstreamRequest::~UpstreamRequest() {
   if (span_ != nullptr) {
     Tracing::HttpTracerUtility::finalizeUpstreamSpan(*span_, upstream_headers_.get(),
                                                      upstream_trailers_.get(), stream_info_,
-                                                     Tracing::EgressConfig::get());
+                                                     &Tracing::EgressConfig::get());
   }
 
   if (per_try_timeout_ != nullptr) {

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -118,7 +118,7 @@ public:
                                      const Http::ResponseHeaderMap* response_headers,
                                      const Http::ResponseTrailerMap* response_trailers,
                                      const StreamInfo::StreamInfo& stream_info,
-                                     const Config& tracing_config);
+                                     const Config* tracing_config);
 
   /**
    * Adds information obtained from the upstream request headers as tags to the active span.
@@ -127,7 +127,7 @@ public:
   static void finalizeUpstreamSpan(Span& span, const Http::ResponseHeaderMap* response_headers,
                                    const Http::ResponseTrailerMap* response_trailers,
                                    const StreamInfo::StreamInfo& stream_info,
-                                   const Config& tracing_config);
+                                   const Config* tracing_config);
 
   /**
    * Create a custom tag according to the configuration.
@@ -139,7 +139,7 @@ private:
   static void setCommonTags(Span& span, const Http::ResponseHeaderMap* response_headers,
                             const Http::ResponseTrailerMap* response_trailers,
                             const StreamInfo::StreamInfo& stream_info,
-                            const Config& tracing_config);
+                            const Config* tracing_config);
 
   static const std::string IngressOperation;
   static const std::string EgressOperation;
@@ -180,7 +180,7 @@ public:
 class HttpNullTracer : public HttpTracer {
 public:
   // Tracing::HttpTracer
-  SpanPtr startSpan(const Config&, Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
+  SpanPtr startSpan(const Config*, Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                     const Tracing::Decision) override {
     return SpanPtr{new NullSpan()};
   }
@@ -191,7 +191,7 @@ public:
   HttpTracerImpl(DriverPtr&& driver, const LocalInfo::LocalInfo& local_info);
 
   // Tracing::HttpTracer
-  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  SpanPtr startSpan(const Config* config, Http::RequestHeaderMap& request_headers,
                     const StreamInfo::StreamInfo& stream_info,
                     const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -60,7 +60,7 @@ public:
   explicit OpenTracingDriver(Stats::Scope& scope);
 
   // Tracer::TracingDriver
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config* config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
@@ -23,7 +23,7 @@ public:
   /**
    * Implements the abstract Driver's startSpan operation.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config* config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -33,7 +33,7 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
   });
 }
 
-Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
+Tracing::SpanPtr Driver::startSpan(const Tracing::Config* config,
                                    Http::RequestHeaderMap& request_headers,
                                    const std::string& operation_name, Envoy::SystemTime start_time,
                                    const Tracing::Decision decision) {

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
@@ -20,7 +20,7 @@ public:
   explicit Driver(const envoy::config::trace::v3::SkyWalkingConfig& config,
                   Server::Configuration::TracerFactoryContext& context);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config* config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation, Envoy::SystemTime start_time,
                              const Tracing::Decision decision) override;
 

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -18,7 +18,7 @@ uint64_t getTimestamp(SystemTime time) {
 
 } // namespace
 
-Tracing::SpanPtr Tracer::startSpan(const Tracing::Config&, SystemTime start_time,
+Tracing::SpanPtr Tracer::startSpan(const Tracing::Config*, SystemTime start_time,
                                    const std::string& operation,
                                    SegmentContextSharedPtr segment_context, Span* parent) {
   SpanStore* span_store = segment_context->createSpanStore(parent ? parent->spanStore() : nullptr);
@@ -67,7 +67,7 @@ void Span::injectContext(Http::RequestHeaderMap& request_headers) {
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config& config, const std::string& operation_name,
                                   SystemTime start_time) {
   // The new child span will share the same context with the parent span.
-  return tracer_.startSpan(config, start_time, operation_name, segment_context_, this);
+  return tracer_.startSpan(&config, start_time, operation_name, segment_context_, this);
 }
 
 void Span::setSampled(bool sampled) { span_store_->setSampled(sampled ? 1 : 0); }

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -50,7 +50,7 @@ public:
    *
    * @return The unique ptr to the newly created span.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, SystemTime start_time,
+  Tracing::SpanPtr startSpan(const Tracing::Config* config, SystemTime start_time,
                              const std::string& operation, SegmentContextSharedPtr segment_context,
                              Span* parent);
 

--- a/source/extensions/tracers/xray/xray_tracer_impl.cc
+++ b/source/extensions/tracers/xray/xray_tracer_impl.cc
@@ -61,7 +61,7 @@ Driver::Driver(const XRayConfiguration& config,
   });
 }
 
-Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
+Tracing::SpanPtr Driver::startSpan(const Tracing::Config* config,
                                    Http::RequestHeaderMap& request_headers,
                                    const std::string& operation_name, Envoy::SystemTime start_time,
                                    const Tracing::Decision tracing_decision) {

--- a/source/extensions/tracers/xray/xray_tracer_impl.h
+++ b/source/extensions/tracers/xray/xray_tracer_impl.h
@@ -19,7 +19,7 @@ public:
   Driver(const XRay::XRayConfiguration& config,
          Server::Configuration::TracerFactoryContext& context);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config* config, Http::RequestHeaderMap& request_headers,
                              const std::string& operation_name, Envoy::SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -117,7 +117,7 @@ public:
    * Thus, this implementation of the virtual function startSpan() ignores the operation name
    * ("ingress" or "egress") passed by the caller.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config&, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config*, Http::RequestHeaderMap& request_headers,
                              const std::string&, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -888,9 +888,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Ingress, config->operationName());
 
             return span;
           }));
@@ -1046,9 +1046,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Ingress, config->operationName());
 
             return span;
           }));
@@ -1112,9 +1112,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Ingress, config->operationName());
 
             return span;
           }));
@@ -1179,9 +1179,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Ingress, config->operationName());
 
             return span;
           }));
@@ -1260,9 +1260,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Egress, config->operationName());
 
             return span;
           }));
@@ -1342,9 +1342,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Egress, config->operationName());
 
             return span;
           }));
@@ -1426,9 +1426,9 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
+          Invoke([&](const Tracing::Config* config, const HeaderMap&, const StreamInfo::StreamInfo&,
                      const Tracing::Decision) -> Tracing::Span* {
-            EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
+            EXPECT_EQ(Tracing::OperationName::Egress, config->operationName());
 
             return span;
           }));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -179,7 +179,7 @@ TEST_F(HttpConnManFinalizerImplTest, OriginalAndLongPath) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, NoGeneratedId) {
@@ -213,7 +213,7 @@ TEST_F(HttpConnManFinalizerImplTest, NoGeneratedId) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, Connect) {
@@ -245,7 +245,7 @@ TEST_F(HttpConnManFinalizerImplTest, Connect) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, NullRequestHeadersAndNullRouteEntry) {
@@ -286,7 +286,7 @@ metadata:
   metadata_key: { key: m.host, path: [ {key: not-found } ] })EOF",
                         false, ""}});
 
-  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
@@ -321,7 +321,7 @@ TEST_F(HttpConnManFinalizerImplTest, StreamInfoLogs) {
   EXPECT_CALL(span, log(log_timestamp, Tracing::Logs::get().LastDownstreamTxByteSent));
 
   EXPECT_CALL(config, verbose).WillOnce(Return(true));
-  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
@@ -341,7 +341,7 @@ TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSet) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
 
-  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, config);
+  HttpTracerUtility::finalizeDownstreamSpan(span, nullptr, nullptr, nullptr, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
@@ -385,7 +385,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, UnixDomainSocketPeerAddressTag) {
@@ -407,7 +407,7 @@ TEST_F(HttpConnManFinalizerImplTest, UnixDomainSocketPeerAddressTag) {
               setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(remote_address->logicalName())));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, SpanCustomTags) {
@@ -526,7 +526,7 @@ metadata:
         false, ""}});
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, nullptr, nullptr, stream_info,
-                                            config);
+                                            &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
@@ -581,7 +581,7 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
@@ -631,7 +631,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
@@ -677,7 +677,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcErrorTag) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
@@ -722,7 +722,7 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcTrailersOnly) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
 
   HttpTracerUtility::finalizeDownstreamSpan(span, &request_headers, &response_headers,
-                                            &response_trailers, stream_info, config);
+                                            &response_trailers, stream_info, &config);
 }
 
 TEST(HttpTracerUtilityTest, operationTypeToString) {
@@ -739,7 +739,7 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
   Http::TestResponseTrailerMapImpl response_trailers;
 
   SpanPtr span_ptr =
-      null_tracer.startSpan(config, request_headers, stream_info, {Reason::Sampling, true});
+      null_tracer.startSpan(&config, request_headers, stream_info, {Reason::Sampling, true});
   EXPECT_TRUE(dynamic_cast<NullSpan*>(span_ptr.get()) != nullptr);
 
   span_ptr->setOperation("foo");
@@ -776,7 +776,7 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNullSpan) {
   const std::string operation_name = "ingress";
   EXPECT_CALL(*driver_, startSpan_(_, _, operation_name, stream_info_.start_time_, _))
       .WillOnce(Return(nullptr));
-  tracer_->startSpan(config_, request_headers_, stream_info_, {Reason::Sampling, true});
+  tracer_->startSpan(&config_, request_headers_, stream_info_, {Reason::Sampling, true});
 }
 
 TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
@@ -791,7 +791,7 @@ TEST_F(HttpTracerImplTest, BasicFunctionalityNodeSet) {
   EXPECT_CALL(*span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*span, setTag(Eq(Tracing::Tags::get().NodeId), Eq("node_name")));
 
-  tracer_->startSpan(config_, request_headers_, stream_info_, {Reason::Sampling, true});
+  tracer_->startSpan(&config_, request_headers_, stream_info_, {Reason::Sampling, true});
 }
 
 } // namespace

--- a/test/common/tracing/http_tracer_manager_impl_test.cc
+++ b/test/common/tracing/http_tracer_manager_impl_test.cc
@@ -22,7 +22,7 @@ namespace {
 
 class SampleTracer : public HttpTracer {
 public:
-  SpanPtr startSpan(const Config&, Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
+  SpanPtr startSpan(const Config*, Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                     const Tracing::Decision) override {
     return nullptr;
   }

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -69,7 +69,7 @@ public:
 TEST_F(OpenTracingDriverTest, FlushSpanWithTag) {
   setupValidDriver();
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->setTag("abc", "123");
   first_span->finishSpan();
@@ -85,7 +85,7 @@ TEST_F(OpenTracingDriverTest, FlushSpanWithTag) {
 TEST_F(OpenTracingDriverTest, FlushSpanWithLog) {
   setupValidDriver();
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   const auto timestamp =
       SystemTime{std::chrono::duration_cast<SystemTime::duration>(std::chrono::hours{123})};
@@ -102,7 +102,7 @@ TEST_F(OpenTracingDriverTest, FlushSpanWithLog) {
 TEST_F(OpenTracingDriverTest, FlushSpanWithBaggage) {
   setupValidDriver();
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->setBaggage("abc", "123");
   first_span->finishSpan();
@@ -116,7 +116,7 @@ TEST_F(OpenTracingDriverTest, FlushSpanWithBaggage) {
 TEST_F(OpenTracingDriverTest, TagSamplingFalseByDecision) {
   setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, {});
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, false});
   first_span->finishSpan();
 
@@ -131,7 +131,7 @@ TEST_F(OpenTracingDriverTest, TagSamplingFalseByDecision) {
 TEST_F(OpenTracingDriverTest, TagSamplingFalseByFlag) {
   setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, {});
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->setSampled(false);
   first_span->finishSpan();
@@ -149,7 +149,7 @@ TEST_F(OpenTracingDriverTest, TagSpanKindClient) {
 
   ON_CALL(config_, operationName()).WillByDefault(testing::Return(Tracing::OperationName::Egress));
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->finishSpan();
 
@@ -165,7 +165,7 @@ TEST_F(OpenTracingDriverTest, TagSpanKindServer) {
 
   ON_CALL(config_, operationName()).WillByDefault(testing::Return(Tracing::OperationName::Ingress));
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->finishSpan();
 
@@ -184,7 +184,7 @@ TEST_F(OpenTracingDriverTest, InjectFailure) {
     propagation_options.inject_error_code = std::make_error_code(std::errc::bad_message);
     setupValidDriver(propagation_mode, propagation_options);
 
-    Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+    Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                start_time_, {Tracing::Reason::Sampling, true});
 
     const auto span_context_injection_error_count =
@@ -202,11 +202,11 @@ TEST_F(OpenTracingDriverTest, ExtractWithUnindexedHeader) {
   propagation_options.propagation_key = "unindexed-header";
   setupValidDriver(OpenTracingDriver::PropagationMode::TracerNative, propagation_options);
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   first_span->injectContext(request_headers_);
 
-  Tracing::SpanPtr second_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr second_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                     start_time_, {Tracing::Reason::Sampling, true});
   second_span->finishSpan();
   first_span->finishSpan();

--- a/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
+++ b/test/extensions/tracers/datadog/datadog_tracer_impl_test.cc
@@ -161,7 +161,7 @@ TEST_F(DatadogDriverTest, FlushSpansTimer) {
             return &request;
           }));
 
-  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
@@ -203,7 +203,7 @@ TEST_F(DatadogDriverTest, NoBody) {
             return &request;
           }));
 
-  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
@@ -247,7 +247,7 @@ TEST_F(DatadogDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     timer_->invokeCallback();
@@ -273,7 +273,7 @@ TEST_F(DatadogDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     timer_->invokeCallback();
@@ -301,7 +301,7 @@ TEST_F(DatadogDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     timer_->invokeCallback();
@@ -332,7 +332,7 @@ TEST_F(DatadogDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     timer_->invokeCallback();
@@ -372,25 +372,25 @@ TEST_F(DatadogDriverTest, CancelInflightRequestsOnDestruction) {
 
   // Trigger 1st report request.
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   timer_->invokeCallback();
   // Trigger 2nd report request.
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   timer_->invokeCallback();
   // Trigger 3rd report request.
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   timer_->invokeCallback();
   // Trigger 4th report request.
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   timer_->invokeCallback();

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -256,7 +256,7 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
 
   // Currently not possible to access the operation from the span, but this
@@ -264,11 +264,11 @@ TEST_F(LightStepDriverTest, FlushSeveralSpans) {
   first_span->setOperation("myOperation");
   first_span->finishSpan();
 
-  Tracing::SpanPtr second_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr second_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                     start_time_, {Tracing::Reason::Sampling, true});
   second_span->finishSpan();
 
-  Tracing::SpanPtr third_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr third_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
   third_span->finishSpan();
 
@@ -308,7 +308,7 @@ TEST_F(LightStepDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     driver_->flush();
@@ -331,7 +331,7 @@ TEST_F(LightStepDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     driver_->flush();
@@ -356,7 +356,7 @@ TEST_F(LightStepDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     driver_->flush();
@@ -384,7 +384,7 @@ TEST_F(LightStepDriverTest, SkipReportIfCollectorClusterHasBeenRemoved) {
 
     // Trigger flush of a span.
     driver_
-        ->startSpan(config_, request_headers_, operation_name_, start_time_,
+        ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                     {Tracing::Reason::Sampling, true})
         ->finishSpan();
     driver_->flush();
@@ -426,12 +426,12 @@ TEST_F(LightStepDriverTest, FlushOneFailure) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
 
-  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr first_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                    start_time_, {Tracing::Reason::Sampling, true});
 
   first_span->finishSpan();
 
-  Tracing::SpanPtr second_span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr second_span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                     start_time_, {Tracing::Reason::Sampling, true});
 
   second_span->finishSpan();
@@ -474,13 +474,13 @@ TEST_F(LightStepDriverTest, FlushWithActiveReport) {
       .WillOnce(Return(5000U));
 
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   driver_->flush();
 
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   driver_->flush();
@@ -519,17 +519,17 @@ TEST_F(LightStepDriverTest, OnFullWithActiveReport) {
       .WillOnce(Return(5000U));
 
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   driver_->flush();
 
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
 
@@ -558,7 +558,7 @@ TEST_F(LightStepDriverTest, FlushSpansTimer) {
             return &request;
           }));
 
-  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
@@ -597,12 +597,12 @@ TEST_F(LightStepDriverTest, CancelRequestOnDestruction) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.lightstep.request_timeout", 5000U))
       .WillOnce(Return(5000U));
 
-  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
   span->finishSpan();
 
   driver_
-      ->startSpan(config_, request_headers_, operation_name_, start_time_,
+      ->startSpan(&config_, request_headers_, operation_name_, start_time_,
                   {Tracing::Reason::Sampling, true})
       ->finishSpan();
 
@@ -621,7 +621,7 @@ TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
     const std::string invalid_context = "notvalidcontext";
     request_headers_.setCopy(Http::CustomHeaders::get().OtSpanContext, invalid_context);
     stats_.counter("tracing.opentracing.span_context_extraction_error").reset();
-    driver_->startSpan(config_, request_headers_, operation_name_, start_time_,
+    driver_->startSpan(&config_, request_headers_, operation_name_, start_time_,
                        {Tracing::Reason::Sampling, true});
     EXPECT_EQ(1U, stats_.counter("tracing.opentracing.span_context_extraction_error").value());
 
@@ -630,7 +630,7 @@ TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
 
     // Supply empty context.
     request_headers_.remove(Http::CustomHeaders::get().OtSpanContext);
-    Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+    Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                start_time_, {Tracing::Reason::Sampling, true});
 
     EXPECT_FALSE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
@@ -646,8 +646,9 @@ TEST_F(LightStepDriverTest, SerializeAndDeserializeContext) {
     EXPECT_TRUE(tracer.Extract(iss));
 
     // Supply parent context, request_headers has properly populated x-ot-span-context.
-    Tracing::SpanPtr span_with_parent = driver_->startSpan(
-        config_, request_headers_, operation_name_, start_time_, {Tracing::Reason::Sampling, true});
+    Tracing::SpanPtr span_with_parent =
+        driver_->startSpan(&config_, request_headers_, operation_name_, start_time_,
+                           {Tracing::Reason::Sampling, true});
     request_headers_.remove(Http::CustomHeaders::get().OtSpanContext);
     span_with_parent->injectContext(request_headers_);
     injected_ctx = std::string(request_headers_.get_(Http::CustomHeaders::get().OtSpanContext));
@@ -682,7 +683,7 @@ TEST_F(LightStepDriverTest, MultiplePropagationModes) {
 
   setup(lightstep_config, true);
 
-  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
 
   EXPECT_FALSE(request_headers_.has(Http::CustomHeaders::get().OtSpanContext));
@@ -696,12 +697,12 @@ TEST_F(LightStepDriverTest, MultiplePropagationModes) {
 TEST_F(LightStepDriverTest, SpawnChild) {
   setupValidDriver();
 
-  Tracing::SpanPtr parent = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr parent = driver_->startSpan(&config_, request_headers_, operation_name_,
                                                start_time_, {Tracing::Reason::Sampling, true});
   parent->injectContext(request_headers_);
 
   Tracing::SpanPtr childViaHeaders = driver_->startSpan(
-      config_, request_headers_, operation_name_, start_time_, {Tracing::Reason::Sampling, true});
+      &config_, request_headers_, operation_name_, start_time_, {Tracing::Reason::Sampling, true});
   Tracing::SpanPtr childViaSpawn = parent->spawnChild(config_, operation_name_, start_time_);
 
   Http::TestRequestHeaderMapImpl base1{{":path", "/"}, {":method", "GET"}, {"x-request-id", "foo"}};
@@ -721,7 +722,7 @@ TEST_F(LightStepDriverTest, SpawnChild) {
 
 TEST_F(LightStepDriverTest, GetAndSetBaggage) {
   setupValidDriver();
-  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+  Tracing::SpanPtr span = driver_->startSpan(&config_, request_headers_, operation_name_,
                                              start_time_, {Tracing::Reason::Sampling, true});
 
   std::string key = "key1";

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -113,7 +113,7 @@ TEST(OpenCensusTracerTest, Span) {
   SystemTime start_time;
 
   {
-    Tracing::SpanPtr span = driver->startSpan(config, request_headers, operation_name, start_time,
+    Tracing::SpanPtr span = driver->startSpan(&config, request_headers, operation_name, start_time,
                                               {Tracing::Reason::Sampling, true});
     span->setOperation("different_name");
     span->setTag("my_key", "my_value");
@@ -213,7 +213,7 @@ void testIncomingHeaders(
   SystemTime start_time;
   Http::TestRequestHeaderMapImpl injected_headers;
   {
-    Tracing::SpanPtr span = driver->startSpan(config, request_headers, operation_name, start_time,
+    Tracing::SpanPtr span = driver->startSpan(&config, request_headers, operation_name, start_time,
                                               {Tracing::Reason::Sampling, false});
     span->injectContext(injected_headers);
     span->finishSpan();

--- a/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
+++ b/test/extensions/tracers/skywalking/skywalking_tracer_impl_test.cc
@@ -96,7 +96,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
   Tracing::Decision decision;
   decision.traced = true;
 
-  Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, request_headers, "TEST_OP",
+  Tracing::SpanPtr org_span = driver_->startSpan(&mock_tracing_config_, request_headers, "TEST_OP",
                                                  time_system_.systemTime(), decision);
   EXPECT_NE(nullptr, org_span.get());
 
@@ -121,7 +121,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
   Http::TestRequestHeaderMapImpl new_request_headers{
       {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
-  Tracing::SpanPtr org_new_span = driver_->startSpan(mock_tracing_config_, new_request_headers, "",
+  Tracing::SpanPtr org_new_span = driver_->startSpan(&mock_tracing_config_, new_request_headers, "",
                                                      time_system_.systemTime(), decision);
 
   Span* new_span = dynamic_cast<Span*>(org_new_span.get());
@@ -141,7 +141,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestWithClientConfig) {
                                                        {":authority", "test.com"},
                                                        {"sw8", "xxxxxx-error-propagation-header"}};
   Tracing::SpanPtr org_null_span = driver_->startSpan(
-      mock_tracing_config_, error_request_headers, "TEST_OP", time_system_.systemTime(), decision);
+      &mock_tracing_config_, error_request_headers, "TEST_OP", time_system_.systemTime(), decision);
 
   EXPECT_EQ(nullptr, dynamic_cast<Span*>(org_null_span.get()));
 
@@ -161,7 +161,7 @@ TEST_F(SkyWalkingDriverTest, SkyWalkingDriverStartSpanTestNoClientConfig) {
   Http::TestRequestHeaderMapImpl request_headers{
       {":path", "/path"}, {":method", "GET"}, {":authority", "test.com"}};
 
-  Tracing::SpanPtr org_span = driver_->startSpan(mock_tracing_config_, request_headers, "TEST_OP",
+  Tracing::SpanPtr org_span = driver_->startSpan(&mock_tracing_config_, request_headers, "TEST_OP",
                                                  time_system_.systemTime(), Tracing::Decision());
   EXPECT_NE(nullptr, org_span.get());
 

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -89,7 +89,7 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
       SkyWalkingTestHelper::createSegmentContext(true, "CURR", "", mock_random_generator_);
 
   Envoy::Tracing::SpanPtr org_span = tracer_->startSpan(
-      mock_tracing_config_, mock_time_source_.systemTime(), "TEST_OP", segment_context, nullptr);
+      &mock_tracing_config_, mock_time_source_.systemTime(), "TEST_OP", segment_context, nullptr);
   Span* span = dynamic_cast<Span*>(org_span.get());
 
   EXPECT_EQ(true, span->spanStore()->isEntrySpan());

--- a/test/extensions/tracers/xray/xray_tracer_impl_test.cc
+++ b/test/extensions/tracers/xray/xray_tracer_impl_test.cc
@@ -39,7 +39,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderNotSampled) {
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+  auto span = driver.startSpan(&tracing_config_, request_headers_, operation_name_, start_time,
                                tracing_decision);
   ASSERT_NE(span, nullptr);
   auto* xray_span = static_cast<XRay::Span*>(span.get());
@@ -55,7 +55,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSampled) {
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+  auto span = driver.startSpan(&tracing_config_, request_headers_, operation_name_, start_time,
                                tracing_decision);
   ASSERT_NE(span, nullptr);
 }
@@ -69,7 +69,7 @@ TEST_F(XRayDriverTest, XRayTraceHeaderSamplingUnknown) {
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+  auto span = driver.startSpan(&tracing_config_, request_headers_, operation_name_, start_time,
                                tracing_decision);
   // sampling should fall back to the default manifest since:
   // a) there is sampling decision in the X-Ray header
@@ -85,7 +85,7 @@ TEST_F(XRayDriverTest, NoXRayTracerHeader) {
 
   Tracing::Decision tracing_decision{Tracing::Reason::Sampling, false /*sampled*/};
   Envoy::SystemTime start_time;
-  auto span = driver.startSpan(tracing_config_, request_headers_, operation_name_, start_time,
+  auto span = driver.startSpan(&tracing_config_, request_headers_, operation_name_, start_time,
                                tracing_decision);
   // sampling should fall back to the default manifest since:
   // a) there is no X-Ray header to determine the sampling decision

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -70,7 +70,7 @@ MockStreamDecoderFilterCallbacks::MockStreamDecoderFilterCallbacks() {
       }));
 
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
-  ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
+  ON_CALL(*this, tracingConfig()).WillByDefault(Return(&tracing_config_));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
   ON_CALL(*this, sendLocalReply(_, _, _, _, _))
       .WillByDefault(Invoke([this](Code code, absl::string_view body,
@@ -109,7 +109,7 @@ MockStreamEncoderFilterCallbacks::MockStreamEncoderFilterCallbacks() {
   initializeMockStreamFilterCallbacks(*this);
   ON_CALL(*this, encodingBuffer()).WillByDefault(Invoke(&buffer_, &Buffer::InstancePtr::get));
   ON_CALL(*this, activeSpan()).WillByDefault(ReturnRef(active_span_));
-  ON_CALL(*this, tracingConfig()).WillByDefault(ReturnRef(tracing_config_));
+  ON_CALL(*this, tracingConfig()).WillByDefault(Return(&tracing_config_));
   ON_CALL(*this, scope()).WillByDefault(ReturnRef(scope_));
 }
 

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -92,7 +92,7 @@ public:
   MOCK_METHOD(void, onRequestDataTooLarge, ());
   MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
   MOCK_METHOD(void, onLocalReply, (Code code));
-  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(Tracing::Config*, tracingConfig, ());
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
 
   ResponseHeaderMapPtr response_headers_;
@@ -194,7 +194,7 @@ public:
   MOCK_METHOD(uint64_t, streamId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
   MOCK_METHOD(Tracing::Span&, activeSpan, ());
-  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(Tracing::Config*, tracingConfig, ());
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, onDecoderFilterAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onDecoderFilterBelowWriteBufferLowWatermark, ());
@@ -278,7 +278,7 @@ public:
   MOCK_METHOD(uint64_t, streamId, (), (const));
   MOCK_METHOD(StreamInfo::StreamInfo&, streamInfo, ());
   MOCK_METHOD(Tracing::Span&, activeSpan, ());
-  MOCK_METHOD(Tracing::Config&, tracingConfig, ());
+  MOCK_METHOD(Tracing::Config*, tracingConfig, ());
   MOCK_METHOD(const ScopeTrackedObject&, scope, ());
   MOCK_METHOD(void, onEncoderFilterAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onEncoderFilterBelowWriteBufferLowWatermark, ());

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -54,14 +54,14 @@ public:
   MockHttpTracer();
   ~MockHttpTracer() override;
 
-  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  SpanPtr startSpan(const Config* config, Http::RequestHeaderMap& request_headers,
                     const StreamInfo::StreamInfo& stream_info,
                     const Tracing::Decision tracing_decision) override {
     return SpanPtr{startSpan_(config, request_headers, stream_info, tracing_decision)};
   }
 
   MOCK_METHOD(Span*, startSpan_,
-              (const Config& config, Http::HeaderMap& request_headers,
+              (const Config* config, Http::HeaderMap& request_headers,
                const StreamInfo::StreamInfo& stream_info,
                const Tracing::Decision tracing_decision));
 };
@@ -71,7 +71,7 @@ public:
   MockDriver();
   ~MockDriver() override;
 
-  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  SpanPtr startSpan(const Config* config, Http::RequestHeaderMap& request_headers,
                     const std::string& operation_name, SystemTime start_time,
                     const Tracing::Decision tracing_decision) override {
     return SpanPtr{
@@ -79,7 +79,7 @@ public:
   }
 
   MOCK_METHOD(Span*, startSpan_,
-              (const Config& config, Http::HeaderMap& request_headers,
+              (const Config* config, Http::HeaderMap& request_headers,
                const std::string& operation_name, SystemTime start_time,
                const Tracing::Decision tracing_decision));
 };


### PR DESCRIPTION
Rather than a reference.

So that callers would know whether tracing is configured or not and then
they can check its value before trying to dereference an invalid reference, thus
avoiding a crash.

Fixes #13164.

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
