### PR TITLE
examples: Add wait_for utility function

### DIFF
--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -113,8 +113,7 @@ responds_without_header \
 
 You can wait for some amount of time (specified in seconds) for a command to return `0`.
 
-For example, the following example will wait for 20 seconds for a service ``my-service``
-to become healthy.
+The following example will wait for 20 seconds for a service ``my-service`` to become healthy.
 
 ```bash
 wait_for 20 sh -c "docker-compose ps my-service | grep healthy | grep -v unhealthy"

--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -109,6 +109,17 @@ responds_without_header \
 
 `responds_without_header` can accept additional curl arguments like `responds_with`
 
+#### Utility functions: `wait_for`
+
+You can wait for some amount of time for a command to return 0
+
+The following example will wait for 20 seconds for a service ``my-service`` to become
+healthy.
+
+```bash
+wait_for 20 sh -c "docker-compose ps my-service | grep healthy | grep -v unhealthy"
+```
+
 ### Slow starting `docker` compositions
 
 Unless your example provides a way for ensuring that all containers are healthy by

--- a/examples/DEVELOPER.md
+++ b/examples/DEVELOPER.md
@@ -111,10 +111,10 @@ responds_without_header \
 
 #### Utility functions: `wait_for`
 
-You can wait for some amount of time for a command to return 0
+You can wait for some amount of time (specified in seconds) for a command to return `0`.
 
-The following example will wait for 20 seconds for a service ``my-service`` to become
-healthy.
+For example, the following example will wait for 20 seconds for a service ``my-service``
+to become healthy.
 
 ```bash
 wait_for 20 sh -c "docker-compose ps my-service | grep healthy | grep -v unhealthy"

--- a/examples/verify-common.sh
+++ b/examples/verify-common.sh
@@ -115,6 +115,20 @@ responds_without_header () {
     }
 }
 
+wait_for () {
+    local i=1 returns=1 seconds="$1"
+    shift
+    while ((i<=seconds)); do
+	if "$@"; then
+	    returns=0
+	    break
+	else
+	    sleep 1
+	    ((i++))
+	fi
+    done
+    return "$returns"
+}
 
 trap 'cleanup' EXIT
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: examples: Add wait_for utility function
Additional Description:

All of the sandbox examples use `docker-compose` > `3`

This version does not have support for `depends_on` `condition` `service_healthy` which makes it hard to wait for services to be ready in `verify.sh` scripts

This PR adds a `wait_for` function so we dont need to add `sleep $ARBITRARY_WAIT` in the example scripts, and can instead wait for a condition to be true

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
