### PR TITLE
router: support for x-forwarded-host header.

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -902,20 +902,25 @@ message RouteAction {
 
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
-    // this value.
+    // this value. The original value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header.
     string host_rewrite_literal = 6
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during forwarding, the host header will be swapped with
-    // the hostname of the upstream host chosen by the cluster manager. This
-    // option is applicable only when the destination cluster for a route is of
-    // type *strict_dns* or *logical_dns*. Setting this to true with other cluster
-    // types has no effect.
+    // the hostname of the upstream host chosen by the cluster manager. The original
+    // value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header. This option is
+    // applicable only when the destination cluster for a route is of type
+    // *strict_dns* or *logical_dns*. Setting this to true with other cluster types
+    // has no effect.
     google.protobuf.BoolValue auto_host_rewrite = 7;
 
     // Indicates that during forwarding, the host header will be swapped with the content of given
     // downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
-    // If header value is empty, host header is left intact.
+    // The original value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header. If header value is empty, host
+    // and XFH headers are left intact.
     //
     // .. attention::
     //
@@ -930,7 +935,9 @@ message RouteAction {
 
     // Indicates that during forwarding, the host header will be swapped with
     // the result of the regex substitution executed on path value with query and fragment removed.
-    // This is useful for transitioning variable content between path segment and subdomain.
+    // The original value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header. This is useful for
+    // transitioning variable content between path segment and subdomain.
     //
     // For example with the following config:
     //

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -902,20 +902,25 @@ message RouteAction {
 
   oneof host_rewrite_specifier {
     // Indicates that during forwarding, the host header will be swapped with
-    // this value.
+    // this value. The original value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header.
     string host_rewrite_literal = 6
         [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
     // Indicates that during forwarding, the host header will be swapped with
-    // the hostname of the upstream host chosen by the cluster manager. This
-    // option is applicable only when the destination cluster for a route is of
-    // type *strict_dns* or *logical_dns*. Setting this to true with other cluster
-    // types has no effect.
+    // the hostname of the upstream host chosen by the cluster manager. The original
+    // value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header. This option is
+    // applicable only when the destination cluster for a route is of type
+    // *strict_dns* or *logical_dns*. Setting this to true with other cluster types
+    // has no effect.
     google.protobuf.BoolValue auto_host_rewrite = 7;
 
     // Indicates that during forwarding, the host header will be swapped with the content of given
     // downstream or :ref:`custom <config_http_conn_man_headers_custom_request_headers>` header.
-    // If header value is empty, host header is left intact.
+    // The original value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header. If header value is empty, host
+    // and XFH headers are left intact.
     //
     // .. attention::
     //
@@ -930,7 +935,9 @@ message RouteAction {
 
     // Indicates that during forwarding, the host header will be swapped with
     // the result of the regex substitution executed on path value with query and fragment removed.
-    // This is useful for transitioning variable content between path segment and subdomain.
+    // The original value of the host header will be appended to the
+    // :ref:`config_http_conn_man_headers_x-forwarded-host` header. This is useful for
+    // transitioning variable content between path segment and subdomain.
     //
     // For example with the following config:
     //

--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -327,6 +327,19 @@ A few very important notes about XFF:
      XFF is parsed to determine if a request is internal. In this scenario, do not forward XFF and
      allow Envoy to generate a new one with a single internal origin IP.
 
+.. _config_http_conn_man_headers_x-forwarded-host:
+
+x-forwarded-host
+----------------
+
+The *x-forwarded-host* (XFH) header is a standard proxy header which indicates the original host
+requested by the client in the *:authority* (*host* in HTTP1) header. A compliant proxy *appends*
+the original value of the *:authority* header to XFH only if the *:authority* header is modified.
+
+Envoy updates the *:authority* header and appends its original value to XFH only if one of the
+:ref:`host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.host_rewrite_literal>` options
+are used.
+
 .. _config_http_conn_man_headers_x-forwarded-proto:
 
 x-forwarded-proto

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -74,6 +74,7 @@ New Features
 * overload: add :ref:`envoy.overload_actions.reduce_timeouts <config_overload_manager_overload_actions>` overload action to enable scaling timeouts down with load.
 * ratelimit: added support for use of various :ref:`metadata <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>` as a ratelimit action.
 * ratelimit: added :ref:`disable_x_envoy_ratelimited_header <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimit>` option to disable `X-Envoy-RateLimited` header.
+* router: added support for *x-forwarded-host* header.
 * sds: improved support for atomic :ref:`key rotations <xds_certificate_rotation>` and added configurable rotation triggers for
   :ref:`TlsCertificate <envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsCertificate.watched_directory>` and
   :ref:`CertificateValidationContext <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.watched_directory>`.

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -285,6 +285,7 @@ private:
   HEADER_FUNC(Expect)                                                                              \
   HEADER_FUNC(ForwardedClientCert)                                                                 \
   HEADER_FUNC(ForwardedFor)                                                                        \
+  HEADER_FUNC(ForwardedHost)                                                                       \
   HEADER_FUNC(ForwardedProto)                                                                      \
   HEADER_FUNC(GrpcTimeout)                                                                         \
   HEADER_FUNC(Host)                                                                                \

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -176,11 +176,26 @@ private:
 void appendXff(RequestHeaderMap& headers, const Network::Address::Instance& remote_address);
 
 /**
+ * Append to x-forwarded-host header.
+ * @param headers supplies the headers to append to.
+ * @param hostname supplies the hostname to append.
+ */
+void appendXfh(RequestHeaderMap& headers, absl::string_view hostname);
+
+/**
  * Append to via header.
  * @param headers supplies the headers to append to.
  * @param via supplies the via header to append.
  */
 void appendVia(RequestOrResponseHeaderMap& headers, const std::string& via);
+
+/**
+ * Update authority with the specified hostname and copy the original authority to the forwarded
+ * host header.
+ * @param headers headers where authority should be updated.
+ * @param hostname hostname that authority should be updated with.
+ */
+void updateAuthority(RequestHeaderMap& headers, absl::string_view hostname);
 
 /**
  * Creates an SSL (https) redirect path based on the input host and path headers.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -548,7 +548,7 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::RequestHeaderMap& headers,
   }
 
   if (!host_rewrite_.empty()) {
-    headers.setHost(host_rewrite_);
+    Http::Utility::updateAuthority(headers, host_rewrite_);
   } else if (auto_host_rewrite_header_) {
     const auto header = headers.get(*auto_host_rewrite_header_);
     if (!header.empty()) {
@@ -556,13 +556,13 @@ void RouteEntryImplBase::finalizeRequestHeaders(Http::RequestHeaderMap& headers,
       // value is used.
       const absl::string_view header_value = header[0]->value().getStringView();
       if (!header_value.empty()) {
-        headers.setHost(header_value);
+        Http::Utility::updateAuthority(headers, header_value);
       }
     }
   } else if (host_rewrite_path_regex_ != nullptr) {
     const std::string path(headers.getPathValue());
     absl::string_view just_path(Http::PathUtil::removeQueryAndFragment(path));
-    headers.setHost(
+    Http::Utility::updateAuthority(headers,
         host_rewrite_path_regex_->replaceAll(just_path, host_rewrite_path_regex_substitution_));
   }
 

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -391,7 +391,7 @@ void UpstreamRequest::onPoolReady(
   calling_encode_headers_ = true;
   auto* headers = parent_.downstreamHeaders();
   if (parent_.routeEntry()->autoHostRewrite() && !host->hostname().empty()) {
-    parent_.downstreamHeaders()->setHost(host->hostname());
+    Http::Utility::updateAuthority(*parent_.downstreamHeaders(), host->hostname());
   }
 
   if (span_ != nullptr) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -1060,6 +1060,7 @@ virtual_hosts:
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     route->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("new_host", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
   // Rewrites host using supplied header.
@@ -1069,6 +1070,7 @@ virtual_hosts:
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     route->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("rewrote", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
   // Does not rewrite host because of missing header.
@@ -1078,6 +1080,7 @@ virtual_hosts:
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     route->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
   // Rewrites host using path.
@@ -1087,6 +1090,7 @@ virtual_hosts:
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     route->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("envoyproxy.io", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
   // Rewrites host using path, removes query parameters
@@ -1096,6 +1100,7 @@ virtual_hosts:
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
     route->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("envoyproxy.io", headers.get_(Http::Headers::get().Host));
+    EXPECT_EQ("api.lyft.com", headers.get_(Http::Headers::get().ForwardedHost));
   }
 
   // Case sensitive rewrite matching test.

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6132,6 +6132,7 @@ TEST_F(RouterTest, AutoHostRewriteEnabled) {
   Http::TestRequestHeaderMapImpl outgoing_headers;
   HttpTestUtility::addDefaultHeaders(outgoing_headers);
   outgoing_headers.setHost(cm_.thread_local_cluster_.conn_pool_.host_->hostname_);
+  outgoing_headers.setForwardedHost().value(req_host);
 
   EXPECT_CALL(callbacks_.route_->route_entry_, timeout())
       .WillOnce(Return(std::chrono::milliseconds(0)));


### PR DESCRIPTION
Commit Message: _Support for x-forwarded-host header._

Additional Description:
_If, for a request, the host/authority header is changed when the
request is proxied, set the x-forwarded-host header as:
x-forwarded-host = append(x-forwarded-host, host)_

Risk Level: _Low_

Testing: _unit test and manual testing_

Docs Changes:
_Added x-forwarded-host header in HTTP header manipulation
(configuration/http/http_conn_man/headers).
Under the host_rewrite options in route_components.proto
(in v2, v3, and v4alpha), added that when host is rewritten,
XFH header is appended with the original value of host header._

Release Notes: _router: added support for *x-forwarded-host* header._

Platform Specific Features: _No_

Fixes https://github.com/envoyproxy/envoy/issues/5940