### PR TITLE
[wasm] fix wasm compilation with clang HEAD

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -19,7 +19,7 @@ pushd $$ROOT/wee8
 rm -rf out/wee8
 
 # Export compiler configuration.
-export CXXFLAGS="$${CXXFLAGS-} -Wno-sign-compare -Wno-deprecated-copy -Wno-unknown-warning-option -Wno-range-loop-analysis"
+export CXXFLAGS="$${CXXFLAGS-} -Wno-sign-compare -Wno-deprecated-copy -Wno-unknown-warning-option -Wno-range-loop-analysis -Wno-shorten-64-to-32"
 if [[ ( `uname` == "Darwin" && $${CXX-} == "" ) || $${CXX-} == *"clang"* ]]; then
   export IS_CLANG=true
   export CC=$${CC:-clang}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Short term fix WASM compilation with clang HEAD.
Additional Description: OSS-Fuzz builds have been failing to compile WASM. They compile with clang at HEAD to get the latest libfuzzer.
```
FAILED: obj/torque_generated_initializers/array-reduce-tq-csa.o 
clang++ -MMD -MF obj/torque_generated_initializers/array-reduce-tq-csa.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_X11=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -DCR_CLANG_REVISION=\"\" -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64 -DENABLE_MINOR_MC -DV8_CONCURRENT_MARKING -DV8_ARRAY_BUFFER_EXTENSION -DV8_ENABLE_LAZY_SOURCE_POSITIONS -DV8_WIN64_UNWINDING_INFO -DV8_ENABLE_REGEXP_INTERPRETER_THREADED_DISPATCH -DV8_SNAPSHOT_COMPRESSION -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_DEPRECATION_WARNINGS -DV8_IMMINENT_DEPRECATION_WARNINGS -DV8_TARGET_ARCH_X64 -DV8_HAVE_TARGET_OS -DV8_TARGET_OS_LINUX -DDISABLE_UNTRUSTED_CODE_MITIGATIONS -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -DV8_DEPRECATION_WARNINGS -DV8_IMMINENT_DEPRECATION_WARNINGS -I../.. -Igen -I../.. -I../../include -Igen -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -funwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -m64 -march=x86-64 -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -Xclang -fdebug-compilation-dir -Xclang . -no-canonical-prefixes -Wall -Werror -Wextra -Wimplicit-fallthrough -Wunreachable-code -Wthread-safety -Wextra-semi -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-unneeded-internal-declaration -Wno-undefined-var-template -fno-omit-frame-pointer -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wmissing-field-initializers -Wunreachable-code -Wshorten-64-to-32 -O3 -fno-ident -fdata-sections -ffunction-sections -g1 -fvisibility=default -Wexit-time-destructors -std=c++14 -fno-trigraphs -Wno-trigraphs -fno-exceptions -fno-rtti -stdlib=libc++ -Wno-sign-compare -Wno-deprecated-copy -Wno-unknown-warning-option -Wno-range-loop-analysis -Wno-implicit-int-float-conversion -Wno-builtin-assume-aligned-alignment -Wno-final-dtor-non-final-class -c gen/torque-generated/src/builtins/array-reduce-tq-csa.cc -o obj/torque_generated_initializers/array-reduce-tq-csa.o
In file included from gen/torque-generated/src/builtins/array-reduce-tq-csa.cc:1:
In file included from ../../src/builtins/builtins-array-gen.h:8:
In file included from ../../src/codegen/code-stub-assembler.h:10:
../../src/base/macros.h:332:12: error: implicit conversion loses integer precision: 'long' to 'int' [-Werror,-Wshorten-64-to-32]
  return x & -m;
  ~~~~~~ ~~^~~~
../../src/heap/spaces.h:157:14: note: in instantiation of function template specialization 'RoundDown<int>' requested here
      return RoundDown(size, kCodeAlignment);
             ^
1 error generated.
```

Testing: Built fuzzers with OSS-Fuzz's docker image from this checkout.

Is there a better place to fix this issue in the longterm?


