### PR TITLE
api: Add boolean do_not_cache field to Resource message.

### DIFF
--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -253,7 +253,7 @@ message DeltaDiscoveryResponse {
   string nonce = 5;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
@@ -288,4 +288,10 @@ message Resource {
   // testing where the fault injection should be terminated in the event that Envoy loses contact
   // with the management server.
   google.protobuf.Duration ttl = 6;
+
+  // If true, xDS proxies may not cache this resource.
+  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
+  // own use, regardless of the value of this field.
+  // [#not-implemented-hide:]
+  bool do_not_cache = 7;
 }

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -290,8 +290,8 @@ message Resource {
   google.protobuf.Duration ttl = 6;
 
   // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
-  // own use, regardless of the value of this field.
+  // Note that this does not apply to clients other than xDS proxies, which must cache resources
+  // for their own use, regardless of the value of this field.
   // [#not-implemented-hide:]
   bool do_not_cache = 7;
 }

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -257,6 +257,15 @@ message DeltaDiscoveryResponse {
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
+  message CacheControl {
+    // If true, xDS proxies may not cache this resource.
+    // Note that this does not apply to clients other than xDS proxies, which must cache resources
+    // for their own use, regardless of the value of this field.
+    bool do_not_cache = 1;
+  }
+
   // The resource's name, to distinguish it from others of the same type of resource.
   string name = 3 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
@@ -289,9 +298,5 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
-  // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to clients other than xDS proxies, which must cache resources
-  // for their own use, regardless of the value of this field.
-  // [#not-implemented-hide:]
-  bool do_not_cache = 7;
+  CacheControl cache_control = 7;
 }

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -298,5 +298,7 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
   CacheControl cache_control = 7;
 }

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -294,8 +294,8 @@ message Resource {
   google.protobuf.Duration ttl = 6;
 
   // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
-  // own use, regardless of the value of this field.
+  // Note that this does not apply to clients other than xDS proxies, which must cache resources
+  // for their own use, regardless of the value of this field.
   // [#not-implemented-hide:]
   bool do_not_cache = 7;
 }

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -305,5 +305,7 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
   CacheControl cache_control = 7;
 }

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -260,6 +260,18 @@ message Resource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.Resource";
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
+  message CacheControl {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.discovery.v3.Resource.CacheControl";
+
+    // If true, xDS proxies may not cache this resource.
+    // Note that this does not apply to clients other than xDS proxies, which must cache resources
+    // for their own use, regardless of the value of this field.
+    bool do_not_cache = 1;
+  }
+
   oneof name_specifier {
     // The resource's name, to distinguish it from others of the same type of resource.
     string name = 3;
@@ -293,9 +305,5 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
-  // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to clients other than xDS proxies, which must cache resources
-  // for their own use, regardless of the value of this field.
-  // [#not-implemented-hide:]
-  bool do_not_cache = 7;
+  CacheControl cache_control = 7;
 }

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -255,7 +255,7 @@ message DeltaDiscoveryResponse {
   string nonce = 5;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.Resource";
@@ -292,4 +292,10 @@ message Resource {
   // testing where the fault injection should be terminated in the event that Envoy loses contact
   // with the management server.
   google.protobuf.Duration ttl = 6;
+
+  // If true, xDS proxies may not cache this resource.
+  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
+  // own use, regardless of the value of this field.
+  // [#not-implemented-hide:]
+  bool do_not_cache = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -253,7 +253,7 @@ message DeltaDiscoveryResponse {
   string nonce = 5;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
@@ -288,4 +288,10 @@ message Resource {
   // testing where the fault injection should be terminated in the event that Envoy loses contact
   // with the management server.
   google.protobuf.Duration ttl = 6;
+
+  // If true, xDS proxies may not cache this resource.
+  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
+  // own use, regardless of the value of this field.
+  // [#not-implemented-hide:]
+  bool do_not_cache = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -290,8 +290,8 @@ message Resource {
   google.protobuf.Duration ttl = 6;
 
   // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
-  // own use, regardless of the value of this field.
+  // Note that this does not apply to clients other than xDS proxies, which must cache resources
+  // for their own use, regardless of the value of this field.
   // [#not-implemented-hide:]
   bool do_not_cache = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -257,6 +257,15 @@ message DeltaDiscoveryResponse {
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
+  message CacheControl {
+    // If true, xDS proxies may not cache this resource.
+    // Note that this does not apply to clients other than xDS proxies, which must cache resources
+    // for their own use, regardless of the value of this field.
+    bool do_not_cache = 1;
+  }
+
   // The resource's name, to distinguish it from others of the same type of resource.
   string name = 3 [(udpa.annotations.field_migrate).oneof_promotion = "name_specifier"];
 
@@ -289,9 +298,5 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
-  // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to clients other than xDS proxies, which must cache resources
-  // for their own use, regardless of the value of this field.
-  // [#not-implemented-hide:]
-  bool do_not_cache = 7;
+  CacheControl cache_control = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -298,5 +298,7 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
   CacheControl cache_control = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -294,8 +294,8 @@ message Resource {
   google.protobuf.Duration ttl = 6;
 
   // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
-  // own use, regardless of the value of this field.
+  // Note that this does not apply to clients other than xDS proxies, which must cache resources
+  // for their own use, regardless of the value of this field.
   // [#not-implemented-hide:]
   bool do_not_cache = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -305,5 +305,7 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
   CacheControl cache_control = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -260,6 +260,18 @@ message Resource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.Resource";
 
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
+  message CacheControl {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.discovery.v3.Resource.CacheControl";
+
+    // If true, xDS proxies may not cache this resource.
+    // Note that this does not apply to clients other than xDS proxies, which must cache resources
+    // for their own use, regardless of the value of this field.
+    bool do_not_cache = 1;
+  }
+
   oneof name_specifier {
     // The resource's name, to distinguish it from others of the same type of resource.
     string name = 3;
@@ -293,9 +305,5 @@ message Resource {
   // with the management server.
   google.protobuf.Duration ttl = 6;
 
-  // If true, xDS proxies may not cache this resource.
-  // Note that this does not apply to clients other than xDS proxies, which must cache resources
-  // for their own use, regardless of the value of this field.
-  // [#not-implemented-hide:]
-  bool do_not_cache = 7;
+  CacheControl cache_control = 7;
 }

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -255,7 +255,7 @@ message DeltaDiscoveryResponse {
   string nonce = 5;
 }
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.Resource";
@@ -292,4 +292,10 @@ message Resource {
   // testing where the fault injection should be terminated in the event that Envoy loses contact
   // with the management server.
   google.protobuf.Duration ttl = 6;
+
+  // If true, xDS proxies may not cache this resource.
+  // Note that this does not apply to non-proxy xDS clients, which must cache resources for their
+  // own use, regardless of the value of this field.
+  // [#not-implemented-hide:]
+  bool do_not_cache = 7;
 }


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Add boolean do_not_cache field to Resource message.
Additional Description: Allows xDS servers to tell clients that resources should not be cached by xDS proxies.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @htuch @jaychenatr 