### PR TITLE
docs: Update quick-start logging info

### DIFF
--- a/docs/root/start/quick-start/_include/envoy-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo.yaml
@@ -12,6 +12,11 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              path: /dev/stdout
           http_filters:
           - name: envoy.filters.http.router
           route_config:

--- a/docs/root/start/quick-start/run-envoy.rst
+++ b/docs/root/start/quick-start/run-envoy.rst
@@ -252,7 +252,6 @@ This can be overridden using :option:`--log-path`.
 
          $ mkdir logs
          $ envoy -c envoy-demo.yaml --log-path logs/custom.log
-         ...
 
    .. tab:: Docker
 
@@ -266,11 +265,25 @@ This can be overridden using :option:`--log-path`.
                envoyproxy/|envoy_docker_image| \
                    -c /etc/envoy/envoy.yaml \
                    --log-path logs/custom.log
-         ...
 
 :ref:`Access log <arch_overview_access_logs>` paths can be set for the
 :ref:`admin interface <start_quick_start_admin>`, and for configured
 :ref:`listeners <envoy_v3_api_file_envoy/config/listener/v3/listener.proto>`.
+
+The :download:`demo configuration <_include/envoy-demo.yaml>` is configured with a
+:ref:`listener <envoy_v3_api_file_envoy/config/listener/v3/listener.proto>` that logs access
+to ``/dev/stdout``:
+
+.. literalinclude:: _include/envoy-demo.yaml
+   :language: yaml
+   :linenos:
+   :lineno-start: 12
+   :lines: 12-22
+   :emphasize-lines: 4-8
+
+Logging to ``/dev/stderr`` and ``/dev/stdout`` for system and access logs can be useful when
+running Envoy inside a container as the streams can be separated, and logging requires no
+additional files or directories to be mounted.
 
 Some Envoy :ref:`filters and extensions <api-v3_config>` may also have additional logging capabilities.
 
@@ -288,8 +301,6 @@ Debugging Envoy
 
 The log level for Envoy system logs can be set using the :option:`-l or --log-level <--log-level>` option.
 
-The default  is ``info``.
-
 The available log levels are:
 
 - ``trace``
@@ -299,6 +310,8 @@ The available log levels are:
 - ``error``
 - ``critical``
 - ``off``
+
+The default  is ``info``.
 
 You can also set the log level for specific components using the :option:`--component-log-level` option.
 

--- a/docs/root/start/quick-start/run-envoy.rst
+++ b/docs/root/start/quick-start/run-envoy.rst
@@ -281,8 +281,10 @@ to ``/dev/stdout``:
    :lines: 12-22
    :emphasize-lines: 4-8
 
-Logging to ``/dev/stderr`` and ``/dev/stdout`` for system and access logs can be useful when
-running Envoy inside a container as the streams can be separated, and logging requires no
+The default configuration in the Envoy Docker container also logs access in this way.
+
+Logging to ``/dev/stderr`` and ``/dev/stdout`` for system and access logs respectively can
+be useful when running Envoy inside a container as the streams can be separated, and logging requires no
 additional files or directories to be mounted.
 
 Some Envoy :ref:`filters and extensions <api-v3_config>` may also have additional logging capabilities.


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Update quick-start logging info
Additional Description:

Follow up from #13935 

Provides basic info/example of access logging

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
