### PR TITLE
http: removing the http1 and http2 connection pools

### DIFF
--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -63,6 +63,8 @@ HttpConnPoolImplBase::HttpConnPoolImplBase(
   }
 }
 
+HttpConnPoolImplBase::~HttpConnPoolImplBase() { destructAllConnections(); }
+
 ConnectionPool::Cancellable*
 HttpConnPoolImplBase::newStream(Http::ResponseDecoder& response_decoder,
                                 Http::ConnectionPool::Callbacks& callbacks) {

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -154,8 +154,8 @@ public:
   }
 
 protected:
-  CreateCodecFn codec_fn_;
-  CreateClientFn client_fn_;
+  const CreateCodecFn codec_fn_;
+  const CreateClientFn client_fn_;
 };
 
 } // namespace Http

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -34,8 +34,15 @@ public:
   HttpAttachContext context_;
 };
 
-// An implementation of Envoy::ConnectionPool::ConnPoolImplBase for shared code
-// between HTTP/1.1 and HTTP/2
+class ActiveClient;
+
+/* An implementation of Envoy::ConnectionPool::ConnPoolImplBase for shared code
+ * between HTTP/1.1 and HTTP/2
+ *
+ * NOTE: The connection pool does NOT do DNS resolution. It assumes it is being given a numeric IP
+ *       address. Higher layer code should handle resolving DNS on error and creating a new pool
+ *       bound to a different IP address.
+ */
 class HttpConnPoolImplBase : public Envoy::ConnectionPool::ConnPoolImplBase,
                              public Http::ConnectionPool::Instance {
 public:
@@ -45,6 +52,7 @@ public:
                        const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
                        Random::RandomGenerator& random_generator,
                        std::vector<Http::Protocol> protocol);
+  ~HttpConnPoolImplBase() override;
 
   // ConnectionPool::Instance
   void addDrainedCallback(DrainedCb cb) override { addDrainedCallbackImpl(cb); }
@@ -71,8 +79,10 @@ public:
                    Envoy::ConnectionPool::AttachContext& context) override;
 
   virtual CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) PURE;
+  Random::RandomGenerator& randomGenerator() { return random_generator_; }
 
 protected:
+  friend class ActiveClient;
   Random::RandomGenerator& random_generator_;
   Http::Protocol protocol_;
 };
@@ -111,8 +121,41 @@ public:
   }
   size_t numActiveStreams() const override { return codec_client_->numActiveRequests(); }
   uint64_t id() const override { return codec_client_->id(); }
+  HttpConnPoolImplBase& parent() { return *static_cast<HttpConnPoolImplBase*>(&parent_); }
 
   Http::CodecClientPtr codec_client_;
+};
+
+/* An implementation of Envoy::ConnectionPool::ConnPoolImplBase for HTTP/1 and HTTP/2
+ */
+class FixedHttpConnPoolImpl : public HttpConnPoolImplBase {
+public:
+  using CreateClientFn =
+      std::function<Envoy::ConnectionPool::ActiveClientPtr(HttpConnPoolImplBase* pool)>;
+  using CreateCodecFn = std::function<CodecClientPtr(Upstream::Host::CreateConnectionData& data,
+                                                     HttpConnPoolImplBase* pool)>;
+
+  FixedHttpConnPoolImpl(Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
+                        Event::Dispatcher& dispatcher,
+                        const Network::ConnectionSocket::OptionsSharedPtr& options,
+                        const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                        Random::RandomGenerator& random_generator, CreateClientFn client_fn,
+                        CreateCodecFn codec_fn, std::vector<Http::Protocol> protocol)
+      : HttpConnPoolImplBase(host, priority, dispatcher, options, transport_socket_options,
+                             random_generator, protocol),
+        codec_fn_(codec_fn), client_fn_(client_fn) {}
+
+  CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override {
+    return codec_fn_(data, this);
+  }
+
+  Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override {
+    return client_fn_(this);
+  }
+
+protected:
+  CreateCodecFn codec_fn_;
+  CreateClientFn client_fn_;
 };
 
 } // namespace Http

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -23,35 +23,22 @@ namespace Envoy {
 namespace Http {
 namespace Http1 {
 
-ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
-                           Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-                           const Network::ConnectionSocket::OptionsSharedPtr& options,
-                           const Network::TransportSocketOptionsSharedPtr& transport_socket_options)
-    : HttpConnPoolImplBase(std::move(host), std::move(priority), dispatcher, options,
-                           transport_socket_options, random_generator, {Protocol::Http11}) {}
-
-ConnPoolImpl::~ConnPoolImpl() { destructAllConnections(); }
-
-Envoy::ConnectionPool::ActiveClientPtr ConnPoolImpl::instantiateActiveClient() {
-  return std::make_unique<ActiveClient>(*this);
-}
-
-ConnPoolImpl::StreamWrapper::StreamWrapper(ResponseDecoder& response_decoder, ActiveClient& parent)
+ActiveClient::StreamWrapper::StreamWrapper(ResponseDecoder& response_decoder, ActiveClient& parent)
     : RequestEncoderWrapper(parent.codec_client_->newStream(*this)),
       ResponseDecoderWrapper(response_decoder), parent_(parent) {
   RequestEncoderWrapper::inner_.getStream().addCallbacks(*this);
 }
 
-ConnPoolImpl::StreamWrapper::~StreamWrapper() {
+ActiveClient::StreamWrapper::~StreamWrapper() {
   // Upstream connection might be closed right after response is complete. Setting delay=true
   // here to attach pending requests in next dispatcher loop to handle that case.
   // https://github.com/envoyproxy/envoy/issues/2715
   parent_.parent().onStreamClosed(parent_, true);
 }
 
-void ConnPoolImpl::StreamWrapper::onEncodeComplete() { encode_complete_ = true; }
+void ActiveClient::StreamWrapper::onEncodeComplete() { encode_complete_ = true; }
 
-void ConnPoolImpl::StreamWrapper::decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
+void ActiveClient::StreamWrapper::decodeHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.fixed_connection_close")) {
     close_connection_ =
         HeaderUtility::shouldCloseConnection(parent_.codec_client_->protocol(), *headers);
@@ -76,7 +63,7 @@ void ConnPoolImpl::StreamWrapper::decodeHeaders(ResponseHeaderMapPtr&& headers, 
   ResponseDecoderWrapper::decodeHeaders(std::move(headers), end_stream);
 }
 
-void ConnPoolImpl::StreamWrapper::onDecodeComplete() {
+void ActiveClient::StreamWrapper::onDecodeComplete() {
   ASSERT(!decode_complete_);
   decode_complete_ = encode_complete_;
 
@@ -90,35 +77,33 @@ void ConnPoolImpl::StreamWrapper::onDecodeComplete() {
     parent_.codec_client_->close();
   } else {
     auto* pool = &parent_.parent();
-    pool->dispatcher_.post([pool]() -> void { pool->onUpstreamReady(); });
+    pool->dispatcher().post([pool]() -> void { pool->onUpstreamReady(); });
     parent_.stream_wrapper_.reset();
 
     pool->checkForDrained();
   }
 }
 
-ConnPoolImpl::ActiveClient::ActiveClient(ConnPoolImpl& parent)
-    : Envoy::Http::ActiveClient(
-          parent, parent.host_->cluster().maxRequestsPerConnection(),
-          1 // HTTP1 always has a concurrent-request-limit of 1 per connection.
-      ) {
-  parent.host_->cluster().stats().upstream_cx_http1_total_.inc();
+void ActiveClient::StreamWrapper::onResetStream(StreamResetReason, absl::string_view) {
+  parent_.codec_client_->close();
 }
 
-bool ConnPoolImpl::ActiveClient::closingWithIncompleteStream() const {
+ActiveClient::ActiveClient(HttpConnPoolImplBase& parent)
+    : Envoy::Http::ActiveClient(
+          parent, parent.host()->cluster().maxRequestsPerConnection(),
+          1 // HTTP1 always has a concurrent-request-limit of 1 per connection.
+      ) {
+  parent.host()->cluster().stats().upstream_cx_http1_total_.inc();
+}
+
+bool ActiveClient::closingWithIncompleteStream() const {
   return (stream_wrapper_ != nullptr) && (!stream_wrapper_->decode_complete_);
 }
 
-RequestEncoder& ConnPoolImpl::ActiveClient::newStreamEncoder(ResponseDecoder& response_decoder) {
+RequestEncoder& ActiveClient::newStreamEncoder(ResponseDecoder& response_decoder) {
   ASSERT(!stream_wrapper_);
   stream_wrapper_ = std::make_unique<StreamWrapper>(response_decoder, *this);
   return *stream_wrapper_;
-}
-
-CodecClientPtr ProdConnPoolImpl::createCodecClient(Upstream::Host::CreateConnectionData& data) {
-  CodecClientPtr codec{new CodecClientProd(CodecClient::Type::HTTP1, std::move(data.connection_),
-                                           data.host_description_, dispatcher_, random_generator_)};
-  return codec;
 }
 
 ConnectionPool::InstancePtr
@@ -126,8 +111,17 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
                  const Network::TransportSocketOptionsSharedPtr& transport_socket_options) {
-  return std::make_unique<Http::Http1::ProdConnPoolImpl>(
-      dispatcher, random_generator, host, priority, options, transport_socket_options);
+  return std::make_unique<FixedHttpConnPoolImpl>(
+      std::move(host), std::move(priority), dispatcher, options, transport_socket_options,
+      random_generator,
+      [](HttpConnPoolImplBase* pool) { return std::make_unique<ActiveClient>(*pool); },
+      [](Upstream::Host::CreateConnectionData& data, HttpConnPoolImplBase* pool) {
+        CodecClientPtr codec{new CodecClientProd(
+            CodecClient::Type::HTTP1, std::move(data.connection_), data.host_description_,
+            pool->dispatcher(), pool->randomGenerator())};
+        return codec;
+      },
+      std::vector<Protocol>{Protocol::Http11});
 }
 
 } // namespace Http1

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -12,29 +12,20 @@ namespace Http {
 namespace Http1 {
 
 /**
- * A connection pool implementation for HTTP/1.1 connections.
- * NOTE: The connection pool does NOT do DNS resolution. It assumes it is being given a numeric IP
- *       address. Higher layer code should handle resolving DNS on error and creating a new pool
- *       bound to a different IP address.
+ * An active client for HTTP/1.1 connections.
  */
-class ConnPoolImpl : public Http::HttpConnPoolImplBase {
+class ActiveClient : public Envoy::Http::ActiveClient {
 public:
-  ConnPoolImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
-               Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-               const Network::ConnectionSocket::OptionsSharedPtr& options,
-               const Network::TransportSocketOptionsSharedPtr& transport_socket_options);
+  ActiveClient(HttpConnPoolImplBase& parent);
 
-  ~ConnPoolImpl() override;
-
-  // ConnPoolImplBase
-  Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override;
-
-protected:
-  class ActiveClient;
+  // ConnPoolImplBase::ActiveClient
+  bool closingWithIncompleteStream() const override;
+  RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) override;
 
   struct StreamWrapper : public RequestEncoderWrapper,
                          public ResponseDecoderWrapper,
-                         public StreamCallbacks {
+                         public StreamCallbacks,
+                         protected Logger::Loggable<Logger::Id::pool> {
     StreamWrapper(ResponseDecoder& response_decoder, ActiveClient& parent);
     ~StreamWrapper() override;
 
@@ -47,9 +38,7 @@ protected:
     void onDecodeComplete() override;
 
     // Http::StreamCallbacks
-    void onResetStream(StreamResetReason, absl::string_view) override {
-      parent_.codec_client_->close();
-    }
+    void onResetStream(StreamResetReason, absl::string_view) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
 
@@ -58,32 +47,9 @@ protected:
     bool close_connection_{};
     bool decode_complete_{};
   };
-
   using StreamWrapperPtr = std::unique_ptr<StreamWrapper>;
 
-  class ActiveClient : public Envoy::Http::ActiveClient {
-  public:
-    ActiveClient(ConnPoolImpl& parent);
-
-    ConnPoolImpl& parent() { return *static_cast<ConnPoolImpl*>(&parent_); }
-
-    // ConnPoolImplBase::ActiveClient
-    bool closingWithIncompleteStream() const override;
-    RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) override;
-
-    StreamWrapperPtr stream_wrapper_;
-  };
-};
-
-/**
- * Production implementation of the ConnPoolImpl.
- */
-class ProdConnPoolImpl : public ConnPoolImpl {
-public:
-  using ConnPoolImpl::ConnPoolImpl;
-
-  // ConnPoolImpl
-  CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;
+  StreamWrapperPtr stream_wrapper_;
 };
 
 ConnectionPool::InstancePtr

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -16,20 +16,7 @@ namespace Http2 {
 // side we do 2^29.
 static const uint64_t DEFAULT_MAX_STREAMS = (1 << 29);
 
-ConnPoolImpl::ConnPoolImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
-                           Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-                           const Network::ConnectionSocket::OptionsSharedPtr& options,
-                           const Network::TransportSocketOptionsSharedPtr& transport_socket_options)
-    : HttpConnPoolImplBase(std::move(host), std::move(priority), dispatcher, options,
-                           transport_socket_options, random_generator, {Protocol::Http2}) {}
-
-ConnPoolImpl::~ConnPoolImpl() { destructAllConnections(); }
-
-Envoy::ConnectionPool::ActiveClientPtr ConnPoolImpl::instantiateActiveClient() {
-  return std::make_unique<ActiveClient>(*this);
-}
-
-void ConnPoolImpl::ActiveClient::onGoAway(Http::GoAwayErrorCode) {
+void ActiveClient::onGoAway(Http::GoAwayErrorCode) {
   ENVOY_CONN_LOG(debug, "remote goaway", *codec_client_);
   parent_.host()->cluster().stats().upstream_cx_close_notify_.inc();
   if (state_ != ActiveClient::State::DRAINING) {
@@ -41,7 +28,7 @@ void ConnPoolImpl::ActiveClient::onGoAway(Http::GoAwayErrorCode) {
   }
 }
 
-void ConnPoolImpl::ActiveClient::onStreamDestroy() {
+void ActiveClient::onStreamDestroy() {
   parent().onStreamClosed(*this, false);
 
   // If we are destroying this stream because of a disconnect, do not check for drain here. We will
@@ -52,7 +39,7 @@ void ConnPoolImpl::ActiveClient::onStreamDestroy() {
   }
 }
 
-void ConnPoolImpl::ActiveClient::onStreamReset(Http::StreamResetReason reason) {
+void ActiveClient::onStreamReset(Http::StreamResetReason reason) {
   if (reason == StreamResetReason::ConnectionTermination ||
       reason == StreamResetReason::ConnectionFailure) {
     parent_.host()->cluster().stats().upstream_rq_pending_failure_eject_.inc();
@@ -68,7 +55,7 @@ uint64_t maxStreamsPerConnection(uint64_t max_streams_config) {
   return (max_streams_config != 0) ? max_streams_config : DEFAULT_MAX_STREAMS;
 }
 
-ConnPoolImpl::ActiveClient::ActiveClient(Envoy::Http::HttpConnPoolImplBase& parent)
+ActiveClient::ActiveClient(HttpConnPoolImplBase& parent)
     : Envoy::Http::ActiveClient(
           parent, maxStreamsPerConnection(parent.host()->cluster().maxRequestsPerConnection()),
           parent.host()->cluster().http2Options().max_concurrent_streams().value()) {
@@ -77,18 +64,10 @@ ConnPoolImpl::ActiveClient::ActiveClient(Envoy::Http::HttpConnPoolImplBase& pare
   parent.host()->cluster().stats().upstream_cx_http2_total_.inc();
 }
 
-bool ConnPoolImpl::ActiveClient::closingWithIncompleteStream() const {
-  return closed_with_active_rq_;
-}
+bool ActiveClient::closingWithIncompleteStream() const { return closed_with_active_rq_; }
 
-RequestEncoder& ConnPoolImpl::ActiveClient::newStreamEncoder(ResponseDecoder& response_decoder) {
+RequestEncoder& ActiveClient::newStreamEncoder(ResponseDecoder& response_decoder) {
   return codec_client_->newStream(response_decoder);
-}
-
-CodecClientPtr ProdConnPoolImpl::createCodecClient(Upstream::Host::CreateConnectionData& data) {
-  CodecClientPtr codec{new CodecClientProd(CodecClient::Type::HTTP2, std::move(data.connection_),
-                                           data.host_description_, dispatcher_, random_generator_)};
-  return codec;
 }
 
 ConnectionPool::InstancePtr
@@ -96,8 +75,16 @@ allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
                  const Network::TransportSocketOptionsSharedPtr& transport_socket_options) {
-  return std::make_unique<Http::Http2::ProdConnPoolImpl>(
-      dispatcher, random_generator, host, priority, options, transport_socket_options);
+  return std::make_unique<FixedHttpConnPoolImpl>(
+      host, priority, dispatcher, options, transport_socket_options, random_generator,
+      [](HttpConnPoolImplBase* pool) { return std::make_unique<ActiveClient>(*pool); },
+      [](Upstream::Host::CreateConnectionData& data, HttpConnPoolImplBase* pool) {
+        CodecClientPtr codec{new CodecClientProd(
+            CodecClient::Type::HTTP2, std::move(data.connection_), data.host_description_,
+            pool->dispatcher(), pool->randomGenerator())};
+        return codec;
+      },
+      std::vector<Protocol>{Protocol::Http2});
 }
 
 } // namespace Http2

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -12,57 +12,27 @@ namespace Http {
 namespace Http2 {
 
 /**
- * Implementation of a "connection pool" for HTTP/2. This mainly handles stats as well as
- * shifting to a new connection if we reach max streams on the primary. This is a base class
- * used for both the prod implementation as well as the testing one.
+ * Implementation of an active client for HTTP/2
  */
-class ConnPoolImpl : public Envoy::Http::HttpConnPoolImplBase {
+class ActiveClient : public CodecClientCallbacks,
+                     public Http::ConnectionCallbacks,
+                     public Envoy::Http::ActiveClient {
 public:
-  ConnPoolImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
-               Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-               const Network::ConnectionSocket::OptionsSharedPtr& options,
-               const Network::TransportSocketOptionsSharedPtr& transport_socket_options);
+  ActiveClient(HttpConnPoolImplBase& parent);
+  ~ActiveClient() override = default;
 
-  ~ConnPoolImpl() override;
+  // ConnPoolImpl::ActiveClient
+  bool closingWithIncompleteStream() const override;
+  RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) override;
 
-  // ConnPoolImplBase
-  Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override;
+  // CodecClientCallbacks
+  void onStreamDestroy() override;
+  void onStreamReset(Http::StreamResetReason reason) override;
 
-  class ActiveClient : public CodecClientCallbacks,
-                       public Http::ConnectionCallbacks,
-                       public Envoy::Http::ActiveClient {
-  public:
-    ActiveClient(Envoy::Http::HttpConnPoolImplBase& parent);
-    ActiveClient(Envoy::Http::HttpConnPoolImplBase& parent,
-                 Upstream::Host::CreateConnectionData& data);
-    ~ActiveClient() override = default;
+  // Http::ConnectionCallbacks
+  void onGoAway(Http::GoAwayErrorCode error_code) override;
 
-    ConnPoolImpl& parent() { return static_cast<ConnPoolImpl&>(parent_); }
-
-    // ConnPoolImpl::ActiveClient
-    bool closingWithIncompleteStream() const override;
-    RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) override;
-
-    // CodecClientCallbacks
-    void onStreamDestroy() override;
-    void onStreamReset(Http::StreamResetReason reason) override;
-
-    // Http::ConnectionCallbacks
-    void onGoAway(Http::GoAwayErrorCode error_code) override;
-
-    bool closed_with_active_rq_{};
-  };
-};
-
-/**
- * Production implementation of the HTTP/2 connection pool.
- */
-class ProdConnPoolImpl : public ConnPoolImpl {
-public:
-  using ConnPoolImpl::ConnPoolImpl;
-
-private:
-  CodecClientPtr createCodecClient(Upstream::Host::CreateConnectionData& data) override;
+  bool closed_with_active_rq_{};
 };
 
 ConnectionPool::InstancePtr

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -298,7 +298,7 @@ public:
     EXPECT_CALL(*mock_host_, createConnection_(_, _)).WillRepeatedly(Return(connection_data));
     EXPECT_CALL(*mock_host_, cluster()).WillRepeatedly(ReturnRef(*cluster_info_ptr_));
     EXPECT_CALL(*mock_host_description_, locality()).WillRepeatedly(ReturnRef(host_locality_));
-    http_conn_pool_ = std::make_unique<Http::Http2::ProdConnPoolImpl>(
+    http_conn_pool_ = Http::Http2::allocateConnPool(
         *dispatcher_, random_, host_ptr_, Upstream::ResourcePriority::Default, nullptr, nullptr);
     EXPECT_CALL(cm_, httpConnPoolForCluster(_, _, _, _))
         .WillRepeatedly(Return(http_conn_pool_.get()));

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -48,12 +48,19 @@ namespace {
 /**
  * A test version of ConnPoolImpl that allows for mocking beneath the codec clients.
  */
-class ConnPoolImplForTest : public ConnPoolImpl {
+class ConnPoolImplForTest : public HttpConnPoolImplBase {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher,
-                      Upstream::ClusterInfoConstSharedPtr cluster)
-      : ConnPoolImpl(dispatcher, random_, Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
-                     Upstream::ResourcePriority::Default, nullptr, nullptr),
+                      Upstream::ClusterInfoConstSharedPtr cluster,
+                      Random::RandomGenerator& random_generator)
+      : FixedHttpConnPoolImpl(
+            Upstream::makeTestHost(cluster, "tcp://127.0.0.1:9000"),
+            Upstream::ResourcePriority::Default, dispatcher, nullptr, nullptr, random_generator,
+            [](HttpConnPoolImplBase* pool) { return std::make_unique<ActiveClient>(*pool); },
+            [](Upstream::Host::CreateConnectionData&, HttpConnPoolImplBase*) {
+              return nullptr; // Not used: createCodecClient overloaded.
+            },
+            std::vector<Protocol>{Protocol::Http11}),
         api_(Api::createApiForTest()), mock_dispatcher_(dispatcher) {}
 
   ~ConnPoolImplForTest() override {
@@ -116,7 +123,6 @@ public:
 
   Api::ApiPtr api_;
   Event::MockDispatcher& mock_dispatcher_;
-  NiceMock<Random::MockRandomGenerator> random_;
   Event::PostCb post_cb_;
   std::vector<TestCodecClient> test_clients_;
 };
@@ -127,12 +133,13 @@ public:
 class Http1ConnPoolImplTest : public testing::Test {
 public:
   Http1ConnPoolImplTest()
-      : conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_)) {}
+      : conn_pool_(std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_, random_)) {}
 
   ~Http1ConnPoolImplTest() override {
     EXPECT_EQ("", TestUtility::nonZeroedGauges(cluster_->stats_store_.gauges()));
   }
 
+  NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   std::unique_ptr<ConnPoolImplForTest> conn_pool_;
@@ -283,7 +290,7 @@ TEST_F(Http1ConnPoolImplTest, VerifyAlpnFallback) {
 
   // Recreate the conn pool so that the host re-evaluates the transport socket match, arriving at
   // our test transport socket factory.
-  conn_pool_ = std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_);
+  conn_pool_ = std::make_unique<ConnPoolImplForTest>(dispatcher_, cluster_, random_);
   NiceMock<MockResponseDecoder> outer_decoder;
   ConnPoolCallbacks callbacks;
   conn_pool_->expectClientCreate(Protocol::Http11);

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -48,7 +48,7 @@ namespace {
 /**
  * A test version of ConnPoolImpl that allows for mocking beneath the codec clients.
  */
-class ConnPoolImplForTest : public HttpConnPoolImplBase {
+class ConnPoolImplForTest : public FixedHttpConnPoolImpl {
 public:
   ConnPoolImplForTest(Event::MockDispatcher& dispatcher,
                       Upstream::ClusterInfoConstSharedPtr cluster,


### PR DESCRIPTION
This is a refactor to make #13922 safe long term.

Basically the HTTP/1 and HTTP/2 logic used to be split between the ActiveClient, and the ConnectionPool classes.
Prior refactors moved all the logic from the pool to the client, so that the new MixedConnectionPool could have HTTP/1 or HTTP/2 clients, with all the logic contained in the ActiveClient.  This does away with the pool classes entirely, so folks don't add any logic back.

This could go one of two ways.  We can keep the FixedConnectionPool and MixedConnectionPool long term, or we can have a single merged pool with if (alpn) {alpn_logic} else {fixed_logic}.  I don't have strong feelings, but felt the split was a bit cleaner.

Risk Level: Medium
Testing: n/a (pure refactor)
Docs Changes: n/a
Release Notes: n/a
Part of  #3431
