### PR TITLE
redis: skip resolution for ip address

### DIFF
--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -206,6 +206,7 @@ private:
     ~RedisDiscoverySession() override;
 
     void registerDiscoveryAddress(std::list<Network::DnsResponse>&& response, const uint32_t port);
+    void registerAddress(Network::Address::InstanceConstSharedPtr address);
 
     // Start discovery against a random host from existing hosts
     void startResolveRedis();


### PR DESCRIPTION
The resolution will fail under macos for ip address.

Signed-off-by: 吕海涛 <ihaitao@qq.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
