### PR TITLE
Fix fake_upstreams_ index for xds_upstream_ in tests

### DIFF
--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -415,7 +415,7 @@ void BaseIntegrationTest::createXdsUpstream() {
         std::move(cfg), context_manager_, *upstream_stats_store_, std::vector<std::string>{});
     addFakeUpstream(std::move(context), FakeHttpConnection::Type::HTTP2);
   }
-  xds_upstream_ = fake_upstreams_[1].get();
+  xds_upstream_ = fake_upstreams_.back().get();
 }
 
 void BaseIntegrationTest::createXdsConnection() {


### PR DESCRIPTION
Commit Message:

Fix fake_upstreams_ index for xds_upstream_ in tests

fake_upstreams_ could have more or less than 2 elements depending on fake_upstream_count_

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description: See [`createUpstreams()`](https://github.com/envoyproxy/envoy/blob/master/test/integration/base_integration_test.cc#L136) in [`BaseIntegrationTest::initialize()`](https://github.com/envoyproxy/envoy/blob/master/test/integration/base_integration_test.cc#L99)
Risk Level: Low
Testing: Run integration tests that set `fake_upstream_count_` != 2 (protocol_integration_test and tcp_proxy_integration_test)
Docs Changes: N/A
Release Notes: N/A