### PR TITLE
health-check: fix grpc health check multiple resets

### DIFF
--- a/source/common/upstream/health_checker_impl.cc
+++ b/source/common/upstream/health_checker_impl.cc
@@ -781,7 +781,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onRpcComplete(
 
   // |end_stream| will be false if we decided to stop healthcheck before HTTP stream has ended -
   // invalid gRPC payload, unexpected message stream or wrong content-type.
-  if (end_stream) {
+  if (end_stream || !request_encoder_) {
     resetState();
   } else {
     // resetState() will be called by onResetStream().
@@ -789,7 +789,7 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onRpcComplete(
     request_encoder_->getStream().resetStream(Http::StreamResetReason::LocalReset);
   }
 
-  if (!parent_.reuse_connection_ || goaway) {
+  if (client_ && (!parent_.reuse_connection_ || goaway)) {
     client_->close();
   }
 }

--- a/test/common/upstream/health_check_corpus/double_reset.fuzz
+++ b/test/common/upstream/health_check_corpus/double_reset.fuzz
@@ -1,0 +1,46 @@
+health_check_config {
+  timeout {
+    seconds: 1
+  }
+  interval {
+    seconds: 1
+  }
+  unhealthy_threshold {
+    value: 2
+  }
+  healthy_threshold {
+    value: 2
+  }
+  grpc_health_check {
+    service_name: "service"
+    authority: "wwnvoyproxy.io"
+  }
+  event_log_path: "200"
+}
+actions {
+  respond {
+    http_respond {
+      status: 200
+    }
+    tcp_respond {
+    }
+    grpc_respond {
+      grpc_respond_headers {
+        headers {
+          headers {
+            key: "content-type"
+            value: "application/grpc"
+          }
+        }
+        status: 200
+      }
+      grpc_respond_bytes {
+        grpc_respond_unstructured_bytes {
+          data: "\000\000\000\000\000\000\000\000\000\000\000\000\000\00000000000000000000000000000000000\000\000\000\000\000\000\000\000\000\000\000\000\000c_r000\000\000\000\000\000\000\000"
+          data: "200"
+        }
+      }
+    }
+  }
+}
+http_verify_cluster: true


### PR DESCRIPTION
Commit Message: health-check: fix grpc health check multiple resets
Additional Description:
Multiple resets caused failure accessing `request_encoder_` after the health check was already reset.
This PR verifies that `request_encoder_` and `client_` are valid before calling them.
 
Risk Level: Low - adding a check
Testing: Added fuzz test.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.
Fixes fuzz test: [26848](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26848)

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
