### PR TITLE
jwt_authn: change allow_missing implementation under RequiresAny

### DIFF
--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -274,7 +274,7 @@ public:
     }
 
     // RequiresAny only has one missing or failed requirement.
-    if (verifiers_.size() == 0 && (is_allow_failed_ || is_allow_missing_)) {
+    if (verifiers_.empty() && (is_allow_failed_ || is_allow_missing_)) {
       JwtRequirement requirement;
       if (is_allow_failed_) {
         requirement.mutable_allow_missing_or_failed();

--- a/source/extensions/filters/http/jwt_authn/verifier.cc
+++ b/source/extensions/filters/http/jwt_authn/verifier.cc
@@ -302,7 +302,7 @@ public:
     if (++completion_state.number_completed_children_ == verifiers_.size()) {
       // Aggregate all children status into a final status.
       // JwtMissing should be treated differently than other failure status
-      // since it simplely means there is not Jwt token for the required provider.
+      // since it simply means there is not Jwt token for the required provider.
       // If there is a failure status other than JwtMissing in the children,
       // it should be used as the final status.
       Status final_status = Status::JwtMissed;


### PR DESCRIPTION
This is to fix:  https://github.com/envoyproxy/envoy/issues/13458

The current implementation of allow_missing or allow_missing_or_failed under RequiresAny is buggy.  This is how it implemented currently.  If you have following JwtRequirement:
```
    require_any:
         provider_name:  A
         provider_name:  B
         allow_missing:
```
We create following 3 verifiers: 
```
  1) a verifier for A, 
  2) a verifier for B,
  3) a verifier for A, B, with allow_missing. 
```
The 3) veirifier causes two problems:
1) Token for provider A or B are verified twice.  
2) If 3) veirfier is done first (since it has allow_missing flag, it can be done first). Its successful return will abort 1) or 2).  That is the root cause of https://github.com/envoyproxy/envoy/issues/13458

This PR will make following changes:
* Remember the return status for all children verifier for GroupVerifier,  especially for AnyVerifier.
* AnyVerifier will aggregate the final return based on its children result. 
* Not to create 3) verifier, instead mark the `allow_missing` or `allow_failed` flag in AnyVerifier.   Use the flag in the final status aggregation.
* Not need to pass parent_provider to Verifier::innerCreate().  It was only used when creating a AllowMissing or AllowFailed verifier under `require_any`. It is not needed any more. 

Risk Level:  Low.  It only impacts `allow_missing` or `allow_missing_or_failed` flag under `require_any`.  This is a rarely used feature.  
Testing:  unit-tested
Docs Changes:  None
Release Notes: None
