### PR TITLE
backport to 1.15: test: disable exact memory checks until we can sort out what changed in tcmalloc (#13447)

### DIFF
--- a/test/common/stats/stat_test_utility.cc
+++ b/test/common/stats/stat_test_utility.cc
@@ -119,19 +119,27 @@ MemoryTest::Mode MemoryTest::mode() {
   const size_t end_mem = Memory::Stats::totalCurrentlyAllocated();
   bool can_measure_memory = end_mem > start_mem;
 
+  // As of Oct 8, 2020, tcmalloc has changed such that Memory::Stats::totalCurrentlyAllocated
+  // is not deterministic, even with single-threaded tests. When possible, this should be fixed,
+  // and the following block of code uncommented. This affects approximate comparisons, not
+  // just exact ones.
+#if 0
   if (getenv("ENVOY_MEMORY_TEST_EXACT") != nullptr) { // Set in "ci/do_ci.sh" for 'release' tests.
     RELEASE_ASSERT(can_measure_memory,
                    "$ENVOY_MEMORY_TEST_EXACT is set for canonical memory measurements, "
                    "but memory measurement looks broken");
     return Mode::Canonical;
   } else {
-    // Different versions of STL and other compiler/architecture differences may
-    // also impact memory usage, so when not compiling with MEMORY_TEST_EXACT,
-    // memory comparisons must be given some slack. There have recently emerged
-    // some memory-allocation differences between development and Envoy CI and
-    // Bazel CI (which compiles Envoy as a test of Bazel).
-    return can_measure_memory ? Mode::Approximate : Mode::Disabled;
+#endif
+  // Different versions of STL and other compiler/architecture differences may
+  // also impact memory usage, so when not compiling with MEMORY_TEST_EXACT,
+  // memory comparisons must be given some slack. There have recently emerged
+  // some memory-allocation differences between development and Envoy CI and
+  // Bazel CI (which compiles Envoy as a test of Bazel).
+  return can_measure_memory ? Mode::Approximate : Mode::Disabled;
+#if 0
   }
+#endif
 #endif
 }
 


### PR DESCRIPTION
Commit Message: tcmalloc changed and the data coming out of tcmalloc::MallocExtension::GetNumericProperty("generic.current_allocated_bytes") no longer appears to be deterministic, even in unthreaded tests. So disable exact mem checks till we sort that out
Additional Description:
Risk Level: low
Testing: just thread_local_store_test
Docs Changes: n/a
Release Notes: n/a
