### PR TITLE
cleanup: Replace deprecated thread annotations macros

### DIFF
--- a/source/common/common/assert.cc
+++ b/source/common/common/assert.cc
@@ -83,7 +83,7 @@ private:
 
   using EnvoyBugMap = absl::flat_hash_map<std::string, uint64_t>;
   static absl::Mutex mutex_;
-  static EnvoyBugMap counters_ GUARDED_BY(mutex_);
+  static EnvoyBugMap counters_ ABSL_GUARDED_BY(mutex_);
 };
 
 std::function<void()> ActionRegistrationImpl::debug_assertion_failure_record_action_;

--- a/source/extensions/common/wasm/wasm_extension.h
+++ b/source/extensions/common/wasm/wasm_extension.h
@@ -77,8 +77,8 @@ public:
   virtual void onEvent(WasmEvent event, const PluginSharedPtr& plugin) = 0;
   virtual void onRemoteCacheEntriesChanged(int remote_cache_entries) = 0;
   virtual void createStats(const Stats::ScopeSharedPtr& scope, const PluginSharedPtr& plugin)
-      EXCLUSIVE_LOCKS_REQUIRED(mutex_) = 0;
-  virtual void resetStats() EXCLUSIVE_LOCKS_REQUIRED(mutex_) = 0; // Delete stats pointers
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) = 0;
+  virtual void resetStats() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) = 0; // Delete stats pointers
 
   // NB: the Scope can become invalid if, for example, the owning FilterChain is deleted. When that
   // happens the stats must be recreated. This hook verifies the Scope of any existing stats and if

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -30,11 +30,11 @@ public:
                    AutonomousUpstream& upstream, bool allow_incomplete_streams);
   ~AutonomousStream() override;
 
-  void setEndStream(bool set) EXCLUSIVE_LOCKS_REQUIRED(lock_) override;
+  void setEndStream(bool set) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) override;
 
 private:
   AutonomousUpstream& upstream_;
-  void sendResponse() EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  void sendResponse() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   const bool allow_incomplete_streams_{false};
   std::unique_ptr<Http::MetadataMapVector> pre_response_headers_metadata_;
 };

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -209,7 +209,7 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
-  virtual void setEndStream(bool end) EXCLUSIVE_LOCKS_REQUIRED(lock_) { end_stream_ = end; }
+  virtual void setEndStream(bool end) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) { end_stream_ = end; }
 
   Event::TestTimeSystem& timeSystem() { return time_system_; }
 


### PR DESCRIPTION
Commit Message:
cleanup: Replace deprecated thread annotations macros

Additional Description:
Abseil thread annotation macros are now prefixed by `ABSL_`. There is no semantic change; this is just a rename.

Risk Level:
None

Testing:
Unit tests

Signed-off-by: Teju Nareddy <nareddyt@google.com>