### PR TITLE
stats: rename TestSymbolTable to be inside Stats::TestUtil, and add help text to a common assert pointing to that as a remedy.

### DIFF
--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -246,7 +246,7 @@ void SymbolTableImpl::incRefCount(const StatName& stat_name) {
     static const char assert_help[] =
         "Please see "
         "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
-        "debugging-symbol-table-asserts for hints on how to fix";
+        "debugging-symbol-table-asserts";
 
     ASSERT(decode_search != decode_map_.end(), assert_help);
     auto encode_search = encode_map_.find(decode_search->second->toStringView());

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -243,14 +243,16 @@ void SymbolTableImpl::incRefCount(const StatName& stat_name) {
   Thread::LockGuard lock(lock_);
   for (Symbol symbol : symbols) {
     auto decode_search = decode_map_.find(symbol);
-    static const char assert_help[] =
-        "Please see "
-        "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
-        "debugging-symbol-table-asserts";
 
-    ASSERT(decode_search != decode_map_.end(), assert_help);
+    ASSERT(decode_search != decode_map_.end(),
+           "Please see "
+           "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
+           "debugging-symbol-table-asserts");
     auto encode_search = encode_map_.find(decode_search->second->toStringView());
-    ASSERT(encode_search != encode_map_.end(), assert_help);
+    ASSERT(encode_search != encode_map_.end(),
+           "Please see "
+           "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
+           "debugging-symbol-table-asserts");
 
     ++encode_search->second.ref_count_;
   }

--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -243,10 +243,14 @@ void SymbolTableImpl::incRefCount(const StatName& stat_name) {
   Thread::LockGuard lock(lock_);
   for (Symbol symbol : symbols) {
     auto decode_search = decode_map_.find(symbol);
-    ASSERT(decode_search != decode_map_.end());
+    static const char assert_help[] =
+        "Please see "
+        "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
+        "debugging-symbol-table-asserts for hints on how to fix";
 
+    ASSERT(decode_search != decode_map_.end(), assert_help);
     auto encode_search = encode_map_.find(decode_search->second->toStringView());
-    ASSERT(encode_search != encode_map_.end());
+    ASSERT(encode_search != encode_map_.end(), assert_help);
 
     ++encode_search->second.ref_count_;
   }

--- a/source/docs/stats.md
+++ b/source/docs/stats.md
@@ -267,8 +267,10 @@ Developers trying to can iterate through changes in these tests locally with:
 If you are visiting this section because you saw a message like:
 
 ```bash
-[2020-12-11 18:30:54.059][16][critical][assert] [source/common/stats/symbol_table_impl.cc:251] assert failure: decode_search != decode_map_.end(). Details: Please see https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#debugging-symbol-table-asserts for hints on how to fix
-
+[...][16][critical][assert] [source/common/stats/symbol_table_impl.cc:251] assert failure:
+decode_search != decode_map_.end(). Details: Please see 
+https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#debugging-symbol-table-asserts
+for hints on how to fix
 ```
 then you have come to the right place.
 

--- a/source/docs/stats.md
+++ b/source/docs/stats.md
@@ -270,7 +270,6 @@ If you are visiting this section because you saw a message like:
 [...][16][critical][assert] [source/common/stats/symbol_table_impl.cc:251] assert failure:
 decode_search != decode_map_.end(). Details: Please see 
 https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#debugging-symbol-table-asserts
-for hints on how to fix
 ```
 then you have come to the right place.
 

--- a/test/common/grpc/context_impl_test.cc
+++ b/test/common/grpc/context_impl_test.cc
@@ -18,7 +18,7 @@ namespace Grpc {
 
 TEST(GrpcContextTest, ChargeStats) {
   NiceMock<Upstream::MockClusterInfo> cluster;
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Stats::StatNamePool pool(*symbol_table_);
   const Stats::StatName service = pool.add("service");
   const Stats::StatName method = pool.add("method");
@@ -68,7 +68,7 @@ TEST(GrpcContextTest, ResolveServiceAndMethod) {
   Http::TestRequestHeaderMapImpl headers;
   headers.setPath("/service_name/method_name?a=b");
   const Http::HeaderEntry* path = headers.Path();
-  Stats::TestSymbolTable symbol_table;
+  Stats::TestUtil::TestSymbolTable symbol_table;
   ContextImpl context(*symbol_table);
   absl::optional<Context::RequestStatNames> request_names =
       context.resolveDynamicServiceAndMethod(path);

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -441,7 +441,7 @@ public:
   FakeHttpConnectionPtr fake_connection_;
   std::vector<FakeStreamPtr> fake_streams_;
   const Protobuf::MethodDescriptor* method_descriptor_;
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Stats::IsolatedStoreImpl* stats_store_ = new Stats::IsolatedStoreImpl(*symbol_table_);
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;

--- a/test/common/http/codes_test.cc
+++ b/test/common/http/codes_test.cc
@@ -44,7 +44,7 @@ public:
     code_stats_.chargeResponseStat(info);
   }
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Stats::TestUtil::TestStore global_store_;
   Stats::TestUtil::TestStore cluster_scope_;
   Http::CodeStatsImpl code_stats_;

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -319,7 +319,7 @@ most_specific_header_mutations_wins: {0}
     return fmt::format(yaml, most_specific_wins);
   }
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Api::ApiPtr api_;
   NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   Event::SimulatedTimeSystem test_time_;

--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -13,6 +13,7 @@
 
 namespace Envoy {
 namespace Stats {
+namespace TestUtil {
 
 class TestSymbolTableHelper {
 public:
@@ -28,9 +29,6 @@ private:
 // are constructed without any context, but StatNames that are symbolized from
 // one mock may need to be entered into stat storage in another one. Thus they
 // must be connected by global state.
-//
-// TODO(jmarantz): rename this as Stats::TestUtil::GlobalSymbolTable to clarify
-// the motivation, and rename the 10 call-sites for it.
 class TestSymbolTable {
 public:
   SymbolTable& operator*() { return global_.get().symbolTable(); }
@@ -39,8 +37,6 @@ public:
   const SymbolTable* operator->() const { return &global_.get().constSymbolTable(); }
   Envoy::Test::Global<TestSymbolTableHelper> global_;
 };
-
-namespace TestUtil {
 
 /**
  * Calls fn for a sampling of plausible stat names given a number of clusters.

--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -33,7 +33,7 @@ public:
 
   ~GrpcHttp1BridgeFilterTest() override { filter_.onDestroy(); }
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Grpc::ContextImpl context_;
   Http1BridgeFilter filter_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;

--- a/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
+++ b/test/extensions/filters/http/grpc_web/grpc_web_filter_test.cc
@@ -103,7 +103,7 @@ public:
               request_headers.get_(Http::CustomHeaders::get().GrpcAcceptEncoding));
   }
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Grpc::ContextImpl grpc_context_;
   GrpcWebFilter filter_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -119,7 +119,7 @@ public:
   SystemTime start_time_;
   StreamInfo::MockStreamInfo stream_info_;
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Grpc::ContextImpl grpc_context_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_;

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -253,7 +253,7 @@ public:
   Stats::StatName statName() const override { return stat_name_.statName(); }
   VirtualClusterStats& stats() const override { return stats_; }
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Stats::StatNameManagedStorage stat_name_{"fake_virtual_cluster", *symbol_table_};
   Stats::IsolatedStoreImpl stats_store_;
   mutable VirtualClusterStats stats_{generateStats(stats_store_)};
@@ -281,7 +281,7 @@ public:
     return stat_name_->statName();
   }
 
-  mutable Stats::TestSymbolTable symbol_table_;
+  mutable Stats::TestUtil::TestSymbolTable symbol_table_;
   std::string name_{"fake_vhost"};
   mutable std::unique_ptr<Stats::StatNameManagedStorage> stat_name_;
   testing::NiceMock<MockRateLimitPolicy> rate_limit_policy_;

--- a/test/mocks/router/router_filter_interface.h
+++ b/test/mocks/router/router_filter_interface.h
@@ -54,7 +54,7 @@ public:
 
   envoy::extensions::filters::http::router::v3::Router router_proto;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Stats::StatNamePool pool_;
   FilterConfig config_;
   Upstream::ClusterInfoConstSharedPtr cluster_info_;

--- a/test/mocks/server/hot_restart.h
+++ b/test/mocks/server/hot_restart.h
@@ -29,7 +29,7 @@ public:
   MOCK_METHOD(Stats::Allocator&, statsAllocator, ());
 
 private:
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Thread::MutexBasicLockable log_lock_;
   Thread::MutexBasicLockable access_log_lock_;
   Stats::AllocatorImpl stats_allocator_;

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -84,7 +84,7 @@ public:
     }
   }
 
-  TestSymbolTable symbol_table_; // Must outlive name_.
+  TestUtil::TestSymbolTable symbol_table_; // Must outlive name_.
   MetricName name_;
 
   void setTags(const TagVector& tags) {
@@ -324,7 +324,7 @@ public:
     return textReadout(symbol_table_->toString(name));
   }
 
-  TestSymbolTable symbol_table_;
+  TestUtil::TestSymbolTable symbol_table_;
   testing::NiceMock<MockCounter> counter_;
   std::vector<std::unique_ptr<MockHistogram>> histograms_;
 };

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -75,7 +75,7 @@ public:
   NiceMock<Config::MockSubscriptionFactory> subscription_factory_;
   absl::flat_hash_map<std::string, std::unique_ptr<MockCluster>> active_clusters_;
   absl::flat_hash_map<std::string, std::unique_ptr<MockCluster>> warming_clusters_;
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   ClusterStatNames cluster_stat_names_;
   ClusterLoadReportStatNames cluster_load_report_stat_names_;
   ClusterRequestResponseSizeStatNames cluster_request_response_size_stat_names_;

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -113,7 +113,7 @@ public:
   Network::TransportSocketFactoryPtr socket_factory_;
   testing::NiceMock<MockClusterInfo> cluster_;
   HostStats stats_;
-  mutable Stats::TestSymbolTable symbol_table_;
+  mutable Stats::TestUtil::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;
 };
 
@@ -199,7 +199,7 @@ public:
   Network::TransportSocketFactoryPtr socket_factory_;
   testing::NiceMock<Outlier::MockDetectorHostMonitor> outlier_detector_;
   HostStats stats_;
-  mutable Stats::TestSymbolTable symbol_table_;
+  mutable Stats::TestUtil::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;
 };
 

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -91,7 +91,7 @@ protected:
     EXPECT_EQ(0, symbol_table_->numSymbols());
   }
 
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
   Stats::AllocatorImpl alloc_;
   Stats::StatNamePool pool_;
   std::vector<Stats::CounterSharedPtr> counters_;

--- a/test/tools/router_check/router.h
+++ b/test/tools/router_check/router.h
@@ -50,7 +50,7 @@ struct ToolConfig {
 private:
   ToolConfig(std::unique_ptr<Http::TestRequestHeaderMapImpl> request_headers,
              std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers, int random_value);
-  Stats::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestSymbolTable symbol_table_;
 };
 
 /**


### PR DESCRIPTION
Commit Message: An earlier refactor required moving `TestSymbolTable` from the mocking infrastructure into `test/common/stats/stat_test_utility.h`, but leaving it outside the `TestUtil` namespace to avoid making a large PR even larger. This makes the namespace consistent again.

More importantly, a common reason to use `TestSymbolTable` is an assertion that arises in tests where names from two different symbol tables get joined(). We now annotate this assertion with a pointer to a section in stats.md where we explain why that assertion occurs and how to remedy it.
Additional Description:
Risk Level: low
Testing: //test/..., plus I manually tested by temporarily changing the stats_store in logical_dns_cluster_test.cc to an Isolated StoreImpl, to watch the assert fire and the message that comes out.
Docs Changes: stats.md updated here.
Release Notes: n/a
Platform Specific Features: n/a

