### PR TITLE
docs: correct URL for caching example page

### DIFF
--- a/examples/cache/README.md
+++ b/examples/cache/README.md
@@ -1,2 +1,2 @@
 To learn about this sandbox and for instructions on how to run it please head over
-to the [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/http_cache.html)
+to the [envoy docs](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/cache.html)


### PR DESCRIPTION
Commit Message: docs: correct URL for caching example page
Additional Description: N/A
Risk Level: N/A
Testing: N/A
Docs Changes: Update URL to correct value
Release Notes:
Platform Specific Features: N/A
