### PR TITLE
vrp: fix local build flow, add to examples CI validation.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /*
+!/build*
 !/ci
 !/configs/google-vrp
 !/configs/*yaml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 /*
-!/build*
+!/build_envoy
 !/ci
 !/configs/google-vrp
 !/configs/*yaml

--- a/ci/docker_rebuild_google-vrp.sh
+++ b/ci/docker_rebuild_google-vrp.sh
@@ -35,8 +35,10 @@ if [[ -n "$1" ]]; then
   BASE_DOCKER_IMAGE="ubuntu:20.04"
   # Copy the binary to deal with symlinks in Bazel cache and Docker daemon confusion.
   declare -r LOCAL_ENVOY="envoy-binary"
-  cp -f "$1" "${PWD}/${LOCAL_ENVOY}"
-  sed -i -e "s@# ADD %local envoy bin%@ADD ${LOCAL_ENVOY}@" "${DOCKER_BUILD_FILE}"
+  declare -r LOCAL_ENVOY_DIR="build_envoy"
+  mkdir -p "${LOCAL_ENVOY_DIR}"
+  cp -f "$1" "${LOCAL_ENVOY_DIR}/${LOCAL_ENVOY}"
+  sed -i -e "s@# ADD %local envoy bin%@ADD ${LOCAL_ENVOY_DIR}/${LOCAL_ENVOY}@" "${DOCKER_BUILD_FILE}"
 fi
 
 cat "${DOCKER_BUILD_FILE}"
@@ -44,6 +46,6 @@ cat "${DOCKER_BUILD_FILE}"
 docker build -t "envoy-google-vrp:local" --build-arg "ENVOY_VRP_BASE_IMAGE=${BASE_DOCKER_IMAGE}" -f "${DOCKER_BUILD_FILE}" .
 
 if [[ -n "$1" ]]; then
-  rm -f "${LOCAL_ENVOY}"
+  rm -rf "${LOCAL_ENVOY_DIR}"
 fi
 rm -r "${BUILD_DIR}"

--- a/examples/vrp-local/Dockerfile-vrp
+++ b/examples/vrp-local/Dockerfile-vrp
@@ -1,0 +1,1 @@
+FROM envoy-google-vrp:local

--- a/examples/vrp-local/README.md
+++ b/examples/vrp-local/README.md
@@ -1,0 +1,3 @@
+Simple test to verify local Envoy binary injection into the VRP image. For more
+details on VRP, please see
+https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/google_vrp.

--- a/examples/vrp-local/docker-compose.yaml
+++ b/examples/vrp-local/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: "3.7"
+services:
+
+  vrp:
+    build:
+      context: .
+      dockerfile: Dockerfile-vrp
+    environment:
+      ENVOY_EDGE_EXTRA_ARGS: ""
+      ENVOY_ORIGIN_EXTRA_ARGS: ""
+    networks:
+      - envoymesh
+    ports:
+      - "10000:10000"
+
+networks:
+  envoymesh: {}

--- a/examples/vrp-local/verify.sh
+++ b/examples/vrp-local/verify.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+export NAME=vrp-local
+export DELAY=10
+
+pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
+# Follow instructions from
+# https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/google_vrp#rebuilding-the-docker-image
+bazel build //source/exe:envoy-static
+./ci/docker_rebuild_google-vrp.sh bazel-bin/source/exe/envoy-static
+popd
+
+# shellcheck source=examples/verify-common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
+
+run_log "Test proxy"
+responds_with \
+    normal \
+    https://localhost:10000/content \
+    -k

--- a/examples/vrp-local/verify.sh
+++ b/examples/vrp-local/verify.sh
@@ -3,11 +3,16 @@
 export NAME=vrp-local
 export DELAY=10
 
+# Grab an Envoy binary to use from latest dev.
+CONTAINER_ID=$(docker create envoyproxy/envoy-google-vrp-dev:latest)
+docker cp "${CONTAINER_ID}":/usr/local/bin/envoy /tmp/envoy
+docker rm "${CONTAINER_ID}"
+
 pushd "$(dirname "${BASH_SOURCE[0]}")"/../..
 # Follow instructions from
-# https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/google_vrp#rebuilding-the-docker-image
-bazel build //source/exe:envoy-static
-./ci/docker_rebuild_google-vrp.sh bazel-bin/source/exe/envoy-static
+# https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/google_vrp#rebuilding-the-docker-image,
+# but rather than do a full build (slow), use an Envoy we built earlier.
+./ci/docker_rebuild_google-vrp.sh /tmp/envoy
 popd
 
 # shellcheck source=examples/verify-common.sh


### PR DESCRIPTION
Changes to .dockerignore broke the flow described at
https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/google_vrp#rebuilding-the-docker-image.

This PR fixes and adds a CI verify-example test.

Risk level: Low
Testing: New verify-examples case.

Signed-off-by: Harvey Tuch <htuch@google.com>