### PR TITLE
build: exclude wee8/out from inputs

### DIFF
--- a/bazel/external/wee8.BUILD
+++ b/bazel/external/wee8.BUILD
@@ -26,7 +26,10 @@ cc_library(
 
 genrule(
     name = "build",
-    srcs = glob(["wee8/**"]),
+    srcs = glob(
+        ["wee8/**"],
+        exclude = ["wee8/out/**"],
+    ),
     outs = [
         "libwee8.a",
     ],


### PR DESCRIPTION
If you build without sandboxing for performance, the output files from
this custom build genrule contained timestamps which caused it to
rebuild every single build.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>