### PR TITLE
dependencies: allowlist CVE-2020-8277 to prevent false positives.

### DIFF
--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -34,6 +34,9 @@ IGNORES_CVES = set([
     'CVE-2020-8252',
     # Fixed via the nghttp2 1.41.0 bump in Envoy 8b6ea4.
     'CVE-2020-11080',
+    # Node.js issue rooted in a c-ares bug. Does not appear to affect
+    # http-parser or our use of c-ares, c-ares has been bumped regardless.
+    'CVE-2020-8277',
 ])
 
 # Subset of CVE fields that are useful below.


### PR DESCRIPTION
The CVE scanner is alerting on CVE-2020-8277 despite the c-ares
upgrade in #14213, since the CVE applies to nodejs (and http-parser)
rather than c-ares.

Signed-off-by: Harvey Tuch <htuch@google.com>