### PR TITLE
Windows: Fix active_quic_listener_test

### DIFF
--- a/test/extensions/quic_listeners/quiche/BUILD
+++ b/test/extensions/quic_listeners/quiche/BUILD
@@ -162,10 +162,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "active_quic_listener_test",
     srcs = ["active_quic_listener_test.cc"],
-    tags = [
-        "fails_on_windows",
-        "nofips",
-    ],
+    tags = ["nofips"],
     deps = [
         ":quic_test_utils_for_envoy_lib",
         ":test_utils_lib",

--- a/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
+++ b/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
@@ -344,7 +344,11 @@ TEST_P(ActiveQuicListenerTest, ProcessBufferedChlos) {
   for (size_t i = 1; i <= count; ++i) {
     sendCHLO(quic::test::TestConnectionId(i));
   }
-  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  // Rerun event loop until all connections are established. Especially on Windows, this test fails
+  // as non-blocking mode doesn't always pick up all connection events immediately.
+  while (connection_handler_.numConnections() < count) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  }
 
   // The first kNumSessionsToCreatePerLoop were processed immediately, the next
   // kNumSessionsToCreatePerLoop were buffered for the next run of the event loop, and the last one


### PR DESCRIPTION
Commit Message:
Windows: Fix active_quic_listener_test

Rerun event loop until all client connections are consumed by the event
loop. Running a non-blocking event loop, all outstanding socket events
(especially on Windows) may not be picked up before the dispatcher
exits.

Additional Description:
Another alternative would be to run the run the dispatcher in blocking
mode and make it exit in a mocked callback on the last request
processing. This is doable for the non-TLS quic path, but not as
straightforward when testing a quic version with TLS with the network
filter chain setup etc.

Risk Level: Low
Testing: Locally on Windows + RBE, modifies unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A