### PR TITLE
test: reset coverage expectations for source/common/event/...

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -12,6 +12,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/singleton:95.1"
 "source/common/api:72.9"
 "source/common/api/posix:71.8"
+"source/common/event:92.9"
 "source/common/filter:96.3"
 "source/common/filter/http:96.3"
 "source/common/init:96.2"


### PR DESCRIPTION
Commit Message: I suspect there's a flakiness in either the coverage system or in the tests for source/common/event/... This should probably be looked at somehow but this shouldn't become a flakiness issue for everyone running coverage tests in every PR.
Additional Description:
Risk Level: low
Testing: none
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
