### PR TITLE
test: use simulated time for Envoy server in integration test

### DIFF
--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -45,7 +45,7 @@ using ::testing::ReturnRef;
 BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstream_address_fn,
                                          Network::Address::IpVersion version,
                                          const std::string& config)
-    : api_(Api::createApiForTest(stats_store_)),
+    : api_(Api::createApiForTest(stats_store_, time_system_)),
       mock_buffer_factory_(new NiceMock<MockBufferFactory>),
       dispatcher_(api_->allocateDispatcher("test_thread",
                                            Buffer::WatermarkFactoryPtr{mock_buffer_factory_})),


### PR DESCRIPTION
Commit Message: Use simulated time for integration test Envoy
Additional Description:
Use simulated time for the integration test to ensure that timers don't
time out due to the test running slow. This prevents test flakes, and
TSAN errors when running in that mode.

Risk Level: low
Testing: ran affected test 100+ times
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a