### PR TITLE
upstream: avoid reset after end_stream

### DIFF
--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -14,6 +14,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/route/v3/route_components.pb.h"
 #include "envoy/config/typed_metadata.h"
+#include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/conn_pool.h"
@@ -1256,9 +1257,8 @@ public:
  *
  * It is similar logically to RequestEncoder, only without the getStream interface.
  */
-class GenericUpstream {
+class GenericUpstream : public Event::DeferredDeletable {
 public:
-  virtual ~GenericUpstream() = default;
   /**
    * Encode a data frame.
    * @param data supplies the data to encode. The data may be moved by the encoder.

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -25,6 +25,8 @@ absl::string_view statusCodeToString(StatusCode code) {
     return "CodecClientError";
   case StatusCode::InboundFramesWithEmptyPayload:
     return "InboundFramesWithEmptyPayloadError";
+  case StatusCode::StreamAlreadyReset:
+    return "StreamAlreadyReset";
   }
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
@@ -110,6 +112,12 @@ Status inboundFramesWithEmptyPayloadError() {
   absl::Status status(absl::StatusCode::kInternal,
                       "Too many consecutive frames with an empty payload");
   storePayload(status, EnvoyStatusPayload(StatusCode::InboundFramesWithEmptyPayload));
+  return status;
+}
+
+Status streamAlreadyReset() {
+  absl::Status status(absl::StatusCode::kInternal, "Attempted to proxy headers after stream has been reset.");
+  storePayload(status, EnvoyStatusPayload(StatusCode::StreamAlreadyReset));
   return status;
 }
 

--- a/source/common/http/status.cc
+++ b/source/common/http/status.cc
@@ -116,7 +116,8 @@ Status inboundFramesWithEmptyPayloadError() {
 }
 
 Status streamAlreadyReset() {
-  absl::Status status(absl::StatusCode::kInternal, "Attempted to proxy headers after stream has been reset.");
+  absl::Status status(absl::StatusCode::kInternal,
+                      "Attempted to proxy headers after stream has been reset.");
   storePayload(status, EnvoyStatusPayload(StatusCode::StreamAlreadyReset));
   return status;
 }

--- a/source/common/http/status.h
+++ b/source/common/http/status.h
@@ -74,6 +74,11 @@ enum class StatusCode : int {
    * Indicates that peer sent too many consecutive DATA frames with empty payload.
    */
   InboundFramesWithEmptyPayload = 5,
+
+  /**
+   * Indicates that we attempted to proxy upstream headers to a stream that has already been reset.
+   */
+  StreamAlreadyReset = 6,
 };
 
 using Status = absl::Status;
@@ -94,6 +99,7 @@ Status bufferFloodError(absl::string_view message);
 Status prematureResponseError(absl::string_view message, Http::Code http_code);
 Status codecClientError(absl::string_view message);
 Status inboundFramesWithEmptyPayloadError();
+Status streamAlreadyReset();
 
 /**
  * Returns Envoy::StatusCode of the given status object.
@@ -109,6 +115,7 @@ ABSL_MUST_USE_RESULT bool isBufferFloodError(const Status& status);
 ABSL_MUST_USE_RESULT bool isPrematureResponseError(const Status& status);
 ABSL_MUST_USE_RESULT bool isCodecClientError(const Status& status);
 ABSL_MUST_USE_RESULT bool isInboundFramesWithEmptyPayloadError(const Status& status);
+ABSL_MUST_USE_RESULT bool isStreamAlreadyReset(const Status& status);
 
 /**
  * Returns Http::Code value of the PrematureResponseError status.

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -480,8 +480,8 @@ void UpstreamRequest::clearRequestEncoder() {
   // Before clearing the encoder, unsubscribe from callbacks.
   if (upstream_) {
     parent_.callbacks()->removeDownstreamWatermarkCallbacks(downstream_watermark_manager_);
+    parent_.callbacks()->dispatcher().deferredDelete(std::move(upstream_));
   }
-  parent_.callbacks()->dispatcher().deferredDelete(std::move(upstream_));
 }
 
 void UpstreamRequest::DownstreamWatermarkManager::onAboveWriteBufferHighWatermark() {

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -481,7 +481,7 @@ void UpstreamRequest::clearRequestEncoder() {
   if (upstream_) {
     parent_.callbacks()->removeDownstreamWatermarkCallbacks(downstream_watermark_manager_);
   }
-  upstream_.reset();
+  parent_.callbacks()->dispatcher().deferredDelete(std::move(upstream_));
 }
 
 void UpstreamRequest::DownstreamWatermarkManager::onAboveWriteBufferHighWatermark() {

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -87,6 +87,11 @@ void TcpUpstream::resetStream() {
 
 void TcpUpstream::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   upstream_request_->decodeData(data, end_stream);
+  // This ensures that if we get a reset after end_stream we won't propagate two
+  // "end streams" to the upstream_request_.
+  if (end_stream) {
+    upstream_request_ = nullptr;
+  }
 }
 
 void TcpUpstream::onEvent(Network::ConnectionEvent event) {

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -11,6 +11,7 @@
 #include "common/http/header_map_impl.h"
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
+#include "common/http/status.h"
 #include "common/network/transport_socket_options_impl.h"
 #include "common/router/router.h"
 
@@ -45,6 +46,11 @@ void TcpUpstream::encodeData(Buffer::Instance& data, bool end_stream) {
 
 Envoy::Http::Status TcpUpstream::encodeHeaders(const Envoy::Http::RequestHeaderMap&,
                                                bool end_stream) {
+  if (!upstream_request_) {
+    // TODO(snowp): Should this return something else in this case?
+    return Envoy::Http::okStatus();
+  }
+
   // Headers should only happen once, so use this opportunity to add the proxy
   // proto header, if configured.
   ASSERT(upstream_request_->routeEntry().connectConfig().has_value());
@@ -86,6 +92,10 @@ void TcpUpstream::resetStream() {
 }
 
 void TcpUpstream::onUpstreamData(Buffer::Instance& data, bool end_stream) {
+  if (!upstream_request_) {
+    return;
+  }
+
   upstream_request_->decodeData(data, end_stream);
   // This ensures that if we get a reset after end_stream we won't propagate two
   // "end streams" to the upstream_request_.

--- a/source/extensions/upstreams/http/tcp/upstream_request.cc
+++ b/source/extensions/upstreams/http/tcp/upstream_request.cc
@@ -47,8 +47,7 @@ void TcpUpstream::encodeData(Buffer::Instance& data, bool end_stream) {
 Envoy::Http::Status TcpUpstream::encodeHeaders(const Envoy::Http::RequestHeaderMap&,
                                                bool end_stream) {
   if (!upstream_request_) {
-    // TODO(snowp): Should this return something else in this case?
-    return Envoy::Http::okStatus();
+    return Envoy::Http::streamAlreadyReset();
   }
 
   // Headers should only happen once, so use this opportunity to add the proxy

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6230,7 +6230,7 @@ TEST_F(WatermarkTest, UpstreamWatermarks) {
 
   Buffer::OwnedImpl data;
   EXPECT_CALL(encoder_, getStream()).Times(2).WillRepeatedly(ReturnRef(stream_));
-    EXPECT_CALL(callbacks_.dispatcher_, deferredDelete_(_));
+  EXPECT_CALL(callbacks_.dispatcher_, deferredDelete_(_));
   response_decoder_->decodeData(data, true);
 }
 

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -145,6 +145,7 @@ public:
 
     Http::TestRequestHeaderMapImpl headers(request_headers_init);
     HttpTestUtility::addDefaultHeaders(headers);
+    EXPECT_CALL(callbacks_.dispatcher_, deferredDelete_(_));
     router_->decodeHeaders(headers, true);
 
     EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _)).WillOnce(Return(RetryStatus::No));
@@ -186,6 +187,7 @@ public:
                                            {"x-envoy-internal", "true"},
                                            {"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
     HttpTestUtility::addDefaultHeaders(headers);
+    EXPECT_CALL(callbacks_.dispatcher_, deferredDelete_(_)).Times(2);
     router_->decodeHeaders(headers, true);
 
     router_->retry_state_->expectResetRetry();

--- a/test/extensions/upstreams/http/tcp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/tcp/upstream_request_test.cc
@@ -185,6 +185,15 @@ TEST_F(TcpUpstreamTest, V2Header) {
   tcp_upstream_->encodeData(buffer, false);
 }
 
+// Verifies that a reset after end_stream=true doesn't trigger a callback
+// on the router filter.
+TEST_F(TcpUpstreamTest, ResetAfterEndStream) {
+  Buffer::OwnedImpl buffer("something");
+  EXPECT_CALL(mock_router_filter_, onUpstreamData(BufferStringEqual("something"), _, true));
+  tcp_upstream_->onUpstreamData(buffer, true);
+  tcp_upstream_->onEvent(Network::ConnectionEvent::RemoteClose);
+}
+
 TEST_F(TcpUpstreamTest, TrailersEndStream) {
   // Swallow the headers.
   EXPECT_TRUE(tcp_upstream_->encodeHeaders(request_, false).ok());

--- a/test/extensions/upstreams/http/tcp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/tcp/upstream_request_test.cc
@@ -194,6 +194,19 @@ TEST_F(TcpUpstreamTest, ResetAfterEndStream) {
   tcp_upstream_->onEvent(Network::ConnectionEvent::RemoteClose);
 }
 
+// Verifies that if we send data after the upstream has been reset nothing crashes.
+TEST_F(TcpUpstreamTest, DataAfterReset) {
+  tcp_upstream_->onEvent(Network::ConnectionEvent::LocalClose);
+  Buffer::OwnedImpl buffer("something");
+  tcp_upstream_->onUpstreamData(buffer, true);
+}
+
+// Verifies that if we send headers after the upstream has been reset nothing crashes.
+TEST_F(TcpUpstreamTest, HeadersAfterReset) {
+  tcp_upstream_->onEvent(Network::ConnectionEvent::LocalClose);
+  EXPECT_TRUE(tcp_upstream_->encodeHeaders(request_, false).ok());
+}
+
 TEST_F(TcpUpstreamTest, TrailersEndStream) {
   // Swallow the headers.
   EXPECT_TRUE(tcp_upstream_->encodeHeaders(request_, false).ok());

--- a/test/extensions/upstreams/http/tcp/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/tcp/upstream_request_test.cc
@@ -196,15 +196,15 @@ TEST_F(TcpUpstreamTest, ResetAfterEndStream) {
 
 // Verifies that if we send data after the upstream has been reset nothing crashes.
 TEST_F(TcpUpstreamTest, DataAfterReset) {
-  tcp_upstream_->onEvent(Network::ConnectionEvent::LocalClose);
+  tcp_upstream_->resetStream();
   Buffer::OwnedImpl buffer("something");
   tcp_upstream_->onUpstreamData(buffer, true);
 }
 
 // Verifies that if we send headers after the upstream has been reset nothing crashes.
 TEST_F(TcpUpstreamTest, HeadersAfterReset) {
-  tcp_upstream_->onEvent(Network::ConnectionEvent::LocalClose);
-  EXPECT_TRUE(tcp_upstream_->encodeHeaders(request_, false).ok());
+  tcp_upstream_->resetStream();
+  EXPECT_FALSE(tcp_upstream_->encodeHeaders(request_, false).ok());
 }
 
 TEST_F(TcpUpstreamTest, TrailersEndStream) {


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Risk Level: Medium
Testing: New UT
Docs Changes: n/a
Release Notes: n/a
