### PR TITLE
 lua: update deprecated lua_open to luaL_newstate

### DIFF
--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -52,7 +52,7 @@ ThreadLocalState::ThreadLocalState(const std::string& code, ThreadLocal::SlotAll
     : tls_slot_(ThreadLocal::TypedSlot<LuaThreadLocal>::makeUnique(tls)) {
 
   // First verify that the supplied code can be parsed.
-  CSmartPtr<lua_State, lua_close> state(lua_open());
+  CSmartPtr<lua_State, lua_close> state(luaL_newstate());
   RELEASE_ASSERT(state.get() != nullptr, "unable to create new Lua state object");
   luaL_openlibs(state.get());
 
@@ -90,7 +90,7 @@ CoroutinePtr ThreadLocalState::createCoroutine() {
   return std::make_unique<Coroutine>(std::make_pair(lua_newthread(state), state));
 }
 
-ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : state_(lua_open()) {
+ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : state_(luaL_newstate()) {
   RELEASE_ASSERT(state_.get() != nullptr, "unable to create new Lua state object");
   luaL_openlibs(state_.get());
   int rc = luaL_dostring(state_.get(), code.c_str());

--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -90,7 +90,9 @@ CoroutinePtr ThreadLocalState::createCoroutine() {
   return std::make_unique<Coroutine>(std::make_pair(lua_newthread(state), state));
 }
 
-ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code) : state_(luaL_newstate()) {
+ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code)
+    : state_(luaL_newstate()) {
+
   RELEASE_ASSERT(state_.get() != nullptr, "unable to create new Lua state object");
   luaL_openlibs(state_.get());
   int rc = luaL_dostring(state_.get(), code.c_str());

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -893,7 +893,7 @@ TEST_P(LuaIntegrationTest, BasicTestOfLuaPerRoute) {
 // Test whether Rds can correctly deliver LuaPerRoute configuration.
 TEST_P(LuaIntegrationTest, RdsTestOfLuaPerRoute) {
 // When the route configuration is updated dynamically via RDS and the configuration contains an
-// inline Lua code, Envoy may call luaL_newstate
+// inline Lua code, Envoy may call `luaL_newstate`
 // (https://www.lua.org/manual/5.1/manual.html#luaL_newstate) in multiple threads to create new
 // lua_State objects.
 // During lua_State creation, 'LuaJIT' uses some static local variables shared by multiple threads

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -893,7 +893,9 @@ TEST_P(LuaIntegrationTest, BasicTestOfLuaPerRoute) {
 // Test whether Rds can correctly deliver LuaPerRoute configuration.
 TEST_P(LuaIntegrationTest, RdsTestOfLuaPerRoute) {
 // When the route configuration is updated dynamically via RDS and the configuration contains an
-// inline Lua code, Envoy may call luaL_newstate in multiple threads to create new lua_State objects.
+// inline Lua code, Envoy may call luaL_newstate
+// (https://www.lua.org/manual/5.1/manual.html#luaL_newstate) in multiple threads to create new
+// lua_State objects.
 // During lua_State creation, 'LuaJIT' uses some static local variables shared by multiple threads
 // to aid memory allocation. Although 'LuaJIT' itself guarantees that there is no thread safety
 // issue here, the use of these static local variables by multiple threads will cause a TSAN alarm.

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -893,7 +893,7 @@ TEST_P(LuaIntegrationTest, BasicTestOfLuaPerRoute) {
 // Test whether Rds can correctly deliver LuaPerRoute configuration.
 TEST_P(LuaIntegrationTest, RdsTestOfLuaPerRoute) {
 // When the route configuration is updated dynamically via RDS and the configuration contains an
-// inline Lua code, Envoy may call lua_open in multiple threads to create new lua_State objects.
+// inline Lua code, Envoy may call luaL_newstate in multiple threads to create new lua_State objects.
 // During lua_State creation, 'LuaJIT' uses some static local variables shared by multiple threads
 // to aid memory allocation. Although 'LuaJIT' itself guarantees that there is no thread safety
 // issue here, the use of these static local variables by multiple threads will cause a TSAN alarm.


### PR DESCRIPTION
Commit Message: Use  `luaL_newstate` instead of the deprecated `lua_open`
Additional Description:
`lua_open` is deprecated in Lua 5.1 and removed in the later version, though LuaJIT might keep the API unchanged.

Risk Level: Low.  In LuaJIT, lua_open is just an alias of luaL_newstate.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform-Specific Features: N/A

Signed-off-by: spacewander <spacewanderlzx@gmail.com>
