### PR TITLE
clear old context from contexts when secret is updated

### DIFF
--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -22,15 +22,17 @@ public:
   /**
    * Builds a ClientContext from a ClientContextConfig.
    */
-  virtual ClientContextSharedPtr createSslClientContext(Stats::Scope& scope,
-                                                        const ClientContextConfig& config) PURE;
+  virtual ClientContextSharedPtr
+  createSslClientContext(Stats::Scope& scope, const ClientContextConfig& config,
+                         Envoy::Ssl::ClientContextSharedPtr old_context) PURE;
 
   /**
    * Builds a ServerContext from a ServerContextConfig.
    */
   virtual ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const ServerContextConfig& config,
-                         const std::vector<std::string>& server_names) PURE;
+                         const std::vector<std::string>& server_names,
+                         Envoy::Ssl::ServerContextSharedPtr old_context) PURE;
 
   /**
    * @return the number of days until the next certificate being managed will expire.

--- a/include/envoy/ssl/context_manager.h
+++ b/include/envoy/ssl/context_manager.h
@@ -40,7 +40,7 @@ public:
   virtual size_t daysUntilFirstCertExpires() const PURE;
 
   /**
-   * Iterate through all currently allocated contexts.
+   * Iterates through the contexts currently attached to a listener.
    */
   virtual void iterateContexts(std::function<void(const Context&)> callback) PURE;
 

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -28,7 +28,7 @@ void ContextManagerImpl::removeOldContext(std::shared_ptr<Envoy::Ssl::Context> o
   if (old_context) {
     contexts_.remove_if([old_context](const std::weak_ptr<Envoy::Ssl::Context>& n) {
       std::shared_ptr<Envoy::Ssl::Context> sp = n.lock();
-      if (old_context && sp) {
+      if (sp) {
         return old_context == sp;
       }
       return false;

--- a/source/extensions/transport_sockets/tls/context_manager_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.cc
@@ -24,30 +24,44 @@ void ContextManagerImpl::removeEmptyContexts() {
   contexts_.remove_if([](const std::weak_ptr<Envoy::Ssl::Context>& n) { return n.expired(); });
 }
 
+void ContextManagerImpl::removeOldContext(std::shared_ptr<Envoy::Ssl::Context> old_context) {
+  if (old_context) {
+    contexts_.remove_if([old_context](const std::weak_ptr<Envoy::Ssl::Context>& n) {
+      std::shared_ptr<Envoy::Ssl::Context> sp = n.lock();
+      if (old_context && sp) {
+        return old_context == sp;
+      }
+      return false;
+    });
+  }
+}
+
 Envoy::Ssl::ClientContextSharedPtr
 ContextManagerImpl::createSslClientContext(Stats::Scope& scope,
-                                           const Envoy::Ssl::ClientContextConfig& config) {
+                                           const Envoy::Ssl::ClientContextConfig& config,
+                                           Envoy::Ssl::ClientContextSharedPtr old_context) {
   if (!config.isReady()) {
     return nullptr;
   }
 
   Envoy::Ssl::ClientContextSharedPtr context =
       std::make_shared<ClientContextImpl>(scope, config, time_source_);
+  removeOldContext(old_context);
   removeEmptyContexts();
   contexts_.emplace_back(context);
   return context;
 }
 
-Envoy::Ssl::ServerContextSharedPtr
-ContextManagerImpl::createSslServerContext(Stats::Scope& scope,
-                                           const Envoy::Ssl::ServerContextConfig& config,
-                                           const std::vector<std::string>& server_names) {
+Envoy::Ssl::ServerContextSharedPtr ContextManagerImpl::createSslServerContext(
+    Stats::Scope& scope, const Envoy::Ssl::ServerContextConfig& config,
+    const std::vector<std::string>& server_names, Envoy::Ssl::ServerContextSharedPtr old_context) {
   if (!config.isReady()) {
     return nullptr;
   }
 
   Envoy::Ssl::ServerContextSharedPtr context =
       std::make_shared<ServerContextImpl>(scope, config, server_names, time_source_);
+  removeOldContext(old_context);
   removeEmptyContexts();
   contexts_.emplace_back(context);
   return context;

--- a/source/extensions/transport_sockets/tls/context_manager_impl.h
+++ b/source/extensions/transport_sockets/tls/context_manager_impl.h
@@ -29,11 +29,12 @@ public:
 
   // Ssl::ContextManager
   Ssl::ClientContextSharedPtr
-  createSslClientContext(Stats::Scope& scope,
-                         const Envoy::Ssl::ClientContextConfig& config) override;
+  createSslClientContext(Stats::Scope& scope, const Envoy::Ssl::ClientContextConfig& config,
+                         Envoy::Ssl::ClientContextSharedPtr old_context) override;
   Ssl::ServerContextSharedPtr
   createSslServerContext(Stats::Scope& scope, const Envoy::Ssl::ServerContextConfig& config,
-                         const std::vector<std::string>& server_names) override;
+                         const std::vector<std::string>& server_names,
+                         Envoy::Ssl::ServerContextSharedPtr old_context) override;
   size_t daysUntilFirstCertExpires() const override;
   absl::optional<uint64_t> secondsUntilFirstOcspResponseExpires() const override;
   void iterateContexts(std::function<void(const Envoy::Ssl::Context&)> callback) override;
@@ -43,6 +44,7 @@ public:
 
 private:
   void removeEmptyContexts();
+  void removeOldContext(std::shared_ptr<Envoy::Ssl::Context> old_context);
   TimeSource& time_source_;
   std::list<std::weak_ptr<Envoy::Ssl::Context>> contexts_;
   PrivateKeyMethodManagerImpl private_key_method_manager_{};

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -327,7 +327,7 @@ ClientSslSocketFactory::ClientSslSocketFactory(Envoy::Ssl::ClientContextConfigPt
                                                Stats::Scope& stats_scope)
     : manager_(manager), stats_scope_(stats_scope), stats_(generateStats("client", stats_scope)),
       config_(std::move(config)),
-      ssl_ctx_(manager_.createSslClientContext(stats_scope_, *config_)) {
+      ssl_ctx_(manager_.createSslClientContext(stats_scope_, *config_, nullptr)) {
   config_->setSecretUpdateCallback([this]() { onAddOrUpdateSecret(); });
 }
 
@@ -357,7 +357,7 @@ void ClientSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
   {
     absl::WriterMutexLock l(&ssl_ctx_mu_);
-    ssl_ctx_ = manager_.createSslClientContext(stats_scope_, *config_);
+    ssl_ctx_ = manager_.createSslClientContext(stats_scope_, *config_, ssl_ctx_);
   }
   stats_.ssl_context_update_by_sds_.inc();
 }
@@ -368,7 +368,7 @@ ServerSslSocketFactory::ServerSslSocketFactory(Envoy::Ssl::ServerContextConfigPt
                                                const std::vector<std::string>& server_names)
     : manager_(manager), stats_scope_(stats_scope), stats_(generateStats("server", stats_scope)),
       config_(std::move(config)), server_names_(server_names),
-      ssl_ctx_(manager_.createSslServerContext(stats_scope_, *config_, server_names_)) {
+      ssl_ctx_(manager_.createSslServerContext(stats_scope_, *config_, server_names_, nullptr)) {
   config_->setSecretUpdateCallback([this]() { onAddOrUpdateSecret(); });
 }
 
@@ -398,7 +398,7 @@ void ServerSslSocketFactory::onAddOrUpdateSecret() {
   ENVOY_LOG(debug, "Secret is updated.");
   {
     absl::WriterMutexLock l(&ssl_ctx_mu_);
-    ssl_ctx_ = manager_.createSslServerContext(stats_scope_, *config_, server_names_);
+    ssl_ctx_ = manager_.createSslServerContext(stats_scope_, *config_, server_names_, ssl_ctx_);
   }
   stats_.ssl_context_update_by_sds_.inc();
 }

--- a/source/server/ssl_context_manager.cc
+++ b/source/server/ssl_context_manager.cc
@@ -14,14 +14,16 @@ namespace Server {
 class SslContextManagerNoTlsStub final : public Envoy::Ssl::ContextManager {
   Ssl::ClientContextSharedPtr
   createSslClientContext(Stats::Scope& /* scope */,
-                         const Envoy::Ssl::ClientContextConfig& /* config */) override {
+                         const Envoy::Ssl::ClientContextConfig& /* config */,
+                         Envoy::Ssl::ClientContextSharedPtr /* old_context */) override {
     throwException();
   }
 
   Ssl::ServerContextSharedPtr
   createSslServerContext(Stats::Scope& /* scope */,
                          const Envoy::Ssl::ServerContextConfig& /* config */,
-                         const std::vector<std::string>& /* server_names */) override {
+                         const std::vector<std::string>& /* server_names */,
+                         Envoy::Ssl::ServerContextSharedPtr /* old_context */) override {
     throwException();
   }
 

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -43,7 +43,7 @@ public:
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_store_,
         singleton_manager_, tls_, validation_visitor_, *api_);
     if (uses_tls) {
-      EXPECT_CALL(ssl_context_manager_, createSslClientContext(_, _, nullptr));
+      EXPECT_CALL(ssl_context_manager_, createSslClientContext(_, _, _));
     }
     EXPECT_CALL(*dns_cache_manager_, getCache(_));
     // Below we return a nullptr handle which has no effect on the code under test but isn't

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -43,7 +43,7 @@ public:
         admin_, ssl_context_manager_, *scope, cm_, local_info_, dispatcher_, stats_store_,
         singleton_manager_, tls_, validation_visitor_, *api_);
     if (uses_tls) {
-      EXPECT_CALL(ssl_context_manager_, createSslClientContext(_, _));
+      EXPECT_CALL(ssl_context_manager_, createSslClientContext(_, _, nullptr));
     }
     EXPECT_CALL(*dns_cache_manager_, getCache(_));
     // Below we return a nullptr handle which has no effect on the code under test but isn't

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -332,7 +332,7 @@ TEST_F(SslContextImplTest, TestContextUpdate) {
   Envoy::Ssl::ClientContextSharedPtr new_context(
       manager_.createSslClientContext(store_, expiring_cfg, context));
 
-  // Validate that when the context is uppdated, daysUntilFirstCertExpires reflects the current
+  // Validate that when the context is updated, daysUntilFirstCertExpires reflects the current
   // context expiry.
   auto cert_expiry = TestUtility::parseTime(TEST_UNITTEST_CERT_NOT_AFTER, "%b %d %H:%M:%S %Y GMT");
   int64_t days_until_expiry = absl::ToInt64Hours(cert_expiry - absl::Now()) / 24;

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -251,7 +251,7 @@ TEST_F(SslContextImplTest, TestCipherSuites) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
   ClientContextConfigImpl cfg(tls_context, factory_context_);
   EXPECT_THROW_WITH_MESSAGE(
-      manager_.createSslClientContext(store_, cfg), EnvoyException,
+      manager_.createSslClientContext(store_, cfg, nullptr), EnvoyException,
       "Failed to initialize cipher suites "
       "-ALL:+[AES128-SHA|BOGUS1-SHA256]:BOGUS2-SHA:AES256-SHA. The following "
       "ciphers were rejected when tried individually: BOGUS1-SHA256, BOGUS2-SHA");
@@ -271,7 +271,7 @@ TEST_F(SslContextImplTest, TestExpiringCert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
 
   ClientContextConfigImpl cfg(tls_context, factory_context_);
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
 
   // Calculate the days until test cert expires
   auto cert_expiry = TestUtility::parseTime(TEST_UNITTEST_CERT_NOT_AFTER, "%b %d %H:%M:%S %Y GMT");
@@ -292,8 +292,59 @@ TEST_F(SslContextImplTest, TestExpiredCert) {
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
   ClientContextConfigImpl cfg(tls_context, factory_context_);
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
   EXPECT_EQ(0U, context->daysUntilFirstCertExpires());
+}
+
+// Validate that when the context is updated, the daysUntilFirstCertExpires returns the current
+// context value.
+TEST_F(SslContextImplTest, TestContextUpdate) {
+  const std::string expired_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/expired_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/expired_key.pem"
+)EOF";
+
+  // Validate that daysUntilFirstCertExpires returns correctly when single context is available.
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(expired_yaml), tls_context);
+  ClientContextConfigImpl cfg(tls_context, factory_context_);
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
+  EXPECT_EQ(manager_.daysUntilFirstCertExpires(), 0U);
+
+  const std::string expiring_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/unittest_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/unittest_key.pem"
+ )EOF";
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext expiring_context;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(expiring_yaml), expiring_context);
+
+  ClientContextConfigImpl expiring_cfg(expiring_context, factory_context_);
+
+  Envoy::Ssl::ClientContextSharedPtr new_context(
+      manager_.createSslClientContext(store_, expiring_cfg, context));
+
+  // Validate that when the context is uppdated, daysUntilFirstCertExpires reflects the current
+  // context expiry.
+  auto cert_expiry = TestUtility::parseTime(TEST_UNITTEST_CERT_NOT_AFTER, "%b %d %H:%M:%S %Y GMT");
+  int64_t days_until_expiry = absl::ToInt64Hours(cert_expiry - absl::Now()) / 24;
+  EXPECT_EQ(new_context->daysUntilFirstCertExpires(), days_until_expiry);
+  EXPECT_EQ(manager_.daysUntilFirstCertExpires(), days_until_expiry);
+
+  // Update the context again and validate daysUntilFirstCertExpires still reflects the current
+  // expiry.
+  Envoy::Ssl::ClientContextSharedPtr updated_context(
+      manager_.createSslClientContext(store_, cfg, new_context));
+  EXPECT_EQ(updated_context->daysUntilFirstCertExpires(), 0U);
+  EXPECT_EQ(manager_.daysUntilFirstCertExpires(), 0U);
 }
 
 TEST_F(SslContextImplTest, TestGetCertInformation) {
@@ -313,7 +364,7 @@ TEST_F(SslContextImplTest, TestGetCertInformation) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
   ClientContextConfigImpl cfg(tls_context, factory_context_);
 
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
   // This is similar to the hack above, but right now we generate the ca_cert and it expires in 15
   // days only in the first second that it's valid. We will partially match for up until Days until
   // Expiration: 1.
@@ -363,7 +414,7 @@ TEST_F(SslContextImplTest, TestGetCertInformationWithSAN) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
   ClientContextConfigImpl cfg(tls_context, factory_context_);
 
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
   std::string ca_cert_json = absl::StrCat(R"EOF({
  "path": "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_cert.pem",
  "serial_number": ")EOF",
@@ -417,7 +468,7 @@ TEST_F(SslContextImplTest, TestGetCertInformationWithIPSAN) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
   ClientContextConfigImpl cfg(tls_context, factory_context_);
 
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
   std::string ca_cert_json = absl::StrCat(R"EOF({
  "path": "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_ip_cert.pem",
  "serial_number": ")EOF",
@@ -475,7 +526,7 @@ TEST_F(SslContextImplTest, TestGetCertInformationWithExpiration) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(yaml), tls_context);
   ClientContextConfigImpl cfg(tls_context, factory_context_);
 
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
   std::string ca_cert_json =
       absl::StrCat(R"EOF({
  "path": "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns3_cert.pem",
@@ -505,7 +556,7 @@ TEST_F(SslContextImplTest, TestGetCertInformationWithExpiration) {
 TEST_F(SslContextImplTest, TestNoCert) {
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext config;
   ClientContextConfigImpl cfg(config, factory_context_);
-  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg));
+  Envoy::Ssl::ClientContextSharedPtr context(manager_.createSslClientContext(store_, cfg, nullptr));
   EXPECT_EQ(nullptr, context->getCaCertInformation());
   EXPECT_TRUE(context->getCertChainInformation().empty());
 }
@@ -527,9 +578,9 @@ TEST_F(SslContextImplTest, AtMostOneRsaCert) {
   )EOF";
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
   ServerContextConfigImpl server_context_config(tls_context, factory_context_);
-  EXPECT_THROW_WITH_REGEX(manager_.createSslServerContext(store_, server_context_config, {}),
-                          EnvoyException,
-                          "at most one certificate of a given type may be specified");
+  EXPECT_THROW_WITH_REGEX(
+      manager_.createSslServerContext(store_, server_context_config, {}, nullptr), EnvoyException,
+      "at most one certificate of a given type may be specified");
 }
 
 // Multiple ECDSA certificates are rejected.
@@ -549,9 +600,9 @@ TEST_F(SslContextImplTest, AtMostOneEcdsaCert) {
   )EOF";
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
   ServerContextConfigImpl server_context_config(tls_context, factory_context_);
-  EXPECT_THROW_WITH_REGEX(manager_.createSslServerContext(store_, server_context_config, {}),
-                          EnvoyException,
-                          "at most one certificate of a given type may be specified");
+  EXPECT_THROW_WITH_REGEX(
+      manager_.createSslServerContext(store_, server_context_config, {}, nullptr), EnvoyException,
+      "at most one certificate of a given type may be specified");
 }
 
 // Certificates with no subject CN and no SANs are rejected.
@@ -567,14 +618,15 @@ TEST_F(SslContextImplTest, MustHaveSubjectOrSAN) {
   )EOF";
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
   ServerContextConfigImpl server_context_config(tls_context, factory_context_);
-  EXPECT_THROW_WITH_REGEX(manager_.createSslServerContext(store_, server_context_config, {}),
-                          EnvoyException, "has neither subject CN nor SAN names");
+  EXPECT_THROW_WITH_REGEX(
+      manager_.createSslServerContext(store_, server_context_config, {}, nullptr), EnvoyException,
+      "has neither subject CN nor SAN names");
 }
 
 class SslServerContextImplOcspTest : public SslContextImplTest {
 public:
   Envoy::Ssl::ServerContextSharedPtr loadConfig(ServerContextConfigImpl& cfg) {
-    return manager_.createSslServerContext(store_, cfg, std::vector<std::string>{});
+    return manager_.createSslServerContext(store_, cfg, std::vector<std::string>{}, nullptr);
   }
 
   Envoy::Ssl::ServerContextSharedPtr loadConfigYaml(const std::string& yaml) {
@@ -790,7 +842,7 @@ class SslServerContextImplTicketTest : public SslContextImplTest {
 public:
   void loadConfig(ServerContextConfigImpl& cfg) {
     Envoy::Ssl::ServerContextSharedPtr server_ctx(
-        manager_.createSslServerContext(store_, cfg, std::vector<std::string>{}));
+        manager_.createSslServerContext(store_, cfg, std::vector<std::string>{}, nullptr));
   }
 
   void loadConfigV2(envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext& cfg) {
@@ -1138,7 +1190,7 @@ TEST_F(ClientContextConfigImplTest, InvalidCertificateHash) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config),
+  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config, nullptr),
                           EnvoyException, "Invalid hex-encoded SHA-256 .*");
 }
 
@@ -1154,7 +1206,7 @@ TEST_F(ClientContextConfigImplTest, InvalidCertificateSpki) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config),
+  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config, nullptr),
                           EnvoyException, "Invalid base64-encoded SHA-256 .*");
 }
 
@@ -1173,7 +1225,7 @@ TEST_F(ClientContextConfigImplTest, RSA2048Cert) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  manager.createSslClientContext(store, client_context_config);
+  manager.createSslClientContext(store, client_context_config, nullptr);
 }
 
 // Validate that 1024-bit RSA certificates are rejected.
@@ -1200,7 +1252,7 @@ TEST_F(ClientContextConfigImplTest, RSA1024Cert) {
       "with 2048-bit or larger keys are supported"
 #endif
   );
-  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config),
+  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config, nullptr),
                           EnvoyException, error_msg);
 }
 
@@ -1219,7 +1271,7 @@ TEST_F(ClientContextConfigImplTest, RSA3072Cert) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  manager.createSslClientContext(store, client_context_config);
+  manager.createSslClientContext(store, client_context_config, nullptr);
 }
 
 // Validate that 4096-bit RSA certificates load successfully in non-FIPS builds, but are rejected
@@ -1240,11 +1292,11 @@ TEST_F(ClientContextConfigImplTest, RSA4096Cert) {
   Stats::IsolatedStoreImpl store;
 #ifdef BORINGSSL_FIPS
   EXPECT_THROW_WITH_REGEX(
-      manager.createSslClientContext(store, client_context_config), EnvoyException,
+      manager.createSslClientContext(store, client_context_config, nullptr), EnvoyException,
       "Failed to load certificate chain from .*selfsigned_rsa_4096_cert.pem, only RSA certificates "
       "with 2048-bit or 3072-bit keys are supported in FIPS mode");
 #else
-  manager.createSslClientContext(store, client_context_config);
+  manager.createSslClientContext(store, client_context_config, nullptr);
 #endif
 }
 
@@ -1263,7 +1315,7 @@ TEST_F(ClientContextConfigImplTest, P256EcdsaCert) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  manager.createSslClientContext(store, client_context_config);
+  manager.createSslClientContext(store, client_context_config, nullptr);
 }
 
 // Validate that non-P256 ECDSA certs are rejected.
@@ -1281,7 +1333,7 @@ TEST_F(ClientContextConfigImplTest, NonP256EcdsaCert) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config),
+  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config, nullptr),
                           EnvoyException,
                           "Failed to load certificate chain from .*selfsigned_ecdsa_p384_cert.pem, "
                           "only P-256 ECDSA certificates are supported");
@@ -1487,7 +1539,7 @@ TEST_F(ClientContextConfigImplTest, PasswordNotSuppliedTlsCertificates) {
   Event::SimulatedTimeSystem time_system;
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
-  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config),
+  EXPECT_THROW_WITH_REGEX(manager.createSslClientContext(store, client_context_config, nullptr),
                           EnvoyException,
                           absl::StrCat("Failed to load private key from ", private_key_path));
 }
@@ -1729,8 +1781,8 @@ TEST_F(ServerContextConfigImplTest, TlsCertificateNonEmpty) {
   ContextManagerImpl manager(time_system);
   Stats::IsolatedStoreImpl store;
   EXPECT_THROW_WITH_MESSAGE(
-      Envoy::Ssl::ServerContextSharedPtr server_ctx(
-          manager.createSslServerContext(store, client_context_config, std::vector<std::string>{})),
+      Envoy::Ssl::ServerContextSharedPtr server_ctx(manager.createSslServerContext(
+          store, client_context_config, std::vector<std::string>{}, nullptr)),
       EnvoyException, "Server TlsCertificates must have a certificate specified");
 }
 
@@ -1827,8 +1879,8 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoMethod) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
   ServerContextConfigImpl server_context_config(tls_context, factory_context_);
   EXPECT_THROW_WITH_MESSAGE(
-      Envoy::Ssl::ServerContextSharedPtr server_ctx(
-          manager.createSslServerContext(store, server_context_config, std::vector<std::string>{})),
+      Envoy::Ssl::ServerContextSharedPtr server_ctx(manager.createSslServerContext(
+          store, server_context_config, std::vector<std::string>{}, nullptr)),
       EnvoyException, "Failed to get BoringSSL private key method from provider");
 }
 

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -24,10 +24,12 @@ public:
   ~MockContextManager() override;
 
   MOCK_METHOD(ClientContextSharedPtr, createSslClientContext,
-              (Stats::Scope & scope, const ClientContextConfig& config));
+              (Stats::Scope & scope, const ClientContextConfig& config,
+               Envoy::Ssl::ClientContextSharedPtr old_context));
   MOCK_METHOD(ServerContextSharedPtr, createSslServerContext,
               (Stats::Scope & stats, const ServerContextConfig& config,
-               const std::vector<std::string>& server_names));
+               const std::vector<std::string>& server_names,
+               Envoy::Ssl::ServerContextSharedPtr old_context));
   MOCK_METHOD(size_t, daysUntilFirstCertExpires, (), (const));
   MOCK_METHOD(absl::optional<uint64_t>, secondsUntilFirstOcspResponseExpires, (), (const));
   MOCK_METHOD(void, iterateContexts, (std::function<void(const Context&)> callback));

--- a/test/server/admin/server_info_handler_test.cc
+++ b/test/server/admin/server_info_handler_test.cc
@@ -28,7 +28,7 @@ TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
   Extensions::TransportSockets::Tls::ClientContextConfigImpl cfg(config, factory_context);
   Stats::IsolatedStoreImpl store;
   Envoy::Ssl::ClientContextSharedPtr client_ctx(
-      server_.sslContextManager().createSslClientContext(store, cfg));
+      server_.sslContextManager().createSslClientContext(store, cfg, nullptr));
 
   const std::string expected_empty_json = R"EOF({
  "certificates": [

--- a/test/server/ssl_context_manager_test.cc
+++ b/test/server/ssl_context_manager_test.cc
@@ -23,10 +23,11 @@ TEST(SslContextManager, createStub) {
   // Check we've created a stub, not real manager.
   EXPECT_EQ(manager->daysUntilFirstCertExpires(), std::numeric_limits<int>::max());
   EXPECT_EQ(manager->secondsUntilFirstOcspResponseExpires(), absl::nullopt);
-  EXPECT_THROW_WITH_MESSAGE(manager->createSslClientContext(scope, client_config), EnvoyException,
-                            "SSL is not supported in this configuration");
-  EXPECT_THROW_WITH_MESSAGE(manager->createSslServerContext(scope, server_config, server_names),
+  EXPECT_THROW_WITH_MESSAGE(manager->createSslClientContext(scope, client_config, nullptr),
                             EnvoyException, "SSL is not supported in this configuration");
+  EXPECT_THROW_WITH_MESSAGE(
+      manager->createSslServerContext(scope, server_config, server_names, nullptr), EnvoyException,
+      "SSL is not supported in this configuration");
   EXPECT_NO_THROW(manager->iterateContexts([](const Envoy::Ssl::Context&) -> void {}));
 }
 


### PR DESCRIPTION
Signed-off-by: Rama Chavali <rama.rao@salesforce.com>

Commit Message: clear old context from contexts when secret is updated
Additional Description: When secret is updated via SDS, the old contexts still linger in the context list making the "/certs" render them and also "DaysUntilFirstCertExpiry" is incorrect - it reflects the replaced stats.
Risk Level: Low
Testing: Added
Docs Changes: N/A
Release Notes: N/A
Fixes https://github.com/envoyproxy/envoy/issues/8614
