### PR TITLE
examples: Fix verify.sh sed commands for mac compatibility

### DIFF
--- a/examples/dynamic-config-cp/verify.sh
+++ b/examples/dynamic-config-cp/verify.sh
@@ -56,8 +56,8 @@ curl -s http://localhost:19000/config_dump \
     | grep '"address": "service1"'
 
 run_log "Edit resource.go"
-sed -i s/service1/service2/ resource.go
-sed -i s/\"1\",/\"2\",/ resource.go
+sed -i'.bak' s/service1/service2/ resource.go
+sed -i'.bak' s/\"1\",/\"2\",/ resource.go
 
 run_log "Bring back up the control plane"
 docker-compose up --build -d go-control-plane

--- a/examples/wasm-cc/verify.sh
+++ b/examples/wasm-cc/verify.sh
@@ -30,7 +30,7 @@ run_log "Check for the compiled update"
 ls -l lib/*updated*wasm
 
 run_log "Edit the Docker recipe to use the updated binary"
-sed -i s/\\.\\/lib\\/envoy_filter_http_wasm_example.wasm/.\\/lib\\/envoy_filter_http_wasm_updated_example.wasm/ Dockerfile-proxy
+sed -i'.bak' s/\\.\\/lib\\/envoy_filter_http_wasm_example.wasm/.\\/lib\\/envoy_filter_http_wasm_updated_example.wasm/ Dockerfile-proxy
 
 run_log "Bring the proxy back up"
 docker-compose up --build -d proxy


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: examples: Fix verify.sh sed commands for mac compatibility
Additional Description:

Further followup from #13853 - fixes `sed` command in other sandboxes so should work on gnu and bsd sed

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
