### PR TITLE
ci: fix CodeQL-build by removing deprecated set-env command

### DIFF
--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Get build targets
       run: |
        . .github/workflows/get_build_targets.sh
-       echo ::set-env name=BUILD_TARGETS::$(echo $BUILD_TARGETS_LOCAL)
+       echo 'BUILD_TARGETS<<EOF' >> $GITHUB_ENV
+       echo $BUILD_TARGETS_LOCAL >> $GITHUB_ENV
+       echo 'EOF' >> $GITHUB_ENV
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -13,6 +13,7 @@ namespace Http {
 
 namespace {
 absl::optional<std::string> canonicalizePath(absl::string_view original_path) {
+  // Testing build - delete this
   std::string canonical_path;
   chromium_url::Component in_component(0, original_path.size());
   chromium_url::Component out_component;

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -13,7 +13,6 @@ namespace Http {
 
 namespace {
 absl::optional<std::string> canonicalizePath(absl::string_view original_path) {
-  // Testing build - delete this
   std::string canonical_path;
   chromium_url::Component in_component(0, original_path.size());
   chromium_url::Component out_component;


### PR DESCRIPTION
Commit Message:

ci: fix CodeQL-build by removing deprecated set-env command
    
Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description: Tests seem to be failing for PRs with failures like [this](https://github.com/envoyproxy/envoy/pull/14025/checks?check_run_id=1408306295). Followed the example [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#example-6) to try to fix
Risk Level: Low
Testing: See if tests pass for this PR
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes #14047