### PR TITLE
event: preserve file event activations across calls to setEnabled.

### DIFF
--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -28,7 +28,6 @@ public:
 private:
   void assignEvents(uint32_t events, event_base* base);
   void mergeInjectedEventsAndRunCb(uint32_t events);
-  void updateEvents(uint32_t events);
 
   FileReadyCb cb_;
   os_fd_t fd_;

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -169,7 +169,7 @@ TEST_P(FileEventImplActivateTest, ActivateChaining) {
   os_sys_calls_.close(fd);
 }
 
-TEST_P(FileEventImplActivateTest, SetEnableCancelsActivate) {
+TEST_P(FileEventImplActivateTest, SetEnablePreservesActivate) {
   os_fd_t fd = os_sys_calls_.socket(domain(), SOCK_DGRAM, 0).rc_;
   ASSERT_TRUE(SOCKET_VALID(fd));
 
@@ -214,11 +214,12 @@ TEST_P(FileEventImplActivateTest, SetEnableCancelsActivate) {
   EXPECT_CALL(fd_event, ready());
   EXPECT_CALL(read_event, ready());
   EXPECT_CALL(write_event, ready());
-  // Second loop iteration: handle real write event after resetting event mask via setEnabled. Close
-  // injected event is discarded by the setEnable call.
+  // Second loop iteration: handle real write event after resetting event mask via setEnabled and
+  // Close event injected before the setEnable call.
   EXPECT_CALL(prepare_watcher, ready());
   EXPECT_CALL(fd_event, ready());
   EXPECT_CALL(write_event, ready());
+  EXPECT_CALL(closed_event, ready());
   // Third loop iteration: poll returned no new real events.
   EXPECT_CALL(prepare_watcher, ready());
 


### PR DESCRIPTION
Risk Level: medium/high
Testing: updated unit tests
Docs Changes: n/a
Release Notes: not yet
