### PR TITLE
[test host utils] use make_shared to avoid memory leaks

### DIFF
--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -117,7 +117,7 @@ makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,
                                                              const std::string& url) {
-  return std::make_shared<HostDescription>(
+  return std::make_shared<HostDescriptionImpl>(
       cluster, "", Network::Utility::resolveUrl(url), nullptr,
       envoy::config::core::v3::Locality().default_instance(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0);

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -79,48 +79,45 @@ inline envoy::config::cluster::v3::Cluster defaultStaticCluster(const std::strin
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                                   const std::string& url, uint32_t weight = 1) {
-  return HostSharedPtr{
-      new HostImpl(cluster, hostname, Network::Utility::resolveUrl(url), nullptr, weight,
+  return std::make_shared<HostImpl>(cluster, hostname, Network::Utility::resolveUrl(url), nullptr, weight,
                    envoy::config::core::v3::Locality(),
                    envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-                   envoy::config::core::v3::UNKNOWN)};
+                   envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   uint32_t weight = 1, uint32_t priority = 0) {
-  return HostSharedPtr{
-      new HostImpl(cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
+  return std::make_shared<HostImpl>(cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
                    envoy::config::core::v3::Locality(),
                    envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(),
-                   priority, envoy::config::core::v3::UNKNOWN)};
+                   priority, envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   const envoy::config::core::v3::Metadata& metadata,
                                   uint32_t weight = 1) {
-  return HostSharedPtr{
-      new HostImpl(cluster, "", Network::Utility::resolveUrl(url),
+  return std::make_shared<HostImpl>(cluster, "", Network::Utility::resolveUrl(url),
                    std::make_shared<const envoy::config::core::v3::Metadata>(metadata), weight,
                    envoy::config::core::v3::Locality(),
                    envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-                   envoy::config::core::v3::UNKNOWN)};
+                   envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostSharedPtr
 makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
              const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
              uint32_t weight = 1) {
-  return HostSharedPtr{new HostImpl(cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
+  return std::make_shared<HostImpl>(cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
                                     envoy::config::core::v3::Locality(), health_check_config, 0,
-                                    envoy::config::core::v3::UNKNOWN)};
+                                    envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,
                                                              const std::string& url) {
-  return HostDescriptionConstSharedPtr{new HostDescriptionImpl(
+  return std::make_shared<HostDescription>(
       cluster, "", Network::Utility::resolveUrl(url), nullptr,
       envoy::config::core::v3::Locality().default_instance(),
-      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0)};
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0);
 }
 
 inline HostsPerLocalitySharedPtr makeHostsPerLocality(std::vector<HostVector>&& locality_hosts,

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -79,28 +79,31 @@ inline envoy::config::cluster::v3::Cluster defaultStaticCluster(const std::strin
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& hostname,
                                   const std::string& url, uint32_t weight = 1) {
-  return std::make_shared<HostImpl>(cluster, hostname, Network::Utility::resolveUrl(url), nullptr, weight,
-                   envoy::config::core::v3::Locality(),
-                   envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-                   envoy::config::core::v3::UNKNOWN);
+  return std::make_shared<HostImpl>(
+      cluster, hostname, Network::Utility::resolveUrl(url), nullptr, weight,
+      envoy::config::core::v3::Locality(),
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
+      envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   uint32_t weight = 1, uint32_t priority = 0) {
-  return std::make_shared<HostImpl>(cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
-                   envoy::config::core::v3::Locality(),
-                   envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(),
-                   priority, envoy::config::core::v3::UNKNOWN);
+  return std::make_shared<HostImpl>(
+      cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
+      envoy::config::core::v3::Locality(),
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), priority,
+      envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostSharedPtr makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
                                   const envoy::config::core::v3::Metadata& metadata,
                                   uint32_t weight = 1) {
-  return std::make_shared<HostImpl>(cluster, "", Network::Utility::resolveUrl(url),
-                   std::make_shared<const envoy::config::core::v3::Metadata>(metadata), weight,
-                   envoy::config::core::v3::Locality(),
-                   envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
-                   envoy::config::core::v3::UNKNOWN);
+  return std::make_shared<HostImpl>(
+      cluster, "", Network::Utility::resolveUrl(url),
+      std::make_shared<const envoy::config::core::v3::Metadata>(metadata), weight,
+      envoy::config::core::v3::Locality(),
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
+      envoy::config::core::v3::UNKNOWN);
 }
 
 inline HostSharedPtr


### PR DESCRIPTION
Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>

Commit Message: Switch to using `std::make_shared` in host util test code. Clang tidy is unhappy about current state of code and has been complaining about potential memory leaks, sample log here: https://dev.azure.com/cncf/envoy/_build/results?buildId=57303&view=logs&jobId=b7634614-24f3-5416-e791-4f3affaaed6c&j=b7634614-24f3-5416-e791-4f3affaaed6c&t=21e6aa7d-f369-5abd-5e4e-e888cac18e9c. Issue discovered in this [PR](https://github.com/envoyproxy/envoy/pull/13631). We may need to create dedicated issue to fix problem globally. 
Risk Level: Low
Testing: Covered by existing tests
Docs Changes: NA
Release Notes: NA

