### PR TITLE
[grpc] validate grpc config for illegal characters

### DIFF
--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -81,7 +81,7 @@ GoogleAsyncClientFactoryImpl::GoogleAsyncClientFactoryImpl(
   ASSERT(google_tls_slot_ != nullptr);
 #endif
 
-  // Check metadata for grpc API compliance. Uppercases are lowered in the HeaderParser.
+  // Check metadata for gRPC API compliance. Uppercased characters are lowered in the HeaderParser.
   // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
   for (const auto& header : config.initial_metadata()) {
     if (!validateGrpcHeaderChars(header.key()) || !validateGrpcHeaderChars(header.value())) {

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -81,7 +81,7 @@ GoogleAsyncClientFactoryImpl::GoogleAsyncClientFactoryImpl(
   ASSERT(google_tls_slot_ != nullptr);
 #endif
 
-  // Check metadata for gRPC API compliance. Uppercased characters are lowered in the HeaderParser.
+  // Check metadata for gRPC API compliance. Uppercase characters are lowered in the HeaderParser.
   // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
   for (const auto& header : config.initial_metadata()) {
     if (!validateGrpcHeaderChars(header.key()) || !validateGrpcHeaderChars(header.value())) {

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -17,7 +17,7 @@ namespace {
 // See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 bool validateGrpcHeaderChars(absl::string_view key) {
   for (auto ch : key) {
-    if (!absl::ascii_isalnum(ch) || ch == '_' || ch == '.' || ch == '-') {
+    if (!(absl::ascii_isalnum(ch) || ch == '_' || ch == '.' || ch == '-')) {
       return false;
     }
   }

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -11,6 +11,20 @@
 
 namespace Envoy {
 namespace Grpc {
+namespace {
+
+// Validates a string for gRPC header key compliance. This is a subset of legal HTTP characters.
+// See https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+bool validateGrpcHeaderChars(absl::string_view key) {
+  for (auto ch : key) {
+    if (!absl::ascii_isalnum(ch) || ch == '_' || ch == '.' || ch == '-') {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
 
 AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
                                                const envoy::config::core::v3::GrpcService& config,
@@ -66,6 +80,14 @@ GoogleAsyncClientFactoryImpl::GoogleAsyncClientFactoryImpl(
 #else
   ASSERT(google_tls_slot_ != nullptr);
 #endif
+
+  // Check metadata for grpc API compliance. Uppercases are lowered in the HeaderParser.
+  // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+  for (const auto& header : config.initial_metadata()) {
+    if (!validateGrpcHeaderChars(header.key()) || !validateGrpcHeaderChars(header.value())) {
+      throw EnvoyException("Illegal characters in gRPC initial metadata.");
+    }
+  }
 }
 
 RawAsyncClientPtr GoogleAsyncClientFactoryImpl::create() {

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -108,6 +108,24 @@ TEST_F(AsyncClientManagerImplTest, GoogleGrpcIllegalChars) {
 #endif
 }
 
+TEST_F(AsyncClientManagerImplTest, LegalGoogleGrpcChar) {
+  EXPECT_CALL(scope_, createScope_("grpc.foo."));
+  envoy::config::core::v3::GrpcService grpc_service;
+  grpc_service.mutable_google_grpc()->set_stat_prefix("foo");
+
+  auto& metadata = *grpc_service.mutable_initial_metadata()->Add();
+  metadata.set_key("_legal-character.");
+  metadata.set_value("value");
+
+#ifdef ENVOY_GOOGLE_GRPC
+  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(grpc_service, scope_, false));
+#else
+  EXPECT_THROW_WITH_MESSAGE(
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Google C++ gRPC client is not linked");
+#endif
+}
+
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknownOk) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -88,6 +88,26 @@ TEST_F(AsyncClientManagerImplTest, GoogleGrpc) {
 #endif
 }
 
+TEST_F(AsyncClientManagerImplTest, GoogleGrpcIllegalChars) {
+  EXPECT_CALL(scope_, createScope_("grpc.foo."));
+  envoy::config::core::v3::GrpcService grpc_service;
+  grpc_service.mutable_google_grpc()->set_stat_prefix("foo");
+
+  auto& metadata = *grpc_service.mutable_initial_metadata()->Add();
+  metadata.set_key("illegalcharacter;");
+  metadata.set_value("value");
+
+#ifdef ENVOY_GOOGLE_GRPC
+  EXPECT_THROW_WITH_MESSAGE(
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Illegal characters in gRPC initial metadata.");
+#else
+  EXPECT_THROW_WITH_MESSAGE(
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Google C++ gRPC client is not linked");
+#endif
+}
+
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknownOk) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");

--- a/test/server/server_corpus/grpc_illegal_characters
+++ b/test/server/server_corpus/grpc_illegal_characters
@@ -1,0 +1,64 @@
+cluster_manager {
+  load_stats_config {
+    api_type: GRPC
+    grpc_services {
+      google_grpc {
+        target_uri: "48?"
+        stat_prefix: "$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "2"
+      }
+      initial_metadata {
+        key: "2"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2;"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "1"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "2"
+      }
+      initial_metadata {
+        key: "2"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "4"
+        value: "$$"
+      }
+      initial_metadata {
+        key: "2"
+        value: "1"
+      }
+      initial_metadata {
+        key: "10"
+        value: "$$"
+      }
+    }
+  }
+}
+enable_dispatcher_stats: true


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Prevent configuring initial metadata with illegal header characters as per https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests. Otherwise, the start call for a gRPC stream will throw an assertion failure in the grpc library and cause cause a crash.
Risk Level: Low, config only.
Testing: Added unit test and corpus entry.
Fixes 
https://github.com/envoyproxy/envoy/issues/14128
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23829
