### PR TITLE
Fix some errors in the switch statement when decode dubbo response

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl.cc
@@ -55,14 +55,14 @@ DubboHessian2SerializerImpl::deserializeRpcResult(Buffer::Instance& buffer,
   switch (type) {
   case RpcResponseType::ResponseWithException:
   case RpcResponseType::ResponseWithExceptionWithAttachments:
-  case RpcResponseType::ResponseWithValue:
     result->setException(true);
     break;
   case RpcResponseType::ResponseWithNullValue:
+  case RpcResponseType::ResponseNullValueWithAttachments:
     has_value = false;
     FALLTHRU;
+  case RpcResponseType::ResponseWithValue:
   case RpcResponseType::ResponseValueWithAttachments:
-  case RpcResponseType::ResponseNullValueWithAttachments:
     result->setException(false);
     break;
   default:

--- a/test/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/dubbo_hessian2_serializer_impl_test.cc
@@ -109,7 +109,7 @@ TEST(HessianProtocolTest, deserializeRpcResult) {
     context->setBodySize(4);
     auto result = serializer.deserializeRpcResult(buffer, context);
     EXPECT_TRUE(result.second);
-    EXPECT_TRUE(result.first->hasException());
+    EXPECT_FALSE(result.first->hasException());
   }
 
   // incorrect body size


### PR DESCRIPTION
Signed-off-by: wbpcode <comems@msn.com>


Commit Message: Fix some errors in the switch statement when decode dubbo response.
Additional Description:

It seems that there are some errors when decode the dubbo response type. But this needs to be confirmed by @zyfjeff.
If there is no problem with this code, please close this PR directly.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
