### PR TITLE
fix Postgres filter's incorrect transaction metrics calculation

### DIFF
--- a/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
@@ -301,14 +301,10 @@ void DecoderImpl::decodeBackendStatements() {
   }
   std::string statement = message_.substr(0, position);
 
-  ENVOY_LOG(debug, "statement = {} {}", statement, statement.length());
-
   auto it = BE_statements_.find(statement);
   if (it != BE_statements_.end()) {
-    ENVOY_LOG(debug, "FOUND statement", statement);
     (*it).second(this);
   } else {
-    ENVOY_LOG(debug, "NOT FOUND statement", statement);
     callbacks_->incStatements(DecoderCallbacks::StatementType::Other);
     callbacks_->incTransactions();
     callbacks_->incTransactionsCommit();

--- a/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
@@ -295,7 +295,7 @@ void DecoderImpl::decodeBackendStatements() {
   // try to find for the null terminator character (\0).
   std::size_t position = message_.find(' ');
   if (position == std::string::npos) {
-    // If the null terminator character (\0) cannot befound then
+    // If the null terminator character (\0) cannot be found then
     // take the whole message.
     position = message_.find('\0');
   }

--- a/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
@@ -299,7 +299,7 @@ void DecoderImpl::decodeBackendStatements() {
     // take the whole message.
     position = message_.find('\0');
   }
-  std::string statement = message_.substr(0, position);
+  const std::string statement = message_.substr(0, position);
 
   auto it = BE_statements_.find(statement);
   if (it != BE_statements_.end()) {

--- a/source/extensions/filters/network/postgres_proxy/postgres_filter.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_filter.cc
@@ -92,7 +92,7 @@ void PostgresFilter::incTransactionsCommit() {
 }
 
 void PostgresFilter::incTransactionsRollback() {
-  if (!decoder_->getSession().inTransaction()) {
+  if (decoder_->getSession().inTransaction()) {
     config_->stats_.transactions_rollback_.inc();
   }
 }

--- a/source/extensions/filters/network/postgres_proxy/postgres_message.h
+++ b/source/extensions/filters/network/postgres_proxy/postgres_message.h
@@ -11,7 +11,7 @@ namespace PostgresProxy {
 
 /**
  * Postgres messages are described in official Postgres documentation:
- * https://www.postgresql.org/docs/12/protocol-message-formats.html
+ * https://www.postgresql.org/docs/current/protocol-message-formats.html
  *
  * Most of messages start with 1-byte message identifier followed by 4-bytes length field. Few
  * messages are defined without starting 1-byte character and are used during well-defined initial

--- a/test/extensions/filters/network/postgres_proxy/postgres_decoder_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_decoder_test.cc
@@ -363,7 +363,7 @@ TEST_F(PostgresProxyDecoderTest, Backend) {
   decoder_->onData(data_, false);
   data_.drain(data_.length());
 
-  EXPECT_CALL(callbacks_, incStatements(DecoderCallbacks::StatementType::Noop));
+  EXPECT_CALL(callbacks_, incStatements(DecoderCallbacks::StatementType::Other));
   EXPECT_CALL(callbacks_, incTransactionsCommit());
   createPostgresMsg(data_, "C", "COMMIT");
   decoder_->onData(data_, false);
@@ -375,7 +375,7 @@ TEST_F(PostgresProxyDecoderTest, Backend) {
   decoder_->onData(data_, false);
   data_.drain(data_.length());
 
-  EXPECT_CALL(callbacks_, incStatements(DecoderCallbacks::StatementType::Noop));
+  EXPECT_CALL(callbacks_, incStatements(DecoderCallbacks::StatementType::Other));
   EXPECT_CALL(callbacks_, incTransactionsRollback());
   createPostgresMsg(data_, "C", "ROLLBACK");
   decoder_->onData(data_, false);


### PR DESCRIPTION
Commit Message: fix incorrect transaction metrics calculation on Postgres filter
Additional Description:
In Postgres all single statements are considered as an implicit transaction if they are not executed inside an explicit transaction block, but if they are so the transaction metrics should be increased once per transaction block and not for each statement.

Risk Level: Low
Testing: Improved unit tests
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.
Fixes #14065 