### PR TITLE
tcp: fixing a tls logging bug with the new TCP pool

### DIFF
--- a/test/common/tcp/BUILD
+++ b/test/common/tcp/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test(
         "//test/mocks/event:event_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/tcp:tcp_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/test_common:simulated_time_system_lib",

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -58,9 +58,11 @@ using AutonomousHttpConnectionPtr = std::unique_ptr<AutonomousHttpConnection>;
 // An upstream which creates AutonomousHttpConnection for new incoming connections.
 class AutonomousUpstream : public FakeUpstream {
 public:
-  AutonomousUpstream(const Network::Address::InstanceConstSharedPtr& address,
+  AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
+                     const Network::Address::InstanceConstSharedPtr& address,
                      const FakeUpstreamConfig& config, bool allow_incomplete_streams)
-      : FakeUpstream(address, config), allow_incomplete_streams_(allow_incomplete_streams),
+      : FakeUpstream(std::move(transport_socket_factory), address, config),
+        allow_incomplete_streams_(allow_incomplete_streams),
         response_trailers_(std::make_unique<Http::TestResponseTrailerMapImpl>()),
         response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
             Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -135,12 +135,15 @@ common_tls_context:
 
 void BaseIntegrationTest::createUpstreams() {
   for (uint32_t i = 0; i < fake_upstreams_count_; ++i) {
+    Network::TransportSocketFactoryPtr factory =
+        upstream_tls_ ? createUpstreamTlsContext() : Network::Test::createRawBufferSocketFactory();
     auto endpoint = upstream_address_fn_(i);
     if (autonomous_upstream_) {
-      fake_upstreams_.emplace_back(
-          new AutonomousUpstream(endpoint, upstreamConfig(), autonomous_allow_incomplete_streams_));
+      fake_upstreams_.emplace_back(new AutonomousUpstream(
+          std::move(factory), endpoint, upstreamConfig(), autonomous_allow_incomplete_streams_));
     } else {
-      fake_upstreams_.emplace_back(new FakeUpstream(endpoint, upstreamConfig()));
+      fake_upstreams_.emplace_back(
+          new FakeUpstream(std::move(factory), endpoint, upstreamConfig()));
     }
   }
 }

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -413,6 +413,7 @@ protected:
   bool create_xds_upstream_{false};
   bool tls_xds_upstream_{false};
   bool use_lds_{true}; // Use the integration framework's LDS set up.
+  bool upstream_tls_{false};
 
   Network::TransportSocketFactoryPtr createUpstreamTlsContext();
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -430,11 +430,24 @@ FakeUpstream::FakeUpstream(uint32_t port, Network::Address::IpVersion version,
 }
 
 FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
+                           const Network::Address::InstanceConstSharedPtr& address,
+                           const FakeUpstreamConfig& config)
+    : FakeUpstream(std::move(transport_socket_factory),
+                   config.udp_fake_upstream_ ? makeUdpListenSocket(address)
+                                             : makeTcpListenSocket(address),
+                   config) {
+  ENVOY_LOG(info, "starting fake server on socket {}:{}. Address version is {}. UDP={}",
+            address->ip()->addressAsString(), address->ip()->port(),
+            Network::Test::addressVersionAsString(address->ip()->version()),
+            config.udp_fake_upstream_);
+}
+
+FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
                            uint32_t port, Network::Address::IpVersion version,
                            const FakeUpstreamConfig& config)
     : FakeUpstream(std::move(transport_socket_factory), makeTcpListenSocket(port, version),
                    config) {
-  ENVOY_LOG(info, "starting fake SSL server on port {}. Address version is {}",
+  ENVOY_LOG(info, "starting fake server on port {}. Address version is {}",
             localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
 }
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -547,6 +547,11 @@ public:
   FakeUpstream(const std::string& uds_path, const FakeUpstreamConfig& config);
 
   // Creates a fake upstream bound to the specified |address|.
+  FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
+               const Network::Address::InstanceConstSharedPtr& address,
+               const FakeUpstreamConfig& config);
+
+  // Creates a fake upstream bound to the specified |address|.
   FakeUpstream(const Network::Address::InstanceConstSharedPtr& address,
                const FakeUpstreamConfig& config);
 


### PR DESCRIPTION
Also adding an integration test of tcp proxy tls-to-upstream (which passes without this PR, I just noticed we didn't have one)

Risk Level: n/a (only affects the new TCP pool)
Testing: unit test regression test
Docs Changes: n/a
Release Notes: n/a