### PR TITLE
dns: preserve custom resolver after channel destruction

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -20,6 +20,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* dns: fix a bug where custom resolvers provided in configuration were not preserved after network issues.
 * http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
 * tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
 

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -87,6 +87,9 @@ private:
     int optmask_;
   };
 
+  static absl::optional<std::string>
+  maybeBuildResolversCsv(const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers);
+
   // Callback for events on sockets tracked in events_.
   void onEventCallback(os_fd_t fd, uint32_t events);
   // c-ares callback when a socket state changes, indicating that libevent
@@ -105,6 +108,7 @@ private:
   bool dirty_channel_{};
   const bool use_tcp_for_dns_lookups_;
   absl::node_hash_map<int, Event::FileEventPtr> events_;
+  const absl::optional<std::string> resolvers_csv_;
 };
 
 } // namespace Network

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -440,17 +440,17 @@ public:
         Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
     listener_ = dispatcher_->createListener(socket_, *server_, true, ENVOY_TCP_BACKLOG_SIZE);
 
-    if (set_resolver_in_constructor()) {
+    if (setResolverInConstructor()) {
       resolver_ =
-          dispatcher_->createDnsResolver({socket_->localAddress()}, use_tcp_for_dns_lookups());
+          dispatcher_->createDnsResolver({socket_->localAddress()}, useTcpForDnsLookups());
     } else {
-      resolver_ = dispatcher_->createDnsResolver({}, use_tcp_for_dns_lookups());
+      resolver_ = dispatcher_->createDnsResolver({}, useTcpForDnsLookups());
     }
 
     // Point c-ares at the listener with no search domains and TCP-only.
     peer_ = std::make_unique<DnsResolverImplPeer>(dynamic_cast<DnsResolverImpl*>(resolver_.get()));
-    if (tcp_only()) {
-      peer_->resetChannelTcpOnly(zero_timeout());
+    if (tcpOnly()) {
+      peer_->resetChannelTcpOnly(zeroTimeout());
     }
     ares_set_servers_ports_csv(peer_->channel(), socket_->localAddress()->asString().c_str());
   }
@@ -544,10 +544,10 @@ public:
 
 protected:
   // Should the DnsResolverImpl use a zero timeout for c-ares queries?
-  virtual bool zero_timeout() const { return false; }
-  virtual bool tcp_only() const { return true; }
-  virtual bool use_tcp_for_dns_lookups() const { return false; }
-  virtual bool set_resolver_in_constructor() const { return false; }
+  virtual bool zeroTimeout() const { return false; }
+  virtual bool tcpOnly() const { return true; }
+  virtual bool useTcpForDnsLookups() const { return false; }
+  virtual bool setResolverInConstructor() const { return false; }
   std::unique_ptr<TestDnsServer> server_;
   std::unique_ptr<DnsResolverImplPeer> peer_;
   Network::MockConnectionHandler connection_handler_;
@@ -585,7 +585,7 @@ TEST_P(DnsImplTest, DestructCallback) {
 
   // This simulates destruction thanks to another query setting the dirty_channel_ bit, thus causing
   // a subsequent result to call ares_destroy.
-  peer_->resetChannelTcpOnly(zero_timeout());
+  peer_->resetChannelTcpOnly(zeroTimeout());
   ares_set_servers_ports_csv(peer_->channel(), socket_->localAddress()->asString().c_str());
 
   dispatcher_->run(Event::Dispatcher::RunType::Block);
@@ -710,8 +710,8 @@ TEST_P(DnsImplTest, DestroyChannelOnRefused) {
   EXPECT_FALSE(peer_->isChannelDirty());
 
   // Reset the channel to point to the TestDnsServer, and make sure resolution is healthy.
-  if (tcp_only()) {
-    peer_->resetChannelTcpOnly(zero_timeout());
+  if (tcpOnly()) {
+    peer_->resetChannelTcpOnly(zeroTimeout());
   }
   ares_set_servers_ports_csv(peer_->channel(), socket_->localAddress()->asString().c_str());
 
@@ -884,7 +884,7 @@ TEST_P(DnsImplTest, PendingTimerEnable) {
 
 class DnsImplZeroTimeoutTest : public DnsImplTest {
 protected:
-  bool zero_timeout() const override { return true; }
+  bool zeroTimeout() const override { return true; }
 };
 
 // Parameterize the DNS test server socket address.
@@ -904,8 +904,8 @@ TEST_P(DnsImplZeroTimeoutTest, Timeout) {
 
 class DnsImplAresFlagsForTcpTest : public DnsImplTest {
 protected:
-  bool tcp_only() const override { return false; }
-  bool use_tcp_for_dns_lookups() const override { return true; }
+  bool tcpOnly() const override { return false; }
+  bool useTcpForDnsLookups() const override { return true; }
 };
 
 // Parameterize the DNS test server socket address.
@@ -929,7 +929,7 @@ TEST_P(DnsImplAresFlagsForTcpTest, TcpLookupsEnabled) {
 
 class DnsImplAresFlagsForUdpTest : public DnsImplTest {
 protected:
-  bool tcp_only() const override { return false; }
+  bool tcpOnly() const override { return false; }
 };
 
 // Parameterize the DNS test server socket address.
@@ -952,9 +952,9 @@ TEST_P(DnsImplAresFlagsForUdpTest, UdpLookupsEnabled) {
 }
 
 class DnsImplCustomResolverTest : public DnsImplTest {
-  bool tcp_only() const override { return false; }
-  bool use_tcp_for_dns_lookups() const override { return true; }
-  bool set_resolver_in_constructor() const override { return true; }
+  bool tcpOnly() const override { return false; }
+  bool useTcpForDnsLookups() const override { return true; }
+  bool setResolverInConstructor() const override { return true; }
 };
 
 // Parameterize the DNS test server socket address.

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -956,6 +956,11 @@ class DnsImplCustomResolverTest : public DnsImplTest {
   bool set_resolver_in_constructor() const override { return true; }
 };
 
+// Parameterize the DNS test server socket address.
+INSTANTIATE_TEST_SUITE_P(IpVersions, DnsImplCustomResolverTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
 TEST_P(DnsImplCustomResolverTest, CustomResolverValidAfterChannelDestruction) {
   ASSERT_FALSE(peer_->isChannelDirty());
   server_->addHosts("some.good.domain", {"201.134.56.7"}, RecordType::A);

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -967,7 +967,7 @@ TEST_P(DnsImplCustomResolverTest, CustomResolverValidAfterChannelDestruction) {
   server_->setRefused(true);
 
   EXPECT_NE(nullptr,
-            resolveWithExpectations("", DnsLookupFamily::V4Only,
+            resolveWithExpectations("some.good.domain", DnsLookupFamily::V4Only,
                                     DnsResolver::ResolutionStatus::Failure, {}, {}, absl::nullopt));
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   // The c-ares channel should be dirty because the TestDnsServer replied with return code REFUSED;

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -441,7 +441,8 @@ public:
     listener_ = dispatcher_->createListener(socket_, *server_, true, ENVOY_TCP_BACKLOG_SIZE);
 
     if (set_resolver_in_constructor()) {
-      resolver_ = dispatcher_->createDnsResolver({socket_->localAddress()}, use_tcp_for_dns_lookups());
+      resolver_ =
+          dispatcher_->createDnsResolver({socket_->localAddress()}, use_tcp_for_dns_lookups());
     } else {
       resolver_ = dispatcher_->createDnsResolver({}, use_tcp_for_dns_lookups());
     }

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -983,6 +983,9 @@ TEST_P(DnsImplCustomResolverTest, CustomResolverValidAfterChannelDestruction) {
 
   server_->setRefused(false);
 
+  // The next query destroys, and reinitializes the channel. Furthermore, because the test dns
+  // server's address was passed as a custom resolver on construction, the new channel should still
+  // point to the test dns server, and the query should succeed.
   EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::Auto,
                                              DnsResolver::ResolutionStatus::Success,
                                              {"201.134.56.7"}, {}, absl::nullopt));

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -441,8 +441,7 @@ public:
     listener_ = dispatcher_->createListener(socket_, *server_, true, ENVOY_TCP_BACKLOG_SIZE);
 
     if (setResolverInConstructor()) {
-      resolver_ =
-          dispatcher_->createDnsResolver({socket_->localAddress()}, useTcpForDnsLookups());
+      resolver_ = dispatcher_->createDnsResolver({socket_->localAddress()}, useTcpForDnsLookups());
     } else {
       resolver_ = dispatcher_->createDnsResolver({}, useTcpForDnsLookups());
     }

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -983,7 +983,7 @@ TEST_P(DnsImplCustomResolverTest, CustomResolverValidAfterChannelDestruction) {
 
   server_->setRefused(false);
 
-  // The next query destroys, and reinitializes the channel. Furthermore, because the test dns
+  // The next query destroys, and re-initializes the channel. Furthermore, because the test dns
   // server's address was passed as a custom resolver on construction, the new channel should still
   // point to the test dns server, and the query should succeed.
   EXPECT_NE(nullptr, resolveWithExpectations("some.good.domain", DnsLookupFamily::Auto,


### PR DESCRIPTION
Commit Message: dns - preserve custom resolver after channel destruction
Additional Description: previously when the c-ares channel was destroyed and re-initialized, custom resolver addresses passed in during construction were not preserved. This PR reproduces the issue with a new test, and fixes.
Risk Level: low - fixing issue with reproduced test
Testing: repro issue, and verified fix with new unit test.
Release Notes: updated 
Fixes #13794 

Signed-off-by: Jose Nino <jnino@lyft.com>