### PR TITLE
grpc-json-transcoder: Bypass "verb"-related logic

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -301,8 +301,11 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
   const size_t pos = path.find('?');
   if (pos != std::string::npos) {
     args = path.substr(pos + 1);
-    path = path.substr(0, pos);
+    path.resize(pos);
   }
+
+  // Deal with custom verbs.
+  path += ':';
 
   struct RequestInfo request_info;
   std::vector<VariableBinding> variable_bindings;

--- a/test/proto/bookstore.proto
+++ b/test/proto/bookstore.proto
@@ -96,6 +96,11 @@ service Bookstore {
       get: "/indexStream"
     };
   }
+  rpc EchoPathArg(EchoBodyRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      get: "/echoPath/{arg=**}"
+    };
+  }
   rpc PostBody(EchoBodyRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/postBody"


### PR DESCRIPTION
Commit Message: Avoid non-intentional altering of `:path` header in grpc json transcoder filter by bypassing path matcher's "verb"-related logic.
Additional Description: Path matcher unconditionally replaces the last colon in the path by a slash. Unconditionally add a colon to the path to avoid non-intentional altering of `:path` header.
Path matcher strips all slashes from the end of the path so it leads to an expected behavior (`/a/b//` and /a/b` are equivalent paths from matching perspective).
Risk Level: Low
Testing: added unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features
Fixes #13920 
