### PR TITLE
logging: Remove --log-format-prefix-with-location option

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -116,9 +116,6 @@ following are the command line options that Envoy supports.
    *(optional)* The format string to use for laying out the log message metadata. If this is not
    set, a default format string ``"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"`` is used.
 
-   When used in conjunction with :option:`--log-format-prefix-with-location` set to 1, the logger can be
-   configured to prefix ``%v`` by a file path and a line number.
-
    When used in conjunction with :option:`--log-format-escaped`, the logger can be configured
    to log in a format that is parsable by log viewers. Known integrations are documented
    in the :ref:`application logging configuration <config_application_logs>` section.
@@ -160,14 +157,6 @@ following are the command line options that Envoy supports.
    :%g: Full relative path of the source file ("/some/dir/my_file.cc")
    :%#: Source line ("123")
    :%!: Source function ("myFunc")
-
-.. option:: --log-format-prefix-with-location <1|0>
-
-   *(optional)* This temporary flag allows replacing all entries of ``"%v"`` in the log format by
-   ``"[%g:%#] %v"``. This flag is provided for migration purposes only. If this is not set, a
-   default value 0 is used.
-
-   **NOTE**: The flag will be removed at 1.17.0 release.
 
 .. option:: --log-format-escaped
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -72,4 +72,5 @@ New Features
 Deprecated
 ----------
 * gzip: :ref:`HTTP Gzip filter <config_http_filters_gzip>` is rejected now unless explicitly allowed with :ref:`runtime override <config_runtime_deprecation>` `envoy.deprecated_features.allow_deprecated_gzip_http_filter` set to `true`.
+* logging: the :option:`--log-format-prefix-with-location` option is removed.
 * ratelimit: the :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` action is deprecated in favor of the more generic :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` action.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -72,5 +72,5 @@ New Features
 Deprecated
 ----------
 * gzip: :ref:`HTTP Gzip filter <config_http_filters_gzip>` is rejected now unless explicitly allowed with :ref:`runtime override <config_runtime_deprecation>` `envoy.deprecated_features.allow_deprecated_gzip_http_filter` set to `true`.
-* logging: the :option:`--log-format-prefix-with-location` option is removed.
+* logging: the `--log-format-prefix-with-location` option is removed.
 * ratelimit: the :ref:`dynamic metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.dynamic_metadata>` action is deprecated in favor of the more generic :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` action.

--- a/docs/root/version_history/v1.15.0.rst
+++ b/docs/root/version_history/v1.15.0.rst
@@ -108,7 +108,7 @@ New Features
 * listener: added in place filter chain update flow for tcp listener update which doesn't close connections if the corresponding network filter chain is equivalent during the listener update.
   Can be disabled by setting runtime feature `envoy.reloadable_features.listener_in_place_filterchain_update` to false.
   Also added additional draining filter chain stat for :ref:`listener manager <config_listener_manager_stats>` to track the number of draining filter chains and the number of in place update attempts.
-* logger: added :option:`--log-format-prefix-with-location` command line option to prefix '%v' with file path and line number.
+* logger: added `--log-format-prefix-with-location` command line option to prefix '%v' with file path and line number.
 * lrs: added new *envoy_api_field_service.load_stats.v2.LoadStatsResponse.send_all_clusters* field
   in LRS response, which allows management servers to avoid explicitly listing all clusters it is
   interested in; behavior is allowed based on new "envoy.lrs.supports_send_all_clusters" capability

--- a/docs/root/version_history/v1.16.0.rst
+++ b/docs/root/version_history/v1.16.0.rst
@@ -42,7 +42,7 @@ Minor Behavior Changes
 * http: the per-stream FilterState maintained by the HTTP connection manager will now provide read/write access to the downstream connection FilterState. As such, code that relies on interacting with this might
   see a change in behavior.
 * logging: added fine-grain logging for file level log control with logger management at administration interface. It can be enabled by option :option:`--enable-fine-grain-logging`.
-* logging: changed default log format to `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` and default value of :option:`--log-format-prefix-with-location` to `0`.
+* logging: changed default log format to `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` and default value of `--log-format-prefix-with-location` to `0`.
 * logging: nghttp2 log messages no longer appear at trace level unless `ENVOY_NGHTTP2_TRACE` is set
   in the environment.
 * lua: changed the response body returned by `httpCall()` API to raw data. Previously, the returned data was string.

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -111,11 +111,6 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   TCLAP::SwitchArg enable_fine_grain_logging(
       "", "enable-fine-grain-logging",
       "Logger mode: enable file level log control(Fancy Logger)or not", cmd, false);
-  TCLAP::ValueArg<bool> log_format_prefix_with_location(
-      "", "log-format-prefix-with-location",
-      "Prefix all occurrences of '%v' in log format with with '[%g:%#] ' ('[path/to/file.cc:99] "
-      "').",
-      false, false, "bool", cmd);
   TCLAP::ValueArg<std::string> log_path("", "log-path", "Path to logfile", false, "", "string",
                                         cmd);
   TCLAP::ValueArg<uint32_t> restart_epoch("", "restart-epoch", "hot restart epoch #", false, 0,
@@ -201,9 +196,6 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
   }
 
   log_format_ = log_format.getValue();
-  if (log_format_prefix_with_location.getValue()) {
-    log_format_ = absl::StrReplaceAll(log_format_, {{"%%", "%%"}, {"%v", "[%g:%#] %v"}});
-  }
   log_format_escaped_ = log_format_escaped.getValue();
   enable_fine_grain_logging_ = enable_fine_grain_logging.getValue();
 

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -300,8 +300,7 @@ TEST_F(OptionsImplTest, OptionsAreInSyncWithProto) {
   // 4. allow-unknown-fields  - deprecated alias of allow-unknown-static-fields.
   // 5. use-fake-symbol-table - short-term override for rollout of real symbol-table implementation.
   // 6. hot restart version - print the hot restart version and exit.
-  // 7. log-format-prefix-with-location - short-term override for rollout of dynamic log format.
-  const uint32_t options_not_in_proto = 7;
+  const uint32_t options_not_in_proto = 6;
 
   // There are two deprecated options: "max_stats" and "max_obj_name_len".
   const uint32_t deprecated_options = 2;
@@ -457,17 +456,10 @@ TEST_F(OptionsImplTest, LogFormatDefault) {
   EXPECT_EQ(options->logFormat(), "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v");
 }
 
-TEST_F(OptionsImplTest, LogFormatDefaultNoPrefix) {
-  std::unique_ptr<OptionsImpl> options =
-      createOptionsImpl({"envoy", "-c", "hello", "--log-format-prefix-with-location", "0"});
-  EXPECT_EQ(options->logFormat(), "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v");
-}
-
 TEST_F(OptionsImplTest, LogFormatOverride) {
   std::unique_ptr<OptionsImpl> options =
-      createOptionsImpl({"envoy", "-c", "hello", "--log-format", "%%v %v %t %v",
-                         "--log-format-prefix-with-location 1"});
-  EXPECT_EQ(options->logFormat(), "%%v [%g:%#] %v %t [%g:%#] %v");
+      createOptionsImpl({"envoy", "-c", "hello", "--log-format", "%%v %v %t %v"});
+  EXPECT_EQ(options->logFormat(), "%%v %v %t %v");
 }
 
 TEST_F(OptionsImplTest, LogFormatOverrideNoPrefix) {


### PR DESCRIPTION
Commit Message: The option was stated to be deleted at 1.17.0 release.
Additional Description:
Risk Level: medium (option deletion)
Testing: n/a
Docs Changes: updated
Release Notes: updated
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
