### PR TITLE
nghttp2 as an external dependency in protocol_constraints_lib

### DIFF
--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -137,9 +137,11 @@ envoy_cc_library(
     name = "protocol_constraints_lib",
     srcs = ["protocol_constraints.cc"],
     hdrs = ["protocol_constraints.h"],
+    external_deps = [
+        "nghttp2",
+    ],
     deps = [
         ":codec_stats_lib",
-        "//bazel/foreign_cc:nghttp2",
         "//include/envoy/network:connection_interface",
         "//source/common/common:assert_lib",
         "//source/common/http:status_lib",


### PR DESCRIPTION
Commit Message: Use nghttp2 as an external dependency in protocol_constraints_lib instead of "//bazel/foreign_cc:nghttp2".
Additional Description: We build envoy using our own nghttp2 build, having such direct dependency breaks it.  
Risk Level: Low
Testing: CI tests
Docs Changes: None
Release Notes: None
Platform Specific Features: None

