### PR TITLE
test: fix use-after-free in fake upstream

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -628,18 +628,15 @@ testing::AssertionResult FakeUpstream::rawWriteConnection(uint32_t index, const 
 
 FakeRawConnection::~FakeRawConnection() {
   if (read_filter_) {
-    EXPECT_TRUE(shared_connection_.executeOnDispatcher([this](Network::Connection& connection) {
-      connection.removeReadFilter(read_filter_);
-    }));
+    EXPECT_TRUE(shared_connection_.executeOnDispatcher(
+        [this](Network::Connection& connection) { connection.removeReadFilter(read_filter_); }));
   }
 }
 
 testing::AssertionResult FakeRawConnection::initialize() {
   read_filter_ = Network::ReadFilterSharedPtr{new ReadFilter(*this)};
-  testing::AssertionResult result =
-      shared_connection_.executeOnDispatcher([this](Network::Connection& connection) {
-        connection.addReadFilter(read_filter_);
-      });
+  testing::AssertionResult result = shared_connection_.executeOnDispatcher(
+      [this](Network::Connection& connection) { connection.addReadFilter(read_filter_); });
   if (!result) {
     return result;
   }

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -522,7 +522,7 @@ private:
   };
 
   std::string data_ ABSL_GUARDED_BY(lock_);
-  Network::ReadFilterSharedPtr read_filter_;
+  std::weak_ptr<Network::ReadFilter> read_filter_;
 };
 
 using FakeRawConnectionPtr = std::unique_ptr<FakeRawConnection>;


### PR DESCRIPTION
Commit Message: Fix a test-only use-after-free that causes flakes of //test/integration:tcp_tunneling_integration_test.
Additional Description:
The bug causes rare flakes of tcp_tunneling_integration_test, on the order of 0.5-1% under msan. The ReadFilter gets registered with the connection but shouldn't call into its parent after the parent has been deleted. This is done by using a weak_ptr proxy to the parent.

Risk Level: low
Testing: ran affected test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a