### PR TITLE
tls: refactor secret config provider to create mock provider factory

### DIFF
--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -45,7 +45,7 @@ public:
 
 using TlsCertificatePtr =
     std::unique_ptr<envoy::extensions::transport_sockets::tls::v3::TlsCertificate>;
-using CertificateValidationContextPtr =
+using CertificateValidationContextSharedPtr =
     std::unique_ptr<envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>;
 using TlsSessionTicketKeysPtr =
     std::unique_ptr<envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys>;

--- a/include/envoy/ssl/BUILD
+++ b/include/envoy/ssl/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
         ":certificate_validation_context_config_interface",
         ":handshaker_interface",
         ":tls_certificate_config_interface",
+        "//include/envoy/secret:secret_manager_interface",
     ],
 )
 

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "envoy/common/pure.h"
+#include "envoy/secret/secret_manager.h"
 #include "envoy/ssl/certificate_validation_context_config.h"
 #include "envoy/ssl/handshaker.h"
 #include "envoy/ssl/tls_certificate_config.h"
@@ -15,6 +16,40 @@
 
 namespace Envoy {
 namespace Ssl {
+
+class TlsCertificateConfigProvidersFactory {
+public:
+  virtual ~TlsCertificateConfigProvidersFactory() = default;
+
+  /**
+   * Create the certificate config providers factory
+   */
+  virtual std::vector<Secret::TlsCertificateConfigProviderSharedPtr> create() PURE;
+};
+
+using TlsCertificateConfigProvidersFactoryPtr =
+    std::unique_ptr<TlsCertificateConfigProvidersFactory>;
+
+class CertificateValidationContextConfigProviderFactory {
+public:
+  virtual ~CertificateValidationContextConfigProviderFactory() = default;
+
+  /**
+   * Create the validation context config provider.
+   */
+  virtual Secret::CertificateValidationContextConfigProviderSharedPtr create() PURE;
+
+  /**
+   * To get default certificate validation context. This value is nullptr by default except for
+   * validation context type is combined validation context.
+   */
+  virtual std::shared_ptr<
+      envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>
+  defaultCvc() const PURE;
+};
+
+using CertificateValidationContextConfigProviderFactoryPtr =
+    std::unique_ptr<CertificateValidationContextConfigProviderFactory>;
 
 /**
  * Supplies the configuration for an SSL context.

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -22,13 +22,16 @@ public:
   virtual ~TlsCertificateConfigProvidersFactory() = default;
 
   /**
-   * Create the certificate config providers factory
+   * Create the certificate config providers factories.
    */
   virtual std::vector<Secret::TlsCertificateConfigProviderSharedPtr> create() PURE;
 };
 
 using TlsCertificateConfigProvidersFactoryPtr =
     std::unique_ptr<TlsCertificateConfigProvidersFactory>;
+
+using CertificateValidationContextPtr =
+    std::shared_ptr<envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>;
 
 class CertificateValidationContextConfigProviderFactory {
 public:
@@ -40,16 +43,27 @@ public:
   virtual Secret::CertificateValidationContextConfigProviderSharedPtr create() PURE;
 
   /**
-   * To get default certificate validation context. This value is nullptr by default except for
-   * validation context type is combined validation context.
+   * Get the default certificate validation context. This value is nullptr by default, except for
+   * when the validation context type is a combined validation context.
    */
-  virtual std::shared_ptr<
-      envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>
-  defaultCvc() const PURE;
+  virtual CertificateValidationContextPtr defaultCertificateValidationContext() const PURE;
 };
 
 using CertificateValidationContextConfigProviderFactoryPtr =
     std::unique_ptr<CertificateValidationContextConfigProviderFactory>;
+
+class TlsSessionTicketKeysConfigProviderFactory {
+public:
+  virtual ~TlsSessionTicketKeysConfigProviderFactory() = default;
+
+  /**
+   * Create the tls session ticket keys config provider.
+   */
+  virtual Secret::TlsSessionTicketKeysConfigProviderSharedPtr create() PURE;
+};
+
+using TlsSessionTicketKeysConfigProviderFactoryPtr =
+    std::unique_ptr<TlsSessionTicketKeysConfigProviderFactory>;
 
 /**
  * Supplies the configuration for an SSL context.

--- a/include/envoy/ssl/context_config.h
+++ b/include/envoy/ssl/context_config.h
@@ -30,7 +30,7 @@ public:
 using TlsCertificateConfigProvidersFactoryPtr =
     std::unique_ptr<TlsCertificateConfigProvidersFactory>;
 
-using CertificateValidationContextPtr =
+using CertificateValidationContextSharedPtr =
     std::shared_ptr<envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>;
 
 class CertificateValidationContextConfigProviderFactory {
@@ -46,7 +46,7 @@ public:
    * Get the default certificate validation context. This value is nullptr by default, except for
    * when the validation context type is a combined validation context.
    */
-  virtual CertificateValidationContextPtr defaultCertificateValidationContext() const PURE;
+  virtual CertificateValidationContextSharedPtr defaultCertificateValidationContext() const PURE;
 };
 
 using CertificateValidationContextConfigProviderFactoryPtr =

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -235,7 +235,7 @@ protected:
   std::vector<std::string> getDataSourceFilenames() override;
 
 private:
-  CertificateValidationContextPtr certificate_validation_context_secrets_;
+  CertificateValidationContextSharedPtr certificate_validation_context_secrets_;
   Common::CallbackManager<
       const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&>
       validation_callback_manager_;

--- a/source/common/secret/secret_provider_impl.h
+++ b/source/common/secret/secret_provider_impl.h
@@ -53,7 +53,7 @@ public:
   Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
 
 private:
-  Secret::CertificateValidationContextPtr certificate_validation_context_;
+  Secret::CertificateValidationContextSharedPtr certificate_validation_context_;
 };
 
 class TlsSessionTicketKeysConfigProviderImpl : public TlsSessionTicketKeysConfigProvider {

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -42,7 +42,7 @@ public:
 
   Secret::CertificateValidationContextConfigProviderSharedPtr create() override;
 
-  Ssl::CertificateValidationContextPtr defaultCertificateValidationContext() const override {
+  Ssl::CertificateValidationContextSharedPtr defaultCertificateValidationContext() const override {
     return default_cvc_;
   }
 
@@ -56,7 +56,7 @@ private:
   // If certificate validation context type is combined_validation_context. default_cvc_
   // holds a copy of CombinedCertificateValidationContext::default_validation_context.
   // Otherwise, default_cvc_ is nullptr.
-  Ssl::CertificateValidationContextPtr default_cvc_;
+  Ssl::CertificateValidationContextSharedPtr default_cvc_;
 };
 
 class TlsSessionTicketKeysConfigProviderFactoryImpl

--- a/test/mocks/ssl/mocks.cc
+++ b/test/mocks/ssl/mocks.cc
@@ -24,5 +24,13 @@ MockPrivateKeyMethodManager::~MockPrivateKeyMethodManager() = default;
 MockPrivateKeyMethodProvider::MockPrivateKeyMethodProvider() = default;
 MockPrivateKeyMethodProvider::~MockPrivateKeyMethodProvider() = default;
 
+MockTlsCertificateConfigProvidersFactory::MockTlsCertificateConfigProvidersFactory() = default;
+MockTlsCertificateConfigProvidersFactory::~MockTlsCertificateConfigProvidersFactory() = default;
+
+MockCertificateValicationContextConfigProviderFactory::
+    MockCertificateValicationContextConfigProviderFactory() = default;
+MockCertificateValicationContextConfigProviderFactory::
+    ~MockCertificateValicationContextConfigProviderFactory() = default;
+
 } // namespace Ssl
 } // namespace Envoy

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <gmock/gmock-function-mocker.h>
+
 #include <functional>
 #include <string>
 
@@ -181,6 +183,26 @@ public:
 #ifdef OPENSSL_IS_BORINGSSL
   MOCK_METHOD(BoringSslPrivateKeyMethodSharedPtr, getBoringSslPrivateKeyMethod, ());
 #endif
+};
+
+class MockTlsCertificateConfigProvidersFactory : public TlsCertificateConfigProvidersFactory {
+public:
+  MockTlsCertificateConfigProvidersFactory();
+  ~MockTlsCertificateConfigProvidersFactory() override;
+
+  MOCK_METHOD(std::vector<Secret::TlsCertificateConfigProviderSharedPtr>, create, ());
+};
+
+class MockCertificateValicationContextConfigProviderFactory
+    : public CertificateValidationContextConfigProviderFactory {
+public:
+  MockCertificateValicationContextConfigProviderFactory();
+  ~MockCertificateValicationContextConfigProviderFactory() override;
+
+  MOCK_METHOD(Secret::CertificateValidationContextConfigProviderSharedPtr, create, ());
+  MOCK_METHOD(
+      std::shared_ptr<envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>,
+      defaultCvc, (), (const));
 };
 
 } // namespace Ssl

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -202,7 +202,7 @@ public:
   MOCK_METHOD(Secret::CertificateValidationContextConfigProviderSharedPtr, create, ());
   MOCK_METHOD(
       std::shared_ptr<envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>,
-      defaultCvc, (), (const));
+      defaultCertificateValidationContext, (), (const));
 };
 
 } // namespace Ssl


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Refactoring for secret config provider to be loosely coupled between `CommonContext` and `xxxConfigProviderFactory`. It will be easily to create mocks of this and achieve clear unit test when it required. 
Additional Description:
Risk Level: Low
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
