### PR TITLE
adaptive concurrency: Fix divide-by-zero in GradientController

### DIFF
--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -132,7 +132,7 @@ std::chrono::milliseconds GradientController::applyJitter(std::chrono::milliseco
     return interval;
   }
 
-  const uint32_t jitter_range_ms = interval.count() * jitter_pct;
+  const uint32_t jitter_range_ms = std::ceil(interval.count() * jitter_pct);
   return std::chrono::milliseconds(interval.count() + (random_.random() % jitter_range_ms));
 }
 

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6268043707285504
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6268043707285504
@@ -1,0 +1,7 @@
+config {
+  name: "envoy.filters.http.adaptive_concurrency"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.adaptive_concurrency.v3.AdaptiveConcurrency"
+    value: "\n\'\022\n\032\010\010\334\340\240\001\020\200~\032\031\n\010\010\334\340\230\001\020\200~\022\002\010\001\032\t\t\000\000\000\000\000\010\000\000"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Joseph Griego <jjgriego@google.com>

Commit Message:
As title--fixes bug identified by fuzzing: https://oss-fuzz.com/testcase-detail/6268043707285504

Risk Level: low

Testing:
Add the fuzzer input to the corpus and re-ran to verify the fix

