### PR TITLE
Always start containerized Envoy as PID 1

### DIFF
--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$ENVOY_UID" != "0" ]; then
     fi
     # Ensure the envoy user is able to write to container logs
     chown envoy:envoy /dev/stdout /dev/stderr
-    su-exec envoy "${@}"
+    exec su-exec envoy "${@}"
 else
     exec "${@}"
 fi


### PR DESCRIPTION
Signed-off-by: Anatole Beuzon <anatole.beuzon@datadoghq.com>

Commit Message: Always start containerized Envoy as PID 1
Additional Description: Previously, su-exec was starting Envoy as a child process of PID 1, instead of PID 1 directly. Signals like SIGTERM sent by the container runtime did not reach Envoy, therefore preventing it from shutting down gracefully. This commit ensures that Envoy always start as PID 1.
Risk Level: low
Testing: did not build an official Envoy image, but verified with a minimal Dockerfile on top of an Envoy image that the change works. `docker exec <container> ps` show that Envoy is PID 1 and `docker stop <container> && docker logs <container>` shows that Envoy does receive SIGTERMs from the container runtime. 

Fixes #13944 
Thanks @phlax for the fix suggestion.
