### PR TITLE
http: add functionality to configure kill header in KillRequest proto

### DIFF
--- a/api/envoy/extensions/filters/http/kill_request/v3/kill_request.proto
+++ b/api/envoy/extensions/filters/http/kill_request/v3/kill_request.proto
@@ -20,4 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message KillRequest {
   // The probability that a Kill request will be triggered.
   type.v3.FractionalPercent probability = 1;
+
+  // The name of the kill request header. If this field is not empty, it will override the :ref:`default header <config_http_filters_kill_request_http_header>` name. Otherwise the default header name will be used.
+  string kill_request_header = 2;
 }

--- a/docs/root/configuration/http/http_filters/kill_request_filter.rst
+++ b/docs/root/configuration/http/http_filters/kill_request_filter.rst
@@ -16,7 +16,7 @@ Configuration
 Enable Kill Request via HTTP header
 --------------------------------------------
 
-The KillRequest filter requires the following header in the request:
+The KillRequest filter requires a kill header in the request. If *kill_request_header* is not empty in *KillRequest* proto, the name of the kill header must match *KillRequest.kill_request_header*, otherwise it must match the default kill header below:
 
 x-envoy-kill-request
   whether the request is a Kill request.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,6 +19,7 @@ Minor Behavior Changes
 * grpc_web filter: if a `grpc-accept-encoding` header is present it's passed as-is to the upstream and if it isn't `grpc-accept-encoding:identity` is sent instead. The header was always overwriten with `grpc-accept-encoding:identity,deflate,gzip` before.
 * http: upstream protocol will now only be logged if an upstream stream was established.
 * jwt_authn filter: added support of Jwt time constraint verification with a clock skew (default to 60 seconds) and added a filter config field :ref:`clock_skew_seconds <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.clock_skew_seconds>` to configure it.
+* kill_request: enable a way to configure kill header name in KillRequest proto.
 * memory: enable new tcmalloc with restartable sequences for aarch64 builds.
 * mongo proxy metrics: swapped network connection remote and local closed counters previously set reversed (`cx_destroy_local_with_active_rq` and `cx_destroy_remote_with_active_rq`).
 * tls: removed RSA key transport and SHA-1 cipher suites from the client-side defaults.

--- a/generated_api_shadow/envoy/extensions/filters/http/kill_request/v3/kill_request.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/kill_request/v3/kill_request.proto
@@ -20,4 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message KillRequest {
   // The probability that a Kill request will be triggered.
   type.v3.FractionalPercent probability = 1;
+
+  // The name of the kill request header. If this field is not empty, it will override the :ref:`default header <config_http_filters_kill_request_http_header>` name. Otherwise the default header name will be used.
+  string kill_request_header = 2;
 }

--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -15,7 +15,12 @@ bool KillRequestFilter::isKillRequestEnabled() {
 }
 
 Http::FilterHeadersStatus KillRequestFilter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
-  const auto kill_request_header = headers.get(KillRequestHeaders::get().KillRequest);
+  // If not empty, configured kill header name will override the default header name.
+  const Http::LowerCaseString kill_request_header_name =
+      kill_request_.kill_request_header().empty()
+          ? KillRequestHeaders::get().KillRequest
+          : Http::LowerCaseString(kill_request_.kill_request_header());
+  const auto kill_request_header = headers.get(kill_request_header_name);
   bool is_kill_request = false;
   // This is an implicitly untrusted header, so per the API documentation only
   // the first value is used.

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -42,6 +42,17 @@ TEST_F(KillRequestFilterTest, KillRequestCrashEnvoy) {
   EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
 }
 
+TEST_F(KillRequestFilterTest, KillRequestCrashEnvoyWithCustomKillHeader) {
+  envoy::extensions::filters::http::kill_request::v3::KillRequest kill_request;
+  kill_request.mutable_probability()->set_numerator(1);
+  kill_request.set_kill_request_header("x-custom-kill-request");
+  setUpTest(kill_request);
+  request_headers_.addCopy("x-custom-kill-request", "true");
+
+  ON_CALL(random_generator_, random()).WillByDefault(Return(0));
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
+}
+
 TEST_F(KillRequestFilterTest, KillRequestWithMillionDenominatorCrashEnvoy) {
   envoy::extensions::filters::http::kill_request::v3::KillRequest kill_request;
   kill_request.mutable_probability()->set_numerator(1);


### PR DESCRIPTION
Add functionality to configure kill header in KillRequest proto. If configured in the proto, it will override the default kill header.

@htuch 

Risk Level: Low, new feature.
Testing: Unit/integration tests.
Docs Changes: Added
Release Notes: Added
Issue: #13978