### PR TITLE
backport to 1.16: examples: Fix more deprecations/warnings in configs (#13529)

### DIFF
--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -30,7 +30,7 @@ static_resources:
           http_filters:
           - name: envoy.filters.http.fault
             typed_config:
-              "@type": type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault
+              "@type": type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
               abort:
                 http_status: 503
                 percentage:

--- a/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
@@ -15,7 +15,7 @@ static_resources:
             provider:
               name: envoy.tracers.dynamic_ot
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.DynamicOtConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
                 library: /usr/local/lib/libjaegertracing_plugin.so
                 config:
                   service_name: front-proxy

--- a/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
@@ -42,7 +42,7 @@ static_resources:
             provider:
               name: envoy.tracers.dynamic_ot
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.DynamicOtConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
                 library: /usr/local/lib/libjaegertracing_plugin.so
                 config:
                   service_name: service1

--- a/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.dynamic_ot
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.DynamicOtConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
                 library: /usr/local/lib/libjaegertracing_plugin.so
                 config:
                   service_name: service2

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -15,7 +15,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false
@@ -51,7 +51,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false

--- a/examples/mysql/envoy.yaml
+++ b/examples/mysql/envoy.yaml
@@ -9,11 +9,11 @@ static_resources:
     - filters:
       - name: envoy.filters.network.mysql_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.mysql_proxy.v1alpha1.MySQLProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.mysql_proxy.v3.MySQLProxy
           stat_prefix: egress_mysql
       - name: envoy.filters.network.tcp_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: mysql_tcp
           cluster: mysql_cluster
 

--- a/examples/redis/envoy.yaml
+++ b/examples/redis/envoy.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.redis_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
           stat_prefix: egress_redis
           settings:
             op_timeout: 5s

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -15,7 +15,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON
@@ -50,7 +50,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>
Signed-off-by: Antonio Vicente <avd@google.com>