### PR TITLE
wasm: enable WAVM's stack unwinding feature

### DIFF
--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -318,7 +318,7 @@ envoy_cmake_external(
         "LLVM_DIR": "$EXT_BUILD_DEPS/copy_llvm/llvm/lib/cmake/llvm",
         "WAVM_ENABLE_STATIC_LINKING": "on",
         "WAVM_ENABLE_RELEASE_ASSERTS": "on",
-        "WAVM_ENABLE_UNWIND": "no",
+        "WAVM_ENABLE_UNWIND": "on",
         # Workaround for the issue with statically linked libstdc++
         # using -l:libstdc++.a.
         "CMAKE_CXX_FLAGS": "-lstdc++ -Wno-unused-command-line-argument",
@@ -335,6 +335,7 @@ envoy_cmake_external(
     static_libraries = select({
         "//conditions:default": [
             "libWAVM.a",
+            "libWAVMUnwind.a",
         ],
     }),
     deps = [":llvm"],


### PR DESCRIPTION
This PR enables WAVM's stack unwind feature, which enhance WASM extension developers debuggability dramatically. 
Without `WAVM_ENABLE_UNWIND=on`, the returned call stack is always empty as you can see [here](https://github.com/WAVM/WAVM/blob/master/Lib/Platform/POSIX/DiagnosticsPOSIX.cpp#L36-L52).

The corresponding PR in proxy-wasm-cpp-host is here: https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/84

The stack trace message is something like this:
```
[2020-10-28 14:24:10.551][979699][trace][wasm] [source/extensions/common/wasm/wasm_vm.cc:29] Function proxy_on_tick failed:
WAVM message: wavm.reachedUnreachable
wasm backrace:
  1: wasm!helloworld!runtime._panic+7
  2: wasm!helloworld!command-line-arguments.C+2
  3: wasm!helloworld!command-line-arguments.B+0
  4: wasm!helloworld!command-line-arguments.A+0
  5: wasm!helloworld!(*command-line-arguments.helloWorld).OnTick+74
  6: wasm!helloworld!proxy_on_tick+0
```

Signed-off-by: mathetake <takeshi@tetrate.io>

___

cc @lizan @PiotrSikora 