### PR TITLE
CI: mitigate apt-get update failure in azure pipeline

### DIFF
--- a/.azure-pipelines/cleanup.sh
+++ b/.azure-pipelines/cleanup.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Temporary script to remove tools from Azure pipelines agent to create more disk space room.
-sudo apt-get update -y
+sudo apt-get update -y || true
 sudo apt-get purge -y --no-upgrade 'ghc-*' 'zulu-*-azure-jdk' 'libllvm*' 'mysql-*' 'dotnet-*' 'libgl1' \
   'adoptopenjdk-*' 'azure-cli' 'google-chrome-stable' 'firefox' 'hhvm'
 


### PR DESCRIPTION
Commit Message:
Unblock CI presubmit by allow apt-get update failure.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
fix #13907
[Optional Deprecated:]
