### PR TITLE
format: only check sh format for repository files

### DIFF
--- a/tools/code_format/check_shellcheck_format.sh
+++ b/tools/code_format/check_shellcheck_format.sh
@@ -8,7 +8,7 @@ find_shell_files () {
     shellfiles=()
     shellfiles+=("$(git grep "^#!/bin/bash" | cut -d: -f1)")
     shellfiles+=("$(git grep "^#!/bin/sh" | cut -d: -f1)")
-    shellfiles+=("$(find . -name "*.sh" | cut -d/ -f2-)")
+    shellfiles+=("$(git ls-files|grep '\.sh$')")
     shellfiles=("$(echo "${shellfiles[@]}" | tr ' ' '\n' | sort | uniq)")
     for file in "${shellfiles[@]}"; do
 	echo "$file"


### PR DESCRIPTION
Commit Message: Only run shellcheck on repository files
Additional Description:
Right now, the shellcheck format checks all files under the directory,
which is unfriendly for a number of reasons (git worktrees, dev scripts,
autogenerated code). Instead of using find, use `git ls-files` to list
files which can then be filtered.

Risk Level: low
Testing: ran CI fix_format
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a