### PR TITLE
matcher: fix UB bug caused by dereferencing a bad optional

### DIFF
--- a/source/common/matcher/field_matcher.h
+++ b/source/common/matcher/field_matcher.h
@@ -16,7 +16,12 @@ struct FieldMatchResult {
   // The result, if matching was completed.
   absl::optional<bool> result_;
 
-  bool result() const { return *result_; }
+  // The unwrapped result. Should only be called if match_state_ == MatchComplete.
+  bool result() const {
+    ASSERT(match_state_ == MatchState::MatchComplete);
+    ASSERT(result_.has_value());
+    return *result_;
+  }
 };
 
 /**
@@ -87,6 +92,7 @@ public:
 
       if (result.match_state_ == MatchState::UnableToMatch) {
         unable_to_match_some_matchers = true;
+        continue;
       }
 
       if (result.result()) {


### PR DESCRIPTION
This fixes a flaky test on master.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, fixes unused code
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
