### PR TITLE
docs: fix command in grpc_bridge example

### DIFF
--- a/docs/root/start/sandboxes/grpc_bridge.rst
+++ b/docs/root/start/sandboxes/grpc_bridge.rst
@@ -98,7 +98,7 @@ Set a key:
 
 .. code-block:: console
 
-  $ docker-compose exec python /client/client.py set foo bar
+  $ docker-compose exec grpc-client python /client/grpc-kv-client.py set foo bar
   setf foo to bar
 
 
@@ -106,21 +106,21 @@ Get a key:
 
 .. code-block:: console
 
-  $ docker-compose exec python /client/client.py get foo
+  $ docker-compose exec grpc-client python /client/grpc-kv-client.py get foo
   bar
 
 Modify an existing key:
 
 .. code-block:: console
 
-  $ docker-compose exec python /client/client.py set foo baz
+  $ docker-compose exec grpc-client python /client/grpc-kv-client.py set foo baz
   setf foo to baz
 
 Get the modified key:
 
 .. code-block:: console
 
-  $ docker-compose exec python /client/client.py get foo
+  $ docker-compose exec grpc-client python /client/grpc-kv-client.py get foo
   baz
 
 In the running docker-compose container, you should see the gRPC service printing a record of its activity:


### PR DESCRIPTION
Signed-off-by: Jonathan Chang <ttjtftx@gmail.com>
Commit Message: docs: fix command in grpc_bridge example
Additional Description:
I tried to run the example and failed, I think this is the correct commands so I fixed it.
BTW, the pre-push check failed. I don't know why and ignored it.

Risk Level: Low
Testing: follow the updated example/tutorial and the command runs and output matches
Docs Changes: grpc_bridge example updated
Release Notes: N/A
Platform Specific Features: N/A