### PR TITLE
[Windows] fix http2 flaky test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -343,10 +343,6 @@ envoy_cc_test(
         "http2_integration_test.h",
     ],
     shard_count = 4,
-    # TODO(envoyproxy/windows-dev): Diagnose flake, observed to fail at;
-    # IpVersions/Http2MetadataIntegrationTest.UpstreamMetadataAfterEndStream/IPv6
-    # (expected 200, received 503)
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/buffer:buffer_lib",

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -1592,8 +1592,8 @@ TEST_P(Http2MetadataIntegrationTest, UpstreamMetadataAfterEndStream) {
   upstream_request_->encodeMetadata(metadata_map_vector);
 
   // Cleanup.
-  ASSERT_TRUE(fake_upstream_connection_->close());
   response->waitForEndStream();
+  ASSERT_TRUE(fake_upstream_connection_->close());
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
 }


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Commit Message: Fix flaky `IpVersions/Http2MetadataIntegrationTest.UpstreamMetadataAfterEndStream/IPv6`  on Windows and remove the `flaky_on_windows` tag.

Additional Description:
Validated in 200 independent runs in bazel
Risk Level: None (Test only)
Testing: N/A
