### PR TITLE
backport to 1.16: test: avoid use after free in oauth_integration_test (#14103)

### DIFF
--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -91,8 +91,6 @@ TEST_F(OauthIntegrationTest, UnauthenticatedFlow) {
                                          {":authority", "authority"}};
   auto encoder_decoder = codec_client_->startRequest(headers);
 
-  Buffer::OwnedImpl buffer;
-  encoder_decoder.first.encodeData(buffer, true);
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 


### PR DESCRIPTION
Commit Message:
test: fix use after free in oauth_integration_test

The client request stream can be deleted under the call stack of Envoy::IntegrationCodecClient::startRequest if the proxy replies quickly enough. Attempts to send an end stream on that request result in use-after-free on the client stream in cases where the client processed the full reply inside startRequest.
Additional Description:
Risk Level: n/a test-only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Fixes #12960