### PR TITLE
[fuzz] Scaled Load balancer fuzz to 60k hosts

### DIFF
--- a/test/common/upstream/load_balancer_fuzz.proto
+++ b/test/common/upstream/load_balancer_fuzz.proto
@@ -15,10 +15,10 @@ message UpdateHealthFlags {
   uint32 num_degraded_hosts = 3;
   uint32 num_excluded_hosts = 4;
   // This is used to determine which hosts get marked as healthy, degraded, and excluded.
-  //bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 40000}];
-  // TODO: What should this be capped at?
+  // TODO: What should this be capped at? There might be some efficiency/code coverage tradeoff
+  // dependent on the amount of digits this random_bytestring is allowed to scale too.
   repeated uint32 random_bytestring = 5
-      [(validate.rules).repeated = {min_items: 1, max_items: 10000}];
+      [(validate.rules).repeated = {min_items: 1, max_items: 60000}];
 }
 
 message LbAction {
@@ -42,7 +42,7 @@ message SetupPriorityLevel {
   uint32 num_hosts_locality_c = 4 [(validate.rules).uint32.lte = 60000];
   // For choosing which hosts go in which locality
   repeated uint32 random_bytestring = 5
-      [(validate.rules).repeated = {min_items: 1, max_items: 10000}];
+      [(validate.rules).repeated = {min_items: 1, max_items: 60000}];
 }
 
 // This message represents what LoadBalancerFuzzBase will interact with, performing setup of host sets and calling into load balancers.

--- a/test/common/upstream/load_balancer_fuzz.proto
+++ b/test/common/upstream/load_balancer_fuzz.proto
@@ -15,7 +15,7 @@ message UpdateHealthFlags {
   uint32 num_degraded_hosts = 3;
   uint32 num_excluded_hosts = 4;
   // This is used to determine which hosts get marked as healthy, degraded, and excluded.
-  // TODO: What should this be capped at? There might be some efficiency/code coverage tradeoff
+  // TODO: What should this be capped at? There might be some efficiency/code coverage trade off
   // dependent on the amount of digits this random_bytestring is allowed to scale too.
   repeated uint32 random_bytestring = 5
       [(validate.rules).repeated = {min_items: 1, max_items: 60000}];

--- a/test/common/upstream/load_balancer_fuzz.proto
+++ b/test/common/upstream/load_balancer_fuzz.proto
@@ -15,7 +15,7 @@ message UpdateHealthFlags {
   uint32 num_degraded_hosts = 3;
   uint32 num_excluded_hosts = 4;
   // This is used to determine which hosts get marked as healthy, degraded, and excluded.
-  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 1, max_len: 256}];
+  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 40000}];
 }
 
 message LbAction {
@@ -32,13 +32,13 @@ message LbAction {
 }
 
 message SetupPriorityLevel {
-  uint32 num_hosts_in_priority_level = 1 [(validate.rules).uint32.lte = 500];
-  uint32 num_hosts_locality_a = 2 [(validate.rules).uint32.lte = 500];
-  uint32 num_hosts_locality_b = 3 [(validate.rules).uint32.lte = 500];
+  uint32 num_hosts_in_priority_level = 1 [(validate.rules).uint32.lte = 10000];
+  uint32 num_hosts_locality_a = 2 [(validate.rules).uint32.lte = 10000];
+  uint32 num_hosts_locality_b = 3 [(validate.rules).uint32.lte = 10000];
   // Hard cap at 3 localities for simplicity
-  uint32 num_hosts_locality_c = 4 [(validate.rules).uint32.lte = 500];
+  uint32 num_hosts_locality_c = 4 [(validate.rules).uint32.lte = 10000];
   // For choosing which hosts go in which locality
-  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 1, max_len: 256}];
+  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 40000}];
 }
 
 // This message represents what LoadBalancerFuzzBase will interact with, performing setup of host sets and calling into load balancers.

--- a/test/common/upstream/load_balancer_fuzz.proto
+++ b/test/common/upstream/load_balancer_fuzz.proto
@@ -15,7 +15,10 @@ message UpdateHealthFlags {
   uint32 num_degraded_hosts = 3;
   uint32 num_excluded_hosts = 4;
   // This is used to determine which hosts get marked as healthy, degraded, and excluded.
-  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 40000}];
+  //bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 40000}];
+  // TODO: What should this be capped at?
+  repeated uint32 random_bytestring = 5
+      [(validate.rules).repeated = {min_items: 1, max_items: 10000}];
 }
 
 message LbAction {
@@ -38,7 +41,8 @@ message SetupPriorityLevel {
   // Hard cap at 3 localities for simplicity
   uint32 num_hosts_locality_c = 4 [(validate.rules).uint32.lte = 60000];
   // For choosing which hosts go in which locality
-  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 50000}];
+  repeated uint32 random_bytestring = 5
+      [(validate.rules).repeated = {min_items: 1, max_items: 10000}];
 }
 
 // This message represents what LoadBalancerFuzzBase will interact with, performing setup of host sets and calling into load balancers.

--- a/test/common/upstream/load_balancer_fuzz.proto
+++ b/test/common/upstream/load_balancer_fuzz.proto
@@ -8,7 +8,7 @@ import "google/protobuf/empty.proto";
 
 message UpdateHealthFlags {
   // The host priority determines what host set within the priority set which will get updated.
-  uint64 host_priority = 1;
+  uint32 host_priority = 1;
   // These will determine how many hosts will get placed into health hosts, degraded hosts, and
   // excluded hosts from the full host list.
   uint32 num_healthy_hosts = 2;
@@ -32,13 +32,13 @@ message LbAction {
 }
 
 message SetupPriorityLevel {
-  uint32 num_hosts_in_priority_level = 1 [(validate.rules).uint32.lte = 10000];
-  uint32 num_hosts_locality_a = 2 [(validate.rules).uint32.lte = 10000];
-  uint32 num_hosts_locality_b = 3 [(validate.rules).uint32.lte = 10000];
+  uint32 num_hosts_in_priority_level = 1 [(validate.rules).uint32.lte = 60000];
+  uint32 num_hosts_locality_a = 2 [(validate.rules).uint32.lte = 60000];
+  uint32 num_hosts_locality_b = 3 [(validate.rules).uint32.lte = 60000];
   // Hard cap at 3 localities for simplicity
-  uint32 num_hosts_locality_c = 4 [(validate.rules).uint32.lte = 10000];
+  uint32 num_hosts_locality_c = 4 [(validate.rules).uint32.lte = 60000];
   // For choosing which hosts go in which locality
-  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 40000}];
+  bytes random_bytestring = 5 [(validate.rules).bytes = {min_len: 4, max_len: 50000}];
 }
 
 // This message represents what LoadBalancerFuzzBase will interact with, performing setup of host sets and calling into load balancers.

--- a/test/common/upstream/load_balancer_fuzz_base.cc
+++ b/test/common/upstream/load_balancer_fuzz_base.cc
@@ -12,20 +12,18 @@ constexpr uint32_t MaxNumHostsPerPriorityLevel = 60000;
 // Helper function for converting repeated proto fields to byte vectors to pass into random subset
 std::vector<uint32_t>
 constructByteVectorForRandom(const Protobuf::RepeatedField<Protobuf::uint32>& random_bytestring) {
-  std::vector<uint32_t> random_bytestring_vector;
-  for (int i = 0; i < random_bytestring.size(); ++i) {
-    random_bytestring_vector.push_back(random_bytestring.at(i));
-  }
+  std::vector<uint32_t> random_bytestring_vector(random_bytestring.begin(),
+                                                 random_bytestring.end());
   return random_bytestring_vector;
 }
 
 } // namespace
 
 HostVector
-LoadBalancerFuzzBase::initializeHostsForUseInFuzzing(std::shared_ptr<MockClusterInfo> info_) {
+LoadBalancerFuzzBase::initializeHostsForUseInFuzzing(std::shared_ptr<MockClusterInfo> info) {
   HostVector hosts;
   for (uint32_t i = 1; i <= 60000; ++i) {
-    hosts.push_back(makeTestHost(info_, "tcp://127.0.0.1:" + std::to_string(i)));
+    hosts.push_back(makeTestHost(info, "tcp://127.0.0.1:" + std::to_string(i)));
   }
   return hosts;
 }
@@ -38,7 +36,8 @@ void LoadBalancerFuzzBase::initializeASingleHostSet(
                  priority_level, num_hosts_in_priority_level);
   MockHostSet& host_set = *priority_set_.getMockHostSet(priority_level);
   uint32_t hosts_made = 0;
-  // Cap each host set at 256 hosts for efficiency - Leave port clause in for future changes
+  // Cap each host set at 60000 hosts - however, let port number enforce a max of 60k hosts across
+  // all priority levels.
   while (hosts_made < std::min(num_hosts_in_priority_level, MaxNumHostsPerPriorityLevel) &&
          port < 60000) {
     host_set.hosts_.push_back(initialized_hosts_[port]);

--- a/test/common/upstream/load_balancer_fuzz_base.h
+++ b/test/common/upstream/load_balancer_fuzz_base.h
@@ -36,6 +36,8 @@ public:
   ~LoadBalancerFuzzBase() = default;
   void replay(const Protobuf::RepeatedPtrField<test::common::upstream::LbAction>& actions);
 
+  void clearStaticHostsHealthFlags();
+
   // These public objects shared amongst all types of load balancers will be used to construct load
   // balancers in specific load balancer fuzz classes
   Stats::IsolatedStoreImpl stats_store_;
@@ -43,7 +45,8 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   Random::PsuedoRandomGenerator64 random_;
   NiceMock<MockPrioritySet> priority_set_;
-  std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
+  //std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
+  static std::shared_ptr<MockClusterInfo> info_;
   std::unique_ptr<LoadBalancerBase> lb_;
 
 private:
@@ -61,6 +64,10 @@ private:
   // localities Key - index of host within full host list, value - locality level host at index is
   // in
   absl::node_hash_map<uint8_t, uint8_t> locality_indexes_;
+
+  // Will statically initialize 10000? hosts in this vector
+  // Will have to clear flags at the end of each iteration here
+  static HostVector initialized_hosts_;
 };
 
 } // namespace Upstream

--- a/test/common/upstream/load_balancer_fuzz_base.h
+++ b/test/common/upstream/load_balancer_fuzz_base.h
@@ -45,8 +45,6 @@ public:
   NiceMock<Runtime::MockLoader> runtime_;
   Random::PsuedoRandomGenerator64 random_;
   NiceMock<MockPrioritySet> priority_set_;
-  //std::shared_ptr<MockClusterInfo> info_{new NiceMock<MockClusterInfo>()};
-  static std::shared_ptr<MockClusterInfo> info_;
   std::unique_ptr<LoadBalancerBase> lb_;
 
 private:
@@ -65,9 +63,11 @@ private:
   // in
   absl::node_hash_map<uint8_t, uint8_t> locality_indexes_;
 
+  static HostVector initializeHostsForUseInFuzzing(std::shared_ptr<MockClusterInfo> info_);
+
   // Will statically initialize 10000? hosts in this vector
   // Will have to clear flags at the end of each iteration here
-  static HostVector initialized_hosts_;
+  HostVector initialized_hosts_;
 };
 
 } // namespace Upstream

--- a/test/common/upstream/load_balancer_fuzz_base.h
+++ b/test/common/upstream/load_balancer_fuzz_base.h
@@ -23,10 +23,10 @@ public:
   // Initializes load balancer components shared amongst every load balancer, random_, and
   // priority_set_
   void initializeLbComponents(const test::common::upstream::LoadBalancerTestCase& input);
-  void updateHealthFlagsForAHostSet(const uint64_t host_priority, const uint32_t num_healthy_hosts,
-                                    const uint32_t num_degraded_hosts,
-                                    const uint32_t num_excluded_hosts,
-                                    const std::string random_bytestring);
+  void
+  updateHealthFlagsForAHostSet(const uint64_t host_priority, const uint32_t num_healthy_hosts,
+                               const uint32_t num_degraded_hosts, const uint32_t num_excluded_hosts,
+                               const Protobuf::RepeatedField<Protobuf::uint32>& random_bytestring);
   // These two actions have a lot of logic attached to them. However, all the logic that the load
   // balancer needs to run its algorithm is already encapsulated within the load balancer. Thus,
   // once the load balancer is constructed, all this class has to do is call lb_->peekAnotherHost()

--- a/test/common/upstream/load_balancer_fuzz_base.h
+++ b/test/common/upstream/load_balancer_fuzz_base.h
@@ -63,10 +63,10 @@ private:
   // in
   absl::node_hash_map<uint8_t, uint8_t> locality_indexes_;
 
-  static HostVector initializeHostsForUseInFuzzing(std::shared_ptr<MockClusterInfo> info_);
+  static HostVector initializeHostsForUseInFuzzing(std::shared_ptr<MockClusterInfo> info);
 
-  // Will statically initialize 10000? hosts in this vector
-  // Will have to clear flags at the end of each iteration here
+  // Will statically initialize 60000 hosts in this vector. Will have to clear these static
+  // hosts flags at the end of each fuzz iteration
   HostVector initialized_hosts_;
 };
 

--- a/test/common/upstream/random_load_balancer_corpus/random_256_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_256_ports
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 256
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 256
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_256_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_256_ports
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 256
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 256
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02\x01\x02\x01\x02"
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_256_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_256_ports
@@ -6,7 +6,7 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 256
-        random_bytestring: "\x01\x02\x03\x04\x45\x80"
+        random_bytestring: 1
     }
 }
 actions {
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 256
-    random_bytestring: "\x01\x02\x01\x02\x01\x02\x01\x02"
+    random_bytestring: 1
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 256
-    random_bytestring: "\x01\x02\x01\x02\x01\x02\x01\x02"
+    random_bytestring: 1
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_NoHosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_NoHosts
@@ -14,11 +14,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 2
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_NoHosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_NoHosts
@@ -14,11 +14,17 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 2
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_Normal
+++ b/test/common/upstream/random_load_balancer_corpus/random_Normal
@@ -6,7 +6,7 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "\x01\x02"
+        random_bytestring: "\x01\x02\x01\x02"
     }
 }
 actions {
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 2
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_Normal
+++ b/test/common/upstream/random_load_balancer_corpus/random_Normal
@@ -6,7 +6,10 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "aergteawthgrstyhaersgeasrgreasg"
+        random_bytestring: 1
+        random_bytestring: 2
+        random_bytestring: 1
+        random_bytestring: 2
     }
 }
 actions {
@@ -31,11 +34,17 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 2
-    random_bytestring: "aergagerageraegr"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "agreaergvaergaegr"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-55abbf82c64b5a62e299b93d7b254045471199c9
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-55abbf82c64b5a62e299b93d7b254045471199c9
@@ -6,7 +6,7 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "aergteawthgrstyhaersgeasrgreasg"
+        random_bytestring: "aegrkiyuttkyumfae"
     }
 }
 actions {
@@ -30,12 +30,12 @@ actions {
     }
 }
 setup_priority_levels {
-    num_hosts_in_priority_level: 2
-    random_bytestring: "aergagerageraegr"
+    num_hosts_in_priority_level: 250
+    random_bytestring: "ukjyrkjyrujaegregaeagr"
 }
 setup_priority_levels {
-    num_hosts_in_priority_level: 0
-    random_bytestring: "agreaergvaergaegr"
+    num_hosts_in_priority_level: 250
+    random_bytestring: "aerhyytjtyukytufagfe"
 }
-seed_for_prng: 1
+seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-55abbf82c64b5a62e299b93d7b254045471199c9
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-55abbf82c64b5a62e299b93d7b254045471199c9
@@ -6,7 +6,7 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "aegrkiyuttkyumfae"
+        random_bytestring: 1
     }
 }
 actions {
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 250
-    random_bytestring: "ukjyrkjyrujaegregaeagr"
+    random_bytestring: 1
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 250
-    random_bytestring: "aerhyytjtyukytufagfe"
+    random_bytestring: 1
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-5a64c214e5c2038299c8f2e85f143f1163077c1b
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-5a64c214e5c2038299c8f2e85f143f1163077c1b
@@ -1,0 +1,25 @@
+load_balancer_test_case {
+  common_lb_config {
+    healthy_panic_threshold {
+      value: 4.88907830238399e-311
+    }
+    consistent_hashing_lb_config {
+      use_hostname_for_hashing: true
+      hash_balance_factor {
+        value: 1024
+      }
+    }
+  }
+  actions {
+    update_health_flags {
+      host_priority: 270582939648
+      num_degraded_hosts: 4194304
+      random_bytestring: "aergaergaerghaerhgaerghaergaerg"
+    }
+  }
+  setup_priority_levels {
+    num_hosts_in_priority_level: 1024
+    random_bytestring: "yrfukykyrthrtgrgera"
+  }
+  seed_for_prng: 62208
+}

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-5a64c214e5c2038299c8f2e85f143f1163077c1b
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-5a64c214e5c2038299c8f2e85f143f1163077c1b
@@ -14,12 +14,12 @@ load_balancer_test_case {
     update_health_flags {
       host_priority: 270582939648
       num_degraded_hosts: 4194304
-      random_bytestring: "aergaergaerghaerhgaerghaergaerg"
+      random_bytestring: 1
     }
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 1024
-    random_bytestring: "yrfukykyrthrtgrgera"
+    random_bytestring: 1
   }
   seed_for_prng: 62208
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-ba5efdfd9c412a8507087120783fe6529b1ac0cb
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-ba5efdfd9c412a8507087120783fe6529b1ac0cb
@@ -28,11 +28,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 2
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 9007199259945536
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
 }
 seed_for_prng: 6
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-ba5efdfd9c412a8507087120783fe6529b1ac0cb
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-ba5efdfd9c412a8507087120783fe6529b1ac0cb
@@ -28,11 +28,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 2
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 9007199259945536
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 6
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_largest-port-value
+++ b/test/common/upstream/random_load_balancer_corpus/random_largest-port-value
@@ -24,11 +24,11 @@ actions {
 }
 nsetup_priority_levels {
     num_hosts_in_priority_level: 65455
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 65455
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
 }
 seed_for_prng: 5
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_largest-port-value
+++ b/test/common/upstream/random_load_balancer_corpus/random_largest-port-value
@@ -24,11 +24,11 @@ actions {
 }
 nsetup_priority_levels {
     num_hosts_in_priority_level: 65455
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 65455
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 5
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_many_choose_hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_many_choose_hosts
@@ -51,11 +51,15 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 2
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_many_choose_hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_many_choose_hosts
@@ -51,11 +51,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 2
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 0
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_max_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_max_ports
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 32726
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 32726
-    random_bytestring: "\x01\x02"
+    random_bytestring: "\x01\x02\x01\x02"
 }
 seed_for_prng: 88
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_max_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_max_ports
@@ -6,7 +6,10 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "\x01\x02\x03\x04"
+        random_bytestring: 1
+        random_bytestring: 2
+        random_bytestring: 3
+        random_bytestring: 4
     }
 }
 actions {
@@ -31,11 +34,17 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 32726
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 32726
-    random_bytestring: "\x01\x02\x01\x02"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 88
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_overflowing_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_overflowing_ports
@@ -6,7 +6,7 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "\x01\x02"
+        random_bytestring: "laierghilaerghfliakreg"
     }
 }
 actions {
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 60000
-    random_bytestring: "\x01\x02"
+    random_bytestring: "aergaergaegrfkijhilaegr"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 60000
-    random_bytestring: "\x01\x02"
+    random_bytestring: "3q4tgsrht674eu43"
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_overflowing_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_overflowing_ports
@@ -6,7 +6,10 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "laierghilaerghfliakreg"
+        random_bytestring: 1
+        random_bytestring: 2
+        random_bytestring: 1
+        random_bytestring: 2
     }
 }
 actions {
@@ -31,11 +34,17 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 60000
-    random_bytestring: "aergaergaegrfkijhilaegr"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 60000
-    random_bytestring: "3q4tgsrht674eu43"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_slow-unit-eed4596101efb3e737f736c8d5bcd4f0815a8728
+++ b/test/common/upstream/random_load_balancer_corpus/random_slow-unit-eed4596101efb3e737f736c8d5bcd4f0815a8728
@@ -7,7 +7,10 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_healthy_hosts: 2
-      random_bytestring: "\001\002\003\004"
+      random_bytestring: 1
+      random_bytestring: 2
+      random_bytestring: 3
+      random_bytestring: 4
     }
   }
   actions {
@@ -25,16 +28,25 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_healthy_hosts: 2
-      random_bytestring: "\001\002\003\004"
+      random_bytestring: 1
+      random_bytestring: 2
+      random_bytestring: 3
+      random_bytestring: 4
     }
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 536903638
-    random_bytestring: "\001\002\003\004"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 3
+    random_bytestring: 4
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 32726
-    random_bytestring: "\001\002\003\004"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 3
+    random_bytestring: 4
   }
   seed_for_prng: 88
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_slow-unit-eed4596101efb3e737f736c8d5bcd4f0815a8728
+++ b/test/common/upstream/random_load_balancer_corpus/random_slow-unit-eed4596101efb3e737f736c8d5bcd4f0815a8728
@@ -30,11 +30,11 @@ load_balancer_test_case {
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 536903638
-    random_bytestring: "\001\002"
+    random_bytestring: "\001\002\003\004"
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 32726
-    random_bytestring: "\001\002"
+    random_bytestring: "\001\002\003\004"
   }
   seed_for_prng: 88
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_slow-unit-test
+++ b/test/common/upstream/random_load_balancer_corpus/random_slow-unit-test
@@ -7,7 +7,10 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_healthy_hosts: 2
-      random_bytestring: "aergswyhtydjkkyugikt"
+      random_bytestring: 1
+      random_bytestring: 2
+      random_bytestring: 1
+      random_bytestring: 2
     }
   }
   actions {
@@ -25,7 +28,10 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_healthy_hosts: 2
-      random_bytestring: "arwefawefeaqgftrsehttyjhui"
+      random_bytestring: 1
+      random_bytestring: 2
+      random_bytestring: 1
+      random_bytestring: 2
     }
   }
   setup_priority_levels {
@@ -33,14 +39,20 @@ load_balancer_test_case {
     num_hosts_locality_one: 50
     num_hosts_locality_two: 50
     num_hosts_locality_three: 50
-    random_bytestring: "awertfeyjuhytukgjmu"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 500
     num_hosts_locality_one: 50
     num_hosts_locality_two: 50
     num_hosts_locality_three: 50
-    random_bytestring: "awerfuilyetrs"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
   }
   seed_for_prng: 88
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_slow-unit-test
+++ b/test/common/upstream/random_load_balancer_corpus/random_slow-unit-test
@@ -7,7 +7,7 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_healthy_hosts: 2
-      random_bytestring: "\001\002\003\004"
+      random_bytestring: "aergswyhtydjkkyugikt"
     }
   }
   actions {
@@ -25,7 +25,7 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_healthy_hosts: 2
-      random_bytestring: "\001\002\003\004"
+      random_bytestring: "arwefawefeaqgftrsehttyjhui"
     }
   }
   setup_priority_levels {
@@ -33,14 +33,14 @@ load_balancer_test_case {
     num_hosts_locality_one: 50
     num_hosts_locality_two: 50
     num_hosts_locality_three: 50
-    random_bytestring: "\001\002"
+    random_bytestring: "awertfeyjuhytukgjmu"
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 500
     num_hosts_locality_one: 50
     num_hosts_locality_two: 50
     num_hosts_locality_three: 50
-    random_bytestring: "\001\002"
+    random_bytestring: "awerfuilyetrs"
   }
   seed_for_prng: 88
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_test_something
+++ b/test/common/upstream/random_load_balancer_corpus/random_test_something
@@ -6,7 +6,7 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "\x01\x02"
+        random_bytestring: "aegrkiyuttkyumfae"
     }
 }
 actions {
@@ -31,11 +31,11 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 250
-    random_bytestring: "\x01\x02"
+    random_bytestring: "ukjyrkjyrujaegregaeagr"
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 250
-    random_bytestring: "\x01\x02"
+    random_bytestring: "aerhyytjtyukytufagfe"
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_test_something
+++ b/test/common/upstream/random_load_balancer_corpus/random_test_something
@@ -6,7 +6,10 @@ actions {
     update_health_flags {
         host_priority: 0
         num_healthy_hosts: 2
-        random_bytestring: "aegrkiyuttkyumfae"
+        random_bytestring: 1
+        random_bytestring: 2
+        random_bytestring: 1
+        random_bytestring: 2
     }
 }
 actions {
@@ -31,11 +34,17 @@ actions {
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 250
-    random_bytestring: "ukjyrkjyrujaegregaeagr"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 250
-    random_bytestring: "aerhyytjtyukytufagfe"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 4
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_timeout-6b0d6b83136a4cf0b9ccd468f11207a792859d43
+++ b/test/common/upstream/random_load_balancer_corpus/random_timeout-6b0d6b83136a4cf0b9ccd468f11207a792859d43
@@ -20,12 +20,12 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_excluded_hosts: 268435456
-      random_bytestring: "\x01\x02"
+      random_bytestring: "aergaergyhreaggear"
     }
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 13534154135
-    random_bytestring: "\x01\x02"
+    random_bytestring: "earghaegraergaergaergaerg"
   }
   seed_for_prng: 32
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_timeout-6b0d6b83136a4cf0b9ccd468f11207a792859d43
+++ b/test/common/upstream/random_load_balancer_corpus/random_timeout-6b0d6b83136a4cf0b9ccd468f11207a792859d43
@@ -20,12 +20,18 @@ load_balancer_test_case {
   actions {
     update_health_flags {
       num_excluded_hosts: 268435456
-      random_bytestring: "aergaergyhreaggear"
+      random_bytestring: 1
+      random_bytestring: 2
+      random_bytestring: 1
+      random_bytestring: 2
     }
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 13534154135
-    random_bytestring: "earghaegraergaergaergaerg"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
   }
   seed_for_prng: 32
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_timeout-9144cfbb40b5101ecc28b205b10e6c36a72aae83
+++ b/test/common/upstream/random_load_balancer_corpus/random_timeout-9144cfbb40b5101ecc28b205b10e6c36a72aae83
@@ -14,12 +14,18 @@ load_balancer_test_case {
     update_health_flags {
       host_priority: 270582939648
       num_degraded_hosts: 4194304
-      random_bytestring: "aergaergaerghaerhgaerghaergaerg"
+      random_bytestring: 1
+      random_bytestring: 2
+      random_bytestring: 1
+      random_bytestring: 2
     }
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 1024
-    random_bytestring: "yrfukykyrthrtgrgera"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
   }
   seed_for_prng: 62208
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_timeout-9144cfbb40b5101ecc28b205b10e6c36a72aae83
+++ b/test/common/upstream/random_load_balancer_corpus/random_timeout-9144cfbb40b5101ecc28b205b10e6c36a72aae83
@@ -14,12 +14,12 @@ load_balancer_test_case {
     update_health_flags {
       host_priority: 270582939648
       num_degraded_hosts: 4194304
-      random_bytestring: "\x01\x02\x03\x04"
+      random_bytestring: "aergaergaerghaerhgaerghaergaerg"
     }
   }
   setup_priority_levels {
     num_hosts_in_priority_level: 1024
-    random_bytestring: "\x01\x02"
+    random_bytestring: "yrfukykyrthrtgrgera"
   }
   seed_for_prng: 62208
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with-locality
+++ b/test/common/upstream/random_load_balancer_corpus/random_with-locality
@@ -8,7 +8,10 @@ actions {
         num_healthy_hosts: 2
         num_degraded_hosts: 3
         num_excluded_hosts: 4
-        random_bytestring: "eargfaergaergaergaerggaereargaegr"
+        random_bytestring: 1
+        random_bytestring: 2
+        random_bytestring: 1
+        random_bytestring: 2
     }
 }
 actions {
@@ -36,14 +39,20 @@ setup_priority_levels {
     num_hosts_locality_a: 3
     num_hosts_locality_b: 4
     num_hosts_locality_c: 5
-    random_bytestring: "eragaerghahtgrathaertthgrtahrathggraaergeargaergae"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 20
     num_hosts_locality_a: 3
     num_hosts_locality_b: 4
     num_hosts_locality_c: 5
-    random_bytestring: "dsfawetfawertfrawawetukyfyguukytfufrrawer"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with-locality-high-number-of-hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_with-locality-high-number-of-hosts
@@ -8,7 +8,10 @@ actions {
         num_healthy_hosts: 2
         num_degraded_hosts: 3
         num_excluded_hosts: 4
-        random_bytestring: "eargfaergaergaergaerggaereargaegr"
+        random_bytestring: 100000
+        random_bytestring: 1000000
+        random_bytestring: 1500000
+        random_bytestring: 2000000
     }
 }
 actions {
@@ -36,14 +39,20 @@ setup_priority_levels {
     num_hosts_locality_a: 1000
     num_hosts_locality_b: 500
     num_hosts_locality_c: 1500
-    random_bytestring: "eragaerghahtgrathaertthgrtahrathggraaergeargaergae"
+    random_bytestring: 100000
+    random_bytestring: 1000000
+    random_bytestring: 1500000
+    random_bytestring: 2000000
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 3000
     num_hosts_locality_a: 300
     num_hosts_locality_b: 1200
     num_hosts_locality_c: 1500
-    random_bytestring: "dsfawetfawertfrawawetukyfyguukytfufrrawer"
+    random_bytestring: 100000
+    random_bytestring: 1000000
+    random_bytestring: 1500000
+    random_bytestring: 2000000
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with-locality-high-number-of-hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_with-locality-high-number-of-hosts
@@ -32,17 +32,17 @@ actions {
     }
 }
 setup_priority_levels {
-    num_hosts_in_priority_level: 20
-    num_hosts_locality_a: 3
-    num_hosts_locality_b: 4
-    num_hosts_locality_c: 5
+    num_hosts_in_priority_level: 3000
+    num_hosts_locality_a: 1000
+    num_hosts_locality_b: 500
+    num_hosts_locality_c: 1500
     random_bytestring: "eragaerghahtgrathaertthgrtahrathggraaergeargaergae"
 }
 setup_priority_levels {
-    num_hosts_in_priority_level: 20
-    num_hosts_locality_a: 3
-    num_hosts_locality_b: 4
-    num_hosts_locality_c: 5
+    num_hosts_in_priority_level: 3000
+    num_hosts_locality_a: 300
+    num_hosts_locality_b: 1200
+    num_hosts_locality_c: 1500
     random_bytestring: "dsfawetfawertfrawawetukyfyguukytfufrrawer"
 }
 seed_for_prng: 1

--- a/test/common/upstream/random_load_balancer_corpus/random_with_locality-50000-hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_with_locality-50000-hosts
@@ -8,7 +8,10 @@ actions {
         num_healthy_hosts: 2
         num_degraded_hosts: 3
         num_excluded_hosts: 4
-        random_bytestring: "eargfaergaergaergaerggaereargaegr"
+        random_bytestring: 1
+        random_bytestring: 2
+        random_bytestring: 1
+        random_bytestring: 2
     }
 }
 actions {
@@ -36,14 +39,20 @@ setup_priority_levels {
     num_hosts_locality_a: 1000
     num_hosts_locality_b: 500
     num_hosts_locality_c: 1500
-    random_bytestring: "eragaerghahtgrathaertthgrtahrathggraaergeargaergae"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 setup_priority_levels {
     num_hosts_in_priority_level: 50000
     num_hosts_locality_a: 300
     num_hosts_locality_b: 1200
     num_hosts_locality_c: 1500
-    random_bytestring: "dsfawetfawertfrawawetukyfyguukytfufrrawer"
+    random_bytestring: 1
+    random_bytestring: 2
+    random_bytestring: 1
+    random_bytestring: 2
 }
 seed_for_prng: 1
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with_locality-50000-hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_with_locality-50000-hosts
@@ -1,0 +1,49 @@
+load_balancer_test_case {
+common_lb_config {
+
+}
+actions {
+    update_health_flags {
+        host_priority: 0
+        num_healthy_hosts: 2
+        num_degraded_hosts: 3
+        num_excluded_hosts: 4
+        random_bytestring: "eargfaergaergaergaerggaereargaegr"
+    }
+}
+actions {
+    prefetch {
+
+    }
+}
+actions {
+    prefetch {
+
+    }
+}
+actions {
+    choose_host {
+
+    }
+}
+actions {
+    choose_host {
+
+    }
+}
+setup_priority_levels {
+    num_hosts_in_priority_level: 50000
+    num_hosts_locality_a: 1000
+    num_hosts_locality_b: 500
+    num_hosts_locality_c: 1500
+    random_bytestring: "eragaerghahtgrathaertthgrtahrathggraaergeargaergae"
+}
+setup_priority_levels {
+    num_hosts_in_priority_level: 50000
+    num_hosts_locality_a: 300
+    num_hosts_locality_b: 1200
+    num_hosts_locality_c: 1500
+    random_bytestring: "dsfawetfawertfrawawetukyfyguukytfufrrawer"
+}
+seed_for_prng: 1
+}

--- a/test/fuzz/random.h
+++ b/test/fuzz/random.h
@@ -84,9 +84,14 @@ private:
 
     for (uint32_t i = 0; i < number_of_elements_in_subset && !(num_elements_left_ == 0); i++) {
       // Index of bytestring will wrap around if it "overflows" past the random bytestring's length.
-      uint32_t* bytes_from_bytestring = reinterpret_cast<uint32_t*>(
-          &random_bytestring_ + (index_of_random_bytestring_ % random_bytestring_.length()));
-      uint32_t index_of_index_vector = *bytes_from_bytestring % num_elements_left_;
+      // uint32_t* bytes_from_bytestring = reinterpret_cast<uint32_t*>(
+      //    &random_bytestring_[index_of_random_bytestring_ % random_bytestring_.length()]);
+      std::string bytes_from_bytestring =
+          random_bytestring_.substr(index_of_random_bytestring_ % random_bytestring_.length(), 4);
+      /*uint32_t random_32_bits;
+      absl::SimpleAtoi(bytes_from_bytestring, &random_32_bits);*/
+      uint32_t index_of_index_vector =
+          *reinterpret_cast<uint32_t*>(&bytes_from_bytestring) % num_elements_left_;
       uint32_t index = index_vector.at(index_of_index_vector);
       subset.push_back(index);
       // Move the index chosen to the end of the vector - will not be chosen again

--- a/test/fuzz/random.h
+++ b/test/fuzz/random.h
@@ -36,16 +36,8 @@ namespace Fuzz {
 
 class ProperSubsetSelector {
 public:
-  ProperSubsetSelector(const std::string& random_bytestring)
-      : random_bytestring_(random_bytestring) {
-    // Must be at least 4 bytes wide to serve as randomness for the subset selector
-    ASSERT(random_bytestring_.length() >= 4);
-    // Pull off the last few bits to make random_bytestring_ a multiple of 4 - this will make
-    // iteration through the bytestring a lot easier and cleaner
-    while (random_bytestring_.length() % 4 != 0) {
-      random_bytestring_.pop_back();
-    }
-  }
+  ProperSubsetSelector(const std::vector<uint32_t>& random_bytestring)
+      : random_bytestring_(random_bytestring) {}
 
   /**
    * This function does proper subset selection on a certain number of elements. It returns a vector
@@ -83,22 +75,16 @@ private:
     std::vector<uint32_t> subset;
 
     for (uint32_t i = 0; i < number_of_elements_in_subset && !(num_elements_left_ == 0); i++) {
-      // Index of bytestring will wrap around if it "overflows" past the random bytestring's length.
-      // uint32_t* bytes_from_bytestring = reinterpret_cast<uint32_t*>(
-      //    &random_bytestring_[index_of_random_bytestring_ % random_bytestring_.length()]);
-      std::string bytes_from_bytestring =
-          random_bytestring_.substr(index_of_random_bytestring_ % random_bytestring_.length(), 4);
-      /*uint32_t random_32_bits;
-      absl::SimpleAtoi(bytes_from_bytestring, &random_32_bits);*/
       uint32_t index_of_index_vector =
-          *reinterpret_cast<uint32_t*>(&bytes_from_bytestring) % num_elements_left_;
+          random_bytestring_.at(index_of_random_bytestring_ % random_bytestring_.size()) %
+          num_elements_left_;
       uint32_t index = index_vector.at(index_of_index_vector);
       subset.push_back(index);
       // Move the index chosen to the end of the vector - will not be chosen again
       std::swap(index_vector[index_of_index_vector], index_vector[num_elements_left_ - 1]);
       --num_elements_left_;
 
-      index_of_random_bytestring_ += 4;
+      ++index_of_random_bytestring_;
     }
 
     return subset;
@@ -106,8 +92,7 @@ private:
 
   // This bytestring will be iterated through representing randomness in order to choose
   // subsets
-  std::string random_bytestring_;
-  // This will iterate by 4 every time bytestring is iterated
+  std::vector<uint32_t> random_bytestring_;
   uint32_t index_of_random_bytestring_ = 0;
 
   // Used to make subset construction linear time complexity with std::swap - chosen indexes will be

--- a/test/fuzz/random_test.cc
+++ b/test/fuzz/random_test.cc
@@ -9,16 +9,14 @@ namespace Envoy {
 namespace Fuzz {
 
 // Test the subset selection - since selection is based on a passed in random bytestring you can
-// work the algorithm yourself Pass in 5 elements, expect first subset to be element 2 and element
-// 4, second subset to be elements 1, 2, 3
+// work the algorithm yourself Pass in 5 elements, expect first subset to be element 0 and element
+// 4, second subset to be elements 2, 3, 1
 TEST(BasicSubsetSelection, RandomTest) {
-  // \x01 chooses the first element, which gets swapped with last element, 0x3 chooses the third
-  // index, which gets swapped with last element etc.
-  std::string random_bytestring = "\x01\x03\x09\x04\x33";
+  std::string random_bytestring = "aergaergaerwhgaerlgnj";
   ProperSubsetSelector subset_selector(random_bytestring);
-  const std::vector<std::vector<uint8_t>> subsets = subset_selector.constructSubsets({2, 3}, 5);
-  const std::vector<uint8_t> expected_subset_one = {1, 3};
-  const std::vector<uint8_t> expected_subset_two = {0, 2, 4};
+  const std::vector<std::vector<uint32_t>> subsets = subset_selector.constructSubsets({2, 3}, 5);
+  const std::vector<uint32_t> expected_subset_one = {0, 4};
+  const std::vector<uint32_t> expected_subset_two = {2, 3, 1};
   EXPECT_THAT(subsets[0], ContainerEq(expected_subset_one));
   EXPECT_THAT(subsets[1], ContainerEq(expected_subset_two));
 }

--- a/test/fuzz/random_test.cc
+++ b/test/fuzz/random_test.cc
@@ -9,14 +9,18 @@ namespace Envoy {
 namespace Fuzz {
 
 // Test the subset selection - since selection is based on a passed in random bytestring you can
-// work the algorithm yourself Pass in 5 elements, expect first subset to be element 0 and element
-// 4, second subset to be elements 2, 3, 1
-TEST(BasicSubsetSelection, RandomTest) {
-  std::string random_bytestring = "aergaergaerwhgaerlgnj";
+// work the algorithm yourself. This test also tests if the subset selection handles 32 bits.
+TEST(BasicSubsetSelection, ValidateScaleTest) {
+  std::vector<uint32_t> random_bytestring;
+  random_bytestring.push_back(1000000);
+  random_bytestring.push_back(1500000);
+  random_bytestring.push_back(2000000);
+  random_bytestring.push_back(2500000);
   ProperSubsetSelector subset_selector(random_bytestring);
-  const std::vector<std::vector<uint32_t>> subsets = subset_selector.constructSubsets({2, 3}, 5);
-  const std::vector<uint32_t> expected_subset_one = {0, 4};
-  const std::vector<uint32_t> expected_subset_two = {2, 3, 1};
+  const std::vector<std::vector<uint32_t>> subsets =
+      subset_selector.constructSubsets({2, 2}, 10000000);
+  const std::vector<uint32_t> expected_subset_one = {1000000, 1500000};
+  const std::vector<uint32_t> expected_subset_two = {2000000, 2500000};
   EXPECT_THAT(subsets[0], ContainerEq(expected_subset_one));
   EXPECT_THAT(subsets[1], ContainerEq(expected_subset_two));
 }


### PR DESCRIPTION
Commit Message: Scaled Load Balancer Fuzz to 60k hosts.
Additional Description: In order to truly represent the production search space for Load Balancing in regards to upstream hosts, the Load Balancer fuzzer requires at least 10k upstream hosts. This PR scales it up to 60k hosts. It fixes the bottleneck of constructing thousands of hosts each run by statically declaring the host vector. Also, this PR scales my random subset selector to 32 bits in order to randomly represent this search space, as before it was 8 bits and could only represent 256 hosts.
Risk Level: Low
Testing: Regression tests for 60k hosts.