### PR TITLE
server: split thread_local_object.h and overload_manager.h

### DIFF
--- a/include/envoy/runtime/BUILD
+++ b/include/envoy/runtime/BUILD
@@ -17,7 +17,7 @@ envoy_cc_library(
     ],
     deps = [
         "//include/envoy/stats:stats_interface",
-        "//include/envoy/thread_local:thread_local_interface",
+        "//include/envoy/thread_local:thread_local_object",
         "//source/common/common:assert_lib",
         "//source/common/singleton:threadsafe_singleton",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",

--- a/include/envoy/runtime/runtime.h
+++ b/include/envoy/runtime/runtime.h
@@ -9,7 +9,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/stats/store.h"
-#include "envoy/thread_local/thread_local.h"
+#include "envoy/thread_local/thread_local_object.h"
 #include "envoy/type/v3/percent.pb.h"
 
 #include "common/common/assert.h"

--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -127,7 +127,7 @@ envoy_cc_library(
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/secret:secret_manager_interface",
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//include/envoy/ssl:context_manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/tracing:http_tracer_interface",
@@ -151,8 +151,8 @@ envoy_cc_library(
     name = "worker_interface",
     hdrs = ["worker.h"],
     deps = [
-        ":overload_manager_interface",
         "//include/envoy/server:guarddog_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
     ],
 )
 
@@ -183,7 +183,7 @@ envoy_cc_library(
         "//include/envoy/local_info:local_info_interface",
         "//include/envoy/network:drain_decision_interface",
         "//include/envoy/runtime:runtime_interface",
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//include/envoy/singleton:manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/tracing:http_tracer_interface",
@@ -207,8 +207,8 @@ envoy_cc_library(
         "//include/envoy/config:typed_config_interface",
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
-        "//include/envoy/server:overload_manager_interface",
         "//include/envoy/server:transport_socket_config_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//include/envoy/singleton:manager_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/tracing:http_tracer_interface",
@@ -299,16 +299,6 @@ envoy_cc_library(
         "//include/envoy/api:api_interface",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/protobuf:message_validator_interface",
-    ],
-)
-
-envoy_cc_library(
-    name = "overload_manager_interface",
-    hdrs = ["overload_manager.h"],
-    deps = [
-        "//include/envoy/event:timer_interface",
-        "//include/envoy/thread_local:thread_local_interface",
-        "//source/common/singleton:const_singleton",
     ],
 )
 

--- a/include/envoy/server/factory_context.h
+++ b/include/envoy/server/factory_context.h
@@ -19,7 +19,7 @@
 #include "envoy/server/admin.h"
 #include "envoy/server/drain_manager.h"
 #include "envoy/server/lifecycle_notifier.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/server/process_context.h"
 #include "envoy/singleton/manager.h"
 #include "envoy/stats/scope.h"

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -23,7 +23,7 @@
 #include "envoy/server/lifecycle_notifier.h"
 #include "envoy/server/listener_manager.h"
 #include "envoy/server/options.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/ssl/context_manager.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/tracing/http_tracer.h"

--- a/include/envoy/server/overload/BUILD
+++ b/include/envoy/server/overload/BUILD
@@ -1,0 +1,29 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_library(
+    name = "overload_manager_interface",
+    hdrs = ["overload_manager.h"],
+    deps = [
+        ":thread_local_overload_state",
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/thread_local:thread_local_interface",
+        "//source/common/singleton:const_singleton",
+    ],
+)
+
+envoy_cc_library(
+    name = "thread_local_overload_state",
+    hdrs = ["thread_local_overload_state.h"],
+    deps = [
+        "//include/envoy/event:timer_interface",
+        "//include/envoy/thread_local:thread_local_object",
+    ],
+)

--- a/include/envoy/server/overload/overload_manager.h
+++ b/include/envoy/server/overload/overload_manager.h
@@ -3,64 +3,13 @@
 #include <string>
 
 #include "envoy/common/pure.h"
-#include "envoy/event/timer.h"
-#include "envoy/thread_local/thread_local.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/server/overload/thread_local_overload_state.h"
 
-#include "common/common/macros.h"
 #include "common/singleton/const_singleton.h"
 
 namespace Envoy {
 namespace Server {
-
-/**
- * Tracks the state of an overload action. The state is a number between 0 and 1 that represents the
- * level of saturation. The values are categorized in two groups:
- * - Saturated (value = 1): indicates that an overload action is active because at least one of its
- *   triggers has reached saturation.
- * - Scaling (0 <= value < 1): indicates that an overload action is not saturated.
- */
-class OverloadActionState {
-public:
-  static constexpr OverloadActionState inactive() { return OverloadActionState(0); }
-
-  static constexpr OverloadActionState saturated() { return OverloadActionState(1.0); }
-
-  explicit constexpr OverloadActionState(float value)
-      : action_value_(std::min(1.0f, std::max(0.0f, value))) {}
-
-  float value() const { return action_value_; }
-  bool isSaturated() const { return action_value_ == 1; }
-
-private:
-  float action_value_;
-};
-
-/**
- * Callback invoked when an overload action changes state.
- */
-using OverloadActionCb = std::function<void(OverloadActionState)>;
-
-enum class OverloadTimerType {
-  // Timers created with this type will never be scaled. This should only be used for testing.
-  UnscaledRealTimerForTest,
-  // The amount of time an HTTP connection to a downstream client can remain idle (no streams). This
-  // corresponds to the HTTP_DOWNSTREAM_CONNECTION_IDLE TimerType in overload.proto.
-  HttpDownstreamIdleConnectionTimeout,
-};
-
-/**
- * Thread-local copy of the state of each configured overload action.
- */
-class ThreadLocalOverloadState : public ThreadLocal::ThreadLocalObject {
-public:
-  // Get a thread-local reference to the value for the given action key.
-  virtual const OverloadActionState& getState(const std::string& action) PURE;
-
-  // Get a scaled timer whose minimum corresponds to the configured value for the given timer type.
-  virtual Event::TimerPtr createScaledTimer(OverloadTimerType timer_type,
-                                            Event::TimerCb callback) PURE;
-};
-
 /**
  * Well-known overload action names.
  */

--- a/include/envoy/server/overload/thread_local_overload_state.h
+++ b/include/envoy/server/overload/thread_local_overload_state.h
@@ -1,0 +1,63 @@
+
+#pragma once
+
+#include <string>
+
+#include "envoy/common/pure.h"
+#include "envoy/event/timer.h"
+#include "envoy/thread_local/thread_local_object.h"
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * Tracks the state of an overload action. The state is a number between 0 and 1 that represents the
+ * level of saturation. The values are categorized in two groups:
+ * - Saturated (value = 1): indicates that an overload action is active because at least one of its
+ *   triggers has reached saturation.
+ * - Scaling (0 <= value < 1): indicates that an overload action is not saturated.
+ */
+class OverloadActionState {
+public:
+  static constexpr OverloadActionState inactive() { return OverloadActionState(0); }
+
+  static constexpr OverloadActionState saturated() { return OverloadActionState(1.0); }
+
+  explicit constexpr OverloadActionState(float value)
+      : action_value_(std::min(1.0f, std::max(0.0f, value))) {}
+
+  float value() const { return action_value_; }
+  bool isSaturated() const { return action_value_ == 1; }
+
+private:
+  float action_value_;
+};
+
+/**
+ * Callback invoked when an overload action changes state.
+ */
+using OverloadActionCb = std::function<void(OverloadActionState)>;
+
+enum class OverloadTimerType {
+  // Timers created with this type will never be scaled. This should only be used for testing.
+  UnscaledRealTimerForTest,
+  // The amount of time an HTTP connection to a downstream client can remain idle (no streams). This
+  // corresponds to the HTTP_DOWNSTREAM_CONNECTION_IDLE TimerType in overload.proto.
+  HttpDownstreamIdleConnectionTimeout,
+};
+
+/**
+ * Thread-local copy of the state of each configured overload action.
+ */
+class ThreadLocalOverloadState : public ThreadLocal::ThreadLocalObject {
+public:
+  // Get a thread-local reference to the value for the given action key.
+  virtual const OverloadActionState& getState(const std::string& action) PURE;
+
+  // Get a scaled timer whose minimum corresponds to the configured value for the given timer type.
+  virtual Event::TimerPtr createScaledTimer(OverloadTimerType timer_type,
+                                            Event::TimerCb callback) PURE;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/include/envoy/server/worker.h
+++ b/include/envoy/server/worker.h
@@ -3,7 +3,7 @@
 #include <functional>
 
 #include "envoy/server/guarddog.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 
 namespace Envoy {
 namespace Server {

--- a/include/envoy/thread_local/BUILD
+++ b/include/envoy/thread_local/BUILD
@@ -11,5 +11,15 @@ envoy_package()
 envoy_cc_library(
     name = "thread_local_interface",
     hdrs = ["thread_local.h"],
-    deps = ["//include/envoy/event:dispatcher_interface"],
+    deps = [
+        ":thread_local_object",
+        "//include/envoy/event:dispatcher_interface",
+        "//source/common/common:assert_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "thread_local_object",
+    hdrs = ["thread_local_object.h"],
+    deps = ["//source/common/common:assert_lib"],
 )

--- a/include/envoy/thread_local/thread_local.h
+++ b/include/envoy/thread_local/thread_local.h
@@ -7,29 +7,12 @@
 #include "envoy/common/optref.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/thread_local/thread_local_object.h"
+
+#include "common/common/assert.h"
 
 namespace Envoy {
 namespace ThreadLocal {
-
-/**
- * All objects that are stored via the ThreadLocal interface must derive from this type.
- */
-class ThreadLocalObject {
-public:
-  virtual ~ThreadLocalObject() = default;
-
-  /**
-   * Return the object casted to a concrete type. See getTyped() below for comments on the casts.
-   */
-  template <class T> T& asType() {
-    ASSERT(dynamic_cast<T*>(this) != nullptr);
-    return *static_cast<T*>(this);
-  }
-};
-
-using ThreadLocalObjectSharedPtr = std::shared_ptr<ThreadLocalObject>;
-
-template <class T = ThreadLocalObject> class TypedSlot;
 
 /**
  * An individual allocated TLS slot. When the slot is destroyed the stored thread local will

--- a/include/envoy/thread_local/thread_local_object.h
+++ b/include/envoy/thread_local/thread_local_object.h
@@ -10,8 +10,8 @@ namespace Envoy {
 namespace ThreadLocal {
 
 /**
-* All objects that are stored via the ThreadLocal interface must derive from this type.
-*/
+ * All objects that are stored via the ThreadLocal interface must derive from this type.
+ */
 class ThreadLocalObject {
 public:
   virtual ~ThreadLocalObject() = default;

--- a/include/envoy/thread_local/thread_local_object.h
+++ b/include/envoy/thread_local/thread_local_object.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "common/common/assert.h"
+
+namespace Envoy {
+namespace ThreadLocal {
+
+/**
+* All objects that are stored via the ThreadLocal interface must derive from this type.
+*/
+class ThreadLocalObject {
+public:
+  virtual ~ThreadLocalObject() = default;
+
+  /**
+   * Return the object casted to a concrete type. See getTyped() below for comments on the casts.
+   */
+  template <class T> T& asType() {
+    ASSERT(dynamic_cast<T*>(this) != nullptr);
+    return *static_cast<T*>(this);
+  }
+};
+
+using ThreadLocalObjectSharedPtr = std::shared_ptr<ThreadLocalObject>;
+
+template <class T = ThreadLocalObject> class TypedSlot;
+
+} // namespace ThreadLocal
+} // namespace Envoy

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -171,7 +171,7 @@ envoy_cc_library(
         "//include/envoy/api:api_interface",
         "//include/envoy/grpc:google_grpc_creds_interface",
         "//include/envoy/thread:thread_interface",
-        "//include/envoy/thread_local:thread_local_interface",
+        "//include/envoy/thread_local:thread_local_object",
         "//source/common/common:base64_lib",
         "//source/common/common:empty_string",
         "//source/common/common:linked_object",

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -10,7 +10,7 @@
 #include "envoy/grpc/async_client.h"
 #include "envoy/stats/scope.h"
 #include "envoy/thread/thread.h"
-#include "envoy/thread_local/thread_local.h"
+#include "envoy/thread_local/thread_local_object.h"
 #include "envoy/tracing/http_tracer.h"
 
 #include "common/common/linked_object.h"

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -216,7 +216,7 @@ envoy_cc_library(
         "//include/envoy/router:rds_interface",
         "//include/envoy/router:scopes_interface",
         "//include/envoy/runtime:runtime_interface",
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//include/envoy/ssl:connection_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/stats:stats_macros",

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -26,7 +26,7 @@
 #include "envoy/router/rds.h"
 #include "envoy/router/scopes.h"
 #include "envoy/runtime/runtime.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/ssl/connection.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"

--- a/source/common/memory/BUILD
+++ b/source/common/memory/BUILD
@@ -35,7 +35,7 @@ envoy_cc_library(
     deps = [
         ":utils_lib",
         "//include/envoy/event:dispatcher_interface",
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//include/envoy/stats:stats_interface",
         "//source/common/stats:symbol_table_lib",
     ],

--- a/source/common/memory/heap_shrinker.h
+++ b/source/common/memory/heap_shrinker.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "envoy/event/dispatcher.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
 

--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -32,6 +32,7 @@ envoy_cc_library(
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/server:lifecycle_notifier_interface",
+        "//include/envoy/thread_local:thread_local_object",
         "//include/envoy/upstream:cluster_manager_interface",
         "//source/common/config:datasource_lib",
         "//source/common/singleton:const_singleton",

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -11,7 +11,7 @@
 #include "envoy/server/lifecycle_notifier.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"
-#include "envoy/thread_local/thread_local.h"
+#include "envoy/thread_local/thread_local_object.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/common/assert.h"

--- a/source/extensions/filters/http/admission_control/BUILD
+++ b/source/extensions/filters/http/admission_control/BUILD
@@ -25,6 +25,7 @@ envoy_cc_extension(
     deps = [
         "//include/envoy/http:filter_interface",
         "//include/envoy/runtime:runtime_interface",
+        "//include/envoy/thread_local:thread_local_object",
         "//source/common/common:cleanup_lib",
         "//source/common/http:codes_lib",
         "//source/common/runtime:runtime_lib",

--- a/source/extensions/filters/http/admission_control/thread_local_controller.h
+++ b/source/extensions/filters/http/admission_control/thread_local_controller.h
@@ -3,7 +3,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/http/codes.h"
-#include "envoy/thread_local/thread_local.h"
+#include "envoy/thread_local/thread_local_object.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -254,7 +254,7 @@ envoy_cc_library(
     srcs = ["overload_manager_impl.cc"],
     hdrs = ["overload_manager_impl.h"],
     deps = [
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//include/envoy/stats:stats_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:logger_lib",

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -14,7 +14,7 @@
 #include "envoy/server/admin.h"
 #include "envoy/server/instance.h"
 #include "envoy/server/listener_manager.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/upstream/outlier_detection.h"
 #include "envoy/upstream/resource_manager.h"
 

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -5,7 +5,6 @@
 #include "envoy/common/exception.h"
 #include "envoy/config/overload/v3/overload.pb.h"
 #include "envoy/config/overload/v3/overload.pb.validate.h"
-#include "envoy/server/overload_manager.h"
 #include "envoy/stats/scope.h"
 
 #include "common/common/fmt.h"

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -8,7 +8,7 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/scaled_range_timer_manager.h"
 #include "envoy/protobuf/message_validator.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/server/resource_monitor.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats.h"

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -161,7 +161,7 @@ envoy_cc_mock(
     srcs = ["overload_manager.cc"],
     hdrs = ["overload_manager.h"],
     deps = [
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
         "//test/mocks/event:event_mocks",
     ],
 )
@@ -207,7 +207,7 @@ envoy_cc_mock(
     hdrs = ["main.h"],
     deps = [
         "//include/envoy/server:configuration_interface",
-        "//include/envoy/server:overload_manager_interface",
+        "//include/envoy/server/overload:overload_manager_interface",
     ],
 )
 

--- a/test/mocks/server/main.h
+++ b/test/mocks/server/main.h
@@ -6,7 +6,7 @@
 #include <string>
 
 #include "envoy/server/configuration.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 
 #include "gmock/gmock.h"
 

--- a/test/mocks/server/overload_manager.h
+++ b/test/mocks/server/overload_manager.h
@@ -2,7 +2,8 @@
 
 #include <string>
 
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
+#include "envoy/server/overload/thread_local_overload_state.h"
 
 #include "gmock/gmock.h"
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -1,7 +1,7 @@
 #include <chrono>
 
 #include "envoy/config/overload/v3/overload.pb.h"
-#include "envoy/server/overload_manager.h"
+#include "envoy/server/overload/overload_manager.h"
 #include "envoy/server/resource_monitor.h"
 #include "envoy/server/resource_monitor_config.h"
 


### PR DESCRIPTION
Commit Message: refactor thread_local_object.h and overload_manager.h
Additional Description:
Move the interfaces declared in these files into separate files to allow the
Dispatcher to reference the ThreadLocalOverloadState.

For #13800
Risk Level: low, just refactoring
Testing: ran affected test targets
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: none

/assign @antoniovicente