### PR TITLE
stats: use 2-phase creation for circuit breaker stats;

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -346,6 +346,7 @@ public:
    */
   virtual const ClusterStatNames& clusterStatNames() const PURE;
   virtual const ClusterLoadReportStatNames& clusterLoadReportStatNames() const PURE;
+  virtual const ClusterCircuitBreakersStatNames& clusterCircuitBreakersStatNames() const PURE;
   virtual const ClusterRequestResponseSizeStatNames&
   clusterRequestResponseSizeStatNames() const PURE;
   virtual const ClusterTimeoutBudgetStatNames& clusterTimeoutBudgetStatNames() const PURE;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -610,11 +610,13 @@ public:
   COUNTER(upstream_rq_dropped)
 
 /**
- * Cluster circuit breakers gauges. We define these just as StatNames because
- * depending on flags, we will use null gauges for the remaining_* ones. Note
- * that the instantiation of the stats struct in
- * ClusterInfoImpl::generateCircuitBreakersStats is hand-coded and must be
- * changed if we change the set of gauges in this macro.
+ * Cluster circuit breakers gauges. Note that we do not generate a stats
+ * structure from this macro. This is because depending on flags, we want to use
+ * null gauges for all the "remaining" ones. This is hard to automate with the
+ * 2-phase macros, so ClusterInfoImpl::generateCircuitBreakersStats is
+ * hand-coded and must be changed if we alter the set of gauges in this macro.
+ * We also include stat-names in this structure that are used when composing
+ * the circuit breaker names, depending on priority settings.
  */
 #define ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)      \
   GAUGE(cx_open, Accumulate)                                                                       \
@@ -657,6 +659,9 @@ MAKE_STAT_NAMES_STRUCT(ClusterLoadReportStatNames, ALL_CLUSTER_LOAD_REPORT_STATS
 MAKE_STATS_STRUCT(ClusterLoadReportStats, ClusterLoadReportStatNames,
                   ALL_CLUSTER_LOAD_REPORT_STATS);
 
+// We can't use macros to make the Stats class for circuit breakers due to
+// the conditional inclusion of 'remaining' gauges. But we do auto-generate
+// the StatNames struct.
 MAKE_STAT_NAMES_STRUCT(ClusterCircuitBreakersStatNames, ALL_CLUSTER_CIRCUIT_BREAKERS_STATS);
 
 MAKE_STAT_NAMES_STRUCT(ClusterRequestResponseSizeStatNames,

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -610,20 +610,23 @@ public:
   COUNTER(upstream_rq_dropped)
 
 /**
- * Cluster circuit breakers stats. Open circuit breaker stats and remaining resource stats
- * can be handled differently by passing in different macros.
+ * Cluster circuit breakers gauges. We define these just as StatNames because
+ * depending on flags, we will use null gauges for the remaining_* ones.
  */
-#define ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(OPEN_GAUGE, REMAINING_GAUGE)                            \
-  OPEN_GAUGE(cx_open, Accumulate)                                                                  \
-  OPEN_GAUGE(cx_pool_open, Accumulate)                                                             \
-  OPEN_GAUGE(rq_open, Accumulate)                                                                  \
-  OPEN_GAUGE(rq_pending_open, Accumulate)                                                          \
-  OPEN_GAUGE(rq_retry_open, Accumulate)                                                            \
-  REMAINING_GAUGE(remaining_cx, Accumulate)                                                        \
-  REMAINING_GAUGE(remaining_cx_pools, Accumulate)                                                  \
-  REMAINING_GAUGE(remaining_pending, Accumulate)                                                   \
-  REMAINING_GAUGE(remaining_retries, Accumulate)                                                   \
-  REMAINING_GAUGE(remaining_rq, Accumulate)
+#define ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)      \
+  GAUGE(cx_open, Accumulate)                                                                       \
+  GAUGE(cx_pool_open, Accumulate)                                                                  \
+  GAUGE(rq_open, Accumulate)                                                                       \
+  GAUGE(rq_pending_open, Accumulate)                                                               \
+  GAUGE(rq_retry_open, Accumulate)                                                                 \
+  GAUGE(remaining_cx, Accumulate)                                                                  \
+  GAUGE(remaining_cx_pools, Accumulate)                                                            \
+  GAUGE(remaining_pending, Accumulate)                                                             \
+  GAUGE(remaining_retries, Accumulate)                                                             \
+  GAUGE(remaining_rq, Accumulate)                                                                  \
+  STATNAME(circuit_breakers)                                                                       \
+  STATNAME(default)                                                                                \
+  STATNAME(high)
 
 /**
  * All stats tracking request/response headers and body sizes. Not used by default.
@@ -651,6 +654,8 @@ MAKE_STAT_NAMES_STRUCT(ClusterLoadReportStatNames, ALL_CLUSTER_LOAD_REPORT_STATS
 MAKE_STATS_STRUCT(ClusterLoadReportStats, ClusterLoadReportStatNames,
                   ALL_CLUSTER_LOAD_REPORT_STATS);
 
+MAKE_STAT_NAMES_STRUCT(ClusterCircuitBreakersStatNames, ALL_CLUSTER_CIRCUIT_BREAKERS_STATS);
+
 MAKE_STAT_NAMES_STRUCT(ClusterRequestResponseSizeStatNames,
                        ALL_CLUSTER_REQUEST_RESPONSE_SIZE_STATS);
 MAKE_STATS_STRUCT(ClusterRequestResponseSizeStats, ClusterRequestResponseSizeStatNames,
@@ -664,7 +669,7 @@ MAKE_STATS_STRUCT(ClusterTimeoutBudgetStats, ClusterTimeoutBudgetStatNames,
  * Struct definition for cluster circuit breakers stats. @see stats_macros.h
  */
 struct ClusterCircuitBreakersStats {
-  ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(GENERATE_GAUGE_STRUCT, GENERATE_GAUGE_STRUCT)
+  ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(c, GENERATE_GAUGE_STRUCT, h, tr, GENERATE_STATNAME_STRUCT)
 };
 
 using ClusterRequestResponseSizeStatsPtr = std::unique_ptr<ClusterRequestResponseSizeStats>;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -611,7 +611,10 @@ public:
 
 /**
  * Cluster circuit breakers gauges. We define these just as StatNames because
- * depending on flags, we will use null gauges for the remaining_* ones.
+ * depending on flags, we will use null gauges for the remaining_* ones. Note
+ * that the instantiation of the stats struct in
+ * ClusterInfoImpl::generateCircuitBreakersStats is hand-coded and must be
+ * changed if we change the set of gauges in this macro.
  */
 #define ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)      \
   GAUGE(cx_open, Accumulate)                                                                       \

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -261,6 +261,7 @@ ClusterManagerImpl::ClusterManagerImpl(
       http_context_(http_context), router_context_(router_context),
       cluster_stat_names_(stats.symbolTable()),
       cluster_load_report_stat_names_(stats.symbolTable()),
+      cluster_circuit_breakers_stat_names_(stats.symbolTable()),
       cluster_request_response_size_stat_names_(stats.symbolTable()),
       cluster_timeout_budget_stat_names_(stats.symbolTable()),
       subscription_factory_(local_info, main_thread_dispatcher, *this,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -302,6 +302,9 @@ public:
   const ClusterLoadReportStatNames& clusterLoadReportStatNames() const override {
     return cluster_load_report_stat_names_;
   }
+  const ClusterCircuitBreakersStatNames& clusterCircuitBreakersStatNames() const override {
+    return cluster_circuit_breakers_stat_names_;
+  }
   const ClusterRequestResponseSizeStatNames& clusterRequestResponseSizeStatNames() const override {
     return cluster_request_response_size_stat_names_;
   }
@@ -597,6 +600,7 @@ private:
   Router::Context& router_context_;
   ClusterStatNames cluster_stat_names_;
   ClusterLoadReportStatNames cluster_load_report_stat_names_;
+  ClusterCircuitBreakersStatNames cluster_circuit_breakers_stat_names_;
   ClusterRequestResponseSizeStatNames cluster_request_response_size_stat_names_;
   ClusterTimeoutBudgetStatNames cluster_timeout_budget_stat_names_;
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1194,6 +1194,8 @@ ClusterInfoImpl::generateCircuitBreakersStats(Stats::Scope& scope, Stats::StatNa
       REMAINING_GAUGE(stat_names.remaining_retries_),
       REMAINING_GAUGE(stat_names.remaining_rq_),
   };
+
+#undef REMAINING_GAUGE
 }
 
 Http::Http1::CodecStats& ClusterInfoImpl::http1CodecStats() const {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -756,7 +756,8 @@ ClusterInfoImpl::ClusterInfoImpl(
                                         config, *stats_scope_, factory_context.clusterManager())
                                   : nullptr),
       features_(parseFeatures(config, http_protocol_options_)),
-      resource_managers_(config, runtime, name_, *stats_scope_),
+      resource_managers_(config, runtime, name_, *stats_scope_,
+                         factory_context.clusterManager().clusterCircuitBreakersStatNames()),
       maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),
       source_address_(getSourceAddress(config, bind_config)),
       lb_least_request_config_(config.least_request_lb_config()),
@@ -1160,7 +1161,9 @@ ClusterInfoImpl::OptionalClusterStats::OptionalClusterStats(
 
 ClusterInfoImpl::ResourceManagers::ResourceManagers(
     const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
-    const std::string& cluster_name, Stats::Scope& stats_scope) {
+    const std::string& cluster_name, Stats::Scope& stats_scope,
+    const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names)
+    : circuit_breakers_stat_names_(circuit_breakers_stat_names) {
   managers_[enumToInt(ResourcePriority::Default)] =
       load(config, runtime, cluster_name, stats_scope, envoy::config::core::v3::DEFAULT);
   managers_[enumToInt(ResourcePriority::High)] =
@@ -1169,15 +1172,31 @@ ClusterInfoImpl::ResourceManagers::ResourceManagers(
 
 ClusterCircuitBreakersStats
 ClusterInfoImpl::generateCircuitBreakersStats(Stats::Scope& scope, const std::string& stat_prefix,
-                                              bool track_remaining) {
-  std::string prefix(fmt::format("circuit_breakers.{}.", stat_prefix));
-  if (track_remaining) {
-    return {ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(POOL_GAUGE_PREFIX(scope, prefix),
-                                               POOL_GAUGE_PREFIX(scope, prefix))};
-  } else {
-    return {ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(POOL_GAUGE_PREFIX(scope, prefix),
-                                               NULL_POOL_GAUGE(scope))};
-  }
+                                              bool track_remaining,
+                                              const ClusterCircuitBreakersStatNames& stat_names) {
+  Stats::StatNameManagedStorage prefix_storage(stat_prefix, scope.symbolTable());
+  Stats::StatName prefix = prefix_storage.statName();
+
+  auto make_gauge = [&stat_names, &scope, prefix](Stats::StatName stat_name) -> Stats::Gauge& {
+    return Stats::Utility::gaugeFromElements(scope,
+                                             {stat_names.circuit_breakers_, prefix, stat_name},
+                                             Stats::Gauge::ImportMode::Accumulate);
+  };
+
+#define REMAINING_GAUGE(stat_name) track_remaining ? make_gauge(stat_name) : scope.nullGauge("")
+
+  return {
+      make_gauge(stat_names.cx_open_),
+      make_gauge(stat_names.cx_pool_open_),
+      make_gauge(stat_names.rq_open_),
+      make_gauge(stat_names.rq_pending_open_),
+      make_gauge(stat_names.rq_retry_open_),
+      REMAINING_GAUGE(stat_names.remaining_cx_),
+      REMAINING_GAUGE(stat_names.remaining_cx_pools_),
+      REMAINING_GAUGE(stat_names.remaining_pending_),
+      REMAINING_GAUGE(stat_names.remaining_retries_),
+      REMAINING_GAUGE(stat_names.remaining_rq_),
+  };
 }
 
 Http::Http1::CodecStats& ClusterInfoImpl::http1CodecStats() const {
@@ -1251,7 +1270,8 @@ ClusterInfoImpl::ResourceManagers::load(const envoy::config::cluster::v3::Cluste
   return std::make_unique<ResourceManagerImpl>(
       runtime, runtime_prefix, max_connections, max_pending_requests, max_requests, max_retries,
       max_connection_pools,
-      ClusterInfoImpl::generateCircuitBreakersStats(stats_scope, priority_name, track_remaining),
+      ClusterInfoImpl::generateCircuitBreakersStats(stats_scope, priority_name, track_remaining,
+                                                    circuit_breakers_stat_names_),
       budget_percent, min_retry_concurrency);
 }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -531,8 +531,7 @@ public:
   static ClusterLoadReportStats
   generateLoadReportStats(Stats::Scope& scope, const ClusterLoadReportStatNames& stat_names);
   static ClusterCircuitBreakersStats
-  generateCircuitBreakersStats(Stats::Scope& scope, const std::string& stat_prefix,
-                               bool track_remaining,
+  generateCircuitBreakersStats(Stats::Scope& scope, Stats::StatName prefix, bool track_remaining,
                                const ClusterCircuitBreakersStatNames& stat_names);
   static ClusterRequestResponseSizeStats
   generateRequestResponseSizeStats(Stats::Scope&,

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -530,9 +530,10 @@ public:
                                     const ClusterStatNames& cluster_stat_names);
   static ClusterLoadReportStats
   generateLoadReportStats(Stats::Scope& scope, const ClusterLoadReportStatNames& stat_names);
-  static ClusterCircuitBreakersStats generateCircuitBreakersStats(Stats::Scope& scope,
-                                                                  const std::string& stat_prefix,
-                                                                  bool track_remaining);
+  static ClusterCircuitBreakersStats
+  generateCircuitBreakersStats(Stats::Scope& scope, const std::string& stat_prefix,
+                               bool track_remaining,
+                               const ClusterCircuitBreakersStatNames& stat_names);
   static ClusterRequestResponseSizeStats
   generateRequestResponseSizeStats(Stats::Scope&,
                                    const ClusterRequestResponseSizeStatNames& stat_names);
@@ -653,7 +654,8 @@ public:
 private:
   struct ResourceManagers {
     ResourceManagers(const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
-                     const std::string& cluster_name, Stats::Scope& stats_scope);
+                     const std::string& cluster_name, Stats::Scope& stats_scope,
+                     const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names);
     ResourceManagerImplPtr load(const envoy::config::cluster::v3::Cluster& config,
                                 Runtime::Loader& runtime, const std::string& cluster_name,
                                 Stats::Scope& stats_scope,
@@ -662,6 +664,7 @@ private:
     using Managers = std::array<ResourceManagerImplPtr, NumResourcePriorities>;
 
     Managers managers_;
+    const ClusterCircuitBreakersStatNames& circuit_breakers_stat_names_;
   };
 
   struct OptionalClusterStats {

--- a/test/common/upstream/resource_manager_impl_test.cc
+++ b/test/common/upstream/resource_manager_impl_test.cc
@@ -17,6 +17,11 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
+ClusterCircuitBreakersStats clusterCircuitBreakersStats(Stats::Store& store) {
+  return {
+      ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(c, POOL_GAUGE(store), h, tr, GENERATE_STATNAME_STRUCT)};
+}
+
 TEST(ResourceManagerImplTest, RuntimeResourceManager) {
   NiceMock<Runtime::MockLoader> runtime;
   NiceMock<Stats::MockGauge> gauge;
@@ -26,9 +31,7 @@ TEST(ResourceManagerImplTest, RuntimeResourceManager) {
 
   ResourceManagerImpl resource_manager(
       runtime, "circuit_breakers.runtime_resource_manager_test.default.", 0, 0, 0, 1, 0,
-      ClusterCircuitBreakersStats{
-          ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(POOL_GAUGE(store), POOL_GAUGE(store))},
-      absl::nullopt, absl::nullopt);
+      clusterCircuitBreakersStats(store), absl::nullopt, absl::nullopt);
 
   EXPECT_CALL(
       runtime.snapshot_,
@@ -83,8 +86,7 @@ TEST(ResourceManagerImplTest, RemainingResourceGauges) {
   NiceMock<Runtime::MockLoader> runtime;
   Stats::IsolatedStoreImpl store;
 
-  auto stats = ClusterCircuitBreakersStats{
-      ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(POOL_GAUGE(store), POOL_GAUGE(store))};
+  auto stats = clusterCircuitBreakersStats(store);
   ResourceManagerImpl resource_manager(runtime,
                                        "circuit_breakers.runtime_resource_manager_test.default.", 1,
                                        2, 1, 0, 3, stats, absl::nullopt, absl::nullopt);
@@ -149,8 +151,7 @@ TEST(ResourceManagerImplTest, RetryBudgetOverrideGauge) {
   NiceMock<Runtime::MockLoader> runtime;
   Stats::IsolatedStoreImpl store;
 
-  auto stats = ClusterCircuitBreakersStats{
-      ALL_CLUSTER_CIRCUIT_BREAKERS_STATS(POOL_GAUGE(store), POOL_GAUGE(store))};
+  auto stats = clusterCircuitBreakersStats(store);
 
   // Test retry budgets disable remaining_retries gauge (it should always be 0).
   ResourceManagerImpl rm(runtime, "circuit_breakers.runtime_resource_manager_test.default.", 1, 2,

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -55,7 +55,8 @@ MockClusterInfo::MockClusterInfo()
           std::make_unique<ClusterTimeoutBudgetStats>(ClusterInfoImpl::generateTimeoutBudgetStats(
               timeout_budget_stats_store_, cluster_timeout_budget_stat_names_))),
       circuit_breakers_stats_(ClusterInfoImpl::generateCircuitBreakersStats(
-          stats_store_, "default", true, cluster_circuit_breakers_stat_names_)),
+          stats_store_, cluster_circuit_breakers_stat_names_.default_, true,
+          cluster_circuit_breakers_stat_names_)),
       resource_manager_(new Upstream::ResourceManagerImpl(
           runtime_, "fake_key", 1, 1024, 1024, 1, std::numeric_limits<uint64_t>::max(),
           circuit_breakers_stats_, absl::nullopt, absl::nullopt)) {

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -41,6 +41,7 @@ MockClusterInfo::MockClusterInfo()
           envoy::config::core::v3::Http2ProtocolOptions())),
       stat_names_(stats_store_.symbolTable()),
       cluster_load_report_stat_names_(stats_store_.symbolTable()),
+      cluster_circuit_breakers_stat_names_(stats_store_.symbolTable()),
       cluster_request_response_size_stat_names_(stats_store_.symbolTable()),
       cluster_timeout_budget_stat_names_(stats_store_.symbolTable()),
       stats_(ClusterInfoImpl::generateStats(stats_store_, stat_names_)),
@@ -53,8 +54,8 @@ MockClusterInfo::MockClusterInfo()
       timeout_budget_stats_(
           std::make_unique<ClusterTimeoutBudgetStats>(ClusterInfoImpl::generateTimeoutBudgetStats(
               timeout_budget_stats_store_, cluster_timeout_budget_stat_names_))),
-      circuit_breakers_stats_(
-          ClusterInfoImpl::generateCircuitBreakersStats(stats_store_, "default", true)),
+      circuit_breakers_stats_(ClusterInfoImpl::generateCircuitBreakersStats(
+          stats_store_, "default", true, cluster_circuit_breakers_stat_names_)),
       resource_manager_(new Upstream::ResourceManagerImpl(
           runtime_, "fake_key", 1, 1024, 1024, 1, std::numeric_limits<uint64_t>::max(),
           circuit_breakers_stats_, absl::nullopt, absl::nullopt)) {

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -158,6 +158,7 @@ public:
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStatNames stat_names_;
   ClusterLoadReportStatNames cluster_load_report_stat_names_;
+  ClusterCircuitBreakersStatNames cluster_circuit_breakers_stat_names_;
   ClusterRequestResponseSizeStatNames cluster_request_response_size_stat_names_;
   ClusterTimeoutBudgetStatNames cluster_timeout_budget_stat_names_;
   ClusterStats stats_;

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -18,6 +18,7 @@ MockClusterManager::MockClusterManager(TimeSource&) : MockClusterManager() {}
 
 MockClusterManager::MockClusterManager()
     : cluster_stat_names_(*symbol_table_), cluster_load_report_stat_names_(*symbol_table_),
+      cluster_circuit_breakers_stat_names_(*symbol_table_),
       cluster_request_response_size_stat_names_(*symbol_table_),
       cluster_timeout_budget_stat_names_(*symbol_table_) {
   ON_CALL(*this, httpConnPoolForCluster(_, _, _, _)).WillByDefault(Return(&conn_pool_));

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -74,6 +74,9 @@ public:
   const ClusterLoadReportStatNames& clusterLoadReportStatNames() const override {
     return cluster_load_report_stat_names_;
   }
+  const ClusterCircuitBreakersStatNames& clusterCircuitBreakersStatNames() const override {
+    return cluster_circuit_breakers_stat_names_;
+  }
   const ClusterRequestResponseSizeStatNames& clusterRequestResponseSizeStatNames() const override {
     return cluster_request_response_size_stat_names_;
   }
@@ -96,6 +99,7 @@ public:
   Stats::TestSymbolTable symbol_table_;
   ClusterStatNames cluster_stat_names_;
   ClusterLoadReportStatNames cluster_load_report_stat_names_;
+  ClusterCircuitBreakersStatNames cluster_circuit_breakers_stat_names_;
   ClusterRequestResponseSizeStatNames cluster_request_response_size_stat_names_;
   ClusterTimeoutBudgetStatNames cluster_timeout_budget_stat_names_;
 };


### PR DESCRIPTION
Commit Message: Use 2-phase creation for circuit breaker stats. This was a little messy because of the creative use of the 1-phase stats macros to conditionally null out some of the gauges. This was resolved by manually instantiating the stats structure.
Additional Description:
Risk Level: low
Testing: //tes/t...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
