### PR TITLE
metrics service: use snapshot time for all metrics flushed

### DIFF
--- a/include/envoy/stats/BUILD
+++ b/include/envoy/stats/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
         ":refcount_ptr_interface",
         ":symbol_table_interface",
         "//include/envoy/common:interval_set_interface",
+        "//include/envoy/common:time_interface",
     ],
 )
 

--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -44,7 +44,7 @@ public:
   /**
    * @return a snapshot of all text readouts.
    */
-  virtual int64_t snapShotTimeInMillis() PURE;
+  virtual int64_t snapshotTimeMs() PURE;
 };
 
 /**

--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -43,10 +43,8 @@ public:
 
   /**
    * @return the time in milliseconds when the snapshot was created.
-   *
-   * Stores converted timestamp here to avoid repeated conversions for every metric.
    */
-  virtual int64_t snapshotTimeMs() const PURE;
+  virtual std::chrono::milliseconds snapshotTime() const PURE;
 };
 
 /**

--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -40,6 +40,11 @@ public:
    * @return a snapshot of all text readouts.
    */
   virtual const std::vector<std::reference_wrapper<const TextReadout>>& textReadouts() PURE;
+
+  /**
+   * @return a snapshot of all text readouts.
+   */
+  virtual int64_t snapShotTimeInMillis() PURE;
 };
 
 /**

--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "envoy/common/pure.h"
+#include "envoy/common/time.h"
 #include "envoy/stats/histogram.h"
 #include "envoy/stats/stats.h"
 
@@ -42,9 +43,9 @@ public:
   virtual const std::vector<std::reference_wrapper<const TextReadout>>& textReadouts() PURE;
 
   /**
-   * @return the time in milliseconds when the snapshot was created.
+   * @return the time in UTC since epoch when the snapshot was created.
    */
-  virtual std::chrono::milliseconds snapshotTime() const PURE;
+  virtual SystemTime snapshotTime() const PURE;
 };
 
 /**

--- a/include/envoy/stats/sink.h
+++ b/include/envoy/stats/sink.h
@@ -42,9 +42,11 @@ public:
   virtual const std::vector<std::reference_wrapper<const TextReadout>>& textReadouts() PURE;
 
   /**
-   * @return a snapshot of all text readouts.
+   * @return the time in milliseconds when the snapshot was created.
+   *
+   * Stores converted timestamp here to avoid repeated conversions for every metric.
    */
-  virtual int64_t snapshotTimeMs() PURE;
+  virtual int64_t snapshotTimeMs() const PURE;
 };
 
 /**

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -36,7 +36,7 @@ MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
           server.localInfo(), transport_api_version);
 
   return std::make_unique<MetricsServiceSink>(
-      grpc_metrics_streamer, server.timeSource(),
+      grpc_metrics_streamer,
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, report_counters_as_deltas, false));
 }
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -113,19 +113,19 @@ void MetricsServiceSink::flush(Stats::MetricSnapshot& snapshot) {
                                             snapshot.histograms().size());
   for (const auto& counter : snapshot.counters()) {
     if (counter.counter_.get().used()) {
-      flushCounter(counter, snapshot.snapshotTimeMs());
+      flushCounter(counter, snapshot.snapshotTime().count());
     }
   }
 
   for (const auto& gauge : snapshot.gauges()) {
     if (gauge.get().used()) {
-      flushGauge(gauge.get(), snapshot.snapshotTimeMs());
+      flushGauge(gauge.get(), snapshot.snapshotTime().count());
     }
   }
 
   for (const auto& histogram : snapshot.histograms()) {
     if (histogram.get().used()) {
-      flushHistogram(histogram.get(), snapshot.snapshotTimeMs());
+      flushHistogram(histogram.get(), snapshot.snapshotTime().count());
     }
   }
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -38,20 +38,17 @@ void GrpcMetricsStreamerImpl::send(envoy::service::metrics::v3::StreamMetricsMes
 }
 
 MetricsServiceSink::MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_metrics_streamer,
-                                       TimeSource& time_source,
                                        const bool report_counters_as_deltas)
-    : grpc_metrics_streamer_(grpc_metrics_streamer), time_source_(time_source),
+    : grpc_metrics_streamer_(grpc_metrics_streamer),
       report_counters_as_deltas_(report_counters_as_deltas) {}
 
 void MetricsServiceSink::flushCounter(
-    const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot) {
+    const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot, int64_t snapshot_time) {
   io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
   metrics_family->set_type(io::prometheus::client::MetricType::COUNTER);
   metrics_family->set_name(counter_snapshot.counter_.get().name());
   auto* metric = metrics_family->add_metric();
-  metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                               time_source_.systemTime().time_since_epoch())
-                               .count());
+  metric->set_timestamp_ms(snapshot_time);
   auto* counter_metric = metric->mutable_counter();
   if (report_counters_as_deltas_) {
     counter_metric->set_value(counter_snapshot.delta_);
@@ -60,19 +57,18 @@ void MetricsServiceSink::flushCounter(
   }
 }
 
-void MetricsServiceSink::flushGauge(const Stats::Gauge& gauge) {
+void MetricsServiceSink::flushGauge(const Stats::Gauge& gauge, int64_t snapshot_time) {
   io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
   metrics_family->set_type(io::prometheus::client::MetricType::GAUGE);
   metrics_family->set_name(gauge.name());
   auto* metric = metrics_family->add_metric();
-  metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                               time_source_.systemTime().time_since_epoch())
-                               .count());
+  metric->set_timestamp_ms(snapshot_time);
   auto* gauge_metric = metric->mutable_gauge();
   gauge_metric->set_value(gauge.value());
 }
 
-void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_histogram) {
+void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_histogram,
+                                        int64_t snapshot_time) {
   // TODO(ramaraochavali): Currently we are sending both quantile information and bucket
   // information. We should make this configurable if it turns out that sending both affects
   // performance.
@@ -82,9 +78,7 @@ void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_hist
   summary_metrics_family->set_type(io::prometheus::client::MetricType::SUMMARY);
   summary_metrics_family->set_name(envoy_histogram.name());
   auto* summary_metric = summary_metrics_family->add_metric();
-  summary_metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                       time_source_.systemTime().time_since_epoch())
-                                       .count());
+  summary_metric->set_timestamp_ms(snapshot_time);
   auto* summary = summary_metric->mutable_summary();
   const Stats::HistogramStatistics& hist_stats = envoy_histogram.intervalStatistics();
   for (size_t i = 0; i < hist_stats.supportedQuantiles().size(); i++) {
@@ -98,9 +92,7 @@ void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_hist
   histogram_metrics_family->set_type(io::prometheus::client::MetricType::HISTOGRAM);
   histogram_metrics_family->set_name(envoy_histogram.name());
   auto* histogram_metric = histogram_metrics_family->add_metric();
-  histogram_metric->set_timestamp_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                         time_source_.systemTime().time_since_epoch())
-                                         .count());
+  histogram_metric->set_timestamp_ms(snapshot_time);
   auto* histogram = histogram_metric->mutable_histogram();
   histogram->set_sample_count(hist_stats.sampleCount());
   histogram->set_sample_sum(hist_stats.sampleSum());
@@ -121,19 +113,19 @@ void MetricsServiceSink::flush(Stats::MetricSnapshot& snapshot) {
                                             snapshot.histograms().size());
   for (const auto& counter : snapshot.counters()) {
     if (counter.counter_.get().used()) {
-      flushCounter(counter);
+      flushCounter(counter, snapshot.snapShotTimeInMillis());
     }
   }
 
   for (const auto& gauge : snapshot.gauges()) {
     if (gauge.get().used()) {
-      flushGauge(gauge.get());
+      flushGauge(gauge.get(), snapshot.snapShotTimeInMillis());
     }
   }
 
   for (const auto& histogram : snapshot.histograms()) {
     if (histogram.get().used()) {
-      flushHistogram(histogram.get());
+      flushHistogram(histogram.get(), snapshot.snapShotTimeInMillis());
     }
   }
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -43,12 +43,12 @@ MetricsServiceSink::MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_
       report_counters_as_deltas_(report_counters_as_deltas) {}
 
 void MetricsServiceSink::flushCounter(
-    const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot, int64_t snapshot_time) {
+    const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot, int64_t snapshot_time_ms) {
   io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
   metrics_family->set_type(io::prometheus::client::MetricType::COUNTER);
   metrics_family->set_name(counter_snapshot.counter_.get().name());
   auto* metric = metrics_family->add_metric();
-  metric->set_timestamp_ms(snapshot_time);
+  metric->set_timestamp_ms(snapshot_time_ms);
   auto* counter_metric = metric->mutable_counter();
   if (report_counters_as_deltas_) {
     counter_metric->set_value(counter_snapshot.delta_);
@@ -57,18 +57,18 @@ void MetricsServiceSink::flushCounter(
   }
 }
 
-void MetricsServiceSink::flushGauge(const Stats::Gauge& gauge, int64_t snapshot_time) {
+void MetricsServiceSink::flushGauge(const Stats::Gauge& gauge, int64_t snapshot_time_ms) {
   io::prometheus::client::MetricFamily* metrics_family = message_.add_envoy_metrics();
   metrics_family->set_type(io::prometheus::client::MetricType::GAUGE);
   metrics_family->set_name(gauge.name());
   auto* metric = metrics_family->add_metric();
-  metric->set_timestamp_ms(snapshot_time);
+  metric->set_timestamp_ms(snapshot_time_ms);
   auto* gauge_metric = metric->mutable_gauge();
   gauge_metric->set_value(gauge.value());
 }
 
 void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_histogram,
-                                        int64_t snapshot_time) {
+                                        int64_t snapshot_time_ms) {
   // TODO(ramaraochavali): Currently we are sending both quantile information and bucket
   // information. We should make this configurable if it turns out that sending both affects
   // performance.
@@ -78,7 +78,7 @@ void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_hist
   summary_metrics_family->set_type(io::prometheus::client::MetricType::SUMMARY);
   summary_metrics_family->set_name(envoy_histogram.name());
   auto* summary_metric = summary_metrics_family->add_metric();
-  summary_metric->set_timestamp_ms(snapshot_time);
+  summary_metric->set_timestamp_ms(snapshot_time_ms);
   auto* summary = summary_metric->mutable_summary();
   const Stats::HistogramStatistics& hist_stats = envoy_histogram.intervalStatistics();
   for (size_t i = 0; i < hist_stats.supportedQuantiles().size(); i++) {
@@ -92,7 +92,7 @@ void MetricsServiceSink::flushHistogram(const Stats::ParentHistogram& envoy_hist
   histogram_metrics_family->set_type(io::prometheus::client::MetricType::HISTOGRAM);
   histogram_metrics_family->set_name(envoy_histogram.name());
   auto* histogram_metric = histogram_metrics_family->add_metric();
-  histogram_metric->set_timestamp_ms(snapshot_time);
+  histogram_metric->set_timestamp_ms(snapshot_time_ms);
   auto* histogram = histogram_metric->mutable_histogram();
   histogram->set_sample_count(hist_stats.sampleCount());
   histogram->set_sample_sum(hist_stats.sampleSum());
@@ -113,19 +113,19 @@ void MetricsServiceSink::flush(Stats::MetricSnapshot& snapshot) {
                                             snapshot.histograms().size());
   for (const auto& counter : snapshot.counters()) {
     if (counter.counter_.get().used()) {
-      flushCounter(counter, snapshot.snapShotTimeInMillis());
+      flushCounter(counter, snapshot.snapshotTimeMs());
     }
   }
 
   for (const auto& gauge : snapshot.gauges()) {
     if (gauge.get().used()) {
-      flushGauge(gauge.get(), snapshot.snapShotTimeInMillis());
+      flushGauge(gauge.get(), snapshot.snapshotTimeMs());
     }
   }
 
   for (const auto& histogram : snapshot.histograms()) {
     if (histogram.get().used()) {
-      flushHistogram(histogram.get(), snapshot.snapShotTimeInMillis());
+      flushHistogram(histogram.get(), snapshot.snapshotTimeMs());
     }
   }
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -111,21 +111,22 @@ void MetricsServiceSink::flush(Stats::MetricSnapshot& snapshot) {
   // preallocating the pointer array).
   message_.mutable_envoy_metrics()->Reserve(snapshot.counters().size() + snapshot.gauges().size() +
                                             snapshot.histograms().size());
+  int64_t snapshot_time_ms = snapshot.snapshotTime().count();
   for (const auto& counter : snapshot.counters()) {
     if (counter.counter_.get().used()) {
-      flushCounter(counter, snapshot.snapshotTime().count());
+      flushCounter(counter, snapshot_time_ms);
     }
   }
 
   for (const auto& gauge : snapshot.gauges()) {
     if (gauge.get().used()) {
-      flushGauge(gauge.get(), snapshot.snapshotTime().count());
+      flushGauge(gauge.get(), snapshot_time_ms);
     }
   }
 
   for (const auto& histogram : snapshot.histograms()) {
     if (histogram.get().used()) {
-      flushHistogram(histogram.get(), snapshot.snapshotTime().count());
+      flushHistogram(histogram.get(), snapshot_time_ms);
     }
   }
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -1,5 +1,7 @@
 #include "extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h"
 
+#include <chrono>
+
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/service/metrics/v3/metrics_service.pb.h"
@@ -111,7 +113,9 @@ void MetricsServiceSink::flush(Stats::MetricSnapshot& snapshot) {
   // preallocating the pointer array).
   message_.mutable_envoy_metrics()->Reserve(snapshot.counters().size() + snapshot.gauges().size() +
                                             snapshot.histograms().size());
-  int64_t snapshot_time_ms = snapshot.snapshotTime().count();
+  int64_t snapshot_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 snapshot.snapshotTime().time_since_epoch())
+                                 .count();
   for (const auto& counter : snapshot.counters()) {
     if (counter.counter_.get().used()) {
       flushCounter(counter, snapshot_time_ms);

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -80,18 +80,18 @@ class MetricsServiceSink : public Stats::Sink {
 public:
   // MetricsService::Sink
   MetricsServiceSink(const GrpcMetricsStreamerSharedPtr& grpc_metrics_streamer,
-                     TimeSource& time_system, const bool report_counters_as_deltas);
+                     const bool report_counters_as_deltas);
   void flush(Stats::MetricSnapshot& snapshot) override;
   void onHistogramComplete(const Stats::Histogram&, uint64_t) override {}
 
-  void flushCounter(const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot);
-  void flushGauge(const Stats::Gauge& gauge);
-  void flushHistogram(const Stats::ParentHistogram& envoy_histogram);
+  void flushCounter(const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot,
+                    int64_t snapshot_time);
+  void flushGauge(const Stats::Gauge& gauge, int64_t snapshot_time);
+  void flushHistogram(const Stats::ParentHistogram& envoy_histogram, int64_t snapshot_time);
 
 private:
   GrpcMetricsStreamerSharedPtr grpc_metrics_streamer_;
   envoy::service::metrics::v3::StreamMetricsMessage message_;
-  TimeSource& time_source_;
   const bool report_counters_as_deltas_;
 };
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -85,9 +85,9 @@ public:
   void onHistogramComplete(const Stats::Histogram&, uint64_t) override {}
 
   void flushCounter(const Stats::MetricSnapshot::CounterSnapshot& counter_snapshot,
-                    int64_t snapshot_time);
-  void flushGauge(const Stats::Gauge& gauge, int64_t snapshot_time);
-  void flushHistogram(const Stats::ParentHistogram& envoy_histogram, int64_t snapshot_time);
+                    int64_t snapshot_time_ms);
+  void flushGauge(const Stats::Gauge& gauge, int64_t snapshot_time_ms);
+  void flushHistogram(const Stats::ParentHistogram& envoy_histogram, int64_t snapshot_time_ms);
 
 private:
   GrpcMetricsStreamerSharedPtr grpc_metrics_streamer_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -174,7 +174,7 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store, TimeSource& time_sou
     text_readouts_.push_back(*text_readout);
   }
 
-  snapshot_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(
+  snapshot_time_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(
                        time_source.systemTime().time_since_epoch())
                        .count();
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -175,7 +175,7 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store, TimeSource& time_sou
   }
 
   snapshot_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          time_source.systemTime().time_since_epoch());
+      time_source.systemTime().time_since_epoch());
 }
 
 void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -175,8 +175,8 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store, TimeSource& time_sou
   }
 
   snapshot_time_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-                       time_source.systemTime().time_since_epoch())
-                       .count();
+                          time_source.systemTime().time_since_epoch())
+                          .count();
 }
 
 void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -2,6 +2,7 @@
 
 #include <csignal>
 #include <cstdint>
+#include <ctime>
 #include <functional>
 #include <memory>
 #include <string>
@@ -174,8 +175,7 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store, TimeSource& time_sou
     text_readouts_.push_back(*text_readout);
   }
 
-  snapshot_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-      time_source.systemTime().time_since_epoch());
+  snapshot_time_ = time_source.systemTime();
 }
 
 void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -174,9 +174,8 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store, TimeSource& time_sou
     text_readouts_.push_back(*text_readout);
   }
 
-  snapshot_time_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          time_source.systemTime().time_since_epoch())
-                          .count();
+  snapshot_time_ = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          time_source.systemTime().time_since_epoch());
 }
 
 void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -397,7 +397,7 @@ public:
   const std::vector<std::reference_wrapper<const Stats::TextReadout>>& textReadouts() override {
     return text_readouts_;
   }
-  std::chrono::milliseconds snapshotTime() const override { return snapshot_time_; }
+  SystemTime snapshotTime() const override { return snapshot_time_; }
 
 private:
   std::vector<Stats::CounterSharedPtr> snapped_counters_;
@@ -408,7 +408,7 @@ private:
   std::vector<std::reference_wrapper<const Stats::ParentHistogram>> histograms_;
   std::vector<Stats::TextReadoutSharedPtr> snapped_text_readouts_;
   std::vector<std::reference_wrapper<const Stats::TextReadout>> text_readouts_;
-  std::chrono::milliseconds snapshot_time_;
+  SystemTime snapshot_time_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -408,7 +408,7 @@ private:
   std::vector<std::reference_wrapper<const Stats::ParentHistogram>> histograms_;
   std::vector<Stats::TextReadoutSharedPtr> snapped_text_readouts_;
   std::vector<std::reference_wrapper<const Stats::TextReadout>> text_readouts_;
-   std::chrono::milliseconds snapshot_time_;
+  std::chrono::milliseconds snapshot_time_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -113,7 +113,8 @@ public:
    * @param sinks supplies the list of sinks.
    * @param store provides the store being flushed.
    */
-  static void flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store);
+  static void flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, Stats::Store& store,
+                                  TimeSource& time_source);
 
   /**
    * Load a bootstrap config and perform validation.
@@ -383,7 +384,7 @@ private:
 //                     copying and probably be a cleaner API in general.
 class MetricSnapshotImpl : public Stats::MetricSnapshot {
 public:
-  explicit MetricSnapshotImpl(Stats::Store& store);
+  explicit MetricSnapshotImpl(Stats::Store& store, TimeSource& time_source);
 
   // Stats::MetricSnapshot
   const std::vector<CounterSnapshot>& counters() override { return counters_; }
@@ -396,6 +397,7 @@ public:
   const std::vector<std::reference_wrapper<const Stats::TextReadout>>& textReadouts() override {
     return text_readouts_;
   }
+  int64_t snapShotTimeInMillis() override { return snapshot_time_; }
 
 private:
   std::vector<Stats::CounterSharedPtr> snapped_counters_;
@@ -406,6 +408,7 @@ private:
   std::vector<std::reference_wrapper<const Stats::ParentHistogram>> histograms_;
   std::vector<Stats::TextReadoutSharedPtr> snapped_text_readouts_;
   std::vector<std::reference_wrapper<const Stats::TextReadout>> text_readouts_;
+  int64_t snapshot_time_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -397,7 +397,7 @@ public:
   const std::vector<std::reference_wrapper<const Stats::TextReadout>>& textReadouts() override {
     return text_readouts_;
   }
-  int64_t snapshotTimeMs() const override { return snapshot_time_ms_; }
+  std::chrono::milliseconds snapshotTime() const override { return snapshot_time_; }
 
 private:
   std::vector<Stats::CounterSharedPtr> snapped_counters_;
@@ -408,8 +408,7 @@ private:
   std::vector<std::reference_wrapper<const Stats::ParentHistogram>> histograms_;
   std::vector<Stats::TextReadoutSharedPtr> snapped_text_readouts_;
   std::vector<std::reference_wrapper<const Stats::TextReadout>> text_readouts_;
-  // We store converted timestamp here to avoid repeated conversions for every metric.
-  int64_t snapshot_time_ms_;
+   std::chrono::milliseconds snapshot_time_;
 };
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -397,7 +397,7 @@ public:
   const std::vector<std::reference_wrapper<const Stats::TextReadout>>& textReadouts() override {
     return text_readouts_;
   }
-  int64_t snapshotTimeMs() override { return snapshot_time_ms_; }
+  int64_t snapshotTimeMs() const override { return snapshot_time_ms_; }
 
 private:
   std::vector<Stats::CounterSharedPtr> snapped_counters_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -397,7 +397,7 @@ public:
   const std::vector<std::reference_wrapper<const Stats::TextReadout>>& textReadouts() override {
     return text_readouts_;
   }
-  int64_t snapShotTimeInMillis() override { return snapshot_time_; }
+  int64_t snapshotTimeMs() override { return snapshot_time_ms_; }
 
 private:
   std::vector<Stats::CounterSharedPtr> snapped_counters_;
@@ -408,7 +408,8 @@ private:
   std::vector<std::reference_wrapper<const Stats::ParentHistogram>> histograms_;
   std::vector<Stats::TextReadoutSharedPtr> snapped_text_readouts_;
   std::vector<std::reference_wrapper<const Stats::TextReadout>> text_readouts_;
-  int64_t snapshot_time_;
+  // We store converted timestamp here to avoid repeated conversions for every metric.
+  int64_t snapshot_time_ms_;
 };
 
 } // namespace Server

--- a/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
@@ -96,12 +96,11 @@ public:
   MetricsServiceSinkTest() = default;
 
   NiceMock<Stats::MockMetricSnapshot> snapshot_;
-  Event::SimulatedTimeSystem time_system_;
   std::shared_ptr<MockGrpcMetricsStreamer> streamer_{new MockGrpcMetricsStreamer()};
 };
 
 TEST_F(MetricsServiceSinkTest, CheckSendCall) {
-  MetricsServiceSink sink(streamer_, time_system_, false);
+  MetricsServiceSink sink(streamer_, false);
 
   auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
   counter->name_ = "test_counter";
@@ -125,7 +124,7 @@ TEST_F(MetricsServiceSinkTest, CheckSendCall) {
 }
 
 TEST_F(MetricsServiceSinkTest, CheckStatsCount) {
-  MetricsServiceSink sink(streamer_, time_system_, false);
+  MetricsServiceSink sink(streamer_, false);
 
   auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
   counter->name_ = "test_counter";
@@ -156,7 +155,7 @@ TEST_F(MetricsServiceSinkTest, CheckStatsCount) {
 
 // Test that verifies counters are correctly reported as current value when configured to do so.
 TEST_F(MetricsServiceSinkTest, ReportCountersValues) {
-  MetricsServiceSink sink(streamer_, time_system_, false);
+  MetricsServiceSink sink(streamer_, false);
 
   auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
   counter->name_ = "test_counter";
@@ -174,7 +173,7 @@ TEST_F(MetricsServiceSinkTest, ReportCountersValues) {
 
 // Test that verifies counters are reported as the delta between flushes when configured to do so.
 TEST_F(MetricsServiceSinkTest, ReportCountersAsDeltas) {
-  MetricsServiceSink sink(streamer_, time_system_, true);
+  MetricsServiceSink sink(streamer_, true);
 
   auto counter = std::make_shared<NiceMock<Stats::MockCounter>>();
   counter->name_ = "test_counter";

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -87,6 +87,7 @@ public:
       const Protobuf::RepeatedPtrField<::io::prometheus::client::MetricFamily>& envoy_metrics =
           request_msg.envoy_metrics();
 
+      int64_t previous_time_stamp = 0;
       for (const ::io::prometheus::client::MetricFamily& metrics_family : envoy_metrics) {
         if (metrics_family.name() == "cluster.cluster_0.membership_change" &&
             metrics_family.type() == ::io::prometheus::client::MetricType::COUNTER) {
@@ -112,6 +113,11 @@ public:
                     Stats::HistogramSettingsImpl::defaultBuckets().size());
         }
         ASSERT(metrics_family.metric(0).has_timestamp_ms());
+        // Validate that all metrics have the same timestamp.
+        if (previous_time_stamp > 0) {
+                  EXPECT_EQ(previous_time_stamp, metrics_family.metric(0).timestamp_ms());
+        }
+        previous_time_stamp = metrics_family.metric(0).timestamp_ms();
         if (known_counter_exists && known_gauge_exists && known_histogram_exists) {
           break;
         }

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -115,7 +115,7 @@ public:
         ASSERT(metrics_family.metric(0).has_timestamp_ms());
         // Validate that all metrics have the same timestamp.
         if (previous_time_stamp > 0) {
-                  EXPECT_EQ(previous_time_stamp, metrics_family.metric(0).timestamp_ms());
+          EXPECT_EQ(previous_time_stamp, metrics_family.metric(0).timestamp_ms());
         }
         previous_time_stamp = metrics_family.metric(0).timestamp_ms();
         if (known_counter_exists && known_gauge_exists && known_histogram_exists) {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -280,13 +280,13 @@ public:
   MOCK_METHOD(const std::vector<std::reference_wrapper<const ParentHistogram>>&, histograms, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const TextReadout>>&, textReadouts, ());
 
-  std::chrono::milliseconds snapshotTime() const override { return snapshot_time_; }
+  SystemTime snapshotTime() const override { return snapshot_time_; }
 
   std::vector<CounterSnapshot> counters_;
   std::vector<std::reference_wrapper<const Gauge>> gauges_;
   std::vector<std::reference_wrapper<const ParentHistogram>> histograms_;
   std::vector<std::reference_wrapper<const TextReadout>> text_readouts_;
-  std::chrono::milliseconds snapshot_time_;
+  SystemTime snapshot_time_;
 };
 
 class MockSink : public Sink {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -280,13 +280,13 @@ public:
   MOCK_METHOD(const std::vector<std::reference_wrapper<const ParentHistogram>>&, histograms, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const TextReadout>>&, textReadouts, ());
 
-  int64_t snapshotTimeMs() const override { return snapshot_time_ms_; }
+  std::chrono::milliseconds snapshotTime() const override { return snapshot_time_; }
 
   std::vector<CounterSnapshot> counters_;
   std::vector<std::reference_wrapper<const Gauge>> gauges_;
   std::vector<std::reference_wrapper<const ParentHistogram>> histograms_;
   std::vector<std::reference_wrapper<const TextReadout>> text_readouts_;
-  int64_t snapshot_time_ms_;
+  std::chrono::milliseconds snapshot_time_;
 };
 
 class MockSink : public Sink {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -280,13 +280,13 @@ public:
   MOCK_METHOD(const std::vector<std::reference_wrapper<const ParentHistogram>>&, histograms, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const TextReadout>>&, textReadouts, ());
 
-  int64_t snapShotTimeInMillis() override { return snapshot_time_; }
+  int64_t snapshotTimeMs() override { return snapshot_time_ms_; }
 
   std::vector<CounterSnapshot> counters_;
   std::vector<std::reference_wrapper<const Gauge>> gauges_;
   std::vector<std::reference_wrapper<const ParentHistogram>> histograms_;
   std::vector<std::reference_wrapper<const TextReadout>> text_readouts_;
-  int64_t snapshot_time_;
+  int64_t snapshot_time_ms_;
 };
 
 class MockSink : public Sink {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -280,10 +280,13 @@ public:
   MOCK_METHOD(const std::vector<std::reference_wrapper<const ParentHistogram>>&, histograms, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const TextReadout>>&, textReadouts, ());
 
+  int64_t snapShotTimeInMillis() override { return snapshot_time_; }
+
   std::vector<CounterSnapshot> counters_;
   std::vector<std::reference_wrapper<const Gauge>> gauges_;
   std::vector<std::reference_wrapper<const ParentHistogram>> histograms_;
   std::vector<std::reference_wrapper<const TextReadout>> text_readouts_;
+  int64_t snapshot_time_;
 };
 
 class MockSink : public Sink {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -280,7 +280,7 @@ public:
   MOCK_METHOD(const std::vector<std::reference_wrapper<const ParentHistogram>>&, histograms, ());
   MOCK_METHOD(const std::vector<std::reference_wrapper<const TextReadout>>&, textReadouts, ());
 
-  int64_t snapshotTimeMs() override { return snapshot_time_ms_; }
+  int64_t snapshotTimeMs() const override { return snapshot_time_ms_; }
 
   std::vector<CounterSnapshot> counters_;
   std::vector<std::reference_wrapper<const Gauge>> gauges_;


### PR DESCRIPTION
Commit Message: use snapshot time for all metrics flushed
Additional Description: use snapshot time for all metrics flushed during a flush cycle instead of computing timestamp for every metric.
Risk Level: Low
Testing: Updated tests
Docs Changes: N/A
Release Notes: N/A

Fixes https://github.com/envoyproxy/envoy/issues/13782
