### PR TITLE
backport to rel-1.16: proxy_proto - fixing hashing bug #13768

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -14,6 +14,12 @@ Bug Fixes
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 * listener: fix crash when disabling or re-enabling listeners due to overload while processing LDS updates.
 
+* dns: fix a bug where custom resolvers provided in configuration were not preserved after network issues.
+* http: fixed URL parsing for HTTP/1.1 fully qualified URLs and connect requests containing IPv6 addresses.
+* http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
+* proxy_proto: fixed a bug where the wrong downstream address got sent to upstream connections.
+* tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+
 Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,12 +13,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 * listener: fix crash when disabling or re-enabling listeners due to overload while processing LDS updates.
-
-* dns: fix a bug where custom resolvers provided in configuration were not preserved after network issues.
-* http: fixed URL parsing for HTTP/1.1 fully qualified URLs and connect requests containing IPv6 addresses.
-* http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
 * proxy_proto: fixed a bug where the wrong downstream address got sent to upstream connections.
-* tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
 
 Removed Config or Runtime
 -------------------------

--- a/include/envoy/network/proxy_protocol.h
+++ b/include/envoy/network/proxy_protocol.h
@@ -8,6 +8,10 @@ namespace Network {
 struct ProxyProtocolData {
   const Network::Address::InstanceConstSharedPtr src_addr_;
   const Network::Address::InstanceConstSharedPtr dst_addr_;
+  std::string asStringForHash() const {
+    return std::string(src_addr_ ? src_addr_->asString() : "null") +
+           (dst_addr_ ? dst_addr_->asString() : "null");
+  }
 };
 
 } // namespace Network

--- a/include/envoy/network/transport_socket.h
+++ b/include/envoy/network/transport_socket.h
@@ -14,6 +14,7 @@
 namespace Envoy {
 namespace Network {
 
+class TransportSocketFactory;
 class Connection;
 enum class ConnectionEvent;
 
@@ -198,11 +199,13 @@ public:
   virtual absl::optional<Network::ProxyProtocolData> proxyProtocolOptions() const PURE;
 
   /**
-   * @param vector of bytes to which the option should append hash key data that will be used
-   *        to separate connections based on the option. Any data already in the key vector must
-   *        not be modified.
+   * @param key supplies a vector of bytes to which the option should append hash key data that will
+   *        be used to separate connections based on the option. Any data already in the key vector
+   *        must not be modified.
+   * @param factory supplies the factor which will be used for creating the transport socket.
    */
-  virtual void hashKey(std::vector<uint8_t>& key) const PURE;
+  virtual void hashKey(std::vector<uint8_t>& key,
+                       const Network::TransportSocketFactory& factory) const PURE;
 };
 
 // TODO(mattklein123): Rename to TransportSocketOptionsConstSharedPtr in a dedicated follow up.
@@ -226,6 +229,11 @@ public:
    */
   virtual TransportSocketPtr
   createTransportSocket(TransportSocketOptionsSharedPtr options) const PURE;
+
+  /**
+   * @return bool whether the transport socket will use proxy protocol options.
+   */
+  virtual bool usesProxyProtocolOptions() const PURE;
 };
 
 using TransportSocketFactoryPtr = std::unique_ptr<TransportSocketFactory>;

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -32,6 +32,7 @@ public:
   // Network::TransportSocketFactory
   TransportSocketPtr createTransportSocket(TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  bool usesProxyProtocolOptions() const override { return false; }
 };
 
 } // namespace Network

--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -16,7 +16,8 @@
 namespace Envoy {
 namespace Network {
 namespace {
-void commonHashKey(const TransportSocketOptions& options, std::vector<std::uint8_t>& key) {
+void commonHashKey(const TransportSocketOptions& options, std::vector<std::uint8_t>& key,
+                   const Network::TransportSocketFactory& factory) {
   const auto& server_name_overide = options.serverNameOverride();
   if (server_name_overide.has_value()) {
     pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(server_name_overide.value()), key);
@@ -35,19 +36,30 @@ void commonHashKey(const TransportSocketOptions& options, std::vector<std::uint8
       pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(protocol), key);
     }
   }
+
   const auto& alpn_fallback = options.applicationProtocolFallback();
   if (alpn_fallback.has_value()) {
     pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(*alpn_fallback), key);
   }
+
+  // Proxy protocol options should only be included in the hash if the upstream
+  // socket intends to use them.
+  const auto& proxy_protocol_options = options.proxyProtocolOptions();
+  if (proxy_protocol_options.has_value() && factory.usesProxyProtocolOptions()) {
+    pushScalarToByteVector(
+        StringUtil::CaseInsensitiveHash()(proxy_protocol_options.value().asStringForHash()), key);
+  }
 }
 } // namespace
 
-void AlpnDecoratingTransportSocketOptions::hashKey(std::vector<uint8_t>& key) const {
-  commonHashKey(*this, key);
+void AlpnDecoratingTransportSocketOptions::hashKey(
+    std::vector<uint8_t>& key, const Network::TransportSocketFactory& factory) const {
+  commonHashKey(*this, key, factory);
 }
 
-void TransportSocketOptionsImpl::hashKey(std::vector<uint8_t>& key) const {
-  commonHashKey(*this, key);
+void TransportSocketOptionsImpl::hashKey(std::vector<uint8_t>& key,
+                                         const Network::TransportSocketFactory& factory) const {
+  commonHashKey(*this, key, factory);
 }
 
 TransportSocketOptionsSharedPtr

--- a/source/common/network/transport_socket_options_impl.h
+++ b/source/common/network/transport_socket_options_impl.h
@@ -29,7 +29,8 @@ public:
   absl::optional<Network::ProxyProtocolData> proxyProtocolOptions() const override {
     return inner_options_->proxyProtocolOptions();
   }
-  void hashKey(std::vector<uint8_t>& key) const override;
+  void hashKey(std::vector<uint8_t>& key,
+               const Network::TransportSocketFactory& factory) const override;
 
 private:
   const absl::optional<std::string> alpn_fallback_;
@@ -67,7 +68,8 @@ public:
   absl::optional<Network::ProxyProtocolData> proxyProtocolOptions() const override {
     return proxy_protocol_options_;
   }
-  void hashKey(std::vector<uint8_t>& key) const override;
+  void hashKey(std::vector<uint8_t>& key,
+               const Network::TransportSocketFactory& factory) const override;
 
 private:
   const absl::optional<std::string> override_server_name_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1380,7 +1380,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::connPool(
 
   bool have_transport_socket_options = false;
   if (context && context->upstreamTransportSocketOptions()) {
-    context->upstreamTransportSocketOptions()->hashKey(hash_key);
+    context->upstreamTransportSocketOptions()->hashKey(hash_key, host->transportSocketFactory());
     have_transport_socket_options = true;
   }
 
@@ -1440,7 +1440,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
   bool have_transport_socket_options = false;
   if (context != nullptr && context->upstreamTransportSocketOptions() != nullptr) {
     have_transport_socket_options = true;
-    context->upstreamTransportSocketOptions()->hashKey(hash_key);
+    context->upstreamTransportSocketOptions()->hashKey(hash_key, host->transportSocketFactory());
   }
 
   TcpConnPoolsContainer& container = parent_.host_tcp_conn_pool_map_[host];

--- a/source/extensions/quic_listeners/quiche/quic_transport_socket_factory.h
+++ b/source/extensions/quic_listeners/quiche/quic_transport_socket_factory.h
@@ -24,6 +24,7 @@ public:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
   bool implementsSecureTransport() const override { return true; }
+  bool usesProxyProtocolOptions() const override { return false; }
 };
 
 // TODO(danzh): when implement ProofSource, examine of it's necessary to

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -98,6 +98,7 @@ public:
   TsiSocketFactory(HandshakerFactory handshaker_factory, HandshakeValidator handshake_validator);
 
   bool implementsSecureTransport() const override;
+  bool usesProxyProtocolOptions() const override { return false; }
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
 

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
@@ -49,6 +49,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  bool usesProxyProtocolOptions() const override { return true; }
 
 private:
   Network::TransportSocketFactoryPtr transport_socket_factory_;

--- a/source/extensions/transport_sockets/tap/tap.cc
+++ b/source/extensions/transport_sockets/tap/tap.cc
@@ -66,6 +66,10 @@ bool TapSocketFactory::implementsSecureTransport() const {
   return transport_socket_factory_->implementsSecureTransport();
 }
 
+bool TapSocketFactory::usesProxyProtocolOptions() const {
+  return transport_socket_factory_->usesProxyProtocolOptions();
+}
+
 } // namespace Tap
 } // namespace TransportSockets
 } // namespace Extensions

--- a/source/extensions/transport_sockets/tap/tap.h
+++ b/source/extensions/transport_sockets/tap/tap.h
@@ -41,6 +41,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  bool usesProxyProtocolOptions() const override;
 
 private:
   Network::TransportSocketFactoryPtr transport_socket_factory_;

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -108,6 +108,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  bool usesProxyProtocolOptions() const override { return false; }
 
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;
@@ -132,6 +133,7 @@ public:
   Network::TransportSocketPtr
   createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
   bool implementsSecureTransport() const override;
+  bool usesProxyProtocolOptions() const override { return false; }
 
   // Secret::SecretCallbacks
   void onAddOrUpdateSecret() override;

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -234,6 +234,15 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "raw_buffer_socket_test",
+    srcs = ["raw_buffer_socket_test.cc"],
+    deps = [
+        "//source/common/network:raw_buffer_socket_lib",
+        "//test/test_common:network_utility_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "udp_listener_impl_test_base_lib",
     hdrs = ["udp_listener_impl_test_base.h"],

--- a/test/common/network/raw_buffer_socket_test.cc
+++ b/test/common/network/raw_buffer_socket_test.cc
@@ -1,0 +1,16 @@
+#include "common/network/raw_buffer_socket.h"
+
+#include "test/test_common/network_utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Network {
+
+TEST(RawBufferSocketFactory, RawBufferSocketFactory) {
+  TransportSocketFactoryPtr factory = Envoy::Network::Test::createRawBufferSocketFactory();
+  EXPECT_FALSE(factory->usesProxyProtocolOptions());
+}
+
+} // namespace Network
+} // namespace Envoy

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -31,6 +31,7 @@ namespace {
 class FakeTransportSocketFactory : public Network::TransportSocketFactory {
 public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
+  MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsSharedPtr), (const));
   FakeTransportSocketFactory(std::string id) : id_(std::move(id)) {}
@@ -46,6 +47,7 @@ class FooTransportSocketFactory
       Logger::Loggable<Logger::Id::upstream> {
 public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
+  MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
               (Network::TransportSocketOptionsSharedPtr), (const));
 

--- a/test/extensions/transport_sockets/alts/tsi_socket_test.cc
+++ b/test/extensions/transport_sockets/alts/tsi_socket_test.cc
@@ -55,7 +55,6 @@ protected:
     client_.tsi_socket_ =
         std::make_unique<TsiSocket>(client_.handshaker_factory_, client_validator,
                                     Network::TransportSocketPtr{client_.raw_socket_});
-
     ON_CALL(client_.callbacks_.connection_, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
     ON_CALL(server_.callbacks_.connection_, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
 
@@ -194,6 +193,7 @@ static const std::string ClientToServerData = "hello from client";
 TEST_F(TsiSocketTest, DoesNotHaveSsl) {
   initialize(nullptr, nullptr);
   EXPECT_EQ(nullptr, client_.tsi_socket_->ssl());
+  EXPECT_FALSE(client_.tsi_socket_->canFlushClose());
 
   const auto& socket_ = *client_.tsi_socket_;
   EXPECT_EQ(nullptr, socket_.ssl());
@@ -404,6 +404,10 @@ TEST_F(TsiSocketFactoryTest, CreateTransportSocket) {
 
 TEST_F(TsiSocketFactoryTest, ImplementsSecureTransport) {
   EXPECT_TRUE(socket_factory_->implementsSecureTransport());
+}
+
+TEST_F(TsiSocketFactoryTest, UsesProxyProtocolOptions) {
+  EXPECT_FALSE(socket_factory_->usesProxyProtocolOptions());
 }
 
 } // namespace

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -190,9 +190,10 @@ void BaseIntegrationTest::setUpstreamProtocol(FakeHttpConnection::Type protocol)
 
 IntegrationTcpClientPtr
 BaseIntegrationTest::makeTcpConnection(uint32_t port,
-                                       const Network::ConnectionSocket::OptionsSharedPtr& options) {
+                                       const Network::ConnectionSocket::OptionsSharedPtr& options,
+                                       Network::Address::InstanceConstSharedPtr source_address) {
   return std::make_unique<IntegrationTcpClient>(*dispatcher_, *mock_buffer_factory_, port, version_,
-                                                enable_half_close_, options);
+                                                enable_half_close_, options, source_address);
 }
 
 void BaseIntegrationTest::registerPort(const std::string& key, uint32_t port) {

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -86,7 +86,9 @@ public:
 
   IntegrationTcpClientPtr
   makeTcpConnection(uint32_t port,
-                    const Network::ConnectionSocket::OptionsSharedPtr& options = nullptr);
+                    const Network::ConnectionSocket::OptionsSharedPtr& options = nullptr,
+                    Network::Address::InstanceConstSharedPtr source_address =
+                        Network::Address::InstanceConstSharedPtr());
 
   // Test-wide port map.
   void registerPort(const std::string& key, uint32_t port);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -513,6 +513,12 @@ public:
     };
   }
 
+  // Creates a ValidatorFunction which returns true when data_to_wait_for is
+  // contains at least bytes_read bytes.
+  static ValidatorFunction waitForAtLeastBytes(uint32_t bytes) {
+    return [bytes](const std::string& data) -> bool { return data.size() >= bytes; };
+  }
+
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {
     ReadFilter(FakeRawConnection& parent) : parent_(parent) {}

--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -37,7 +37,8 @@ using ::testing::NiceMock;
 IntegrationTcpClient::IntegrationTcpClient(
     Event::Dispatcher& dispatcher, MockBufferFactory& factory, uint32_t port,
     Network::Address::IpVersion version, bool enable_half_close,
-    const Network::ConnectionSocket::OptionsSharedPtr& options)
+    const Network::ConnectionSocket::OptionsSharedPtr& options,
+    Network::Address::InstanceConstSharedPtr source_address)
     : payload_reader_(new WaitForPayloadReader(dispatcher)),
       callbacks_(new ConnectionCallbacks(*this)) {
   EXPECT_CALL(factory, create_(_, _, _))
@@ -51,7 +52,7 @@ IntegrationTcpClient::IntegrationTcpClient(
   connection_ = dispatcher.createClientConnection(
       Network::Utility::resolveUrl(
           fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version), port)),
-      Network::Address::InstanceConstSharedPtr(), Network::Test::createRawBufferSocket(), options);
+      source_address, Network::Test::createRawBufferSocket(), options);
 
   ON_CALL(*client_write_buffer_, drain(_))
       .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));

--- a/test/integration/integration_tcp_client.h
+++ b/test/integration/integration_tcp_client.h
@@ -28,7 +28,8 @@ class IntegrationTcpClient {
 public:
   IntegrationTcpClient(Event::Dispatcher& dispatcher, MockBufferFactory& factory, uint32_t port,
                        Network::Address::IpVersion version, bool enable_half_close,
-                       const Network::ConnectionSocket::OptionsSharedPtr& options);
+                       const Network::ConnectionSocket::OptionsSharedPtr& options,
+                       Network::Address::InstanceConstSharedPtr source_address = nullptr);
 
   void close();
   void waitForData(const std::string& data, bool exact_match = true);

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -36,6 +36,7 @@ public:
   ~MockTransportSocketFactory() override;
 
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
+  MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(TransportSocketPtr, createTransportSocket, (TransportSocketOptionsSharedPtr),
               (const));
 };


### PR DESCRIPTION
Fix a bug where the transport socket options for the first downstream got reused for subsequent upstream connections.

Risk Level: low
Testing: new integration test
Docs Changes: n/a
Release Notes:
Platform Specific Features:
Fixes #13659