### PR TITLE
server: Return nullopt when process_context is nullptr

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -246,6 +246,14 @@ void InstanceImpl::flushStatsInternal() {
 
 bool InstanceImpl::healthCheckFailed() { return !live_.load(); }
 
+ProcessContextOptRef InstanceImpl::processContext() {
+  if (process_context_ == nullptr) {
+    return absl::nullopt;
+  } else {
+    return *process_context_;
+  }
+}
+
 namespace {
 // Loads a bootstrap object, potentially at a specific version (upgrading if necessary).
 void loadBootstrap(absl::optional<uint32_t> bootstrap_version,

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -249,9 +249,9 @@ bool InstanceImpl::healthCheckFailed() { return !live_.load(); }
 ProcessContextOptRef InstanceImpl::processContext() {
   if (process_context_ == nullptr) {
     return absl::nullopt;
-  } else {
-    return *process_context_;
   }
+
+  return *process_context_;
 }
 
 namespace {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -251,7 +251,7 @@ public:
   Stats::Store& stats() override { return stats_store_; }
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
-  ProcessContextOptRef processContext() override { return *process_context_; }
+  ProcessContextOptRef processContext() override;
   ThreadLocal::Instance& threadLocal() override { return thread_local_; }
   const LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1411,6 +1411,28 @@ TEST_P(ServerInstanceImplTest, DisabledExtension) {
   ASSERT_TRUE(disabled_filter_found);
 }
 
+TEST_P(ServerInstanceImplTest, NullProcessContextTest) {
+  // These are already the defaults. Repeated here for clarity.
+  process_object_ = nullptr;
+  process_context_ = nullptr;
+
+  initialize("test/server/test_data/server/empty_bootstrap.yaml");
+  ProcessContextOptRef context = server_->processContext();
+  EXPECT_FALSE(context.has_value());
+
+  // Prior to the commit when this test was added, the code would return a
+  // context where has_value() was true, producing an opt ref that has a value
+  // which is a reference pointing to null.  Doing anything on that reference
+  // would cause a crash.  The rest of this test is ensuring that case doesn't
+  // occur again.
+  if (context.has_value()) {
+    // Compiler will not directly let us compare the rhs with null
+    // as it is assumed this is impossible.
+    void* foo = &context->get();
+    EXPECT_FALSE(foo == nullptr);
+  }
+}
+
 } // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1422,8 +1422,8 @@ TEST_P(ServerInstanceImplTest, NullProcessContextTest) {
 
   // Prior to the commit when this test was added, the code would return a
   // context where has_value() was true, producing an opt ref that has a value
-  // which is a reference pointing to null.  Doing anything on that reference
-  // would cause a crash.  The rest of this test is ensuring that case doesn't
+  // which is a reference pointing to null. Doing anything on that reference
+  // would cause a crash. The rest of this test is ensuring that case doesn't
   // occur again.
   if (context.has_value()) {
     // Compiler will not directly let us compare the rhs with null

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1419,18 +1419,6 @@ TEST_P(ServerInstanceImplTest, NullProcessContextTest) {
   initialize("test/server/test_data/server/empty_bootstrap.yaml");
   ProcessContextOptRef context = server_->processContext();
   EXPECT_FALSE(context.has_value());
-
-  // Prior to the commit when this test was added, the code would return a
-  // context where has_value() was true, producing an opt ref that has a value
-  // which is a reference pointing to null. Doing anything on that reference
-  // would cause a crash. The rest of this test is ensuring that case doesn't
-  // occur again.
-  if (context.has_value()) {
-    // Compiler will not directly let us compare the rhs with null
-    // as it is assumed this is impossible.
-    void* foo = &context->get();
-    EXPECT_FALSE(foo == nullptr);
-  }
 }
 
 } // namespace


### PR DESCRIPTION
The InstanceImpl::processContext() function returns a ProcessContextOptRef
a.k.a. absl::optional<std::reference_wrapper<ProcessContext>>.  When
InstanceImpl::process_context_ is nullptr, the returned value an
absl::optional with a value of std::reference_wrapper<>(nullptr),
better known as an illegal reference to nullptr.  While everything is
fine in the InstanceImpl, anyone who tries to use the returned
reference will be greeted with a crash.

This commit follows the lead of the initializer of InstanceImpl::api_
and returns absl::nullopt when InstanceImpl::process_context_ is
nullptr.

Risk: Low
Testing: bazel test //test/server:server_test
Documentation: N/A
Release Notes: N/A

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

