### PR TITLE
access_loggers: removed redundant dep

### DIFF
--- a/source/extensions/access_loggers/common/BUILD
+++ b/source/extensions/access_loggers/common/BUILD
@@ -35,7 +35,6 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/grpc:typed_async_client_lib",
         "//source/common/protobuf:utility_lib",
-        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/types:optional",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
Signed-off-by: Adi Suissa-Peleg <adip@google.com>

Commit Message: Cleanup - removing a redundant dependency. 
Additional Description:
Removing a redundant dependency from  source/extensions/access_loggers/common:grpc_access_logger that was added in #14175.
Risk Level: Low
Testing: None added.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.

