### PR TITLE
benchmark: convert recent_lookups_speed_test and symbol_table_speed_test so they use the benchmark framework

### DIFF
--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -4,7 +4,6 @@ load(
     "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
-    "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -61,8 +60,8 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_binary(
-    name = "recent_lookups_speed_test",
+envoy_cc_benchmark_binary(
+    name = "recent_lookups_benchmark",
     srcs = ["recent_lookups_speed_test.cc"],
     external_deps = [
         "benchmark",
@@ -73,6 +72,11 @@ envoy_cc_test_binary(
         "//source/common/runtime:runtime_lib",
         "//source/common/stats:recent_lookups_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "recent_lookups_benchmark_test",
+    benchmark_binary = "recent_lookups_benchmark",
 )
 
 envoy_cc_test(
@@ -178,8 +182,8 @@ envoy_cc_fuzz_test(
     ],
 )
 
-envoy_cc_test_binary(
-    name = "symbol_table_speed_test",
+envoy_cc_benchmark_binary(
+    name = "symbol_table_benchmark",
     srcs = [
         "make_elements_helper.cc",
         "make_elements_helper.h",
@@ -199,6 +203,11 @@ envoy_cc_test_binary(
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
     ],
+)
+
+envoy_benchmark_test(
+    name = "symbol_table_benchmark_test",
+    benchmark_binary = "symbol_table_benchmark",
 )
 
 envoy_cc_test(

--- a/test/common/stats/recent_lookups_speed_test.cc
+++ b/test/common/stats/recent_lookups_speed_test.cc
@@ -56,28 +56,16 @@ static void BM_LookupsMixed(benchmark::State& state) {
   RecentLookupsSpeedTest speed_test(1000, 500);
   speed_test.test(state);
 }
-BENCHMARK(BM_LookupsMixed);
+BENCHMARK(BM_LookupsMixed)->Unit(::benchmark::kMillisecond);
 
 static void BM_LookupsNoEvictions(benchmark::State& state) {
   RecentLookupsSpeedTest speed_test(1000, 1000);
   speed_test.test(state);
 }
-BENCHMARK(BM_LookupsNoEvictions);
+BENCHMARK(BM_LookupsNoEvictions)->Unit(::benchmark::kMillisecond);
 
 static void BM_LookupsAllEvictions(benchmark::State& state) {
   RecentLookupsSpeedTest speed_test(1000, 10);
   speed_test.test(state);
 }
-BENCHMARK(BM_LookupsAllEvictions);
-
-int main(int argc, char** argv) {
-  Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logger_context(spdlog::level::warn,
-                                        Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}
+BENCHMARK(BM_LookupsAllEvictions)->Unit(::benchmark::kMillisecond);

--- a/test/common/stats/recent_lookups_speed_test.cc
+++ b/test/common/stats/recent_lookups_speed_test.cc
@@ -40,6 +40,7 @@ public:
 
   void test(benchmark::State& state) {
     for (auto _ : state) {
+      UNREFERENCED_PARAMETER(_);
       Envoy::Random::RandomGeneratorImpl random;
       for (uint64_t i = 0; i < lookups_.size(); ++i) {
         recent_lookups_.lookup(lookups_[random.random() % lookups_.size()]);
@@ -52,20 +53,20 @@ private:
   Envoy::Stats::RecentLookups recent_lookups_;
 };
 
-static void BM_LookupsMixed(benchmark::State& state) {
+static void bmLookupsMixed(benchmark::State& state) {
   RecentLookupsSpeedTest speed_test(1000, 500);
   speed_test.test(state);
 }
-BENCHMARK(BM_LookupsMixed)->Unit(::benchmark::kMillisecond);
+BENCHMARK(bmLookupsMixed)->Unit(::benchmark::kMillisecond);
 
-static void BM_LookupsNoEvictions(benchmark::State& state) {
+static void bmLookupsNoEvictions(benchmark::State& state) {
   RecentLookupsSpeedTest speed_test(1000, 1000);
   speed_test.test(state);
 }
-BENCHMARK(BM_LookupsNoEvictions)->Unit(::benchmark::kMillisecond);
+BENCHMARK(bmLookupsNoEvictions)->Unit(::benchmark::kMillisecond);
 
-static void BM_LookupsAllEvictions(benchmark::State& state) {
+static void bmLookupsAllEvictions(benchmark::State& state) {
   RecentLookupsSpeedTest speed_test(1000, 10);
   speed_test.test(state);
 }
-BENCHMARK(BM_LookupsAllEvictions)->Unit(::benchmark::kMillisecond);
+BENCHMARK(bmLookupsAllEvictions)->Unit(::benchmark::kMillisecond);

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -17,46 +17,48 @@
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_CreateRace(benchmark::State& state) {
-  Envoy::Thread::ThreadFactory& thread_factory = Envoy::Thread::threadFactoryForTest();
+  for (auto _ : state) {
+    Envoy::Thread::ThreadFactory& thread_factory = Envoy::Thread::threadFactoryForTest();
 
-  // Make 100 threads, each of which will race to encode an overlapping set of
-  // symbols, triggering corner-cases in SymbolTable::toSymbol.
-  constexpr int num_threads = 36;
-  std::vector<Envoy::Thread::ThreadPtr> threads;
-  threads.reserve(num_threads);
-  Envoy::ConditionalInitializer access, wait;
-  absl::BlockingCounter accesses(num_threads);
-  Envoy::Stats::SymbolTableImpl table;
-  const absl::string_view stat_name_string = "here.is.a.stat.name";
-  Envoy::Stats::StatNameStorage initial(stat_name_string, table);
+    // Make 100 threads, each of which will race to encode an overlapping set of
+    // symbols, triggering corner-cases in SymbolTable::toSymbol.
+    constexpr int num_threads = 100;
+    std::vector<Envoy::Thread::ThreadPtr> threads;
+    threads.reserve(num_threads);
+    Envoy::ConditionalInitializer access, wait;
+    absl::BlockingCounter accesses(num_threads);
+    Envoy::Stats::SymbolTableImpl table;
+    const absl::string_view stat_name_string = "here.is.a.stat.name";
+    Envoy::Stats::StatNameStorage initial(stat_name_string, table);
 
-  for (int i = 0; i < num_threads; ++i) {
-    threads.push_back(
-        thread_factory.createThread([&access, &accesses, &state, &table, &stat_name_string]() {
-          // Block each thread on waking up a common condition variable,
-          // so we make it likely to race on access.
-          access.wait();
+    for (int i = 0; i < num_threads; ++i) {
+      threads.push_back(
+          thread_factory.createThread([&access, &accesses, &table, &stat_name_string]() {
+            // Block each thread on waking up a common condition variable,
+            // so we make it likely to race on access.
+            access.wait();
 
-          for (auto _ : state) {
-            Envoy::Stats::StatNameStorage second(stat_name_string, table);
-            second.free(table);
-          }
-          accesses.DecrementCount();
-        }));
+            for (int count = 0; count < 1000; ++count) {
+              Envoy::Stats::StatNameStorage second(stat_name_string, table);
+              second.free(table);
+            }
+            accesses.DecrementCount();
+          }));
+    }
+
+    // But when we access the already-existing symbols, we guarantee that no
+    // further mutex contentions occur.
+    access.setReady();
+    accesses.Wait();
+
+    for (auto& thread : threads) {
+      thread->join();
+    }
+
+    initial.free(table);
   }
-
-  // But when we access the already-existing symbols, we guarantee that no
-  // further mutex contentions occur.
-  access.setReady();
-  accesses.Wait();
-
-  for (auto& thread : threads) {
-    thread->join();
-  }
-
-  initial.free(table);
 }
-BENCHMARK(BM_CreateRace);
+BENCHMARK(BM_CreateRace)->Unit(::benchmark::kMillisecond);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_JoinStatNames(benchmark::State& state) {
@@ -89,15 +91,3 @@ static void BM_JoinElements(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_JoinElements);
-
-int main(int argc, char** argv) {
-  Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logger_context(spdlog::level::warn,
-                                        Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
-  benchmark::Initialize(&argc, argv);
-
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -16,8 +16,9 @@
 #include "benchmark/benchmark.h"
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-static void BM_CreateRace(benchmark::State& state) {
+static void bmCreateRace(benchmark::State& state) {
   for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
     Envoy::Thread::ThreadFactory& thread_factory = Envoy::Thread::threadFactoryForTest();
 
     // Make 100 threads, each of which will race to encode an overlapping set of
@@ -58,10 +59,10 @@ static void BM_CreateRace(benchmark::State& state) {
     initial.free(table);
   }
 }
-BENCHMARK(BM_CreateRace)->Unit(::benchmark::kMillisecond);
+BENCHMARK(bmCreateRace)->Unit(::benchmark::kMillisecond);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-static void BM_JoinStatNames(benchmark::State& state) {
+static void bmJoinStatNames(benchmark::State& state) {
   Envoy::Stats::SymbolTableImpl symbol_table;
   Envoy::Stats::IsolatedStoreImpl store(symbol_table);
   Envoy::Stats::StatNamePool pool(symbol_table);
@@ -71,13 +72,14 @@ static void BM_JoinStatNames(benchmark::State& state) {
   Envoy::Stats::StatName d = pool.add("d");
   Envoy::Stats::StatName e = pool.add("e");
   for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
     Envoy::Stats::Utility::counterFromStatNames(store, Envoy::Stats::makeStatNames(a, b, c, d, e));
   }
 }
-BENCHMARK(BM_JoinStatNames);
+BENCHMARK(bmJoinStatNames);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-static void BM_JoinElements(benchmark::State& state) {
+static void bmJoinElements(benchmark::State& state) {
   Envoy::Stats::SymbolTableImpl symbol_table;
   Envoy::Stats::IsolatedStoreImpl store(symbol_table);
   Envoy::Stats::StatNamePool pool(symbol_table);
@@ -86,8 +88,9 @@ static void BM_JoinElements(benchmark::State& state) {
   Envoy::Stats::StatName c = pool.add("c");
   Envoy::Stats::StatName e = pool.add("e");
   for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
     Envoy::Stats::Utility::counterFromElements(
         store, Envoy::Stats::makeElements(a, b, c, Envoy::Stats::DynamicName("d"), e));
   }
 }
-BENCHMARK(BM_JoinElements);
+BENCHMARK(bmJoinElements);


### PR DESCRIPTION
Risk Level: n/a test only (adding benchmarks)
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: