### PR TITLE
cluster manager: initialization cleanups

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -371,36 +371,24 @@ ClusterManagerImpl::ClusterManagerImpl(
   cm_stats_.cluster_added_.add(bootstrap.static_resources().clusters().size());
   updateClusterCounts();
 
-  if (local_cluster_name_ &&
-      (active_clusters_.find(local_cluster_name_.value()) == active_clusters_.end())) {
-    throw EnvoyException(
-        fmt::format("local cluster '{}' must be defined", local_cluster_name_.value()));
+  absl::optional<ThreadLocalClusterManagerImpl::LocalClusterParams> local_cluster_params;
+  if (local_cluster_name_) {
+    auto local_cluster = active_clusters_.find(local_cluster_name_.value());
+    if (local_cluster == active_clusters_.end()) {
+      throw EnvoyException(
+          fmt::format("local cluster '{}' must be defined", local_cluster_name_.value()));
+    }
+    local_cluster_params.emplace();
+    local_cluster_params->info_ = local_cluster->second->cluster().info();
+    local_cluster_params->load_balancer_factory_ = local_cluster->second->loadBalancerFactory();
+    local_cluster->second->setAddedOrUpdated();
   }
 
   // Once the initial set of static bootstrap clusters are created (including the local cluster),
   // we can instantiate the thread local cluster manager.
-  tls_.set([this](Event::Dispatcher& dispatcher) {
-    return std::make_shared<ThreadLocalClusterManagerImpl>(*this, dispatcher);
+  tls_.set([this, local_cluster_params](Event::Dispatcher& dispatcher) {
+    return std::make_shared<ThreadLocalClusterManagerImpl>(*this, dispatcher, local_cluster_params);
   });
-
-  // For active clusters that exist in bootstrap, post an empty thread local cluster update to
-  // populate them.
-  // TODO(mattklein123): It would be nice if we did not do this and instead all thread local cluster
-  // creation happened as part of the cluster init flow, however there are certain cases that depend
-  // on this behavior including route checking. It may be possible to fix static route checking to
-  // not depend on this behavior, but for now this is consistent with the way we have always done
-  // this so in the interest of minimal change it is not being done now.
-  for (auto& cluster : active_clusters_) {
-    // Skip posting the thread local cluster which is created as part of the thread local cluster
-    // manager constructor. See the TODO in that code for eventually cleaning this up.
-    if (local_cluster_name_ && local_cluster_name_.value() == cluster.first) {
-      continue;
-    }
-
-    // Avoid virtual call in the constructor. This only impacts tests. Remove this when fixing
-    // the above TODO.
-    postThreadLocalClusterUpdateNonVirtual(*cluster.second, ThreadLocalClusterUpdateParams());
-  }
 
   // We can now potentially create the CDS API once the backing cluster exists.
   if (dyn_resources.has_cds_config()) {
@@ -536,14 +524,11 @@ void ClusterManagerImpl::onClusterInit(ClusterManagerCluster& cm_cluster) {
     params.per_priority_update_params_.emplace_back(host_set->priority(), host_set->hosts(),
                                                     HostVector{});
   }
-  // At this point the update is posted if either there are actual updates or the cluster has
-  // not been added yet. The latter can only happen with dynamic cluster as static clusters are
-  // added immediately.
-  // TODO(mattklein123): Per related TODOs we will see if we can centralize all logic so that
-  // clusters only get added in this path and all of the special casing can be removed.
-  if (!params.per_priority_update_params_.empty() || !cm_cluster.addedOrUpdated()) {
-    postThreadLocalClusterUpdate(cm_cluster, std::move(params));
-  }
+  // NOTE: In all cases *other* than the local cluster, this is when a cluster is added/updated
+  // The local cluster must currently be statically defined and must exist prior to other
+  // clusters being added/updated. We could gate the below update on hosts being available on
+  // the cluster or the cluster not already existing, but the special logic is not worth it.
+  postThreadLocalClusterUpdate(cm_cluster, std::move(params));
 }
 
 bool ClusterManagerImpl::scheduleUpdate(ClusterManagerCluster& cluster, uint32_t priority,
@@ -931,18 +916,10 @@ void ClusterManagerImpl::postThreadLocalDrainConnections(const Cluster& cluster,
 
 void ClusterManagerImpl::postThreadLocalClusterUpdateNonVirtual(
     ClusterManagerCluster& cm_cluster, ThreadLocalClusterUpdateParams&& params) {
-  const bool is_local_cluster = local_cluster_name_.has_value() &&
-                                local_cluster_name_.value() == cm_cluster.cluster().info()->name();
   bool add_or_update_cluster = false;
   if (!cm_cluster.addedOrUpdated()) {
     add_or_update_cluster = true;
     cm_cluster.setAddedOrUpdated();
-  }
-  if (is_local_cluster) {
-    // TODO(mattklein123): This is needed because of the special case of how local cluster is
-    // initialized in the thread local cluster manager constructor. This will all be cleaned up
-    // in a follow up.
-    add_or_update_cluster = false;
   }
 
   LoadBalancerFactorySharedPtr load_balancer_factory;
@@ -961,6 +938,7 @@ void ClusterManagerImpl::postThreadLocalClusterUpdateNonVirtual(
   tls_.runOnAllThreads(
       [info = cm_cluster.cluster().info(), params = std::move(params), add_or_update_cluster,
        load_balancer_factory](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+        ThreadLocalClusterManagerImpl::ClusterEntry* new_cluster = nullptr;
         if (add_or_update_cluster) {
           if (cluster_manager->thread_local_clusters_.count(info->name()) > 0) {
             ENVOY_LOG(debug, "updating TLS cluster {}", info->name());
@@ -968,15 +946,9 @@ void ClusterManagerImpl::postThreadLocalClusterUpdateNonVirtual(
             ENVOY_LOG(debug, "adding TLS cluster {}", info->name());
           }
 
-          auto thread_local_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(
-              *cluster_manager, info, load_balancer_factory);
-          cluster_manager->thread_local_clusters_[info->name()].reset(thread_local_cluster);
-          // TODO(mattklein123): It would be better if update callbacks were done after the initial
-          // cluster member is seeded, assuming it is. In the interest of minimal change this is
-          // deferred for a future change.
-          for (auto& cb : cluster_manager->update_callbacks_) {
-            cb->onClusterAddOrUpdate(*thread_local_cluster);
-          }
+          new_cluster = new ThreadLocalClusterManagerImpl::ClusterEntry(*cluster_manager, info,
+                                                                        load_balancer_factory);
+          cluster_manager->thread_local_clusters_[info->name()].reset(new_cluster);
         }
 
         for (const auto& per_priority : params.per_priority_update_params_) {
@@ -984,6 +956,12 @@ void ClusterManagerImpl::postThreadLocalClusterUpdateNonVirtual(
               info->name(), per_priority.priority_, per_priority.update_hosts_params_,
               per_priority.locality_weights_, per_priority.hosts_added_,
               per_priority.hosts_removed_, per_priority.overprovisioning_factor_);
+        }
+
+        if (new_cluster != nullptr) {
+          for (auto& cb : cluster_manager->update_callbacks_) {
+            cb->onClusterAddOrUpdate(*new_cluster);
+          }
         }
       });
 }
@@ -1059,22 +1037,17 @@ ProtobufTypes::MessagePtr ClusterManagerImpl::dumpClusterConfigs() {
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::ThreadLocalClusterManagerImpl(
-    ClusterManagerImpl& parent, Event::Dispatcher& dispatcher)
+    ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
+    const absl::optional<LocalClusterParams>& local_cluster_params)
     : parent_(parent), thread_local_dispatcher_(dispatcher) {
   // If local cluster is defined then we need to initialize it first.
-  // TODO(mattklein123): Technically accessing active_clusters_ here is a race condition. This has
-  // been this way "forever" but should be fixed in a follow up.
-  if (parent.localClusterName()) {
-    ENVOY_LOG(debug, "adding TLS local cluster {}", parent.localClusterName().value());
-    auto& local_cluster = parent.active_clusters_.at(parent.localClusterName().value());
-    thread_local_clusters_[parent.localClusterName().value()] = std::make_unique<ClusterEntry>(
-        *this, local_cluster->cluster_->info(), local_cluster->loadBalancerFactory());
+  if (local_cluster_params.has_value()) {
+    const auto& local_cluster_name = local_cluster_params->info_->name();
+    ENVOY_LOG(debug, "adding TLS local cluster {}", local_cluster_name);
+    thread_local_clusters_[local_cluster_name] = std::make_unique<ClusterEntry>(
+        *this, local_cluster_params->info_, local_cluster_params->load_balancer_factory_);
+    local_priority_set_ = &thread_local_clusters_[local_cluster_name]->priority_set_;
   }
-
-  local_priority_set_ =
-      parent.localClusterName()
-          ? &thread_local_clusters_[parent.localClusterName().value()]->priority_set_
-          : nullptr;
 }
 
 ClusterManagerImpl::ThreadLocalClusterManagerImpl::~ThreadLocalClusterManagerImpl() {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -914,8 +914,8 @@ void ClusterManagerImpl::postThreadLocalDrainConnections(const Cluster& cluster,
   });
 }
 
-void ClusterManagerImpl::postThreadLocalClusterUpdateNonVirtual(
-    ClusterManagerCluster& cm_cluster, ThreadLocalClusterUpdateParams&& params) {
+void ClusterManagerImpl::postThreadLocalClusterUpdate(ClusterManagerCluster& cm_cluster,
+                                                      ThreadLocalClusterUpdateParams&& params) {
   bool add_or_update_cluster = false;
   if (!cm_cluster.addedOrUpdated()) {
     add_or_update_cluster = true;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -327,9 +327,7 @@ protected:
   };
 
   virtual void postThreadLocalClusterUpdate(ClusterManagerCluster& cm_cluster,
-                                            ThreadLocalClusterUpdateParams&& params) {
-    return postThreadLocalClusterUpdateNonVirtual(cm_cluster, std::move(params));
-  }
+                                            ThreadLocalClusterUpdateParams&& params);
 
 private:
   /**
@@ -562,8 +560,6 @@ private:
                              ClusterMap& cluster_map);
   void onClusterInit(ClusterManagerCluster& cluster);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
-  void postThreadLocalClusterUpdateNonVirtual(ClusterManagerCluster& cm_cluster,
-                                              ThreadLocalClusterUpdateParams&& params);
   void updateClusterCounts();
   void clusterWarmingToActive(const std::string& cluster_name);
   static void maybePrefetch(ThreadLocalClusterManagerImpl::ClusterEntry& cluster_entry,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -422,7 +422,13 @@ private:
 
     using ClusterEntryPtr = std::unique_ptr<ClusterEntry>;
 
-    ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher);
+    struct LocalClusterParams {
+      LoadBalancerFactorySharedPtr load_balancer_factory_;
+      ClusterInfoConstSharedPtr info_;
+    };
+
+    ThreadLocalClusterManagerImpl(ClusterManagerImpl& parent, Event::Dispatcher& dispatcher,
+                                  const absl::optional<LocalClusterParams>& local_cluster_params);
     ~ThreadLocalClusterManagerImpl() override;
     void drainConnPools(const HostVector& hosts);
     void drainConnPools(HostSharedPtr old_host, ConnPoolsContainer& container);

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -168,7 +168,7 @@ rules:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
   // Make sure that the thread callbacks are not invoked inline.
-  server_context.thread_local_.defer_data = true;
+  server_context.thread_local_.defer_data_ = true;
   {
     // Scope in all the things that the filter depends on, so they are destroyed as we leave the
     // scope.

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -1174,7 +1174,7 @@ TEST_F(RedisConnPoolImplTest, AskRedirectionFailure) {
 
 TEST_F(RedisConnPoolImplTest, MakeRequestAndRedirectFollowedByDelete) {
   cm_.initializeThreadLocalClusters({"fake_cluster"});
-  tls_.defer_delete = true;
+  tls_.defer_delete_ = true;
   std::unique_ptr<NiceMock<Stats::MockStore>> store =
       std::make_unique<NiceMock<Stats::MockStore>>();
   cluster_refresh_manager_ =

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -201,7 +201,7 @@ TEST_F(LightStepDriverTest, DeferredTlsInitialization) {
 
   auto propagation_mode = Common::Ot::OpenTracingDriver::PropagationMode::TracerNative;
 
-  tls_.defer_data = true;
+  tls_.defer_data_ = true;
   cm_.initializeClusters({"fake_cluster"}, {});
   ON_CALL(*cm_.active_clusters_["fake_cluster"]->info_, features())
       .WillByDefault(Return(Upstream::ClusterInfo::Features::HTTP2));

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -50,25 +50,32 @@ public:
 
     ~SlotImpl() override {
       // Do not actually clear slot data during shutdown. This mimics the production code.
-      // The defer_delete mimics the recycle() code with Bookkeeper.
-      if (!parent_.shutdown_ && !parent_.defer_delete) {
+      // The defer_delete mimics the slot being deleted on the main thread but the update not yet
+      // getting to a worker.
+      if (!parent_.shutdown_ && !parent_.defer_delete_) {
         EXPECT_LT(index_, parent_.data_.size());
         parent_.data_[index_].reset();
       }
     }
 
     // ThreadLocal::Slot
-    ThreadLocalObjectSharedPtr get() override { return parent_.data_[index_]; }
+    ThreadLocalObjectSharedPtr get() override {
+      EXPECT_TRUE(was_set_);
+      return parent_.data_[index_];
+    }
     bool currentThreadRegistered() override { return parent_.registered_; }
     void runOnAllThreads(const UpdateCb& cb) override {
+      EXPECT_TRUE(was_set_);
       parent_.runOnAllThreads([cb, this]() { cb(parent_.data_[index_]); });
     }
     void runOnAllThreads(const UpdateCb& cb, const Event::PostCb& main_callback) override {
+      EXPECT_TRUE(was_set_);
       parent_.runOnAllThreads([cb, this]() { cb(parent_.data_[index_]); }, main_callback);
     }
 
     void set(InitializeCb cb) override {
-      if (parent_.defer_data) {
+      was_set_ = true;
+      if (parent_.defer_data_) {
         parent_.deferred_data_[index_] = cb;
       } else {
         parent_.data_[index_] = cb(parent_.dispatcher_);
@@ -77,6 +84,7 @@ public:
 
     MockInstance& parent_;
     const uint32_t index_;
+    bool was_set_{}; // set() must be called before other functions.
   };
 
   void call() {
@@ -90,10 +98,10 @@ public:
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   std::vector<ThreadLocalObjectSharedPtr> data_;
   std::vector<Slot::InitializeCb> deferred_data_;
-  bool defer_data{};
+  bool defer_data_{};
   bool shutdown_{};
   bool registered_{true};
-  bool defer_delete{};
+  bool defer_delete_{};
 };
 
 } // namespace ThreadLocal


### PR DESCRIPTION
Final follow up from #13906. This PR does:
1) Simplify the logic during startup by making thread local clusters
   only appear after a cluster has been initialized. This is now uniform
   both for bootstrap clusters as well as CDS clusters, making the logic
   simpler to follow.
2) Aggregate cluster needed fixes due to assumptions on startup
   existence of the thread local cluster. This change also
   fixes https://github.com/envoyproxy/envoy/issues/14119
3) Make TLS mocks verify that set() is called before other functions.

Risk Level: Medium. Scary startup stuff.
Testing: Existing and fixed tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A