### PR TITLE
[fuzz] Added coverage for onGoAway in gRPC Health Checking

### DIFF
--- a/test/common/upstream/health_check_corpus/grpc_end_stream_headers
+++ b/test/common/upstream/health_check_corpus/grpc_end_stream_headers
@@ -1,0 +1,49 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    grpc_health_check {
+        service_name: "service"
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+            }
+            status: 200
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+                headers {
+                    key: "content-type"
+                    value: "application/grpc"
+                }
+            }
+            status: 200
+            }
+            }
+        }
+    }
+}

--- a/test/common/upstream/health_check_corpus/grpc_raise-go-away
+++ b/test/common/upstream/health_check_corpus/grpc_raise-go-away
@@ -59,8 +59,8 @@ actions {
     }
 }
 actions {
-    raise_go_away: true
+    raise_go_away: NO_ERROR
 }
 actions {
-    raise_go_away: false
+    raise_go_away: ERROR
 }

--- a/test/common/upstream/health_check_corpus/grpc_raise-go-away
+++ b/test/common/upstream/health_check_corpus/grpc_raise-go-away
@@ -1,0 +1,66 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    grpc_health_check {
+        service_name: "service"
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+            }
+            status: 200
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+                headers {
+                    key: "content-type"
+                    value: "application/grpc"
+                }
+            }
+            status: 200
+            }
+            grpc_respond_bytes {
+                status: SERVING
+                chunk_size_for_structured_response: 3
+            }
+            grpc_respond_trailers {
+            trailers {
+                headers {
+                    key: "grpc-status"
+                    value: "0"
+                }
+            }
+            }
+        }
+    }
+}
+actions {
+    raise_go_away: true
+}
+actions {
+    raise_go_away: false
+}

--- a/test/common/upstream/health_check_corpus/http_headers-with-connection
+++ b/test/common/upstream/health_check_corpus/http_headers-with-connection
@@ -1,0 +1,51 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    no_traffic_interval {
+        seconds: 1
+    }
+    interval_jitter {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    http_health_check {
+        path: "/healthcheck"
+        service_name_matcher {
+            prefix: "locations"
+        }
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+                headers {
+                    key: "connection"
+                    value: "close"
+                }
+            }
+            status: 200
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+                
+            }
+        }
+    }
+}

--- a/test/common/upstream/health_check_corpus/http_headers-with-proxy-connection
+++ b/test/common/upstream/health_check_corpus/http_headers-with-proxy-connection
@@ -1,0 +1,51 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    no_traffic_interval {
+        seconds: 1
+    }
+    interval_jitter {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    http_health_check {
+        path: "/healthcheck"
+        service_name_matcher {
+            prefix: "locations"
+        }
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+                headers {
+                    key: "proxy-connection"
+                    value: "close"
+                }
+            }
+            status: 200
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+                
+            }
+        }
+    }
+}

--- a/test/common/upstream/health_check_corpus/http_raise-go-away
+++ b/test/common/upstream/health_check_corpus/http_raise-go-away
@@ -62,8 +62,8 @@ actions {
     }
 }
 actions {
-    raise_go_away: true
+    raise_go_away: NO_ERROR
 }
 actions {
-    raise_go_away: false
+    raise_go_away: ERROR
 }

--- a/test/common/upstream/health_check_corpus/http_raise-go-away
+++ b/test/common/upstream/health_check_corpus/http_raise-go-away
@@ -1,0 +1,69 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    http_health_check {
+        path: "/healthcheck"
+        service_name_matcher {
+            prefix: "locations"
+        }
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+            }
+            status: 200
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+                headers {
+                    key: "content-type"
+                    value: "application/grpc"
+                }
+            }
+            status: 200
+            }
+            grpc_respond_bytes {
+                status: SERVING
+                chunk_size_for_structured_response: 3
+            }
+            grpc_respond_trailers {
+            trailers {
+                headers {
+                    key: "grpc-status"
+                    value: "0"
+                }
+            }
+            }
+        }
+    }
+}
+actions {
+    raise_go_away: true
+}
+actions {
+    raise_go_away: false
+}

--- a/test/common/upstream/health_check_corpus/tcp_raise-go-away
+++ b/test/common/upstream/health_check_corpus/tcp_raise-go-away
@@ -64,8 +64,8 @@ actions {
     }
 }
 actions {
-    raise_go_away: true
+    raise_go_away: NO_ERROR
 }
 actions {
-    raise_go_away: false
+    raise_go_away: ERROR
 }

--- a/test/common/upstream/health_check_corpus/tcp_raise-go-away
+++ b/test/common/upstream/health_check_corpus/tcp_raise-go-away
@@ -1,0 +1,71 @@
+health_check_config {
+    timeout {
+        seconds: 1
+    }
+    interval {
+        seconds: 1
+    }
+    unhealthy_threshold {
+        value: 2
+    }
+    healthy_threshold: {
+        value: 2
+    }
+    tcp_health_check {
+        send {
+            text: "01"
+        }
+        receive [{
+            text: "02"
+        }]
+    }
+}
+actions {
+    respond {
+        http_respond {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+            }
+            status: 200
+        }
+        tcp_respond {
+            
+        }
+        grpc_respond {
+            grpc_respond_headers {
+            headers {
+                headers {
+                    key: ":status"
+                    value: "200"
+                }
+                headers {
+                    key: "content-type"
+                    value: "application/grpc"
+                }
+            }
+            status: 200
+            }
+            grpc_respond_bytes {
+                status: SERVING
+                chunk_size_for_structured_response: 3
+            }
+            grpc_respond_trailers {
+            trailers {
+                headers {
+                    key: "grpc-status"
+                    value: "0"
+                }
+            }
+            }
+        }
+    }
+}
+actions {
+    raise_go_away: true
+}
+actions {
+    raise_go_away: false
+}

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -555,7 +555,8 @@ void HealthCheckFuzz::replay(const test::common::upstream::HealthCheckTestCase& 
       break;
     }
     case test::common::upstream::Action::kRaiseGoAway: {
-      raiseGoAway(event.raise_go_away());
+      raiseGoAway(event.raise_go_away() == test::common::upstream::RaiseGoAway::NO_ERROR);
+      break;
     }
     default:
       break;

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -554,6 +554,9 @@ void HealthCheckFuzz::replay(const test::common::upstream::HealthCheckTestCase& 
       raiseEvent(getEventTypeFromProto(event.raise_event()), last_action);
       break;
     }
+    case test::common::upstream::Action::kRaiseGoAway: {
+      raiseGoAway(event.raise_go_away());
+    }
     default:
       break;
     }

--- a/test/common/upstream/health_check_fuzz.h
+++ b/test/common/upstream/health_check_fuzz.h
@@ -28,6 +28,8 @@ public:
   virtual void triggerIntervalTimer(bool expect_client_create) PURE;
   virtual void triggerTimeoutTimer(bool last_action) PURE;
   virtual void raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) PURE;
+  // Only implemented by gRPC, otherwise no-op
+  virtual void raiseGoAway(bool no_error) PURE;
 
   virtual ~HealthCheckFuzz() = default;
 
@@ -45,6 +47,14 @@ public:
   void triggerIntervalTimer(bool expect_client_create) override;
   void triggerTimeoutTimer(bool last_action) override;
   void raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) override;
+  // No op
+  void raiseGoAway(bool no_error) override {
+    if (no_error) {
+      return;
+    } else {
+      return;
+    }
+  }
   ~HttpHealthCheckFuzz() override = default;
 
   // Determines whether the client gets reused or not after response
@@ -59,6 +69,14 @@ public:
   void triggerIntervalTimer(bool expect_client_create) override;
   void triggerTimeoutTimer(bool last_action) override;
   void raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) override;
+  // No op
+  void raiseGoAway(bool no_error) override {
+    if (no_error) {
+      return;
+    } else {
+      return;
+    }
+  }
   ~TcpHealthCheckFuzz() override = default;
 
   // Determines whether the client gets reused or not after response
@@ -78,7 +96,7 @@ public:
   void triggerIntervalTimer(bool expect_client_create) override;
   void triggerTimeoutTimer(bool last_action) override;
   void raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) override;
-  void raiseGoAway(bool no_error);
+  void raiseGoAway(bool no_error) override;
   ~GrpcHealthCheckFuzz() override = default;
 
   // Determines whether the client gets reused or not after response

--- a/test/common/upstream/health_check_fuzz.h
+++ b/test/common/upstream/health_check_fuzz.h
@@ -48,13 +48,7 @@ public:
   void triggerTimeoutTimer(bool last_action) override;
   void raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) override;
   // No op
-  void raiseGoAway(bool no_error) override {
-    if (no_error) {
-      return;
-    } else {
-      return;
-    }
-  }
+  void raiseGoAway(bool) override {}
   ~HttpHealthCheckFuzz() override = default;
 
   // Determines whether the client gets reused or not after response
@@ -70,13 +64,7 @@ public:
   void triggerTimeoutTimer(bool last_action) override;
   void raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) override;
   // No op
-  void raiseGoAway(bool no_error) override {
-    if (no_error) {
-      return;
-    } else {
-      return;
-    }
-  }
+  void raiseGoAway(bool) override {}
   ~TcpHealthCheckFuzz() override = default;
 
   // Determines whether the client gets reused or not after response

--- a/test/common/upstream/health_check_fuzz.proto
+++ b/test/common/upstream/health_check_fuzz.proto
@@ -72,6 +72,11 @@ enum RaiseEvent {
   LOCAL_CLOSE = 2;
 }
 
+enum RaiseGoAway {
+  NO_ERROR = 0;
+  ERROR = 1;
+}
+
 message Action {
   oneof action_selector {
     option (validate.required) = true;
@@ -80,7 +85,7 @@ message Action {
     //TODO: respondBody, respondTrailers
     google.protobuf.Empty trigger_timeout_timer = 3;
     RaiseEvent raise_event = 4 [(validate.rules).enum.defined_only = true];
-    bool raise_go_away = 5;
+    RaiseGoAway raise_go_away = 5;
   }
 }
 

--- a/test/common/upstream/health_check_fuzz.proto
+++ b/test/common/upstream/health_check_fuzz.proto
@@ -80,6 +80,7 @@ message Action {
     //TODO: respondBody, respondTrailers
     google.protobuf.Empty trigger_timeout_timer = 3;
     RaiseEvent raise_event = 4 [(validate.rules).enum.defined_only = true];
+    bool raise_go_away = 5;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Added coverage for onGoAway in gRPC Health Checking
Additional Description: I had a function that raised go away events in my gRPC fuzzer, but it was never called. This PR adds an action which calls this already written function. Adds 20 lines of coverage over source/common/upstream/health_checker_impl.cc. 20/715 total lines * 100 = 2.8% code coverage increase.
![Screenshot 2020-10-29 at 5 03 18 PM](https://user-images.githubusercontent.com/39203661/97632878-88f94f00-1a09-11eb-961c-9ac2244c5027.png)

Risk Level: Low
Testing: Added regression tests