### PR TITLE
cluster configuration updated directly on Envoy container's filesystem

### DIFF
--- a/examples/dynamic-config-fs/verify.sh
+++ b/examples/dynamic-config-fs/verify.sh
@@ -19,7 +19,7 @@ curl -s http://localhost:19000/config_dump \
     | grep '"address": "service1"'
 
 run_log "Set upstream to service2"
-sed -i s/service1/service2/ configs/cds.yaml
+docker exec -t dynamic-config-fs_proxy_1 sed -i s/service1/service2/ /var/lib/envoy/cds.yaml
 
 run_log "Check for response comes from service2 upstream"
 responds_with \

--- a/examples/dynamic-config-fs/verify.sh
+++ b/examples/dynamic-config-fs/verify.sh
@@ -19,7 +19,7 @@ curl -s http://localhost:19000/config_dump \
     | grep '"address": "service1"'
 
 run_log "Set upstream to service2"
-docker exec -t dynamic-config-fs_proxy_1 sed -i s/service1/service2/ /var/lib/envoy/cds.yaml
+docker-compose exec -T proxy sed -i s/service1/service2/ /var/lib/envoy/cds.yaml
 
 run_log "Check for response comes from service2 upstream"
 responds_with \


### PR DESCRIPTION
Signed-off-by: Andrea Di Lisio <andrea.dilisio91@gmail.com>

Commit Message: cluster configuration updated directly on Envoy container's filesystem
Additional Description: changes the way cluster configuration is updated in examples/dynamic-config-fs. Configuration file updated on the envoy container and not on the host system.
Risk Level: Low
Testing: run updated `./verify.sh`.
Docs Changes: probably [this](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/dynamic-configuration-filesystem#step-5-dump-envoy-s-dynamic-active-clusters-config) can be updated accordingly: starting Note section on umask and chmod might be removed, I would mention to not use vim [or similar tools](https://unix.stackexchange.com/questions/188873/using-inotifywait-along-with-vim) to update the config files on the container 

Fixes #13853
