### PR TITLE
fix dubbo proxy parse hessian2 missing some case in switch

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/hessian_utils.cc
+++ b/source/extensions/filters/network/dubbo_proxy/hessian_utils.cc
@@ -210,6 +210,9 @@ long HessianUtils::peekLong(Buffer::Instance& buffer, size_t* size, uint64_t off
   case 0xe8:
   case 0xe9:
   case 0xea:
+  case 0xeb:
+  case 0xec:
+  case 0xed:
   case 0xee:
   case 0xef:
 
@@ -229,6 +232,8 @@ long HessianUtils::peekLong(Buffer::Instance& buffer, size_t* size, uint64_t off
   case 0xf9:
   case 0xfa:
   case 0xfb:
+  case 0xfc:
+  case 0xfd:
   case 0xfe:
   case 0xff:
 
@@ -340,6 +345,7 @@ int HessianUtils::peekInt(Buffer::Instance& buffer, size_t* size, uint64_t offse
   case 0xc9:
   case 0xca:
   case 0xcb:
+  case 0xcc:
   case 0xcd:
   case 0xce:
   case 0xcf:

--- a/test/extensions/filters/network/dubbo_proxy/hessian_utils_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/hessian_utils_test.cc
@@ -176,6 +176,30 @@ TEST(HessianUtilsTest, peekLong) {
   // Single octet longs
   {
     Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xeb'}));
+    size_t size;
+    EXPECT_EQ(11, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(1, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xec'}));
+    size_t size;
+    EXPECT_EQ(12, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(1, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xed'}));
+    size_t size;
+    EXPECT_EQ(13, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(1, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
     buffer.add(std::string({'\xef'}));
     size_t size;
     EXPECT_EQ(15, HessianUtils::peekLong(buffer, &size));
@@ -220,6 +244,38 @@ TEST(HessianUtilsTest, peekLong) {
     buffer.add(std::string({'\xf7', 0x00}));
     size_t size;
     EXPECT_EQ(-256, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(2, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xfc', 0x00}));
+    size_t size;
+    EXPECT_EQ(1024, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(2, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xfc', '\xff'}));
+    size_t size;
+    EXPECT_EQ(1279, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(2, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xfd', 0x00}));
+    size_t size;
+    EXPECT_EQ(1280, HessianUtils::peekLong(buffer, &size));
+    EXPECT_EQ(2, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xfd', '\xff'}));
+    size_t size;
+    EXPECT_EQ(1535, HessianUtils::peekLong(buffer, &size));
     EXPECT_EQ(2, size);
   }
 
@@ -406,6 +462,22 @@ TEST(HessianUtilsTest, peekInt) {
     buffer.add(std::string({'\xc7', 0x00}));
     size_t size;
     EXPECT_EQ(-256, HessianUtils::peekInt(buffer, &size));
+    EXPECT_EQ(2, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xcc', 0x00}));
+    size_t size;
+    EXPECT_EQ(1024, HessianUtils::peekInt(buffer, &size));
+    EXPECT_EQ(2, size);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    buffer.add(std::string({'\xcc', '\xff'}));
+    size_t size;
+    EXPECT_EQ(1279, HessianUtils::peekInt(buffer, &size));
     EXPECT_EQ(2, size);
   }
 


### PR DESCRIPTION
Signed-off-by: serverglen <serverglen@gmail.com>

Commit Message:fix dubbo proxy parse hessian2 missing some case in switch
Additional Description:
Risk Level: Low
Testing:unit test and integration
Docs Changes:N/A
Release Notes:N/A
Platform Specific Features:
Fixes #13913 
