### PR TITLE
http2: Add integration tests for PRIORITY frame flood mitigation for upstream servers

### DIFF
--- a/source/common/http/http2/protocol_constraints.cc
+++ b/source/common/http/http2/protocol_constraints.cc
@@ -63,6 +63,10 @@ Status ProtocolConstraints::trackInboundFrames(const nghttp2_frame_hd* hd,
   case NGHTTP2_HEADERS:
   case NGHTTP2_CONTINUATION:
     // Track new streams.
+
+    // TODO(yanavlasov): The protocol constraint tracker for upstream connections considers the
+    // stream to be in the OPEN state after the server sends complete response headers. The
+    // correctness of this is debatable and needs to be revisited.
     if (hd->flags & NGHTTP2_FLAG_END_HEADERS) {
       inbound_streams_++;
     }

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -1315,7 +1315,7 @@ TEST_P(Http2FloodMitigationTest, UpstreamPriorityNoOpenStreams) {
   // this is debatable and needs to be revisited.
 
   // The `floodClient` method sends request headers to open upstream connection, but upstream does
-  // send any response. In this case the number of streams tracked by the upstream protocol
+  // not send any response. In this case the number of streams tracked by the upstream protocol
   // constraints checker is still 0.
   floodClient(Http2Frame::makePriorityFrame(Http2Frame::makeClientStreamId(1),
                                             Http2Frame::makeClientStreamId(2)),


### PR DESCRIPTION
Risk Level: Low, tests only
Testing: Integration Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Part of #12281

Signed-off-by: Yan Avlasov <yavlasov@google.com>
