### PR TITLE
cluster manager: make add/update and initial host set update atomic

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -56,47 +56,48 @@ void addOptionsIfNotNull(Network::Socket::OptionsSharedPtr& options,
 
 } // namespace
 
-void ClusterManagerInitHelper::addCluster(Cluster& cluster) {
+void ClusterManagerInitHelper::addCluster(ClusterManagerCluster& cluster) {
   // See comments in ClusterManagerImpl::addOrUpdateCluster() for why this is only called during
   // server initialization.
   ASSERT(state_ != State::AllClustersInitialized);
 
   const auto initialize_cb = [&cluster, this] { onClusterInit(cluster); };
-  if (cluster.initializePhase() == Cluster::InitializePhase::Primary) {
+  if (cluster.cluster().initializePhase() == Cluster::InitializePhase::Primary) {
     primary_init_clusters_.push_back(&cluster);
-    cluster.initialize(initialize_cb);
+    cluster.cluster().initialize(initialize_cb);
   } else {
-    ASSERT(cluster.initializePhase() == Cluster::InitializePhase::Secondary);
+    ASSERT(cluster.cluster().initializePhase() == Cluster::InitializePhase::Secondary);
     secondary_init_clusters_.push_back(&cluster);
     if (started_secondary_initialize_) {
       // This can happen if we get a second CDS update that adds new clusters after we have
       // already started secondary init. In this case, just immediately initialize.
-      cluster.initialize(initialize_cb);
+      cluster.cluster().initialize(initialize_cb);
     }
   }
 
-  ENVOY_LOG(debug, "cm init: adding: cluster={} primary={} secondary={}", cluster.info()->name(),
-            primary_init_clusters_.size(), secondary_init_clusters_.size());
+  ENVOY_LOG(debug, "cm init: adding: cluster={} primary={} secondary={}",
+            cluster.cluster().info()->name(), primary_init_clusters_.size(),
+            secondary_init_clusters_.size());
 }
 
-void ClusterManagerInitHelper::onClusterInit(Cluster& cluster) {
+void ClusterManagerInitHelper::onClusterInit(ClusterManagerCluster& cluster) {
   ASSERT(state_ != State::AllClustersInitialized);
   per_cluster_init_callback_(cluster);
   removeCluster(cluster);
 }
 
-void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
+void ClusterManagerInitHelper::removeCluster(ClusterManagerCluster& cluster) {
   if (state_ == State::AllClustersInitialized) {
     return;
   }
 
   // There is a remote edge case where we can remove a cluster via CDS that has not yet been
   // initialized. When called via the remove cluster API this code catches that case.
-  std::list<Cluster*>* cluster_list;
-  if (cluster.initializePhase() == Cluster::InitializePhase::Primary) {
+  std::list<ClusterManagerCluster*>* cluster_list;
+  if (cluster.cluster().initializePhase() == Cluster::InitializePhase::Primary) {
     cluster_list = &primary_init_clusters_;
   } else {
-    ASSERT(cluster.initializePhase() == Cluster::InitializePhase::Secondary);
+    ASSERT(cluster.cluster().initializePhase() == Cluster::InitializePhase::Secondary);
     cluster_list = &secondary_init_clusters_;
   }
 
@@ -104,7 +105,8 @@ void ClusterManagerInitHelper::removeCluster(Cluster& cluster) {
   // present in the initializer list. If so, this is fine.
   cluster_list->remove(&cluster);
   ENVOY_LOG(debug, "cm init: init complete: cluster={} primary={} secondary={}",
-            cluster.info()->name(), primary_init_clusters_.size(), secondary_init_clusters_.size());
+            cluster.cluster().info()->name(), primary_init_clusters_.size(),
+            secondary_init_clusters_.size());
   maybeFinishInitialize();
 }
 
@@ -114,10 +116,10 @@ void ClusterManagerInitHelper::initializeSecondaryClusters() {
   // the item currently being initialized, so we eschew range-based-for and do this complicated
   // dance to increment the iterator before calling initialize.
   for (auto iter = secondary_init_clusters_.begin(); iter != secondary_init_clusters_.end();) {
-    Cluster* cluster = *iter;
+    ClusterManagerCluster* cluster = *iter;
     ++iter;
-    ENVOY_LOG(debug, "initializing secondary cluster {}", cluster->info()->name());
-    cluster->initialize([cluster, this] { onClusterInit(*cluster); });
+    ENVOY_LOG(debug, "initializing secondary cluster {}", cluster->cluster().info()->name());
+    cluster->cluster().initialize([cluster, this] { onClusterInit(*cluster); });
   }
 }
 
@@ -242,7 +244,7 @@ ClusterManagerImpl::ClusterManagerImpl(
       random_(api.randomGenerator()),
       bind_config_(bootstrap.cluster_manager().upstream_bind_config()), local_info_(local_info),
       cm_stats_(generateStats(stats)),
-      init_helper_(*this, [this](Cluster& cluster) { onClusterInit(cluster); }),
+      init_helper_(*this, [this](ClusterManagerCluster& cluster) { onClusterInit(cluster); }),
       config_tracker_entry_(
           admin.getConfigTracker().add("clusters", [this] { return dumpClusterConfigs(); })),
       time_source_(main_thread_dispatcher.timeSource()), dispatcher_(main_thread_dispatcher),
@@ -362,9 +364,26 @@ ClusterManagerImpl::ClusterManagerImpl(
 
   // Once the initial set of static bootstrap clusters are created (including the local cluster),
   // we can instantiate the thread local cluster manager.
-  tls_.set([this, local_cluster_name = local_cluster_name_](Event::Dispatcher& dispatcher) {
-    return std::make_shared<ThreadLocalClusterManagerImpl>(*this, dispatcher, local_cluster_name);
+  tls_.set([this](Event::Dispatcher& dispatcher) {
+    return std::make_shared<ThreadLocalClusterManagerImpl>(*this, dispatcher);
   });
+
+  // For active clusters that exist in bootstrap, post an empty thread local cluster update to
+  // populate them.
+  // TODO(mattklein123): It would be nice if we did not do this and instead all thread local cluster
+  // creation happened as part of the cluster init flow, however there are certain cases that depend
+  // on this behavior including route checking. It may be possible to fix static route checking to
+  // not depend on this behavior, but for now this is consistent with the way we have always done
+  // this so in the interest of minimal change it is not being done now.
+  for (auto& cluster : active_clusters_) {
+    // Skip posting the thread local cluster which is created as part of the thread local cluster
+    // manager constructor. See the TODO in that code for eventually cleaning this up.
+    if (local_cluster_name_ && local_cluster_name_.value() == cluster.first) {
+      continue;
+    }
+
+    postThreadLocalClusterUpdate(*cluster.second, ThreadLocalClusterUpdateParams());
+  }
 
   // We can now potentially create the CDS API once the backing cluster exists.
   if (dyn_resources.has_cds_config()) {
@@ -378,7 +397,7 @@ ClusterManagerImpl::ClusterManagerImpl(
   // initialize any primary clusters. Post-init processing further initializes any thread
   // aware load balancer and sets up the per-worker host set updates.
   for (auto& cluster : active_clusters_) {
-    init_helper_.addCluster(*cluster.second->cluster_);
+    init_helper_.addCluster(*cluster.second);
   }
 
   // Potentially move to secondary initialization on the static bootstrap clusters if all primary
@@ -411,12 +430,13 @@ ClusterManagerStats ClusterManagerImpl::generateStats(Stats::Scope& scope) {
                                     POOL_GAUGE_PREFIX(scope, final_prefix))};
 }
 
-void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
+void ClusterManagerImpl::onClusterInit(ClusterManagerCluster& cm_cluster) {
   // This routine is called when a cluster has finished initializing. The cluster has not yet
   // been setup for cross-thread updates to avoid needless updates during initialization. The order
   // of operations here is important. We start by initializing the thread aware load balancer if
   // needed. This must happen first so cluster updates are heard first by the load balancer.
   // Also, it assures that all of clusters which this function is called should be always active.
+  auto& cluster = cm_cluster.cluster();
   auto cluster_data = warming_clusters_.find(cluster.info()->name());
   // We have a situation that clusters will be immediately active, such as static and primary
   // cluster. So we must have this prevention logic here.
@@ -451,9 +471,9 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
         }
       });
 
-  cluster.prioritySet().addPriorityUpdateCb([&cluster, this](uint32_t priority,
-                                                             const HostVector& hosts_added,
-                                                             const HostVector& hosts_removed) {
+  cluster.prioritySet().addPriorityUpdateCb([&cm_cluster, this](uint32_t priority,
+                                                                const HostVector& hosts_added,
+                                                                const HostVector& hosts_removed) {
     // This fires when a cluster is about to have an updated member set. We need to send this
     // out to all of the thread local configurations.
 
@@ -470,38 +490,41 @@ void ClusterManagerImpl::onClusterInit(Cluster& cluster) {
     //
     // See https://github.com/envoyproxy/envoy/pull/3941 for more context.
     bool scheduled = false;
-    const auto merge_timeout =
-        PROTOBUF_GET_MS_OR_DEFAULT(cluster.info()->lbConfig(), update_merge_window, 1000);
+    const auto merge_timeout = PROTOBUF_GET_MS_OR_DEFAULT(cm_cluster.cluster().info()->lbConfig(),
+                                                          update_merge_window, 1000);
     // Remember: we only merge updates with no adds/removes — just hc/weight/metadata changes.
     const bool is_mergeable = hosts_added.empty() && hosts_removed.empty();
 
     if (merge_timeout > 0) {
       // If this is not mergeable, we should cancel any scheduled updates since
       // we'll deliver it immediately.
-      scheduled = scheduleUpdate(cluster, priority, is_mergeable, merge_timeout);
+      scheduled = scheduleUpdate(cm_cluster, priority, is_mergeable, merge_timeout);
     }
 
     // If an update was not scheduled for later, deliver it immediately.
     if (!scheduled) {
       cm_stats_.cluster_updated_.inc();
-      postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
+      postThreadLocalClusterUpdate(
+          cm_cluster, ThreadLocalClusterUpdateParams(priority, hosts_added, hosts_removed));
     }
   });
 
-  // Finally, if the cluster has any hosts, post updates cross-thread so the per-thread load
-  // balancers are ready.
+  // Finally, post updates cross-thread so the per-thread load balancers are ready.
+  ThreadLocalClusterUpdateParams params;
   for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
     if (host_set->hosts().empty()) {
       continue;
     }
-    postThreadLocalClusterUpdate(cluster, host_set->priority(), host_set->hosts(), HostVector{});
+    params.per_priority_update_params_.emplace_back(host_set->priority(), host_set->hosts(),
+                                                    HostVector{});
   }
+  postThreadLocalClusterUpdate(cm_cluster, std::move(params));
 }
 
-bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable,
-                                        const uint64_t timeout) {
+bool ClusterManagerImpl::scheduleUpdate(ClusterManagerCluster& cluster, uint32_t priority,
+                                        bool mergeable, const uint64_t timeout) {
   // Find pending updates for this cluster.
-  auto& updates_by_prio = updates_map_[cluster.info()->name()];
+  auto& updates_by_prio = updates_map_[cluster.cluster().info()->name()];
   if (!updates_by_prio) {
     updates_by_prio = std::make_unique<PendingUpdatesByPriorityMap>();
   }
@@ -556,7 +579,7 @@ bool ClusterManagerImpl::scheduleUpdate(const Cluster& cluster, uint32_t priorit
   return true;
 }
 
-void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
+void ClusterManagerImpl::applyUpdates(ClusterManagerCluster& cluster, uint32_t priority,
                                       PendingUpdates& updates) {
   // Deliver pending updates.
 
@@ -566,7 +589,8 @@ void ClusterManagerImpl::applyUpdates(const Cluster& cluster, uint32_t priority,
   static const HostVector hosts_added;
   static const HostVector hosts_removed;
 
-  postThreadLocalClusterUpdate(cluster, priority, hosts_added, hosts_removed);
+  postThreadLocalClusterUpdate(
+      cluster, ThreadLocalClusterUpdateParams(priority, hosts_added, hosts_removed));
 
   cm_stats_.cluster_updated_via_merge_.inc();
   updates.last_updated_ = time_source_.monotonicTime();
@@ -594,7 +618,7 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::config::cluster::v3::Cl
     if (existing_active_cluster != active_clusters_.end()) {
       // The following init manager remove call is a NOP in the case we are already initialized.
       // It's just kept here to avoid additional logic.
-      init_helper_.removeCluster(*existing_active_cluster->second->cluster_);
+      init_helper_.removeCluster(*existing_active_cluster->second);
     }
     cm_stats_.cluster_modified_.inc();
   } else {
@@ -617,15 +641,13 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::config::cluster::v3::Cl
   auto& cluster_entry = warming_clusters_.at(cluster_name);
   if (!all_clusters_initialized) {
     ENVOY_LOG(debug, "add/update cluster {} during init", cluster_name);
-    createOrUpdateThreadLocalCluster(*cluster_entry);
-    init_helper_.addCluster(*cluster_entry->cluster_);
+    init_helper_.addCluster(*cluster_entry);
   } else {
     ENVOY_LOG(debug, "add/update cluster {} starting warming", cluster_name);
     cluster_entry->cluster_->initialize([this, cluster_name] {
       ENVOY_LOG(debug, "warming cluster {} complete", cluster_name);
       auto state_changed_cluster_entry = warming_clusters_.find(cluster_name);
-      createOrUpdateThreadLocalCluster(*state_changed_cluster_entry->second);
-      onClusterInit(*state_changed_cluster_entry->second->cluster_);
+      onClusterInit(*state_changed_cluster_entry->second);
     });
   }
 
@@ -644,32 +666,13 @@ void ClusterManagerImpl::clusterWarmingToActive(const std::string& cluster_name)
   warming_clusters_.erase(warming_it);
 }
 
-void ClusterManagerImpl::createOrUpdateThreadLocalCluster(ClusterData& cluster) {
-  tls_.runOnAllThreads([new_cluster = cluster.cluster_->info(),
-                        thread_aware_lb_factory = cluster.loadBalancerFactory()](
-                           OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
-    if (cluster_manager->thread_local_clusters_.count(new_cluster->name()) > 0) {
-      ENVOY_LOG(debug, "updating TLS cluster {}", new_cluster->name());
-    } else {
-      ENVOY_LOG(debug, "adding TLS cluster {}", new_cluster->name());
-    }
-
-    auto thread_local_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(
-        *cluster_manager, new_cluster, thread_aware_lb_factory);
-    cluster_manager->thread_local_clusters_[new_cluster->name()].reset(thread_local_cluster);
-    for (auto& cb : cluster_manager->update_callbacks_) {
-      cb->onClusterAddOrUpdate(*thread_local_cluster);
-    }
-  });
-}
-
 bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
   bool removed = false;
   auto existing_active_cluster = active_clusters_.find(cluster_name);
   if (existing_active_cluster != active_clusters_.end() &&
       existing_active_cluster->second->added_via_api_) {
     removed = true;
-    init_helper_.removeCluster(*existing_active_cluster->second->cluster_);
+    init_helper_.removeCluster(*existing_active_cluster->second);
     active_clusters_.erase(existing_active_cluster);
 
     ENVOY_LOG(info, "removing cluster {}", cluster_name);
@@ -687,7 +690,7 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
   if (existing_warming_cluster != warming_clusters_.end() &&
       existing_warming_cluster->second->added_via_api_) {
     removed = true;
-    init_helper_.removeCluster(*existing_warming_cluster->second->cluster_);
+    init_helper_.removeCluster(*existing_warming_cluster->second);
     warming_clusters_.erase(existing_warming_cluster);
     ENVOY_LOG(info, "removing warming cluster {}", cluster_name);
   }
@@ -903,19 +906,59 @@ void ClusterManagerImpl::postThreadLocalDrainConnections(const Cluster& cluster,
   });
 }
 
-void ClusterManagerImpl::postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
-                                                      const HostVector& hosts_added,
-                                                      const HostVector& hosts_removed) {
-  const auto& host_set = cluster.prioritySet().hostSetsPerPriority()[priority];
+void ClusterManagerImpl::postThreadLocalClusterUpdate(ClusterManagerCluster& cluster,
+                                                      ThreadLocalClusterUpdateParams&& params) {
+  const bool is_local_cluster = local_cluster_name_.has_value() &&
+                                local_cluster_name_.value() == cluster.cluster().info()->name();
+  bool add_or_update_cluster = cluster.needsAddOrUpdate();
+  if (is_local_cluster) {
+    // TODO(mattklein123): This is needed because of the special case of how local cluster is
+    // initialized in the thread local cluster manager constructor. This will all be cleaned up
+    // in a follow up.
+    add_or_update_cluster = false;
+  }
 
-  tls_.runOnAllThreads([name = cluster.info()->name(), priority,
-                        update_params = HostSetImpl::updateHostsParams(*host_set),
-                        locality_weights = host_set->localityWeights(), hosts_added, hosts_removed,
-                        overprovisioning_factor = host_set->overprovisioningFactor()](
-                           OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
-    cluster_manager->updateClusterMembership(name, priority, update_params, locality_weights,
-                                             hosts_added, hosts_removed, overprovisioning_factor);
-  });
+  LoadBalancerFactorySharedPtr load_balancer_factory;
+  if (add_or_update_cluster) {
+    load_balancer_factory = cluster.loadBalancerFactory();
+  }
+
+  for (auto& per_priority : params.per_priority_update_params_) {
+    const auto& host_set =
+        cluster.cluster().prioritySet().hostSetsPerPriority()[per_priority.priority_];
+    per_priority.update_hosts_params_ = HostSetImpl::updateHostsParams(*host_set);
+    per_priority.locality_weights_ = host_set->localityWeights();
+    per_priority.overprovisioning_factor_ = host_set->overprovisioningFactor();
+  }
+
+  tls_.runOnAllThreads(
+      [info = cluster.cluster().info(), params = std::move(params), add_or_update_cluster,
+       load_balancer_factory](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+        if (add_or_update_cluster) {
+          if (cluster_manager->thread_local_clusters_.count(info->name()) > 0) {
+            ENVOY_LOG(debug, "updating TLS cluster {}", info->name());
+          } else {
+            ENVOY_LOG(debug, "adding TLS cluster {}", info->name());
+          }
+
+          auto thread_local_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(
+              *cluster_manager, info, load_balancer_factory);
+          cluster_manager->thread_local_clusters_[info->name()].reset(thread_local_cluster);
+          // TODO(mattklein123): It would be better if update callbacks were done after the initial
+          // cluster member is seeded, assuming it is. In the interest of minimal change this is
+          // deferred for a future change.
+          for (auto& cb : cluster_manager->update_callbacks_) {
+            cb->onClusterAddOrUpdate(*thread_local_cluster);
+          }
+        }
+
+        for (const auto& per_priority : params.per_priority_update_params_) {
+          cluster_manager->updateClusterMembership(
+              info->name(), per_priority.priority_, per_priority.update_hosts_params_,
+              per_priority.locality_weights_, per_priority.hosts_added_,
+              per_priority.hosts_removed_, per_priority.overprovisioning_factor_);
+        }
+      });
 }
 
 void ClusterManagerImpl::postThreadLocalHealthFailure(const HostSharedPtr& host) {
@@ -1001,32 +1044,22 @@ ProtobufTypes::MessagePtr ClusterManagerImpl::dumpClusterConfigs() {
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl(
-    ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
-    const absl::optional<std::string>& local_cluster_name)
+    ClusterManagerImpl& parent, Event::Dispatcher& dispatcher)
     : parent_(parent), thread_local_dispatcher_(dispatcher) {
   // If local cluster is defined then we need to initialize it first.
-  if (local_cluster_name) {
-    ENVOY_LOG(debug, "adding TLS local cluster {}", local_cluster_name.value());
-    auto& local_cluster = parent.active_clusters_.at(local_cluster_name.value());
-    thread_local_clusters_[local_cluster_name.value()] = std::make_unique<ClusterEntry>(
+  // TODO(mattklein123): Technically accessing active_clusters_ here is a race condition. This has
+  // been this way "forever" but should be fixed in a follow up.
+  if (parent.localClusterName()) {
+    ENVOY_LOG(debug, "adding TLS local cluster {}", parent.localClusterName().value());
+    auto& local_cluster = parent.active_clusters_.at(parent.localClusterName().value());
+    thread_local_clusters_[parent.localClusterName().value()] = std::make_unique<ClusterEntry>(
         *this, local_cluster->cluster_->info(), local_cluster->loadBalancerFactory());
   }
 
-  local_priority_set_ = local_cluster_name
-                            ? &thread_local_clusters_[local_cluster_name.value()]->priority_set_
-                            : nullptr;
-
-  for (auto& cluster : parent.active_clusters_) {
-    // If local cluster name is set then we already initialized this cluster.
-    if (local_cluster_name && local_cluster_name.value() == cluster.first) {
-      continue;
-    }
-
-    ENVOY_LOG(debug, "adding TLS initial cluster {}", cluster.first);
-    ASSERT(thread_local_clusters_.count(cluster.first) == 0);
-    thread_local_clusters_[cluster.first] = std::make_unique<ClusterEntry>(
-        *this, cluster.second->cluster_->info(), cluster.second->loadBalancerFactory());
-  }
+  local_priority_set_ =
+      parent.localClusterName()
+          ? &thread_local_clusters_[parent.localClusterName().value()]->priority_set_
+          : nullptr;
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::~ThreadLocalClusterManagerImpl() {

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -98,6 +98,25 @@ protected:
 class ClusterManagerImpl;
 
 /**
+ * Wrapper for a cluster owned by the cluster manager. Used by both the cluster manager and the
+ * cluster manager init helper which needs to pass clusters back to the cluster manager.
+ */
+class ClusterManagerCluster {
+public:
+  virtual ~ClusterManagerCluster() = default;
+
+  // Return the underlying cluster.
+  virtual Cluster& cluster() PURE;
+
+  // Return a new load balancer factory if the cluster has one.
+  virtual LoadBalancerFactorySharedPtr loadBalancerFactory() PURE;
+
+  // Return true once for a cluster, otherwise false. This is used to sequence logic that needs to
+  // happen a single time for a newly added or updated cluster.
+  virtual bool needsAddOrUpdate() PURE;
+};
+
+/**
  * This is a helper class used during cluster management initialization. Dealing with primary
  * clusters, secondary clusters, and CDS, is quite complicated, so this makes it easier to test.
  */
@@ -107,8 +126,9 @@ public:
    * @param per_cluster_init_callback supplies the callback to call when a cluster has itself
    *        initialized. The cluster manager can use this for post-init processing.
    */
-  ClusterManagerInitHelper(ClusterManager& cm,
-                           const std::function<void(Cluster&)>& per_cluster_init_callback)
+  ClusterManagerInitHelper(
+      ClusterManager& cm,
+      const std::function<void(ClusterManagerCluster&)>& per_cluster_init_callback)
       : cm_(cm), per_cluster_init_callback_(per_cluster_init_callback) {}
 
   enum class State {
@@ -135,9 +155,9 @@ public:
     AllClustersInitialized
   };
 
-  void addCluster(Cluster& cluster);
+  void addCluster(ClusterManagerCluster& cluster);
   void onStaticLoadComplete();
-  void removeCluster(Cluster& cluster);
+  void removeCluster(ClusterManagerCluster& cluster);
   void setCds(CdsApi* cds);
   void setPrimaryClustersInitializedCb(ClusterManager::PrimaryClustersReadyCallback callback);
   void setInitializedCb(ClusterManager::InitializationCompleteCallback callback);
@@ -151,15 +171,15 @@ private:
 
   void initializeSecondaryClusters();
   void maybeFinishInitialize();
-  void onClusterInit(Cluster& cluster);
+  void onClusterInit(ClusterManagerCluster& cluster);
 
   ClusterManager& cm_;
-  std::function<void(Cluster& cluster)> per_cluster_init_callback_;
+  std::function<void(ClusterManagerCluster& cluster)> per_cluster_init_callback_;
   CdsApi* cds_{};
   ClusterManager::PrimaryClustersReadyCallback primary_clusters_initialized_callback_;
   ClusterManager::InitializationCompleteCallback initialized_callback_;
-  std::list<Cluster*> primary_init_clusters_;
-  std::list<Cluster*> secondary_init_clusters_;
+  std::list<ClusterManagerCluster*> primary_init_clusters_;
+  std::list<ClusterManagerCluster*> secondary_init_clusters_;
   State state_{State::Loading};
   bool started_secondary_initialize_{};
 };
@@ -273,9 +293,31 @@ public:
 protected:
   virtual void postThreadLocalDrainConnections(const Cluster& cluster,
                                                const HostVector& hosts_removed);
-  virtual void postThreadLocalClusterUpdate(const Cluster& cluster, uint32_t priority,
-                                            const HostVector& hosts_added,
-                                            const HostVector& hosts_removed);
+
+  // Parameters for calling postThreadLocalClusterUpdate()
+  struct ThreadLocalClusterUpdateParams {
+    struct PerPriority {
+      PerPriority(uint32_t priority, const HostVector& hosts_added, const HostVector& hosts_removed)
+          : priority_(priority), hosts_added_(hosts_added), hosts_removed_(hosts_removed) {}
+
+      const uint32_t priority_;
+      const HostVector hosts_added_;
+      const HostVector hosts_removed_;
+      PrioritySet::UpdateHostsParams update_hosts_params_;
+      LocalityWeightsConstSharedPtr locality_weights_;
+      uint32_t overprovisioning_factor_;
+    };
+
+    ThreadLocalClusterUpdateParams() = default;
+    ThreadLocalClusterUpdateParams(uint32_t priority, const HostVector& hosts_added,
+                                   const HostVector& hosts_removed)
+        : per_priority_update_params_{{priority, hosts_added, hosts_removed}} {}
+
+    std::vector<PerPriority> per_priority_update_params_;
+  };
+
+  virtual void postThreadLocalClusterUpdate(ClusterManagerCluster& cluster,
+                                            ThreadLocalClusterUpdateParams&& params);
 
 private:
   /**
@@ -361,8 +403,7 @@ private:
 
     using ClusterEntryPtr = std::unique_ptr<ClusterEntry>;
 
-    ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
-                                  const absl::optional<std::string>& local_cluster_name);
+    ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher);
     ~ThreadLocalClusterManagerImpl() override;
     void drainConnPools(const HostVector& hosts);
     void drainConnPools(HostSharedPtr old_host, ConnPoolsContainer& container);
@@ -395,7 +436,7 @@ private:
     bool destroying_{};
   };
 
-  struct ClusterData {
+  struct ClusterData : public ClusterManagerCluster {
     ClusterData(const envoy::config::cluster::v3::Cluster& cluster_config,
                 const std::string& version_info, bool added_via_api, ClusterSharedPtr&& cluster,
                 TimeSource& time_source)
@@ -405,12 +446,19 @@ private:
 
     bool blockUpdate(uint64_t hash) { return !added_via_api_ || config_hash_ == hash; }
 
-    LoadBalancerFactorySharedPtr loadBalancerFactory() {
+    // ClusterManagerCluster
+    Cluster& cluster() override { return *cluster_; }
+    LoadBalancerFactorySharedPtr loadBalancerFactory() override {
       if (thread_aware_lb_ != nullptr) {
         return thread_aware_lb_->factory();
       } else {
         return nullptr;
       }
+    }
+    bool needsAddOrUpdate() override {
+      const bool old_value = added_or_updated_;
+      added_or_updated_ = true;
+      return !old_value;
     }
 
     const envoy::config::cluster::v3::Cluster cluster_config_;
@@ -421,6 +469,7 @@ private:
     // Optional thread aware LB depending on the LB type. Not all clusters have one.
     ThreadAwareLoadBalancerPtr thread_aware_lb_;
     SystemTime last_updated_;
+    bool added_or_updated_{};
   };
 
   struct ClusterUpdateCallbacksHandleImpl : public ClusterUpdateCallbacksHandle,
@@ -471,15 +520,14 @@ private:
   using PendingUpdatesByPriorityMapPtr = std::unique_ptr<PendingUpdatesByPriorityMap>;
   using ClusterUpdatesMap = absl::node_hash_map<std::string, PendingUpdatesByPriorityMapPtr>;
 
-  void applyUpdates(const Cluster& cluster, uint32_t priority, PendingUpdates& updates);
-  bool scheduleUpdate(const Cluster& cluster, uint32_t priority, bool mergeable,
+  void applyUpdates(ClusterManagerCluster& cluster, uint32_t priority, PendingUpdates& updates);
+  bool scheduleUpdate(ClusterManagerCluster& cluster, uint32_t priority, bool mergeable,
                       const uint64_t timeout);
-  void createOrUpdateThreadLocalCluster(ClusterData& cluster);
   ProtobufTypes::MessagePtr dumpClusterConfigs();
   static ClusterManagerStats generateStats(Stats::Scope& scope);
   void loadCluster(const envoy::config::cluster::v3::Cluster& cluster,
                    const std::string& version_info, bool added_via_api, ClusterMap& cluster_map);
-  void onClusterInit(Cluster& cluster);
+  void onClusterInit(ClusterManagerCluster& cluster);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
   void updateClusterCounts();
   void clusterWarmingToActive(const std::string& cluster_name);

--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -199,10 +199,12 @@ public:
         local_cluster_update_(local_cluster_update), local_hosts_removed_(local_hosts_removed) {}
 
 protected:
-  void postThreadLocalClusterUpdate(const Cluster&, uint32_t priority,
-                                    const HostVector& hosts_added,
-                                    const HostVector& hosts_removed) override {
-    local_cluster_update_.post(priority, hosts_added, hosts_removed);
+  void postThreadLocalClusterUpdate(ClusterManagerCluster&,
+                                    ThreadLocalClusterUpdateParams&& params) override {
+    for (const auto& per_priority : params.per_priority_update_params_) {
+      local_cluster_update_.post(per_priority.priority_, per_priority.hosts_added_,
+                                 per_priority.hosts_removed_);
+    }
   }
 
   void postThreadLocalDrainConnections(const Cluster&, const HostVector& hosts_removed) override {


### PR DESCRIPTION
Previously, we would do a separate TLS set to add/update the cluster,
and then another TLS operation to populate the initial host set. For
cluster updates for a server already in operation this can lead to a
gap of no hosts.

Fixes https://github.com/envoyproxy/envoy/issues/13070

Risk Level: High
Testing: I didn't add any new tests, because it's unclear to me what tests to add.
I could have added a unit test to cover the race condition, but it would be broken
by the change and then deleted. Note that getting all of the existing tests to pass
was quite difficult, so I do feel there is good coverage here, but if anyone has good
ideas on how to better test this please let me know.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
