### PR TITLE
repokitteh: Fix for welcome message

### DIFF
--- a/ci/repokitteh/modules/newcontributor.star
+++ b/ci/repokitteh/modules/newcontributor.star
@@ -14,8 +14,9 @@ def get_pr_author_association(issue_number):
     path="repos/envoyproxy/envoy/pulls/%s" % issue_number)["json"]["author_association"]
 
 def is_newcontributor(issue_number):
-  return get_pr_author_association(issue_number) in [
-    "NONE", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"]
+  return (
+    get_pr_author_association(issue_number)
+    in ["NONE", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"])
 
 def should_message_newcontributor(action, issue_number):
   return (

--- a/ci/repokitteh/modules/newcontributor.star
+++ b/ci/repokitteh/modules/newcontributor.star
@@ -14,7 +14,8 @@ def get_pr_author_association(issue_number):
     path="repos/envoyproxy/envoy/pulls/%s" % issue_number)["json"]["author_association"]
 
 def is_newcontributor(issue_number):
-  return get_pr_author_association(issue_number) == "FIRST_TIME_CONTRIBUTOR"
+  return get_pr_author_association(issue_number) in [
+    "NONE", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"]
 
 def should_message_newcontributor(action, issue_number):
   return (


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: repokitteh: Fix for welcome message
Additional Description:

Its unclear in the github docs what `author_association` PRs from new contributors should have.

i originally set it to `FIRST_TIME_CONTRIBUTOR` as i thought that would be correct. Debugging this from a new contrib i see a value of `NONE`

this pr catches what i think are all of the possible associations

others seem to have had similar issues here - cf https://github.com/kubernetes/test-infra/issues/9236

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
