### PR TITLE
format: fix Times(1) nit.

### DIFF
--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1311,7 +1311,7 @@ typed_config:
   const InstanceSharedPtr log =
       AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
 
-  EXPECT_CALL(*file_, write(_)).Times(1);
+  EXPECT_CALL(*file_, write(_));
 
   log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
   fields_c["c"].set_bool_value(false);
@@ -1397,7 +1397,7 @@ typed_config:
 
   const InstanceSharedPtr default_true_log =
       AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(default_true_yaml), context_);
-  EXPECT_CALL(*file_, write(_)).Times(1);
+  EXPECT_CALL(*file_, write(_));
 
   default_true_log->log(&request_headers_, &response_headers_, &response_trailers_, stream_info);
 }

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -120,7 +120,7 @@ TEST_F(ConnPoolImplBaseTest, PrefetchOnDisconnect) {
   EXPECT_CALL(pool_, onPoolFailure).WillOnce(InvokeWithoutArgs([&]() -> void {
     pool_.newStream(context_);
   }));
-  EXPECT_CALL(pool_, instantiateActiveClient).Times(1);
+  EXPECT_CALL(pool_, instantiateActiveClient);
   clients_[0]->close();
   CHECK_STATE(0 /*active*/, 1 /*pending*/, 2 /*connecting capacity*/);
 
@@ -136,7 +136,7 @@ TEST_F(ConnPoolImplBaseTest, NoPrefetchIfUnhealthy) {
   EXPECT_EQ(host_->health(), Upstream::Host::Health::Unhealthy);
 
   // On new stream, create 1 connection.
-  EXPECT_CALL(pool_, instantiateActiveClient).Times(1);
+  EXPECT_CALL(pool_, instantiateActiveClient);
   auto cancelable = pool_.newStream(context_);
   CHECK_STATE(0 /*active*/, 1 /*pending*/, 1 /*connecting capacity*/);
 
@@ -153,7 +153,7 @@ TEST_F(ConnPoolImplBaseTest, NoPrefetchIfDegraded) {
   EXPECT_EQ(host_->health(), Upstream::Host::Health::Degraded);
 
   // On new stream, create 1 connection.
-  EXPECT_CALL(pool_, instantiateActiveClient).Times(1);
+  EXPECT_CALL(pool_, instantiateActiveClient);
   auto cancelable = pool_.newStream(context_);
 
   cancelable->cancel(ConnectionPool::CancelPolicy::CloseExcess);

--- a/test/common/event/file_event_impl_test.cc
+++ b/test/common/event/file_event_impl_test.cc
@@ -74,11 +74,11 @@ TEST_P(FileEventImplActivateTest, Activate) {
   Api::ApiPtr api = Api::createApiForTest();
   DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
   ReadyWatcher read_event;
-  EXPECT_CALL(read_event, ready()).Times(1);
+  EXPECT_CALL(read_event, ready());
   ReadyWatcher write_event;
-  EXPECT_CALL(write_event, ready()).Times(1);
+  EXPECT_CALL(write_event, ready());
   ReadyWatcher closed_event;
-  EXPECT_CALL(closed_event, ready()).Times(1);
+  EXPECT_CALL(closed_event, ready());
 
   const FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
@@ -231,9 +231,9 @@ TEST_P(FileEventImplActivateTest, SetEnableCancelsActivate) {
 #ifndef WIN32 // Libevent on Windows doesn't support edge trigger.
 TEST_F(FileEventImplTest, EdgeTrigger) {
   ReadyWatcher read_event;
-  EXPECT_CALL(read_event, ready()).Times(1);
+  EXPECT_CALL(read_event, ready());
   ReadyWatcher write_event;
-  EXPECT_CALL(write_event, ready()).Times(1);
+  EXPECT_CALL(write_event, ready());
 
   Event::FileEventPtr file_event = dispatcher_->createFileEvent(
       fds_[0],

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -56,7 +56,7 @@ public:
   }
 
   virtual void expectSuccess(AsyncClient::Request* sent_request, uint64_t code) {
-    EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+    EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
     EXPECT_CALL(callbacks_, onSuccess_(_, _))
         .WillOnce(Invoke([sent_request, code](const AsyncClient::Request& request,
                                               ResponseMessage* response) -> void {
@@ -545,7 +545,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
   // Finish request 2.
   ResponseHeaderMapPtr response_headers2(new TestResponseHeaderMapImpl{{":status", "503"}});
-  EXPECT_CALL(callbacks2, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks2, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks2, onSuccess_(_, _))
       .WillOnce(Invoke(
           [request2](const AsyncClient::Request& request, ResponseMessage* response) -> void {
@@ -564,7 +564,7 @@ TEST_F(AsyncClientImplTest, MultipleRequests) {
 
   // Finish request 3.
   ResponseHeaderMapPtr response_headers3(new TestResponseHeaderMapImpl{{":status", "500"}});
-  EXPECT_CALL(callbacks3, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks3, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks3, onSuccess_(_, _))
       .WillOnce(Invoke(
           [request3](const AsyncClient::Request& request, ResponseMessage* response) -> void {
@@ -912,7 +912,7 @@ TEST_F(AsyncClientImplTest, ResetAfterResponseStart) {
   auto* request = client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   EXPECT_NE(request, nullptr);
 
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks_, onFailure(_, _))
       .WillOnce(Invoke([sent_request = request](const AsyncClient::Request& request,
                                                 AsyncClient::FailureReason reason) {
@@ -955,7 +955,7 @@ TEST_F(AsyncClientImplTest, CancelRequest) {
   EXPECT_CALL(stream_encoder_, encodeHeaders(HeaderMapEqualRef(&message_->headers()), true));
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
 
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   AsyncClient::Request* request =
       client_.send(std::move(message_), callbacks_, AsyncClient::RequestOptions());
   request->cancel();
@@ -1028,7 +1028,7 @@ TEST_F(AsyncClientImplTest, DestroyWithActiveRequest) {
   EXPECT_NE(request, nullptr);
 
   EXPECT_CALL(stream_encoder_.stream_, resetStream(_));
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks_, onFailure(_, _))
       .WillOnce(Invoke([sent_request = request](const AsyncClient::Request& request,
                                                 AsyncClient::FailureReason reason) {
@@ -1058,7 +1058,7 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
   auto* request = client_.send(std::move(message_), callbacks_, options);
   EXPECT_NE(request, nullptr);
 
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks_, onFailure(_, _))
       .WillOnce(Invoke([sent_request = request](const AsyncClient::Request& request,
                                                 AsyncClient::FailureReason reason) {
@@ -1089,7 +1089,7 @@ TEST_F(AsyncClientImplTest, PoolFailure) {
         return nullptr;
       }));
 
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks_, onSuccess_(_, _))
       .WillOnce(Invoke([](const AsyncClient::Request& request, ResponseMessage* response) -> void {
         // The callback gets called before AsyncClient::send() completes, which means that we don't
@@ -1114,7 +1114,7 @@ TEST_F(AsyncClientImplTest, PoolFailureWithBody) {
         return nullptr;
       }));
 
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   EXPECT_CALL(callbacks_, onSuccess_(_, _))
       .WillOnce(Invoke([](const AsyncClient::Request& request, ResponseMessage* response) -> void {
         // The callback gets called before AsyncClient::send() completes, which means that we don't
@@ -1277,7 +1277,7 @@ TEST_F(AsyncClientImplTest, DisableTimer) {
   AsyncClient::Request* request =
       client_.send(std::move(message_), callbacks_,
                    AsyncClient::RequestOptions().setTimeout(std::chrono::milliseconds(200)));
-  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, onBeforeFinalizeUpstreamSpan(_, _));
   request->cancel();
 }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2644,7 +2644,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutCallbackDisarmsAndReturns408
   std::string response_body;
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
     Event::MockTimer* request_timer = setUpTimer();
-    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
+    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
     EXPECT_CALL(*request_timer, disableTimer()).Times(AtLeast(1));
 
     EXPECT_CALL(response_encoder_, encodeHeaders(_, false))
@@ -2672,8 +2672,8 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsNotDisarmedOnIncompleteReq
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
     Event::MockTimer* request_timer = setUpTimer();
-    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
-    EXPECT_CALL(*request_timer, disableTimer()).Times(1);
+    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
+    EXPECT_CALL(*request_timer, disableTimer());
 
     decoder_ = &conn_manager_->newStream(response_encoder_);
     RequestHeaderMapPtr headers{
@@ -2699,7 +2699,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnCompleteRequestW
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
     Event::MockTimer* request_timer = setUpTimer();
-    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
+    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
 
     decoder_ = &conn_manager_->newStream(response_encoder_);
     RequestHeaderMapPtr headers{
@@ -2725,7 +2725,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnCompleteRequestW
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     Event::MockTimer* request_timer = setUpTimer();
-    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
+    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
 
     decoder_ = &conn_manager_->newStream(response_encoder_);
     RequestHeaderMapPtr headers{
@@ -2752,7 +2752,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnCompleteRequestW
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance& data) -> Http::Status {
     Event::MockTimer* request_timer = setUpTimer();
-    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
+    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
     decoder_ = &conn_manager_->newStream(response_encoder_);
 
     RequestHeaderMapPtr headers{
@@ -2787,7 +2787,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnEncodeHeaders) {
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
     Event::MockTimer* request_timer = setUpTimer();
-    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
+    EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
 
     decoder_ = &conn_manager_->newStream(response_encoder_);
     RequestHeaderMapPtr headers{
@@ -2826,10 +2826,10 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutIsDisarmedOnConnectionTermin
 
   Buffer::OwnedImpl fake_input("1234");
 
-  EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _)).Times(1);
+  EXPECT_CALL(*request_timer, enableTimer(request_timeout_, _));
   conn_manager_->onData(fake_input, false); // kick off request
 
-  EXPECT_CALL(*request_timer, disableTimer()).Times(1);
+  EXPECT_CALL(*request_timer, disableTimer());
   EXPECT_EQ(0U, stats_.named_.downstream_rq_timeout_.value());
 
   expectOnDestroy();
@@ -2854,7 +2854,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestHeaderTimeoutDisarmedAfterHeaders) 
         RequestHeaderMapPtr headers{new TestRequestHeaderMapImpl{
             {":authority", "localhost:8080"}, {":path", "/"}, {":method", "GET"}}};
 
-        EXPECT_CALL(*request_header_timer, disableTimer).Times(1);
+        EXPECT_CALL(*request_header_timer, disableTimer);
         decoder_->decodeHeaders(std::move(headers), false);
         return Http::okStatus();
       });
@@ -2881,7 +2881,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestHeaderTimeoutCallbackDisarmsAndRetu
   Event::MockTimer* request_header_timer;
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
     request_header_timer = setUpTimer();
-    EXPECT_CALL(*request_header_timer, enableTimer(request_headers_timeout_, _)).Times(1);
+    EXPECT_CALL(*request_header_timer, enableTimer(request_headers_timeout_, _));
 
     conn_manager_->newStream(response_encoder_);
     EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, setTrackedObject(_)).Times(2);
@@ -2892,7 +2892,7 @@ TEST_F(HttpConnectionManagerImplTest, RequestHeaderTimeoutCallbackDisarmsAndRetu
   conn_manager_->onData(fake_input, false); // kick off request
 
   // The client took too long to send headers.
-  EXPECT_CALL(*request_header_timer, disableTimer).Times(1);
+  EXPECT_CALL(*request_header_timer, disableTimer);
   request_header_timer->invokeCallback();
 
   EXPECT_EQ(1U, stats_.named_.downstream_rq_header_timeout_.value());
@@ -2937,7 +2937,7 @@ TEST_F(HttpConnectionManagerImplTest, MaxStreamDurationCallbackResetStream) {
   Event::MockTimer* duration_timer = setUpTimer();
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
-    EXPECT_CALL(*duration_timer, enableTimer(max_stream_duration_.value(), _)).Times(1);
+    EXPECT_CALL(*duration_timer, enableTimer(max_stream_duration_.value(), _));
     conn_manager_->newStream(response_encoder_);
     return Http::okStatus();
   }));
@@ -3053,7 +3053,7 @@ TEST_F(HttpConnectionManagerImplTest, MaxStreamDurationCallbackNotCalledIfResetS
   Event::MockTimer* duration_timer = setUpTimer();
 
   EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
-    EXPECT_CALL(*duration_timer, enableTimer(max_stream_duration_.value(), _)).Times(1);
+    EXPECT_CALL(*duration_timer, enableTimer(max_stream_duration_.value(), _));
     conn_manager_->newStream(response_encoder_);
     return Http::okStatus();
   }));

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -892,8 +892,7 @@ TEST_F(ConnectionManagerUtilityTest, MutateResponseHeadersReturnXRequestId) {
                                            {"x-envoy-force-trace", "true"}};
 
   EXPECT_CALL(*request_id_extension_,
-              setInResponse(testing::Ref(response_headers), testing::Ref(request_headers)))
-      .Times(1);
+              setInResponse(testing::Ref(response_headers), testing::Ref(request_headers)));
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, &request_headers, config_, "");
   EXPECT_EQ("request-id", response_headers.get_("x-request-id"));
 }
@@ -917,8 +916,7 @@ TEST_F(ConnectionManagerUtilityTest, AlwaysMutateResponseHeadersReturnXRequestId
   TestRequestHeaderMapImpl request_headers{{"x-request-id", "request-id"}};
 
   EXPECT_CALL(*request_id_extension_,
-              setInResponse(testing::Ref(response_headers), testing::Ref(request_headers)))
-      .Times(1);
+              setInResponse(testing::Ref(response_headers), testing::Ref(request_headers)));
   ON_CALL(config_, alwaysSetRequestIdInResponse()).WillByDefault(Return(true));
   ConnectionManagerUtility::mutateResponseHeaders(response_headers, &request_headers, config_, "");
   EXPECT_EQ("request-id", response_headers.get_("x-request-id"));
@@ -1222,8 +1220,7 @@ TEST_F(ConnectionManagerUtilityTest, RandomSamplingWhenGlobalSet) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
   EXPECT_CALL(*request_id_extension_,
-              setTraceStatus(testing::Ref(request_headers), TraceStatus::Sampled))
-      .Times(1);
+              setTraceStatus(testing::Ref(request_headers), TraceStatus::Sampled));
   callMutateRequestHeaders(request_headers, Protocol::Http2);
 
   EXPECT_EQ(TraceStatus::Sampled, request_id_extension_->getTraceStatus(request_headers));
@@ -1242,8 +1239,7 @@ TEST_F(ConnectionManagerUtilityTest, SamplingWithoutRouteOverride) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
   EXPECT_CALL(*request_id_extension_,
-              setTraceStatus(testing::Ref(request_headers), TraceStatus::Sampled))
-      .Times(1);
+              setTraceStatus(testing::Ref(request_headers), TraceStatus::Sampled));
   callMutateRequestHeaders(request_headers, Protocol::Http2);
 
   EXPECT_EQ(TraceStatus::Sampled, request_id_extension_->getTraceStatus(request_headers));
@@ -1269,8 +1265,7 @@ TEST_F(ConnectionManagerUtilityTest, SamplingWithRouteOverride) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
   EXPECT_CALL(*request_id_extension_,
-              setTraceStatus(testing::Ref(request_headers), TraceStatus::NoTrace))
-      .Times(1);
+              setTraceStatus(testing::Ref(request_headers), TraceStatus::NoTrace));
   callMutateRequestHeaders(request_headers, Protocol::Http2);
 
   EXPECT_EQ(TraceStatus::NoTrace, request_id_extension_->getTraceStatus(request_headers));
@@ -1310,11 +1305,9 @@ TEST_F(ConnectionManagerUtilityTest, NoTraceWhenSamplingSetButGlobalNotSet) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
   EXPECT_CALL(*request_id_extension_,
-              setTraceStatus(testing::Ref(request_headers), TraceStatus::Sampled))
-      .Times(1);
+              setTraceStatus(testing::Ref(request_headers), TraceStatus::Sampled));
   EXPECT_CALL(*request_id_extension_,
-              setTraceStatus(testing::Ref(request_headers), TraceStatus::NoTrace))
-      .Times(1);
+              setTraceStatus(testing::Ref(request_headers), TraceStatus::NoTrace));
   callMutateRequestHeaders(request_headers, Protocol::Http2);
 
   EXPECT_EQ(TraceStatus::NoTrace, request_id_extension_->getTraceStatus(request_headers));
@@ -1334,8 +1327,7 @@ TEST_F(ConnectionManagerUtilityTest, ClientSamplingWhenGlobalSet) {
       {"x-client-trace-id", "f4dca0a9-12c7-4307-8002-969403baf480"},
       {"x-request-id", "125a4afb-6f55-44ba-ad80-413f09f48a28"}};
   EXPECT_CALL(*request_id_extension_,
-              setTraceStatus(testing::Ref(request_headers), TraceStatus::Client))
-      .Times(1);
+              setTraceStatus(testing::Ref(request_headers), TraceStatus::Client));
   callMutateRequestHeaders(request_headers, Protocol::Http2);
 
   EXPECT_EQ(TraceStatus::Client, request_id_extension_->getTraceStatus(request_headers));
@@ -1376,8 +1368,7 @@ TEST_F(ConnectionManagerUtilityTest, ForcedTracedWhenGlobalSet) {
       runtime_.snapshot_,
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(true));
-  EXPECT_CALL(*request_id_extension_, setTraceStatus(testing::Ref(headers), TraceStatus::Forced))
-      .Times(1);
+  EXPECT_CALL(*request_id_extension_, setTraceStatus(testing::Ref(headers), TraceStatus::Forced));
 
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true}),
             callMutateRequestHeaders(headers, Protocol::Http2));
@@ -1396,10 +1387,8 @@ TEST_F(ConnectionManagerUtilityTest, NoTraceWhenForcedTracedButGlobalNotSet) {
       runtime_.snapshot_,
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(false));
-  EXPECT_CALL(*request_id_extension_, setTraceStatus(testing::Ref(headers), TraceStatus::Forced))
-      .Times(1);
-  EXPECT_CALL(*request_id_extension_, setTraceStatus(testing::Ref(headers), TraceStatus::NoTrace))
-      .Times(1);
+  EXPECT_CALL(*request_id_extension_, setTraceStatus(testing::Ref(headers), TraceStatus::Forced));
+  EXPECT_CALL(*request_id_extension_, setTraceStatus(testing::Ref(headers), TraceStatus::NoTrace));
 
   EXPECT_EQ((MutateRequestRet{"10.0.0.1:0", true}),
             callMutateRequestHeaders(headers, Protocol::Http2));
@@ -1526,7 +1515,7 @@ TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestId) {
   ON_CALL(config_, preserveExternalRequestId()).WillByDefault(Return(true));
   TestRequestHeaderMapImpl headers{{"x-request-id", "my-request-id"},
                                    {"x-forwarded-for", "198.51.100.1"}};
-  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false)).Times(1);
+  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false));
   EXPECT_CALL(*request_id_extension_, set(_, true)).Times(0);
   EXPECT_EQ((MutateRequestRet{"134.2.2.11:0", false}),
             callMutateRequestHeaders(headers, Protocol::Http2));
@@ -1540,7 +1529,7 @@ TEST_F(ConnectionManagerUtilityTest, PreseverExternalRequestIdNoReqId) {
   ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
   ON_CALL(config_, preserveExternalRequestId()).WillByDefault(Return(true));
   TestRequestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.1"}};
-  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false)).Times(1);
+  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false));
   EXPECT_CALL(*request_id_extension_, set(_, true)).Times(0);
   EXPECT_EQ((MutateRequestRet{"134.2.2.11:0", false}),
             callMutateRequestHeaders(headers, Protocol::Http2));
@@ -1552,7 +1541,7 @@ TEST_F(ConnectionManagerUtilityTest, PreseverExternalRequestIdNoReqId) {
 TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestIdNoEdgeRequestKeepRequestId) {
   ON_CALL(config_, preserveExternalRequestId()).WillByDefault(Return(true));
   TestRequestHeaderMapImpl headers{{"x-request-id", "myReqId"}};
-  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false)).Times(1);
+  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false));
   EXPECT_CALL(*request_id_extension_, set(_, true)).Times(0);
   callMutateRequestHeaders(headers, Protocol::Http2);
   EXPECT_EQ("myReqId", headers.get_(Headers::get().RequestId));
@@ -1563,7 +1552,7 @@ TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestIdNoEdgeRequestKeepR
 TEST_F(ConnectionManagerUtilityTest, PreserveExternalRequestIdNoEdgeRequestGenerateNewRequestId) {
   ON_CALL(config_, preserveExternalRequestId()).WillByDefault(Return(true));
   TestRequestHeaderMapImpl headers;
-  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false)).Times(1);
+  EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false));
   EXPECT_CALL(*request_id_extension_, set(_, true)).Times(0);
   callMutateRequestHeaders(headers, Protocol::Http2);
   EXPECT_EQ(random_.uuid_, headers.get_(Headers::get().RequestId));
@@ -1579,7 +1568,7 @@ TEST_F(ConnectionManagerUtilityTest, NoPreserveExternalRequestIdEdgeRequestGener
     ON_CALL(config_, useRemoteAddress()).WillByDefault(Return(true));
     TestRequestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.1"},
                                      {"x-request-id", "my-request-id"}};
-    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), true)).Times(1);
+    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), true));
     EXPECT_CALL(*request_id_extension_, set(_, false)).Times(0);
     EXPECT_EQ((MutateRequestRet{"134.2.2.11:0", false}),
               callMutateRequestHeaders(headers, Protocol::Http2));
@@ -1589,7 +1578,7 @@ TEST_F(ConnectionManagerUtilityTest, NoPreserveExternalRequestIdEdgeRequestGener
   // with no request id
   {
     TestRequestHeaderMapImpl headers{{"x-forwarded-for", "198.51.100.1"}};
-    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), true)).Times(1);
+    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), true));
     EXPECT_CALL(*request_id_extension_, set(_, false)).Times(0);
     EXPECT_EQ((MutateRequestRet{"134.2.2.11:0", false}),
               callMutateRequestHeaders(headers, Protocol::Http2));
@@ -1604,7 +1593,7 @@ TEST_F(ConnectionManagerUtilityTest, NoPreserveExternalRequestIdNoEdgeRequest) {
   // with no request id
   {
     TestRequestHeaderMapImpl headers;
-    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false)).Times(1);
+    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false));
     EXPECT_CALL(*request_id_extension_, set(_, true)).Times(0);
     callMutateRequestHeaders(headers, Protocol::Http2);
     EXPECT_EQ(random_.uuid_, headers.get_(Headers::get().RequestId));
@@ -1613,7 +1602,7 @@ TEST_F(ConnectionManagerUtilityTest, NoPreserveExternalRequestIdNoEdgeRequest) {
   // with request id
   {
     TestRequestHeaderMapImpl headers{{"x-request-id", "my-request-id"}};
-    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false)).Times(1);
+    EXPECT_CALL(*request_id_extension_, set(testing::Ref(headers), false));
     EXPECT_CALL(*request_id_extension_, set(_, true)).Times(0);
     callMutateRequestHeaders(headers, Protocol::Http2);
     EXPECT_EQ("my-request-id", headers.get_(Headers::get().RequestId));

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -2628,7 +2628,7 @@ TEST_P(Http1ClientConnectionImplTest, ConnectResponseWithEarlyData) {
   // Send response headers and payload
   EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
   Buffer::OwnedImpl expected_data("12345abcd");
-  EXPECT_CALL(response_decoder, decodeData(BufferEqual(&expected_data), false)).Times(1);
+  EXPECT_CALL(response_decoder, decodeData(BufferEqual(&expected_data), false));
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\n\r\n12345abcd");
   auto status = codec_->dispatch(response);
   EXPECT_TRUE(status.ok());

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1793,7 +1793,7 @@ TEST_P(Http2CodecImplTest, LargeRequestHeadersInvokeResetStream) {
   HttpTestUtility::addDefaultHeaders(request_headers);
   std::string long_string = std::string(63 * 1024, 'q');
   request_headers.addCopy("big", long_string);
-  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(1);
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
 }
 
@@ -1836,7 +1836,7 @@ TEST_P(Http2CodecImplTest, HeaderNameWithUnderscoreAreRejectedByDefault) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   request_headers.addCopy("bad_header", "something");
-  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(1);
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
   EXPECT_EQ(
       1,
@@ -1887,7 +1887,7 @@ TEST_P(Http2CodecImplTest, ManyRequestHeadersInvokeResetStream) {
   for (int i = 0; i < 100; i++) {
     request_headers.addCopy(std::to_string(i), "");
   }
-  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(1);
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
 }
 
@@ -1956,7 +1956,7 @@ TEST_P(Http2CodecImplTest, LargeRequestHeadersOverDefaultCodecLibraryLimit) {
   std::string long_string = std::string(65 * 1024, 'q');
   request_headers.addCopy("big", long_string);
 
-  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _)).Times(1);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _));
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(0);
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, true).ok());
 }
@@ -1992,7 +1992,7 @@ TEST_P(Http2CodecImplTest, ManyLargeRequestHeadersUnderPerHeaderLimit) {
     request_headers.addCopy(std::to_string(i), long_string);
   }
 
-  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _)).Times(1);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _));
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(0);
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, true).ok());
 }
@@ -2010,7 +2010,7 @@ TEST_P(Http2CodecImplTest, LargeRequestHeadersAtMaxConfigurable) {
     request_headers.addCopy(std::to_string(i), long_string);
   }
 
-  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _)).Times(1);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, _));
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _)).Times(0);
   EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, true).ok());
 }
@@ -2233,7 +2233,7 @@ TEST_P(Http2CodecImplTest, ResponseDataFloodMitigationDisabled) {
   // +2 is to account for HEADERS and PING ACK, that is used to trigger mitigation
   EXPECT_CALL(server_connection_, write(_, _))
       .Times(CommonUtility::OptionsLimits::DEFAULT_MAX_OUTBOUND_FRAMES + 2);
-  EXPECT_CALL(response_decoder_, decodeHeaders_(_, false)).Times(1);
+  EXPECT_CALL(response_decoder_, decodeHeaders_(_, false));
   EXPECT_CALL(response_decoder_, decodeData(_, false))
       .Times(CommonUtility::OptionsLimits::DEFAULT_MAX_OUTBOUND_FRAMES);
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -139,7 +139,7 @@ public:
         EXPECT_CALL(*cluster_, perConnectionBufferLimitBytes())
             .Times(num_clients)
             .WillRepeatedly(Return(*buffer_limits));
-        EXPECT_CALL(*test_client.connection_, setBufferLimits(*buffer_limits)).Times(1);
+        EXPECT_CALL(*test_client.connection_, setBufferLimits(*buffer_limits));
       }
     }
     // Finally (for InSequence tests) set up createCodecClient and make sure the

--- a/test/common/http/request_id_extension_uuid_impl_test.cc
+++ b/test/common/http/request_id_extension_uuid_impl_test.cc
@@ -18,11 +18,11 @@ TEST(UUIDRequestIDExtensionTest, SetRequestID) {
   UUIDRequestIDExtension uuid_utils(random);
   TestRequestHeaderMapImpl request_headers;
 
-  EXPECT_CALL(random, uuid()).Times(1).WillOnce(Return("first-request-id"));
+  EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
   uuid_utils.set(request_headers, true);
   EXPECT_EQ("first-request-id", request_headers.get_(Headers::get().RequestId));
 
-  EXPECT_CALL(random, uuid()).Times(1).WillOnce(Return("second-request-id"));
+  EXPECT_CALL(random, uuid()).WillOnce(Return("second-request-id"));
   uuid_utils.set(request_headers, true);
   EXPECT_EQ("second-request-id", request_headers.get_(Headers::get().RequestId));
 }
@@ -32,7 +32,7 @@ TEST(UUIDRequestIDExtensionTest, EnsureRequestID) {
   UUIDRequestIDExtension uuid_utils(random);
   TestRequestHeaderMapImpl request_headers;
 
-  EXPECT_CALL(random, uuid()).Times(1).WillOnce(Return("first-request-id"));
+  EXPECT_CALL(random, uuid()).WillOnce(Return("first-request-id"));
   uuid_utils.set(request_headers, false);
   EXPECT_EQ("first-request-id", request_headers.get_(Headers::get().RequestId));
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1120,7 +1120,7 @@ TEST_P(ConnectionImplTest, WriteWithWatermarks) {
 
   // Clean up the connection. The close() (called via disconnect) will attempt to flush. The
   // call to write() will succeed, bringing the connection back under the low watermark.
-  EXPECT_CALL(client_callbacks_, onBelowWriteBufferLowWatermark()).Times(1);
+  EXPECT_CALL(client_callbacks_, onBelowWriteBufferLowWatermark());
 
   disconnect(true);
 }
@@ -1355,7 +1355,7 @@ TEST_P(ConnectionImplTest, FlushWriteCloseTest) {
   // reading and the connection should close gracefully via FIN.
 
   EXPECT_CALL(stats.delayed_close_timeouts_, inc()).Times(0);
-  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose)).Times(1);
+  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose));
   EXPECT_CALL(*client_read_filter, onData(BufferStringEqual("data"), false))
       .Times(1)
       .WillOnce(InvokeWithoutArgs([&]() -> FilterStatus {
@@ -1363,7 +1363,7 @@ TEST_P(ConnectionImplTest, FlushWriteCloseTest) {
         dispatcher_->exit();
         return FilterStatus::StopIteration;
       }));
-  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose)).Times(1);
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose));
   server_connection_->close(ConnectionCloseType::FlushWrite);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 }
@@ -1406,7 +1406,7 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayCloseTest) {
 
   // Client closes the connection so delayed close timer on the server conn should not fire.
   EXPECT_CALL(stats.delayed_close_timeouts_, inc()).Times(0);
-  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose)).Times(1);
+  EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::LocalClose));
   EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::RemoteClose))
       .Times(1)
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher_->exit(); }));
@@ -1446,8 +1446,8 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayCloseTimerTriggerTest) {
         return FilterStatus::StopIteration;
       }));
   server_connection_->close(ConnectionCloseType::FlushWriteAndDelay);
-  EXPECT_CALL(stats.delayed_close_timeouts_, inc()).Times(1);
-  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose)).Times(1);
+  EXPECT_CALL(stats.delayed_close_timeouts_, inc());
+  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose));
   EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose))
       .Times(1)
       .WillOnce(Invoke([&](Network::ConnectionEvent) -> void { dispatcher_->exit(); }));
@@ -1485,7 +1485,7 @@ TEST_P(ConnectionImplTest, FlushWriteAfterFlushWriteAndDelayWithPendingWrite) {
   // The socket close will happen as a result of the write flush and not due to the delayed close
   // timer triggering.
   EXPECT_CALL(stats.delayed_close_timeouts_, inc()).Times(0);
-  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose)).Times(1);
+  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose));
   EXPECT_CALL(*client_read_filter, onData(BufferStringEqual("Connection: Close"), false))
       .Times(1)
       .WillOnce(InvokeWithoutArgs([&]() -> FilterStatus {
@@ -1528,7 +1528,7 @@ TEST_P(ConnectionImplTest, FlushWriteAfterFlushWriteAndDelayWithoutPendingWrite)
 
   // The write buffer has been flushed and a delayed close timer has been set. The socket close
   // will happen as part of the close() since the timeout is no longer required.
-  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose)).Times(1);
+  EXPECT_CALL(server_callbacks_, onEvent(ConnectionEvent::LocalClose));
   server_connection_->close(ConnectionCloseType::FlushWrite);
   EXPECT_CALL(stats.delayed_close_timeouts_, inc()).Times(0);
   EXPECT_CALL(client_callbacks_, onEvent(ConnectionEvent::RemoteClose))
@@ -1607,7 +1607,7 @@ TEST_P(ConnectionImplTest, DelayedCloseTimerResetWithPendingWriteBufferFlushes) 
   Buffer::OwnedImpl data("data");
   server_connection->write(data, false);
 
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   server_connection->close(ConnectionCloseType::FlushWriteAndDelay);
 
   // The write ready event cb (ConnectionImpl::onWriteReady()) will reset the timer to its
@@ -1619,7 +1619,7 @@ TEST_P(ConnectionImplTest, DelayedCloseTimerResetWithPendingWriteBufferFlushes) 
         buffer.drain(bytes_drained);
         return IoResult{PostIoAction::KeepOpen, bytes_drained, false};
       }));
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   (*mocks.file_ready_cb_)(Event::FileReadyType::Write);
 
   EXPECT_CALL(*transport_socket, doWrite(BufferStringEqual("ata"), _))
@@ -1629,7 +1629,7 @@ TEST_P(ConnectionImplTest, DelayedCloseTimerResetWithPendingWriteBufferFlushes) 
         buffer.drain(buffer.length());
         return IoResult{PostIoAction::KeepOpen, bytes_drained, false};
       }));
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   (*mocks.file_ready_cb_)(Event::FileReadyType::Write);
 
   // Force the delayed close timeout to trigger so the connection is cleaned up.
@@ -1668,7 +1668,7 @@ TEST_P(ConnectionImplTest, IgnoreSpuriousFdWriteEventsDuringFlushWriteAndDelay) 
   Buffer::OwnedImpl data("data");
   server_connection->write(data, false);
 
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   server_connection->close(ConnectionCloseType::FlushWriteAndDelay);
 
   // The write ready event cb (ConnectionImpl::onWriteReady()) will reset the timer to its
@@ -1680,7 +1680,7 @@ TEST_P(ConnectionImplTest, IgnoreSpuriousFdWriteEventsDuringFlushWriteAndDelay) 
         buffer.drain(bytes_drained);
         return IoResult{PostIoAction::KeepOpen, bytes_drained, false};
       }));
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   (*mocks.file_ready_cb_)(Event::FileReadyType::Write);
 
   // Handle a write event and drain 0 bytes from the buffer. Verify that the timer is not reset.
@@ -1702,7 +1702,7 @@ TEST_P(ConnectionImplTest, IgnoreSpuriousFdWriteEventsDuringFlushWriteAndDelay) 
         EXPECT_EQ(server_connection->state(), Connection::State::Closing);
         return IoResult{PostIoAction::KeepOpen, bytes_drained, false};
       }));
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   (*mocks.file_ready_cb_)(Event::FileReadyType::Write);
 
   // Handle a write event after entering the half-closed state. Verify that the timer is not reset
@@ -1722,7 +1722,7 @@ TEST_P(ConnectionImplTest, IgnoreSpuriousFdWriteEventsDuringFlushWriteAndDelay) 
         EXPECT_EQ(server_connection->state(), Connection::State::Closing);
         return IoResult{PostIoAction::KeepOpen, 1, false};
       }));
-  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(timeout, _));
   (*mocks.file_ready_cb_)(Event::FileReadyType::Write);
 
   // Force the delayed close timeout to trigger so the connection is cleaned up.
@@ -1756,10 +1756,10 @@ TEST_P(ConnectionImplTest, DelayedCloseTimeoutDisableOnSocketClose) {
         return IoResult{PostIoAction::KeepOpen, buffer.length(), false};
       }));
   server_connection->write(data, false);
-  EXPECT_CALL(*mocks.timer_, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(_, _));
   // Enable the delayed close timer.
   server_connection->close(ConnectionCloseType::FlushWriteAndDelay);
-  EXPECT_CALL(*mocks.timer_, disableTimer()).Times(1);
+  EXPECT_CALL(*mocks.timer_, disableTimer());
   // This close() will call closeSocket(), which should disable the timer to avoid triggering it
   // after the connection's data structures have been reset.
   server_connection->close(ConnectionCloseType::NoFlush);
@@ -1797,9 +1797,9 @@ TEST_P(ConnectionImplTest, DelayedCloseTimeoutNullStats) {
       }));
   server_connection->write(data, false);
 
-  EXPECT_CALL(*mocks.timer_, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*mocks.timer_, enableTimer(_, _));
   server_connection->close(ConnectionCloseType::FlushWriteAndDelay);
-  EXPECT_CALL(*mocks.timer_, disableTimer()).Times(1);
+  EXPECT_CALL(*mocks.timer_, disableTimer());
   // The following close() will call closeSocket() and reset internal data structures such as
   // stats.
   server_connection->close(ConnectionCloseType::NoFlush);
@@ -2263,7 +2263,7 @@ TEST_F(MockTransportConnectionImplTest, ReadMultipleEndStream) {
   EXPECT_CALL(*transport_socket_, doRead(_))
       .Times(2)
       .WillRepeatedly(Return(IoResult{PostIoAction::KeepOpen, 0, true}));
-  EXPECT_CALL(*read_filter, onData(_, true)).Times(1);
+  EXPECT_CALL(*read_filter, onData(_, true));
   file_ready_cb_(Event::FileReadyType::Read);
   file_ready_cb_(Event::FileReadyType::Read);
 }

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -413,7 +413,7 @@ TEST_F(RdsRouteConfigSubscriptionTest, CreatesNoopInitManager) {
       rds, server_factory_context_, "stat_prefix", outer_init_manager_);
   RdsRouteConfigSubscription& subscription =
       (dynamic_cast<RdsRouteConfigProviderImpl*>(route_config_provider.get()))->subscription();
-  init_watcher_.expectReady().Times(1); // The parent_init_target_ will call once.
+  init_watcher_.expectReady(); // The parent_init_target_ will call once.
   outer_init_manager_.initialize(init_watcher_);
   std::unique_ptr<Init::ManagerImpl> noop_init_manager;
   std::unique_ptr<Cleanup> init_vhds;

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -287,7 +287,7 @@ public:
 
   void sendRequest(bool end_stream = true) {
     if (end_stream) {
-      EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_)).Times(1);
+      EXPECT_CALL(callbacks_.dispatcher_, createTimer_(_));
     }
     EXPECT_CALL(cm_.conn_pool_, newStream(_, _))
         .WillOnce(Invoke(
@@ -1865,7 +1865,7 @@ TEST_F(RouterTest, TimeoutBudgetHistogramStatDuringRetries) {
   test_time_.advanceTimeWait(std::chrono::milliseconds(100));
   EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(callbacks_, encodeData(_, true));
-  EXPECT_CALL(*router_.retry_state_, shouldRetryReset(_, _)).Times(1);
+  EXPECT_CALL(*router_.retry_state_, shouldRetryReset(_, _));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginTimeout, _));
   per_try_timeout_->invokeCallback();
@@ -3331,8 +3331,8 @@ TEST_F(RouterTest, HedgedPerTryTimeoutGlobalTimeout) {
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
 
   // Now trigger global timeout, expect everything to be reset
-  EXPECT_CALL(encoder1.stream_, resetStream(_)).Times(1);
-  EXPECT_CALL(encoder2.stream_, resetStream(_)).Times(1);
+  EXPECT_CALL(encoder1.stream_, resetStream(_));
+  EXPECT_CALL(encoder2.stream_, resetStream(_));
   EXPECT_CALL(
       cm_.conn_pool_.host_->outlier_detector_,
       putResult(Upstream::Outlier::Result::LocalOriginTimeout, absl::optional<uint64_t>(504)));
@@ -3367,8 +3367,7 @@ TEST_F(RouterTest, HedgingRetriesExhaustedBadResponse) {
           }));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess,
-                        absl::optional<uint64_t>(absl::nullopt)))
-      .Times(1);
+                        absl::optional<uint64_t>(absl::nullopt)));
   expectPerTryTimerCreate();
   expectResponseTimerCreate();
 
@@ -3401,8 +3400,7 @@ TEST_F(RouterTest, HedgingRetriesExhaustedBadResponse) {
           }));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess,
-                        absl::optional<uint64_t>(absl::nullopt)))
-      .Times(1);
+                        absl::optional<uint64_t>(absl::nullopt)));
   expectPerTryTimerCreate();
   router_.retry_state_->callback_();
   EXPECT_EQ(2U,
@@ -3458,8 +3456,7 @@ TEST_F(RouterTest, HedgingRetriesProceedAfterReset) {
           }));
   // First is reset
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _))
-      .Times(1);
+              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess,
                         absl::optional<uint64_t>(absl::nullopt)))
@@ -3547,8 +3544,7 @@ TEST_F(RouterTest, HedgingRetryImmediatelyReset) {
           }));
   EXPECT_CALL(cm_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess,
-                        absl::optional<uint64_t>(absl::nullopt)))
-      .Times(1);
+                        absl::optional<uint64_t>(absl::nullopt)));
 
   Http::TestRequestHeaderMapImpl headers{{"x-envoy-upstream-rq-per-try-timeout-ms", "5"}};
   HttpTestUtility::addDefaultHeaders(headers);
@@ -3558,7 +3554,7 @@ TEST_F(RouterTest, HedgingRetryImmediatelyReset) {
   expectPerTryTimerCreate();
   expectResponseTimerCreate();
   Buffer::OwnedImpl body("test body");
-  EXPECT_CALL(encoder, encodeData(_, _)).Times(1);
+  EXPECT_CALL(encoder, encodeData(_, _));
   Buffer::InstancePtr body_data(new Buffer::OwnedImpl("hello"));
   router_.retry_state_->expectHedgedPerTryTimeoutRetry();
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, router_.decodeData(*body_data, true));
@@ -3669,7 +3665,7 @@ TEST_F(RouterTest, RetryUpstreamReset) {
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, false);
   EXPECT_CALL(*router_.retry_state_, enabled()).WillOnce(Return(true));
-  EXPECT_CALL(callbacks_, addDecodedData(_, _)).Times(1);
+  EXPECT_CALL(callbacks_, addDecodedData(_, _));
   Buffer::OwnedImpl body("test body");
   router_.decodeData(body, true);
   EXPECT_EQ(1U,
@@ -4808,7 +4804,7 @@ TEST_F(RouterTest, CrossSchemeRedirectRejectedByPolicy) {
 
   redirect_headers_->setLocation("https://www.foo.com");
 
-  EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
+  EXPECT_CALL(callbacks_, decodingBuffer());
   EXPECT_CALL(callbacks_, recreateStream(_)).Times(0);
 
   response_decoder_->decodeHeaders(std::move(redirect_headers_), true);
@@ -4828,8 +4824,8 @@ TEST_F(RouterTest, InternalRedirectRejectedByPredicate) {
 
   auto mock_predicate = std::make_shared<NiceMock<MockInternalRedirectPredicate>>();
 
-  EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
-  EXPECT_CALL(callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(callbacks_, decodingBuffer());
+  EXPECT_CALL(callbacks_, clearRouteCache());
   EXPECT_CALL(callbacks_.route_->route_entry_.internal_redirect_policy_, predicates())
       .WillOnce(Return(std::vector<InternalRedirectPredicateSharedPtr>({mock_predicate})));
   EXPECT_CALL(*mock_predicate, acceptTargetRoute(_, _, _, _)).WillOnce(Return(false));
@@ -4855,9 +4851,9 @@ TEST_F(RouterTest, HttpInternalRedirectSucceeded) {
   default_request_headers_.setForwardedProto("http");
   sendRequest();
 
-  EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
-  EXPECT_CALL(callbacks_, clearRouteCache()).Times(1);
-  EXPECT_CALL(callbacks_, recreateStream(_)).Times(1).WillOnce(Return(true));
+  EXPECT_CALL(callbacks_, decodingBuffer());
+  EXPECT_CALL(callbacks_, clearRouteCache());
+  EXPECT_CALL(callbacks_, recreateStream(_)).WillOnce(Return(true));
   response_decoder_->decodeHeaders(std::move(redirect_headers_), false);
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("upstream_internal_redirect_succeeded_total")
@@ -4880,10 +4876,10 @@ TEST_F(RouterTest, HttpsInternalRedirectSucceeded) {
   sendRequest();
 
   redirect_headers_->setLocation("https://www.foo.com");
-  EXPECT_CALL(connection_, ssl()).Times(1).WillOnce(Return(ssl_connection));
-  EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
-  EXPECT_CALL(callbacks_, clearRouteCache()).Times(1);
-  EXPECT_CALL(callbacks_, recreateStream(_)).Times(1).WillOnce(Return(true));
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_connection));
+  EXPECT_CALL(callbacks_, decodingBuffer());
+  EXPECT_CALL(callbacks_, clearRouteCache());
+  EXPECT_CALL(callbacks_, recreateStream(_)).WillOnce(Return(true));
   response_decoder_->decodeHeaders(std::move(redirect_headers_), false);
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("upstream_internal_redirect_succeeded_total")
@@ -4901,13 +4897,13 @@ TEST_F(RouterTest, CrossSchemeRedirectAllowedByPolicy) {
   sendRequest();
 
   redirect_headers_->setLocation("http://www.foo.com");
-  EXPECT_CALL(connection_, ssl()).Times(1).WillOnce(Return(ssl_connection));
-  EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
+  EXPECT_CALL(connection_, ssl()).WillOnce(Return(ssl_connection));
+  EXPECT_CALL(callbacks_, decodingBuffer());
   EXPECT_CALL(callbacks_.route_->route_entry_.internal_redirect_policy_,
               isCrossSchemeRedirectAllowed())
       .WillOnce(Return(true));
-  EXPECT_CALL(callbacks_, clearRouteCache()).Times(1);
-  EXPECT_CALL(callbacks_, recreateStream(_)).Times(1).WillOnce(Return(true));
+  EXPECT_CALL(callbacks_, clearRouteCache());
+  EXPECT_CALL(callbacks_, recreateStream(_)).WillOnce(Return(true));
   response_decoder_->decodeHeaders(std::move(redirect_headers_), false);
   EXPECT_EQ(1U, cm_.thread_local_cluster_.cluster_.info_->stats_store_
                     .counter("upstream_internal_redirect_succeeded_total")
@@ -6466,7 +6462,7 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
   HttpTestUtility::addDefaultHeaders(headers);
   router_.decodeHeaders(headers, false);
   Buffer::OwnedImpl data("1234567890123");
-  EXPECT_CALL(*router_.retry_state_, enabled()).Times(1).WillOnce(Return(true));
+  EXPECT_CALL(*router_.retry_state_, enabled()).WillOnce(Return(true));
   EXPECT_CALL(*router_.retry_state_, shouldRetryHeaders(_, _)).Times(0);
   EXPECT_CALL(*router_.retry_state_, shouldRetryReset(_, _)).Times(0);
   // This will result in retry_state_ being deleted.

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -1063,7 +1063,7 @@ key:
 
   ScopeKeyPtr scope_key = getScopedRdsProvider()->config<ScopedConfigImpl>()->computeScopeKey(
       TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}});
-  EXPECT_CALL(event_dispatcher_, post(_)).Times(1);
+  EXPECT_CALL(event_dispatcher_, post(_));
   std::function<void(bool)> route_config_updated_cb = [](bool) {};
   getScopedRdsProvider()->onDemandRdsUpdate(std::move(scope_key), event_dispatcher_,
                                             std::move(route_config_updated_cb));
@@ -1135,8 +1135,8 @@ key:
             "foo_routes");
   ScopeKeyPtr scope_key = getScopedRdsProvider()->config<ScopedConfigImpl>()->computeScopeKey(
       TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-bar-key"}});
-  EXPECT_CALL(server_factory_context_.dispatcher_, post(_)).Times(1);
-  EXPECT_CALL(event_dispatcher_, post(_)).Times(1);
+  EXPECT_CALL(server_factory_context_.dispatcher_, post(_));
+  EXPECT_CALL(event_dispatcher_, post(_));
   std::function<void(bool)> route_config_updated_cb = [](bool) {};
   getScopedRdsProvider()->onDemandRdsUpdate(std::move(scope_key), event_dispatcher_,
                                             std::move(route_config_updated_cb));
@@ -1274,7 +1274,7 @@ key:
   pushRdsConfig({"foo_routes"}, "111");
   // Route table have been fetched, callbacks will be executed immediately.
   for (int i = 0; i < 5; i++) {
-    EXPECT_CALL(event_dispatcher_, post(_)).Times(1);
+    EXPECT_CALL(event_dispatcher_, post(_));
     ScopeKeyPtr scope_key = getScopedRdsProvider()->config<ScopedConfigImpl>()->computeScopeKey(
         TestRequestHeaderMapImpl{{"Addr", "x-foo-key;x-foo-key"}});
     std::function<void(bool)> route_config_updated_cb = [](bool) {};
@@ -1304,7 +1304,7 @@ TEST_F(ScopedRdsTest, DanglingSubscriptionOnDemandUpdate) {
                                             std::move(route_config_updated_cb));
   // Destroy the scoped_rds subscription by destroying its only config provider.
   provider_.reset();
-  EXPECT_CALL(event_dispatcher_, post(_)).Times(1);
+  EXPECT_CALL(event_dispatcher_, post(_));
   EXPECT_NO_THROW(temp_post_cb());
 }
 
@@ -1337,7 +1337,7 @@ key:
                                               std::move(route_config_updated_cb));
   }
   // After on demand request, push rds update, the callbacks will be executed.
-  EXPECT_CALL(event_dispatcher_, post(_)).Times(1);
+  EXPECT_CALL(event_dispatcher_, post(_));
   pushRdsConfig({"foo_routes"}, "111");
 
   ScopeKeyPtr scope_key = getScopedRdsProvider()->config<ScopedConfigImpl>()->computeScopeKey(
@@ -1345,7 +1345,7 @@ key:
   // Delete the scope route.
   EXPECT_NO_THROW(srds_subscription_->onConfigUpdate({}, "2"));
   EXPECT_EQ(0UL, all_scopes_.value());
-  EXPECT_CALL(event_dispatcher_, post(_)).Times(1);
+  EXPECT_CALL(event_dispatcher_, post(_));
   // Scope no longer exists after srds update.
   std::function<void(bool)> route_config_updated_cb = [](bool scope_exist) {
     EXPECT_FALSE(scope_exist);

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1135,7 +1135,7 @@ TEST_F(RtdsLoaderImplTest, MultipleRtdsLayers) {
       foo: bar
       baz: meh
   )EOF");
-  EXPECT_CALL(rtds_init_callback_, Call()).Times(1);
+  EXPECT_CALL(rtds_init_callback_, Call());
   doOnConfigUpdateVerifyNoThrow(runtime, 0);
 
   EXPECT_EQ("bar", loader_->snapshot().get("foo").value().get());
@@ -1181,7 +1181,7 @@ TEST_F(RtdsLoaderImplTest, BadConfigSource) {
   rtds_layer->set_name("some_resource");
   rtds_layer->mutable_rtds_config();
 
-  EXPECT_CALL(cm_, subscriptionFactory()).Times(1);
+  EXPECT_CALL(cm_, subscriptionFactory());
   LoaderImpl loader(dispatcher_, tls_, config, local_info_, store_, generator_, validation_visitor_,
                     *api_);
 

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -1168,8 +1168,7 @@ TEST_F(TcpProxyTest, ConnectAttemptsUpstreamLocalFailReentrant) {
   // cancellation call.
   EXPECT_CALL(*conn_pool_handles_.at(0), cancel(Tcp::ConnectionPool::CancelPolicy::CloseExcess))
       .Times(0);
-  EXPECT_CALL(*conn_pool_handles_.at(1), cancel(Tcp::ConnectionPool::CancelPolicy::CloseExcess))
-      .Times(1);
+  EXPECT_CALL(*conn_pool_handles_.at(1), cancel(Tcp::ConnectionPool::CancelPolicy::CloseExcess));
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1469,7 +1469,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
       .WillOnce(Return(std::make_pair(cluster1, nullptr)));
   EXPECT_CALL(*cluster1, initializePhase()).Times(0);
   EXPECT_CALL(*cluster1, initialize(_));
-  EXPECT_CALL(*callbacks, onClusterAddOrUpdate(_)).Times(1);
+  EXPECT_CALL(*callbacks, onClusterAddOrUpdate(_));
   EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(defaultStaticCluster("fake_cluster"), ""));
   checkStats(1 /*added*/, 0 /*modified*/, 0 /*removed*/, 0 /*active*/, 1 /*warming*/);
   EXPECT_EQ(1, cluster_manager_->warmingClusterCount());
@@ -1498,7 +1498,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
         // Test inline init.
         initialize_callback();
       }));
-  EXPECT_CALL(*callbacks, onClusterAddOrUpdate(_)).Times(1);
+  EXPECT_CALL(*callbacks, onClusterAddOrUpdate(_));
   EXPECT_TRUE(cluster_manager_->addOrUpdateCluster(update_cluster, ""));
 
   EXPECT_EQ(cluster2->info_, cluster_manager_->getThreadLocalCluster("fake_cluster")->info());
@@ -1527,7 +1527,7 @@ TEST_F(ClusterManagerImplTest, DynamicAddRemove) {
   // tcp connections.
   Http::ConnectionPool::Instance::DrainedCb drained_cb;
   Tcp::ConnectionPool::Instance::DrainedCb drained_cb2;
-  EXPECT_CALL(*callbacks, onClusterRemoval(_)).Times(1);
+  EXPECT_CALL(*callbacks, onClusterRemoval(_));
   EXPECT_CALL(*cp, addDrainedCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
   EXPECT_CALL(*cp2, addDrainedCallback(_)).WillOnce(SaveArg<0>(&drained_cb2));
   EXPECT_TRUE(cluster_manager_->removeCluster("fake_cluster"));
@@ -3036,7 +3036,7 @@ TEST_F(ClusterManagerImplTest, AddUpstreamFilters) {
   create(parseBootstrapFromV3Yaml(yaml));
   Network::MockClientConnection* connection = new NiceMock<Network::MockClientConnection>();
   EXPECT_CALL(*connection, addReadFilter(_)).Times(0);
-  EXPECT_CALL(*connection, addWriteFilter(_)).Times(1);
+  EXPECT_CALL(*connection, addWriteFilter(_));
   EXPECT_CALL(*connection, addFilter(_)).Times(0);
   EXPECT_CALL(factory_.tls_.dispatcher_, createClientConnection_(_, _, _, _))
       .WillOnce(Return(connection));

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -1791,7 +1791,7 @@ TEST_F(EdsAssignmentTimeoutTest, AssignmentTimeoutEnableDisable) {
       Protobuf::util::TimeUtil::SecondsToDuration(1));
 
   EXPECT_CALL(*interval_timer_, enableTimer(_, _)).Times(2); // Timer enabled twice.
-  EXPECT_CALL(*interval_timer_, disableTimer()).Times(1);    // Timer disabled once.
+  EXPECT_CALL(*interval_timer_, disableTimer());             // Timer disabled once.
   EXPECT_CALL(*interval_timer_, enabled()).Times(6);         // Includes calls by test.
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment_lease);
   // Check that the timer is enabled.

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -672,7 +672,7 @@ public:
 
 TEST_F(HttpHealthCheckerImplTest, Success) {
   setupNoServiceValidationHC();
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -848,7 +848,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessIntervalJitterPercent) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessWithSpurious100Continue) {
   setupNoServiceValidationHC();
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -876,7 +876,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessWithSpurious100Continue) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessWithSpuriousMetadata) {
   setupNoServiceValidationHC();
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -993,7 +993,7 @@ TEST_F(HttpHealthCheckerImplTest, ZeroRetryInterval) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1069,7 +1069,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1104,7 +1104,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServicePrefixPatternCheck) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1139,7 +1139,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceExactPatternCheck) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1174,7 +1174,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceRegexPatternCheck) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1218,7 +1218,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValueOnTheHos
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   cluster_->info_->stats().upstream_cx_total_.inc();
@@ -1263,7 +1263,7 @@ TEST_F(HttpHealthCheckerImplTest,
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {test_host};
   cluster_->info_->stats().upstream_cx_total_.inc();
@@ -1297,7 +1297,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithCustomHostValue) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1355,7 +1355,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAdditionalHeaders) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   auto metadata = TestUtility::parseYaml<envoy::config::core::v3::Metadata>(
       R"EOF(
         filter_metadata:
@@ -1418,7 +1418,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithoutUserAgent) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
   auto metadata = TestUtility::parseYaml<envoy::config::core::v3::Metadata>(
       R"EOF(
         filter_metadata:
@@ -1461,7 +1461,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceDoesNotMatchFail) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -1492,7 +1492,7 @@ TEST_F(HttpHealthCheckerImplTest, ServicePatternDoesNotMatchFail) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -1523,7 +1523,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceNotPresentInResponseFail) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -1552,7 +1552,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOff) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(false));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1578,7 +1578,7 @@ TEST_F(HttpHealthCheckerImplTest, ServiceCheckRuntimeOffWithStringPattern) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(false));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1609,7 +1609,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedFailFirstServiceCheck) {
 
 TEST_F(HttpHealthCheckerImplTest, SuccessNoTraffic) {
   setupNoServiceValidationHC();
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1659,7 +1659,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessStartFailedSuccessFirst) {
   health_checker_->start();
 
   // Test fast success immediately moves us to healthy.
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(event_logger_, logAddHealthy(_, _, true));
   EXPECT_CALL(runtime_.snapshot_, getInteger("health_check.max_interval", _)).WillOnce(Return(500));
   EXPECT_CALL(runtime_.snapshot_, getInteger("health_check.min_interval", _));
@@ -1837,7 +1837,7 @@ TEST_F(HttpHealthCheckerImplTest, HttpFailLogError) {
 TEST_F(HttpHealthCheckerImplTest, Disconnect) {
   setupNoServiceValidationHC();
   EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, true));
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -1973,14 +1973,14 @@ TEST_F(HttpHealthCheckerImplTest, TimeoutAfterDisconnect) {
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _)).Times(2);
   health_checker_->start();
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::ChangePending));
   EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_, _)).Times(2);
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
   for (auto& session : test_sessions_) {
     session->client_connection_->close(Network::ConnectionCloseType::NoFlush);
   }
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
   EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer());
 
@@ -2432,7 +2432,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheckWithAltPort) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   // Prepares a host with its designated health check port.
   const HostWithHealthCheckMap hosts{{"127.0.0.1:80", makeHealthCheckConfig(8000)}};
@@ -2738,7 +2738,7 @@ TEST_F(HttpHealthCheckerImplTest, DEPRECATED_FEATURE_TEST(ServiceNameMatch)) {
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Unchanged));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
@@ -2772,7 +2772,7 @@ TEST_F(HttpHealthCheckerImplTest, DEPRECATED_FEATURE_TEST(ServiceNameMismatch)) 
   EXPECT_CALL(runtime_.snapshot_, featureEnabled("health_check.verify_cluster", 100))
       .WillOnce(Return(true));
 
-  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(1);
+  EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed));
   EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _));
 
   cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
@@ -3154,7 +3154,7 @@ TEST_F(TcpHealthCheckerImplTest, DataWithoutReusingConnection) {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
   expectSessionCreate();
   expectClientCreate();
-  EXPECT_CALL(*connection_, write(_, _)).Times(1);
+  EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_, _));
   health_checker_->start();
 
@@ -3163,7 +3163,7 @@ TEST_F(TcpHealthCheckerImplTest, DataWithoutReusingConnection) {
   // Expected execution flow when a healthcheck is successful and reuse_connection is false.
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
-  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
 
   Buffer::OwnedImpl response;
   addUint8(response, 2);
@@ -3183,7 +3183,7 @@ TEST_F(TcpHealthCheckerImplTest, WrongData) {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
   expectSessionCreate();
   expectClientCreate();
-  EXPECT_CALL(*connection_, write(_, _)).Times(1);
+  EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_, _));
   health_checker_->start();
 
@@ -3366,7 +3366,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
       makeTestHost(cluster_->info_, "tcp://127.0.0.1:80", simTime())};
   expectSessionCreate();
   expectClientCreate();
-  EXPECT_CALL(*connection_, write(_, _)).Times(1);
+  EXPECT_CALL(*connection_, write(_, _));
   EXPECT_CALL(*timeout_timer_, enableTimer(_, _));
   health_checker_->start();
 
@@ -3375,7 +3375,7 @@ TEST_F(TcpHealthCheckerImplTest, TimeoutWithoutReusingConnection) {
   // Expected flow when a healthcheck is successful and reuse_connection is false.
   EXPECT_CALL(*timeout_timer_, disableTimer());
   EXPECT_CALL(*interval_timer_, enableTimer(_, _));
-  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  EXPECT_CALL(*connection_, close(Network::ConnectionCloseType::NoFlush));
 
   Buffer::OwnedImpl response;
   addUint8(response, 2);

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -190,9 +190,9 @@ TEST_F(GrpcAccessLoggerImplTest, WatermarksOverrun) {
 
   // Now allow the flush to happen. The stored log will get logged, and the next log will succeed.
   EXPECT_CALL(stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-  EXPECT_CALL(stream, sendMessageRaw_(_, _)).Times(1);
+  EXPECT_CALL(stream, sendMessageRaw_(_, _));
   EXPECT_CALL(stream, isAboveWriteBufferHighWatermark()).WillOnce(Return(false));
-  EXPECT_CALL(stream, sendMessageRaw_(_, _)).Times(1);
+  EXPECT_CALL(stream, sendMessageRaw_(_, _));
   logger_->log(envoy::data::accesslog::v3::HTTPAccessLogEntry(entry));
   EXPECT_EQ(
       2,

--- a/test/extensions/clusters/redis/redis_cluster_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_test.cc
@@ -474,7 +474,7 @@ protected:
     EXPECT_CALL(initialized_, ready());
     cluster_->initialize([&]() -> void { initialized_.ready(); });
 
-    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
     expectClusterSlotResponse(singleSlotPrimaryReplica("127.0.0.1", "127.0.0.2", 22120));
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
 
@@ -482,14 +482,14 @@ protected:
     expectRedisResolve();
     EXPECT_CALL(membership_updated_, ready());
     resolve_timer_->invokeCallback();
-    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
     expectClusterSlotResponse(twoSlotsPrimaries());
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
 
     // No change.
     expectRedisResolve();
     resolve_timer_->invokeCallback();
-    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).WillOnce(Return(false));
     expectClusterSlotResponse(twoSlotsPrimaries());
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
 
@@ -497,7 +497,7 @@ protected:
     expectRedisResolve();
     EXPECT_CALL(membership_updated_, ready());
     resolve_timer_->invokeCallback();
-    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
     expectClusterSlotResponse(twoSlotsPrimariesWithReplica());
     expectHealthyHosts(std::list<std::string>(
         {"127.0.0.1:22120", "127.0.0.3:22120", "127.0.0.2:22120", "127.0.0.4:22120"}));
@@ -505,7 +505,7 @@ protected:
     // No change.
     expectRedisResolve();
     resolve_timer_->invokeCallback();
-    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).WillOnce(Return(false));
     expectClusterSlotResponse(twoSlotsPrimariesWithReplica());
     expectHealthyHosts(std::list<std::string>(
         {"127.0.0.1:22120", "127.0.0.3:22120", "127.0.0.2:22120", "127.0.0.4:22120"}));
@@ -514,7 +514,7 @@ protected:
     expectRedisResolve();
     EXPECT_CALL(membership_updated_, ready());
     resolve_timer_->invokeCallback();
-    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+    EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
     expectClusterSlotResponse(singleSlotPrimaryReplica("127.0.0.1", "127.0.0.2", 22120));
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
   }
@@ -652,7 +652,7 @@ TEST_P(RedisDnsParamTest, ImmediateResolveDns) {
         std::list<std::string> address_pair = std::get<2>(GetParam());
         cb(Network::DnsResolver::ResolutionStatus::Success,
            TestUtility::makeDnsResponse(address_pair));
-        EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+        EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
         expectClusterSlotResponse(
             singleSlotPrimaryReplica(address_pair.front(), address_pair.back(), 22120));
         return nullptr;
@@ -764,7 +764,7 @@ TEST_F(RedisClusterTest, RedisResolveFailure) {
   resolve_timer_->invokeCallback();
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(initialized_, ready());
-  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
   expectClusterSlotResponse(singleSlotPrimaryReplica("127.0.0.1", "127.0.0.2", 22120));
   expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120", "127.0.0.2:22120"}));
 
@@ -836,7 +836,7 @@ TEST_F(RedisClusterTest, RedisErrorResponse) {
   resolve_timer_->invokeCallback();
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(initialized_, ready());
-  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
   std::bitset<ResponseFlagSize> single_slot_primary(0xfff);
   std::bitset<ResponseReplicaFlagSize> no_replica(0);
   expectClusterSlotResponse(createResponse(single_slot_primary, no_replica));
@@ -851,7 +851,7 @@ TEST_F(RedisClusterTest, RedisErrorResponse) {
     expectRedisResolve();
     resolve_timer_->invokeCallback();
     if (flags.all()) {
-      EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1).WillOnce(Return(false));
+      EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).WillOnce(Return(false));
     }
     expectClusterSlotResponse(createResponse(flags, no_replica));
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120"}));
@@ -872,7 +872,7 @@ TEST_F(RedisClusterTest, RedisReplicaErrorResponse) {
 
   EXPECT_CALL(membership_updated_, ready());
   EXPECT_CALL(initialized_, ready());
-  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
   std::bitset<ResponseFlagSize> single_slot_primary(0xfff);
   std::bitset<ResponseReplicaFlagSize> no_replica(0);
   expectClusterSlotResponse(createResponse(single_slot_primary, no_replica));
@@ -888,7 +888,7 @@ TEST_F(RedisClusterTest, RedisReplicaErrorResponse) {
     resolve_timer_->invokeCallback();
     if (replica_flags.all()) {
       EXPECT_CALL(membership_updated_, ready());
-      EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1).WillOnce(Return(false));
+      EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).WillOnce(Return(false));
     }
     expectHealthyHosts(std::list<std::string>({"127.0.0.1:22120"}));
     expectClusterSlotResponse(createResponse(single_slot_primary, replica_flags));
@@ -976,7 +976,7 @@ TEST_F(RedisClusterTest, HostRemovalAfterHcFail) {
   EXPECT_CALL(initialized_, ready());
   cluster_->initialize([&]() -> void { initialized_.ready(); });
 
-  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _)).Times(1);
+  EXPECT_CALL(*cluster_callback_, onClusterSlotUpdate(_, _));
   expectClusterSlotResponse(singleSlotPrimaryReplica("127.0.0.1", "127.0.0.2", 22120));
 
   // Verify that both hosts are initially marked with FAILED_ACTIVE_HC, then

--- a/test/extensions/common/aws/credentials_provider_impl_test.cc
+++ b/test/extensions/common/aws/credentials_provider_impl_test.cc
@@ -396,8 +396,8 @@ TEST(CredentialsProviderChainTest, getCredentials_noCredentials) {
   auto mock_provider1 = std::make_shared<MockCredentialsProvider>();
   auto mock_provider2 = std::make_shared<MockCredentialsProvider>();
 
-  EXPECT_CALL(*mock_provider1, getCredentials()).Times(1);
-  EXPECT_CALL(*mock_provider2, getCredentials()).Times(1);
+  EXPECT_CALL(*mock_provider1, getCredentials());
+  EXPECT_CALL(*mock_provider2, getCredentials());
 
   CredentialsProviderChain chain;
   chain.add(mock_provider1);
@@ -430,7 +430,7 @@ TEST(CredentialsProviderChainTest, getCredentials_secondProviderReturns) {
 
   const Credentials creds("access_key", "secret_key");
 
-  EXPECT_CALL(*mock_provider1, getCredentials()).Times(1);
+  EXPECT_CALL(*mock_provider1, getCredentials());
   EXPECT_CALL(*mock_provider2, getCredentials()).WillOnce(Return(creds));
 
   CredentialsProviderChain chain;

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -615,8 +615,8 @@ TEST_P(WasmCommonTest, WASI) {
   wasm->setCreateContextForTesting(
       nullptr, [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
         auto root_context = new TestContext(wasm, plugin);
-        EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("WASI write to stdout"))).Times(1);
-        EXPECT_CALL(*root_context, log_(spdlog::level::err, Eq("WASI write to stderr"))).Times(1);
+        EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("WASI write to stdout")));
+        EXPECT_CALL(*root_context, log_(spdlog::level::err, Eq("WASI write to stderr")));
         return root_context;
       });
   wasm->start(plugin);

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -39,11 +39,11 @@ public:
     EXPECT_CALL(connection_, remoteAddress()).WillOnce(ReturnRef(addr_));
     EXPECT_CALL(connection_, localAddress()).WillOnce(ReturnRef(addr_));
     EXPECT_CALL(Const(connection_), ssl()).Times(2).WillRepeatedly(Return(ssl_));
-    EXPECT_CALL(callbacks_, streamId()).Times(1).WillOnce(Return(0));
+    EXPECT_CALL(callbacks_, streamId()).WillOnce(Return(0));
     EXPECT_CALL(callbacks_, decodingBuffer()).WillOnce(Return(buffer_.get()));
-    EXPECT_CALL(callbacks_, streamInfo()).Times(1).WillOnce(ReturnRef(req_info_));
+    EXPECT_CALL(callbacks_, streamInfo()).WillOnce(ReturnRef(req_info_));
     EXPECT_CALL(req_info_, protocol()).Times(2).WillRepeatedly(ReturnPointee(&protocol_));
-    EXPECT_CALL(req_info_, startTime()).Times(1).WillOnce(Return(SystemTime()));
+    EXPECT_CALL(req_info_, startTime()).WillOnce(Return(SystemTime()));
   }
 
   void callHttpCheckAndValidateRequestAttributes(bool include_peer_certificate) {
@@ -259,7 +259,7 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeer) {
   EXPECT_CALL(Const(connection_), ssl()).WillRepeatedly(Return(ssl_));
   EXPECT_CALL(callbacks_, streamId()).WillRepeatedly(Return(0));
   EXPECT_CALL(callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));
-  EXPECT_CALL(callbacks_, decodingBuffer()).Times(1);
+  EXPECT_CALL(callbacks_, decodingBuffer());
   EXPECT_CALL(req_info_, protocol()).WillRepeatedly(ReturnPointee(&protocol_));
   EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
   EXPECT_CALL(*ssl_, uriSanLocalCertificate())

--- a/test/extensions/filters/common/rbac/engine_impl_test.cc
+++ b/test/extensions/filters/common/rbac/engine_impl_test.cc
@@ -413,7 +413,7 @@ TEST(RoleBasedAccessControlEngineImpl, ConjunctiveCondition) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   Envoy::Network::Address::InstanceConstSharedPtr addr =
       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
-  EXPECT_CALL(Const(info), downstreamLocalAddress()).Times(1).WillRepeatedly(ReturnRef(addr));
+  EXPECT_CALL(Const(info), downstreamLocalAddress()).WillOnce(ReturnRef(addr));
   checkEngine(engine, false, LogResult::Undecided, info, conn, headers);
 }
 

--- a/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/aws_request_signing_filter_test.cc
@@ -41,7 +41,7 @@ public:
 // Verify filter functionality when signing works.
 TEST_F(AwsRequestSigningFilterTest, SignSucceeds) {
   setup();
-  EXPECT_CALL(*(filter_config_->signer_), sign(_)).Times(1);
+  EXPECT_CALL(*(filter_config_->signer_), sign(_));
 
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
@@ -52,7 +52,7 @@ TEST_F(AwsRequestSigningFilterTest, SignSucceeds) {
 TEST_F(AwsRequestSigningFilterTest, SignWithHostRewrite) {
   setup();
   filter_config_->host_rewrite_ = "foo";
-  EXPECT_CALL(*(filter_config_->signer_), sign(_)).Times(1);
+  EXPECT_CALL(*(filter_config_->signer_), sign(_));
 
   Http::TestRequestHeaderMapImpl headers;
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));

--- a/test/extensions/filters/http/cache/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_test.cc
@@ -49,7 +49,7 @@ protected:
               Http::FilterHeadersStatus::StopAllIterationAndWatermark);
 
     // The filter should continue decoding when the cache lookup result (miss) is ready.
-    EXPECT_CALL(decoder_callbacks_, continueDecoding).Times(1);
+    EXPECT_CALL(decoder_callbacks_, continueDecoding);
 
     // The cache lookup callback should be posted to the dispatcher.
     // Run events on the dispatcher so that the callback is invoked.

--- a/test/extensions/filters/http/cdn_loop/filter_test.cc
+++ b/test/extensions/filters/http/cdn_loop/filter_test.cc
@@ -41,7 +41,7 @@ TEST(CdnLoopFilterTest, OtherCdnsInHeader) {
 
 TEST(CdnLoopFilterTest, LoopDetected) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _)).Times(1);
+  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _));
   CdnLoopFilter filter("cdn", 0);
   filter.setDecoderFilterCallbacks(decoder_callbacks);
 
@@ -52,7 +52,7 @@ TEST(CdnLoopFilterTest, LoopDetected) {
 
 TEST(CdnLoopFilterTest, MultipleTransitsAllowed) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _)).Times(1);
+  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadGateway, _, _, _, _));
   CdnLoopFilter filter("cdn", 3);
   filter.setDecoderFilterCallbacks(decoder_callbacks);
 
@@ -101,7 +101,7 @@ TEST(CdnLoopFilterTest, MultipleHeadersAllowed) {
 
 TEST(CdnLoopFilterTest, UnparseableHeader) {
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadRequest, _, _, _, _)).Times(1);
+  EXPECT_CALL(decoder_callbacks, sendLocalReply(Http::Code::BadRequest, _, _, _, _));
   CdnLoopFilter filter("cdn", 0);
   filter.setDecoderFilterCallbacks(decoder_callbacks);
 

--- a/test/extensions/filters/http/common/jwks_fetcher_test.cc
+++ b/test/extensions/filters/http/common/jwks_fetcher_test.cc
@@ -70,7 +70,7 @@ TEST_F(JwksFetcherTest, TestGetSuccess) {
   MockJwksReceiver receiver;
   std::unique_ptr<JwksFetcher> fetcher(JwksFetcher::create(mock_factory_ctx_.cluster_manager_));
   EXPECT_TRUE(fetcher != nullptr);
-  EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_)).Times(1);
+  EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_));
   EXPECT_CALL(receiver, onJwksError(testing::_)).Times(0);
 
   // Act
@@ -84,7 +84,7 @@ TEST_F(JwksFetcherTest, TestGet400) {
   std::unique_ptr<JwksFetcher> fetcher(JwksFetcher::create(mock_factory_ctx_.cluster_manager_));
   EXPECT_TRUE(fetcher != nullptr);
   EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_)).Times(0);
-  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network)).Times(1);
+  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network));
 
   // Act
   fetcher->fetch(uri_, parent_span_, receiver);
@@ -97,7 +97,7 @@ TEST_F(JwksFetcherTest, TestGetNoBody) {
   std::unique_ptr<JwksFetcher> fetcher(JwksFetcher::create(mock_factory_ctx_.cluster_manager_));
   EXPECT_TRUE(fetcher != nullptr);
   EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_)).Times(0);
-  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network)).Times(1);
+  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network));
 
   // Act
   fetcher->fetch(uri_, parent_span_, receiver);
@@ -110,7 +110,7 @@ TEST_F(JwksFetcherTest, TestGetInvalidJwks) {
   std::unique_ptr<JwksFetcher> fetcher(JwksFetcher::create(mock_factory_ctx_.cluster_manager_));
   EXPECT_TRUE(fetcher != nullptr);
   EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_)).Times(0);
-  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::InvalidJwks)).Times(1);
+  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::InvalidJwks));
 
   // Act
   fetcher->fetch(uri_, parent_span_, receiver);
@@ -124,7 +124,7 @@ TEST_F(JwksFetcherTest, TestHttpFailure) {
   std::unique_ptr<JwksFetcher> fetcher(JwksFetcher::create(mock_factory_ctx_.cluster_manager_));
   EXPECT_TRUE(fetcher != nullptr);
   EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_)).Times(0);
-  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network)).Times(1);
+  EXPECT_CALL(receiver, onJwksError(JwksFetcher::JwksReceiver::Failure::Network));
 
   // Act
   fetcher->fetch(uri_, parent_span_, receiver);
@@ -137,7 +137,7 @@ TEST_F(JwksFetcherTest, TestCancel) {
   MockJwksReceiver receiver;
   std::unique_ptr<JwksFetcher> fetcher(JwksFetcher::create(mock_factory_ctx_.cluster_manager_));
   EXPECT_TRUE(fetcher != nullptr);
-  EXPECT_CALL(request, cancel()).Times(1);
+  EXPECT_CALL(request, cancel());
   EXPECT_CALL(receiver, onJwksSuccessImpl(testing::_)).Times(0);
   EXPECT_CALL(receiver, onJwksError(testing::_)).Times(0);
 

--- a/test/extensions/filters/http/compressor/compressor_filter_test.cc
+++ b/test/extensions/filters/http/compressor/compressor_filter_test.cc
@@ -19,9 +19,9 @@ TEST(CompressorFilterConfigTests, MakeCompressorTest) {
   NiceMock<Runtime::MockLoader> runtime;
   Stats::TestUtil::TestStore stats;
   auto compressor_factory(std::make_unique<Compression::Compressor::MockCompressorFactory>());
-  EXPECT_CALL(*compressor_factory, createCompressor()).Times(1);
-  EXPECT_CALL(*compressor_factory, statsPrefix()).Times(1);
-  EXPECT_CALL(*compressor_factory, contentEncoding()).Times(1);
+  EXPECT_CALL(*compressor_factory, createCompressor());
+  EXPECT_CALL(*compressor_factory, statsPrefix());
+  EXPECT_CALL(*compressor_factory, contentEncoding());
   CompressorFilterConfig config(compressor_cfg, "test.compressor.", stats, runtime,
                                 std::move(compressor_factory));
   Envoy::Compression::Compressor::CompressorPtr compressor = config.makeCompressor();

--- a/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
+++ b/test/extensions/filters/http/dynamo/dynamo_filter_test.cc
@@ -635,11 +635,9 @@ TEST_F(DynamoFilterTest, PartitionIdStats) {
           Property(&Stats::Metric::name, "prefix.dynamodb.table.locations.upstream_rq_time"), _));
 
   EXPECT_CALL(stats_,
-              counter("prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_1"))
-      .Times(1);
+              counter("prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_1"));
   EXPECT_CALL(stats_,
-              counter("prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_2"))
-      .Times(1);
+              counter("prefix.dynamodb.table.locations.capacity.GetItem.__partition_id=ition_2"));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -812,12 +810,10 @@ TEST_F(DynamoFilterTest, PartitionIdStatsForSingleTableBatchOperation) {
 
   EXPECT_CALL(
       stats_,
-      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_1"))
-      .Times(1);
+      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_1"));
   EXPECT_CALL(
       stats_,
-      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_2"))
-      .Times(1);
+      counter("prefix.dynamodb.table.locations.capacity.BatchGetItem.__partition_id=ition_2"));
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -42,11 +42,11 @@ void expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion api_version) {
   EXPECT_CALL(context, getServerFactoryContext())
       .Times(1)
       .WillOnce(testing::ReturnRef(server_context));
-  EXPECT_CALL(server_context, singletonManager()).Times(1);
-  EXPECT_CALL(context, threadLocal()).Times(1);
-  EXPECT_CALL(context, messageValidationVisitor()).Times(1);
-  EXPECT_CALL(context, clusterManager()).Times(1);
-  EXPECT_CALL(context, runtime()).Times(1);
+  EXPECT_CALL(server_context, singletonManager());
+  EXPECT_CALL(context, threadLocal());
+  EXPECT_CALL(context, messageValidationVisitor());
+  EXPECT_CALL(context, clusterManager());
+  EXPECT_CALL(context, runtime());
   EXPECT_CALL(context, scope()).Times(2);
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
       .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
@@ -115,10 +115,10 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
   TestUtility::loadFromYaml(yaml, *proto_config);
   testing::StrictMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor()).Times(1);
-  EXPECT_CALL(context, clusterManager()).Times(1);
-  EXPECT_CALL(context, runtime()).Times(1);
-  EXPECT_CALL(context, scope()).Times(1);
+  EXPECT_CALL(context, messageValidationVisitor());
+  EXPECT_CALL(context, clusterManager());
+  EXPECT_CALL(context, runtime());
+  EXPECT_CALL(context, scope());
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   testing::StrictMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -199,7 +199,7 @@ TEST_F(HttpFilterTest, StatsWithPrefix) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_CALL(filter_callbacks_, continueDecoding()).Times(0);
-  EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _)).Times(1);
+  EXPECT_CALL(filter_callbacks_, encodeHeaders_(_, _));
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::Error;
@@ -399,7 +399,7 @@ TEST_F(HttpFilterTest, RequestDataIsTooLarge) {
   )EOF");
 
   ON_CALL(filter_callbacks_, connection()).WillByDefault(Return(&connection_));
-  EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_));
   EXPECT_CALL(connection_, remoteAddress()).Times(0);
   EXPECT_CALL(connection_, localAddress()).Times(0);
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
@@ -435,7 +435,7 @@ TEST_F(HttpFilterTest, RequestDataWithPartialMessage) {
   EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   EXPECT_CALL(connection_, remoteAddress()).WillOnce(ReturnRef(addr_));
   EXPECT_CALL(connection_, localAddress()).WillOnce(ReturnRef(addr_));
-  EXPECT_CALL(*client_, check(_, _, _, _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, _, _));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -533,7 +533,7 @@ TEST_F(HttpFilterTest, RequestDataWithSmallBuffer) {
   EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   EXPECT_CALL(connection_, remoteAddress()).WillOnce(ReturnRef(addr_));
   EXPECT_CALL(connection_, localAddress()).WillOnce(ReturnRef(addr_));
-  EXPECT_CALL(*client_, check(_, _, _, _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, _, _));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers_, false));
@@ -816,7 +816,7 @@ TEST_F(HttpFilterTest, ClearCache) {
           WithArgs<0>(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks) -> void {
             request_callbacks_ = &callbacks;
           })));
-  EXPECT_CALL(filter_callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(filter_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -861,7 +861,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAppendOnly) {
           WithArgs<0>(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks) -> void {
             request_callbacks_ = &callbacks;
           })));
-  EXPECT_CALL(filter_callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(filter_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -903,7 +903,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToAddOnly) {
           WithArgs<0>(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks) -> void {
             request_callbacks_ = &callbacks;
           })));
-  EXPECT_CALL(filter_callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(filter_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -945,7 +945,7 @@ TEST_F(HttpFilterTest, ClearCacheRouteHeadersToRemoveOnly) {
           WithArgs<0>(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks) -> void {
             request_callbacks_ = &callbacks;
           })));
-  EXPECT_CALL(filter_callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(filter_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -1192,7 +1192,7 @@ TEST_F(HttpFilterTest, FilterEnabled) {
       .WillByDefault(Return(true));
 
   // Make sure check is called once.
-  EXPECT_CALL(*client_, check(_, _, _, _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, _, _));
   // Engage the filter.
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
@@ -1259,7 +1259,7 @@ TEST_F(HttpFilterTest, MetadataEnabled) {
   prepareCheck();
 
   // Make sure check is called once.
-  EXPECT_CALL(*client_, check(_, _, _, _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, _, _));
   // Engage the filter.
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
@@ -1394,7 +1394,7 @@ TEST_F(HttpFilterTest, FilterEnabledAndMetadataEnabled) {
   prepareCheck();
 
   // Make sure check is called once.
-  EXPECT_CALL(*client_, check(_, _, _, _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, _, _));
   // Engage the filter.
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
@@ -1531,7 +1531,7 @@ TEST_P(HttpFilterTestParam, DisabledOnRoute) {
 
   // baseline: make sure that when not disabled, check is called
   test_disable(false);
-  EXPECT_CALL(*client_, check(_, _, testing::A<Tracing::Span&>(), _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, testing::A<Tracing::Span&>(), _));
   // Engage the filter.
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
@@ -1573,7 +1573,7 @@ TEST_P(HttpFilterTestParam, DisabledOnRouteWithRequestBody) {
   test_disable(false);
   ON_CALL(filter_callbacks_, connection()).WillByDefault(Return(&connection_));
   // When filter is not disabled, setDecoderBufferLimit is called.
-  EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_));
   EXPECT_CALL(connection_, remoteAddress()).Times(0);
   EXPECT_CALL(connection_, localAddress()).Times(0);
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
@@ -2076,7 +2076,7 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
   test_disable_request_body_buffering(false);
   ON_CALL(filter_callbacks_, connection()).WillByDefault(Return(&connection_));
   // When request body buffering is not skipped, setDecoderBufferLimit is called.
-  EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_));
   EXPECT_CALL(connection_, remoteAddress()).Times(0);
   EXPECT_CALL(connection_, localAddress()).Times(0);
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
@@ -2089,7 +2089,7 @@ TEST_P(HttpFilterTestParam, DisableRequestBodyBufferingOnRoute) {
   EXPECT_CALL(filter_callbacks_, setDecoderBufferLimit(_)).Times(0);
   EXPECT_CALL(connection_, remoteAddress()).WillOnce(ReturnRef(addr_));
   EXPECT_CALL(connection_, localAddress()).WillOnce(ReturnRef(addr_));
-  EXPECT_CALL(*client_, check(_, _, _, _)).Times(1);
+  EXPECT_CALL(*client_, check(_, _, _, _));
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -85,7 +85,7 @@ protected:
 
 TEST_F(ExtProcStreamTest, OpenCloseStream) {
   auto stream = client_->start(*this, 200ms);
-  EXPECT_CALL(stream_, closeStream()).Times(1);
+  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 
@@ -95,13 +95,13 @@ TEST_F(ExtProcStreamTest, SendToStream) {
   EXPECT_CALL(stream_, sendMessageRaw_(_, false));
   ProcessingRequest req;
   stream->send(std::move(req), false);
-  EXPECT_CALL(stream_, closeStream()).Times(1);
+  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 
 TEST_F(ExtProcStreamTest, SendAndClose) {
   auto stream = client_->start(*this, 200ms);
-  EXPECT_CALL(stream_, sendMessageRaw_(_, true)).Times(1);
+  EXPECT_CALL(stream_, sendMessageRaw_(_, true));
   ProcessingRequest req;
   stream->send(std::move(req), true);
 }
@@ -131,7 +131,7 @@ TEST_F(ExtProcStreamTest, ReceiveFromStream) {
   auto empty_response_trailers = Http::ResponseTrailerMapImpl::create();
   stream_callbacks_->onReceiveTrailingMetadata(std::move(empty_response_trailers));
 
-  EXPECT_CALL(stream_, closeStream()).Times(1);
+  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 
@@ -146,7 +146,7 @@ TEST_F(ExtProcStreamTest, StreamClosed) {
   EXPECT_TRUE(grpc_closed_);
   EXPECT_EQ(grpc_status_, 0);
 
-  EXPECT_CALL(stream_, closeStream()).Times(1);
+  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 
@@ -161,7 +161,7 @@ TEST_F(ExtProcStreamTest, StreamError) {
   EXPECT_FALSE(grpc_closed_);
   EXPECT_EQ(grpc_status_, 123);
 
-  EXPECT_CALL(stream_, closeStream()).Times(1);
+  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -37,7 +37,7 @@ TEST(HttpExtProcConfigTest, CorrectConfig) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::StrictMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor()).Times(1);
+  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -69,8 +69,8 @@ TEST_F(IpTaggingFilterTest, InternalRequest) {
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit"));
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total"));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ("internal_request", request_headers.get_(Http::Headers::get().EnvoyIpTags));
@@ -97,8 +97,8 @@ ip_tags:
   EXPECT_EQ(FilterRequestType::EXTERNAL, config_->requestType());
   Http::TestRequestHeaderMapImpl request_headers;
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit")).Times(1);
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total"));
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit"));
 
   Network::Address::InstanceConstSharedPtr remote_address =
       Network::Utility::parseInternetAddress("1.2.3.4");
@@ -135,8 +135,8 @@ ip_tags:
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
 
   EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(2);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit")).Times(1);
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit"));
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.external_request.hit"));
 
   Network::Address::InstanceConstSharedPtr remote_address =
       Network::Utility::parseInternetAddress("1.2.3.5");
@@ -163,8 +163,8 @@ TEST_F(IpTaggingFilterTest, NoHits) {
       Network::Utility::parseInternetAddress("10.2.3.5");
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.no_hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.no_hit"));
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total"));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_FALSE(request_headers.has(Http::Headers::get().EnvoyIpTags));
@@ -213,9 +213,9 @@ ip_tags:
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
 
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit")).Times(1);
-  EXPECT_CALL(stats_, counter("prefix.ip_tagging.duplicate_request.hit")).Times(1);
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.total"));
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.internal_request.hit"));
+  EXPECT_CALL(stats_, counter("prefix.ip_tagging.duplicate_request.hit"));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
@@ -276,7 +276,7 @@ TEST_F(IpTaggingFilterTest, ClearRouteCache) {
   EXPECT_CALL(filter_callbacks_.stream_info_, downstreamRemoteAddress())
       .WillOnce(ReturnRef(remote_address));
 
-  EXPECT_CALL(filter_callbacks_, clearRouteCache()).Times(1);
+  EXPECT_CALL(filter_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   EXPECT_EQ("internal_request", request_headers.get_(Http::Headers::get().EnvoyIpTags));
 

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -116,14 +116,14 @@ protected:
 };
 
 TEST_F(AllowFailedInSingleRequirementTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -131,7 +131,7 @@ TEST_F(AllowFailedInSingleRequirementTest, BadJwt) {
 }
 
 TEST_F(AllowFailedInSingleRequirementTest, MissingIssToken) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ES256WithoutIssToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -139,7 +139,7 @@ TEST_F(AllowFailedInSingleRequirementTest, MissingIssToken) {
 }
 
 TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -147,7 +147,7 @@ TEST_F(AllowFailedInSingleRequirementTest, OneGoodJwt) {
 }
 
 TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -157,7 +157,7 @@ TEST_F(AllowFailedInSingleRequirementTest, TwoGoodJwts) {
 }
 
 TEST_F(AllowFailedInSingleRequirementTest, GoodAndBadJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -182,14 +182,14 @@ requires_any:
 };
 
 TEST_F(SingleAllowMissingInOrListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(SingleAllowMissingInOrListTest, BadJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -197,7 +197,7 @@ TEST_F(SingleAllowMissingInOrListTest, BadJwt) {
 }
 
 TEST_F(SingleAllowMissingInOrListTest, MissingIssToken) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ES256WithoutIssToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -205,7 +205,7 @@ TEST_F(SingleAllowMissingInOrListTest, MissingIssToken) {
 }
 
 TEST_F(SingleAllowMissingInOrListTest, OneGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -213,7 +213,7 @@ TEST_F(SingleAllowMissingInOrListTest, OneGoodJwt) {
 }
 
 TEST_F(SingleAllowMissingInOrListTest, TwoGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -223,7 +223,7 @@ TEST_F(SingleAllowMissingInOrListTest, TwoGoodJwts) {
 }
 
 TEST_F(SingleAllowMissingInOrListTest, GoodAndBadJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -249,14 +249,14 @@ requires_any:
 };
 
 TEST_F(AllowFailedInOrListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInOrListTest, BadJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -264,7 +264,7 @@ TEST_F(AllowFailedInOrListTest, BadJwt) {
 }
 
 TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -274,7 +274,7 @@ TEST_F(AllowFailedInOrListTest, GoodAndBadJwt) {
 }
 
 TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -286,7 +286,7 @@ TEST_F(AllowFailedInOrListTest, TwoGoodJwts) {
 }
 
 TEST_F(AllowFailedInOrListTest, BadAndGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken},
                                                 {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -313,14 +313,14 @@ requires_all:
 };
 
 TEST_F(AllowFailedInAndListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInAndListTest, BadJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -328,7 +328,7 @@ TEST_F(AllowFailedInAndListTest, BadJwt) {
 }
 
 TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{
       {kExampleHeader, GoodToken},
   };
@@ -338,7 +338,7 @@ TEST_F(AllowFailedInAndListTest, OneGoodJwt) {
 }
 
 TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -349,7 +349,7 @@ TEST_F(AllowFailedInAndListTest, GoodAndBadJwts) {
 }
 
 TEST_F(AllowFailedInAndListTest, TwoGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -380,14 +380,14 @@ requires_all:
 };
 
 TEST_F(AllowFailedInAndOfOrListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
 }
 
 TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -395,7 +395,7 @@ TEST_F(AllowFailedInAndOfOrListTest, BadJwt) {
 }
 
 TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -403,7 +403,7 @@ TEST_F(AllowFailedInAndOfOrListTest, OneGoodJwt) {
 }
 
 TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -411,7 +411,7 @@ TEST_F(AllowFailedInAndOfOrListTest, OtherGoodJwt) {
 }
 
 TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken},
                                                 {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -421,7 +421,7 @@ TEST_F(AllowFailedInAndOfOrListTest, BadAndGoodJwt) {
 }
 
 TEST_F(AllowFailedInAndOfOrListTest, TwoGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -447,7 +447,7 @@ requires_any:
 };
 
 TEST_F(AllowMissingInOrListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -455,7 +455,7 @@ TEST_F(AllowMissingInOrListTest, NoJwt) {
 
 TEST_F(AllowMissingInOrListTest, BadJwt) {
   // Bad JWT should fail.
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -463,7 +463,7 @@ TEST_F(AllowMissingInOrListTest, BadJwt) {
 }
 
 TEST_F(AllowMissingInOrListTest, OtherGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -472,7 +472,7 @@ TEST_F(AllowMissingInOrListTest, OtherGoodJwt) {
 }
 
 TEST_F(AllowMissingInOrListTest, BadAndGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken},
                                                 {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -498,7 +498,7 @@ requires_all:
 };
 
 TEST_F(AllowMissingInAndListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -506,7 +506,7 @@ TEST_F(AllowMissingInAndListTest, NoJwt) {
 
 TEST_F(AllowMissingInAndListTest, BadJwt) {
   // Bad JWT should fail.
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -515,7 +515,7 @@ TEST_F(AllowMissingInAndListTest, BadJwt) {
 
 TEST_F(AllowMissingInAndListTest, GoodJwt) {
   // Bad JWT should fail.
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -524,7 +524,7 @@ TEST_F(AllowMissingInAndListTest, GoodJwt) {
 
 TEST_F(AllowMissingInAndListTest, TwoGoodJwts) {
   // Bad JWT should fail.
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -555,7 +555,7 @@ requires_all:
 };
 
 TEST_F(AllowMissingInAndOfOrListTest, NoJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -563,7 +563,7 @@ TEST_F(AllowMissingInAndOfOrListTest, NoJwt) {
 
 TEST_F(AllowMissingInAndOfOrListTest, BadJwt) {
   // Bad JWT should fail.
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtVerificationFail));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, NonExistKidToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -571,7 +571,7 @@ TEST_F(AllowMissingInAndOfOrListTest, BadJwt) {
 }
 
 TEST_F(AllowMissingInAndOfOrListTest, OneGoodJwt) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -579,7 +579,7 @@ TEST_F(AllowMissingInAndOfOrListTest, OneGoodJwt) {
 }
 
 TEST_F(AllowMissingInAndOfOrListTest, TwoGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -589,7 +589,7 @@ TEST_F(AllowMissingInAndOfOrListTest, TwoGoodJwts) {
 }
 
 TEST_F(AllowMissingInAndOfOrListTest, GoodAndBadJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   // Use the token with example.com issuer for x-other.
   auto headers =
       Http::TestRequestHeaderMapImpl{{kExampleHeader, GoodToken}, {kOtherHeader, GoodToken}};
@@ -600,7 +600,7 @@ TEST_F(AllowMissingInAndOfOrListTest, GoodAndBadJwts) {
 }
 
 TEST_F(AllowMissingInAndOfOrListTest, BadAndGoodJwts) {
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired));
   auto headers = Http::TestRequestHeaderMapImpl{{kExampleHeader, ExpiredToken},
                                                 {kOtherHeader, OtherGoodToken}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -204,7 +204,7 @@ TEST_F(AuthenticatorTest, TestMissedJWT) {
 
 // Test multiple tokens; the one from query parameter is bad, verification should fail.
 TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromQuery) {
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _));
 
   // headers with multiple tokens: one good, one bad
   Http::TestRequestHeaderMapImpl headers{
@@ -217,7 +217,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromQuery) {
 
 // Test multiple tokens; the one from header is bad, verification should fail.
 TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromHeader) {
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _));
 
   // headers with multiple tokens: one good, one bad
   Http::TestRequestHeaderMapImpl headers{
@@ -230,7 +230,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTOneBadFromHeader) {
 
 // Test multiple tokens; all are good, verification is ok.
 TEST_F(AuthenticatorTest, TestMultipleJWTAllGood) {
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _));
 
   // headers with multiple tokens: all are good
   Http::TestRequestHeaderMapImpl headers{
@@ -245,7 +245,7 @@ TEST_F(AuthenticatorTest, TestMultipleJWTAllGood) {
 TEST_F(AuthenticatorTest, TestMultipleJWTOneBadAllowFails) {
   createAuthenticator(nullptr, absl::make_optional<std::string>(ProviderName),
                       /*allow_failed=*/true, /*all_missing=*/false);
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _));
 
   // headers with multiple tokens: one good, one bad
   Http::TestRequestHeaderMapImpl headers{
@@ -382,10 +382,10 @@ TEST_F(AuthenticatorTest, TestPubkeyFetchFail) {
 // onComplete() callback should not be called, but internal request->cancel() should be called.
 // Most importantly, no crash.
 TEST_F(AuthenticatorTest, TestOnDestroy) {
-  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(1);
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _));
 
   // Cancel is called once.
-  EXPECT_CALL(*raw_fetcher_, cancel()).Times(1);
+  EXPECT_CALL(*raw_fetcher_, cancel());
 
   Http::TestRequestHeaderMapImpl headers{{"Authorization", "Bearer " + std::string(GoodToken)}};
   initTokenExtractor();

--- a/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/group_verifier_test.cc
@@ -91,7 +91,7 @@ public:
             }
             callback(status);
           }));
-      EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
+      EXPECT_CALL(*mock_auth, onDestroy());
       mock_auths_[it.first] = std::move(mock_auth);
     }
     createVerifier();
@@ -118,7 +118,7 @@ public:
                                                SetPayloadCallback, AuthenticatorCallback callback) {
             callbacks_[iss] = std::move(callback);
           }));
-      EXPECT_CALL(*mock_auth, onDestroy()).Times(1);
+      EXPECT_CALL(*mock_auth, onDestroy());
       mock_auths_[provider] = std::move(mock_auth);
     }
     createVerifier();
@@ -171,7 +171,7 @@ rules:
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload({"example_provider"})));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"sec-istio-auth-userinfo", ""},
   };
@@ -208,7 +208,7 @@ rules:
   mock_auths_["example_provider"] = std::move(mock_auth);
   createVerifier();
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -225,7 +225,7 @@ TEST_F(GroupVerifierTest, TestRequiresAll) {
         payload, getExpectedPayload({"example_provider", "other_provider"})));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -243,7 +243,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllBadFormat) {
 
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtBadFormat)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtBadFormat));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -266,7 +266,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllMissing) {
 
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -289,7 +289,7 @@ TEST_F(GroupVerifierTest, TestRequiresAllBothFailed) {
 
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -311,7 +311,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyFirstAuthOK) {
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload({"example_provider"})));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -332,7 +332,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyLastAuthOk) {
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload({"other_provider"})));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -353,7 +353,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyAllAuthFailed) {
 
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtHeaderBadKid)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtHeaderBadKid));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -377,7 +377,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyLastIsJwtMissed) {
 
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtHeaderBadKid)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtHeaderBadKid));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -398,7 +398,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyLastIsJwtUnknownIssuer) {
 
   // onComplete with failure status, not payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtHeaderBadKid)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtHeaderBadKid));
   auto headers = Http::TestRequestHeaderMapImpl{
       {"example-auth-userinfo", ""},
       {"other-auth-userinfo", ""},
@@ -419,7 +419,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllFirstAnyIsOk) {
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload({"provider_1", "provider_3"})));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -437,7 +437,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllLastAnyIsOk) {
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload({"provider_2", "provider_3"})));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -452,7 +452,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyIsOk) {
 
   // AsyncMockVerifier doesn't set payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -469,7 +469,7 @@ TEST_F(GroupVerifierTest, TestAnyInAllBothInRequireAnyFailed) {
       std::vector<std::string>{"provider_1", "provider_2", "provider_3"});
 
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwksFetchFail)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwksFetchFail));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -487,7 +487,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllFailed) {
       StatusMap{{"provider_1", Status::JwksFetchFail}, {"provider_3", Status::JwtExpired}});
 
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -502,7 +502,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyFirstAllIsOk) {
 
   // AsyncMockVerifier doesn't set payload
   EXPECT_CALL(mock_cb_, setPayload(_)).Times(0);
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -518,7 +518,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyLastAllIsOk) {
   createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"provider_1", "provider_2", "provider_3", "provider_4"});
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -534,7 +534,7 @@ TEST_F(GroupVerifierTest, TestAllInAnyBothRequireAllAreOk) {
   createAsyncMockAuthsAndVerifier(
       std::vector<std::string>{"provider_1", "provider_2", "provider_3", "provider_4"});
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
   verifier_->verify(context_);
@@ -554,7 +554,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowFailed) {
       ->mutable_allow_missing_or_failed();
 
   createAsyncMockAuthsAndVerifier(std::vector<std::string>{"example_provider", "other_provider"});
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
 
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -573,7 +573,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowMissingButFailed) {
       ->mutable_allow_missing();
 
   createAsyncMockAuthsAndVerifier(std::vector<std::string>{"example_provider", "other_provider"});
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtExpired));
 
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -592,7 +592,7 @@ TEST_F(GroupVerifierTest, TestRequiresAnyWithAllowMissingButOk) {
       ->mutable_allow_missing();
 
   createAsyncMockAuthsAndVerifier(std::vector<std::string>{"example_provider", "other_provider"});
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
 
   auto headers = Http::TestRequestHeaderMapImpl{};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -62,7 +62,7 @@ TEST_F(ProviderVerifierTest, TestOkJWT) {
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload("my_payload")));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
 
   auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
@@ -84,13 +84,13 @@ TEST_F(ProviderVerifierTest, TestSpanPassedDown) {
     EXPECT_TRUE(TestUtility::protoEqual(payload, getExpectedPayload("my_payload")));
   }));
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::Ok)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::Ok));
 
   auto options = Http::AsyncClient::RequestOptions()
                      .setTimeout(std::chrono::milliseconds(5 * 1000))
                      .setParentSpan(parent_span_)
                      .setChildSpanName("JWT Remote PubKey Fetch");
-  EXPECT_CALL(mock_factory_ctx_.cluster_manager_.async_client_, send_(_, _, Eq(options))).Times(1);
+  EXPECT_CALL(mock_factory_ctx_.cluster_manager_.async_client_, send_(_, _, Eq(options)));
 
   auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},
@@ -104,7 +104,7 @@ TEST_F(ProviderVerifierTest, TestMissedJWT) {
   TestUtility::loadFromYaml(ExampleConfig, proto_config_);
   createVerifier();
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtMissed));
 
   auto headers = Http::TestRequestHeaderMapImpl{{"sec-istio-auth-userinfo", ""}};
   context_ = Verifier::createContext(headers, parent_span_, &mock_cb_);
@@ -139,7 +139,7 @@ rules:
   TestUtility::loadFromYaml(config, proto_config_);
   createVerifier();
 
-  EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer)).Times(1);
+  EXPECT_CALL(mock_cb_, onComplete(Status::JwtUnknownIssuer));
 
   auto headers = Http::TestRequestHeaderMapImpl{
       {"Authorization", "Bearer " + std::string(GoodToken)},

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -59,7 +59,7 @@ response_headers_to_add:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(1);
+  EXPECT_CALL(context.dispatcher_, createTimer_(_));
   const auto route_config = factory.createRouteSpecificFilterConfig(
       *proto_config, context, ProtobufMessage::getNullValidationVisitor());
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
@@ -81,7 +81,7 @@ token_bucket:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(1);
+  EXPECT_CALL(context.dispatcher_, createTimer_(_));
   const auto route_config = factory.createRouteSpecificFilterConfig(
       *proto_config, context, ProtobufMessage::getNullValidationVisitor());
   const auto* config = dynamic_cast<const FilterConfig*>(route_config.get());
@@ -119,7 +119,7 @@ token_bucket:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  EXPECT_CALL(context.dispatcher_, createTimer_(_)).Times(1);
+  EXPECT_CALL(context.dispatcher_, createTimer_(_));
   EXPECT_THROW(factory.createRouteSpecificFilterConfig(*proto_config, context,
                                                        ProtobufMessage::getNullValidationVisitor()),
                EnvoyException);

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -106,7 +106,7 @@ public:
   void setupSecureConnection(const bool secure) {
     ssl_ = std::make_shared<NiceMock<Envoy::Ssl::MockConnectionInfo>>();
     EXPECT_CALL(decoder_callbacks_, connection()).WillOnce(Return(&connection_));
-    EXPECT_CALL(Const(connection_), ssl()).Times(1).WillOnce(Return(secure ? ssl_ : nullptr));
+    EXPECT_CALL(Const(connection_), ssl()).WillOnce(Return(secure ? ssl_ : nullptr));
   }
 
   void setupMetadata(const std::string& yaml) {

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -204,7 +204,7 @@ TEST_F(OAuth2Test, OAuthOkPass) {
   };
 
   // cookie-validation mocking
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   // Sanitized return reference mocking
@@ -250,7 +250,7 @@ TEST_F(OAuth2Test, OAuthErrorNonOAuthHttpCallback) {
   };
 
   // explicitly tell the validator to fail the validation
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
@@ -275,7 +275,7 @@ TEST_F(OAuth2Test, OAuthErrorQueryString) {
       {Http::Headers::get().ContentType.get(), "text/plain"},
   };
 
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
@@ -303,7 +303,7 @@ TEST_F(OAuth2Test, OAuthCallbackStartsAuthentication) {
   };
 
   // Deliberately fail the HMAC Validation check.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   EXPECT_CALL(*oauth_client_, asyncGetAccessToken("123", TEST_CLIENT_ID, "asdf_client_secret_fdsa",
@@ -327,7 +327,7 @@ TEST_F(OAuth2Test, OAuthOptionsRequestAndContinue) {
       {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Options},
   };
 
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 }
@@ -414,7 +414,7 @@ TEST_F(OAuth2Test, OAuthTestInvalidUrlInStateQueryParam) {
   };
 
   // Succeed the HMAC validation.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   std::string legit_token{"legit_token"};
@@ -447,7 +447,7 @@ TEST_F(OAuth2Test, OAuthTestCallbackUrlInStateQueryParam) {
   };
 
   // Succeed the HMAC validation.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   std::string legit_token{"legit_token"};
@@ -502,7 +502,7 @@ TEST_F(OAuth2Test, OAuthTestUpdatePathAfterSuccess) {
   };
 
   // Succeed the HMAC validation.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
 
   std::string legit_token{"legit_token"};
@@ -557,7 +557,7 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
   };
 
   // Fail the validation to trigger the OAuth flow.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   // Check that the redirect includes the escaped parameter characters, '?', '&' and '='.
@@ -577,7 +577,7 @@ TEST_F(OAuth2Test, OAuthTestFullFlowPostWithParameters) {
   };
 
   // Deliberately fail the HMAC validation check.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   EXPECT_CALL(*oauth_client_, asyncGetAccessToken("123", TEST_CLIENT_ID, "asdf_client_secret_fdsa",
@@ -629,7 +629,7 @@ TEST_F(OAuth2Test, OAuthBearerTokenFlowFromHeader) {
   };
 
   // Fail the validation to trigger the OAuth flow.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
@@ -655,7 +655,7 @@ TEST_F(OAuth2Test, OAuthBearerTokenFlowFromQueryParameters) {
   };
 
   // Fail the validation to trigger the OAuth flow.
-  EXPECT_CALL(*validator_, setParams(_, _)).Times(1);
+  EXPECT_CALL(*validator_, setParams(_, _));
   EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -167,8 +167,8 @@ TEST_F(HttpRateLimitFilterTest, NoApplicableRateLimit) {
 TEST_F(HttpRateLimitFilterTest, NoDescriptor) {
   SetUpTest(filter_config_);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(1);
-  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _)).Times(1);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _));
+  EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _));
   EXPECT_CALL(*client_, limit(_, _, _, _, _)).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
@@ -199,15 +199,13 @@ TEST_F(HttpRateLimitFilterTest, OkResponse) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(*client_, limit(_, "foo",
                               testing::ContainerEq(std::vector<RateLimit::Descriptor>{
@@ -246,15 +244,13 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithHeaders) {
   SetUpTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(*client_, limit(_, "foo",
                               testing::ContainerEq(std::vector<RateLimit::Descriptor>{
@@ -304,15 +300,13 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithFilterHeaders) {
   SetUpTest(enable_x_ratelimit_headers_config_);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(*client_, limit(_, "foo",
                               testing::ContainerEq(std::vector<RateLimit::Descriptor>{
@@ -830,15 +824,13 @@ TEST_F(HttpRateLimitFilterTest, InternalRequestType) {
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(*client_, limit(_, "foo",
                               testing::ContainerEq(std::vector<RateLimit::Descriptor>{
@@ -876,15 +868,13 @@ TEST_F(HttpRateLimitFilterTest, ExternalRequestType) {
   Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "false"}};
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(*client_, limit(_, "foo",
                               testing::ContainerEq(std::vector<RateLimit::Descriptor>{
@@ -1037,8 +1027,7 @@ TEST_F(HttpRateLimitFilterTest, OverrideVHRateLimitOptionWithoutRouteRateLimit) 
       .WillOnce(Return(true));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));
@@ -1086,8 +1075,7 @@ TEST_F(HttpRateLimitFilterTest, IncludeVHRateLimitOptionWithOnlyVHRateLimitSet) 
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_two_));
@@ -1137,8 +1125,7 @@ TEST_F(HttpRateLimitFilterTest, IncludeVHRateLimitOptionWithRouteAndVHRateLimitS
       .WillOnce(Return(&per_route_config_));
 
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.virtual_host_.rate_limit_policy_,
-              getApplicableRateLimit(0))
-      .Times(1);
+              getApplicableRateLimit(0));
 
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_two_));

--- a/test/extensions/filters/http/router/config_test.cc
+++ b/test/extensions/filters/http/router/config_test.cc
@@ -79,7 +79,7 @@ TEST(RouterFilterConfigTest, RouterV2Filter) {
   RouterFilterConfig factory;
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(router_config, "stats.", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_)).Times(1);
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
 }
 
@@ -89,7 +89,7 @@ TEST(RouterFilterConfigTest, RouterFilterWithEmptyProtoConfig) {
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats.", context);
   Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_)).Times(1);
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
 }
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -367,17 +367,16 @@ TEST_P(WasmHttpFilterTest, BodyRequestBufferBody) {
 
   Buffer::OwnedImpl data1("hello");
   bufferedBody.add(data1);
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello")))).Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello"))));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter().decodeData(data1, false));
 
   Buffer::OwnedImpl data2(" again ");
   bufferedBody.add(data2);
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello again "))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello again "))));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter().decodeData(data2, false));
 
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello again hello"))))
-      .Times(1);
+  EXPECT_CALL(filter(),
+              log_(spdlog::level::err, Eq(absl::string_view("onBody hello again hello"))));
   Buffer::OwnedImpl data3("hello");
   bufferedBody.add(data3);
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data3, true));
@@ -452,33 +451,29 @@ TEST_P(WasmHttpFilterTest, BodyRequestBufferThenStreamBody) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().encodeHeaders(response_headers, false));
 
   Buffer::OwnedImpl data1("hello");
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello")))).Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello"))));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter().decodeData(data1, false));
   bufferedBody.add(data1);
 
   Buffer::OwnedImpl data2(", there, ");
   bufferedBody.add(data2);
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, "))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, "))));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter().decodeData(data2, false));
 
   // Previous callbacks returned "Buffer" so we have buffered so far
   Buffer::OwnedImpl data3("world!");
   bufferedBody.add(data3);
   EXPECT_CALL(filter(),
-              log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, world!"))))
-      .Times(1);
+              log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, world!"))));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data3, false));
 
   // Last callback returned "continue" so we just see individual chunks.
   Buffer::OwnedImpl data4("So it's ");
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody So it's "))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody So it's "))));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data4, false));
 
   Buffer::OwnedImpl data5("goodbye, then!");
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody goodbye, then!"))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody goodbye, then!"))));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data5, true));
 
   filter().onDestroy();
@@ -501,33 +496,29 @@ TEST_P(WasmHttpFilterTest, BodyResponseBufferThenStreamBody) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().encodeHeaders(response_headers, false));
 
   Buffer::OwnedImpl data1("hello");
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello")))).Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello"))));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter().encodeData(data1, false));
   bufferedBody.add(data1);
 
   Buffer::OwnedImpl data2(", there, ");
   bufferedBody.add(data2);
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, "))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, "))));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter().encodeData(data2, false));
 
   // Previous callbacks returned "Buffer" so we have buffered so far
   Buffer::OwnedImpl data3("world!");
   bufferedBody.add(data3);
   EXPECT_CALL(filter(),
-              log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, world!"))))
-      .Times(1);
+              log_(spdlog::level::err, Eq(absl::string_view("onBody hello, there, world!"))));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data3, false));
 
   // Last callback returned "continue" so we just see individual chunks.
   Buffer::OwnedImpl data4("So it's ");
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody So it's "))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody So it's "))));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data4, false));
 
   Buffer::OwnedImpl data5("goodbye, then!");
-  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody goodbye, then!"))))
-      .Times(1);
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody goodbye, then!"))));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data5, true));
 
   filter().onDestroy();

--- a/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
@@ -29,7 +29,7 @@ TEST(HttpInspectorConfigFactoryTest, TestCreateFactory) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   Server::Configuration::MockListenerFactoryContext context;
-  EXPECT_CALL(context, scope()).Times(1);
+  EXPECT_CALL(context, scope());
   Network::ListenerFilterFactoryCb cb =
       factory->createListenerFilterFactoryFromProto(*proto_config, nullptr, context);
 

--- a/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_test.cc
@@ -86,7 +86,7 @@ TEST_F(HttpInspectorTest, InlineReadIoError) {
       }));
   EXPECT_CALL(dispatcher_, createFileEvent_(_, _, _, _)).Times(0);
   EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
-  EXPECT_CALL(socket_, close()).Times(1);
+  EXPECT_CALL(socket_, close());
   auto accepted = filter_->onAccept(cb_);
   EXPECT_EQ(accepted, Network::FilterStatus::StopIteration);
   // It's arguable if io error should bump the not_found counter

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -1460,8 +1460,8 @@ TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   Server::Configuration::MockListenerFactoryContext context;
-  EXPECT_CALL(context, scope()).Times(1);
-  EXPECT_CALL(context, messageValidationVisitor()).Times(1);
+  EXPECT_CALL(context, scope());
+  EXPECT_CALL(context, messageValidationVisitor());
   Network::ListenerFilterFactoryCb cb =
       factory->createListenerFilterFactoryFromProto(*proto_config, nullptr, context);
 

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -446,7 +446,7 @@ TEST_F(ConnectionManagerTest, OnDataHandlesProtocolErrorOnWrite) {
 
   callbacks->startUpstreamResponse();
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_NE(DubboFilters::UpstreamResponseStatus::Complete, callbacks->upstreamData(write_buffer_));
   EXPECT_EQ(1U, store_.counter("test.response_decoding_error").value());
 
@@ -506,7 +506,7 @@ TEST_F(ConnectionManagerTest, OnWriteHandlesResponse) {
   EXPECT_EQ(callbacks->connection(), &(filter_callbacks_.connection_));
   EXPECT_GE(callbacks->streamId(), 0);
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(DubboFilters::UpstreamResponseStatus::Complete, callbacks->upstreamData(write_buffer_));
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
@@ -540,7 +540,7 @@ TEST_F(ConnectionManagerTest, HandlesResponseContainExceptionInfo) {
 
   callbacks->startUpstreamResponse();
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(DubboFilters::UpstreamResponseStatus::Complete, callbacks->upstreamData(write_buffer_));
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
@@ -574,7 +574,7 @@ TEST_F(ConnectionManagerTest, HandlesResponseError) {
 
   callbacks->startUpstreamResponse();
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(DubboFilters::UpstreamResponseStatus::Complete, callbacks->upstreamData(write_buffer_));
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
@@ -605,7 +605,7 @@ TEST_F(ConnectionManagerTest, OnWriteHandlesResponseException) {
 
   callbacks->startUpstreamResponse();
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(DubboFilters::UpstreamResponseStatus::Reset, callbacks->upstreamData(write_buffer_));
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
@@ -759,7 +759,7 @@ TEST_F(ConnectionManagerTest, OnEvent) {
     writePartialHessianRequestMessage(buffer_, false, false, 1, true);
     EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
 
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
     conn_manager_->onEvent(Network::ConnectionEvent::RemoteClose);
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 
@@ -772,7 +772,7 @@ TEST_F(ConnectionManagerTest, OnEvent) {
     writePartialHessianRequestMessage(buffer_, false, false, 1, true);
     EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
 
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
     conn_manager_->onEvent(Network::ConnectionEvent::LocalClose);
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 
@@ -787,7 +787,7 @@ TEST_F(ConnectionManagerTest, OnEvent) {
     writeHessianRequestMessage(buffer_, false, false, 1);
     EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
 
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
     conn_manager_->onEvent(Network::ConnectionEvent::RemoteClose);
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 
@@ -802,7 +802,7 @@ TEST_F(ConnectionManagerTest, OnEvent) {
     writeHessianRequestMessage(buffer_, false, false, 1);
     EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
 
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
     conn_manager_->onEvent(Network::ConnectionEvent::LocalClose);
     filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 
@@ -867,7 +867,7 @@ TEST_F(ConnectionManagerTest, OnDataWithFilterSendsLocalReply) {
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
         EXPECT_EQ(fake_response, buffer.toString());
       }));
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
   EXPECT_EQ(SerializationType::Hessian2, callbacks->serializationType());
   EXPECT_EQ(ProtocolType::Dubbo, callbacks->protocolType());
@@ -912,7 +912,7 @@ TEST_F(ConnectionManagerTest, OnDataWithFilterSendsLocalErrorReply) {
       .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> void {
         EXPECT_EQ(fake_response, buffer.toString());
       }));
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
@@ -935,9 +935,8 @@ TEST_F(ConnectionManagerTest, TwoWayRequestWithEndStream) {
         return FilterStatus::StopIteration;
       }));
 
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite))
-      .Times(1);
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(conn_manager_->onData(buffer_, true), Network::FilterStatus::StopIteration);
   EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
 }
@@ -954,9 +953,8 @@ TEST_F(ConnectionManagerTest, OneWayRequestWithEndStream) {
       .WillOnce(Invoke([&](MessageMetadataSharedPtr, ContextSharedPtr) -> FilterStatus {
         return FilterStatus::StopIteration;
       }));
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite))
-      .Times(1);
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(conn_manager_->onData(buffer_, true), Network::FilterStatus::StopIteration);
   EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
 }
@@ -1017,8 +1015,7 @@ TEST_F(ConnectionManagerTest, SendsLocalReplyWithCloseConnection) {
         buffer.add(fake_response);
         return DubboFilters::DirectResponse::ResponseType::ErrorReply;
       }));
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
 
   MessageMetadata metadata;
   conn_manager_->sendLocalReply(metadata, direct_response, true);
@@ -1041,9 +1038,8 @@ TEST_F(ConnectionManagerTest, ContinueDecodingWithHalfClose) {
       .WillOnce(Invoke([&](MessageMetadataSharedPtr, ContextSharedPtr) -> FilterStatus {
         return FilterStatus::StopIteration;
       }));
-  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite))
-      .Times(1);
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(conn_manager_->onData(buffer_, true), Network::FilterStatus::StopIteration);
   EXPECT_EQ(1U, store_.counter("test.cx_destroy_remote_with_active_rq").value());
 
@@ -1106,7 +1102,7 @@ TEST_F(ConnectionManagerTest, ResetStream) {
 
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   callbacks->resetStream();
 }
 
@@ -1289,7 +1285,7 @@ TEST_F(ConnectionManagerTest, SendLocalReplyInMessageDecoded) {
       }));
 
   // The sendLocalReply is called, the ActiveMessage object should be destroyed.
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
 
   writeHessianRequestMessage(buffer_, false, false, 1);
 
@@ -1316,9 +1312,9 @@ TEST_F(ConnectionManagerTest, HandleResponseWithEncoderFilter) {
   EXPECT_CALL(*decoder_filter, setDecoderFilterCallbacks(_))
       .WillOnce(Invoke([&](DubboFilters::DecoderFilterCallbacks& cb) -> void { callbacks = &cb; }));
 
-  EXPECT_CALL(*encoder_filter, setEncoderFilterCallbacks(_)).Times(1);
+  EXPECT_CALL(*encoder_filter, setEncoderFilterCallbacks(_));
 
-  EXPECT_CALL(*decoder_filter, onDestroy()).Times(1);
+  EXPECT_CALL(*decoder_filter, onDestroy());
 
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
   EXPECT_EQ(1U, store_.counter("test.request").value());
@@ -1341,9 +1337,9 @@ TEST_F(ConnectionManagerTest, HandleResponseWithEncoderFilter) {
             return FilterStatus::Continue;
           }));
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(DubboFilters::UpstreamResponseStatus::Complete, callbacks->upstreamData(write_buffer_));
-  EXPECT_CALL(*encoder_filter, onDestroy()).Times(1);
+  EXPECT_CALL(*encoder_filter, onDestroy());
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 
   EXPECT_EQ(1U, store_.counter("test.response").value());
@@ -1368,7 +1364,7 @@ TEST_F(ConnectionManagerTest, HandleResponseWithCodecFilter) {
         return FilterStatus::Continue;
       }));
 
-  EXPECT_CALL(*mock_codec_filter, setEncoderFilterCallbacks(_)).Times(1);
+  EXPECT_CALL(*mock_codec_filter, setEncoderFilterCallbacks(_));
 
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
   EXPECT_EQ(1U, store_.counter("test.request").value());
@@ -1391,9 +1387,9 @@ TEST_F(ConnectionManagerTest, HandleResponseWithCodecFilter) {
             return FilterStatus::Continue;
           }));
 
-  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, deferredDelete_(_));
   EXPECT_EQ(DubboFilters::UpstreamResponseStatus::Complete, callbacks->upstreamData(write_buffer_));
-  EXPECT_CALL(*mock_codec_filter, onDestroy()).Times(1);
+  EXPECT_CALL(*mock_codec_filter, onDestroy());
 
   filter_callbacks_.connection_.dispatcher_.clearDeferredDeleteList();
 

--- a/test/extensions/filters/network/dubbo_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/decoder_test.cc
@@ -66,7 +66,7 @@ public:
 };
 
 TEST_F(DubboDecoderStateMachineTest, EmptyData) {
-  EXPECT_CALL(protocol_, decodeHeader(_, _)).Times(1);
+  EXPECT_CALL(protocol_, decodeHeader(_, _));
   EXPECT_CALL(delegate_, newStream(_, _)).Times(0);
   EXPECT_CALL(delegate_, onHeartbeat(_)).Times(0);
 
@@ -93,7 +93,7 @@ TEST_F(DubboDecoderStateMachineTest, RequestMessageCallbacks) {
 
   EXPECT_CALL(delegate_, onHeartbeat(_)).Times(0);
   EXPECT_CALL(protocol_, decodeData(_, _, _)).WillOnce(Return(true));
-  EXPECT_CALL(handler_, onStreamDecoded(_, _)).Times(1);
+  EXPECT_CALL(handler_, onStreamDecoded(_, _));
 
   DecoderStateMachine dsm(protocol_, delegate_);
   Buffer::OwnedImpl buffer;
@@ -108,7 +108,7 @@ TEST_F(DubboDecoderStateMachineTest, ResponseMessageCallbacks) {
 
   EXPECT_CALL(delegate_, onHeartbeat(_)).Times(0);
   EXPECT_CALL(protocol_, decodeData(_, _, _)).WillOnce(Return(true));
-  EXPECT_CALL(handler_, onStreamDecoded(_, _)).Times(1);
+  EXPECT_CALL(handler_, onStreamDecoded(_, _));
 
   DecoderStateMachine dsm(protocol_, delegate_);
   Buffer::OwnedImpl buffer;
@@ -121,7 +121,7 @@ TEST_F(DubboDecoderStateMachineTest, SerializeRpcInvocationException) {
   initHandler();
   initProtocolDecoder(MessageType::Request, 0);
 
-  EXPECT_CALL(delegate_, newStream(_, _)).Times(1);
+  EXPECT_CALL(delegate_, newStream(_, _));
   EXPECT_CALL(delegate_, onHeartbeat(_)).Times(0);
   EXPECT_CALL(handler_, onStreamDecoded(_, _)).Times(0);
 
@@ -141,7 +141,7 @@ TEST_F(DubboDecoderStateMachineTest, SerializeRpcResultException) {
   initHandler();
   initProtocolDecoder(MessageType::Response, 0);
 
-  EXPECT_CALL(delegate_, newStream(_, _)).Times(1);
+  EXPECT_CALL(delegate_, newStream(_, _));
   EXPECT_CALL(delegate_, onHeartbeat(_)).Times(0);
   EXPECT_CALL(handler_, onStreamDecoded(_, _)).Times(0);
 
@@ -235,7 +235,7 @@ TEST_F(DubboDecoderTest, DecodeResponseMessage) {
   EXPECT_CALL(protocol_, decodeData(_, _, _)).WillOnce(Return(true));
   EXPECT_CALL(response_callbacks_, newStream()).WillOnce(ReturnRef(handler_));
   EXPECT_CALL(response_callbacks_, onHeartbeat(_)).Times(0);
-  EXPECT_CALL(handler_, onStreamDecoded(_, _)).Times(1);
+  EXPECT_CALL(handler_, onStreamDecoded(_, _));
 
   ResponseDecoder decoder(protocol_, response_callbacks_);
 
@@ -258,7 +258,7 @@ TEST_F(DubboDecoderTest, DecodeResponseMessage) {
   EXPECT_CALL(protocol_, decodeData(_, _, _)).WillOnce(Return(true));
   EXPECT_CALL(response_callbacks_, newStream()).WillOnce(ReturnRef(handler_));
   EXPECT_CALL(response_callbacks_, onHeartbeat(_)).Times(0);
-  EXPECT_CALL(handler_, onStreamDecoded(_, _)).Times(1);
+  EXPECT_CALL(handler_, onStreamDecoded(_, _));
 
   buffer_underflow = false;
   EXPECT_EQ(decoder.onData(buffer, buffer_underflow), FilterStatus::Continue);

--- a/test/extensions/filters/network/dubbo_proxy/router_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/router_test.cc
@@ -331,7 +331,7 @@ TEST_F(DubboRouterTest, PoolConnectionFailureWithOnewayMessage) {
   EXPECT_CALL(callbacks_, protocolType()).WillOnce(Return(ProtocolType::Dubbo));
   EXPECT_CALL(callbacks_, serializationType()).WillOnce(Return(SerializationType::Hessian2));
   EXPECT_CALL(callbacks_, sendLocalReply(_, _)).Times(0);
-  EXPECT_CALL(callbacks_, resetStream()).Times(1);
+  EXPECT_CALL(callbacks_, resetStream());
   EXPECT_EQ(FilterStatus::StopIteration, router_->onMessageDecoded(metadata_, message_context_));
 
   context_.cluster_manager_.tcp_conn_pool_.poolFailure(
@@ -443,8 +443,8 @@ TEST_F(DubboRouterTest, DecoderFilterCallbacks) {
   initializeMetadata(MessageType::Request);
 
   EXPECT_CALL(upstream_connection_, write(_, false));
-  EXPECT_CALL(callbacks_, startUpstreamResponse()).Times(1);
-  EXPECT_CALL(callbacks_, upstreamData(_)).Times(1);
+  EXPECT_CALL(callbacks_, startUpstreamResponse());
+  EXPECT_CALL(callbacks_, upstreamData(_));
 
   startRequest(MessageType::Request);
   connectUpstream();
@@ -460,7 +460,7 @@ TEST_F(DubboRouterTest, UpstreamDataReset) {
   initializeRouter();
   initializeMetadata(MessageType::Request);
 
-  EXPECT_CALL(callbacks_, startUpstreamResponse()).Times(1);
+  EXPECT_CALL(callbacks_, startUpstreamResponse());
   EXPECT_CALL(callbacks_, upstreamData(_))
       .WillOnce(Return(DubboFilters::UpstreamResponseStatus::Reset));
   EXPECT_CALL(upstream_connection_, close(Network::ConnectionCloseType::NoFlush));
@@ -506,7 +506,7 @@ TEST_F(DubboRouterTest, LocalClosedWhileResponseComplete) {
   initializeRouter();
   initializeMetadata(MessageType::Request);
 
-  EXPECT_CALL(callbacks_, startUpstreamResponse()).Times(1);
+  EXPECT_CALL(callbacks_, startUpstreamResponse());
   EXPECT_CALL(callbacks_, upstreamData(_))
       .WillOnce(Return(DubboFilters::UpstreamResponseStatus::Complete));
   EXPECT_CALL(callbacks_, sendLocalReply(_, _)).Times(0);

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -266,7 +266,7 @@ TEST_F(ExtAuthzFilterTest, FailClose) {
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
 
-  EXPECT_CALL(filter_callbacks_.connection_, close(_)).Times(1);
+  EXPECT_CALL(filter_callbacks_.connection_, close(_));
   EXPECT_CALL(filter_callbacks_, continueReading()).Times(0);
   request_callbacks_->onComplete(makeAuthzResponse(Filters::Common::ExtAuthz::CheckStatus::Error));
 

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -2164,13 +2164,13 @@ TEST_F(FilterChainTest, CreateCustomUpgradeFilterChain) {
 
   {
     Http::MockFilterChainFactoryCallbacks callbacks;
-    EXPECT_CALL(callbacks, addStreamDecoderFilter(_)).Times(1);
+    EXPECT_CALL(callbacks, addStreamDecoderFilter(_));
     EXPECT_TRUE(config.createUpgradeFilterChain("websocket", nullptr, callbacks));
   }
 
   {
     Http::MockFilterChainFactoryCallbacks callbacks;
-    EXPECT_CALL(callbacks, addStreamDecoderFilter(_)).Times(1);
+    EXPECT_CALL(callbacks, addStreamDecoderFilter(_));
     EXPECT_CALL(callbacks, addStreamFilter(_)).Times(2); // Buffer
     EXPECT_TRUE(config.createUpgradeFilterChain("Foo", nullptr, callbacks));
   }

--- a/test/extensions/filters/network/postgres_proxy/postgres_decoder_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_decoder_test.cc
@@ -232,14 +232,14 @@ TEST_F(PostgresProxyDecoderTest, TwoMessagesInOneBuffer) {
 TEST_F(PostgresProxyDecoderTest, Unknown) {
   // Create invalid message. The first byte is invalid "="
   // Message must be at least 5 bytes to be parsed.
-  EXPECT_CALL(callbacks_, incMessagesUnknown()).Times(1);
+  EXPECT_CALL(callbacks_, incMessagesUnknown());
   createPostgresMsg(data_, "=", "some not important string which will be ignored anyways");
   decoder_->onData(data_, true);
 }
 
 // Test if each frontend command calls incMessagesFrontend() method.
 TEST_P(PostgresProxyFrontendDecoderTest, FrontendInc) {
-  EXPECT_CALL(callbacks_, incMessagesFrontend()).Times(1);
+  EXPECT_CALL(callbacks_, incMessagesFrontend());
   createPostgresMsg(data_, GetParam(), "SELECT 1;");
   decoder_->onData(data_, true);
 
@@ -262,7 +262,7 @@ TEST_F(PostgresProxyFrontendDecoderTest, TerminateMessage) {
 
   // Now set the decoder to be in_transaction state.
   decoder_->getSession().setInTransaction(true);
-  EXPECT_CALL(callbacks_, incTransactionsRollback()).Times(1);
+  EXPECT_CALL(callbacks_, incTransactionsRollback());
   createPostgresMsg(data_, "X");
   decoder_->onData(data_, true);
   ASSERT_FALSE(decoder_->getSession().inTransaction());
@@ -270,7 +270,7 @@ TEST_F(PostgresProxyFrontendDecoderTest, TerminateMessage) {
 
 // Query message should invoke filter's callback message
 TEST_F(PostgresProxyFrontendDecoderTest, QueryMessage) {
-  EXPECT_CALL(callbacks_, processQuery).Times(1);
+  EXPECT_CALL(callbacks_, processQuery);
   createPostgresMsg(data_, "Q", "SELECT * FROM whatever;");
   decoder_->onData(data_, true);
 }
@@ -307,7 +307,7 @@ TEST_F(PostgresProxyFrontendDecoderTest, ParseMessage) {
 
 // Test if each backend command calls incMessagesBackend()) method.
 TEST_P(PostgresProxyBackendDecoderTest, BackendInc) {
-  EXPECT_CALL(callbacks_, incMessagesBackend()).Times(1);
+  EXPECT_CALL(callbacks_, incMessagesBackend());
   createPostgresMsg(data_, GetParam(), "Some not important message");
   decoder_->onData(data_, false);
 }

--- a/test/extensions/filters/network/rocketmq_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/rocketmq_proxy/conn_manager_test.cc
@@ -233,7 +233,7 @@ TEST_F(RocketmqConnectionManagerTest, OnHeartbeatWithDownstreamConnecitonClosed)
 
   BufferUtility::fillRequestBuffer(buffer_, RequestCode::HeartBeat);
   NiceMock<Network::MockConnection> connection;
-  EXPECT_CALL(connection, state()).Times(1).WillOnce(Invoke([&]() -> Network::Connection::State {
+  EXPECT_CALL(connection, state()).WillOnce(Invoke([&]() -> Network::Connection::State {
     return Network::Connection::State::Closed;
   }));
   EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(Invoke([&]() -> Network::Connection& {

--- a/test/extensions/filters/network/thrift_proxy/decoder_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/decoder_test.cc
@@ -870,7 +870,7 @@ TEST(DecoderTest, OnData) {
         EXPECT_EQ(100U, metadata->sequenceId());
         return FilterStatus::Continue;
       }));
-  EXPECT_CALL(callbacks, passthroughEnabled()).Times(1).WillRepeatedly(Return(false));
+  EXPECT_CALL(callbacks, passthroughEnabled()).WillOnce(Return(false));
 
   EXPECT_CALL(proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
   EXPECT_CALL(handler, structBegin(absl::string_view())).WillOnce(Return(FilterStatus::Continue));
@@ -938,7 +938,7 @@ TEST(DecoderTest, OnDataWithProtocolHint) {
         EXPECT_EQ(100U, metadata->sequenceId());
         return FilterStatus::Continue;
       }));
-  EXPECT_CALL(callbacks, passthroughEnabled()).Times(1);
+  EXPECT_CALL(callbacks, passthroughEnabled());
 
   EXPECT_CALL(proto, readStructBegin(Ref(buffer), _)).WillOnce(Return(true));
   EXPECT_CALL(handler, structBegin(absl::string_view())).WillOnce(Return(FilterStatus::Continue));
@@ -1181,7 +1181,7 @@ TEST(DecoderTest, OnDataHandlesStopIterationAndResumes) {
         EXPECT_EQ(100U, metadata->sequenceId());
         return FilterStatus::StopIteration;
       }));
-  EXPECT_CALL(callbacks, passthroughEnabled()).Times(1).WillRepeatedly(Return(false));
+  EXPECT_CALL(callbacks, passthroughEnabled()).WillOnce(Return(false));
   EXPECT_EQ(FilterStatus::StopIteration, decoder.onData(buffer, underflow));
   EXPECT_FALSE(underflow);
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -185,7 +185,7 @@ TEST_F(ThriftRateLimitFilterTest, NoApplicableRateLimit) {
 TEST_F(ThriftRateLimitFilterTest, NoDescriptor) {
   setupTest(filter_config_);
 
-  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _)).Times(1);
+  EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _));
   EXPECT_CALL(*client_, limit(_, _, _, _, _)).Times(0);
 
   EXPECT_EQ(ThriftProxy::FilterStatus::Continue, filter_->messageBegin(request_metadata_));
@@ -204,8 +204,7 @@ TEST_F(ThriftRateLimitFilterTest, OkResponse) {
   setupTest(filter_config_);
   InSequence s;
 
-  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0))
-      .Times(1);
+  EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _, _))
       .WillOnce(SetArgReferee<1>(descriptor_));

--- a/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
@@ -639,7 +639,7 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnSingleAddress) {
   InSequence s;
 
   auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string expected_address("130.207.244.251");
   const std::string domain("www.foobaz.com");
@@ -691,7 +691,7 @@ TEST_F(DnsFilterTest, ExternalResolutionIpv6SingleAddress) {
   InSequence s;
 
   auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string expected_address("2a04:4e42:d::323");
   const std::string domain("www.foobaz.com");
@@ -710,7 +710,7 @@ TEST_F(DnsFilterTest, ExternalResolutionIpv6SingleAddress) {
   // Send a query to for a name not in our configuration
   sendQueryFromClient("10.0.0.1:1000", query);
 
-  EXPECT_CALL(*timeout_timer, disableTimer()).Times(1);
+  EXPECT_CALL(*timeout_timer, disableTimer());
 
   // Execute resolve callback
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
@@ -744,7 +744,7 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnMultipleAddresses) {
   InSequence s;
 
   auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::list<std::string> expected_address{"130.207.244.251", "130.207.244.252",
                                                 "130.207.244.253", "130.207.244.254"};
@@ -763,7 +763,7 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnMultipleAddresses) {
   // Send a query to for a name not in our configuration
   sendQueryFromClient("10.0.0.1:1000", query);
 
-  EXPECT_CALL(*timeout_timer, disableTimer()).Times(1);
+  EXPECT_CALL(*timeout_timer, disableTimer());
 
   // Execute resolve callback
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success,
@@ -798,7 +798,7 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnNoAddresses) {
   InSequence s;
 
   auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
@@ -815,7 +815,7 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnNoAddresses) {
   // Send a query to for a name not in our configuration
   sendQueryFromClient("10.0.0.1:1000", query);
 
-  EXPECT_CALL(*timeout_timer, disableTimer()).Times(1);
+  EXPECT_CALL(*timeout_timer, disableTimer());
 
   // Execute resolve callback
   resolve_cb(Network::DnsResolver::ResolutionStatus::Success, TestUtility::makeDnsResponse({}));
@@ -841,7 +841,7 @@ TEST_F(DnsFilterTest, ExternalResolutionTimeout) {
   InSequence s;
 
   auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
@@ -880,7 +880,7 @@ TEST_F(DnsFilterTest, ExternalResolutionTimeout2) {
   InSequence s;
 
   auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _)).Times(1);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);

--- a/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
+++ b/test/extensions/stats_sinks/common/statsd/udp_statsd_test.cc
@@ -174,8 +174,7 @@ TEST(UdpStatsdSinkTest, CheckActualStats) {
   counter.latch_ = 1;
   snapshot.counters_.push_back({1, counter});
 
-  EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr), writeBuffer(_))
-      .Times(1);
+  EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr), writeBuffer(_));
   sink.flush(snapshot);
   EXPECT_EQ(writer_ptr->buffer_writes.size(), 1);
   EXPECT_EQ(writer_ptr->buffer_writes.at(0), "envoy.test_counter:1|c");
@@ -256,8 +255,7 @@ TEST(UdpStatsdSinkTest, CheckBufferedWritesWithinBufferSize) {
   snapshot.gauges_.push_back(gauge);
 
   // Expect both metrics to be present in single write
-  EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr), writeBuffer(_))
-      .Times(1);
+  EXPECT_CALL(*std::dynamic_pointer_cast<NiceMock<MockWriter>>(writer_ptr), writeBuffer(_));
   sink.flush(snapshot);
   EXPECT_EQ(writer_ptr->buffer_writes.size(), 1);
   EXPECT_EQ(writer_ptr->buffer_writes.at(0), "envoy.test_counter:1|c\nenvoy.test_gauge:1|g");

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -164,7 +164,7 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   EXPECT_EQ(2, second_child_span->spanStore()->spanId());
   EXPECT_EQ(0, second_child_span->spanStore()->parentSpanId());
 
-  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _)).Times(1);
+  EXPECT_CALL(*mock_stream_ptr_, sendMessageRaw_(_, _));
 
   // When the child span ends, the data is not reported immediately, but the end time is set.
   first_child_span->finishSpan();

--- a/test/extensions/transport_sockets/common/passthrough_test.cc
+++ b/test/extensions/transport_sockets/common/passthrough_test.cc
@@ -29,58 +29,57 @@ protected:
 // Test setTransportSocketCallbacks method defers to inner socket
 TEST_F(PassthroughTest, SetTransportSocketCallbacksDefersToInnerSocket) {
   auto transport_callbacks = std::make_unique<NiceMock<Network::MockTransportSocketCallbacks>>();
-  EXPECT_CALL(*inner_socket_, setTransportSocketCallbacks(Ref(*transport_callbacks))).Times(1);
+  EXPECT_CALL(*inner_socket_, setTransportSocketCallbacks(Ref(*transport_callbacks)));
   passthrough_socket_->setTransportSocketCallbacks(*transport_callbacks);
 }
 
 // Test protocol method defers to inner socket
 TEST_F(PassthroughTest, ProtocolDefersToInnerSocket) {
-  EXPECT_CALL(*inner_socket_, protocol()).Times(1);
+  EXPECT_CALL(*inner_socket_, protocol());
   passthrough_socket_->protocol();
 }
 
 // Test failureReason method defers to inner socket
 TEST_F(PassthroughTest, FailureReasonDefersToInnerSocket) {
-  EXPECT_CALL(*inner_socket_, failureReason()).Times(1);
+  EXPECT_CALL(*inner_socket_, failureReason());
   passthrough_socket_->failureReason();
 }
 
 // Test canFlushClose method defers to inner socket
 TEST_F(PassthroughTest, CanFlushCloseDefersToInnerSocket) {
-  EXPECT_CALL(*inner_socket_, canFlushClose()).Times(1);
+  EXPECT_CALL(*inner_socket_, canFlushClose());
   passthrough_socket_->canFlushClose();
 }
 
 // Test closeSocket method defers to inner socket
 TEST_F(PassthroughTest, CloseSocketDefersToInnerSocket) {
-  EXPECT_CALL(*inner_socket_, closeSocket(testing::Eq(Network::ConnectionEvent::LocalClose)))
-      .Times(1);
+  EXPECT_CALL(*inner_socket_, closeSocket(testing::Eq(Network::ConnectionEvent::LocalClose)));
   passthrough_socket_->closeSocket(Network::ConnectionEvent::LocalClose);
 }
 
 // Test doRead method defers to inner socket
 TEST_F(PassthroughTest, DoReadDefersToInnerSocket) {
   auto buff = Buffer::OwnedImpl("data");
-  EXPECT_CALL(*inner_socket_, doRead(BufferEqual(&buff))).Times(1);
+  EXPECT_CALL(*inner_socket_, doRead(BufferEqual(&buff)));
   passthrough_socket_->doRead(buff);
 }
 
 // Test doWrite method defers to inner socket
 TEST_F(PassthroughTest, DoWriteDefersToInnerSocket) {
   auto buff = Buffer::OwnedImpl("data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&buff), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&buff), false));
   passthrough_socket_->doWrite(buff, false);
 }
 
 // Test onConnected method defers to inner socket
 TEST_F(PassthroughTest, OnConnectedDefersToInnerSocket) {
-  EXPECT_CALL(*inner_socket_, onConnected()).Times(1);
+  EXPECT_CALL(*inner_socket_, onConnected());
   passthrough_socket_->onConnected();
 }
 
 // Test ssl method defers to inner socket
 TEST_F(PassthroughTest, SslDefersToInnerSocket) {
-  EXPECT_CALL(*inner_socket_, ssl()).Times(1);
+  EXPECT_CALL(*inner_socket_, ssl());
   passthrough_socket_->ssl();
 }
 

--- a/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_test.cc
@@ -74,8 +74,8 @@ TEST_F(ProxyProtocolTest, InjectesHeaderOnlyOnce) {
 
   {
     InSequence s;
-    EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
-    EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg2), false)).Times(1);
+    EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
+    EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg2), false));
   }
 
   proxy_protocol_socket_->doWrite(msg, false);
@@ -195,7 +195,7 @@ TEST_F(ProxyProtocolTest, V1IPV4LocalAddressWhenTransportOptionsAreNull) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -219,7 +219,7 @@ TEST_F(ProxyProtocolTest, V1IPV4LocalAddressesWhenHeaderOptionsAreNull) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -243,7 +243,7 @@ TEST_F(ProxyProtocolTest, V1IPV6LocalAddressesWhenHeaderOptionsAreNull) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -275,7 +275,7 @@ TEST_F(ProxyProtocolTest, V1IPV4DownstreamAddresses) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -307,7 +307,7 @@ TEST_F(ProxyProtocolTest, V1IPV6DownstreamAddresses) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -329,7 +329,7 @@ TEST_F(ProxyProtocolTest, V2IPV4LocalCommandWhenTransportOptionsAreNull) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -352,7 +352,7 @@ TEST_F(ProxyProtocolTest, V2IPV4LocalCommandWhenHeaderOptionsAreNull) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -384,7 +384,7 @@ TEST_F(ProxyProtocolTest, V2IPV4DownstreamAddresses) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -416,7 +416,7 @@ TEST_F(ProxyProtocolTest, V2IPV6DownstreamAddresses) {
         return Api::IoCallUint64Result(length, Api::IoErrorPtr(nullptr, [](Api::IoError*) {}));
       }));
   auto msg = Buffer::OwnedImpl("some data");
-  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false)).Times(1);
+  EXPECT_CALL(*inner_socket_, doWrite(BufferEqual(&msg), false));
 
   proxy_protocol_socket_->doWrite(msg, false);
 }
@@ -438,7 +438,7 @@ TEST_F(ProxyProtocolTest, OnConnectedCallsInnerOnConnected) {
       Network::Utility::resolveUrl("tcp://[e:b:c:f::]:8080");
   initialize(ProxyProtocolConfig_Version::ProxyProtocolConfig_Version_V2, socket_options);
 
-  EXPECT_CALL(*inner_socket_, onConnected()).Times(1);
+  EXPECT_CALL(*inner_socket_, onConnected());
   proxy_protocol_socket_->onConnected();
 }
 

--- a/test/extensions/transport_sockets/tls/handshaker_test.cc
+++ b/test/extensions/transport_sockets/tls/handshaker_test.cc
@@ -125,7 +125,7 @@ TEST_F(HandshakerTest, NormalOperation) {
   ON_CALL(mock_connection, state).WillByDefault(Return(Network::Connection::State::Closed));
 
   NiceMock<MockHandshakeCallbacks> handshake_callbacks;
-  EXPECT_CALL(handshake_callbacks, onSuccess).Times(1);
+  EXPECT_CALL(handshake_callbacks, onSuccess);
   ON_CALL(handshake_callbacks, connection()).WillByDefault(ReturnRef(mock_connection));
 
   SslHandshakerImpl handshaker(std::move(server_ssl_), 0, &handshake_callbacks);
@@ -153,7 +153,7 @@ TEST_F(HandshakerTest, ErrorCbOnAbnormalOperation) {
   SSL_set_bio(client_ssl_.get(), bio, bio);
 
   StrictMock<MockHandshakeCallbacks> handshake_callbacks;
-  EXPECT_CALL(handshake_callbacks, onFailure).Times(1);
+  EXPECT_CALL(handshake_callbacks, onFailure);
 
   SslHandshakerImpl handshaker(std::move(server_ssl_), 0, &handshake_callbacks);
 
@@ -222,7 +222,7 @@ TEST_F(HandshakerTest, NormalOperationWithSslHandshakerImplForTest) {
   ::testing::MockFunction<void()> requested_cert_cb;
 
   StrictMock<MockHandshakeCallbacks> handshake_callbacks;
-  EXPECT_CALL(handshake_callbacks, onSuccess).Times(1);
+  EXPECT_CALL(handshake_callbacks, onSuccess);
 
   SslHandshakerImplForTest handshaker(std::move(server_ssl_), &handshake_callbacks,
                                       requested_cert_cb.AsStdFunction());

--- a/test/server/admin/runtime_handler_test.cc
+++ b/test/server/admin/runtime_handler_test.cc
@@ -85,7 +85,7 @@ TEST_P(AdminInstanceTest, RuntimeModify) {
   overrides["foo"] = "bar";
   overrides["x"] = "42";
   overrides["nothing"] = "";
-  EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
+  EXPECT_CALL(loader, mergeValues(overrides));
   EXPECT_EQ(Http::Code::OK,
             postCallback("/runtime_modify?foo=bar&x=42&nothing=", header_map, response));
   EXPECT_EQ("OK\n", response.toString());
@@ -98,7 +98,7 @@ TEST_P(AdminInstanceTest, RuntimeModifyParamsInBody) {
   const std::string key = "routing.traffic_shift.foo";
   const std::string value = "numerator: 1\ndenominator: TEN_THOUSAND\n";
   const absl::node_hash_map<std::string, std::string> overrides = {{key, value}};
-  EXPECT_CALL(loader, mergeValues(overrides)).Times(1);
+  EXPECT_CALL(loader, mergeValues(overrides));
 
   const std::string body = fmt::format("{}={}", key, value);
   Http::TestResponseHeaderMapImpl header_map;

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -289,7 +289,7 @@ TEST_F(ConnectionHandlerTest, RemoveListenerDuringRebalance) {
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
   current_handler->incNumConnections();
 #ifndef NDEBUG
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
 #endif
   current_handler->post(Network::ConnectionSocketPtr{connection});
 
@@ -354,7 +354,7 @@ TEST_F(ConnectionHandlerTest, ListenerConnectionLimitEnforced) {
 
   // We expect that listener 2 accepts the connection, so there will be a call to
   // createServerConnection and active cx should increase, while cx overflow remains the same.
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   listener_callbacks2->onAccept(
       Network::ConnectionSocketPtr{new NiceMock<Network::MockConnectionSocket>()});
   EXPECT_EQ(0, handler_->numConnections());
@@ -407,7 +407,7 @@ TEST_F(ConnectionHandlerTest, RemoveListener) {
   handler_->addListener(absl::nullopt, *test_listener);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
   EXPECT_EQ(0UL, handler_->numConnections());
 
@@ -508,7 +508,7 @@ TEST_F(ConnectionHandlerTest, SetsTransportSocketConnectTimeout) {
       .WillOnce(Return(std::chrono::seconds(5)));
   EXPECT_CALL(*server_connection,
               setTransportSocketConnectTimeout(std::chrono::milliseconds(5 * 1000)));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
 
   listener_callbacks->onAccept(std::make_unique<NiceMock<Network::MockConnectionSocket>>());
 
@@ -526,7 +526,7 @@ TEST_F(ConnectionHandlerTest, DestroyCloseConnections) {
   handler_->addListener(absl::nullopt, *test_listener);
 
   Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
   EXPECT_EQ(0UL, handler_->numConnections());
 
@@ -551,7 +551,7 @@ TEST_F(ConnectionHandlerTest, CloseDuringFilterChainCreate) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   EXPECT_CALL(*connection, state()).WillOnce(Return(Network::Connection::State::Closed));
   EXPECT_CALL(*connection, addConnectionCallbacks(_)).Times(0);
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
   EXPECT_EQ(0UL, handler_->numConnections());
@@ -575,7 +575,7 @@ TEST_F(ConnectionHandlerTest, CloseConnectionOnEmptyFilterChain) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(false));
   EXPECT_CALL(*connection, close(Network::ConnectionCloseType::NoFlush));
   EXPECT_CALL(*connection, addConnectionCallbacks(_)).Times(0);
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
   EXPECT_EQ(0UL, handler_->numConnections());
@@ -703,7 +703,7 @@ TEST_F(ConnectionHandlerTest, FallbackToWildcardListener) {
 
   EXPECT_CALL(*listener2, onDestroy());
   EXPECT_CALL(*listener1, onDestroy());
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
 }
 
 TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
@@ -746,7 +746,7 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithOriginalDst) {
   EXPECT_EQ(1UL, handler_->numConnections());
 
   EXPECT_CALL(*listener1, onDestroy());
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
 }
 
 TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
@@ -782,7 +782,7 @@ TEST_F(ConnectionHandlerTest, WildcardListenerWithNoOriginalDst) {
   EXPECT_EQ(1UL, handler_->numConnections());
 
   EXPECT_CALL(*listener1, onDestroy());
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
 }
 
 TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
@@ -798,7 +798,7 @@ TEST_F(ConnectionHandlerTest, TransportProtocolDefault) {
       .WillOnce(Return(absl::string_view("")));
   EXPECT_CALL(*accepted_socket, setDetectedTransportProtocol(absl::string_view("raw_buffer")));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
 
   EXPECT_CALL(*listener, onDestroy());
@@ -829,7 +829,7 @@ TEST_F(ConnectionHandlerTest, TransportProtocolCustom) {
   EXPECT_CALL(*accepted_socket, setDetectedTransportProtocol(dummy));
   EXPECT_CALL(*accepted_socket, detectedTransportProtocol()).WillOnce(Return(dummy));
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
 
   EXPECT_CALL(*listener, onDestroy());
@@ -867,7 +867,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeout) {
   EXPECT_EQ(1UL, downstream_pre_cx_active.value());
 
   EXPECT_CALL(*timeout, disableTimer());
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   timeout->invokeCallback();
   EXPECT_CALL(*test_filter, destroy_());
   dispatcher_.clearDeferredDeleteList();
@@ -914,7 +914,7 @@ TEST_F(ConnectionHandlerTest, ContinueOnListenerFilterTimeout) {
   EXPECT_CALL(*test_filter, destroy_());
   // Barrier: test_filter must be destructed before findFilterChain
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   EXPECT_CALL(*timeout, disableTimer());
   timeout->invokeCallback();
   dispatcher_.clearDeferredDeleteList();
@@ -959,7 +959,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterTimeoutResetOnSuccess) {
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{accepted_socket});
   EXPECT_CALL(*test_filter, destroy_());
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   EXPECT_CALL(*timeout, disableTimer());
   listener_filter_cb->continueFilterChain(true);
 
@@ -988,7 +988,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterDisabledTimeout) {
       .WillOnce(Invoke([&](Network::ListenerFilterCallbacks&) -> Network::FilterStatus {
         return Network::FilterStatus::StopIteration;
       }));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   EXPECT_CALL(dispatcher_, createTimer_(_)).Times(0);
   EXPECT_CALL(*test_filter, destroy_());
   Network::MockConnectionSocket* accepted_socket = new NiceMock<Network::MockConnectionSocket>();
@@ -1022,7 +1022,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterReportError) {
         cb.socket().close();
         return Network::FilterStatus::StopIteration;
       }));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   // The last filter won't be invoked
   EXPECT_CALL(*last_filter, onAccept(_)).Times(0);
   EXPECT_CALL(*first_filter, destroy_());
@@ -1099,7 +1099,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerInplaceUpdate) {
       .WillOnce(ReturnRef(*current_handler));
   EXPECT_CALL(manager_, findFilterChain(_)).Times(0);
   EXPECT_CALL(*overridden_filter_chain_manager, findFilterChain(_)).WillOnce(Return(nullptr));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   EXPECT_CALL(*mock_connection_balancer, unregisterHandler(_));
   old_listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
   EXPECT_EQ(0UL, handler_->numConnections());
@@ -1121,7 +1121,7 @@ TEST_F(ConnectionHandlerTest, TcpListenerRemoveFilterChain) {
   auto* server_connection = new NiceMock<Network::MockServerConnection>();
   EXPECT_CALL(dispatcher_, createServerConnection_()).WillOnce(Return(server_connection));
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
 
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
 
@@ -1208,7 +1208,7 @@ TEST_F(ConnectionHandlerTest, ListenerFilterWorks) {
   EXPECT_CALL(*disabled_listener_filter, destroy_());
   EXPECT_CALL(*enabled_filter, destroy_());
   EXPECT_CALL(manager_, findFilterChain(_)).WillOnce(Return(nullptr));
-  EXPECT_CALL(*access_log_, log(_, _, _, _)).Times(1);
+  EXPECT_CALL(*access_log_, log(_, _, _, _));
   listener_callbacks->onAccept(std::make_unique<NiceMock<Network::MockConnectionSocket>>());
   EXPECT_CALL(*listener, onDestroy());
 }

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -199,7 +199,7 @@ TEST_F(FilterChainManagerImplTest, DuplicateContextsAreNotBuilt) {
     filter_chain_messages.push_back(std::move(new_filter_chain));
   }
 
-  EXPECT_CALL(filter_chain_factory_builder_, buildFilterChain(_, _)).Times(1);
+  EXPECT_CALL(filter_chain_factory_builder_, buildFilterChain(_, _));
   filter_chain_manager_.addFilterChains(
       std::vector<const envoy::config::listener::v3::FilterChain*>{&filter_chain_messages[0]},
       nullptr, filter_chain_factory_builder_, filter_chain_manager_);

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -85,7 +85,7 @@ TEST_F(HotRestartImplTest, VersionString) {
 TEST_F(HotRestartImplTest, DomainSocketAlreadyInUse) {
   EXPECT_CALL(os_sys_calls_, bind(_, _, _))
       .WillOnce(Return(Api::SysCallIntResult{-1, SOCKET_ERROR_ADDR_IN_USE}));
-  EXPECT_CALL(os_sys_calls_, close(_)).Times(1);
+  EXPECT_CALL(os_sys_calls_, close(_));
 
   EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0),
                Server::HotRestartDomainSocketInUseException);
@@ -96,7 +96,7 @@ TEST_F(HotRestartImplTest, DomainSocketAlreadyInUse) {
 TEST_F(HotRestartImplTest, DomainSocketError) {
   EXPECT_CALL(os_sys_calls_, bind(_, _, _))
       .WillOnce(Return(Api::SysCallIntResult{-1, SOCKET_ERROR_ACCESS}));
-  EXPECT_CALL(os_sys_calls_, close(_)).Times(1);
+  EXPECT_CALL(os_sys_calls_, close(_));
 
   EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, "@envoy_domain_socket", 0), EnvoyException);
 }

--- a/test/server/listener_manager_impl_test.cc
+++ b/test/server/listener_manager_impl_test.cc
@@ -856,11 +856,11 @@ dynamic_listeners:
         seconds: 1001001001
         nanos: 1000000
 )EOF");
-    EXPECT_CALL(listener_foo->target_, initialize()).Times(1);
+    EXPECT_CALL(listener_foo->target_, initialize());
     server_init_mgr.initialize(server_init_watcher);
     // Since listener_foo->target_ is not ready, the listener's listener_init_target will not be
     // ready until the destruction happens.
-    server_init_watcher.expectReady().Times(1);
+    server_init_watcher.expectReady();
     EXPECT_CALL(*listener_foo, onDestroy());
     EXPECT_TRUE(manager_->removeListener("foo"));
   }
@@ -884,7 +884,7 @@ static_listeners:
     ListenerHandle* listener_foo2 = expectListenerCreate(true, true);
     EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, {true}));
     // Version 2 listener will be initialized by listener manager directly.
-    EXPECT_CALL(listener_foo2->target_, initialize()).Times(1);
+    EXPECT_CALL(listener_foo2->target_, initialize());
     EXPECT_TRUE(manager_->addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml),
                                               "version2", true));
     // Version2 is in warming list as listener_foo2->target_ is not ready yet.
@@ -1844,8 +1844,8 @@ filter_chains:
   EXPECT_EQ(2UL, manager_->listeners().size());
 
   // Validate that stop listener is only called once - for inbound listeners.
-  EXPECT_CALL(*worker_, stopListener(_, _)).Times(1);
-  EXPECT_CALL(*listener_factory_.socket_, close()).Times(1);
+  EXPECT_CALL(*worker_, stopListener(_, _));
+  EXPECT_CALL(*listener_factory_.socket_, close());
   manager_->stopListeners(ListenerManager::StopListenersType::InboundOnly);
   EXPECT_EQ(1, server_.stats_store_.counterFromString("listener_manager.listener_stopped").value());
 

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -303,6 +303,8 @@ def runChecks():
   errors += checkAndFixError(
       "cpp_std.cc",
       "term absl::make_unique< should be replaced with standard library term std::make_unique<")
+  errors += checkAndFixError("code_conventions.cc",
+                             "term .Times(1); should be replaced with preferred term ;")
 
   errors += checkFileExpectingOK("real_time_source_override.cc")
   errors += checkFileExpectingOK("duration_value_zero.cc")

--- a/tools/testdata/check_format/code_conventions.cc
+++ b/tools/testdata/check_format/code_conventions.cc
@@ -1,0 +1,11 @@
+namespace Envoy {
+
+void foo() {
+  EXPECT_CALL(a, b).Times(1);
+  EXPECT_CALL(a, b)
+    .Times(1);
+  EXPECT_CALL(a, b).Times(1).WillRepeatedly(foo);
+  EXPECT_CALL(a, b).Times(1).WillOnce(foo);
+}
+
+}

--- a/tools/testdata/check_format/code_conventions.cc.gold
+++ b/tools/testdata/check_format/code_conventions.cc.gold
@@ -1,0 +1,10 @@
+namespace Envoy {
+
+void foo() {
+  EXPECT_CALL(a, b);
+  EXPECT_CALL(a, b);
+  EXPECT_CALL(a, b).WillOnce(foo);
+  EXPECT_CALL(a, b).WillOnce(foo);
+}
+
+} // namespace Envoy


### PR DESCRIPTION
This removes one source of constant nit nagging in PR reviews.

The rewrite validity is based on
https://github.com/google/googletest/blob/master/googlemock/docs/for_dummies.md#cardinalities-how-many-times-will-it-be-called

Testing: Added check_format test.

Signed-off-by: Harvey Tuch <htuch@google.com>