### PR TITLE
oauth2_filter: preserve authorization endpoint params, allow custom scopes, allow additional authorization parameters

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
@@ -44,7 +44,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 9]
+// [#next-free-field: 11]
 message OAuth2Config {
   // Endpoint on the authorization server to retrieve the access token from.
   config.core.v3.HttpUri token_endpoint = 1;
@@ -74,6 +74,15 @@ message OAuth2Config {
 
   // Any request that matches any of the provided matchers will be passed through without OAuth validation.
   repeated config.route.v3.HeaderMatcher pass_through_matcher = 8;
+
+  // Authorization scopes, as defined by https://tools.ietf.org/html/rfc6749#section-3.3
+  repeated string scopes = 9 [(validate.rules).repeated = {items {string {min_len: 1}}}];
+
+  // Additional parameters supplied to the authorization request.
+  map<string, string> additional_authorization_parameters = 10 [(validate.rules).map = {
+    keys {string {min_len: 1}}
+    values {string {min_len: 1}}
+  }];
 }
 
 // Filter config.

--- a/api/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
@@ -47,7 +47,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 9]
+// [#next-free-field: 11]
 message OAuth2Config {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.oauth2.v3alpha.OAuth2Config";
@@ -80,6 +80,15 @@ message OAuth2Config {
 
   // Any request that matches any of the provided matchers will be passed through without OAuth validation.
   repeated config.route.v4alpha.HeaderMatcher pass_through_matcher = 8;
+
+  // Authorization scopes, as defined by https://tools.ietf.org/html/rfc6749#section-3.3
+  repeated string scopes = 9 [(validate.rules).repeated = {items {string {min_len: 1}}}];
+
+  // Additional parameters supplied to the authorization request.
+  map<string, string> additional_authorization_parameters = 10 [(validate.rules).map = {
+    keys {string {min_len: 1}}
+    values {string {min_len: 1}}
+  }];
 }
 
 // Filter config.

--- a/docs/root/configuration/http/http_filters/oauth2_filter.rst
+++ b/docs/root/configuration/http/http_filters/oauth2_filter.rst
@@ -71,6 +71,13 @@ The following is an example configuring the filter.
         name: hmac
         sds_config:
           path: "/etc/envoy/hmac.yaml"
+    # (Optional): defaults to "user" if unset
+    scopes:
+    - user
+    - openid
+    # (Optional): set of additional parameters to supply to the authorization endpoint
+    aditional_authorization_parameters:
+      blog: "1245"
 
 Below is a complete code example of how we employ the filter as one of
 :ref:`HttpConnectionManager HTTP filters

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -25,6 +25,7 @@ Minor Behavior Changes
 * watchdog: the watchdog action :ref:`abort_action <envoy_v3_api_msg_watchdog.v3alpha.AbortActionConfig>` is now the default action to terminate the process if watchdog kill / multikill is enabled.
 * xds: to support TTLs, heartbeating has been added to xDS. As a result, responses that contain empty resources without updating the version will no longer be propagated to the
   subscribers. To undo this for VHDS (which is the only subscriber that wants empty resources), the `envoy.reloadable_features.vhds_heartbeats` can be set to "false".
+* oauth2 filter: preserve query parameters in authorization urls, as per the Oauth2 spec. Add the ability to configure requested scopes using the optional :ref: `scopes <config_http_filters_oauth>` parameter, with a default value of 'user'. Add the ability to pass additional query parameters to the authorization endpoint using the :ref: `additional_authorization_parameters <config_http_filters_oauth>` field.
 
 Bug Fixes
 ---------

--- a/generated_api_shadow/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/oauth2/v3alpha/oauth.proto
@@ -44,7 +44,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 9]
+// [#next-free-field: 11]
 message OAuth2Config {
   // Endpoint on the authorization server to retrieve the access token from.
   config.core.v3.HttpUri token_endpoint = 1;
@@ -74,6 +74,15 @@ message OAuth2Config {
 
   // Any request that matches any of the provided matchers will be passed through without OAuth validation.
   repeated config.route.v3.HeaderMatcher pass_through_matcher = 8;
+
+  // Authorization scopes, as defined by https://tools.ietf.org/html/rfc6749#section-3.3
+  repeated string scopes = 9 [(validate.rules).repeated = {items {string {min_len: 1}}}];
+
+  // Additional parameters supplied to the authorization request.
+  map<string, string> additional_authorization_parameters = 10 [(validate.rules).map = {
+    keys {string {min_len: 1}}
+    values {string {min_len: 1}}
+  }];
 }
 
 // Filter config.

--- a/generated_api_shadow/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/oauth2/v4alpha/oauth.proto
@@ -47,7 +47,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 9]
+// [#next-free-field: 11]
 message OAuth2Config {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.oauth2.v3alpha.OAuth2Config";
@@ -80,6 +80,15 @@ message OAuth2Config {
 
   // Any request that matches any of the provided matchers will be passed through without OAuth validation.
   repeated config.route.v4alpha.HeaderMatcher pass_through_matcher = 8;
+
+  // Authorization scopes, as defined by https://tools.ietf.org/html/rfc6749#section-3.3
+  repeated string scopes = 9 [(validate.rules).repeated = {items {string {min_len: 1}}}];
+
+  // Additional parameters supplied to the authorization request.
+  map<string, string> additional_authorization_parameters = 10 [(validate.rules).map = {
+    keys {string {min_len: 1}}
+    values {string {min_len: 1}}
+  }];
 }
 
 // Filter config.

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -8,6 +9,7 @@
 #include "envoy/config/core/v3/http_uri.pb.h"
 #include "envoy/extensions/filters/http/oauth2/v3alpha/oauth.pb.h"
 #include "envoy/http/header_map.h"
+#include "envoy/http/query_params.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/stream_info/stream_info.h"
@@ -123,6 +125,10 @@ public:
   std::string clientSecret() const { return secret_reader_->clientSecret(); }
   std::string tokenSecret() const { return secret_reader_->tokenSecret(); }
   FilterStats& stats() { return stats_; }
+  const std::vector<std::string>& scopes() { return scopes_; }
+  const Envoy::Http::Utility::QueryParams& additionalAuthorizationParameters() {
+    return additional_authorization_parameters_;
+  }
 
 private:
   static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);
@@ -137,6 +143,8 @@ private:
   FilterStats stats_;
   const bool forward_bearer_token_ : 1;
   const std::vector<Http::HeaderUtility::HeaderData> pass_through_header_matchers_;
+  const std::vector<std::string> scopes_;
+  const Envoy::Http::Utility::QueryParams additional_authorization_parameters_;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;


### PR DESCRIPTION
This is somewhat duplicative of https://github.com/envoyproxy/envoy/pull/14168, but due to changes in structure, would not cleanly merge with that change. My original intent was just to add the additional parameters, but subsuming the scopes change seems like the best change, to avoid a merge conflict.

Commit Message: oauth2_filter: preserve parameters in authorization endpoint, allow for customizing scopes, allow additional authorization endpoint parameters
Additional Description: This PR makes several small improvements to the oauth2 filter.
  1. Preserves any query parameters in the authorization endpoint URI, per https://tools.ietf.org/html/rfc6749#section-3.1
  2. Adds a new 'scopes' field for controlling the requested scopes, defaulting to 'user' (the current value) if none are provided.
  3. Add a new 'additional_authorization_parameters' configuration option, for passing additional parameters to the authorization endpoint. This will permit 'non-standard' options to be passed to the authorization server (for a motivating case, see Wordpress's use of the 'blog' parameter as documented here: https://developer.wordpress.com/docs/oauth2/#receiving-an-access-token
It also makes some small organizational changes in order to unify how parameters are encoded.

Risk Level: medium (feature added to existing filter)
Testing: new unit tests added to cover additional functionality, all existing tests pass.
Docs Changes: update example configuration to include new fields.

