### PR TITLE
add OAuth documentation and fix filter inconsistencies

### DIFF
--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -230,15 +230,18 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     return Http::FilterHeadersStatus::Continue;
   }
 
+  // Save the request headers for later modification if needed.
+  if (config_->forwardBearerToken()) {
+    request_headers_ = &headers;
+  }
+
   // If a bearer token is supplied as a header or param, we ingest it here and kick off the
   // user resolution immediately. Note this comes after HMAC validation, so technically this
   // header is sanitized in a way, as the validation check forces the correct Bearer Cookie value.
   access_token_ = extractAccessToken(headers);
   if (!access_token_.empty()) {
     found_bearer_token_ = true;
-    request_headers_ = &headers;
     finishFlow();
-
     return Http::FilterHeadersStatus::Continue;
   }
 
@@ -375,6 +378,9 @@ void OAuth2Filter::finishFlow() {
   // We have fully completed the entire OAuth flow, whether through Authorization header or from
   // user redirection to the auth server.
   if (found_bearer_token_) {
+    if (config_->forwardBearerToken()) {
+      setBearerToken(*request_headers_, access_token_);
+    }
     config_->stats().oauth_success_.inc();
     decoder_callbacks_->continueDecoding();
     return;

--- a/source/extensions/filters/http/oauth2/oauth_client.cc
+++ b/source/extensions/filters/http/oauth2/oauth_client.cc
@@ -39,6 +39,7 @@ void OAuth2ClientImpl::asyncGetAccessToken(const std::string& auth_code,
   Http::RequestMessagePtr request = createPostRequest();
   const std::string body = fmt::format(GetAccessTokenBodyFormatString, auth_code, encoded_client_id,
                                        encoded_secret, encoded_cb_url);
+  request->body().add(body);
   ENVOY_LOG(debug, "Dispatching OAuth request for access token.");
   dispatchRequest(std::move(request));
 

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -449,7 +449,8 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
   std::string legit_token{"legit_token"};
   EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
-  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_response_headers), false));
+  EXPECT_CALL(decoder_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&expected_response_headers), false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
             filter_->decodeHeaders(request_headers, false));
 
@@ -503,7 +504,8 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
   std::string legit_token{"legit_token"};
   EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
-  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_response_headers), true));
+  EXPECT_CALL(decoder_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&expected_response_headers), true));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Http::TestRequestHeaderMapImpl final_request_headers{

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -436,7 +436,7 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
        "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
   };
 
-  Http::TestRequestHeaderMapImpl expected_headers{
+  Http::TestRequestHeaderMapImpl expected_response_headers{
       {Http::Headers::get().Status.get(), "401"},
       {Http::Headers::get().ContentLength.get(), "18"},
       {Http::Headers::get().ContentType.get(), "text/plain"},
@@ -449,9 +449,25 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
   std::string legit_token{"legit_token"};
   EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
-  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_response_headers), false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
             filter_->decodeHeaders(request_headers, false));
+
+  Http::TestRequestHeaderMapImpl final_request_headers{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Path.get(), "/_oauth?code=abcdefxyz123&scope=user&"
+                                        "state=https%3A%2F%2Ftraffic.example.com%2F_oauth"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(),
+       "OauthHMAC="
+       "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+      {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_token"},
+  };
+
+  EXPECT_EQ(request_headers, final_request_headers);
 }
 
 /**
@@ -475,7 +491,7 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
        "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
   };
 
-  Http::TestRequestHeaderMapImpl expected_headers{
+  Http::TestRequestHeaderMapImpl expected_response_headers{
       {Http::Headers::get().Status.get(), "302"},
       {Http::Headers::get().Location.get(), "https://traffic.example.com/original_path"},
   };
@@ -487,8 +503,24 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
   std::string legit_token{"legit_token"};
   EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
-  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_response_headers), true));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+
+  Http::TestRequestHeaderMapImpl final_request_headers{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Path.get(), "/_oauth?code=abcdefxyz123&scope=user&"
+                                        "state=https%3A%2F%2Ftraffic.example.com%2Foriginal_path"},
+      {Http::Headers::get().Cookie.get(), "OauthExpires=123;version=test"},
+      {Http::Headers::get().Cookie.get(), "BearerToken=legit_token;version=test"},
+      {Http::Headers::get().Cookie.get(),
+       "OauthHMAC="
+       "ZTRlMzU5N2Q4ZDIwZWE5ZTU5NTg3YTU3YTcxZTU0NDFkMzY1ZTc1NjMyODYyMj"
+       "RlNjMxZTJmNTZkYzRmZTM0ZQ====;version=test"},
+      {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_token"},
+  };
+
+  EXPECT_EQ(request_headers, final_request_headers);
 }
 
 /**

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -205,7 +205,7 @@ TEST_F(OAuth2Test, OAuthOkPass) {
 
   // Sanitized return reference mocking
   std::string legit_token{"legit_token"};
-  EXPECT_CALL(*validator_, token()).WillOnce(ReturnRef(legit_token));
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(mock_request_headers, false));
@@ -414,7 +414,7 @@ TEST_F(OAuth2Test, OAuthTestInvalidUrlInStateQueryParam) {
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   std::string legit_token{"legit_token"};
-  EXPECT_CALL(*validator_, token()).WillOnce(ReturnRef(legit_token));
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
@@ -447,7 +447,7 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   std::string legit_token{"legit_token"};
-  EXPECT_CALL(*validator_, token()).WillOnce(ReturnRef(legit_token));
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
@@ -485,7 +485,7 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   std::string legit_token{"legit_token"};
-  EXPECT_CALL(*validator_, token()).WillOnce(ReturnRef(legit_token));
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), true));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));


### PR DESCRIPTION
Commit Message:
This commit adds missing documentation for the OAuth filter, including an overview of the OAuth procedure and clarifications on what each configuration feature provides. Additionally, we fix a bug in the OAuth client that interfaces with the token endpoint, as well as inconsistencies with what forward_bearer_token does. We should appropriately forward the access_token upstream, when available, as a header and a cookie value if this boolean is enabled.

Risk Level: Low
Testing: Unit test
Docs Changes: Added bulk of documentation to the filter.
