### PR TITLE
jwt_authn: Support per-route config

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -388,8 +388,18 @@ message RequirementRule {
   //
   config.route.v3.RouteMatch match = 1 [(validate.rules).message = {required: true}];
 
-  // Specify a Jwt Requirement. Please detail comment in message JwtRequirement.
-  JwtRequirement requires = 2;
+  // Specify a Jwt requirement.
+  // If not specified, Jwt verification is disabled.
+  oneof requirement_type {
+    // Specify a Jwt requirement. Please see detail comment in message JwtRequirement.
+    JwtRequirement requires = 2;
+
+    // Use requirement_name to specify a Jwt requirement.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`.
+    string requirement_name = 3 [(validate.rules).string = {min_len: 1}];
+  }
 }
 
 // This message specifies Jwt requirements based on stream_info.filterState.
@@ -541,13 +551,13 @@ message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt Authentication for this route.
-    bool bypass = 1;
+    // Disable Jwt Authentication for this route.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
 
     // Use requirement_name to specify a JwtRequirement.
     // This requirement_name MUST be specified at the
     // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
     // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
-    string requirement_name = 2;
+    string requirement_name = 2 [(validate.rules).string = {min_len: 1}];
   }
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -529,3 +529,18 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 }
+
+// Specify per-route config.
+// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
+message PerRouteConfig {
+  oneof requirement_specifier {
+    option (validate.required) = true;
+
+    // Bypass Jwt authentication.
+    bool bypass = 1;
+
+    // Specify a Jwt Requirement.
+    // Its providers must be specified in the `providers` field in JwtAuthentication.
+    JwtRequirement requires = 2;
+  }
+}

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -530,26 +530,24 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 
-  // A map of unique requirement_names as string to JwtRequirements.
-  // With this map, each JwtRequirement can be indexed by a string requirement_name.
-  // PerRouteConfig, or other places in the future, could use a requirement_name
-  // to specify a JwtRequirement.
+  // A map of unique requirement_names to JwtRequirements.
+  // :ref:`requirement_name <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig.requirement_name>`
+  // in `PerRouteConfig` uses this map to specify a JwtRequirement.
   map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
-// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
 message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt authentication.
+    // Bypass Jwt Authentication for this route.
     bool bypass = 1;
 
     // Use requirement_name to specify a JwtRequirement.
-    // This requirement_name MUST be specified at the `requirement_map` in the
-    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
-    // will be rejected with 401.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
     string requirement_name = 2;
   }
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -462,6 +462,7 @@ message FilterStateRule {
 //              - provider_name: provider1
 //              - provider_name: provider2
 //
+// [#next-free-field: 6]
 message JwtAuthentication {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication";
@@ -528,6 +529,12 @@ message JwtAuthentication {
   // <http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ regardless of JWT
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
+
+  // A map of unique requirement_names as string to JwtRequirements.
+  // With this map, each JwtRequirement can be indexed by a string requirement_name.
+  // PerRouteConfig, or other places in the future, could use a requirement_name
+  // to specify a JwtRequirement.
+  map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
@@ -539,8 +546,10 @@ message PerRouteConfig {
     // Bypass Jwt authentication.
     bool bypass = 1;
 
-    // Specify a Jwt Requirement.
-    // Its providers must be specified in the `providers` field in JwtAuthentication.
-    JwtRequirement requires = 2;
+    // Use requirement_name to specify a JwtRequirement.
+    // This requirement_name MUST be specified at the `requirement_map` in the
+    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
+    // will be rejected with 401.
+    string requirement_name = 2;
   }
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -530,15 +530,13 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 
-  // A map of unique requirement_names as string to JwtRequirements.
-  // With this map, each JwtRequirement can be indexed by a string requirement_name.
-  // PerRouteConfig, or other places in the future, could use a requirement_name
-  // to specify a JwtRequirement.
+  // A map of unique requirement_names to JwtRequirements.
+  // :ref:`requirement_name <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig.requirement_name>`
+  // in `PerRouteConfig` uses this map to specify a JwtRequirement.
   map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
-// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
 message PerRouteConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig";
@@ -546,13 +544,13 @@ message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt authentication.
+    // Bypass Jwt Authentication for this route.
     bool bypass = 1;
 
     // Use requirement_name to specify a JwtRequirement.
-    // This requirement_name MUST be specified at the `requirement_map` in the
-    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
-    // will be rejected with 401.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
     string requirement_name = 2;
   }
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -462,6 +462,7 @@ message FilterStateRule {
 //              - provider_name: provider1
 //              - provider_name: provider2
 //
+// [#next-free-field: 6]
 message JwtAuthentication {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication";
@@ -528,6 +529,12 @@ message JwtAuthentication {
   // <http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ regardless of JWT
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
+
+  // A map of unique requirement_names as string to JwtRequirements.
+  // With this map, each JwtRequirement can be indexed by a string requirement_name.
+  // PerRouteConfig, or other places in the future, could use a requirement_name
+  // to specify a JwtRequirement.
+  map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
@@ -542,8 +549,10 @@ message PerRouteConfig {
     // Bypass Jwt authentication.
     bool bypass = 1;
 
-    // Specify a Jwt Requirement.
-    // Its providers must be specified in the `providers` field in JwtAuthentication.
-    JwtRequirement requires = 2;
+    // Use requirement_name to specify a JwtRequirement.
+    // This requirement_name MUST be specified at the `requirement_map` in the
+    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
+    // will be rejected with 401.
+    string requirement_name = 2;
   }
 }

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -529,3 +529,21 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 }
+
+// Specify per-route config.
+// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
+message PerRouteConfig {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig";
+
+  oneof requirement_specifier {
+    option (validate.required) = true;
+
+    // Bypass Jwt authentication.
+    bool bypass = 1;
+
+    // Specify a Jwt Requirement.
+    // Its providers must be specified in the `providers` field in JwtAuthentication.
+    JwtRequirement requires = 2;
+  }
+}

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -388,8 +388,18 @@ message RequirementRule {
   //
   config.route.v4alpha.RouteMatch match = 1 [(validate.rules).message = {required: true}];
 
-  // Specify a Jwt Requirement. Please detail comment in message JwtRequirement.
-  JwtRequirement requires = 2;
+  // Specify a Jwt requirement.
+  // If not specified, Jwt verification is disabled.
+  oneof requirement_type {
+    // Specify a Jwt requirement. Please see detail comment in message JwtRequirement.
+    JwtRequirement requires = 2;
+
+    // Use requirement_name to specify a Jwt requirement.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`.
+    string requirement_name = 3 [(validate.rules).string = {min_len: 1}];
+  }
 }
 
 // This message specifies Jwt requirements based on stream_info.filterState.
@@ -544,13 +554,13 @@ message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt Authentication for this route.
-    bool bypass = 1;
+    // Disable Jwt Authentication for this route.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
 
     // Use requirement_name to specify a JwtRequirement.
     // This requirement_name MUST be specified at the
     // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
     // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
-    string requirement_name = 2;
+    string requirement_name = 2 [(validate.rules).string = {min_len: 1}];
   }
 }

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -36,6 +36,7 @@ New Features
 * hds: added support for delta updates in the :ref:`HealthCheckSpecifier <envoy_v3_api_msg_service.health.v3.HealthCheckSpecifier>`, making only the Endpoints and Health Checkers that changed be reconstructed on receiving a new message, rather than the entire HDS.
 * health_check: added option to use :ref:`no_traffic_healthy_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_healthy_interval>` which allows a different no traffic interval when the host is healthy.
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
+* jwt_authn: added support for :ref:`per-route config` <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * lua: added `downstreamDirectRemoteAddress()` and `downstreamLocalAddress()` APIs to :ref:`streamInfo() <config_http_filters_lua_stream_info_wrapper>`.
 * mongo_proxy: the list of commands to produce metrics for is now :ref:`configurable <envoy_v3_api_field_extensions.filters.network.mongo_proxy.v3.MongoProxy.commands>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -36,7 +36,7 @@ New Features
 * hds: added support for delta updates in the :ref:`HealthCheckSpecifier <envoy_v3_api_msg_service.health.v3.HealthCheckSpecifier>`, making only the Endpoints and Health Checkers that changed be reconstructed on receiving a new message, rather than the entire HDS.
 * health_check: added option to use :ref:`no_traffic_healthy_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_healthy_interval>` which allows a different no traffic interval when the host is healthy.
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
-* jwt_authn: added support for :ref:`per-route config <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
+* jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * lua: added `downstreamDirectRemoteAddress()` and `downstreamLocalAddress()` APIs to :ref:`streamInfo() <config_http_filters_lua_stream_info_wrapper>`.
 * mongo_proxy: the list of commands to produce metrics for is now :ref:`configurable <envoy_v3_api_field_extensions.filters.network.mongo_proxy.v3.MongoProxy.commands>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -36,7 +36,7 @@ New Features
 * hds: added support for delta updates in the :ref:`HealthCheckSpecifier <envoy_v3_api_msg_service.health.v3.HealthCheckSpecifier>`, making only the Endpoints and Health Checkers that changed be reconstructed on receiving a new message, rather than the entire HDS.
 * health_check: added option to use :ref:`no_traffic_healthy_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_healthy_interval>` which allows a different no traffic interval when the host is healthy.
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
-* jwt_authn: added support for :ref:`per-route config` <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
+* jwt_authn: added support for :ref:`per-route config <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * lua: added `downstreamDirectRemoteAddress()` and `downstreamLocalAddress()` APIs to :ref:`streamInfo() <config_http_filters_lua_stream_info_wrapper>`.
 * mongo_proxy: the list of commands to produce metrics for is now :ref:`configurable <envoy_v3_api_field_extensions.filters.network.mongo_proxy.v3.MongoProxy.commands>`.

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -388,8 +388,18 @@ message RequirementRule {
   //
   config.route.v3.RouteMatch match = 1 [(validate.rules).message = {required: true}];
 
-  // Specify a Jwt Requirement. Please detail comment in message JwtRequirement.
-  JwtRequirement requires = 2;
+  // Specify a Jwt requirement.
+  // If not specified, Jwt verification is disabled.
+  oneof requirement_type {
+    // Specify a Jwt requirement. Please see detail comment in message JwtRequirement.
+    JwtRequirement requires = 2;
+
+    // Use requirement_name to specify a Jwt requirement.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`.
+    string requirement_name = 3 [(validate.rules).string = {min_len: 1}];
+  }
 }
 
 // This message specifies Jwt requirements based on stream_info.filterState.
@@ -541,13 +551,13 @@ message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt Authentication for this route.
-    bool bypass = 1;
+    // Disable Jwt Authentication for this route.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
 
     // Use requirement_name to specify a JwtRequirement.
     // This requirement_name MUST be specified at the
     // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
     // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
-    string requirement_name = 2;
+    string requirement_name = 2 [(validate.rules).string = {min_len: 1}];
   }
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -529,3 +529,18 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 }
+
+// Specify per-route config.
+// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
+message PerRouteConfig {
+  oneof requirement_specifier {
+    option (validate.required) = true;
+
+    // Bypass Jwt authentication.
+    bool bypass = 1;
+
+    // Specify a Jwt Requirement.
+    // Its providers must be specified in the `providers` field in JwtAuthentication.
+    JwtRequirement requires = 2;
+  }
+}

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -530,26 +530,24 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 
-  // A map of unique requirement_names as string to JwtRequirements.
-  // With this map, each JwtRequirement can be indexed by a string requirement_name.
-  // PerRouteConfig, or other places in the future, could use a requirement_name
-  // to specify a JwtRequirement.
+  // A map of unique requirement_names to JwtRequirements.
+  // :ref:`requirement_name <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig.requirement_name>`
+  // in `PerRouteConfig` uses this map to specify a JwtRequirement.
   map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
-// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
 message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt authentication.
+    // Bypass Jwt Authentication for this route.
     bool bypass = 1;
 
     // Use requirement_name to specify a JwtRequirement.
-    // This requirement_name MUST be specified at the `requirement_map` in the
-    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
-    // will be rejected with 401.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
     string requirement_name = 2;
   }
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -462,6 +462,7 @@ message FilterStateRule {
 //              - provider_name: provider1
 //              - provider_name: provider2
 //
+// [#next-free-field: 6]
 message JwtAuthentication {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication";
@@ -528,6 +529,12 @@ message JwtAuthentication {
   // <http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ regardless of JWT
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
+
+  // A map of unique requirement_names as string to JwtRequirements.
+  // With this map, each JwtRequirement can be indexed by a string requirement_name.
+  // PerRouteConfig, or other places in the future, could use a requirement_name
+  // to specify a JwtRequirement.
+  map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
@@ -539,8 +546,10 @@ message PerRouteConfig {
     // Bypass Jwt authentication.
     bool bypass = 1;
 
-    // Specify a Jwt Requirement.
-    // Its providers must be specified in the `providers` field in JwtAuthentication.
-    JwtRequirement requires = 2;
+    // Use requirement_name to specify a JwtRequirement.
+    // This requirement_name MUST be specified at the `requirement_map` in the
+    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
+    // will be rejected with 401.
+    string requirement_name = 2;
   }
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -530,15 +530,13 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 
-  // A map of unique requirement_names as string to JwtRequirements.
-  // With this map, each JwtRequirement can be indexed by a string requirement_name.
-  // PerRouteConfig, or other places in the future, could use a requirement_name
-  // to specify a JwtRequirement.
+  // A map of unique requirement_names to JwtRequirements.
+  // :ref:`requirement_name <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.PerRouteConfig.requirement_name>`
+  // in `PerRouteConfig` uses this map to specify a JwtRequirement.
   map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
-// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
 message PerRouteConfig {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig";
@@ -546,13 +544,13 @@ message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt authentication.
+    // Bypass Jwt Authentication for this route.
     bool bypass = 1;
 
     // Use requirement_name to specify a JwtRequirement.
-    // This requirement_name MUST be specified at the `requirement_map` in the
-    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
-    // will be rejected with 401.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
     string requirement_name = 2;
   }
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -462,6 +462,7 @@ message FilterStateRule {
 //              - provider_name: provider1
 //              - provider_name: provider2
 //
+// [#next-free-field: 6]
 message JwtAuthentication {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication";
@@ -528,6 +529,12 @@ message JwtAuthentication {
   // <http://www.w3.org/TR/cors/#cross-origin-request-with-preflight>`_ regardless of JWT
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
+
+  // A map of unique requirement_names as string to JwtRequirements.
+  // With this map, each JwtRequirement can be indexed by a string requirement_name.
+  // PerRouteConfig, or other places in the future, could use a requirement_name
+  // to specify a JwtRequirement.
+  map<string, JwtRequirement> requirement_map = 5;
 }
 
 // Specify per-route config.
@@ -542,8 +549,10 @@ message PerRouteConfig {
     // Bypass Jwt authentication.
     bool bypass = 1;
 
-    // Specify a Jwt Requirement.
-    // Its providers must be specified in the `providers` field in JwtAuthentication.
-    JwtRequirement requires = 2;
+    // Use requirement_name to specify a JwtRequirement.
+    // This requirement_name MUST be specified at the `requirement_map` in the
+    // `JwtAuthentication`. If no, or there is a typo, the requests using this route
+    // will be rejected with 401.
+    string requirement_name = 2;
   }
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -529,3 +529,21 @@ message JwtAuthentication {
   // requirements specified in the rules.
   bool bypass_cors_preflight = 4;
 }
+
+// Specify per-route config.
+// If a route doesn't specify a per-route config, the JwtAuthentication will be used.
+message PerRouteConfig {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig";
+
+  oneof requirement_specifier {
+    option (validate.required) = true;
+
+    // Bypass Jwt authentication.
+    bool bypass = 1;
+
+    // Specify a Jwt Requirement.
+    // Its providers must be specified in the `providers` field in JwtAuthentication.
+    JwtRequirement requires = 2;
+  }
+}

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -388,8 +388,18 @@ message RequirementRule {
   //
   config.route.v4alpha.RouteMatch match = 1 [(validate.rules).message = {required: true}];
 
-  // Specify a Jwt Requirement. Please detail comment in message JwtRequirement.
-  JwtRequirement requires = 2;
+  // Specify a Jwt requirement.
+  // If not specified, Jwt verification is disabled.
+  oneof requirement_type {
+    // Specify a Jwt requirement. Please see detail comment in message JwtRequirement.
+    JwtRequirement requires = 2;
+
+    // Use requirement_name to specify a Jwt requirement.
+    // This requirement_name MUST be specified at the
+    // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
+    // in `JwtAuthentication`.
+    string requirement_name = 3 [(validate.rules).string = {min_len: 1}];
+  }
 }
 
 // This message specifies Jwt requirements based on stream_info.filterState.
@@ -544,13 +554,13 @@ message PerRouteConfig {
   oneof requirement_specifier {
     option (validate.required) = true;
 
-    // Bypass Jwt Authentication for this route.
-    bool bypass = 1;
+    // Disable Jwt Authentication for this route.
+    bool disabled = 1 [(validate.rules).bool = {const: true}];
 
     // Use requirement_name to specify a JwtRequirement.
     // This requirement_name MUST be specified at the
     // :ref:`requirement_map <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.requirement_map>`
     // in `JwtAuthentication`. If no, the requests using this route will be rejected with 403.
-    string requirement_name = 2;
+    string requirement_name = 2 [(validate.rules).string = {min_len: 1}];
   }
 }

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -70,17 +70,15 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
       if (!error_msg.empty()) {
         stats_.denied_.inc();
         state_ = Responded;
-        decoder_callbacks_->sendLocalReply(Http::Code::Forbidden,
-                                           absl::StrCat("Failed JWT authentication: ", error_msg),
-                                           nullptr, absl::nullopt,
-                                           absl::StrCat(kRcDetailJwtAuthnPrefix, "{", error_msg, "}"));
+        decoder_callbacks_->sendLocalReply(
+            Http::Code::Forbidden, absl::StrCat("Failed JWT authentication: ", error_msg), nullptr,
+            absl::nullopt, absl::StrCat(kRcDetailJwtAuthnPrefix, "{", error_msg, "}"));
         return Http::FilterHeadersStatus::StopIteration;
       }
     }
   }
   if (!use_per_route) {
-    verifier =
-        config_->findVerifier(headers, *decoder_callbacks_->streamInfo().filterState());
+    verifier = config_->findVerifier(headers, *decoder_callbacks_->streamInfo().filterState());
   }
 
   if (verifier == nullptr) {

--- a/source/extensions/filters/http/jwt_authn/filter.cc
+++ b/source/extensions/filters/http/jwt_authn/filter.cc
@@ -35,7 +35,7 @@ std::string generateRcDetails(absl::string_view error_msg) {
   // Replace space with underscore since RCDetails may be written to access log.
   // Some log processors assume each log segment is separated by whitespace.
   return absl::StrCat(kRcDetailJwtAuthnPrefix, "{",
-                      absl::StrJoin(absl::StrSplit(error_msg, " "), "_"), "}");
+                      absl::StrJoin(absl::StrSplit(error_msg, ' '), "_"), "}");
 }
 
 } // namespace

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -33,12 +33,13 @@ void FilterConfigImpl::init() {
   }
 
   for (const auto& it : proto_config_.requirement_map()) {
-    name_verifiers_.emplace(
-        it.first, Verifier::create(it.second, proto_config_.providers(), *this));
+    name_verifiers_.emplace(it.first,
+                            Verifier::create(it.second, proto_config_.providers(), *this));
   }
 }
 
-std::pair<const Verifier*, std::string> FilterConfigImpl::findPerRouteVerifier(const PerRouteFilterConfig& per_route) const {
+std::pair<const Verifier*, std::string>
+FilterConfigImpl::findPerRouteVerifier(const PerRouteFilterConfig& per_route) const {
   if (per_route.config().bypass()) {
     return std::make_pair(nullptr, EMPTY_STRING);
   }
@@ -48,7 +49,8 @@ std::pair<const Verifier*, std::string> FilterConfigImpl::findPerRouteVerifier(c
     return std::make_pair(it->second.get(), EMPTY_STRING);
   }
 
-  return std::make_pair(nullptr, absl::StrCat("Wrong requirement_name: ", per_route.config().requirement_name()));
+  return std::make_pair(
+      nullptr, absl::StrCat("Wrong requirement_name: ", per_route.config().requirement_name()));
 }
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -4,6 +4,8 @@
 
 #include "common/common/empty_string.h"
 
+using envoy::extensions::filters::http::jwt_authn::v3::RequirementRule;
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -21,19 +23,6 @@ void FilterConfigImpl::init() {
                                               shared_this->api_);
   });
 
-  for (const auto& rule : proto_config_.rules()) {
-    rule_pairs_.emplace_back(Matcher::create(rule),
-                             Verifier::create(rule.requires(), proto_config_.providers(), *this));
-  }
-
-  if (proto_config_.has_filter_state_rules()) {
-    filter_state_name_ = proto_config_.filter_state_rules().name();
-    for (const auto& it : proto_config_.filter_state_rules().requires()) {
-      filter_state_verifiers_.emplace(
-          it.first, Verifier::create(it.second, proto_config_.providers(), *this));
-    }
-  }
-
   std::vector<std::string> names;
   for (const auto& it : proto_config_.requirement_map()) {
     names.push_back(it.first);
@@ -43,11 +32,43 @@ void FilterConfigImpl::init() {
   // sort is just for unit-test since protobuf map order is not deterministic.
   std::sort(names.begin(), names.end());
   all_requirement_names_ = absl::StrJoin(names, ",");
+
+  for (const auto& rule : proto_config_.rules()) {
+    switch (rule.requirement_type_case()) {
+    case RequirementRule::RequirementTypeCase::kRequires:
+      rule_pairs_.emplace_back(Matcher::create(rule),
+                               Verifier::create(rule.requires(), proto_config_.providers(), *this));
+      break;
+    case RequirementRule::RequirementTypeCase::kRequirementName: {
+      // Use requirement_name to lookup requirment_map.
+      auto map_it = proto_config_.requirement_map().find(rule.requirement_name());
+      if (map_it == proto_config_.requirement_map().end()) {
+        throw EnvoyException(fmt::format("Wrong requirement_name: {}. It should be one of [{}]",
+                                         rule.requirement_name(), all_requirement_names_));
+      }
+      rule_pairs_.emplace_back(Matcher::create(rule),
+                               Verifier::create(map_it->second, proto_config_.providers(), *this));
+    } break;
+    case RequirementRule::RequirementTypeCase::REQUIREMENT_TYPE_NOT_SET:
+      rule_pairs_.emplace_back(Matcher::create(rule), nullptr);
+      break;
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+    }
+  }
+
+  if (proto_config_.has_filter_state_rules()) {
+    filter_state_name_ = proto_config_.filter_state_rules().name();
+    for (const auto& it : proto_config_.filter_state_rules().requires()) {
+      filter_state_verifiers_.emplace(
+          it.first, Verifier::create(it.second, proto_config_.providers(), *this));
+    }
+  }
 }
 
 std::pair<const Verifier*, std::string>
 FilterConfigImpl::findPerRouteVerifier(const PerRouteFilterConfig& per_route) const {
-  if (per_route.config().bypass()) {
+  if (per_route.config().disabled()) {
     return std::make_pair(nullptr, EMPTY_STRING);
   }
 

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -31,6 +31,21 @@ void FilterConfigImpl::init() {
   }
 }
 
+const Verifier* FilterConfigImpl::findPerRouteVerifier(const PerRouteFilterConfig& per_route){
+  if (per_route.config().bypass()) {
+    return nullptr;
+  }
+
+  auto& cache = getCache();
+  const Verifier* verifier = cache.getHashVerifier(per_route.hash());
+  if (verifier == nullptr) {
+    auto new_verifier = Verifier::create(per_route.config().requires(), proto_config_.providers(), *this);
+    verifier = new_verifier.get();
+    cache.setHashVerifier(per_route.hash(), std::move(new_verifier));
+  }
+  return verifier;
+}
+
 } // namespace JwtAuthn
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -8,8 +8,8 @@ namespace HttpFilters {
 namespace JwtAuthn {
 namespace {
 
-// The maximum size for this variable.
-constexpr size_t TopRequirementNameForDebugSize = 100;
+// The maximum number of characters for storing requirement_names for debug.
+constexpr size_t TopRequirementNameForDebugMaxChars = 100;
 
 } // namespace
 
@@ -39,7 +39,7 @@ void FilterConfigImpl::init() {
   }
 
   for (const auto& it : proto_config_.requirement_map()) {
-    if (top_requirement_names_for_debug_.size() < TopRequirementNameForDebugSize) {
+    if (top_requirement_names_for_debug_.size() < TopRequirementNameForDebugMaxChars) {
       if (top_requirement_names_for_debug_.empty()) {
         top_requirement_names_for_debug_ = it.first;
       } else {

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -40,7 +40,7 @@ void FilterConfigImpl::init() {
                                Verifier::create(rule.requires(), proto_config_.providers(), *this));
       break;
     case RequirementRule::RequirementTypeCase::kRequirementName: {
-      // Use requirement_name to lookup requirment_map.
+      // Use requirement_name to lookup requirement_map.
       auto map_it = proto_config_.requirement_map().find(rule.requirement_name());
       if (map_it == proto_config_.requirement_map().end()) {
         throw EnvoyException(fmt::format("Wrong requirement_name: {}. It should be one of [{}]",

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -194,6 +194,8 @@ private:
   absl::flat_hash_map<std::string, VerifierConstPtr> filter_state_verifiers_;
   // The requirement_name to verifier map.
   absl::flat_hash_map<std::string, VerifierConstPtr> name_verifiers_;
+  // top requirement_names for debug
+  std::string top_requirement_names_for_debug_;
   TimeSource& time_source_;
   Api::Api& api_;
 };

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -58,14 +58,16 @@ struct JwtAuthnFilterStats {
  * The per-route filter config
  */
 class PerRouteFilterConfig : public Envoy::Router::RouteSpecificFilterConfig {
- public:
-  PerRouteFilterConfig(const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& config)
+public:
+  PerRouteFilterConfig(
+      const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& config)
       : config_(config) {}
 
   const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& config() const {
-    return config_; }
+    return config_;
+  }
 
- private:
+private:
   const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig config_;
 };
 
@@ -85,7 +87,8 @@ public:
                                        const StreamInfo::FilterState& filter_state) const PURE;
 
   // Finds the verifier based on per-route config. If fail, pair.second has the error message.
-  virtual std::pair<const Verifier*, std::string> findPerRouteVerifier(const PerRouteFilterConfig& per_route) const PURE;
+  virtual std::pair<const Verifier*, std::string>
+  findPerRouteVerifier(const PerRouteFilterConfig& per_route) const PURE;
 };
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
@@ -141,7 +144,8 @@ public:
     return nullptr;
   }
 
-  std::pair<const Verifier*, std::string> findPerRouteVerifier(const PerRouteFilterConfig& per_route) const override;
+  std::pair<const Verifier*, std::string>
+  findPerRouteVerifier(const PerRouteFilterConfig& per_route) const override;
 
   // methods for AuthFactory interface. Factory method to help create authenticators.
   AuthenticatorPtr create(const ::google::jwt_verify::CheckAudience* check_audience,

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -194,8 +194,8 @@ private:
   absl::flat_hash_map<std::string, VerifierConstPtr> filter_state_verifiers_;
   // The requirement_name to verifier map.
   absl::flat_hash_map<std::string, VerifierConstPtr> name_verifiers_;
-  // top requirement_names for debug
-  std::string top_requirement_names_for_debug_;
+  // all requirement_names for debug
+  std::string all_requirement_names_;
   TimeSource& time_source_;
   Api::Api& api_;
 };

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -53,10 +53,9 @@ FilterFactory::createFilterFactoryFromProtoTyped(const JwtAuthentication& proto_
 
 Envoy::Router::RouteSpecificFilterConfigConstSharedPtr
 FilterFactory::createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig&
-    per_route,
+    const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& per_route,
     Envoy::Server::Configuration::ServerFactoryContext&,
-    Envoy::ProtobufMessage::ValidationVisitor&){
+    Envoy::ProtobufMessage::ValidationVisitor&) {
   return std::make_shared<PerRouteFilterConfig>(per_route);
 }
 

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -51,6 +51,15 @@ FilterFactory::createFilterFactoryFromProtoTyped(const JwtAuthentication& proto_
   };
 }
 
+Envoy::Router::RouteSpecificFilterConfigConstSharedPtr
+FilterFactory::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig&
+    per_route,
+    Envoy::Server::Configuration::ServerFactoryContext&,
+    Envoy::ProtobufMessage::ValidationVisitor&){
+  return std::make_shared<PerRouteFilterConfig>(per_route);
+}
+
 /**
  * Static registration for this jwt_authn filter. @see RegisterFactory.
  */

--- a/source/extensions/filters/http/jwt_authn/filter_factory.h
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.h
@@ -15,9 +15,9 @@ namespace JwtAuthn {
 /**
  * Config registration for jwt_authn filter.
  */
-class FilterFactory : public Common::FactoryBase<
-    envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication,
-    envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig> {
+class FilterFactory
+    : public Common::FactoryBase<envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication,
+                                 envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig> {
 public:
   FilterFactory() : FactoryBase(HttpFilterNames::get().JwtAuthn) {}
 
@@ -26,10 +26,8 @@ private:
       const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Envoy::Router::RouteSpecificFilterConfigConstSharedPtr
-  createRouteSpecificFilterConfigTyped(
-      const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig&
-          per_route,
+  Envoy::Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig& per_route,
       Envoy::Server::Configuration::ServerFactoryContext&,
       Envoy::ProtobufMessage::ValidationVisitor&) override;
 };

--- a/source/extensions/filters/http/jwt_authn/filter_factory.h
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.h
@@ -16,7 +16,8 @@ namespace JwtAuthn {
  * Config registration for jwt_authn filter.
  */
 class FilterFactory : public Common::FactoryBase<
-                          envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication> {
+    envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication,
+    envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig> {
 public:
   FilterFactory() : FactoryBase(HttpFilterNames::get().JwtAuthn) {}
 
@@ -24,6 +25,13 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  Envoy::Router::RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfigTyped(
+      const envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig&
+          per_route,
+      Envoy::Server::Configuration::ServerFactoryContext&,
+      Envoy::ProtobufMessage::ValidationVisitor&) override;
 };
 
 } // namespace JwtAuthn

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -214,15 +214,14 @@ requirement_map:
   std::tie(verifier, error_msg) =
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
-  EXPECT_TRUE(
-      absl::StartsWith(error_msg, "Wrong requirement_name: wrong-name. Correct names are: "));
+  EXPECT_EQ(error_msg, "Wrong requirement_name: wrong-name. It should be one of [r1,r2]");
 
   // Empty requirement_name
   per_route.Clear();
   std::tie(verifier, error_msg) =
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
-  EXPECT_TRUE(absl::StartsWith(error_msg, "Wrong requirement_name: . Correct names are: "));
+  EXPECT_EQ(error_msg, "Wrong requirement_name: . It should be one of [r1,r2]");
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -215,13 +215,6 @@ requirement_map:
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
   EXPECT_EQ(error_msg, "Wrong requirement_name: wrong-name. It should be one of [r1,r2]");
-
-  // Empty requirement_name
-  per_route.Clear();
-  std::tie(verifier, error_msg) =
-      filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
-  EXPECT_EQ(verifier, nullptr);
-  EXPECT_EQ(error_msg, "Wrong requirement_name: . It should be one of [r1,r2]");
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -214,14 +214,15 @@ requirement_map:
   std::tie(verifier, error_msg) =
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
-  EXPECT_EQ(error_msg, "Wrong requirement_name: wrong-name. Correct names are: r1,r2");
+  EXPECT_TRUE(
+      absl::StartsWith(error_msg, "Wrong requirement_name: wrong-name. Correct names are: "));
 
   // Empty requirement_name
   per_route.Clear();
   std::tie(verifier, error_msg) =
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
-  EXPECT_EQ(error_msg, "Wrong requirement_name: . Correct names are: r1,r2");
+  EXPECT_TRUE(absl::StartsWith(error_msg, "Wrong requirement_name: . Correct names are: "));
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -214,14 +214,14 @@ requirement_map:
   std::tie(verifier, error_msg) =
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
-  EXPECT_EQ(error_msg, "Wrong requirement_name: wrong-name");
+  EXPECT_EQ(error_msg, "Wrong requirement_name: wrong-name. Correct names are: r1,r2");
 
   // Empty requirement_name
   per_route.Clear();
   std::tie(verifier, error_msg) =
       filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
-  EXPECT_EQ(error_msg, "Wrong requirement_name: ");
+  EXPECT_EQ(error_msg, "Wrong requirement_name: . Correct names are: r1,r2");
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -190,31 +190,36 @@ requirement_map:
 
   per_route.Clear();
   per_route.set_bypass(true);
-  std::tie(verifier, error_msg) = filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
+  std::tie(verifier, error_msg) =
+      filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
   EXPECT_EQ(error_msg, EMPTY_STRING);
 
   per_route.Clear();
   per_route.set_requirement_name("r1");
-  std::tie(verifier, error_msg) = filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
+  std::tie(verifier, error_msg) =
+      filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_NE(verifier, nullptr);
   EXPECT_EQ(error_msg, EMPTY_STRING);
 
   per_route.Clear();
   per_route.set_requirement_name("r2");
-  std::tie(verifier, error_msg) = filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
+  std::tie(verifier, error_msg) =
+      filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_NE(verifier, nullptr);
   EXPECT_EQ(error_msg, EMPTY_STRING);
 
   per_route.Clear();
   per_route.set_requirement_name("wrong-name");
-  std::tie(verifier, error_msg) = filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
+  std::tie(verifier, error_msg) =
+      filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
   EXPECT_EQ(error_msg, "Wrong requirement_name: wrong-name");
 
   // Empty requirement_name
   per_route.Clear();
-  std::tie(verifier, error_msg) = filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
+  std::tie(verifier, error_msg) =
+      filter_conf->findPerRouteVerifier(PerRouteFilterConfig(per_route));
   EXPECT_EQ(verifier, nullptr);
   EXPECT_EQ(error_msg, "Wrong requirement_name: ");
 }

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -63,8 +63,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, EmptyPerRouteConfig) {
   PerRouteConfig per_route;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route,
-                                                       context,
+  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
                                                        context.messageValidationVisitor()),
                EnvoyException);
 }
@@ -73,8 +72,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, WrongPerRouteConfigType) {
   JwtAuthentication per_route;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route,
-                                                       context,
+  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route, context,
                                                        context.messageValidationVisitor()),
                std::bad_cast);
 }
@@ -85,9 +83,8 @@ TEST(HttpJwtAuthnFilterFactoryTest, BypassPerRouteConfig) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route,
-                                                     context,
-                                                     context.messageValidationVisitor());
+  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route, context,
+                                                          context.messageValidationVisitor());
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);
@@ -100,9 +97,8 @@ TEST(HttpJwtAuthnFilterFactoryTest, GoodPerRouteConfig) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
-  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route,
-                                                     context,
-                                                     context.messageValidationVisitor());
+  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route, context,
+                                                          context.messageValidationVisitor());
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -77,9 +77,9 @@ TEST(HttpJwtAuthnFilterFactoryTest, WrongPerRouteConfigType) {
                std::bad_cast);
 }
 
-TEST(HttpJwtAuthnFilterFactoryTest, BypassPerRouteConfig) {
+TEST(HttpJwtAuthnFilterFactoryTest, DisabledPerRouteConfig) {
   PerRouteConfig per_route;
-  per_route.set_bypass(true);
+  per_route.set_disabled(true);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactory factory;
@@ -88,7 +88,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, BypassPerRouteConfig) {
   EXPECT_NE(base_ptr, nullptr);
   const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
   EXPECT_NE(typed_ptr, nullptr);
-  EXPECT_TRUE(typed_ptr->config().bypass());
+  EXPECT_TRUE(typed_ptr->config().disabled());
 }
 
 TEST(HttpJwtAuthnFilterFactoryTest, GoodPerRouteConfig) {

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/extensions/filters/http/jwt_authn/v3/config.pb.h"
 #include "envoy/extensions/filters/http/jwt_authn/v3/config.pb.validate.h"
 
+#include "extensions/filters/http/jwt_authn/filter_config.h"
 #include "extensions/filters/http/jwt_authn/filter_factory.h"
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
@@ -10,6 +11,7 @@
 #include "gtest/gtest.h"
 
 using envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication;
+using envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig;
 using testing::_;
 
 namespace Envoy {
@@ -56,6 +58,57 @@ TEST(HttpJwtAuthnFilterFactoryTest, BadLocalJwks) {
   EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context),
                EnvoyException);
 }
+
+TEST(HttpJwtAuthnFilterFactoryTest, EmptyPerRouteConfig) {
+  PerRouteConfig per_route;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  FilterFactory factory;
+  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route,
+                                                       context,
+                                                       context.messageValidationVisitor()),
+               EnvoyException);
+}
+
+TEST(HttpJwtAuthnFilterFactoryTest, WrongPerRouteConfigType) {
+  JwtAuthentication per_route;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  FilterFactory factory;
+  EXPECT_THROW(factory.createRouteSpecificFilterConfig(per_route,
+                                                       context,
+                                                       context.messageValidationVisitor()),
+               std::bad_cast);
+}
+
+TEST(HttpJwtAuthnFilterFactoryTest, BypassPerRouteConfig) {
+  PerRouteConfig per_route;
+  per_route.set_bypass(true);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  FilterFactory factory;
+  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route,
+                                                     context,
+                                                     context.messageValidationVisitor());
+  EXPECT_NE(base_ptr, nullptr);
+  const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
+  EXPECT_NE(typed_ptr, nullptr);
+  EXPECT_TRUE(typed_ptr->config().bypass());
+}
+
+TEST(HttpJwtAuthnFilterFactoryTest, GoodPerRouteConfig) {
+  PerRouteConfig per_route;
+  per_route.set_requirement_name("name");
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  FilterFactory factory;
+  auto base_ptr = factory.createRouteSpecificFilterConfig(per_route,
+                                                     context,
+                                                     context.messageValidationVisitor());
+  EXPECT_NE(base_ptr, nullptr);
+  const PerRouteFilterConfig* typed_ptr = dynamic_cast<const PerRouteFilterConfig*>(base_ptr.get());
+  EXPECT_NE(typed_ptr, nullptr);
+  EXPECT_EQ(typed_ptr->config().requirement_name(), "name");
+}
+
 } // namespace
 } // namespace JwtAuthn
 } // namespace HttpFilters

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -519,7 +519,7 @@ TEST_P(PerRouteIntegrationTest, PerRouteConfigWrongRequireName) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // So the request with a goot Jwt token is rejected.
+  // So the request with a good Jwt token is rejected.
   auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"},
       {":path", "/"},

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -472,11 +472,11 @@ INSTANTIATE_TEST_SUITE_P(Protocols, PerRouteIntegrationTest,
                          testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
                          HttpProtocolIntegrationTest::protocolTestParamsToString);
 
-// This test verifies per-route config bypass.
-TEST_P(PerRouteIntegrationTest, PerRouteConfigBypass) {
-  // per-route config has bypass flag.
+// This test verifies per-route config disabled.
+TEST_P(PerRouteIntegrationTest, PerRouteConfigDisabled) {
+  // per-route config has disabled flag.
   PerRouteConfig per_route;
-  per_route.set_bypass(true);
+  per_route.set_disabled(true);
   // Use a normal filter config that requires jwt_auth.
   setup(ExampleConfig, per_route);
 

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -13,6 +13,7 @@
 #include "test/test_common/registry.h"
 
 using envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication;
+using envoy::extensions::filters::http::jwt_authn::v3::PerRouteConfig;
 using envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter;
 
 namespace Envoy {
@@ -445,6 +446,141 @@ TEST_P(RemoteJwksIntegrationTest, FetchFailedMissingCluster) {
   EXPECT_EQ("401", response->headers().getStatusValue());
 
   cleanup();
+}
+
+class PerRouteIntegrationTest : public HttpProtocolIntegrationTest {
+public:
+  void setup(const std::string& filter_config, const PerRouteConfig& per_route) {
+    config_helper_.addFilter(getAuthFilterConfig(filter_config, true));
+
+    config_helper_.addConfigModifier(
+        [per_route](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
+          auto* virtual_host = hcm.mutable_route_config()->mutable_virtual_hosts(0);
+          auto& per_route_any =
+              (*virtual_host->mutable_routes(0)
+                    ->mutable_typed_per_filter_config())[HttpFilterNames::get().JwtAuthn];
+          per_route_any.PackFrom(per_route);
+        });
+
+    initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(Protocols, PerRouteIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+// This test verifies per-route config bypass.
+TEST_P(PerRouteIntegrationTest, PerRouteConfigBypass) {
+  // per-route config has bypass flag.
+  PerRouteConfig per_route;
+  per_route.set_bypass(true);
+  // Use a normal filter config that requires jwt_auth.
+  setup(ExampleConfig, per_route);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // So the request without a JWT token is OK.
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// This test verifies per-route config with wrong requirement_name
+TEST_P(PerRouteIntegrationTest, PerRouteConfigWrongRequireName) {
+  // A config with a requirement_map
+  const std::string filter_conf = R"(
+  providers:
+    example_provider:
+      issuer: https://example.com
+      audiences:
+      - example_service
+  requirement_map:
+    abc:
+      provider_name: "example_provider"
+)";
+
+  // Per-route config has a wrong requirement_name.
+  PerRouteConfig per_route;
+  per_route.set_requirement_name("wrong-requirement-name");
+  setup(filter_conf, per_route);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // So the request with a goot Jwt token is rejected.
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+      {"Authorization", "Bearer " + std::string(GoodToken)},
+  });
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("403", response->headers().getStatusValue());
+}
+
+// This test verifies per-route config with correct requirement_name
+TEST_P(PerRouteIntegrationTest, PerRouteConfigOK) {
+  // A config with a requirement_map
+  const std::string filter_conf = R"(
+  providers:
+    example_provider:
+      issuer: https://example.com
+      audiences:
+      - example_service
+  requirement_map:
+    abc:
+      provider_name: "example_provider"
+)";
+
+  // Per-route config with correct requirement_name
+  PerRouteConfig per_route;
+  per_route.set_requirement_name("abc");
+  setup(filter_conf, per_route);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // So the request with a JWT token is OK.
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+      {"Authorization", "Bearer " + std::string(GoodToken)},
+  });
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  // A request with missing token is rejected.
+  auto response1 = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+  });
+
+  response1->waitForEndStream();
+  ASSERT_TRUE(response1->complete());
+  EXPECT_EQ("401", response1->headers().getStatusValue());
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -399,7 +399,8 @@ TEST_F(FilterTest, TestPerRouteWrongRequirementName) {
   EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).Times(0);
   // If findPerRouteVerifier is called, and return error message.
   EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_))
-      .WillOnce(Return(std::make_pair(nullptr, "Wrong requirement_name: abc")));
+      .WillOnce(
+          Return(std::make_pair(nullptr, "Wrong requirement_name: abc. Correct names are: r1,r2")));
 
   auto headers = Http::TestRequestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
@@ -408,7 +409,8 @@ TEST_F(FilterTest, TestPerRouteWrongRequirementName) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Wrong requirement_name: abc}");
+  EXPECT_EQ(filter_callbacks_.details(),
+            "jwt_authn_access_denied{Wrong requirement_name: abc. Correct names are: r1,r2}");
 }
 
 // Test verifier from per-route config

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -421,7 +421,7 @@ TEST_F(FilterTest, TestPerRouteVerifierOK) {
 
   // findVerifier is not called.
   EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).Times(0);
-  // If findPerRouteVerifier is called
+  // If findPerRouteVerifier is called, and return the mock_verifier_.
   EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_))
       .WillOnce(Return(std::make_pair(mock_verifier_.get(), EMPTY_STRING)));
 

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -187,8 +187,8 @@ TEST_F(FilterTest, InlineUnauthorizedFailure) {
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
-  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Jwt is not in the form of "
-                                         "Header.Payload.Signature with two dots and 3 sections}");
+  EXPECT_EQ(filter_callbacks_.details(), "jwt_authn_access_denied{Jwt_is_not_in_the_form_of_"
+                                         "Header.Payload.Signature_with_two_dots_and_3_sections}");
 }
 
 // This test verifies Verifier::Callback is called inline with a failure(403 Forbidden) status.
@@ -210,7 +210,7 @@ TEST_F(FilterTest, InlineForbiddenFailure) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
   EXPECT_EQ(filter_callbacks_.details(),
-            "jwt_authn_access_denied{Audiences in Jwt are not allowed}");
+            "jwt_authn_access_denied{Audiences_in_Jwt_are_not_allowed}");
 }
 
 // This test verifies Verifier::Callback is called with OK status after verify().
@@ -410,7 +410,7 @@ TEST_F(FilterTest, TestPerRouteWrongRequirementName) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(trailers_));
   EXPECT_EQ(filter_callbacks_.details(),
-            "jwt_authn_access_denied{Wrong requirement_name: abc. Correct names are: r1,r2}");
+            "jwt_authn_access_denied{Wrong_requirement_name:_abc._Correct_names_are:_r1,r2}");
 }
 
 // Test verifier from per-route config

--- a/test/extensions/filters/http/jwt_authn/filter_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_test.cc
@@ -43,8 +43,7 @@ public:
               (const Http::RequestHeaderMap& headers, const StreamInfo::FilterState& filter_state),
               (const));
   MOCK_METHOD((std::pair<const Verifier*, std::string>), findPerRouteVerifier,
-              (const PerRouteFilterConfig& per_route),
-              (const));
+              (const PerRouteFilterConfig& per_route), (const));
   MOCK_METHOD(bool, bypassCorsPreflightRequest, (), (const));
   MOCK_METHOD(JwtAuthnFilterStats&, stats, ());
 
@@ -371,15 +370,15 @@ TEST_F(FilterTest, TestNoPerRouteConfig) {
 
 // Test bypass requirement from per-route config
 TEST_F(FilterTest, TestPerRouteBypass) {
-  EXPECT_CALL(filter_callbacks_, route())
-      .WillOnce(Return(mock_route_));
+  EXPECT_CALL(filter_callbacks_, route()).WillOnce(Return(mock_route_));
   EXPECT_CALL(mock_route_->route_entry_, perFilterConfig(HttpFilterNames::get().JwtAuthn))
       .WillOnce(Return(per_route_config_.get()));
 
   // findVerifier is not called.
   EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).Times(0);
   // If findPerRouteVerifier is called, and return nullptr, it means bypass
-  EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_)).WillOnce(Return(std::make_pair(nullptr, EMPTY_STRING)));
+  EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_))
+      .WillOnce(Return(std::make_pair(nullptr, EMPTY_STRING)));
 
   auto headers = Http::TestRequestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
@@ -392,15 +391,15 @@ TEST_F(FilterTest, TestPerRouteBypass) {
 
 // Test per-route config with wrong requirement_name
 TEST_F(FilterTest, TestPerRouteWrongRequirementName) {
-  EXPECT_CALL(filter_callbacks_, route())
-      .WillOnce(Return(mock_route_));
+  EXPECT_CALL(filter_callbacks_, route()).WillOnce(Return(mock_route_));
   EXPECT_CALL(mock_route_->route_entry_, perFilterConfig(HttpFilterNames::get().JwtAuthn))
       .WillOnce(Return(per_route_config_.get()));
 
   // findVerifier is not called.
   EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).Times(0);
   // If findPerRouteVerifier is called, and return error message.
-  EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_)).WillOnce(Return(std::make_pair(nullptr, "Wrong requirement_name: abc")));
+  EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_))
+      .WillOnce(Return(std::make_pair(nullptr, "Wrong requirement_name: abc")));
 
   auto headers = Http::TestRequestHeaderMapImpl{};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
@@ -414,15 +413,15 @@ TEST_F(FilterTest, TestPerRouteWrongRequirementName) {
 
 // Test verifier from per-route config
 TEST_F(FilterTest, TestPerRouteVerifierOK) {
-  EXPECT_CALL(filter_callbacks_, route())
-      .WillOnce(Return(mock_route_));
+  EXPECT_CALL(filter_callbacks_, route()).WillOnce(Return(mock_route_));
   EXPECT_CALL(mock_route_->route_entry_, perFilterConfig(HttpFilterNames::get().JwtAuthn))
       .WillOnce(Return(per_route_config_.get()));
 
   // findVerifier is not called.
   EXPECT_CALL(*mock_config_.get(), findVerifier(_, _)).Times(0);
   // If findPerRouteVerifier is called
-  EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_)).WillOnce(Return(std::make_pair(mock_verifier_.get(), EMPTY_STRING)));
+  EXPECT_CALL(*mock_config_.get(), findPerRouteVerifier(_))
+      .WillOnce(Return(std::make_pair(mock_verifier_.get(), EMPTY_STRING)));
 
   // A successful authentication
   EXPECT_CALL(*mock_verifier_, verify(_)).WillOnce(Invoke([](ContextSharedPtr context) {


### PR DESCRIPTION
Adding support on per-route config with following goal:  not to do RouteMatch twice.   Currently the filter is using RouteMatch to match a request with a specific Jwt requirement.   But RouteMatch is also performed at routing, so the RouteMatch is done twice. 

If a Jwt requirement can be specified at the per-route config,  one of RouteMatch can be eliminated.

1) Add a `requirement_map`  to associate a requirement_name with a JwtRequirement in the filter config `JwtAuthentication`.
2) Add per-route-config as followings:
*  a requirement_name to specify a JwtRequirement. or 
*  `bypass` flag to bypass Jwt verification if it is true.

Risk Level:  None.  Added a new feature, old features are not impacted.
Testing:  Added unit-tests and integration tests.
Docs Changes: Yes
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
