### PR TITLE
dependencies: allowlist CVE-2018-21270 to prevent false positives.

### DIFF
--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -39,6 +39,9 @@ IGNORES_CVES = set([
     'CVE-2020-8277',
     # gRPC issue that only affects Javascript bindings.
     'CVE-2020-7768',
+    # Node.js issue unrelated to http-parser, see
+    # https://github.com/mhart/StringStream/issues/7.
+    'CVE-2018-21270',
 ])
 
 # Subset of CVE fields that are useful below.


### PR DESCRIPTION
This does not relate to http-parser.

Signed-off-by: Harvey Tuch <htuch@google.com>