### PR TITLE
Windows: enable listener_manager_impl_quic_only_test

### DIFF
--- a/source/extensions/quic_listeners/quiche/udp_gso_batch_writer_config.cc
+++ b/source/extensions/quic_listeners/quiche/udp_gso_batch_writer_config.cc
@@ -4,9 +4,7 @@
 
 #include "common/api/os_sys_calls_impl.h"
 
-#if defined(__linux__)
 #include "extensions/quic_listeners/quiche/udp_gso_batch_writer.h"
-#endif
 
 namespace Envoy {
 namespace Quic {
@@ -22,7 +20,7 @@ UdpGsoBatchWriterConfigFactory::createUdpPacketWriterFactory(const Protobuf::Mes
                          "for UDP GSO. Reset udp_writer_config to default writer");
   }
 
-#if defined(__linux__)
+#if UDP_GSO_BATCH_WRITER_COMPILETIME_SUPPORT
   return std::make_unique<UdpGsoBatchWriterFactory>();
 #else
   // On non-linux, `supportsUdpGso()` always returns false.

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -269,12 +269,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "listener_manager_impl_quic_only_test",
     srcs = ["listener_manager_impl_quic_only_test.cc"],
-    tags = [
-        "nofips",
-        # Skipping as quiche quic_gso_batch_writer.h does not exist on Windows
-        # required by quic_stream_send_buffer.cc
-        "skip_on_windows",
-    ],
+    tags = ["nofips"],
     deps = [
         ":listener_manager_impl_test_lib",
         ":utility_lib",


### PR DESCRIPTION
Commit Message:
Windows: enable listener_manager_impl_quic_only_test

Accomodate abstraction of UDP GSO batch writer
Additional Description: N/A
Risk Level: Low
Testing: Modifies test to accomodate multiple platforms
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A