### PR TITLE
ci/docs: Use commit sha for all pull request artifact uploads

### DIFF
--- a/ci/upload_gcs_artifact.sh
+++ b/ci/upload_gcs_artifact.sh
@@ -18,8 +18,8 @@ if [ ! -d "${SOURCE_DIRECTORY}" ]; then
   exit 1
 fi
 
-if [[ "$TARGET_SUFFIX" == "docs" ]]; then
-    # docs upload to the last commit sha (first 7 chars) in the developers branch
+if [[ "$BUILD_SOURCEBRANCHNAME" != "master" ]]; then
+    # non-master upload to the last commit sha (first 7 chars) in the developers branch
     UPLOAD_PATH="$(git log --pretty=%P -n 1 | cut -d' ' -f2 | head -c7)"
 else
     UPLOAD_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
@@ -30,16 +30,16 @@ GCS_LOCATION="${GCS_ARTIFACT_BUCKET}/${UPLOAD_PATH}/${TARGET_SUFFIX}"
 echo "Uploading to gs://${GCS_LOCATION} ..."
 gsutil -mq rsync -dr "${SOURCE_DIRECTORY}" "gs://${GCS_LOCATION}"
 
-# For docs uploads, add a redirect `PR_NUMBER` -> `COMMIT_SHA`
-if [[ "$TARGET_SUFFIX" == "docs" ]]; then
+# For non-master uploads, add a redirect `PR_NUMBER` -> `COMMIT_SHA`
+if [[ "$BUILD_SOURCEBRANCHNAME" != "master" ]]; then
     REDIRECT_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
-    TMP_REDIRECT="/tmp/docredirect/${REDIRECT_PATH}/docs"
+    TMP_REDIRECT="/tmp/redirect/${REDIRECT_PATH}/${TARGET_SUFFIX}"
     mkdir -p "$TMP_REDIRECT"
     echo "<meta http-equiv=\"refresh\" content=\"0; URL='https://storage.googleapis.com/${GCS_LOCATION}/index.html'\" />" \
 	 >  "${TMP_REDIRECT}/index.html"
     GCS_REDIRECT="${GCS_ARTIFACT_BUCKET}/${REDIRECT_PATH}"
     echo "Uploading redirect to gs://${GCS_REDIRECT} ..."
-    gsutil -h "Cache-Control:no-cache,max-age=0" -mq rsync -dr "/tmp/docredirect/${REDIRECT_PATH}" "gs://${GCS_REDIRECT}"
+    gsutil -h "Cache-Control:no-cache,max-age=0" -mq rsync -dr "/tmp/redirect/${REDIRECT_PATH}" "gs://${GCS_REDIRECT}"
 fi
 
 echo "Artifacts uploaded to: https://storage.googleapis.com/${GCS_LOCATION}/index.html"

--- a/ci/upload_gcs_artifact.sh
+++ b/ci/upload_gcs_artifact.sh
@@ -37,7 +37,7 @@ if [[ "$BUILD_REASON" == "PullRequest" ]]; then
     mkdir -p "$TMP_REDIRECT"
     echo "<meta http-equiv=\"refresh\" content=\"0; URL='https://storage.googleapis.com/${GCS_LOCATION}/index.html'\" />" \
 	 >  "${TMP_REDIRECT}/index.html"
-    GCS_REDIRECT="${GCS_ARTIFACT_BUCKET}/${REDIRECT_PATH}"
+    GCS_REDIRECT="${GCS_ARTIFACT_BUCKET}/${REDIRECT_PATH}/${TARGET_SUFFIX}"
     echo "Uploading redirect to gs://${GCS_REDIRECT} ..."
     gsutil -h "Cache-Control:no-cache,max-age=0" -mq rsync -dr "/tmp/redirect/${REDIRECT_PATH}" "gs://${GCS_REDIRECT}"
 fi

--- a/ci/upload_gcs_artifact.sh
+++ b/ci/upload_gcs_artifact.sh
@@ -18,7 +18,7 @@ if [ ! -d "${SOURCE_DIRECTORY}" ]; then
   exit 1
 fi
 
-if [[ "$BUILD_SOURCEBRANCHNAME" != "master" ]]; then
+if [[ "$BUILD_REASON" == "PullRequest" ]]; then
     # non-master upload to the last commit sha (first 7 chars) in the developers branch
     UPLOAD_PATH="$(git log --pretty=%P -n 1 | cut -d' ' -f2 | head -c7)"
 else
@@ -30,8 +30,8 @@ GCS_LOCATION="${GCS_ARTIFACT_BUCKET}/${UPLOAD_PATH}/${TARGET_SUFFIX}"
 echo "Uploading to gs://${GCS_LOCATION} ..."
 gsutil -mq rsync -dr "${SOURCE_DIRECTORY}" "gs://${GCS_LOCATION}"
 
-# For non-master uploads, add a redirect `PR_NUMBER` -> `COMMIT_SHA`
-if [[ "$BUILD_SOURCEBRANCHNAME" != "master" ]]; then
+# For PR uploads, add a redirect `PR_NUMBER` -> `COMMIT_SHA`
+if [[ "$BUILD_REASON" == "PullRequest" ]]; then
     REDIRECT_PATH="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-${BUILD_SOURCEBRANCHNAME}}"
     TMP_REDIRECT="/tmp/redirect/${REDIRECT_PATH}/${TARGET_SUFFIX}"
     mkdir -p "$TMP_REDIRECT"

--- a/ci/upload_gcs_artifact.sh
+++ b/ci/upload_gcs_artifact.sh
@@ -39,7 +39,7 @@ if [[ "$BUILD_REASON" == "PullRequest" ]]; then
 	 >  "${TMP_REDIRECT}/index.html"
     GCS_REDIRECT="${GCS_ARTIFACT_BUCKET}/${REDIRECT_PATH}/${TARGET_SUFFIX}"
     echo "Uploading redirect to gs://${GCS_REDIRECT} ..."
-    gsutil -h "Cache-Control:no-cache,max-age=0" -mq rsync -dr "/tmp/redirect/${REDIRECT_PATH}" "gs://${GCS_REDIRECT}"
+    gsutil -h "Cache-Control:no-cache,max-age=0" -mq rsync -dr "${TMP_REDIRECT}" "gs://${GCS_REDIRECT}"
 fi
 
 echo "Artifacts uploaded to: https://storage.googleapis.com/${GCS_LOCATION}/index.html"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci/docs: Use commit sha for all non-master artifact uploads
Additional Description:

Follow up from #13826

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
