### PR TITLE
typo in redis doc

### DIFF
--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -82,7 +82,7 @@ following information:
 * Nodes entering or leaving the cluster.
 
 For topology configuration details, see the Redis Cluster
-:ref:`v2 API reference <envoy_v3_api_msg_extensions.clusters.redis.v3.RedisClusterConfig>`.
+:ref:`v3 API reference <envoy_v3_api_msg_extensions.clusters.redis.v3.RedisClusterConfig>`.
 
 Every Redis cluster has its own extra statistics tree rooted at *cluster.<name>.redis_cluster.* with the following statistics:
 


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: typo in redis configuration docs 
Additional Description: see url https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_protocols/redis#redis-cluster-support-experimental 
Risk Level: low
Testing: unit
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Optional Fixes #14247 
[Optional Deprecated:]
