### PR TITLE
Removed Circle-CI reference.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,14 +345,6 @@ should only be done to correct a DCO mistake.
 
 ## Triggering CI re-run without making changes
 
-To rerun failed tasks in Circle-CI, add a comment with the line
-
-```
-/retest-circle
-```
-
-in it. This should rebuild only the failed tasks.
-
 To rerun failed tasks in Azure pipelines, add a comment with the line
 
 ```


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>
 
Commit Message: Removed Circle-CI reference.
Additional Description: The Circle-CI is no longer used, so removing the reference.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
 