### PR TITLE
connection: add ability for callbacks subscribed via addBytesSentCallback to unsubscribe 

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -80,8 +80,11 @@ public:
   /**
    * Callback function for when bytes have been sent by a connection.
    * @param bytes_sent supplies the number of bytes written to the connection.
+   * @return indicates if callback should be called in the future. If true is returned
+   * the callback will be called again in the future. If false is returned, the callback
+   * will be removed from callback list.
    */
-  using BytesSentCb = std::function<void(uint64_t bytes_sent)>;
+  using BytesSentCb = std::function<bool(uint64_t bytes_sent)>;
 
   struct ConnectionStats {
     Stats::Counter& read_total_;

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -679,8 +679,15 @@ void ConnectionImpl::onWriteReady() {
       delayed_close_timer_->enableTimer(delayed_close_timeout_);
     }
     if (result.bytes_processed_ > 0) {
-      for (BytesSentCb& cb : bytes_sent_callbacks_) {
-        cb(result.bytes_processed_);
+      auto it = bytes_sent_callbacks_.begin();
+      while (it != bytes_sent_callbacks_.end()) {
+        if ((*it)(result.bytes_processed_)) {
+          // move to the next callback.
+          it++;
+        } else {
+          // remove the current callback.
+          it = bytes_sent_callbacks_.erase(it);
+        }
 
         // If a callback closes the socket, stop iterating.
         if (!ioHandle().isOpen()) {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -640,10 +640,14 @@ void Filter::onUpstreamConnection() {
     idle_timer_ = read_callbacks_->connection().dispatcher().createTimer(
         [upstream_callbacks = upstream_callbacks_]() { upstream_callbacks->onIdleTimeout(); });
     resetIdleTimer();
-    read_callbacks_->connection().addBytesSentCallback([this](uint64_t) { resetIdleTimer(); });
+    read_callbacks_->connection().addBytesSentCallback([this](uint64_t) {
+      resetIdleTimer();
+      return true;
+    });
     if (upstream_) {
       upstream_->addBytesSentCallback([upstream_callbacks = upstream_callbacks_](uint64_t) {
         upstream_callbacks->onBytesSent();
+        return true;
       });
     }
   }

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -94,7 +94,7 @@ TYPED_TEST(HttpUpstreamTest, ReadDisable) {
 }
 
 TYPED_TEST(HttpUpstreamTest, AddBytesSentCallbackForCoverage) {
-  this->upstream_->addBytesSentCallback([&](uint64_t) {});
+  this->upstream_->addBytesSentCallback([&](uint64_t) { return true; });
 }
 
 TYPED_TEST(HttpUpstreamTest, DownstreamDisconnect) {

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1428,7 +1428,10 @@ TEST_P(IntegrationTest, TestFlood) {
   uint32_t bytes_to_send = 0;
   raw_connection->readDisable(true);
   // Track locally queued bytes, to make sure the outbound client queue doesn't back up.
-  raw_connection->addBytesSentCallback([&](uint64_t bytes) { bytes_to_send -= bytes; });
+  raw_connection->addBytesSentCallback([&](uint64_t bytes) {
+    bytes_to_send -= bytes;
+    return true;
+  });
 
   // Keep sending requests until flood protection kicks in and kills the connection.
   while (raw_connection->state() == Network::Connection::State::Open) {
@@ -1474,7 +1477,10 @@ TEST_P(IntegrationTest, TestFloodUpstreamErrors) {
   uint32_t bytes_to_send = 0;
   raw_connection->readDisable(true);
   // Track locally queued bytes, to make sure the outbound client queue doesn't back up.
-  raw_connection->addBytesSentCallback([&](uint64_t bytes) { bytes_to_send -= bytes; });
+  raw_connection->addBytesSentCallback([&](uint64_t bytes) {
+    bytes_to_send -= bytes;
+    return true;
+  });
 
   // Keep sending requests until flood protection kicks in and kills the connection.
   while (raw_connection->state() == Network::Connection::State::Open) {

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -170,7 +170,10 @@ RawConnectionDriver::RawConnectionDriver(uint32_t port, DoWriteCallback write_re
   client_->addConnectionCallbacks(*callbacks_);
   client_->addReadFilter(
       Network::ReadFilterSharedPtr{new ForwardingFilter(*this, response_data_callback)});
-  client_->addBytesSentCallback([&](uint64_t bytes) { remaining_bytes_to_send_ -= bytes; });
+  client_->addBytesSentCallback([&](uint64_t bytes) {
+    remaining_bytes_to_send_ -= bytes;
+    return true;
+  });
   client_->connect();
 }
 


### PR DESCRIPTION
Commit Message:
add ability for callbacks subscribed via addBytesSentCallback to unsubscribe from subsequent calls.

Additional Description:
This is pre-requisite for startTls transport socket. StartTls transport socket wants to be notified via BytesSentCB only at the beginning of the session and once initial data has been sent out, it wants to unsubscribe from receiving subsequent calls.

Risk Level: Low
Testing: Added unit test.
Docs Changes: No.
Release Notes: No
