### PR TITLE
docs: Bump sphinxext-rediraffe version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -116,9 +116,9 @@ sphinxcontrib-jsmath==1.0.1 \
 sphinxcontrib-qthelp==1.0.3 \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6
-sphinxext-rediraffe==0.2.4 \
-    --hash=sha256:5428fb614d1fbc16964ba587aaa6b1c8ec92fd0b1d01bb6b369637446f43a27d \
-    --hash=sha256:13e6474342df6643723976a3429edfc5e811e9f48b9f832c9fb6bdd9fe53fd83
+sphinxext-rediraffe==0.2.5 \
+    --hash=sha256:bd337f31f0d0e51e5ff893d533563b4aacd52d78ea64c122cae7befcabbb87fa \
+    --hash=sha256:9dc0502dfc5efbb24dcfe04eab69ddfd07d7c63f9bb4d93e73ec1a92e3f9cd1f
 sphinxcontrib-serializinghtml==1.1.4 \
     --hash=sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc \
     --hash=sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -117,8 +117,8 @@ sphinxcontrib-qthelp==1.0.3 \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6
 sphinxext-rediraffe==0.2.5 \
-    --hash=sha256:bd337f31f0d0e51e5ff893d533563b4aacd52d78ea64c122cae7befcabbb87fa \
-    --hash=sha256:9dc0502dfc5efbb24dcfe04eab69ddfd07d7c63f9bb4d93e73ec1a92e3f9cd1f
+    --hash=sha256:7b706284d20602acecc1783cc58c8d0543937af1ee53f912bfdc4b258a7e649a \
+    --hash=sha256:a17287cdee7763341b91762879e042b33a4916d6a2fc6d2f97a18107325bd2cc
 sphinxcontrib-serializinghtml==1.1.4 \
     --hash=sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc \
     --hash=sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Bump sphinxext-rediraffe version
Additional Description:

bump to v0.2.5

- https://github.com/wpilibsuite/sphinxext-rediraffe/releases
- https://pypi.org/project/sphinxext-rediraffe/#files

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] 
[Optional Deprecated:]
