### PR TITLE
[test] fix legacy default

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -277,8 +277,8 @@ config_setting(
 )
 
 config_setting(
-    name = "enable_new_codecs_in_integration_tests",
-    values = {"define": "use_new_codecs_in_integration_tests=true"},
+    name = "enable_legacy_codecs_in_integration_tests",
+    values = {"define": "use_new_codecs_in_integration_tests=false"},
 )
 
 cc_proto_library(

--- a/bazel/envoy_select.bzl
+++ b/bazel/envoy_select.bzl
@@ -59,9 +59,9 @@ def envoy_select_wasm_wasmtime(xs):
         "//conditions:default": [],
     })
 
-# Select the given values if use legacy codecs in test is on in the current build.
+# Select the given values by default and remove if use new codecs are disabled for current build.
 def envoy_select_new_codecs_in_integration_tests(xs, repository = ""):
     return select({
-        repository + "//bazel:enable_new_codecs_in_integration_tests": xs,
-        "//conditions:default": [],
+        repository + "//bazel:enable_legacy_codecs_in_integration_tests": [],
+        "//conditions:default": xs,
     })


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Because flags are default false, if use_new_codecs_in_integration_test flag wasn't explicitly set, it would be false. Swapped so that the flag refers to legacy codecs (used in compile time options), and by default, we use new codecs unless the flag is set FOR legacy.
Risk Level: Low
Testing: Tested integration tests.

Before on `RouterDownstreamDisconnectBeforeResponseComplete`:
``` 
[2020-11-19 15:03:04.236][20][trace][http] [source/common/http/http1/codec_impl_legacy.cc:465] [C3] completed header: key=host value=host
[2020-11-19 15:03:04.236][20][trace][http] [source/common/http/http1/codec_impl_legacy.cc:465] [C3] completed header: key=x-forwarded-proto value=http
[2020-11-19 15:03:04.236][20][trace][http] [source/common/http/http1/codec_impl_legacy.cc:465] [C3] completed header: key=x-request-id value=ccb817e4-b6c0-473b-bd5f-6e04e1f425c0
[2020-11-19 15:03:04.236][20][trace][http] [source/common/http/http1/codec_impl_legacy.cc:465] [C3] completed header: key=x-envoy-expected-rq-timeout-ms value=15000

```
After
```
[2020-11-19 14:56:33.979][20][trace][http] [source/common/http/http1/codec_impl.cc:489] [C3] completed header: key=host value=host
[2020-11-19 14:56:33.979][20][trace][http] [source/common/http/http1/codec_impl.cc:489] [C3] completed header: key=x-forwarded-proto value=http
[2020-11-19 14:56:33.979][20][trace][http] [source/common/http/http1/codec_impl.cc:489] [C3] completed header: key=x-request-id value=bbd41b99-2689-4470-b407-2f516cda4a1c
[2020-11-19 14:56:33.979][20][trace][http] [source/common/http/http1/codec_impl.cc:489] [C3] completed header: key=x-envoy-expected-rq-timeout-ms value=15000
```

If there's a way to make a config setting with a default value, let me know.