### PR TITLE
ci: compile_time_options fixes

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -291,20 +291,15 @@ elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
   # This doesn't go into CI but is available for developer convenience.
   echo "bazel with different compiletime options build with tests..."
 
-  if [[ "${TEST_TARGETS[*]}" == "//test/..." ]]; then
-    cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
-    TEST_TARGETS=("@envoy//test/...")
-  fi
+  cd "${ENVOY_FILTER_EXAMPLE_SRCDIR}"
+  TEST_TARGETS=("${TEST_TARGETS[@]/#\/\//@envoy\/\/}")
+
   # Building all the dependencies from scratch to link them against libc++.
   echo "Building and testing with wasm=wasmtime: ${TEST_TARGETS[*]}"
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" --define wasm=wasmtime "${COMPILE_TIME_OPTIONS[@]}" -c dbg "${TEST_TARGETS[@]}" --test_tag_filters=-nofips --build_tests_only
 
   echo "Building and testing with wasm=wavm: ${TEST_TARGETS[*]}"
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" --define wasm=wavm "${COMPILE_TIME_OPTIONS[@]}" -c dbg "${TEST_TARGETS[@]}" --test_tag_filters=-nofips --build_tests_only
-
-  # Legacy codecs "--define legacy_codecs_in_integration_tests=true" should also be tested in
-  # integration tests with asan.
-  bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" --define wasm=wavm "${COMPILE_TIME_OPTIONS[@]}" -c dbg @envoy//test/integration/... --config=clang-asan --build_tests_only
 
   # "--define log_debug_assert_in_release=enabled" must be tested with a release build, so run only
   # these tests under "-c opt" to save time in CI.

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -333,7 +333,7 @@ TEST(Fancy, Iteration) {
   FANCY_LOG(info, "Info: iteration test begins.");
   getFancyContext().setAllFancyLoggers(spdlog::level::info);
   std::string output = getFancyContext().listFancyLoggers();
-  EXPECT_EQ(output, "   test/common/common/log_macros_test.cc: 2\n");
+  EXPECT_EQ(output, "   " __FILE__ ": 2\n");
   std::string log_format = "[%T.%e][%t][%l][%n] %v";
   getFancyContext().setFancyLogger(__FILE__, spdlog::level::err);
   // setDefaultFancyLevelFormat relies on previous default and might cause error online


### PR DESCRIPTION
- Always exercise the code path that using filter-example to test Envoy, to catch issues like #14086 in CI.
- Removed no longer existing `legacy_codecs_in_integration_tests` definition.
 
Signed-off-by: Lizan Zhou <lizan@tetrate.io>
