### PR TITLE
[Windows] Address status/fix various flaky_on_windows tests

### DIFF
--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -413,7 +413,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
     testing::InSequence s1;
     EXPECT_CALL(random_generator, random()).WillOnce(Return(std::numeric_limits<uint64_t>::max()));
     // Exiting dispatcher on client side connect event can cause a race, listener accept callback
-    // may not have been triggered, exit dispatcher here to prevent this
+    // may not have been triggered, exit dispatcher here to prevent this.
     EXPECT_CALL(listener_callbacks, onAccept_(_)).WillOnce([&] { dispatcher_->exit(); });
   }
   {

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -412,13 +412,11 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
   {
     testing::InSequence s1;
     EXPECT_CALL(random_generator, random()).WillOnce(Return(std::numeric_limits<uint64_t>::max()));
-    EXPECT_CALL(listener_callbacks, onAccept_(_));
+    EXPECT_CALL(listener_callbacks, onAccept_(_)).WillOnce([&] { dispatcher_->exit(); });
   }
   {
     testing::InSequence s2;
-    EXPECT_CALL(connection_callbacks, onEvent(ConnectionEvent::Connected)).WillOnce([&] {
-      dispatcher_->exit();
-    });
+    EXPECT_CALL(connection_callbacks, onEvent(ConnectionEvent::Connected));
     EXPECT_CALL(connection_callbacks, onEvent(ConnectionEvent::RemoteClose)).Times(0);
   }
 

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -412,6 +412,8 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
   {
     testing::InSequence s1;
     EXPECT_CALL(random_generator, random()).WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+    // Exiting dispatcher on client side connect event can cause a race, listener accept callback
+    // may not have been triggered, exit dispatcher here to prevent this
     EXPECT_CALL(listener_callbacks, onAccept_(_)).WillOnce([&] { dispatcher_->exit(); });
   }
   {

--- a/test/extensions/filters/http/ratelimit/BUILD
+++ b/test/extensions/filters/http/ratelimit/BUILD
@@ -51,6 +51,7 @@ envoy_extension_cc_test(
     name = "ratelimit_integration_test",
     srcs = ["ratelimit_integration_test.cc"],
     extension_name = "envoy.filters.http.ratelimit",
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         "//source/common/buffer:zero_copy_input_stream_lib",

--- a/test/extensions/grpc_credentials/file_based_metadata/BUILD
+++ b/test/extensions/grpc_credentials/file_based_metadata/BUILD
@@ -10,10 +10,9 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_test(
-    name = "file_based_metadata_grpc_credentials_test",
-    srcs = ["file_based_metadata_grpc_credentials_test.cc"],
+    name = "integration_test",
+    srcs = ["integration_test.cc"],
     data = ["//test/config/integration/certs"],
-    tags = ["flaky_on_windows"],
     deps = [
         "//source/extensions/grpc_credentials:well_known_names",
         "//source/extensions/grpc_credentials/file_based_metadata:config",

--- a/test/extensions/grpc_credentials/file_based_metadata/integration_test.cc
+++ b/test/extensions/grpc_credentials/file_based_metadata/integration_test.cc
@@ -41,7 +41,7 @@ public:
         TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
     if (!header_value_1_.empty()) {
       const std::string yaml1 = fmt::format(R"EOF(
-"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig        
+"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig
 secret_data:
   inline_string: {}
 header_key: {}
@@ -56,7 +56,7 @@ header_prefix: {}
     if (!header_value_2_.empty()) {
       // uses default key/prefix
       const std::string yaml2 = fmt::format(R"EOF(
-"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig        
+"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.FileBasedMetadataConfig
 secret_data:
   inline_string: {}
 )EOF",

--- a/test/extensions/quic_listeners/quiche/integration/BUILD
+++ b/test/extensions/quic_listeners/quiche/integration/BUILD
@@ -13,7 +13,11 @@ envoy_cc_test(
     size = "medium",
     srcs = ["quic_http_integration_test.cc"],
     data = ["//test/config/integration/certs"],
-    # TODO(envoyproxy/windows-dev): Diagnose msvc-cl opt build gcp rbe CI flake (passes locally)
+    # TODO(envoyproxy/windows-dev): Diagnose why opt build test under Windows GCP RBE
+    # takes 10x as long as on linux (>300s vs ~30s). Shards = 2 solves for windows, see:
+    #   https://github.com/envoyproxy/envoy/pull/13713/files#r512160087
+    # Each of these tests exceeds 20s;
+    # QuicHttpIntegrationTests/QuicHttpIntegrationTest.MultipleQuicConnections[With|No]BPF*
     tags = [
         "flaky_on_windows",
         "nofips",

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -393,10 +393,10 @@ TEST_P(QuicHttpIntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
             1);
 }
 
-// Only run on platforms that support BPF
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsWithBPF) { testMultipleQuicConnections(); }
-#endif
+// Ensure multiple quic connections work, regardless of platform BPF support
+TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsBPFDefaultMode) {
+  testMultipleQuicConnections();
+}
 
 TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsNoBPF) {
   // Note: This runtime override is a no-op on platforms without BPF

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -394,7 +394,7 @@ TEST_P(QuicHttpIntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
 }
 
 // Ensure multiple quic connections work, regardless of platform BPF support
-TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsBPFDefaultMode) {
+TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsDefaultMode) {
   testMultipleQuicConnections();
 }
 

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -249,6 +249,8 @@ public:
       // create connections with the first 4 bytes of connection id different from each
       // other so they should be evenly distributed.
       designated_connection_ids_.push_back(quic::test::TestConnectionId(i << 32));
+      // TODO(sunjayBhatia,wrowe): deserialize this, establishing all connections in parallel
+      // (Expected to save ~14s each across 6 tests on Windows)
       codec_clients.push_back(makeHttpConnection(lookupPort("http")));
     }
     constexpr auto timeout_first = std::chrono::seconds(15);
@@ -391,9 +393,13 @@ TEST_P(QuicHttpIntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
             1);
 }
 
+// Only run on platforms that support BPF
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
 TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsWithBPF) { testMultipleQuicConnections(); }
+#endif
 
 TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsNoBPF) {
+  // Note: This runtime override is a no-op on platforms without BPF
   config_helper_.addRuntimeOverride(
       "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing", "false");
 

--- a/test/extensions/stats_sinks/metrics_service/BUILD
+++ b/test/extensions/stats_sinks/metrics_service/BUILD
@@ -45,6 +45,7 @@ envoy_extension_cc_test(
     name = "metrics_service_integration_test",
     srcs = ["metrics_service_integration_test.cc"],
     extension_name = "envoy.stat_sinks.metrics_service",
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         "//source/common/buffer:zero_copy_input_stream_lib",

--- a/test/extensions/transport_sockets/alts/BUILD
+++ b/test/extensions/transport_sockets/alts/BUILD
@@ -39,8 +39,6 @@ envoy_extension_cc_test(
     name = "tsi_handshaker_test",
     srcs = ["tsi_handshaker_test.cc"],
     extension_name = "envoy.transport_sockets.alts",
-    # Fails intermittantly on local build
-    tags = ["flaky_on_windows"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//source/extensions/transport_sockets/alts:tsi_handshaker",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -135,6 +135,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "eds_integration_test",
     srcs = ["eds_integration_test.cc"],
+    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -318,7 +319,6 @@ envoy_cc_test(
         "http2_flood_integration_test.cc",
     ],
     shard_count = 4,
-    tags = ["flaky_on_windows"],
     deps = [
         ":autonomous_upstream_lib",
         ":http_integration_lib",
@@ -343,6 +343,7 @@ envoy_cc_test(
         "http2_integration_test.h",
     ],
     shard_count = 4,
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -372,7 +373,7 @@ envoy_cc_test(
     srcs = [
         "http_subset_lb_integration_test.cc",
     ],
-    # Consistently times out in CI on Windows, but observed to pass locally
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -434,6 +435,9 @@ envoy_cc_test(
     # As this test has many H1/H2/v4/v6 tests it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 5,
+    # TODO(envoyproxy/windows-dev): Largely resolved by Level Events PR #13787 - diagose remaining rare failure;
+    # Protocols/DownstreamProtocolIntegrationTest.LargeRequestUrlRejected/IPv6_HttpDownstream_HttpUpstream
+    # test/integration/http_integration.cc(1035): error: Value of: response->complete()  Actual: false  Expected: true
     tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
@@ -458,6 +462,8 @@ envoy_cc_test(
         "http2_upstream_integration_test.cc",
         "http2_upstream_integration_test.h",
     ],
+    # TODO(envoyproxy/windows-dev): Diagnose test timeout observed in msvc-cl opt build
+    # in Http2UpstreamIntegrationTest.RouterUpstreamDisconnectBeforeResponseComplete/IPv4
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -565,7 +571,7 @@ envoy_cc_test(
     # As this test has many pauses for idle timeouts, it takes a while to run.
     # Shard it enough to bring the run time in line with other integration tests.
     shard_count = 2,
-    # Consistently fails in CI on Windows, but observed to pass locally
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
@@ -874,7 +880,7 @@ envoy_cc_test(
         "integration_test.h",
     ],
     shard_count = 2,
-    # Times out on Windows
+    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in clang-cl opt build test
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -921,7 +927,7 @@ envoy_cc_test(
         "websocket_integration_test.cc",
         "websocket_integration_test.h",
     ],
-    # Consistently fails in CI on Windows, but observed to pass locally
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
@@ -984,7 +990,8 @@ envoy_cc_test(
 envoy_cc_test(
     name = "load_stats_integration_test",
     srcs = ["load_stats_integration_test.cc"],
-    # Consistently timing out on Windows, observed to pass locally
+    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test, hangs at
+    # IpVersionsClientType/LoadStatsIntegrationTest.NoLocalLocality/3
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -1007,7 +1014,7 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     shard_count = 2,
-    # Alternately timing out and failing in CI on windows; observed to pass locally
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -1042,7 +1049,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "overload_integration_test",
     srcs = ["overload_integration_test.cc"],
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_protocol_integration_lib",
         "//test/common/config:dummy_config_proto_cc_proto",
@@ -1189,7 +1195,7 @@ envoy_cc_test(
         "//test/config/integration/certs",
     ],
     shard_count = 2,
-    # Fails intermittantly on local build
+    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test
     tags = ["flaky_on_windows"],
     deps = [
         ":integration_lib",
@@ -1225,6 +1231,7 @@ envoy_cc_test(
     data = [
         "//test/config/integration/certs",
     ],
+    # TODO(envoyproxy/windows-dev): Apparently resolved by Level Events PR #13787
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
@@ -1305,6 +1312,7 @@ envoy_cc_test(
         "//test/config/integration:server_xds_files",
         "//test/config/integration/certs",
     ],
+    # TODO(envoyproxy/windows-dev): Diagnose test failure observed in opt build
     tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -128,8 +128,6 @@ envoy_cc_test(
     name = "guarddog_impl_test",
     size = "small",
     srcs = ["guarddog_impl_test.cc"],
-    # Fails intermittantly on local build
-    tags = ["flaky_on_windows"],
     deps = [
         "//include/envoy/common:time_interface",
         "//source/common/api:api_lib",


### PR DESCRIPTION
Commit Message: [Windows] Address status/fix various flaky_on_windows tests
Additional Description:
- Correct listener_impl_test, fixes
TcpListenerImplTest.SetListenerRejectFractionIntermediate
These fixes reflect that the timing on windows is often less
synchronous than linux observations, due to the design of the
underlying socket stack.
- In QuicHttpIntegrationTest, the MultipleQuicConnectionsWithBPF is
never relevant to Windows or macOS (and took a not-insignificant
amount of time per test case.)
- Enable no-longer-failing tests (no failure observed in RBE or locally)
    //test/extensions/grpc_credentials/file_based_metadata:integration_test
    //test/extensions/transport_sockets/alts:tsi_handshaker_test
    //test/integration:http2_flood_integration_test
    //test/integration:http2_upstream_integration_test
    //test/integration:overload_integration_test
    //test/server:guarddog_impl_test

Co-authored-by: Sunjay Bhatia <sunjayb@vmware.com>
Co-authored-by: William A Rowe Jr <wrowe@vmware.com>

Risk Level: Low (test enablement only)
Testing: Windows msvc-cl and clang-cl RBE and locally
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
