### PR TITLE
Build: Propagate user-supplied tags to external headers library.

### DIFF
--- a/bazel/envoy_library.bzl
+++ b/bazel/envoy_library.bzl
@@ -144,7 +144,7 @@ def envoy_cc_library(
         hdrs = hdrs,
         copts = envoy_copts(repository) + copts,
         visibility = visibility,
-        tags = ["nocompdb"],
+        tags = ["nocompdb"] + tags,
         deps = [":" + name],
         strip_include_prefix = strip_include_prefix,
     )


### PR DESCRIPTION
Commit Message: Build: Propagate user-supplied tags to external headers library.
Additional Description:
This change applies user supplied tags to the _with_external_headers
cc_library created by envoy_cc_library.

This is useful for cases where builds are filtered or modified by tag
(e.g., tags = manual, no-remmote, etc).

Signed-off-by: Angus Davis <angus@secureclouddb.com>

Risk Level: Low
Testing:
Execution of the following query pre/post in our external repository:

```
bazel query "let manual = attr(tags, 'manual', ...)
  in somepath( ... - \$manual, @envoy//source/common/grpc:stat_names_lib)"
```

Before this change, paths exist through the foo_with_external_headers library
to envoy libraries. After this change, paths are no longer present.

Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:] None
[Optional Fixes #Issue] None
[Optional Deprecated:] None
