### PR TITLE
Update context_config_impl.cc

### DIFF
--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -373,6 +373,9 @@ bool ClientContextConfigImpl::isSecretReady() const {
       return false;
     }
   }
+  if (certificate_validation_context_provider_ == nullptr) {
+      return false;
+  }
   return certificate_validation_context_provider_->secret() != nullptr;
 }
 


### PR DESCRIPTION
Prevent SIGSEGV by checking that certificate_validation_context_provider_ isn't a nullptr in isSecretReady. Return false if it is nullptr.

Signed-off-by: Matt Tierney <tierney@google.com>

Commit Message: Prevent SIGSEGV by checking that certificate_validation_context_provider_ isn't a nullptr in isSecretReady. Return false if it is nullptr.
Additional Description:
Risk Level: Low
Testing: unit test, integration test
Docs Changes:
Release Notes:
Platform Specific Features:
