### PR TITLE
decompressor: Set window_bits default to 15

### DIFF
--- a/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/api/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -20,8 +20,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Gzip {
   // Value from 9 to 15 that represents the base two logarithmic of the decompressor's window size.
   // The decompression window size needs to be equal or larger than the compression window size.
-  // The default is 12 to match the default in the
-  // :ref:`gzip compressor <envoy_api_field_extensions.compression.gzip.compressor.v3.Gzip.window_bits>`.
+  // The default window size is 15.
+  // This is so that the decompressor can decompress a response compressed by a compressor with any compression window size.
   // For more details about this parameter, please refer to `zlib manual <https://www.zlib.net/manual.html>`_ > inflateInit2.
   google.protobuf.UInt32Value window_bits = 1 [(validate.rules).uint32 = {lte: 15 gte: 9}];
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,6 +13,7 @@ Minor Behavior Changes
 
 * build: the Alpine based debug images are no longer built in CI, use Ubuntu based images instead.
 * cluster manager: the cluster which can't extract secret entity by SDS to be warming and never activate. This feature is disabled by default and is controlled by runtime guard `envoy.reloadable_features.cluster_keep_warming_no_secret_entity`.
+* decompressor: set the default value of window_bits of the decompressor to 15 to be able to decompress responses compressed by a compressor with any window size.
 * expr filter: added `connection.termination_details` property support.
 * ext_authz filter: disable `envoy.reloadable_features.ext_authz_measure_timeout_on_check_created` by default.
 * ext_authz filter: the deprecated field :ref:`use_alpha <envoy_api_field_config.filter.http.ext_authz.v2.ExtAuthz.use_alpha>` is no longer supported and cannot be set anymore.

--- a/generated_api_shadow/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/compression/gzip/decompressor/v3/gzip.proto
@@ -20,8 +20,8 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Gzip {
   // Value from 9 to 15 that represents the base two logarithmic of the decompressor's window size.
   // The decompression window size needs to be equal or larger than the compression window size.
-  // The default is 12 to match the default in the
-  // :ref:`gzip compressor <envoy_api_field_extensions.compression.gzip.compressor.v3.Gzip.window_bits>`.
+  // The default window size is 15.
+  // This is so that the decompressor can decompress a response compressed by a compressor with any compression window size.
   // For more details about this parameter, please refer to `zlib manual <https://www.zlib.net/manual.html>`_ > inflateInit2.
   google.protobuf.UInt32Value window_bits = 1 [(validate.rules).uint32 = {lte: 15 gte: 9}];
 

--- a/source/extensions/compression/gzip/decompressor/config.cc
+++ b/source/extensions/compression/gzip/decompressor/config.cc
@@ -7,7 +7,7 @@ namespace Gzip {
 namespace Decompressor {
 
 namespace {
-const uint32_t DefaultWindowBits = 12;
+const uint32_t DefaultWindowBits = 15;
 const uint32_t DefaultChunkSize = 4096;
 // When logical OR'ed to window bits, this tells zlib library to decompress gzip data per:
 // inflateInit2 in https://www.zlib.net/manual.html


### PR DESCRIPTION
The current default window_bits of 12 for the decompressor causes issues while decompressing responses
which were compressed by a compressor with window_size greater than 12.

Default window_bits to 15 to not run into any surprises when the decompressor is deployed with defaults.

Fixes [14104](https://github.com/envoyproxy/envoy/issues/14104)

Signed-off-by: Bharath Vedartham <vedabharath12345@gmail.com>

Additional Description:
Risk Level: Low
Testing: None required
Docs Changes: Added docs in proto file
Release Notes: Added to release notes
Platform Specific Features: None
Issue: [](https://github.com/envoyproxy/envoy/issues/14104)