### PR TITLE
quiche: add 100 continue support

### DIFF
--- a/source/extensions/quic_listeners/quiche/BUILD
+++ b/source/extensions/quic_listeners/quiche/BUILD
@@ -211,6 +211,7 @@ envoy_cc_library(
         ":quic_filter_manager_connection_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
+        "//source/common/http:codes_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:header_utility_lib",
         "//source/extensions/quic_listeners/quiche/platform:quic_platform_mem_slice_storage_impl_lib",

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_stream.h
@@ -72,6 +72,8 @@ private:
   void maybeDecodeTrailers();
 
   Http::ResponseDecoder* response_decoder_{nullptr};
+
+  bool decoded_100_continue_{false};
 };
 
 } // namespace Quic

--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.cc
@@ -155,7 +155,7 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
   }
   quic::QuicSpdyServerStreamBase::OnInitialHeadersComplete(fin, frame_len, header_list);
   ASSERT(headers_decompressed() && !header_list.empty());
-  ENVOY_STREAM_LOG(debug, "Receive headers: {}.", *this, header_list.DebugString());
+  ENVOY_STREAM_LOG(debug, "Received headers: {}.", *this, header_list.DebugString());
   if (fin) {
     end_stream_decoded_ = true;
   }
@@ -227,7 +227,7 @@ void EnvoyQuicServerStream::OnTrailingHeadersComplete(bool fin, size_t frame_len
   if (read_side_closed()) {
     return;
   }
-  ENVOY_STREAM_LOG(debug, "Receive trailers: {}.", *this, received_trailers().DebugString());
+  ENVOY_STREAM_LOG(debug, "Received trailers: {}.", *this, received_trailers().DebugString());
   quic::QuicSpdyServerStreamBase::OnTrailingHeadersComplete(fin, frame_len, header_list);
   ASSERT(trailers_decompressed());
   if (session()->connection()->connected() && !rst_sent()) {

--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.h
@@ -66,6 +66,7 @@ protected:
                                 const quic::QuicHeaderList& header_list) override;
   void OnTrailingHeadersComplete(bool fin, size_t frame_len,
                                  const quic::QuicHeaderList& header_list) override;
+  void OnHeadersTooLarge() override;
 
 private:
   QuicFilterManagerConnectionImpl* filterManagerConnection();

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
@@ -96,7 +96,7 @@ public:
     return bodyToHttp3StreamPayload(body);
   }
 
-  size_t receiveResponse(const std::string& payload, bool fin) {
+  size_t receiveResponse(const std::string& payload, bool fin, size_t offset = 0) {
     EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
         .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& headers, bool) {
           EXPECT_EQ("200", headers->getStatusValue());
@@ -110,18 +110,18 @@ public:
     if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
       std::string data = absl::StrCat(spdyHeaderToHttp3StreamPayload(spdy_response_headers_),
                                       bodyToStreamPayload(payload));
-      quic::QuicStreamFrame frame(stream_id_, fin, 0, data);
+      quic::QuicStreamFrame frame(stream_id_, fin, offset, data);
       quic_stream_->OnStreamFrame(frame);
       EXPECT_TRUE(quic_stream_->FinishedReadingHeaders());
-      return data.length();
+      return offset + data.length();
     }
     quic_stream_->OnStreamHeaderList(/*fin=*/false, response_headers_.uncompressed_header_bytes(),
                                      response_headers_);
 
-    quic::QuicStreamFrame frame(stream_id_, fin, 0, payload);
+    quic::QuicStreamFrame frame(stream_id_, fin, offset, payload);
     quic_stream_->OnStreamFrame(frame);
     EXPECT_TRUE(quic_stream_->FinishedReadingHeaders());
-    return payload.length();
+    return offset + payload.length();
   }
 
 protected:
@@ -208,6 +208,43 @@ TEST_P(EnvoyQuicClientStreamTest, PostRequestAndResponse) {
   }
 }
 
+TEST_P(EnvoyQuicClientStreamTest, PostRequestAnd100Continue) {
+  const auto result = quic_stream_->encodeHeaders(request_headers_, false);
+  EXPECT_TRUE(result.ok());
+
+  EXPECT_CALL(stream_decoder_, decode100ContinueHeaders_(_))
+      .WillOnce(Invoke([this](const Http::ResponseHeaderMapPtr& headers) {
+        EXPECT_EQ("100", headers->getStatusValue());
+        EXPECT_EQ("0", headers->get(Http::LowerCaseString("i"))[0]->value().getStringView());
+        quic_stream_->encodeData(request_body_, true);
+      }));
+  size_t offset = 0;
+  size_t i = 0;
+  // Receive several 10x headers, only the first 100 Continue header should be
+  // delivered.
+  for (const std::string& status : {"100", "103", "100"}) {
+    if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
+      spdy::SpdyHeaderBlock continue_header;
+      continue_header[":status"] = status;
+      continue_header["i"] = absl::StrCat("", i++);
+      std::string data = spdyHeaderToHttp3StreamPayload(continue_header);
+      quic::QuicStreamFrame frame(stream_id_, false, offset, data);
+      quic_stream_->OnStreamFrame(frame);
+      offset += data.length();
+    } else {
+      quic::QuicHeaderList continue_header;
+      continue_header.OnHeaderBlockStart();
+      continue_header.OnHeader(":status", status);
+      continue_header.OnHeader("i", absl::StrCat("", i++));
+      continue_header.OnHeaderBlockEnd(0, 0);
+      quic_stream_->OnStreamHeaderList(/*fin=*/false, continue_header.uncompressed_header_bytes(),
+                                       continue_header);
+    }
+  }
+
+  receiveResponse(response_body_, true, offset);
+}
+
 TEST_P(EnvoyQuicClientStreamTest, OutOfOrderTrailers) {
   if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
     EXPECT_CALL(stream_callbacks_, onResetStream(_, _));
@@ -226,15 +263,7 @@ TEST_P(EnvoyQuicClientStreamTest, OutOfOrderTrailers) {
   // Trailer should be delivered to HCM later after body arrives.
   quic_stream_->OnStreamHeaderList(/*fin=*/true, trailers_.uncompressed_header_bytes(), trailers_);
 
-  std::string data = response_body_;
-  if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
-    std::unique_ptr<char[]> data_buffer;
-    quic::QuicByteCount data_frame_header_length =
-        quic::HttpEncoder::SerializeDataFrameHeader(response_body_.length(), &data_buffer);
-    absl::string_view data_frame_header(data_buffer.get(), data_frame_header_length);
-    data = absl::StrCat(data_frame_header, response_body_);
-  }
-  quic::QuicStreamFrame frame(stream_id_, false, 0, data);
+  quic::QuicStreamFrame frame(stream_id_, false, 0, response_body_);
   EXPECT_CALL(stream_decoder_, decodeData(_, _))
       .Times(testing::AtMost(2))
       .WillOnce(Invoke([this](Buffer::Instance& buffer, bool finished_reading) {
@@ -401,6 +430,117 @@ TEST_P(EnvoyQuicClientStreamTest, ReceiveResetStream) {
   quic_stream_->OnStreamReset(quic::QuicRstStreamFrame(
       quic::kInvalidControlFrameId, quic_stream_->id(), quic::QUIC_STREAM_NO_ERROR, 0));
   EXPECT_TRUE(quic_stream_->rst_received());
+}
+
+TEST_P(EnvoyQuicClientStreamTest, CloseConnectionDuringDecodingHeader) {
+  const auto result = quic_stream_->encodeHeaders(request_headers_, false);
+  EXPECT_TRUE(result.ok());
+  quic_stream_->encodeData(request_body_, true);
+
+  EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/!quic::VersionUsesHttp3(
+                                                  quic_version_.transport_version)))
+      .WillOnce(Invoke([this](const Http::ResponseHeaderMapPtr&, bool) {
+        quic_connection_->CloseConnection(
+            quic::QUIC_NO_ERROR, "Closed in decodeHeaders",
+            quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
+      }));
+  if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
+    // onResetStream() callback should be triggered because end_stream is
+    // not decoded with header.
+    EXPECT_CALL(stream_callbacks_,
+                onResetStream(Http::StreamResetReason::ConnectionTermination, _));
+    std::string data = spdyHeaderToHttp3StreamPayload(spdy_response_headers_);
+    quic::QuicStreamFrame frame(stream_id_, true, 0, data);
+    quic_stream_->OnStreamFrame(frame);
+  } else {
+    // onResetStream() callback shouldn't be triggered because end_stream is
+    // already decoded.
+    quic_stream_->OnStreamHeaderList(/*fin=*/true, response_headers_.uncompressed_header_bytes(),
+                                     response_headers_);
+  }
+}
+
+TEST_P(EnvoyQuicClientStreamTest, CloseConnectionDuringDecodingDataWithEndStream) {
+  const auto result = quic_stream_->encodeHeaders(request_headers_, false);
+  EXPECT_TRUE(result.ok());
+  quic_stream_->encodeData(request_body_, true);
+
+  EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false));
+  EXPECT_CALL(stream_decoder_, decodeData(_, true))
+      .WillOnce(Invoke([this](Buffer::Instance&, bool) {
+        // onResetStream() callback shouldn't be triggered.
+        quic_connection_->CloseConnection(
+            quic::QUIC_NO_ERROR, "Closed in decodeDdata",
+            quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
+      }));
+  if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
+    std::string data = absl::StrCat(spdyHeaderToHttp3StreamPayload(spdy_response_headers_),
+                                    bodyToStreamPayload(response_body_));
+    quic::QuicStreamFrame frame(stream_id_, true, 0, data);
+    quic_stream_->OnStreamFrame(frame);
+  } else {
+    quic_stream_->OnStreamHeaderList(/*fin=*/false, response_headers_.uncompressed_header_bytes(),
+                                     response_headers_);
+
+    quic::QuicStreamFrame frame(stream_id_, true, 0, response_body_);
+    quic_stream_->OnStreamFrame(frame);
+  }
+}
+
+TEST_P(EnvoyQuicClientStreamTest, CloseConnectionDuringDecodingDataWithTrailer) {
+  const auto result = quic_stream_->encodeHeaders(request_headers_, false);
+  EXPECT_TRUE(result.ok());
+  quic_stream_->encodeData(request_body_, true);
+
+  EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false));
+  EXPECT_CALL(stream_decoder_, decodeData(_, false))
+      .WillOnce(Invoke([this](Buffer::Instance&, bool) {
+        // onResetStream() and decodeTrailers() shouldn't be triggered.
+        quic_connection_->CloseConnection(
+            quic::QUIC_NO_ERROR, "Closed in decodeDdata",
+            quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
+        EXPECT_TRUE(quic_stream_->read_side_closed());
+      }));
+  EXPECT_CALL(stream_callbacks_, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
+  if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
+    std::string data = absl::StrCat(spdyHeaderToHttp3StreamPayload(spdy_response_headers_),
+                                    bodyToStreamPayload(response_body_),
+                                    spdyHeaderToHttp3StreamPayload(spdy_trailers_));
+    quic::QuicStreamFrame frame(stream_id_, true, 0, data);
+    quic_stream_->OnStreamFrame(frame);
+  } else {
+    quic_stream_->OnStreamHeaderList(/*fin=*/false, response_headers_.uncompressed_header_bytes(),
+                                     response_headers_);
+
+    quic::QuicStreamFrame frame(stream_id_, /*fin=*/false, 0, response_body_);
+    quic_stream_->OnStreamFrame(frame);
+    quic_stream_->OnStreamHeaderList(
+        /*fin=*/!quic::VersionUsesHttp3(quic_version_.transport_version),
+        trailers_.uncompressed_header_bytes(), trailers_);
+  }
+}
+
+TEST_P(EnvoyQuicClientStreamTest, CloseConnectionDuringDecodingTrailer) {
+  const auto result = quic_stream_->encodeHeaders(request_headers_, true);
+  EXPECT_TRUE(result.ok());
+
+  size_t offset = receiveResponse(response_body_, false);
+  EXPECT_CALL(stream_decoder_, decodeTrailers_(_))
+      .WillOnce(Invoke([this](const Http::ResponseTrailerMapPtr&) {
+        // onResetStream() callback shouldn't be triggered.
+        quic_connection_->CloseConnection(
+            quic::QUIC_NO_ERROR, "Closed in decodeTrailers",
+            quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
+      }));
+  if (quic::VersionUsesHttp3(quic_version_.transport_version)) {
+    std::string payload = spdyHeaderToHttp3StreamPayload(spdy_trailers_);
+    quic::QuicStreamFrame frame(stream_id_, true, offset, payload);
+    quic_stream_->OnStreamFrame(frame);
+  } else {
+    quic_stream_->OnStreamHeaderList(
+        /*fin=*/!quic::VersionUsesHttp3(quic_version_.transport_version),
+        trailers_.uncompressed_header_bytes(), trailers_);
+  }
 }
 
 } // namespace Quic

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -543,5 +543,33 @@ TEST_P(QuicHttpIntegrationTest, EnvoyProxyingEarlyMultiple1xx) {
                        /*with_multiple_1xx_headers=*/true);
 }
 
+// HTTP3 doesn't support 101 SwitchProtocol response code, the client should
+// reset the request.
+TEST_P(QuicHttpIntegrationTest, Reset101SwitchProtocolResponse) {
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void { hcm.set_proxy_100_continue(true); });
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                 {":path", "/dynamo/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"expect", "100-continue"}});
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  // Wait for the request headers to be received upstream.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "101"}}, false);
+  response->waitForReset();
+  codec_client_->close();
+  EXPECT_FALSE(response->complete());
+}
+
 } // namespace Quic
 } // namespace Envoy

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -537,5 +537,11 @@ TEST_P(QuicHttpIntegrationTest, RequestResponseWithTrailers) {
                /*response_trailers_present=*/true);
 }
 
+// Multiple 1xx before the request completes.
+TEST_P(QuicHttpIntegrationTest, EnvoyProxyingEarlyMultiple1xx) {
+  testEnvoyProxying1xx(/*continue_before_upstream_complete=*/true, /*with_encoder_filter=*/false,
+                       /*with_multiple_1xx_headers=*/true);
+}
+
 } // namespace Quic
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: Add 100 continue support to envoy_quic_client_stream. Fix some quic stream and stream decoder interaction issues.
Additional Description: issues fixed:
Following StreamDecoder callbacks shouldn't be called if decodeHeaders|Data|Traiers() causes stream is reset or connection close. 
decodeHeaders|Data|Traiers() shouldn't be called if quic header/trailers are too large. 
StreamCallback::onResetStream() shouldn't be called if end_stream is decoded.

Risk Level: low, not in use
Testing: Added more stream unit tests and an e2e test

Part of #2557
