### PR TITLE
[fuzz] Increased fuzz coverage for health check fuzz

### DIFF
--- a/test/common/upstream/health_check_corpus/grpc_Success
+++ b/test/common/upstream/health_check_corpus/grpc_Success
@@ -58,4 +58,4 @@ actions {
         }
     }
 }
-upstream_cx_total_inc: true
+upstream_cx_success: true

--- a/test/common/upstream/health_check_corpus/grpc_Success
+++ b/test/common/upstream/health_check_corpus/grpc_Success
@@ -58,3 +58,4 @@ actions {
         }
     }
 }
+upstream_cx_total_inc: true

--- a/test/common/upstream/health_check_corpus/http_Success
+++ b/test/common/upstream/health_check_corpus/http_Success
@@ -45,4 +45,4 @@ actions {
         }
     }
 }
-upstream_cx_total_inc: true
+upstream_cx_success: true

--- a/test/common/upstream/health_check_corpus/http_status-over-600
+++ b/test/common/upstream/health_check_corpus/http_status-over-600
@@ -22,6 +22,10 @@ health_check_config {
         service_name_matcher {
             prefix: "locations"
         }
+        expected_statuses {
+            start: 200
+            end: 700
+        }
     }
 }
 actions {
@@ -45,4 +49,3 @@ actions {
         }
     }
 }
-upstream_cx_total_inc: true

--- a/test/common/upstream/health_check_corpus/http_status-under-100
+++ b/test/common/upstream/health_check_corpus/http_status-under-100
@@ -22,6 +22,10 @@ health_check_config {
         service_name_matcher {
             prefix: "locations"
         }
+        expected_statuses {
+            start: 50
+            end: 500
+        }
     }
 }
 actions {
@@ -45,4 +49,3 @@ actions {
         }
     }
 }
-upstream_cx_total_inc: true

--- a/test/common/upstream/health_check_corpus/tcp_Success
+++ b/test/common/upstream/health_check_corpus/tcp_Success
@@ -38,3 +38,4 @@ actions {
         }
     }
 }
+upstream_cx_success: true

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -104,6 +104,9 @@ void HttpHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase
       .WillByDefault(testing::Return(input.http_verify_cluster()));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  if (input.upstream_cx_total_inc()) {
+    cluster_->info_->stats().upstream_cx_total_.inc();
+  }
   expectSessionCreate();
   expectStreamCreate(0);
   // This sets up the possibility of testing hosts that never become healthy
@@ -317,6 +320,9 @@ void GrpcHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase
   allocGrpcHealthCheckerFromProto(input.health_check_config());
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  if (input.upstream_cx_total_inc()) {
+    cluster_->info_->stats().upstream_cx_total_.inc();
+  }
   expectSessionCreate();
   ON_CALL(dispatcher_, createClientConnection_(_, _, _, _))
       .WillByDefault(testing::InvokeWithoutArgs(

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -104,7 +104,7 @@ void HttpHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase
       .WillByDefault(testing::Return(input.http_verify_cluster()));
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
-  if (input.upstream_cx_total_inc()) {
+  if (input.upstream_cx_success()) {
     cluster_->info_->stats().upstream_cx_total_.inc();
   }
   expectSessionCreate();
@@ -215,6 +215,9 @@ void TcpHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase 
   allocTcpHealthCheckerFromProto(input.health_check_config());
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  if (input.upstream_cx_success()) {
+    cluster_->info_->stats().upstream_cx_total_.inc();
+  }
   expectSessionCreate();
   expectClientCreate();
   health_checker_->start();
@@ -320,7 +323,7 @@ void GrpcHealthCheckFuzz::initialize(test::common::upstream::HealthCheckTestCase
   allocGrpcHealthCheckerFromProto(input.health_check_config());
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
-  if (input.upstream_cx_total_inc()) {
+  if (input.upstream_cx_success()) {
     cluster_->info_->stats().upstream_cx_total_.inc();
   }
   expectSessionCreate();

--- a/test/common/upstream/health_check_fuzz.proto
+++ b/test/common/upstream/health_check_fuzz.proto
@@ -95,4 +95,5 @@ message HealthCheckTestCase {
   repeated Action actions = 2;
   bool http_verify_cluster = 3; //Determines if verify cluster setting is on
   bool start_failed = 4;
+  bool upstream_cx_total_inc = 5;
 }

--- a/test/common/upstream/health_check_fuzz.proto
+++ b/test/common/upstream/health_check_fuzz.proto
@@ -95,5 +95,5 @@ message HealthCheckTestCase {
   repeated Action actions = 2;
   bool http_verify_cluster = 3; //Determines if verify cluster setting is on
   bool start_failed = 4;
-  bool upstream_cx_total_inc = 5;
+  bool upstream_cx_success = 5;
 }


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Increased fuzz coverage for health check fuzz
Additional Description:
Increased 19 lines of coverage/357 lines total * 100 = 5.3% increase in coverage over source/common/upstream/health_checker_base_impl.cc by triggering upstream_cx_total_ in cluster stats.
![Screenshot 2020-11-04 at 6 08 56 PM](https://user-images.githubusercontent.com/39203661/98179636-35857600-1ecd-11eb-9ef7-529b02ce8b5d.png)

Increased 12 lines of coverage/715 lines total * 100 = 1.7% increase in coverage over source/common/upstream/health_checker_impl.cc with out of range statuses (corpus entries checked in).
Risk Level: Low
Testing: Added Regression tests for increased coverage
