### PR TITLE
docs: fix indentation in ip transparency code snippet

### DIFF
--- a/docs/root/intro/arch_overview/other_features/ip_transparency.rst
+++ b/docs/root/intro/arch_overview/other_features/ip_transparency.rst
@@ -59,11 +59,11 @@ Here is an example config for setting up the socket:
       transport_socket:
         name: envoy.transport_sockets.upstream_proxy_protocol
         typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
-        config:
-          version: V1
-        transport_socket:
-          name: envoy.transport_sockets.raw_buffer
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
+          config:
+            version: V1
+          transport_socket:
+            name: envoy.transport_sockets.raw_buffer
       ...
 
 Note: If you are wrapping a TLS socket, the header will be sent before the TLS handshake occurs.


### PR DESCRIPTION
Commit Message: fix indentation in ip transparency code snippet documentation
Additional Description: 
Risk Level: Low
Testing: n/a
Docs Changes: indentation is not correct in ip transparency code snippet

