### PR TITLE
redis: add support for redis modules with custom commands

### DIFF
--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message RedisProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
@@ -208,6 +208,28 @@ message RedisProxy {
     repeated string commands = 4;
   }
 
+  // RedisModule defines modules with custom commands.
+  // [#next-free-field: 7]
+  message RedisModule {
+    // Name of the module.
+    string name = 1;
+
+    // Simple commands that hash to a single server on the first argument.
+    repeated string simple = 2;
+
+    // mget style commands.
+    repeated string mget = 3;
+
+    // mset style commands.
+    repeated string mset = 4;
+
+    // Commands that are hashed to multiple servers and the response coalesced by summing.
+    repeated string multi_sum = 5;
+
+    // Commands which alter the state of the redis.
+    repeated string write = 6;
+  }
+
   reserved 2;
 
   reserved "cluster";
@@ -289,6 +311,24 @@ message RedisProxy {
   // See the :ref:`fault injection section
   // <config_network_filters_redis_proxy_fault_injection>` for more information on how to configure this.
   repeated RedisFault faults = 8;
+
+  // Add routing support to custom redis modules. Specify the additional commands with the type of command
+  // handler it should map to.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //  modules:
+  //  - name: cas
+  //    simple:
+  //    - cas.get
+  //    - cas.set
+  //    mget: cas.mget
+  //    write:
+  //    - cas.set
+  //
+  repeated RedisModule modules = 9;
 
   // If a username is provided an ACL style AUTH command will be required with a username and password.
   // Authenticate Redis client connections locally by forcing downstream clients to issue a `Redis

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message RedisProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
@@ -207,6 +207,28 @@ message RedisProxy {
     repeated string commands = 4;
   }
 
+  // RedisModule defines modules with custom commands.
+  // [#next-free-field: 7]
+  message RedisModule {
+    // Name of the module.
+    string name = 1;
+
+    // Simple commands that hash to a single server on the first argument.
+    repeated string simple = 2;
+
+    // mget style commands.
+    repeated string mget = 3;
+
+    // mset style commands.
+    repeated string mset = 4;
+
+    // Commands that are hashed to multiple servers and the response coalesced by summing.
+    repeated string multi_sum = 5;
+
+    // Commands which alter the state of the redis.
+    repeated string write = 6;
+  }
+
   // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
   string stat_prefix = 1 [(validate.rules).string = {min_len: 1}];
 
@@ -284,6 +306,24 @@ message RedisProxy {
   // See the :ref:`fault injection section
   // <config_network_filters_redis_proxy_fault_injection>` for more information on how to configure this.
   repeated RedisFault faults = 8;
+
+  // Add routing support to custom redis modules. Specify the additional commands with the type of command
+  // handler it should map to.
+  //
+  // Example:
+  //
+  // .. code-block:: yaml
+  //
+  //  modules:
+  //  - name: cas
+  //    simple:
+  //    - cas.get
+  //    - cas.set
+  //    mget: cas.mget
+  //    write:
+  //    - cas.set
+  //
+  repeated RedisModule modules = 9;
 
   // If a username is provided an ACL style AUTH command will be required with a username and password.
   // Authenticate Redis client connections locally by forcing downstream clients to issue a `Redis

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -202,7 +202,8 @@ RedisCluster::RedisDiscoverySession::RedisDiscoverySession(
       client_factory_(client_factory), buffer_timeout_(0),
       redis_command_stats_(
           NetworkFilters::Common::Redis::RedisCommandStats::createRedisCommandStats(
-              parent_.info()->statsScope().symbolTable())) {}
+              parent_.info()->statsScope().symbolTable(),
+              std::make_shared<NetworkFilters::Common::Redis::SupportedCommands>())) {}
 
 // Convert the cluster slot IP/Port response to and address, return null if the response
 // does not match the expected type.

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -177,16 +177,18 @@ bool RedisLoadBalancerContextImpl::isReadRequest(
     return false;
   }
   std::string to_lower_string = absl::AsciiStrToLower(command->asString());
-  return NetworkFilters::Common::Redis::SupportedCommands::isReadCommand(to_lower_string);
+  return supported_commands_->isReadCommand(to_lower_string);
 }
 
 RedisLoadBalancerContextImpl::RedisLoadBalancerContextImpl(
     const std::string& key, bool enabled_hashtagging, bool is_redis_cluster,
     const NetworkFilters::Common::Redis::RespValue& request,
+    NetworkFilters::Common::Redis::SupportedCommandsSharedPtr supported_commands,
     NetworkFilters::Common::Redis::Client::ReadPolicy read_policy)
     : hash_key_(is_redis_cluster ? Crc16::crc16(hashtag(key, true))
                                  : MurmurHash::murmurHash2(hashtag(key, enabled_hashtagging))),
-      is_read_(isReadRequest(request)), read_policy_(read_policy) {}
+      supported_commands_(supported_commands), is_read_(isReadRequest(request)),
+      read_policy_(read_policy) {}
 
 // Inspired by the redis-cluster hashtagging algorithm
 // https://redis.io/topics/cluster-spec#keys-hash-tags

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -76,13 +76,15 @@ public:
    * @param is_redis_cluster specify whether this is a request for redis cluster, if true the key
    * will be hashed using crc16.
    * @param request specify the Redis request.
+   * @param supported_commands specify the commands supported by the upstream Redis server.
    * @param read_policy specify the read policy.
    */
-  RedisLoadBalancerContextImpl(const std::string& key, bool enabled_hashtagging,
-                               bool is_redis_cluster,
-                               const NetworkFilters::Common::Redis::RespValue& request,
-                               NetworkFilters::Common::Redis::Client::ReadPolicy read_policy =
-                                   NetworkFilters::Common::Redis::Client::ReadPolicy::Primary);
+  RedisLoadBalancerContextImpl(
+      const std::string& key, bool enabled_hashtagging, bool is_redis_cluster,
+      const NetworkFilters::Common::Redis::RespValue& request,
+      NetworkFilters::Common::Redis::SupportedCommandsSharedPtr supported_commands,
+      NetworkFilters::Common::Redis::Client::ReadPolicy read_policy =
+          NetworkFilters::Common::Redis::Client::ReadPolicy::Primary);
 
   // Upstream::LoadBalancerContextBase
   absl::optional<uint64_t> computeHashKey() override { return hash_key_; }
@@ -95,10 +97,10 @@ public:
 
 private:
   absl::string_view hashtag(absl::string_view v, bool enabled);
-
-  static bool isReadRequest(const NetworkFilters::Common::Redis::RespValue& request);
+  bool isReadRequest(const NetworkFilters::Common::Redis::RespValue& request);
 
   const absl::optional<uint64_t> hash_key_;
+  NetworkFilters::Common::Redis::SupportedCommandsSharedPtr supported_commands_;
   const bool is_read_;
   const NetworkFilters::Common::Redis::Client::ReadPolicy read_policy_;
 };

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -40,6 +40,7 @@ envoy_cc_library(
     hdrs = ["supported_commands.h"],
     deps = [
         "//source/common/common:macros",
+        "@envoy_api//envoy/extensions/filters/network/redis_proxy/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/network/common/redis/redis_command_stats.cc
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.cc
@@ -3,15 +3,15 @@
 #include "common/stats/timespan_impl.h"
 #include "common/stats/utility.h"
 
-#include "extensions/filters/network/common/redis/supported_commands.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace Common {
 namespace Redis {
 
-RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std::string& prefix)
+RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table,
+                                     SupportedCommandsSharedPtr supported_commands,
+                                     const std::string& prefix)
     : symbol_table_(symbol_table), stat_name_set_(symbol_table_.makeSet("Redis")),
       prefix_(stat_name_set_->add(prefix)),
       upstream_rq_time_(stat_name_set_->add("upstream_rq_time")),
@@ -21,16 +21,11 @@ RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std
       unknown_metric_(stat_name_set_->add("unknown")) {
   // Note: Even if this is disabled, we track the upstream_rq_time.
   // Create StatName for each Redis command. Note that we don't include Auth or Ping.
-  stat_name_set_->rememberBuiltins(
-      Extensions::NetworkFilters::Common::Redis::SupportedCommands::simpleCommands());
-  stat_name_set_->rememberBuiltins(
-      Extensions::NetworkFilters::Common::Redis::SupportedCommands::evalCommands());
-  stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
-                                       hashMultipleSumResultCommands());
-  stat_name_set_->rememberBuiltin(
-      Extensions::NetworkFilters::Common::Redis::SupportedCommands::mget());
-  stat_name_set_->rememberBuiltin(
-      Extensions::NetworkFilters::Common::Redis::SupportedCommands::mset());
+  stat_name_set_->rememberBuiltins(supported_commands->simpleCommands());
+  stat_name_set_->rememberBuiltins(supported_commands->evalCommands());
+  stat_name_set_->rememberBuiltins(supported_commands->hashMultipleSumResultCommands());
+  stat_name_set_->rememberBuiltins(supported_commands->mget());
+  stat_name_set_->rememberBuiltins(supported_commands->mset());
 }
 
 Stats::TimespanPtr RedisCommandStats::createCommandTimer(Stats::Scope& scope,

--- a/source/extensions/filters/network/common/redis/redis_command_stats.h
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.h
@@ -9,6 +9,7 @@
 #include "common/stats/symbol_table_impl.h"
 
 #include "extensions/filters/network/common/redis/codec.h"
+#include "extensions/filters/network/common/redis/supported_commands.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -18,14 +19,17 @@ namespace Redis {
 
 class RedisCommandStats {
 public:
-  RedisCommandStats(Stats::SymbolTable& symbol_table, const std::string& prefix);
+  RedisCommandStats(Stats::SymbolTable& symbol_table, SupportedCommandsSharedPtr supported_commands,
+                    const std::string& prefix);
 
   // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Use Singleton to manage a single
   // RedisCommandStats on the client factory so that it can be used for proxy filter, discovery and
   // health check.
   static std::shared_ptr<RedisCommandStats>
-  createRedisCommandStats(Stats::SymbolTable& symbol_table) {
-    return std::make_shared<Common::Redis::RedisCommandStats>(symbol_table, "upstream_commands");
+  createRedisCommandStats(Stats::SymbolTable& symbol_table,
+                          SupportedCommandsSharedPtr supported_commands) {
+    return std::make_shared<Common::Redis::RedisCommandStats>(symbol_table, supported_commands,
+                                                              "upstream_commands");
   }
 
   Stats::TimespanPtr createCommandTimer(Stats::Scope& scope, Stats::StatName command,

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -10,6 +10,7 @@
 #include "common/common/macros.h"
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/ascii.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -4,6 +4,9 @@
 #include <string>
 #include <vector>
 
+#include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.h"
+#include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.validate.h"
+
 #include "common/common/macros.h"
 
 #include "absl/container/flat_hash_set.h"
@@ -14,39 +17,194 @@ namespace NetworkFilters {
 namespace Common {
 namespace Redis {
 
-struct SupportedCommands {
+class SupportedCommands {
+
+public:
+  SupportedCommands() {
+    simple_ = absl::flat_hash_set<std::string>{"append",
+                                               "bitcount",
+                                               "bitfield",
+                                               "bitpos",
+                                               "decr",
+                                               "decrby",
+                                               "dump",
+                                               "expire",
+                                               "expireat",
+                                               "geoadd",
+                                               "geodist",
+                                               "geohash",
+                                               "geopos",
+                                               "georadius_ro",
+                                               "georadiusbymember_ro",
+                                               "get",
+                                               "getbit",
+                                               "getrange",
+                                               "getset",
+                                               "hdel",
+                                               "hexists",
+                                               "hget",
+                                               "hgetall",
+                                               "hincrby",
+                                               "hincrbyfloat",
+                                               "hkeys",
+                                               "hlen",
+                                               "hmget",
+                                               "hmset",
+                                               "hscan",
+                                               "hset",
+                                               "hsetnx",
+                                               "hstrlen",
+                                               "hvals",
+                                               "incr",
+                                               "incrby",
+                                               "incrbyfloat",
+                                               "lindex",
+                                               "linsert",
+                                               "llen",
+                                               "lpop",
+                                               "lpush",
+                                               "lpushx",
+                                               "lrange",
+                                               "lrem",
+                                               "lset",
+                                               "ltrim",
+                                               "persist",
+                                               "pexpire",
+                                               "pexpireat",
+                                               "pfadd",
+                                               "pfcount",
+                                               "psetex",
+                                               "pttl",
+                                               "restore",
+                                               "rpop",
+                                               "rpush",
+                                               "rpushx",
+                                               "sadd",
+                                               "scard",
+                                               "set",
+                                               "setbit",
+                                               "setex",
+                                               "setnx",
+                                               "setrange",
+                                               "sismember",
+                                               "smembers",
+                                               "spop",
+                                               "srandmember",
+                                               "srem",
+                                               "sscan",
+                                               "strlen",
+                                               "ttl",
+                                               "type",
+                                               "zadd",
+                                               "zcard",
+                                               "zcount",
+                                               "zincrby",
+                                               "zlexcount",
+                                               "zpopmin",
+                                               "zpopmax",
+                                               "zrange",
+                                               "zrangebylex",
+                                               "zrangebyscore",
+                                               "zrank",
+                                               "zrem",
+                                               "zremrangebylex",
+                                               "zremrangebyrank",
+                                               "zremrangebyscore",
+                                               "zrevrange",
+                                               "zrevrangebylex",
+                                               "zrevrangebyscore",
+                                               "zrevrank",
+                                               "zscan",
+                                               "zscore"};
+    eval_ = absl::flat_hash_set<std::string>{"eval", "evalsha"};
+    multi_sum_ = absl::flat_hash_set<std::string>{"del", "exists", "touch", "unlink"};
+    mget_ = absl::flat_hash_set<std::string>{"mget"};
+    mset_ = absl::flat_hash_set<std::string>{"mset"};
+    write_ = absl::flat_hash_set<std::string>{"append",
+                                              "bitfield",
+                                              "decr",
+                                              "decrby",
+                                              "del",
+                                              "expire",
+                                              "expireat",
+                                              "eval",
+                                              "evalsha",
+                                              "geoadd",
+                                              "hdel",
+                                              "hincrby",
+                                              "hincrbyfloat",
+                                              "hmset",
+                                              "hset",
+                                              "hsetnx",
+                                              "incr",
+                                              "incrby",
+                                              "incrbyfloat",
+                                              "linsert",
+                                              "lpop",
+                                              "lpush",
+                                              "lpushx",
+                                              "lrem",
+                                              "lset",
+                                              "ltrim",
+                                              "mset",
+                                              "persist",
+                                              "pexpire",
+                                              "pexpireat",
+                                              "pfadd",
+                                              "psetex",
+                                              "restore",
+                                              "rpop",
+                                              "rpush",
+                                              "rpushx",
+                                              "sadd",
+                                              "set",
+                                              "setbit",
+                                              "setex",
+                                              "setnx",
+                                              "setrange",
+                                              "spop",
+                                              "srem",
+                                              "zadd",
+                                              "zincrby",
+                                              "touch",
+                                              "zpopmin",
+                                              "zpopmax",
+                                              "zrem",
+                                              "zremrangebylex",
+                                              "zremrangebyrank",
+                                              "zremrangebyscore",
+                                              "unlink"};
+  }
+
   /**
    * @return commands which hash to a single server
    */
-  static const absl::flat_hash_set<std::string>& simpleCommands() {
-    CONSTRUCT_ON_FIRST_USE(
-        absl::flat_hash_set<std::string>, "append", "bitcount", "bitfield", "bitpos", "decr",
-        "decrby", "dump", "expire", "expireat", "geoadd", "geodist", "geohash", "geopos",
-        "georadius_ro", "georadiusbymember_ro", "get", "getbit", "getrange", "getset", "hdel",
-        "hexists", "hget", "hgetall", "hincrby", "hincrbyfloat", "hkeys", "hlen", "hmget", "hmset",
-        "hscan", "hset", "hsetnx", "hstrlen", "hvals", "incr", "incrby", "incrbyfloat", "lindex",
-        "linsert", "llen", "lpop", "lpush", "lpushx", "lrange", "lrem", "lset", "ltrim", "persist",
-        "pexpire", "pexpireat", "pfadd", "pfcount", "psetex", "pttl", "restore", "rpop", "rpush",
-        "rpushx", "sadd", "scard", "set", "setbit", "setex", "setnx", "setrange", "sismember",
-        "smembers", "spop", "srandmember", "srem", "sscan", "strlen", "ttl", "type", "zadd",
-        "zcard", "zcount", "zincrby", "zlexcount", "zpopmin", "zpopmax", "zrange", "zrangebylex",
-        "zrangebyscore", "zrank", "zrem", "zremrangebylex", "zremrangebyrank", "zremrangebyscore",
-        "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscan", "zscore");
-  }
+  const absl::flat_hash_set<std::string>& simpleCommands() { return simple_; }
 
   /**
    * @return commands which hash on the fourth argument
    */
-  static const absl::flat_hash_set<std::string>& evalCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "eval", "evalsha");
-  }
+  const absl::flat_hash_set<std::string>& evalCommands() { return eval_; }
 
   /**
    * @return commands which are sent to multiple servers and coalesced by summing the responses
    */
-  static const absl::flat_hash_set<std::string>& hashMultipleSumResultCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "del", "exists", "touch", "unlink");
-  }
+  const absl::flat_hash_set<std::string>& hashMultipleSumResultCommands() { return multi_sum_; }
+
+  /**
+   * @return mget command
+   */
+  const absl::flat_hash_set<std::string>& mget() { return mget_; }
+
+  /**
+   * @return mset command
+   */
+  const absl::flat_hash_set<std::string>& mset() { return mset_; }
+
+  /**
+   * @return commands which alters the state of redis
+   */
+  const absl::flat_hash_set<std::string>& writeCommands() { return write_; }
 
   /**
    * @return auth command
@@ -54,38 +212,43 @@ struct SupportedCommands {
   static const std::string& auth() { CONSTRUCT_ON_FIRST_USE(std::string, "auth"); }
 
   /**
-   * @return mget command
-   */
-  static const std::string& mget() { CONSTRUCT_ON_FIRST_USE(std::string, "mget"); }
-
-  /**
-   * @return mset command
-   */
-  static const std::string& mset() { CONSTRUCT_ON_FIRST_USE(std::string, "mset"); }
-
-  /**
    * @return ping command
    */
   static const std::string& ping() { CONSTRUCT_ON_FIRST_USE(std::string, "ping"); }
 
-  /**
-   * @return commands which alters the state of redis
-   */
-  static const absl::flat_hash_set<std::string>& writeCommands() {
-    CONSTRUCT_ON_FIRST_USE(
-        absl::flat_hash_set<std::string>, "append", "bitfield", "decr", "decrby", "del", "expire",
-        "expireat", "eval", "evalsha", "geoadd", "hdel", "hincrby", "hincrbyfloat", "hmset", "hset",
-        "hsetnx", "incr", "incrby", "incrbyfloat", "linsert", "lpop", "lpush", "lpushx", "lrem",
-        "lset", "ltrim", "mset", "persist", "pexpire", "pexpireat", "pfadd", "psetex", "restore",
-        "rpop", "rpush", "rpushx", "sadd", "set", "setbit", "setex", "setnx", "setrange", "spop",
-        "srem", "zadd", "zincrby", "touch", "zpopmin", "zpopmax", "zrem", "zremrangebylex",
-        "zremrangebyrank", "zremrangebyscore", "unlink");
+  bool isReadCommand(const std::string& command) { return !writeCommands().contains(command); }
+
+  void
+  addModules(const envoy::extensions::filters::network::redis_proxy::v3::RedisProxy& proto_config) {
+    for (auto const& module : proto_config.modules()) {
+      for (const std::string& command : module.simple()) {
+        simple_.insert(absl::AsciiStrToLower(command));
+      }
+      for (const std::string& command : module.mget()) {
+        mget_.insert(absl::AsciiStrToLower(command));
+      }
+      for (const std::string& command : module.mset()) {
+        mset_.insert(absl::AsciiStrToLower(command));
+      }
+      for (const std::string& command : module.multi_sum()) {
+        multi_sum_.insert(absl::AsciiStrToLower(command));
+      }
+      for (const std::string& command : module.write()) {
+        write_.insert(absl::AsciiStrToLower(command));
+      }
+    }
   }
 
-  static bool isReadCommand(const std::string& command) {
-    return !writeCommands().contains(command);
-  }
+private:
+  absl::flat_hash_set<std::string> simple_;
+  absl::flat_hash_set<std::string> eval_;
+  absl::flat_hash_set<std::string> multi_sum_;
+  absl::flat_hash_set<std::string> mget_;
+  absl::flat_hash_set<std::string> mset_;
+  absl::flat_hash_set<std::string> write_;
 };
+
+using SupportedCommandsSharedPtr = std::shared_ptr<SupportedCommands>;
 
 } // namespace Redis
 } // namespace Common

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -336,7 +336,8 @@ class InstanceImpl : public Instance, Logger::Loggable<Logger::Id::redis> {
 public:
   InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::string& stat_prefix,
                TimeSource& time_source, bool latency_in_micros,
-               Common::Redis::FaultManagerPtr&& fault_manager);
+               Common::Redis::FaultManagerPtr&& fault_manager,
+               Common::Redis::SupportedCommandsSharedPtr supported_commands);
 
   // RedisProxy::CommandSplitter::Instance
   SplitRequestPtr makeRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -63,7 +63,8 @@ public:
           config,
       Api::Api& api, Stats::ScopePtr&& stats_scope,
       const Common::Redis::RedisCommandStatsSharedPtr& redis_command_stats,
-      Extensions::Common::Redis::ClusterRefreshManagerSharedPtr refresh_manager);
+      Extensions::Common::Redis::ClusterRefreshManagerSharedPtr refresh_manager,
+      Common::Redis::SupportedCommandsSharedPtr supported_commands);
   // RedisProxy::ConnPool::Instance
   Common::Redis::Client::PoolRequest* makeRequest(const std::string& key, RespVariant&& request,
                                                   PoolCallbacks& callbacks) override;
@@ -178,6 +179,7 @@ private:
     Common::Redis::RedisCommandStatsSharedPtr redis_command_stats_;
     RedisClusterStats redis_cluster_stats_;
     const Extensions::Common::Redis::ClusterRefreshManagerSharedPtr refresh_manager_;
+    Common::Redis::SupportedCommandsSharedPtr supported_commands_;
   };
 
   const std::string cluster_name_;
@@ -190,6 +192,7 @@ private:
   Common::Redis::RedisCommandStatsSharedPtr redis_command_stats_;
   RedisClusterStats redis_cluster_stats_;
   const Extensions::Common::Redis::ClusterRefreshManagerSharedPtr refresh_manager_;
+  Common::Redis::SupportedCommandsSharedPtr supported_commands_;
 };
 
 } // namespace ConnPool

--- a/source/extensions/filters/network/redis_proxy/router_impl.h
+++ b/source/extensions/filters/network/redis_proxy/router_impl.h
@@ -28,7 +28,8 @@ class MirrorPolicyImpl : public MirrorPolicy {
 public:
   MirrorPolicyImpl(const envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::
                        PrefixRoutes::Route::RequestMirrorPolicy&,
-                   const ConnPool::InstanceSharedPtr, Runtime::Loader& runtime);
+                   const ConnPool::InstanceSharedPtr, Runtime::Loader& runtime,
+                   Common::Redis::SupportedCommandsSharedPtr supported_commands);
 
   ConnPool::InstanceSharedPtr upstream() const override { return upstream_; };
 
@@ -40,13 +41,15 @@ private:
   const bool exclude_read_commands_;
   ConnPool::InstanceSharedPtr upstream_;
   Runtime::Loader& runtime_;
+  Common::Redis::SupportedCommandsSharedPtr supported_commands_;
 };
 
 class Prefix : public Route {
 public:
   Prefix(const envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::PrefixRoutes::Route
              route,
-         Upstreams& upstreams, Runtime::Loader& runtime);
+         Upstreams& upstreams, Runtime::Loader& runtime,
+         Common::Redis::SupportedCommandsSharedPtr supported_commands);
 
   ConnPool::InstanceSharedPtr upstream() const override { return upstream_; }
   const MirrorPolicies& mirrorPolicies() const override { return mirror_policies_; };
@@ -66,7 +69,8 @@ class PrefixRoutes : public Router {
 public:
   PrefixRoutes(const envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::PrefixRoutes&
                    prefix_routes,
-               Upstreams&& upstreams, Runtime::Loader& runtime);
+               Upstreams&& upstreams, Runtime::Loader& runtime,
+               Common::Redis::SupportedCommandsSharedPtr supported_commands);
 
   RouteSharedPtr upstreamPool(std::string& key) override;
 

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -36,7 +36,8 @@ RedisHealthChecker::RedisActiveHealthCheckSession::RedisActiveHealthCheckSession
     : ActiveHealthCheckSession(parent, host), parent_(parent) {
   redis_command_stats_ =
       Extensions::NetworkFilters::Common::Redis::RedisCommandStats::createRedisCommandStats(
-          parent_.cluster_.info()->statsScope().symbolTable());
+          parent_.cluster_.info()->statsScope().symbolTable(),
+          std::make_shared<NetworkFilters::Common::Redis::SupportedCommands>());
 }
 
 RedisHealthChecker::RedisActiveHealthCheckSession::~RedisActiveHealthCheckSession() {

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -77,8 +77,8 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    redis_command_stats_ =
-        Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
+    redis_command_stats_ = Common::Redis::RedisCommandStats::createRedisCommandStats(
+        stats_.symbolTable(), std::make_shared<SupportedCommands>());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
                                  *config_, redis_command_stats_, stats_);
@@ -1209,8 +1209,8 @@ TEST(RedisClientFactoryImplTest, Basic) {
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
   Stats::IsolatedStoreImpl stats_;
-  auto redis_command_stats =
-      Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
+  auto redis_command_stats = Common::Redis::RedisCommandStats::createRedisCommandStats(
+      stats_.symbolTable(), std::make_shared<SupportedCommands>());
   const std::string auth_username;
   const std::string auth_password;
   ClientPtr client = factory.create(host, dispatcher, config, redis_command_stats, stats_,

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -55,13 +55,13 @@ public:
   }
 
   void makeRequests() {
-    for (const std::string& command : Common::Redis::SupportedCommands::simpleCommands()) {
+    for (const std::string& command : Common::Redis::SupportedCommands().simpleCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
       splitter_.makeRequest(std::move(request), callbacks_, dispatcher_);
     }
 
-    for (const std::string& command : Common::Redis::SupportedCommands::evalCommands()) {
+    for (const std::string& command : Common::Redis::SupportedCommands().evalCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
       splitter_.makeRequest(std::move(request), callbacks_, dispatcher_);
@@ -74,8 +74,13 @@ public:
   NiceMock<MockFaultManager> fault_manager_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   CommandSplitter::InstanceImpl splitter_{
-      RouterPtr{router_}, store_, "redis.foo.",
-      time_system_,       false,  std::make_unique<NiceMock<MockFaultManager>>(fault_manager_)};
+      RouterPtr{router_},
+      store_,
+      "redis.foo.",
+      time_system_,
+      false,
+      std::make_unique<NiceMock<MockFaultManager>>(fault_manager_),
+      std::make_shared<Common::Redis::SupportedCommands>()};
   NoOpSplitCallbacks callbacks_;
   CommandSplitter::SplitRequestPtr handle_;
 };

--- a/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_lookup_speed_test.cc
@@ -55,13 +55,13 @@ public:
   }
 
   void makeRequests() {
-    for (const std::string& command : Common::Redis::SupportedCommands().simpleCommands()) {
+    for (const std::string& command : supported_commands_->simpleCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
       splitter_.makeRequest(std::move(request), callbacks_, dispatcher_);
     }
 
-    for (const std::string& command : Common::Redis::SupportedCommands().evalCommands()) {
+    for (const std::string& command : supported_commands_->evalCommands()) {
       Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
       makeBulkStringArray(*request, {command, "hello"});
       splitter_.makeRequest(std::move(request), callbacks_, dispatcher_);
@@ -73,14 +73,12 @@ public:
   Event::SimulatedTimeSystem time_system_;
   NiceMock<MockFaultManager> fault_manager_;
   NiceMock<Event::MockDispatcher> dispatcher_;
-  CommandSplitter::InstanceImpl splitter_{
-      RouterPtr{router_},
-      store_,
-      "redis.foo.",
-      time_system_,
-      false,
-      std::make_unique<NiceMock<MockFaultManager>>(fault_manager_),
+  Common::Redis::SupportedCommandsSharedPtr supported_commands_{
       std::make_shared<Common::Redis::SupportedCommands>()};
+  CommandSplitter::InstanceImpl splitter_{
+      RouterPtr{router_}, store_, "redis.foo.",
+      time_system_,       false,  std::make_unique<NiceMock<MockFaultManager>>(fault_manager_),
+      supported_commands_};
   NoOpSplitCallbacks callbacks_;
   CommandSplitter::SplitRequestPtr handle_;
 };

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -78,7 +78,8 @@ public:
                          "redis.foo.",
                          time_system_,
                          latency_in_micros_,
-                         std::make_unique<NiceMock<MockFaultManager>>(fault_manager_)};
+                         std::make_unique<NiceMock<MockFaultManager>>(fault_manager_),
+                         std::make_shared<Common::Redis::SupportedCommands>()};
   MockSplitCallbacks callbacks_;
   SplitRequestPtr handle_;
 };
@@ -370,7 +371,7 @@ TEST_P(RedisSingleServerRequestTest, NoUpstream) {
 };
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestTest, RedisSingleServerRequestTest,
-                         testing::ValuesIn(Common::Redis::SupportedCommands::simpleCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands().simpleCommands()));
 
 INSTANTIATE_TEST_SUITE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
                          RedisSingleServerRequestTest, testing::Values("INCR", "inCrBY"));
@@ -982,7 +983,7 @@ TEST_P(RedisSplitKeysSumResultHandlerTest, NoUpstreamHostForAll) {
 
 INSTANTIATE_TEST_SUITE_P(
     RedisSplitKeysSumResultHandlerTest, RedisSplitKeysSumResultHandlerTest,
-    testing::ValuesIn(Common::Redis::SupportedCommands::hashMultipleSumResultCommands()));
+    testing::ValuesIn(Common::Redis::SupportedCommands().hashMultipleSumResultCommands()));
 
 class RedisSingleServerRequestWithLatencyMicrosTest : public RedisSingleServerRequestTest {
 public:
@@ -1013,7 +1014,7 @@ TEST_P(RedisSingleServerRequestWithLatencyMicrosTest, Success) {
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestWithLatencyMicrosTest,
                          RedisSingleServerRequestWithLatencyMicrosTest,
-                         testing::ValuesIn(Common::Redis::SupportedCommands::simpleCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands().simpleCommands()));
 
 // In subclasses of fault test, we mock the expected faults in the constructor, as the
 // fault manager is owned by the splitter, which is also generated later in construction
@@ -1068,7 +1069,7 @@ public:
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestWithErrorFaultTest,
                          RedisSingleServerRequestWithErrorFaultTest,
-                         testing::ValuesIn(Common::Redis::SupportedCommands::simpleCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands().simpleCommands()));
 
 TEST_P(RedisSingleServerRequestWithErrorWithDelayFaultTest, Fault) {
   InSequence s;
@@ -1102,7 +1103,7 @@ TEST_P(RedisSingleServerRequestWithErrorWithDelayFaultTest, Fault) {
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestWithErrorWithDelayFaultTest,
                          RedisSingleServerRequestWithErrorWithDelayFaultTest,
-                         testing::ValuesIn(Common::Redis::SupportedCommands::simpleCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands().simpleCommands()));
 
 class RedisSingleServerRequestWithDelayFaultTest : public RedisSingleServerRequestWithFaultTest {
 public:
@@ -1154,7 +1155,7 @@ TEST_P(RedisSingleServerRequestWithDelayFaultTest, Fault) {
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestWithDelayFaultTest,
                          RedisSingleServerRequestWithDelayFaultTest,
-                         testing::ValuesIn(Common::Redis::SupportedCommands::simpleCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands().simpleCommands()));
 
 } // namespace CommandSplitter
 } // namespace RedisProxy


### PR DESCRIPTION
Commit Message:
- Fixes https://github.com/envoyproxy/envoy/issues/12822
- Make SupportedCommands a Class with the built in commands as default
- Add additional commands for the different command types via a listener config
- Pass the supported_commands_ around to use in place of the global static
Risk Level: Medium
Testing: 
Docs Changes:
Release Notes: