### PR TITLE
[fuzz] Got rid of all uninteresting call logs in health check fuzzing

### DIFF
--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -145,12 +145,12 @@ envoy_benchmark_test(
 )
 
 envoy_cc_test_library(
-    name = "health_checker_impl_test_lib",
+    name = "health_check_fuzz_utils_lib",
     srcs = [
-        "health_checker_impl_test_utils.cc",
+        "health_check_fuzz_test_utils.cc",
     ],
     hdrs = [
-        "health_checker_impl_test_utils.h",
+        "health_check_fuzz_test_utils.h",
     ],
     deps = [
         ":utility_lib",
@@ -169,7 +169,7 @@ envoy_cc_test(
         "health_checker_impl_test.cc",
     ],
     deps = [
-        ":health_checker_impl_test_lib",
+        ":utility_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/http:headers_lib",
@@ -710,7 +710,7 @@ envoy_cc_test_library(
     hdrs = ["health_check_fuzz.h"],
     deps = [
         ":health_check_fuzz_proto_cc_proto",
-        ":health_checker_impl_test_lib",
+        ":health_check_fuzz_utils_lib",
         ":utility_lib",
         "//test/fuzz:utility_lib",
     ],

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -306,7 +306,7 @@ void TcpHealthCheckFuzz::raiseEvent(const Network::ConnectionEvent& event_type, 
 
 void GrpcHealthCheckFuzz::allocGrpcHealthCheckerFromProto(
     const envoy::config::core::v3::HealthCheck& config) {
-  health_checker_ = std::make_shared<TestGrpcHealthCheckerImpl>(
+  health_checker_ = std::make_shared<NiceMock<TestGrpcHealthCheckerImpl>>(
       *cluster_, config, dispatcher_, runtime_, random_,
       HealthCheckEventLoggerPtr(event_logger_storage_.release()));
   ENVOY_LOG_MISC(trace, "Created Test Grpc Health Checker");

--- a/test/common/upstream/health_check_fuzz.h
+++ b/test/common/upstream/health_check_fuzz.h
@@ -3,7 +3,7 @@
 #include <memory>
 
 #include "test/common/upstream/health_check_fuzz.pb.validate.h"
-#include "test/common/upstream/health_checker_impl_test_utils.h"
+#include "test/common/upstream/health_check_fuzz_test_utils.h"
 #include "test/fuzz/common.pb.h"
 
 namespace Envoy {
@@ -108,7 +108,7 @@ public:
   void expectClientCreate();
   void expectStreamCreate();
 
-  std::shared_ptr<TestGrpcHealthCheckerImpl> health_checker_;
+  std::shared_ptr<NiceMock<TestGrpcHealthCheckerImpl>> health_checker_;
 };
 
 } // namespace Upstream

--- a/test/common/upstream/health_check_fuzz_test_utils.cc
+++ b/test/common/upstream/health_check_fuzz_test_utils.cc
@@ -1,4 +1,4 @@
-#include "test/common/upstream/health_checker_impl_test_utils.h"
+#include "test/common/upstream/health_check_fuzz_test_utils.h"
 
 #include "test/common/upstream/utility.h"
 
@@ -14,8 +14,8 @@ void HttpHealthCheckerImplTestBase::expectSessionCreate(
   TestSessionPtr new_test_session(new TestSession());
   test_sessions_.emplace_back(std::move(new_test_session));
   TestSession& test_session = *test_sessions_.back();
-  test_session.timeout_timer_ = new Event::MockTimer(&dispatcher_);
-  test_session.interval_timer_ = new Event::MockTimer(&dispatcher_);
+  test_session.timeout_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
+  test_session.interval_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
   expectClientCreate(test_sessions_.size() - 1, health_check_map);
 }
 

--- a/test/common/upstream/health_check_fuzz_test_utils.h
+++ b/test/common/upstream/health_check_fuzz_test_utils.h
@@ -11,8 +11,7 @@
 
 namespace Envoy {
 namespace Upstream {
-// TODO IN THIS PR, IF YOU ARE GOING TO EDIT THESE TO NICEMOCKS, MAKE SURE TO CHECKOUT MASTER FOR
-// THESE UNIT TESTS BEFORE I EVER STEPPED FOOT HERE AT GOOGLE
+
 class HealthCheckerTestBase {
 public:
   std::shared_ptr<MockClusterMockPrioritySet> cluster_{

--- a/test/common/upstream/health_check_fuzz_test_utils.h
+++ b/test/common/upstream/health_check_fuzz_test_utils.h
@@ -20,8 +20,6 @@ public:
   std::unique_ptr<NiceMock<MockHealthCheckEventLogger>> event_logger_storage_{
       std::make_unique<NiceMock<MockHealthCheckEventLogger>>()};
   NiceMock<MockHealthCheckEventLogger>& event_logger_{*event_logger_storage_};
-  // NiceMock<MockHealthCheckEventLogger>& event_logger_ = new
-  // NiceMock<MockHealthCheckEventLogger>(*event_logger_storage_);
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Runtime::MockLoader> runtime_;
 };

--- a/test/common/upstream/health_check_fuzz_test_utils.h
+++ b/test/common/upstream/health_check_fuzz_test_utils.h
@@ -11,15 +11,18 @@
 
 namespace Envoy {
 namespace Upstream {
-
+// TODO IN THIS PR, IF YOU ARE GOING TO EDIT THESE TO NICEMOCKS, MAKE SURE TO CHECKOUT MASTER FOR
+// THESE UNIT TESTS BEFORE I EVER STEPPED FOOT HERE AT GOOGLE
 class HealthCheckerTestBase {
 public:
   std::shared_ptr<MockClusterMockPrioritySet> cluster_{
       std::make_shared<NiceMock<MockClusterMockPrioritySet>>()};
   NiceMock<Event::MockDispatcher> dispatcher_;
-  std::unique_ptr<MockHealthCheckEventLogger> event_logger_storage_{
-      std::make_unique<MockHealthCheckEventLogger>()};
-  MockHealthCheckEventLogger& event_logger_{*event_logger_storage_};
+  std::unique_ptr<NiceMock<MockHealthCheckEventLogger>> event_logger_storage_{
+      std::make_unique<NiceMock<MockHealthCheckEventLogger>>()};
+  NiceMock<MockHealthCheckEventLogger>& event_logger_{*event_logger_storage_};
+  // NiceMock<MockHealthCheckEventLogger>& event_logger_ = new
+  // NiceMock<MockHealthCheckEventLogger>(*event_logger_storage_);
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Runtime::MockLoader> runtime_;
 };
@@ -41,8 +44,8 @@ public:
 class HttpHealthCheckerImplTestBase : public HealthCheckerTestBase {
 public:
   struct TestSession {
-    Event::MockTimer* interval_timer_{};
-    Event::MockTimer* timeout_timer_{};
+    NiceMock<Event::MockTimer>* interval_timer_{};
+    NiceMock<Event::MockTimer>* timeout_timer_{};
     Http::MockClientConnection* codec_{};
     Stats::IsolatedStoreImpl stats_store_;
     Network::MockClientConnection* client_connection_{};

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -522,10 +522,9 @@ public:
   void expectSessionCreate(const HostWithHealthCheckMap& health_check_map) {
     // Expectations are in LIFO order.
     TestSessionPtr new_test_session(new TestSession());
+    new_test_session->timeout_timer_ = new Event::MockTimer(&dispatcher_);
+    new_test_session->interval_timer_ = new Event::MockTimer(&dispatcher_);
     test_sessions_.emplace_back(std::move(new_test_session));
-    TestSession& test_session = *test_sessions_.back();
-    test_session.timeout_timer_ = new Event::MockTimer(&dispatcher_);
-    test_session.interval_timer_ = new Event::MockTimer(&dispatcher_);
     expectClientCreate(test_sessions_.size() - 1, health_check_map);
   }
 
@@ -540,7 +539,7 @@ public:
     EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _))
         .Times(testing::AnyNumber())
         .WillRepeatedly(InvokeWithoutArgs([&]() -> Network::ClientConnection* {
-          uint32_t index = connection_index_.front();
+          const uint32_t index = connection_index_.front();
           connection_index_.pop_front();
           return test_sessions_[index]->client_connection_;
         }));
@@ -554,7 +553,7 @@ public:
                 EXPECT_EQ(health_check_config.port_value(),
                           conn_data.host_description_->healthCheckAddress()->ip()->port());
               }
-              uint32_t index = codec_index_.front();
+              const uint32_t index = codec_index_.front();
               codec_index_.pop_front();
               TestSession& test_session = *test_sessions_[index];
               std::shared_ptr<Upstream::MockClusterInfo> cluster{
@@ -3705,10 +3704,9 @@ public:
   void expectSessionCreate() {
     // Expectations are in LIFO order.
     TestSessionPtr new_test_session(new TestSession());
+    new_test_session->timeout_timer_ = new Event::MockTimer(&dispatcher_);
+    new_test_session->interval_timer_ = new Event::MockTimer(&dispatcher_);
     test_sessions_.emplace_back(std::move(new_test_session));
-    TestSession& test_session = *test_sessions_.back();
-    test_session.timeout_timer_ = new Event::MockTimer(&dispatcher_);
-    test_session.interval_timer_ = new Event::MockTimer(&dispatcher_);
     expectClientCreate(test_sessions_.size() - 1);
   }
 
@@ -3722,7 +3720,7 @@ public:
     EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _))
         .Times(testing::AnyNumber())
         .WillRepeatedly(InvokeWithoutArgs([&]() -> Network::ClientConnection* {
-          uint32_t index = connection_index_.front();
+          const uint32_t index = connection_index_.front();
           connection_index_.pop_front();
           return test_sessions_[index]->client_connection_;
         }));
@@ -3730,7 +3728,7 @@ public:
     EXPECT_CALL(*health_checker_, createCodecClient_(_))
         .WillRepeatedly(
             Invoke([&](Upstream::Host::CreateConnectionData& conn_data) -> Http::CodecClient* {
-              uint32_t index = codec_index_.front();
+              const uint32_t index = codec_index_.front();
               codec_index_.pop_front();
               TestSession& test_session = *test_sessions_[index];
               std::shared_ptr<Upstream::MockClusterInfo> cluster{

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -15,10 +15,10 @@
 #include "common/json/json_loader.h"
 #include "common/network/utility.h"
 #include "common/protobuf/utility.h"
+#include "common/upstream/health_checker_impl.h"
 #include "common/upstream/upstream_impl.h"
 
 #include "test/common/http/common.h"
-#include "test/common/upstream/health_checker_impl_test_utils.h"
 #include "test/common/upstream/utility.h"
 #include "test/mocks/access_log/mocks.h"
 #include "test/mocks/api/mocks.h"
@@ -29,6 +29,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/cluster_priority_set.h"
+#include "test/mocks/upstream/health_check_event_logger.h"
 #include "test/mocks/upstream/host_set.h"
 #include "test/mocks/upstream/transport_socket_match.h"
 #include "test/test_common/printers.h"
@@ -98,8 +99,49 @@ TEST(HealthCheckerFactoryTest, CreateGrpc) {
                     .get()));
 }
 
-class HttpHealthCheckerImplTest : public testing::Test, public HttpHealthCheckerImplTestBase {
+class HealthCheckerTestBase {
 public:
+  std::shared_ptr<MockClusterMockPrioritySet> cluster_{
+      std::make_shared<NiceMock<MockClusterMockPrioritySet>>()};
+  NiceMock<Event::MockDispatcher> dispatcher_;
+  std::unique_ptr<MockHealthCheckEventLogger> event_logger_storage_{
+      std::make_unique<MockHealthCheckEventLogger>()};
+  MockHealthCheckEventLogger& event_logger_{*event_logger_storage_};
+  NiceMock<Random::MockRandomGenerator> random_;
+  NiceMock<Runtime::MockLoader> runtime_;
+};
+
+class TestHttpHealthCheckerImpl : public HttpHealthCheckerImpl {
+public:
+  using HttpHealthCheckerImpl::HttpHealthCheckerImpl;
+
+  Http::CodecClient* createCodecClient(Upstream::Host::CreateConnectionData& conn_data) override {
+    return createCodecClient_(conn_data);
+  };
+
+  // HttpHealthCheckerImpl
+  MOCK_METHOD(Http::CodecClient*, createCodecClient_, (Upstream::Host::CreateConnectionData&));
+
+  Http::CodecClient::Type codecClientType() { return codec_client_type_; }
+};
+
+class HttpHealthCheckerImplTest : public testing::Test, public HealthCheckerTestBase {
+public:
+  struct TestSession {
+    Event::MockTimer* interval_timer_{};
+    Event::MockTimer* timeout_timer_{};
+    Http::MockClientConnection* codec_{};
+    Stats::IsolatedStoreImpl stats_store_;
+    Network::MockClientConnection* client_connection_{};
+    NiceMock<Http::MockRequestEncoder> request_encoder_;
+    Http::ResponseDecoder* stream_response_callbacks_{};
+  };
+
+  using TestSessionPtr = std::unique_ptr<TestSession>;
+  using HostWithHealthCheckMap =
+      absl::node_hash_map<std::string,
+                          const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig>;
+
   void allocHealthChecker(const std::string& yaml, bool avoid_boosting = true) {
     health_checker_ = std::make_shared<TestHttpHealthCheckerImpl>(
         *cluster_, parseHealthCheckFromV3Yaml(yaml, avoid_boosting), dispatcher_, runtime_, random_,
@@ -477,6 +519,61 @@ public:
     addCompletionCallback();
   }
 
+  void expectSessionCreate(const HostWithHealthCheckMap& health_check_map) {
+    // Expectations are in LIFO order.
+    TestSessionPtr new_test_session(new TestSession());
+    test_sessions_.emplace_back(std::move(new_test_session));
+    TestSession& test_session = *test_sessions_.back();
+    test_session.timeout_timer_ = new Event::MockTimer(&dispatcher_);
+    test_session.interval_timer_ = new Event::MockTimer(&dispatcher_);
+    expectClientCreate(test_sessions_.size() - 1, health_check_map);
+  }
+
+  void expectClientCreate(size_t index, const HostWithHealthCheckMap& health_check_map) {
+    TestSession& test_session = *test_sessions_[index];
+    test_session.codec_ = new NiceMock<Http::MockClientConnection>();
+    ON_CALL(*test_session.codec_, protocol()).WillByDefault(Return(Http::Protocol::Http11));
+    test_session.client_connection_ = new NiceMock<Network::MockClientConnection>();
+    connection_index_.push_back(index);
+    codec_index_.push_back(index);
+
+    EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(InvokeWithoutArgs([&]() -> Network::ClientConnection* {
+          uint32_t index = connection_index_.front();
+          connection_index_.pop_front();
+          return test_sessions_[index]->client_connection_;
+        }));
+    EXPECT_CALL(*health_checker_, createCodecClient_(_))
+        .WillRepeatedly(
+            Invoke([&](Upstream::Host::CreateConnectionData& conn_data) -> Http::CodecClient* {
+              if (!health_check_map.empty()) {
+                const auto& health_check_config =
+                    health_check_map.at(conn_data.host_description_->address()->asString());
+                // To make sure health checker checks the correct port.
+                EXPECT_EQ(health_check_config.port_value(),
+                          conn_data.host_description_->healthCheckAddress()->ip()->port());
+              }
+              uint32_t index = codec_index_.front();
+              codec_index_.pop_front();
+              TestSession& test_session = *test_sessions_[index];
+              std::shared_ptr<Upstream::MockClusterInfo> cluster{
+                  new NiceMock<Upstream::MockClusterInfo>()};
+              Event::MockDispatcher dispatcher_;
+              return new CodecClientForTest(
+                  Http::CodecClient::Type::HTTP1, std::move(conn_data.connection_),
+                  test_session.codec_, nullptr,
+                  Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
+            }));
+  }
+
+  void expectStreamCreate(size_t index) {
+    test_sessions_[index]->request_encoder_.stream_.callbacks_.clear();
+    EXPECT_CALL(*test_sessions_[index]->codec_, newStream(_))
+        .WillOnce(DoAll(SaveArgAddress(&test_sessions_[index]->stream_response_callbacks_),
+                        ReturnRef(test_sessions_[index]->request_encoder_)));
+  }
+
   void respond(size_t index, const std::string& code, bool conn_close, bool proxy_close = false,
                bool body = false, bool trailers = false,
                const absl::optional<std::string>& service_cluster = absl::optional<std::string>(),
@@ -511,6 +608,9 @@ public:
           Http::ResponseTrailerMapPtr{new Http::TestResponseTrailerMapImpl{{"some", "trailer"}}});
     }
   }
+
+  void expectSessionCreate() { expectSessionCreate(health_checker_map_); }
+  void expectClientCreate(size_t index) { expectClientCreate(index, health_checker_map_); }
 
   void expectSuccessStartFailedFailFirst(
       const absl::optional<std::string>& health_checked_cluster = absl::optional<std::string>()) {
@@ -561,6 +661,12 @@ public:
   }
 
   MOCK_METHOD(void, onHostStatus, (HostSharedPtr host, HealthTransition changed_state));
+
+  std::vector<TestSessionPtr> test_sessions_;
+  std::shared_ptr<TestHttpHealthCheckerImpl> health_checker_;
+  std::list<uint32_t> connection_index_{};
+  std::list<uint32_t> codec_index_{};
+  const HostWithHealthCheckMap health_checker_map_{};
 };
 
 TEST_F(HttpHealthCheckerImplTest, Success) {
@@ -3450,8 +3556,36 @@ TEST_F(TcpHealthCheckerImplTest, ConnectionLocalFailure) {
   EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.passive_failure").value());
 }
 
-class GrpcHealthCheckerImplTestBase : public GrpcHealthCheckerImplTestBaseUtils {
+class TestGrpcHealthCheckerImpl : public GrpcHealthCheckerImpl {
 public:
+  using GrpcHealthCheckerImpl::GrpcHealthCheckerImpl;
+
+  Http::CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& conn_data) override {
+    auto codec_client = createCodecClient_(conn_data);
+    return Http::CodecClientPtr(codec_client);
+  };
+
+  // GrpcHealthCheckerImpl
+  MOCK_METHOD(Http::CodecClient*, createCodecClient_, (Upstream::Host::CreateConnectionData&));
+};
+
+class GrpcHealthCheckerImplTestBase : public HealthCheckerTestBase {
+public:
+  struct TestSession {
+    TestSession() = default;
+
+    Event::MockTimer* interval_timer_{};
+    Event::MockTimer* timeout_timer_{};
+    Http::MockClientConnection* codec_{};
+    Stats::IsolatedStoreImpl stats_store_;
+    Network::MockClientConnection* client_connection_{};
+    NiceMock<Http::MockRequestEncoder> request_encoder_;
+    Http::ResponseDecoder* stream_response_callbacks_{};
+    CodecClientForTest* codec_client_{};
+  };
+
+  using TestSessionPtr = std::unique_ptr<TestSession>;
+
   struct ResponseSpec {
     struct ChunkSpec {
       bool valid;
@@ -3501,11 +3635,15 @@ public:
       return ret;
     }
 
-    std::vector<std::pair<std::string, std::string>>
-        response_headers; // Encapsulates all three types of responses
+    std::vector<std::pair<std::string, std::string>> response_headers;
     std::vector<ChunkSpec> body_chunks;
     std::vector<std::pair<std::string, std::string>> trailers;
   };
+
+  GrpcHealthCheckerImplTestBase() {
+    EXPECT_CALL(*cluster_->info_, features())
+        .WillRepeatedly(Return(Upstream::ClusterInfo::Features::HTTP2));
+  }
 
   void allocHealthChecker(const envoy::config::core::v3::HealthCheck& config) {
     health_checker_ = std::make_shared<TestGrpcHealthCheckerImpl>(
@@ -3562,6 +3700,56 @@ public:
     config.mutable_healthy_threshold()->set_value(3);
     allocHealthChecker(config);
     addCompletionCallback();
+  }
+
+  void expectSessionCreate() {
+    // Expectations are in LIFO order.
+    TestSessionPtr new_test_session(new TestSession());
+    test_sessions_.emplace_back(std::move(new_test_session));
+    TestSession& test_session = *test_sessions_.back();
+    test_session.timeout_timer_ = new Event::MockTimer(&dispatcher_);
+    test_session.interval_timer_ = new Event::MockTimer(&dispatcher_);
+    expectClientCreate(test_sessions_.size() - 1);
+  }
+
+  void expectClientCreate(size_t index) {
+    TestSession& test_session = *test_sessions_[index];
+    test_session.codec_ = new NiceMock<Http::MockClientConnection>();
+    test_session.client_connection_ = new NiceMock<Network::MockClientConnection>();
+    connection_index_.push_back(index);
+    codec_index_.push_back(index);
+
+    EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(InvokeWithoutArgs([&]() -> Network::ClientConnection* {
+          uint32_t index = connection_index_.front();
+          connection_index_.pop_front();
+          return test_sessions_[index]->client_connection_;
+        }));
+
+    EXPECT_CALL(*health_checker_, createCodecClient_(_))
+        .WillRepeatedly(
+            Invoke([&](Upstream::Host::CreateConnectionData& conn_data) -> Http::CodecClient* {
+              uint32_t index = codec_index_.front();
+              codec_index_.pop_front();
+              TestSession& test_session = *test_sessions_[index];
+              std::shared_ptr<Upstream::MockClusterInfo> cluster{
+                  new NiceMock<Upstream::MockClusterInfo>()};
+              Event::MockDispatcher dispatcher_;
+
+              test_session.codec_client_ = new CodecClientForTest(
+                  Http::CodecClient::Type::HTTP1, std::move(conn_data.connection_),
+                  test_session.codec_, nullptr,
+                  Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"), dispatcher_);
+              return test_session.codec_client_;
+            }));
+  }
+
+  void expectStreamCreate(size_t index) {
+    test_sessions_[index]->request_encoder_.stream_.callbacks_.clear();
+    EXPECT_CALL(*test_sessions_[index]->codec_, newStream(_))
+        .WillOnce(DoAll(SaveArgAddress(&test_sessions_[index]->stream_response_callbacks_),
+                        ReturnRef(test_sessions_[index]->request_encoder_)));
   }
 
   // Starts healthchecker and sets up timer expectations, leaving up future specification of
@@ -3714,6 +3902,11 @@ public:
   }
 
   MOCK_METHOD(void, onHostStatus, (HostSharedPtr host, HealthTransition changed_state));
+
+  std::vector<TestSessionPtr> test_sessions_;
+  std::shared_ptr<TestGrpcHealthCheckerImpl> health_checker_;
+  std::list<uint32_t> connection_index_{};
+  std::list<uint32_t> codec_index_{};
 };
 
 class GrpcHealthCheckerImplTest : public testing::Test, public GrpcHealthCheckerImplTestBase {};


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Got rid of all uninteresting call logs in health check fuzzing

Additional Description: Uninteresting call logs were slowing down my health check fuzzer in oss-fuzz. This PR gets rid of all uninteresting call logs by wrapping applicable objects in NiceMocks. However, since at the beginning of my internship I refactored the unit tests to also use fuzz tests, I put the unit test classes back in test/common/upstream:health_checker_impl_test.cc, and renamed test/common/upstream:health_checker_impl_test_utils to health_check_fuzz_test_utils.

No loss in coverage over source/common/upstream/health_checker_impl.cc. Stayed at a constant 30 exec/sec on my cloudtop instance, but will speed up in OSS-Fuzz due to getting rid of logging.

Risk Level: Low
