### PR TITLE
[fuzz] Added status frame support to h2 fuzz test

### DIFF
--- a/test/integration/h2_capture_fuzz.proto
+++ b/test/integration/h2_capture_fuzz.proto
@@ -132,6 +132,7 @@ message H2FrameMetadata {
   Metadata metadata = 3;
 }
 
+// A header that contains an arbitrary status
 message H2FrameStatus {
   bytes status = 1;
   uint32 stream_index = 2;

--- a/test/integration/h2_capture_fuzz.proto
+++ b/test/integration/h2_capture_fuzz.proto
@@ -132,6 +132,11 @@ message H2FrameMetadata {
   Metadata metadata = 3;
 }
 
+message H2FrameStatus {
+  bytes status = 1;
+  uint32 stream_index = 2;
+}
+
 message H2TestFrame {
   // These values map to the frame creation methods in:
   // test/common/http/http2/http2_frame.h
@@ -151,6 +156,7 @@ message H2TestFrame {
     H2FrameRequest request = 13;
     H2FramePostRequest post_request = 14;
     H2FrameGeneric generic = 15;
+    H2FrameStatus status = 16;
     H2FrameMetadata metadata = 77;
   }
 }

--- a/test/integration/h2_corpus/status_test_overflowed_status
+++ b/test/integration/h2_corpus/status_test_overflowed_status
@@ -1,0 +1,45 @@
+events {
+  downstream_send_event {
+    h2_frames {
+      settings {
+        flags: NONE
+      }
+    }
+    h2_frames {
+      settings {
+        flags: ACK
+      }
+    }
+    h2_frames {
+      request {
+        stream_index: 1
+        host: "host"
+        path: "/path/to/long/url"
+      }
+    }
+  }
+}
+events {
+  upstream_send_event {
+    h2_frames {
+      settings {
+        flags: NONE
+      }
+    }
+    h2_frames {
+      settings {
+        flags: ACK
+      }
+    }
+  }
+}
+events {
+  upstream_send_event {
+    h2_frames {
+      status {
+        value: 11111111111111111111111111111111111
+      }
+      stream_index: 0
+    }
+  }
+}

--- a/test/integration/h2_fuzz.cc
+++ b/test/integration/h2_fuzz.cc
@@ -146,6 +146,13 @@ void H2FuzzIntegrationTest::sendFrame(const test::integration::H2TestFrame& prot
         Http2Frame::makeMetadataFrameFromMetadataMap(stream_idx, metadata_map, metadata_flags);
     break;
   }
+  case test::integration::H2TestFrame::kStatus: {
+    const std::string status = proto_frame.status().status();
+    const uint32_t stream_idx = proto_frame.status().stream_index();
+    ENVOY_LOG_MISC(trace, "Sending status frame");
+    h2_frame = Http2Frame::makeHeadersFrameWithStatus(status, stream_idx);
+    break;
+  }
   case test::integration::H2TestFrame::kGeneric: {
     const absl::string_view frame_bytes = proto_frame.generic().frame_bytes();
     ENVOY_LOG_MISC(trace, "Sending generic frame");


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Added status frame support to h2 fuzz test
Additional Description: I added status frame to http2frame to test overflowed statuses in #13314. I added this frame to h2_fuzz.cc.
Risk Level: Low
Testing: Added regression test