### PR TITLE
backport to 1.15: proxy protocol: set downstreamRemoteAddress on StreamInfo (#14131)

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -4,3 +4,4 @@
 Changes
 -------
 * listener: fix crash when disabling or re-enabling listeners due to overload while processing LDS updates.
+* proxy_proto: fixed a bug where network filters would not have the correct downstreamRemoteAddress() when accessed from the StreamInfo. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -837,10 +837,14 @@ envoy_cc_test(
         ":http_integration_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/http:codec_client_lib",
+        "//source/extensions/access_loggers/file:config",
         "//source/extensions/filters/listener/proxy_protocol:config",
+        "//source/extensions/filters/network/tcp_proxy:config",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/filter/network/tcp_proxy/v2:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/integration/proxy_proto_integration_test.h
+++ b/test/integration/proxy_proto_integration_test.h
@@ -16,19 +16,13 @@ namespace Envoy {
 class ProxyProtoIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                   public HttpIntegrationTest {
 public:
-  ProxyProtoIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {
-    config_helper_.addConfigModifier(
-        [&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
-          ::envoy::extensions::filters::listener::proxy_protocol::v3::ProxyProtocol proxy_protocol;
-          auto rule = proxy_protocol.add_rules();
-          rule->set_tlv_type(0x02);
-          rule->mutable_on_tlv_present()->set_key("PP2TypeAuthority");
-
-          auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
-          auto* ppv_filter = listener->add_listener_filters();
-          ppv_filter->set_name("envoy.listener.proxy_protocol");
-          ppv_filter->mutable_typed_config()->PackFrom(proxy_protocol);
-        });
-  }
+  ProxyProtoIntegrationTest();
 };
+
+class ProxyProtoTcpIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                     public BaseIntegrationTest {
+public:
+  ProxyProtoTcpIntegrationTest();
+};
+
 } // namespace Envoy


### PR DESCRIPTION
This fixes a regression which resulted in the downstreamRemoteAddress
on the StreamInfo for a connection not having the address supplied by
the proxy protocol filter, but instead having the address of the
directly connected peer.

This issue does not affect HTTP filters.

Fixes #14087

Signed-off-by: Greg Greenway ggreenway@apple.com

Commit Message:
Additional Description:
Risk Level: Low
Testing: New test added to prevent future regressions
Docs Changes: none needed
Release Notes: added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]