### PR TITLE
tap: warn when using admin tap and admin is listening on a pipe

### DIFF
--- a/source/extensions/common/tap/admin.cc
+++ b/source/extensions/common/tap/admin.cc
@@ -31,6 +31,10 @@ AdminHandler::AdminHandler(Server::Admin& admin, Event::Dispatcher& main_thread_
   const bool rc =
       admin_.addHandler("/tap", "tap filter control", MAKE_ADMIN_HANDLER(handler), true, true);
   RELEASE_ASSERT(rc, "/tap admin endpoint is taken");
+  if (admin_.socket().addressType() == Network::Address::Type::Pipe) {
+    ENVOY_LOG(warn, "Admin tapping (via /tap) is unreliable when the admin endpoint is a pipe and "
+                    "the connection is HTTP/1. Either use an IP address or connect using HTTP/2.");
+  }
 }
 
 AdminHandler::~AdminHandler() {

--- a/test/extensions/common/tap/BUILD
+++ b/test/extensions/common/tap/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test(
         "//source/extensions/common/tap:admin",
         "//test/mocks/server:admin_mocks",
         "//test/mocks/server:admin_stream_mocks",
+        "//test/test_common:logging_lib",
         "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/common/tap/admin_test.cc
+++ b/test/extensions/common/tap/admin_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/mocks/server/admin.h"
 #include "test/mocks/server/admin_stream.h"
+#include "test/test_common/logging.h"
 
 #include "gtest/gtest.h"
 
@@ -28,9 +29,11 @@ public:
 
 class AdminHandlerTest : public testing::Test {
 public:
-  AdminHandlerTest() {
+  void setup(Network::Address::Type socket_type = Network::Address::Type::Ip) {
+    ON_CALL(admin_.socket_, addressType()).WillByDefault(Return(socket_type));
     EXPECT_CALL(admin_, addHandler("/tap", "tap filter control", _, true, true))
         .WillOnce(DoAll(SaveArg<2>(&cb_), Return(true)));
+    EXPECT_CALL(admin_, socket());
     handler_ = std::make_unique<AdminHandler>(admin_, main_thread_dispatcher_);
   }
 
@@ -58,8 +61,18 @@ tap_config:
 )EOF";
 };
 
+// Make sure warn if using a pipe address for the admin handler.
+TEST_F(AdminHandlerTest, AdminWithPipeSocket) {
+  EXPECT_LOG_CONTAINS(
+      "warn",
+      "Admin tapping (via /tap) is unreliable when the admin endpoint is a pipe and the connection "
+      "is HTTP/1. Either use an IP address or connect using HTTP/2.",
+      setup(Network::Address::Type::Pipe));
+}
+
 // Request with no config body.
 TEST_F(AdminHandlerTest, NoBody) {
+  setup();
   EXPECT_CALL(admin_stream_, getRequestBody());
   EXPECT_EQ(Http::Code::BadRequest, cb_("/tap", response_headers_, response_, admin_stream_));
   EXPECT_EQ("/tap requires a JSON/YAML body", response_.toString());
@@ -67,6 +80,7 @@ TEST_F(AdminHandlerTest, NoBody) {
 
 // Request with a config body that doesn't parse/verify.
 TEST_F(AdminHandlerTest, BadBody) {
+  setup();
   Buffer::OwnedImpl bad_body("hello");
   EXPECT_CALL(admin_stream_, getRequestBody()).WillRepeatedly(Return(&bad_body));
   EXPECT_EQ(Http::Code::BadRequest, cb_("/tap", response_headers_, response_, admin_stream_));
@@ -75,6 +89,7 @@ TEST_F(AdminHandlerTest, BadBody) {
 
 // Request that references an unknown config ID.
 TEST_F(AdminHandlerTest, UnknownConfigId) {
+  setup();
   Buffer::OwnedImpl body(admin_request_yaml_);
   EXPECT_CALL(admin_stream_, getRequestBody()).WillRepeatedly(Return(&body));
   EXPECT_EQ(Http::Code::BadRequest, cb_("/tap", response_headers_, response_, admin_stream_));
@@ -84,6 +99,7 @@ TEST_F(AdminHandlerTest, UnknownConfigId) {
 
 // Request while there is already an active tap session.
 TEST_F(AdminHandlerTest, RequestTapWhileAttached) {
+  setup();
   MockExtensionConfig extension_config;
   handler_->registerConfig(extension_config, "test_config_id");
 

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -23,6 +23,7 @@ envoy_cc_mock(
     hdrs = ["admin.h"],
     deps = [
         "//include/envoy/server:admin_interface",
+        "//test/mocks/network:socket_mocks",
         "//test/mocks/server:config_tracker_mocks",
     ],
 )

--- a/test/mocks/server/admin.cc
+++ b/test/mocks/server/admin.cc
@@ -3,11 +3,16 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::Return;
+using testing::ReturnRef;
+
 namespace Envoy {
 namespace Server {
+
 MockAdmin::MockAdmin() {
-  ON_CALL(*this, getConfigTracker()).WillByDefault(testing::ReturnRef(config_tracker_));
-  ON_CALL(*this, concurrency()).WillByDefault(testing::Return(1));
+  ON_CALL(*this, getConfigTracker()).WillByDefault(ReturnRef(config_tracker_));
+  ON_CALL(*this, concurrency()).WillByDefault(Return(1));
+  ON_CALL(*this, socket()).WillByDefault(ReturnRef(socket_));
 }
 
 MockAdmin::~MockAdmin() = default;

--- a/test/mocks/server/admin.h
+++ b/test/mocks/server/admin.h
@@ -4,12 +4,17 @@
 
 #include "envoy/server/admin.h"
 
+#include "test/mocks/network/socket.h"
+
 #include "absl/strings/string_view.h"
 #include "config_tracker.h"
 #include "gmock/gmock.h"
 
+using testing::NiceMock;
+
 namespace Envoy {
 namespace Server {
+
 class MockAdmin : public Admin {
 public:
   MockAdmin();
@@ -33,7 +38,9 @@ public:
   MOCK_METHOD(void, addListenerToHandler, (Network::ConnectionHandler * handler));
   MOCK_METHOD(uint32_t, concurrency, (), (const));
 
-  ::testing::NiceMock<MockConfigTracker> config_tracker_;
+  NiceMock<MockConfigTracker> config_tracker_;
+  NiceMock<Network::MockSocket> socket_;
 };
+
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
Docs were done in a previous PR.

Fixes https://github.com/envoyproxy/envoy/issues/6387

Risk Level: Low
Testing: New UT
Docs Changes: Already done
Release Notes: N/A
Platform Specific Features: N/A
