### PR TITLE
docs: updating 100-continue docs

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -187,6 +187,10 @@ The following command operators are supported:
     HTTP response code. Note that a response code of '0' means that the server never sent the
     beginning of a response. This generally means that the (downstream) client disconnected.
 
+    Note that in the case of 100-continue responses, only the response code of the final headers
+    will be logged. If a 100-continue is followed by a 200, the logged response will be 200.
+    If a 100-continue results in a disconnect, the 100 will be logged.
+
   TCP
     Not implemented ("-").
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -869,6 +869,7 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
   }
 
   if (disconnect_after_100) {
+    response->waitForContinueHeaders();
     codec_client_->close();
     EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("100"));
     return;

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -829,7 +829,9 @@ void HttpIntegrationTest::testGrpcRetry() {
 }
 
 void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_from_upstream,
-                                                       const std::string& via) {
+                                                       const std::string& via,
+                                                       bool disconnect_after_100) {
+  useAccessLog("%RESPONSE_CODE%");
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -865,6 +867,13 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
     upstream_request_->encode100ContinueHeaders(
         Http::TestResponseHeaderMapImpl{{":status", "100"}});
   }
+
+  if (disconnect_after_100) {
+    codec_client_->close();
+    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("100"));
+    return;
+  }
+
   upstream_request_->encodeHeaders(default_response_headers_, false);
   upstream_request_->encodeData(12, true);
 
@@ -879,6 +888,7 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
   } else {
     EXPECT_EQ(via.c_str(), response->headers().getViaValue());
   }
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("200"));
 }
 
 void HttpIntegrationTest::testEnvoyProxying1xx(bool continue_before_upstream_complete,

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -871,6 +871,7 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
   if (disconnect_after_100) {
     response->waitForContinueHeaders();
     codec_client_->close();
+    ASSERT_TRUE(fake_upstream_connection_->close());
     EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("100"));
     return;
   }

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -216,7 +216,7 @@ protected:
   void testGrpcRetry();
 
   void testEnvoyHandling100Continue(bool additional_continue_from_upstream = false,
-                                    const std::string& via = "");
+                                    const std::string& via = "", bool disconnect_after_100 = false);
   void testEnvoyProxying1xx(bool continue_before_upstream_complete = false,
                             bool with_encoder_filter = false,
                             bool with_multiple_1xx_headers = false);

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -993,9 +993,13 @@ TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
   test_server_->waitForCounterEq("http.config_test.downstream_rq_5xx", 1);
 }
 
+// The downstream connection is closed when it is read disabled, and on OSX the
+// connection error is not detected under these circumstances.
+#if !defined(__APPLE__)
 TEST_P(ProtocolIntegrationTest, 100ContinueAndClose) {
   testEnvoyHandling100Continue(false, "", true);
 }
+#endif
 
 TEST_P(ProtocolIntegrationTest, EnvoyHandling100Continue) { testEnvoyHandling100Continue(); }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -993,6 +993,10 @@ TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
   test_server_->waitForCounterEq("http.config_test.downstream_rq_5xx", 1);
 }
 
+TEST_P(ProtocolIntegrationTest, 100ContinueAndClose) {
+  testEnvoyHandling100Continue(false, "", true);
+}
+
 TEST_P(ProtocolIntegrationTest, EnvoyHandling100Continue) { testEnvoyHandling100Continue(); }
 
 TEST_P(ProtocolIntegrationTest, EnvoyHandlingDuplicate100Continue) {


### PR DESCRIPTION
Risk Level: n/a (test, docs only)
Testing: new tests of 100-continue + logging
Docs Changes: docs of how 100-continue works with logging
Release Notes: n/a
Fixes #14008
