### PR TITLE
[access log] Refactor gRPC access logger to support log sinks with different proto messages

### DIFF
--- a/source/extensions/access_loggers/common/BUILD
+++ b/source/extensions/access_loggers/common/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
         "//include/envoy/thread_local:thread_local_interface",
         "//source/common/common:assert_lib",
         "//source/common/grpc:typed_async_client_lib",
+        "//source/common/protobuf:utility_lib",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/types:optional",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/source/extensions/access_loggers/common/BUILD
+++ b/source/extensions/access_loggers/common/BUILD
@@ -21,3 +21,21 @@ envoy_cc_library(
         "//source/common/singleton:const_singleton",
     ],
 )
+
+envoy_cc_library(
+    name = "grpc_access_logger",
+    hdrs = ["grpc_access_logger.h"],
+    deps = [
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/grpc:async_client_manager_interface",
+        "//include/envoy/local_info:local_info_interface",
+        "//include/envoy/singleton:instance_interface",
+        "//include/envoy/stats:stats_interface",
+        "//include/envoy/thread_local:thread_local_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/grpc:typed_async_client_lib",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/types:optional",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/grpc/async_client_manager.h"
+#include "envoy/local_info/local_info.h"
+#include "envoy/singleton/instance.h"
+#include "envoy/stats/scope.h"
+#include "envoy/thread_local/thread_local.h"
+
+#include "common/common/assert.h"
+#include "common/grpc/typed_async_client.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace AccessLoggers {
+namespace Common {
+
+enum class GrpcAccessLoggerType { TCP, HTTP };
+
+namespace Detail {
+
+/**
+ * Fully specialized types of the interfaces below are available through the
+ * `Common::GrpcAccessLogger::Interface` and `Common::GrpcAccessLoggerCache::interface`
+ * aliases.
+ */
+
+/**
+ * Interface for an access logger. The logger provides abstraction on top of gRPC stream, deals with
+ * reconnects and performs batching.
+ */
+template <typename HttpLogProto, typename TcpLogProto> class GrpcAccessLogger {
+public:
+  using SharedPtr = std::shared_ptr<GrpcAccessLogger>;
+
+  virtual ~GrpcAccessLogger() = default;
+
+  /**
+   * Log http access entry.
+   * @param entry supplies the access log to send.
+   */
+  virtual void log(HttpLogProto&& entry) PURE;
+
+  /**
+   * Log tcp access entry.
+   * @param entry supplies the access log to send.
+   */
+  virtual void log(TcpLogProto&& entry) PURE;
+};
+
+/**
+ * Interface for an access logger cache. The cache deals with threading and de-duplicates loggers
+ * for the same configuration.
+ */
+template <typename GrpcAccessLogger, typename ConfigProto> class GrpcAccessLoggerCache {
+public:
+  using SharedPtr = std::shared_ptr<GrpcAccessLoggerCache>;
+  virtual ~GrpcAccessLoggerCache() = default;
+
+  /**
+   * Get existing logger or create a new one for the given configuration.
+   * @param config supplies the configuration for the logger.
+   * @return GrpcAccessLoggerSharedPtr ready for logging requests.
+   */
+  virtual typename GrpcAccessLogger::SharedPtr getOrCreateLogger(const ConfigProto& config,
+                                                                 GrpcAccessLoggerType logger_type,
+                                                                 Stats::Scope& scope) PURE;
+};
+
+template <typename LogRequest, typename LogResponse> class GrpcAccessLogClient {
+public:
+  GrpcAccessLogClient(Grpc::RawAsyncClientPtr&& client,
+                      const Protobuf::MethodDescriptor& service_method)
+      : GrpcAccessLogClient(std::move(client), service_method, absl::nullopt) {}
+  GrpcAccessLogClient(Grpc::RawAsyncClientPtr&& client,
+                      const Protobuf::MethodDescriptor& service_method,
+                      envoy::config::core::v3::ApiVersion transport_api_version)
+      : client_(std::move(client)), service_method_(service_method),
+        transport_api_version_(transport_api_version) {}
+
+public:
+  struct LocalStream : public Grpc::AsyncStreamCallbacks<LogResponse> {
+    LocalStream(GrpcAccessLogClient& parent) : parent_(parent) {}
+
+    // Grpc::AsyncStreamCallbacks
+    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
+    void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
+    void onReceiveMessage(std::unique_ptr<LogResponse>&&) override {}
+    void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
+    void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override {
+      ASSERT(parent_.stream_ != nullptr);
+      if (parent_.stream_->stream_ != nullptr) {
+        // Only reset if we have a stream. Otherwise we had an inline failure and we will clear the
+        // stream data in send().
+        parent_.stream_.reset();
+      }
+    }
+
+    GrpcAccessLogClient& parent_;
+    Grpc::AsyncStream<LogRequest> stream_{};
+  };
+
+  bool isStreamStarted() { return stream_ != nullptr && stream_->stream_ != nullptr; }
+
+  bool log(const LogRequest& request) {
+    if (!stream_) {
+      stream_ = std::make_unique<LocalStream>(*this);
+    }
+
+    if (stream_->stream_ == nullptr) {
+      stream_->stream_ =
+          client_->start(service_method_, *stream_, Http::AsyncClient::StreamOptions());
+    }
+
+    if (stream_->stream_ != nullptr) {
+      if (stream_->stream_->isAboveWriteBufferHighWatermark()) {
+        return false;
+      }
+      if (transport_api_version_.has_value()) {
+        stream_->stream_->sendMessage(request, transport_api_version_.value(), false);
+      } else {
+        stream_->stream_->sendMessage(request, false);
+      }
+    } else {
+      // Clear out the stream data due to stream creation failure.
+      stream_.reset();
+    }
+    return true;
+  }
+
+  Grpc::AsyncClient<LogRequest, LogResponse> client_;
+  std::unique_ptr<LocalStream> stream_;
+  const Protobuf::MethodDescriptor& service_method_;
+  const absl::optional<envoy::config::core::v3::ApiVersion> transport_api_version_;
+};
+
+} // namespace Detail
+
+/**
+ * Base class for defining a gRPC logger with the `HttpLogProto` and `TcpLogProto` access log
+ * entries and `LogRequest` and `LogResponse` gRPC messages.
+ * The log entries and messages are distinct types to support batching of multiple access log
+ * entries in a single gRPC messages that go on the wire.
+ */
+template <typename HttpLogProto, typename TcpLogProto, typename LogRequest, typename LogResponse>
+class GrpcAccessLogger : public Detail::GrpcAccessLogger<HttpLogProto, TcpLogProto> {
+public:
+  using Interface = Detail::GrpcAccessLogger<HttpLogProto, TcpLogProto>;
+
+  GrpcAccessLogger(Grpc::RawAsyncClientPtr&& client,
+                   const Protobuf::MethodDescriptor& service_method)
+      : GrpcAccessLogger(std::move(client), service_method, absl::nullopt) {}
+  GrpcAccessLogger(Grpc::RawAsyncClientPtr&& client,
+                   const Protobuf::MethodDescriptor& service_method,
+                   envoy::config::core::v3::ApiVersion transport_api_version)
+      : client_(std::move(client), service_method, transport_api_version) {}
+
+protected:
+  Detail::GrpcAccessLogClient<LogRequest, LogResponse> client_;
+};
+
+/**
+ * Class for defining logger cache with the `GrpcAccessLogger` interface and
+ * `ConfigProto` configuration.
+ */
+template <typename GrpcAccessLogger, typename ConfigProto>
+class GrpcAccessLoggerCache : public Singleton::Instance,
+                              public Detail::GrpcAccessLoggerCache<GrpcAccessLogger, ConfigProto> {
+public:
+  using Interface = Detail::GrpcAccessLoggerCache<GrpcAccessLogger, ConfigProto>;
+
+  GrpcAccessLoggerCache(Grpc::AsyncClientManager& async_client_manager, Stats::Scope& scope,
+                        ThreadLocal::SlotAllocator& tls, const LocalInfo::LocalInfo& local_info)
+      : async_client_manager_(async_client_manager), scope_(scope), tls_slot_(tls.allocateSlot()),
+        local_info_(local_info) {
+    tls_slot_->set([](Event::Dispatcher& dispatcher) {
+      return std::make_shared<ThreadLocalCache>(dispatcher);
+    });
+  }
+
+  typename GrpcAccessLogger::SharedPtr getOrCreateLogger(const ConfigProto& config,
+                                                         GrpcAccessLoggerType logger_type,
+                                                         Stats::Scope& scope) override {
+    // TODO(euroelessar): Consider cleaning up loggers.
+    auto& cache = tls_slot_->getTyped<ThreadLocalCache>();
+    const auto cache_key = std::make_pair(MessageUtil::hash(config), logger_type);
+    const auto it = cache.access_loggers_.find(cache_key);
+    if (it != cache.access_loggers_.end()) {
+      return it->second;
+    }
+    const Grpc::AsyncClientFactoryPtr factory =
+        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, false);
+    const auto logger = std::make_shared<GrpcAccessLogger>(
+        factory->create(), config.log_name(),
+        std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384), cache.dispatcher_,
+        local_info_, scope, config.transport_api_version());
+    cache.access_loggers_.emplace(cache_key, logger);
+    return logger;
+  }
+
+private:
+  /**
+   * Per-thread cache.
+   */
+  struct ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
+    ThreadLocalCache(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
+
+    Event::Dispatcher& dispatcher_;
+    // Access loggers indexed by the hash of logger's configuration and logger type.
+    absl::flat_hash_map<std::pair<std::size_t, Common::GrpcAccessLoggerType>,
+                        typename GrpcAccessLogger::SharedPtr>
+        access_loggers_;
+  };
+
+  Grpc::AsyncClientManager& async_client_manager_;
+  Stats::Scope& scope_;
+  ThreadLocal::SlotPtr tls_slot_;
+  const LocalInfo::LocalInfo& local_info_;
+};
+
+} // namespace Common
+} // namespace AccessLoggers
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -12,6 +12,7 @@
 
 #include "common/common/assert.h"
 #include "common/grpc/typed_async_client.h"
+#include "common/protobuf/utility.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"

--- a/source/extensions/access_loggers/grpc/BUILD
+++ b/source/extensions/access_loggers/grpc/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         "//source/common/grpc:typed_async_client_lib",
         "//source/common/runtime:runtime_features_lib",
         "//source/extensions/access_loggers/common:access_log_base",
+        "//source/extensions/access_loggers/common:grpc_access_logger",
         "@envoy_api//envoy/data/accesslog/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/access_loggers/grpc/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/accesslog/v3:pkg_cc_proto",

--- a/source/extensions/access_loggers/grpc/config_utils.cc
+++ b/source/extensions/access_loggers/grpc/config_utils.cc
@@ -12,7 +12,7 @@ SINGLETON_MANAGER_REGISTRATION(grpc_access_logger_cache);
 
 GrpcCommon::GrpcAccessLoggerCacheSharedPtr
 getGrpcAccessLoggerCacheSingleton(Server::Configuration::FactoryContext& context) {
-  return context.singletonManager().getTyped<GrpcCommon::GrpcAccessLoggerCache>(
+  return context.singletonManager().getTyped<GrpcCommon::GrpcAccessLoggerCacheImpl>(
       SINGLETON_MANAGER_REGISTERED_NAME(grpc_access_logger_cache), [&context] {
         return std::make_shared<GrpcCommon::GrpcAccessLoggerCacheImpl>(
             context.clusterManager().grpcAsyncClientManager(), context.scope(),

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
@@ -15,35 +15,25 @@ namespace Extensions {
 namespace AccessLoggers {
 namespace GrpcCommon {
 
-void GrpcAccessLoggerImpl::LocalStream::onRemoteClose(Grpc::Status::GrpcStatus,
-                                                      const std::string&) {
-  ASSERT(parent_.stream_ != absl::nullopt);
-  if (parent_.stream_->stream_ != nullptr) {
-    // Only reset if we have a stream. Otherwise we had an inline failure and we will clear the
-    // stream data in send().
-    parent_.stream_.reset();
-  }
-}
-
 GrpcAccessLoggerImpl::GrpcAccessLoggerImpl(
     Grpc::RawAsyncClientPtr&& client, std::string log_name,
     std::chrono::milliseconds buffer_flush_interval_msec, uint64_t max_buffer_size_bytes,
     Event::Dispatcher& dispatcher, const LocalInfo::LocalInfo& local_info, Stats::Scope& scope,
     envoy::config::core::v3::ApiVersion transport_api_version)
-    : stats_({ALL_GRPC_ACCESS_LOGGER_STATS(
+    : GrpcAccessLogger(
+          std::move(client),
+          Grpc::VersionedMethods("envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs",
+                                 "envoy.service.accesslog.v2.AccessLogService.StreamAccessLogs")
+              .getMethodDescriptorForVersion(transport_api_version),
+          transport_api_version),
+      stats_({ALL_GRPC_ACCESS_LOGGER_STATS(
           POOL_COUNTER_PREFIX(scope, "access_logs.grpc_access_log."))}),
-      client_(std::move(client)), log_name_(log_name),
-      buffer_flush_interval_msec_(buffer_flush_interval_msec),
+      log_name_(log_name), buffer_flush_interval_msec_(buffer_flush_interval_msec),
       flush_timer_(dispatcher.createTimer([this]() {
         flush();
         flush_timer_->enableTimer(buffer_flush_interval_msec_);
       })),
-      max_buffer_size_bytes_(max_buffer_size_bytes), local_info_(local_info),
-      service_method_(
-          Grpc::VersionedMethods("envoy.service.accesslog.v3.AccessLogService.StreamAccessLogs",
-                                 "envoy.service.accesslog.v2.AccessLogService.StreamAccessLogs")
-              .getMethodDescriptorForVersion(transport_api_version)),
-      transport_api_version_(transport_api_version) {
+      max_buffer_size_bytes_(max_buffer_size_bytes), local_info_(local_info) {
   flush_timer_->enableTimer(buffer_flush_interval_msec_);
 }
 
@@ -90,63 +80,17 @@ void GrpcAccessLoggerImpl::flush() {
     return;
   }
 
-  if (stream_ == absl::nullopt) {
-    stream_.emplace(*this);
-  }
-
-  if (stream_->stream_ == nullptr) {
-    stream_->stream_ =
-        client_->start(service_method_, *stream_, Http::AsyncClient::StreamOptions());
-
+  if (!client_.isStreamStarted()) {
     auto* identifier = message_.mutable_identifier();
     *identifier->mutable_node() = local_info_.node();
     identifier->set_log_name(log_name_);
   }
 
-  if (stream_->stream_ != nullptr) {
-    if (stream_->stream_->isAboveWriteBufferHighWatermark()) {
-      return;
-    }
-    stream_->stream_->sendMessage(message_, transport_api_version_, false);
-  } else {
-    // Clear out the stream data due to stream creation failure.
-    stream_.reset();
+  if (client_.log(message_)) {
+    // Clear the message regardless of the success.
+    approximate_message_size_bytes_ = 0;
+    message_.Clear();
   }
-
-  // Clear the message regardless of the success.
-  approximate_message_size_bytes_ = 0;
-  message_.Clear();
-}
-
-GrpcAccessLoggerCacheImpl::GrpcAccessLoggerCacheImpl(Grpc::AsyncClientManager& async_client_manager,
-                                                     Stats::Scope& scope,
-                                                     ThreadLocal::SlotAllocator& tls,
-                                                     const LocalInfo::LocalInfo& local_info)
-    : async_client_manager_(async_client_manager), scope_(scope), tls_slot_(tls.allocateSlot()),
-      local_info_(local_info) {
-  tls_slot_->set(
-      [](Event::Dispatcher& dispatcher) { return std::make_shared<ThreadLocalCache>(dispatcher); });
-}
-
-GrpcAccessLoggerSharedPtr GrpcAccessLoggerCacheImpl::getOrCreateLogger(
-    const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-    GrpcAccessLoggerType logger_type, Stats::Scope& scope) {
-  // TODO(euroelessar): Consider cleaning up loggers.
-  auto& cache = tls_slot_->getTyped<ThreadLocalCache>();
-  const auto cache_key = std::make_pair(MessageUtil::hash(config), logger_type);
-  const auto it = cache.access_loggers_.find(cache_key);
-  if (it != cache.access_loggers_.end()) {
-    return it->second;
-  }
-  const Grpc::AsyncClientFactoryPtr factory =
-      async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, false);
-  const GrpcAccessLoggerSharedPtr logger = std::make_shared<GrpcAccessLoggerImpl>(
-      factory->create(), config.log_name(),
-      std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, buffer_size_bytes, 16384), cache.dispatcher_,
-      local_info_, scope, config.transport_api_version());
-  cache.access_loggers_.emplace(cache_key, logger);
-  return logger;
 }
 
 } // namespace GrpcCommon

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.h
@@ -15,6 +15,7 @@
 #include "common/grpc/typed_async_client.h"
 
 #include "extensions/access_loggers/common/access_log_base.h"
+#include "extensions/access_loggers/common/grpc_access_logger.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -35,52 +36,11 @@ struct GrpcAccessLoggerStats {
   ALL_GRPC_ACCESS_LOGGER_STATS(GENERATE_COUNTER_STRUCT)
 };
 
-/**
- * Interface for an access logger. The logger provides abstraction on top of gRPC stream, deals with
- * reconnects and performs batching.
- */
-class GrpcAccessLogger {
-public:
-  virtual ~GrpcAccessLogger() = default;
-
-  /**
-   * Log http access entry.
-   * @param entry supplies the access log to send.
-   */
-  virtual void log(envoy::data::accesslog::v3::HTTPAccessLogEntry&& entry) PURE;
-
-  /**
-   * Log tcp access entry.
-   * @param entry supplies the access log to send.
-   */
-  virtual void log(envoy::data::accesslog::v3::TCPAccessLogEntry&& entry) PURE;
-};
-
-using GrpcAccessLoggerSharedPtr = std::shared_ptr<GrpcAccessLogger>;
-
-enum class GrpcAccessLoggerType { TCP, HTTP };
-
-/**
- * Interface for an access logger cache. The cache deals with threading and de-duplicates loggers
- * for the same configuration.
- */
-class GrpcAccessLoggerCache {
-public:
-  virtual ~GrpcAccessLoggerCache() = default;
-
-  /**
-   * Get existing logger or create a new one for the given configuration.
-   * @param config supplies the configuration for the logger.
-   * @return GrpcAccessLoggerSharedPtr ready for logging requests.
-   */
-  virtual GrpcAccessLoggerSharedPtr getOrCreateLogger(
-      const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-      GrpcAccessLoggerType logger_type, Stats::Scope& scope) PURE;
-};
-
-using GrpcAccessLoggerCacheSharedPtr = std::shared_ptr<GrpcAccessLoggerCache>;
-
-class GrpcAccessLoggerImpl : public GrpcAccessLogger {
+class GrpcAccessLoggerImpl
+    : public Common::GrpcAccessLogger<envoy::data::accesslog::v3::HTTPAccessLogEntry,
+                                      envoy::data::accesslog::v3::TCPAccessLogEntry,
+                                      envoy::service::accesslog::v3::StreamAccessLogsMessage,
+                                      envoy::service::accesslog::v3::StreamAccessLogsResponse> {
 public:
   GrpcAccessLoggerImpl(Grpc::RawAsyncClientPtr&& client, std::string log_name,
                        std::chrono::milliseconds buffer_flush_interval_msec,
@@ -93,74 +53,29 @@ public:
   void log(envoy::data::accesslog::v3::TCPAccessLogEntry&& entry) override;
 
 private:
-  struct LocalStream
-      : public Grpc::AsyncStreamCallbacks<envoy::service::accesslog::v3::StreamAccessLogsResponse> {
-    LocalStream(GrpcAccessLoggerImpl& parent) : parent_(parent) {}
-
-    // Grpc::AsyncStreamCallbacks
-    void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
-    void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
-    void onReceiveMessage(
-        std::unique_ptr<envoy::service::accesslog::v3::StreamAccessLogsResponse>&&) override {}
-    void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
-    void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
-
-    GrpcAccessLoggerImpl& parent_;
-    Grpc::AsyncStream<envoy::service::accesslog::v3::StreamAccessLogsMessage> stream_{};
-  };
-
   void flush();
-
   bool canLogMore();
 
   GrpcAccessLoggerStats stats_;
-  Grpc::AsyncClient<envoy::service::accesslog::v3::StreamAccessLogsMessage,
-                    envoy::service::accesslog::v3::StreamAccessLogsResponse>
-      client_;
   const std::string log_name_;
   const std::chrono::milliseconds buffer_flush_interval_msec_;
   const Event::TimerPtr flush_timer_;
   const uint64_t max_buffer_size_bytes_;
   uint64_t approximate_message_size_bytes_ = 0;
   envoy::service::accesslog::v3::StreamAccessLogsMessage message_;
-  absl::optional<LocalStream> stream_;
-  const LocalInfo::LocalInfo& local_info_;
-  const Protobuf::MethodDescriptor& service_method_;
-  const envoy::config::core::v3::ApiVersion transport_api_version_;
-};
-
-using GrpcAccessLoggerImplPtr = std::unique_ptr<GrpcAccessLoggerImpl>;
-
-class GrpcAccessLoggerCacheImpl : public Singleton::Instance, public GrpcAccessLoggerCache {
-public:
-  GrpcAccessLoggerCacheImpl(Grpc::AsyncClientManager& async_client_manager, Stats::Scope& scope,
-                            ThreadLocal::SlotAllocator& tls,
-                            const LocalInfo::LocalInfo& local_info);
-
-  GrpcAccessLoggerSharedPtr getOrCreateLogger(
-      const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-      GrpcAccessLoggerType logger_type, Stats::Scope& scope) override;
-
-private:
-  /**
-   * Per-thread cache.
-   */
-  struct ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
-    ThreadLocalCache(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
-
-    Event::Dispatcher& dispatcher_;
-    // Access loggers indexed by the hash of logger's configuration and logger type.
-    absl::flat_hash_map<std::pair<std::size_t, GrpcAccessLoggerType>, GrpcAccessLoggerSharedPtr>
-        access_loggers_;
-  };
-
-  Grpc::AsyncClientManager& async_client_manager_;
-  Stats::Scope& scope_;
-  ThreadLocal::SlotPtr tls_slot_;
   const LocalInfo::LocalInfo& local_info_;
 };
 
-using GrpcAccessLoggerCacheImplPtr = std::unique_ptr<GrpcAccessLoggerCacheImpl>;
+/**
+ * Aliases for class interfaces for mock definitions.
+ */
+using GrpcAccessLogger = GrpcAccessLoggerImpl::Interface;
+using GrpcAccessLoggerSharedPtr = GrpcAccessLogger::SharedPtr;
+
+using GrpcAccessLoggerCacheImpl = Common::GrpcAccessLoggerCache<
+    GrpcAccessLoggerImpl, envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig>;
+using GrpcAccessLoggerCache = GrpcAccessLoggerCacheImpl::Interface;
+using GrpcAccessLoggerCacheSharedPtr = GrpcAccessLoggerCache::SharedPtr;
 
 } // namespace GrpcCommon
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -44,7 +44,7 @@ HttpGrpcAccessLog::HttpGrpcAccessLog(
 
   tls_slot_->set([this](Event::Dispatcher&) {
     return std::make_shared<ThreadLocalLogger>(access_logger_cache_->getOrCreateLogger(
-        config_.common_config(), GrpcCommon::GrpcAccessLoggerType::HTTP, scope_));
+        config_.common_config(), Common::GrpcAccessLoggerType::HTTP, scope_));
   });
 }
 

--- a/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
@@ -26,7 +26,7 @@ TcpGrpcAccessLog::TcpGrpcAccessLog(
       tls_slot_(tls.allocateSlot()), access_logger_cache_(std::move(access_logger_cache)) {
   tls_slot_->set([this](Event::Dispatcher&) {
     return std::make_shared<ThreadLocalLogger>(access_logger_cache_->getOrCreateLogger(
-        config_.common_config(), GrpcCommon::GrpcAccessLoggerType::TCP, scope_));
+        config_.common_config(), Common::GrpcAccessLoggerType::TCP, scope_));
   });
 }
 

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -77,7 +77,7 @@ public:
   Event::MockTimer* timer_ = nullptr;
   Event::MockDispatcher dispatcher_;
   Grpc::MockAsyncClient* async_client_{new Grpc::MockAsyncClient};
-  GrpcAccessLoggerImplPtr logger_;
+  std::unique_ptr<GrpcAccessLoggerImpl> logger_;
 };
 
 // Test basic stream logging flow.
@@ -88,8 +88,8 @@ TEST_F(GrpcAccessLoggerImplTest, BasicFlow) {
   // Start a stream for the first log.
   MockAccessLogStream stream;
   AccessLogCallbacks* callbacks;
-  expectStreamStart(stream, &callbacks);
   EXPECT_CALL(local_info_, node());
+  expectStreamStart(stream, &callbacks);
   expectStreamMessage(stream, R"EOF(
 identifier:
   node:
@@ -128,8 +128,9 @@ http_logs:
 
   // Close the stream and make sure we make a new one.
   callbacks->onRemoteClose(Grpc::Status::Internal, "bad");
-  expectStreamStart(stream, &callbacks);
+
   EXPECT_CALL(local_info_, node());
+  expectStreamStart(stream, &callbacks);
   expectStreamMessage(stream, R"EOF(
 identifier:
   node:
@@ -160,8 +161,8 @@ TEST_F(GrpcAccessLoggerImplTest, WatermarksOverrun) {
   // Start a stream for the first log.
   MockAccessLogStream stream;
   AccessLogCallbacks* callbacks;
-  expectStreamStart(stream, &callbacks);
   EXPECT_CALL(local_info_, node());
+  expectStreamStart(stream, &callbacks);
 
   // Fail to flush, so the log stays buffered up.
   envoy::data::accesslog::v3::HTTPAccessLogEntry entry;
@@ -213,8 +214,8 @@ TEST_F(GrpcAccessLoggerImplTest, WatermarksLegacy) {
   // Start a stream for the first log.
   MockAccessLogStream stream;
   AccessLogCallbacks* callbacks;
-  expectStreamStart(stream, &callbacks);
   EXPECT_CALL(local_info_, node());
+  expectStreamStart(stream, &callbacks);
 
   EXPECT_CALL(stream, isAboveWriteBufferHighWatermark())
       .Times(AnyNumber())
@@ -247,6 +248,7 @@ TEST_F(GrpcAccessLoggerImplTest, StreamFailure) {
   InSequence s;
   initLogger(FlushInterval, 0);
 
+  EXPECT_CALL(local_info_, node());
   EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
       .WillOnce(
           Invoke([](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& callbacks,
@@ -254,7 +256,6 @@ TEST_F(GrpcAccessLoggerImplTest, StreamFailure) {
             callbacks.onRemoteClose(Grpc::Status::Internal, "bad");
             return nullptr;
           }));
-  EXPECT_CALL(local_info_, node());
   envoy::data::accesslog::v3::HTTPAccessLogEntry entry;
   logger_->log(envoy::data::accesslog::v3::HTTPAccessLogEntry(entry));
 }
@@ -266,8 +267,8 @@ TEST_F(GrpcAccessLoggerImplTest, Batching) {
 
   MockAccessLogStream stream;
   AccessLogCallbacks* callbacks;
-  expectStreamStart(stream, &callbacks);
   EXPECT_CALL(local_info_, node());
+  expectStreamStart(stream, &callbacks);
   const std::string path1(30, '1');
   const std::string path2(30, '2');
   const std::string path3(80, '3');
@@ -325,8 +326,8 @@ TEST_F(GrpcAccessLoggerImplTest, Flushing) {
 
   MockAccessLogStream stream;
   AccessLogCallbacks* callbacks;
-  expectStreamStart(stream, &callbacks);
   EXPECT_CALL(local_info_, node());
+  expectStreamStart(stream, &callbacks);
   expectStreamMessage(stream, fmt::format(R"EOF(
   identifier:
     node:
@@ -350,10 +351,8 @@ TEST_F(GrpcAccessLoggerImplTest, Flushing) {
 
 class GrpcAccessLoggerCacheImplTest : public testing::Test {
 public:
-  GrpcAccessLoggerCacheImplTest() {
-    logger_cache_ = std::make_unique<GrpcAccessLoggerCacheImpl>(async_client_manager_, scope_, tls_,
-                                                                local_info_);
-  }
+  GrpcAccessLoggerCacheImplTest()
+      : logger_cache_(async_client_manager_, scope_, tls_, local_info_) {}
 
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
@@ -372,7 +371,7 @@ public:
   Grpc::MockAsyncClientManager async_client_manager_;
   Grpc::MockAsyncClient* async_client_ = nullptr;
   Grpc::MockAsyncClientFactory* factory_ = nullptr;
-  GrpcAccessLoggerCacheImplPtr logger_cache_;
+  GrpcAccessLoggerCacheImpl logger_cache_;
   NiceMock<Stats::MockIsolatedStatsStore> scope_;
 };
 
@@ -386,25 +385,30 @@ TEST_F(GrpcAccessLoggerCacheImplTest, Deduplication) {
 
   expectClientCreation();
   GrpcAccessLoggerSharedPtr logger1 =
-      logger_cache_->getOrCreateLogger(config, GrpcAccessLoggerType::HTTP, scope);
-  EXPECT_EQ(logger1, logger_cache_->getOrCreateLogger(config, GrpcAccessLoggerType::HTTP, scope));
+      logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP, scope);
+  EXPECT_EQ(logger1,
+            logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP, scope));
 
   // Do not deduplicate different types of logger
   expectClientCreation();
-  EXPECT_NE(logger1, logger_cache_->getOrCreateLogger(config, GrpcAccessLoggerType::TCP, scope));
+  EXPECT_NE(logger1,
+            logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::TCP, scope));
 
   // Changing log name leads to another logger.
   config.set_log_name("log-2");
   expectClientCreation();
-  EXPECT_NE(logger1, logger_cache_->getOrCreateLogger(config, GrpcAccessLoggerType::HTTP, scope));
+  EXPECT_NE(logger1,
+            logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP, scope));
 
   config.set_log_name("log-1");
-  EXPECT_EQ(logger1, logger_cache_->getOrCreateLogger(config, GrpcAccessLoggerType::HTTP, scope));
+  EXPECT_EQ(logger1,
+            logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP, scope));
 
   // Changing cluster name leads to another logger.
   config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("cluster-2");
   expectClientCreation();
-  EXPECT_NE(logger1, logger_cache_->getOrCreateLogger(config, GrpcAccessLoggerType::HTTP, scope));
+  EXPECT_NE(logger1,
+            logger_cache_.getOrCreateLogger(config, Common::GrpcAccessLoggerType::HTTP, scope));
 }
 
 } // namespace

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -45,7 +45,7 @@ public:
   // GrpcAccessLoggerCache
   MOCK_METHOD(GrpcCommon::GrpcAccessLoggerSharedPtr, getOrCreateLogger,
               (const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig& config,
-               GrpcCommon::GrpcAccessLoggerType logger_type, Stats::Scope& scope));
+               Common::GrpcAccessLoggerType logger_type, Stats::Scope& scope));
 };
 
 class HttpGrpcAccessLogTest : public testing::Test {
@@ -59,9 +59,9 @@ public:
         .WillOnce(
             [this](const envoy::extensions::access_loggers::grpc::v3::CommonGrpcAccessLogConfig&
                        config,
-                   GrpcCommon::GrpcAccessLoggerType logger_type, Stats::Scope&) {
+                   Common::GrpcAccessLoggerType logger_type, Stats::Scope&) {
               EXPECT_EQ(config.DebugString(), config_.common_config().DebugString());
-              EXPECT_EQ(GrpcCommon::GrpcAccessLoggerType::HTTP, logger_type);
+              EXPECT_EQ(Common::GrpcAccessLoggerType::HTTP, logger_type);
               return logger_;
             });
     access_log_ = std::make_unique<HttpGrpcAccessLog>(AccessLog::FilterPtr{filter_}, config_, tls_,


### PR DESCRIPTION
Commit Message:
Refactor gRPC access logger to support log sinks with different proto messages

Additional Description:
This is pre-requisite change for adding OTLP access logger. This change refactors functionality common to all gRPC loggers into a set of template classes parameterized with protos of log entries and gRPC request and response messages.

Refactored functionality:

- base class for creating gRPC access log connections.
- cache of gRPC access log connections

As the OTLP access logger is  being added these classes may be modified and more of the shared code may be moved.

Risk Level: Low (refactor)
Testing: Unit and Integration Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: None

Part of #13801

Signed-off-by: Yan Avlasov <yavlasov@google.com>
