### PR TITLE
[fuzz] Fixed fuzz bug in health check fuzzing

### DIFF
--- a/test/common/upstream/health_check_corpus/clusterfuzz-testcase-health_check_fuzz_test-5704648171978752
+++ b/test/common/upstream/health_check_corpus/clusterfuzz-testcase-health_check_fuzz_test-5704648171978752
@@ -1,0 +1,84 @@
+health_check_config {
+  timeout {
+    nanos: 5
+  }
+  interval {
+    nanos: 65
+  }
+  unhealthy_threshold {
+    value: 538968064
+  }
+  healthy_threshold {
+    value: 538968064
+  }
+  reuse_connection {
+    value: true
+  }
+  grpc_health_check {
+    service_name: "\004"
+  }
+  unhealthy_interval {
+    seconds: 4227858432
+  }
+  event_log_path: "?("
+  tls_options {
+  }
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  raise_event: REMOTE_CLOSE
+}
+actions {
+  raise_go_away: NO_ERROR
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  raise_go_away: NO_ERROR
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  raise_event: CONNECTED
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  trigger_interval_timer {
+  }
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+http_verify_cluster: true

--- a/test/common/upstream/health_check_corpus/clusterfuzz-testcase-health_check_fuzz_test-5713695386370048
+++ b/test/common/upstream/health_check_corpus/clusterfuzz-testcase-health_check_fuzz_test-5713695386370048
@@ -1,0 +1,40 @@
+health_check_config {
+  timeout {
+    seconds: 512
+    nanos: 8
+  }
+  interval {
+    nanos: 8
+  }
+  unhealthy_threshold {
+    value: 36
+  }
+  healthy_threshold {
+  }
+  grpc_health_check {
+  }
+  no_traffic_interval {
+    seconds: 512
+    nanos: 8
+  }
+  initial_jitter {
+    seconds: 512
+    nanos: 262152
+  }
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  raise_go_away: NO_ERROR
+}
+actions {
+  trigger_interval_timer {
+  }
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+http_verify_cluster: true

--- a/test/common/upstream/health_check_corpus/grpc_generalized-crash
+++ b/test/common/upstream/health_check_corpus/grpc_generalized-crash
@@ -1,0 +1,39 @@
+health_check_config {
+  timeout {
+    nanos: 5
+  }
+  interval {
+    nanos: 65
+  }
+  unhealthy_threshold {
+    value: 538968064
+  }
+  healthy_threshold {
+    value: 538968064
+  }
+  reuse_connection {
+    value: true
+  }
+  grpc_health_check {
+    service_name: "\004"
+  }
+  unhealthy_interval {
+    seconds: 4227858432
+  }
+  event_log_path: "?("
+  tls_options {
+  }
+}
+actions {
+  raise_go_away: NO_ERROR
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+actions {
+  raise_event: LOCAL_CLOSE
+}

--- a/test/common/upstream/health_check_corpus/grpc_trigger-interval
+++ b/test/common/upstream/health_check_corpus/grpc_trigger-interval
@@ -1,0 +1,33 @@
+health_check_config {
+  timeout {
+    seconds: 512
+    nanos: 8
+  }
+  interval {
+    nanos: 8
+  }
+  unhealthy_threshold {
+    value: 36
+  }
+  healthy_threshold {
+  }
+  grpc_health_check {
+  }
+  no_traffic_interval {
+    seconds: 512
+    nanos: 8
+  }
+  initial_jitter {
+    seconds: 512
+    nanos: 262152
+  }
+}
+actions {
+  trigger_timeout_timer {
+  }
+}
+
+actions {
+  trigger_interval_timer {
+  }
+}

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -476,6 +476,7 @@ void GrpcHealthCheckFuzz::raiseGoAway(bool no_error) {
     test_session_->codec_client_->raiseGoAway(Http::GoAwayErrorCode::NoError);
     // Will cause other events to blow away client, because this is a "graceful" go away
     received_no_error_goaway_ = true;
+    triggerIntervalTimer(true);
   } else {
     // go away events without no error flag explicitly blow away client
     test_session_->codec_client_->raiseGoAway(Http::GoAwayErrorCode::Other);

--- a/test/common/upstream/health_check_fuzz.cc
+++ b/test/common/upstream/health_check_fuzz.cc
@@ -462,6 +462,7 @@ void GrpcHealthCheckFuzz::triggerTimeoutTimer(bool last_action) {
 void GrpcHealthCheckFuzz::raiseEvent(const Network::ConnectionEvent& event_type, bool last_action) {
   test_session_->client_connection_->raiseEvent(event_type);
   if (!last_action && event_type != Network::ConnectionEvent::Connected) {
+    received_no_error_goaway_ = false; // from resetState()
     // Close events will always blow away the client
     ENVOY_LOG_MISC(trace, "Triggering interval timer after close event");
     // Interval timer is guaranteed to be enabled from a close event - calls


### PR DESCRIPTION
Signed-off-by: Zach Reyes <zasweq@google.com>

Commit Message: Fixed fuzz bug in health check fuzzing.
Additional Description: Fixes issue https://oss-fuzz.com/testcase-detail/5704648171978752. My health check fuzzer ran into a false negative bug. The reason for this bug was that I forgot to update state (received no error go away) in a certain action (raiseEvent). I added the correctly updating state in this pr.

The second commit fixes issue https://oss-fuzz.com/testcase-detail/5713695386370048. This bug came from the faulty logic of thinking a go away event wouldn't blow away client, incorrectly not expecting a stream create in an interval timer invoke, thus leading to problems. Thus, to fix this, I added a triggerIntervalTimer with a stream create after onGoAway event.

Risk Level: Low
Testing: Added two regression test cases which both crash before this PR.