### PR TITLE
jwt_authn: Document that timeout is required in http_uri

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -48,6 +48,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       http_uri:
 //         uri: https://example.com/.well-known/jwks.json
 //         cluster: example_jwks_cluster
+//         timeout: 1s
 //       cache_duration:
 //         seconds: 300
 //
@@ -94,6 +95,7 @@ message JwtProvider {
     //      http_uri:
     //        uri: https://www.googleapis.com/oauth2/v1/certs
     //        cluster: jwt.www.googleapis.com|443
+    //        timeout: 1s
     //      cache_duration:
     //        seconds: 300
     //
@@ -209,6 +211,7 @@ message RemoteJwks {
   //    http_uri:
   //      uri: https://www.googleapis.com/oauth2/v1/certs
   //      cluster: jwt.www.googleapis.com|443
+  //      timeout: 1s
   //
   config.core.v3.HttpUri http_uri = 1;
 
@@ -451,6 +454,7 @@ message FilterStateRule {
 //          http_uri:
 //            uri: https://example.com/.well-known/jwks.json
 //            cluster: example_jwks_cluster
+//            timeout: 1s
 //      provider2:
 //        issuer: issuer2
 //        local_jwks:
@@ -495,6 +499,7 @@ message JwtAuthentication {
   //          http_uri:
   //            uri: https://example.com/.well-known/jwks.json
   //            cluster: example_jwks_cluster
+  //            timeout: 1s
   //      provider2:
   //        issuer: provider2
   //        local_jwks:

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -48,6 +48,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //       http_uri:
 //         uri: https://example.com/.well-known/jwks.json
 //         cluster: example_jwks_cluster
+//         timeout: 1s
 //       cache_duration:
 //         seconds: 300
 //
@@ -94,6 +95,7 @@ message JwtProvider {
     //      http_uri:
     //        uri: https://www.googleapis.com/oauth2/v1/certs
     //        cluster: jwt.www.googleapis.com|443
+    //        timeout: 1s
     //      cache_duration:
     //        seconds: 300
     //
@@ -209,6 +211,7 @@ message RemoteJwks {
   //    http_uri:
   //      uri: https://www.googleapis.com/oauth2/v1/certs
   //      cluster: jwt.www.googleapis.com|443
+  //      timeout: 1s
   //
   config.core.v4alpha.HttpUri http_uri = 1;
 
@@ -451,6 +454,7 @@ message FilterStateRule {
 //          http_uri:
 //            uri: https://example.com/.well-known/jwks.json
 //            cluster: example_jwks_cluster
+//            timeout: 1s
 //      provider2:
 //        issuer: issuer2
 //        local_jwks:
@@ -495,6 +499,7 @@ message JwtAuthentication {
   //          http_uri:
   //            uri: https://example.com/.well-known/jwks.json
   //            cluster: example_jwks_cluster
+  //            timeout: 1s
   //      provider2:
   //        issuer: provider2
   //        local_jwks:

--- a/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
+++ b/docs/root/configuration/http/http_filters/jwt_authn_filter.rst
@@ -77,6 +77,7 @@ Remote JWKS config example
         http_uri:
           uri: https://example.com/jwks.json
           cluster: example_jwks_cluster
+          timeout: 1s
         cache_duration:
           seconds: 300
 
@@ -97,7 +98,9 @@ Following cluster **example_jwks_cluster** is needed to fetch JWKS.
             address:
               socket_address:
                 address: example.com
-                port_value: 80
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
 
 
 Inline JWKS config example

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -48,6 +48,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //       http_uri:
 //         uri: https://example.com/.well-known/jwks.json
 //         cluster: example_jwks_cluster
+//         timeout: 1s
 //       cache_duration:
 //         seconds: 300
 //
@@ -94,6 +95,7 @@ message JwtProvider {
     //      http_uri:
     //        uri: https://www.googleapis.com/oauth2/v1/certs
     //        cluster: jwt.www.googleapis.com|443
+    //        timeout: 1s
     //      cache_duration:
     //        seconds: 300
     //
@@ -209,6 +211,7 @@ message RemoteJwks {
   //    http_uri:
   //      uri: https://www.googleapis.com/oauth2/v1/certs
   //      cluster: jwt.www.googleapis.com|443
+  //      timeout: 1s
   //
   config.core.v3.HttpUri http_uri = 1;
 
@@ -451,6 +454,7 @@ message FilterStateRule {
 //          http_uri:
 //            uri: https://example.com/.well-known/jwks.json
 //            cluster: example_jwks_cluster
+//            timeout: 1s
 //      provider2:
 //        issuer: issuer2
 //        local_jwks:
@@ -495,6 +499,7 @@ message JwtAuthentication {
   //          http_uri:
   //            uri: https://example.com/.well-known/jwks.json
   //            cluster: example_jwks_cluster
+  //            timeout: 1s
   //      provider2:
   //        issuer: provider2
   //        local_jwks:

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -48,6 +48,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //       http_uri:
 //         uri: https://example.com/.well-known/jwks.json
 //         cluster: example_jwks_cluster
+//         timeout: 1s
 //       cache_duration:
 //         seconds: 300
 //
@@ -94,6 +95,7 @@ message JwtProvider {
     //      http_uri:
     //        uri: https://www.googleapis.com/oauth2/v1/certs
     //        cluster: jwt.www.googleapis.com|443
+    //        timeout: 1s
     //      cache_duration:
     //        seconds: 300
     //
@@ -209,6 +211,7 @@ message RemoteJwks {
   //    http_uri:
   //      uri: https://www.googleapis.com/oauth2/v1/certs
   //      cluster: jwt.www.googleapis.com|443
+  //      timeout: 1s
   //
   config.core.v4alpha.HttpUri http_uri = 1;
 
@@ -451,6 +454,7 @@ message FilterStateRule {
 //          http_uri:
 //            uri: https://example.com/.well-known/jwks.json
 //            cluster: example_jwks_cluster
+//            timeout: 1s
 //      provider2:
 //        issuer: issuer2
 //        local_jwks:
@@ -495,6 +499,7 @@ message JwtAuthentication {
   //          http_uri:
   //            uri: https://example.com/.well-known/jwks.json
   //            cluster: example_jwks_cluster
+  //            timeout: 1s
   //      provider2:
   //        issuer: provider2
   //        local_jwks:


### PR DESCRIPTION
Commit Message:
jwt_authn: Document that timeout is required in http_uri

Additional Description:
Currently the examples in the documentation don't include the mandatory
http_uri.timeout field and don't add the tls_transport field required to fetch
JWT signature verification keys from HTTPS servers. This patch fixes both
issues.

Risk Level: Low
Testing: Tested manually
Docs Changes: Included in the patch
Release Notes: Not needed
Platform Specific Features: None
Fixes #14277
