### PR TITLE
backport to 1.16: examples to use v3 configs

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -12,6 +12,7 @@ Minor Behavior Changes
 Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
+* examples: examples use v3 configs.
 * listener: fix crash when disabling or re-enabling listeners due to overload while processing LDS updates.
 * proxy_proto: fixed a bug where the wrong downstream address got sent to upstream connections.
 * tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.

--- a/examples/cors/backend/front-envoy.yaml
+++ b/examples/cors/backend/front-envoy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
             - name: envoy.access_loggers.file
               typed_config:
-                "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                 path: /dev/stdout
           route_config:
             name: local_route

--- a/examples/cors/backend/service-envoy.yaml
+++ b/examples/cors/backend/service-envoy.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/cors/frontend/front-envoy.yaml
+++ b/examples/cors/frontend/front-envoy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
             - name: envoy.access_loggers.file
               typed_config:
-                "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                 path: /dev/stdout
           route_config:
             name: local_route

--- a/examples/cors/frontend/service-envoy.yaml
+++ b/examples/cors/frontend/service-envoy.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/csrf/crosssite/front-envoy.yaml
+++ b/examples/csrf/crosssite/front-envoy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
             - name: envoy.access_loggers.file
               typed_config:
-                "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                 path: "/dev/stdout"
           route_config:
             name: local_route

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
             - name: envoy.access_loggers.file
               typed_config:
-                "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
                 path: "/dev/stdout"
           route_config:
             name: local_route

--- a/examples/csrf/service-envoy.yaml
+++ b/examples/csrf/service-envoy.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/ext_authz/config/grpc-service/v2.yaml
+++ b/examples/ext_authz/config/grpc-service/v2.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/ext_authz/config/grpc-service/v3.yaml
+++ b/examples/ext_authz/config/grpc-service/v3.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/ext_authz/config/http-service.yaml
+++ b/examples/ext_authz/config/http-service.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/ext_authz/config/opa-service/v2.yaml
+++ b/examples/ext_authz/config/opa-service/v2.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
             name: envoy.access_loggers.file
             typed_config:
-              "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
               path: /dev/stdout
           route_config:
             name: local_route

--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -30,7 +30,7 @@ static_resources:
           http_filters:
           - name: envoy.filters.http.fault
             typed_config:
-              "@type": type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault
+              "@type": type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
               abort:
                 http_status: 503
                 percentage:

--- a/examples/front-proxy/front-envoy.yaml
+++ b/examples/front-proxy/front-envoy.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -38,7 +38,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/front-proxy/service-envoy.yaml
+++ b/examples/front-proxy/service-envoy.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:

--- a/examples/grpc-bridge/client/envoy-proxy.yaml
+++ b/examples/grpc-bridge/client/envoy-proxy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           add_user_agent: true
           access_log:
           - name: envoy.access_loggers.file
             typed_config:
-              "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
               path: "/dev/stdout"
           stat_prefix: egress_http
           common_http_protocol_options:

--- a/examples/grpc-bridge/server/envoy-proxy.yaml
+++ b/examples/grpc-bridge/server/envoy-proxy.yaml
@@ -8,13 +8,13 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           access_log:
           - name: envoy.access_loggers.file
             typed_config:
-              "@type": type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
               path: "/dev/stdout"
           route_config:
             name: local_route

--- a/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: true
           tracing:
             provider:

--- a/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
@@ -15,7 +15,7 @@ static_resources:
             provider:
               name: envoy.tracers.dynamic_ot
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.DynamicOtConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
                 library: /usr/local/lib/libjaegertracing_plugin.so
                 config:
                   service_name: front-proxy

--- a/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -37,7 +37,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.dynamic_ot

--- a/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
@@ -42,7 +42,7 @@ static_resources:
             provider:
               name: envoy.tracers.dynamic_ot
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.DynamicOtConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
                 library: /usr/local/lib/libjaegertracing_plugin.so
                 config:
                   service_name: service1

--- a/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.dynamic_ot

--- a/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.dynamic_ot
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.DynamicOtConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.DynamicOtConfig
                 library: /usr/local/lib/libjaegertracing_plugin.so
                 config:
                   service_name: service2

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -15,7 +15,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: true
           tracing:
             provider:

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false
@@ -51,7 +51,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.zipkin
@@ -46,7 +46,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.zipkin

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: jaeger
                 collector_endpoint: "/api/v2/spans"
                 shared_span_context: false

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.zipkin

--- a/examples/load-reporting-service/service-envoy-w-lrs.yaml
+++ b/examples/load-reporting-service/service-envoy-w-lrs.yaml
@@ -8,7 +8,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
           route_config:
@@ -57,7 +57,7 @@ cluster_manager:
   load_stats_config:
     api_type: GRPC
     grpc_services:
-      envoy_grpc: 
+      envoy_grpc:
         cluster_name: load_reporting_cluster
 admin:
   access_log_path: "/dev/null"

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           stat_prefix: ingress_http
           codec_type: auto
           route_config:
@@ -26,7 +26,7 @@ static_resources:
           http_filters:
           - name: envoy.filters.http.lua
             typed_config:
-              "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
+              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
               inline_code: |
                 local mylibrary = require("lib.mylibrary")
 

--- a/examples/mysql/envoy.yaml
+++ b/examples/mysql/envoy.yaml
@@ -9,11 +9,11 @@ static_resources:
     - filters:
       - name: envoy.filters.network.mysql_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.mysql_proxy.v1alpha1.MySQLProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.mysql_proxy.v3.MySQLProxy
           stat_prefix: egress_mysql
       - name: envoy.filters.network.tcp_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: mysql_tcp
           cluster: mysql_cluster
 

--- a/examples/redis/envoy.yaml
+++ b/examples/redis/envoy.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.redis_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
           stat_prefix: egress_redis
           settings:
             op_timeout: 5s

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           generate_request_id: true
           tracing:
             provider:

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -15,7 +15,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.zipkin
@@ -45,7 +45,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.zipkin

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON
@@ -50,7 +50,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -9,7 +9,7 @@ static_resources:
     - filters:
       - name: envoy.filters.network.http_connection_manager
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           tracing:
             provider:
               name: envoy.tracers.zipkin

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -14,7 +14,7 @@ static_resources:
             provider:
               name: envoy.tracers.zipkin
               typed_config:
-                "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+                "@type": type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
                 collector_cluster: zipkin
                 collector_endpoint: "/api/v2/spans"
                 collector_endpoint_version: HTTP_JSON


### PR DESCRIPTION
Commit Message:
Backport PRs: #13529 and #13503 to release 1.16.

Additional Description:
Risk Level: Low
Testing: CI
Docs Changes: No
Release Notes: Yes
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
