### PR TITLE
overload: allow creation of custom scaled timers

### DIFF
--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -42,9 +42,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "scaled_timer_minimum",
+    hdrs = ["scaled_timer_minimum.h"],
+    deps = [],
+)
+
+envoy_cc_library(
     name = "scaled_range_timer_manager_interface",
     hdrs = ["scaled_range_timer_manager.h"],
     deps = [
+        ":scaled_timer_minimum",
         ":timer_interface",
     ],
 )

--- a/include/envoy/event/scaled_range_timer_manager.h
+++ b/include/envoy/event/scaled_range_timer_manager.h
@@ -2,58 +2,10 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/event/timer.h"
-
-#include "absl/types/variant.h"
+#include "envoy/event/scaled_timer_minimum.h"
 
 namespace Envoy {
 namespace Event {
-
-/**
- * Describes a minimum timer value that is equal to a scale factor applied to the maximum.
- */
-struct ScaledMinimum {
-  explicit ScaledMinimum(double scale_factor) : scale_factor_(scale_factor) {}
-  const double scale_factor_;
-};
-
-/**
- * Describes a minimum timer value that is an absolute duration.
- */
-struct AbsoluteMinimum {
-  explicit AbsoluteMinimum(std::chrono::milliseconds value) : value_(value) {}
-  const std::chrono::milliseconds value_;
-};
-
-/**
- * Class that describes how to compute a minimum timeout given a maximum timeout value. It wraps
- * ScaledMinimum and AbsoluteMinimum and provides a single computeMinimum() method.
- */
-class ScaledTimerMinimum : private absl::variant<ScaledMinimum, AbsoluteMinimum> {
-public:
-  // Use base class constructor.
-  using absl::variant<ScaledMinimum, AbsoluteMinimum>::variant;
-
-  // Computes the minimum value for a given maximum timeout. If this object was constructed with a
-  // - ScaledMinimum value:
-  //     the return value is the scale factor applied to the provided maximum.
-  // - AbsoluteMinimum:
-  //     the return value is that minimum, and the provided maximum is ignored.
-  std::chrono::milliseconds computeMinimum(std::chrono::milliseconds maximum) const {
-    struct Visitor {
-      explicit Visitor(std::chrono::milliseconds value) : value_(value) {}
-      std::chrono::milliseconds operator()(ScaledMinimum scale_factor) {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(scale_factor.scale_factor_ *
-                                                                     value_);
-      }
-      std::chrono::milliseconds operator()(AbsoluteMinimum absolute_value) {
-        return absolute_value.value_;
-      }
-      const std::chrono::milliseconds value_;
-    };
-    return absl::visit<Visitor, const absl::variant<ScaledMinimum, AbsoluteMinimum>&>(
-        Visitor(maximum), *this);
-  }
-};
 
 /**
  * Class for creating Timer objects that can be adjusted towards either the minimum or maximum

--- a/include/envoy/event/scaled_range_timer_manager.h
+++ b/include/envoy/event/scaled_range_timer_manager.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "envoy/common/pure.h"
-#include "envoy/event/timer.h"
 #include "envoy/event/scaled_timer_minimum.h"
+#include "envoy/event/timer.h"
 
 namespace Envoy {
 namespace Event {

--- a/include/envoy/event/scaled_timer_minimum.h
+++ b/include/envoy/event/scaled_timer_minimum.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+
 #include "absl/types/variant.h"
 
 namespace Envoy {

--- a/include/envoy/event/scaled_timer_minimum.h
+++ b/include/envoy/event/scaled_timer_minimum.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include "absl/types/variant.h"
 
 namespace Envoy {

--- a/include/envoy/event/scaled_timer_minimum.h
+++ b/include/envoy/event/scaled_timer_minimum.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "absl/types/variant.h"
+
+namespace Envoy {
+namespace Event {
+
+/**
+ * Describes a minimum timer value that is equal to a scale factor applied to the maximum.
+ */
+struct ScaledMinimum {
+  explicit ScaledMinimum(double scale_factor) : scale_factor_(scale_factor) {}
+  const double scale_factor_;
+};
+
+/**
+ * Describes a minimum timer value that is an absolute duration.
+ */
+struct AbsoluteMinimum {
+  explicit AbsoluteMinimum(std::chrono::milliseconds value) : value_(value) {}
+  const std::chrono::milliseconds value_;
+};
+
+/**
+ * Class that describes how to compute a minimum timeout given a maximum timeout value. It wraps
+ * ScaledMinimum and AbsoluteMinimum and provides a single computeMinimum() method.
+ */
+class ScaledTimerMinimum : private absl::variant<ScaledMinimum, AbsoluteMinimum> {
+public:
+  // Use base class constructor.
+  using absl::variant<ScaledMinimum, AbsoluteMinimum>::variant;
+
+  // Computes the minimum value for a given maximum timeout. If this object was constructed with a
+  // - ScaledMinimum value:
+  //     the return value is the scale factor applied to the provided maximum.
+  // - AbsoluteMinimum:
+  //     the return value is that minimum, and the provided maximum is ignored.
+  std::chrono::milliseconds computeMinimum(std::chrono::milliseconds maximum) const {
+    struct Visitor {
+      explicit Visitor(std::chrono::milliseconds value) : value_(value) {}
+      std::chrono::milliseconds operator()(ScaledMinimum scale_factor) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(scale_factor.scale_factor_ *
+                                                                     value_);
+      }
+      std::chrono::milliseconds operator()(AbsoluteMinimum absolute_value) {
+        return absolute_value.value_;
+      }
+      const std::chrono::milliseconds value_;
+    };
+    return absl::visit<Visitor, const absl::variant<ScaledMinimum, AbsoluteMinimum>&>(
+        Visitor(maximum), *this);
+  }
+};
+
+} // namespace Event
+} // namespace Envoy

--- a/include/envoy/server/overload/BUILD
+++ b/include/envoy/server/overload/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
     name = "thread_local_overload_state",
     hdrs = ["thread_local_overload_state.h"],
     deps = [
+        "//include/envoy/event:scaled_timer_minimum",
         "//include/envoy/event:timer_interface",
         "//include/envoy/thread_local:thread_local_object",
     ],

--- a/include/envoy/server/overload/thread_local_overload_state.h
+++ b/include/envoy/server/overload/thread_local_overload_state.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "envoy/common/pure.h"
+#include "envoy/event/scaled_timer_minimum.h"
 #include "envoy/event/timer.h"
 #include "envoy/thread_local/thread_local_object.h"
 
@@ -56,6 +57,10 @@ public:
 
   // Get a scaled timer whose minimum corresponds to the configured value for the given timer type.
   virtual Event::TimerPtr createScaledTimer(OverloadTimerType timer_type,
+                                            Event::TimerCb callback) PURE;
+
+  // Get a scaled timer whose minimum is determined by the given scaling rule.
+  virtual Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum,
                                             Event::TimerCb callback) PURE;
 };
 

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -258,7 +258,8 @@ private:
       Event::TimerPtr createScaledTimer(OverloadTimerType, Event::TimerCb callback) override {
         return dispatcher_.createTimer(callback);
       }
-      Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum, Event::TimerCb callback) override {
+      Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum,
+                                        Event::TimerCb callback) override {
         return dispatcher_.createTimer(callback);
       }
 

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -258,6 +258,9 @@ private:
       Event::TimerPtr createScaledTimer(OverloadTimerType, Event::TimerCb callback) override {
         return dispatcher_.createTimer(callback);
       }
+      Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum, Event::TimerCb callback) override {
+        return dispatcher_.createTimer(callback);
+      }
 
       Event::Dispatcher& dispatcher_;
       const OverloadActionState inactive_ = OverloadActionState::inactive();

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -51,6 +51,11 @@ public:
     return scaled_timer_manager_->createTimer(minimum, std::move(callback));
   }
 
+  Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum,
+                                    Event::TimerCb callback) override {
+    return scaled_timer_manager_->createTimer(minimum, std::move(callback));
+  }
+
   void setState(NamedOverloadActionSymbolTable::Symbol action, OverloadActionState state) {
     actions_[action.index()] = state;
     if (scaled_timer_action_.has_value() && scaled_timer_action_.value() == action) {

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -53,7 +53,7 @@ void HttpConnectionManagerImplTest::setup(bool ssl, const std::string& server_na
   server_name_ = server_name;
   ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(ssl_connection_));
   ON_CALL(Const(filter_callbacks_.connection_), ssl()).WillByDefault(Return(ssl_connection_));
-  ON_CALL(overload_manager_.overload_state_, createScaledTimer_)
+  ON_CALL(overload_manager_.overload_state_, createScaledTypedTimer_)
       .WillByDefault([&](auto, auto callback) {
         return filter_callbacks_.connection_.dispatcher_.createTimer(callback).release();
       });

--- a/test/mocks/server/overload_manager.cc
+++ b/test/mocks/server/overload_manager.cc
@@ -17,12 +17,18 @@ using ::testing::ReturnRef;
 MockThreadLocalOverloadState::MockThreadLocalOverloadState()
     : disabled_state_(OverloadActionState::inactive()) {
   ON_CALL(*this, getState).WillByDefault(ReturnRef(disabled_state_));
-  ON_CALL(*this, createScaledTimer_).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
+  ON_CALL(*this, createScaledTypedTimer_).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
+  ON_CALL(*this, createScaledMinimumTimer_).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
 }
 
 Event::TimerPtr MockThreadLocalOverloadState::createScaledTimer(OverloadTimerType timer_type,
                                                                 Event::TimerCb callback) {
-  return Event::TimerPtr{createScaledTimer_(timer_type, std::move(callback))};
+  return Event::TimerPtr{createScaledTypedTimer_(timer_type, std::move(callback))};
+}
+
+Event::TimerPtr MockThreadLocalOverloadState::createScaledTimer(Event::ScaledTimerMinimum minimum,
+                                                                Event::TimerCb callback) {
+  return Event::TimerPtr{createScaledMinimumTimer_(minimum, std::move(callback))};
 }
 
 MockOverloadManager::MockOverloadManager() {

--- a/test/mocks/server/overload_manager.h
+++ b/test/mocks/server/overload_manager.h
@@ -15,7 +15,9 @@ public:
   MockThreadLocalOverloadState();
   MOCK_METHOD(const OverloadActionState&, getState, (const std::string&), (override));
   Event::TimerPtr createScaledTimer(OverloadTimerType timer_type, Event::TimerCb callback) override;
-  MOCK_METHOD(Event::Timer*, createScaledTimer_, (OverloadTimerType, Event::TimerCb));
+  Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum, Event::TimerCb callback) override;
+  MOCK_METHOD(Event::Timer*, createScaledTypedTimer_, (OverloadTimerType, Event::TimerCb));
+  MOCK_METHOD(Event::Timer*, createScaledMinimumTimer_, (Event::ScaledTimerMinimum, Event::TimerCb));
 
 private:
   const OverloadActionState disabled_state_;

--- a/test/mocks/server/overload_manager.h
+++ b/test/mocks/server/overload_manager.h
@@ -15,9 +15,11 @@ public:
   MockThreadLocalOverloadState();
   MOCK_METHOD(const OverloadActionState&, getState, (const std::string&), (override));
   Event::TimerPtr createScaledTimer(OverloadTimerType timer_type, Event::TimerCb callback) override;
-  Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum, Event::TimerCb callback) override;
+  Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum,
+                                    Event::TimerCb callback) override;
   MOCK_METHOD(Event::Timer*, createScaledTypedTimer_, (OverloadTimerType, Event::TimerCb));
-  MOCK_METHOD(Event::Timer*, createScaledMinimumTimer_, (Event::ScaledTimerMinimum, Event::TimerCb));
+  MOCK_METHOD(Event::Timer*, createScaledMinimumTimer_,
+              (Event::ScaledTimerMinimum, Event::TimerCb));
 
 private:
   const OverloadActionState disabled_state_;

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -74,7 +74,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/watchdog/profile_action:84.9"
 "source/server:94.6"
 "source/server/config_validation:76.6"
-"source/server/admin:95.2"
+"source/server/admin:95.1"
 )
 
 [[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -558,6 +558,30 @@ TEST_F(OverloadManagerImplTest, CreateScaledTimerWithAbsoluteMinimum) {
   EXPECT_EQ(timer.get(), mock_scaled_timer);
 }
 
+TEST_F(OverloadManagerImplTest, CreateScaledTimerWithProvidedMinimum) {
+  setDispatcherExpectation();
+  auto manager(createOverloadManager(kReducedTimeoutsConfig));
+
+  auto* scaled_timer_manager = new Event::MockScaledRangeTimerManager();
+  EXPECT_CALL(*manager, createScaledRangeTimerManager)
+      .WillOnce(Return(ByMove(Event::ScaledRangeTimerManagerPtr{scaled_timer_manager})));
+  manager->start();
+
+  auto* mock_scaled_timer = new Event::MockTimer();
+  MockFunction<Event::TimerCb> mock_callback;
+  EXPECT_CALL(*scaled_timer_manager, createTimer_)
+      .WillOnce([&](Event::ScaledTimerMinimum minimum, auto) {
+        // This timer was created with an absolute minimum. Test that by checking an arbitrary
+        // value.
+        EXPECT_EQ(minimum.computeMinimum(std::chrono::seconds(55)), std::chrono::seconds(3));
+        return mock_scaled_timer;
+      });
+
+  auto timer = manager->getThreadLocalOverloadState().createScaledTimer(
+      Event::AbsoluteMinimum(std::chrono::seconds(3)), mock_callback.AsStdFunction());
+  EXPECT_EQ(timer.get(), mock_scaled_timer);
+}
+
 TEST_F(OverloadManagerImplTest, DuplicateResourceMonitor) {
   const std::string config = R"EOF(
     resource_monitors:


### PR DESCRIPTION
Commit Message: Support creating scaled timers in custom filters
Additional Description:
Add a method to the ThreadLocalOverloadState to support creating
arbitrary scaled timers. This can be used by extension filters to scale
their behavior in response to load without requiring a separate overload
action registration.

Filter factories can obtain a reference to the OverloadManager and use
that to pass references to the thread-local state into the constructed
filters, which can in turn be used to create scaled timers.

Risk Level: low
Testing: added unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
