### PR TITLE
matching: only provide string matcher in SinglePredicate

### DIFF
--- a/api/envoy/config/common/matcher/v3/matcher.proto
+++ b/api/envoy/config/common/matcher/v3/matcher.proto
@@ -4,7 +4,7 @@ package envoy.config.common.matcher.v3;
 
 import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
-import "envoy/type/matcher/v3/value.proto";
+import "envoy/type/matcher/v3/string.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
@@ -58,9 +58,8 @@ message Matcher {
         oneof matcher {
           option (validate.required) = true;
 
-          // Use existing infrastructure for actually matching the
-          // value.
-          type.matcher.v3.ValueMatcher value_match = 2;
+          // Built-in string matcher.
+          type.matcher.v3.StringMatcher value_match = 2;
 
           // Extension for custom matching logic.
           core.v3.TypedExtensionConfig custom_match = 3;

--- a/api/envoy/config/common/matcher/v4alpha/matcher.proto
+++ b/api/envoy/config/common/matcher/v4alpha/matcher.proto
@@ -4,7 +4,7 @@ package envoy.config.common.matcher.v4alpha;
 
 import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
-import "envoy/type/matcher/v4alpha/value.proto";
+import "envoy/type/matcher/v4alpha/string.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -72,9 +72,8 @@ message Matcher {
         oneof matcher {
           option (validate.required) = true;
 
-          // Use existing infrastructure for actually matching the
-          // value.
-          type.matcher.v4alpha.ValueMatcher value_match = 2;
+          // Built-in string matcher.
+          type.matcher.v4alpha.StringMatcher value_match = 2;
 
           // Extension for custom matching logic.
           core.v4alpha.TypedExtensionConfig custom_match = 3;

--- a/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
@@ -4,7 +4,7 @@ package envoy.config.common.matcher.v3;
 
 import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
-import "envoy/type/matcher/v3/value.proto";
+import "envoy/type/matcher/v3/string.proto";
 
 import "udpa/annotations/migrate.proto";
 import "udpa/annotations/status.proto";
@@ -58,9 +58,8 @@ message Matcher {
         oneof matcher {
           option (validate.required) = true;
 
-          // Use existing infrastructure for actually matching the
-          // value.
-          type.matcher.v3.ValueMatcher value_match = 2;
+          // Built-in string matcher.
+          type.matcher.v3.StringMatcher value_match = 2;
 
           // Extension for custom matching logic.
           core.v3.TypedExtensionConfig custom_match = 3;

--- a/generated_api_shadow/envoy/config/common/matcher/v4alpha/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v4alpha/matcher.proto
@@ -4,7 +4,7 @@ package envoy.config.common.matcher.v4alpha;
 
 import "envoy/config/core/v4alpha/extension.proto";
 import "envoy/config/route/v4alpha/route_components.proto";
-import "envoy/type/matcher/v4alpha/value.proto";
+import "envoy/type/matcher/v4alpha/string.proto";
 
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -72,9 +72,8 @@ message Matcher {
         oneof matcher {
           option (validate.required) = true;
 
-          // Use existing infrastructure for actually matching the
-          // value.
-          type.matcher.v4alpha.ValueMatcher value_match = 2;
+          // Built-in string matcher.
+          type.matcher.v4alpha.StringMatcher value_match = 2;
 
           // Extension for custom matching logic.
           core.v4alpha.TypedExtensionConfig custom_match = 3;


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@lyft.com>

Per Slack convo this changes the SinglePredicate default matcher to only match against strings. This simplifies the handling of this default matcher as we can assume that all the inputs are strings and we assume no other types being encoded in the output string. This can be left to extensions that might want to interpret something like JSON values as structured strings.

Risk Level: Low, API not used
Testing: n/a
Docs Changes: n/a
Release Notes: n/a