### PR TITLE
backport to 1.16: vrp: allow supervisord to open its log file (#14066)

### DIFF
--- a/ci/Dockerfile-envoy-google-vrp
+++ b/ci/Dockerfile-envoy-google-vrp
@@ -16,6 +16,9 @@ ADD configs/google-vrp/supervisor.conf /etc/supervisor.conf
 ADD test/config/integration/certs/serverkey.pem /etc/envoy/certs/serverkey.pem
 ADD test/config/integration/certs/servercert.pem /etc/envoy/certs/servercert.pem
 # ADD %local envoy bin% /usr/local/bin/envoy
+RUN chmod 777 /var/log/supervisor
+RUN chmod a+r /etc/supervisor.conf /etc/envoy/* /etc/envoy/certs/*
+RUN chmod a+rx /usr/local/bin/launch_envoy.sh
 
 EXPOSE 10000
 EXPOSE 10001

--- a/configs/google-vrp/supervisor.conf
+++ b/configs/google-vrp/supervisor.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+logfile=/var/log/supervisor/supervisord.log
 
 [program:envoy-edge]
 command=launch_envoy.sh -c /etc/envoy/envoy-edge.yaml %(ENV_ENVOY_EDGE_EXTRA_ARGS)s

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,6 +19,7 @@ Bug Fixes
 * proxy_proto: fixed a bug where network filters would not have the correct downstreamRemoteAddress() when accessed from the StreamInfo. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.
 * tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
 * udp: fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.
+* vrp: allow supervisord to open its log file.
 
 Removed Config or Runtime
 -------------------------


### PR DESCRIPTION
Commit Message: Allow supervisord to open its log file
Additional Description:
Change the default location of the log file and give supervisord
permissions to write to it.

Risk Level: low
Testing: built image locally
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a