### PR TITLE
docs: fix udp proxy example yaml file

### DIFF
--- a/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
+++ b/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
@@ -8,6 +8,7 @@ admin:
 static_resources:
   listeners:
   - name: listener_0
+    reuse_port: true
     address:
       socket_address:
         protocol: UDP


### PR DESCRIPTION
Signed-off-by: fear 1@linux.com

Docs Changes: yes

Commit Message: docs: fix udp proxy example yaml file

Additional Description:

> udp: the reuse_port listener option must now be specified for UDP listeners if concurrency is > 1. This previously crashed so is considered a bug fix.

reference: [1.15.0 (July 7, 2020)](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.15.0.html?highlight=reuse_port#bug-fixes)

