### PR TITLE
repokitteh: add support for randomized auto-assign.

### DIFF
--- a/api/envoy/config/cluster/v3/filter.proto
+++ b/api/envoy/config/cluster/v3/filter.proto
@@ -1,3 +1,4 @@
+// some test change
 syntax = "proto3";
 
 package envoy.config.cluster.v3;

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -200,9 +200,8 @@ def _comment(config, results, assignees, force=False):
       # Is a team member already assigned? The first assigned team member is picked. Bad O(n^2) as
       # Starlark doesn't have sets, n is small.
       for assignee in assignees:
-        user = assignee['login']
-        if user in members:
-          api_assignee = user
+        if assignee in members:
+          api_assignee = assignee
           break
       # Otherwise we need to see if there is a reviewer picked from the team? If so, first wins.
       if not api_assignee:

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -205,7 +205,8 @@ def _comment(config, results, assignees, force=False):
           break
       # Otherwise we need to see if there is a reviewer picked from the team? If so, first wins.
       if not api_assignee:
-        for reviewer in github.pr_list_reviewers():
+        reviewers = github.pr_list_reviews()
+        for reviewer in reviewers:
           user = reviewer['login']
           if user in members:
             api_assignee = user

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -159,7 +159,7 @@ def _reconcile(config, specs=None):
   return results
 
 
-def _comment(config, results, assignees, requested_reviewers, force=False):
+def _comment(config, results, assignees, force=False):
   lines = []
 
   for spec, approved in results:
@@ -205,7 +205,7 @@ def _comment(config, results, assignees, requested_reviewers, force=False):
           break
       # Otherwise we need to see if there is a reviewer picked from the team? If so, first wins.
       if not api_assignee:
-        for reviewer in requested_reviewers:
+        for reviewer in github.pr_list_reviewers():
           user = reviewer['login']
           if user in members:
             api_assignee = user
@@ -220,17 +220,17 @@ def _comment(config, results, assignees, requested_reviewers, force=False):
     github.issue_create_comment('\n'.join(lines))
 
 
-def _reconcile_and_comment(config, assignees, requested_reviewers):
-  _comment(config, _reconcile(config), assignees, requested_reviewers)
+def _reconcile_and_comment(config, assignees):
+  _comment(config, _reconcile(config), assignees)
 
 
-def _force_reconcile_and_comment(config, assignees, requested_reviewers):
-  _comment(config, _reconcile(config), assignees, requested_reviewers, force=True)
+def _force_reconcile_and_comment(config, assignees):
+  _comment(config, _reconcile(config), assignees, force=True)
 
 
-def _pr(action, config, assignees, requested_reviewers):
+def _pr(action, config, assignees):
   if action in ['synchronize', 'opened']:
-    _reconcile_and_comment(config, assignees, requested_reviewers)
+    _reconcile_and_comment(config, assignees)
 
 
 def _pr_review(action, review_state, config):

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -215,7 +215,7 @@ def _comment(config, results, assignees, force=False):
       if not api_assignee:
         api_assignee = members[now().second % len(members)]
       lines.append('API shepherd assignee is %s' % api_assignee)
-      github.issue_assign([api_assignee])
+      github.issue_assign(api_assignee)
 
   if lines:
     github.issue_create_comment('\n'.join(lines))

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -194,7 +194,8 @@ def _comment(config, results, assignees, force=False):
     if spec.auto_assign:
       api_assignee = None
       # Find owners via github.team_get_by_name, github.team_list_members
-      team = github.team_get_by_name(owner)
+      team_name = owner.split('/')[1]
+      team = github.team_get_by_name(team_name)
       members = [m['login'] for m in github.team_list_members(team['id'])]
       # Is a team member already assigned? The first assigned team member is picked. Bad O(n^2) as
       # Starlark doesn't have sets, n is small.

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -179,6 +179,10 @@ def _comment(config, results, assignees, force=False):
 
     mode = spec.owner[-1] == '!' and 'approval' or 'fyi'
 
+    print('debug')
+    print(spec.owner)
+    print(mode)
+
     key = "ownerscheck/%s/%s" % (spec.owner, spec.path_match)
 
     if (not force) and (store_get(key) == mode):
@@ -214,7 +218,7 @@ def _comment(config, results, assignees, force=False):
       # Otherwise, pick at "random" (we just use timestamp).
       if not api_assignee:
         api_assignee = members[now().second % len(members)]
-      lines.append('API shepherd assignee is %s' % api_assignee)
+      lines.append('API shepherd assignee is @%s' % api_assignee)
       github.issue_assign(api_assignee)
 
   if lines:

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -261,7 +261,7 @@ def _lgtm_by_comment(config, comment_id, command, sender, sha):
 
   react(comment_id, None)
 
-  _reconcile(config, assignee, requested_reviewers, specs)
+  _reconcile(config, specs)
 
 
 handlers.pull_request(func=_pr)

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -179,10 +179,6 @@ def _comment(config, results, assignees, force=False):
 
     mode = spec.owner[-1] == '!' and 'approval' or 'fyi'
 
-    print('debug')
-    print(spec.owner)
-    print(mode)
-
     key = "ownerscheck/%s/%s" % (spec.owner, spec.path_match)
 
     if (not force) and (store_get(key) == mode):
@@ -195,7 +191,7 @@ def _comment(config, results, assignees, force=False):
     elif mode == 'fyi':
       lines.append('CC %s: FYI only%s.' % (mention, match_description))
 
-    if spec.auto_assign:
+    if mode != 'skip' and spec.auto_assign:
       api_assignee = None
       # Find owners via github.team_get_by_name, github.team_list_members
       team_name = owner.split('/')[1]

--- a/repokitteh.star
+++ b/repokitteh.star
@@ -21,6 +21,7 @@ use(
       "path": "api/envoy/",
       "label": "api",
       "github_status_label": "any API change",
+      "auto_assign": True,
     },
     {
       "owner": "envoyproxy/api-watchers",


### PR DESCRIPTION
This will allow us to pick dedicated API shepherds for each PR, ensuring
we have clear review ownership.

Fixes #13350

Signed-off-by: Harvey Tuch <htuch@google.com>