### PR TITLE
kafka: fix broker integration test

### DIFF
--- a/test/extensions/filters/network/kafka/broker/integration_test/envoy_config_yaml.j2
+++ b/test/extensions/filters/network/kafka/broker/integration_test/envoy_config_yaml.j2
@@ -8,22 +8,25 @@ static_resources:
     - filters:
       - name: kafka
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.kafka_broker.v2alpha1.KafkaBroker
+          "@type": type.googleapis.com/envoy.extensions.filters.network.kafka_broker.v3.KafkaBroker
           stat_prefix: testfilter
       - name: tcp
         typed_config:
-          "@type": type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: ingress_tcp
           cluster: localinstallation
   clusters:
   - name: localinstallation
     connect_timeout: 0.25s
-    type: strict_dns
-    lb_policy: round_robin
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: {{ data['kafka_real_port'] }}
+    load_assignment:
+      cluster_name: localinstallation
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: {{ data['kafka_real_port'] }}
 admin:
   access_log_path: /dev/null
   profile_path: /dev/null


### PR DESCRIPTION
Follow up to https://github.com/envoyproxy/envoy/pull/13950

Commit Message: kafka: fix broker integration test
Additional Description: fixes manually executed kafka integration test; started to crash due to using now-fatal v2 config AFACT
Risk Level: Low
Testing: manual; `bazel test //test/extensions/filters/network/kafka/broker/integration_test:kafka_broker_integration_test`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a