### PR TITLE
refactor: use unitfloat in more places

### DIFF
--- a/include/envoy/common/BUILD
+++ b/include/envoy/common/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "random_generator_interface",
     hdrs = ["random_generator.h"],
+    deps = ["//source/common/common:interval_value"],
 )
 
 envoy_cc_library(

--- a/include/envoy/common/random_generator.h
+++ b/include/envoy/common/random_generator.h
@@ -53,9 +53,9 @@ public:
    * @return a random boolean value, with probability `p` equaling true.
    */
   bool bernoulli(UnitFloat p) {
-    if (p == UnitFloat::min()) {
+    if (p.isMin()) {
       return false;
-    } else if (p == UnitFloat::max()) {
+    } else if (p.isMax()) {
       return true;
     }
     return random() < static_cast<result_type>(p.value() * static_cast<float>(max()));

--- a/include/envoy/common/random_generator.h
+++ b/include/envoy/common/random_generator.h
@@ -53,9 +53,9 @@ public:
    * @return a random boolean value, with probability `p` equaling true.
    */
   bool bernoulli(UnitFloat p) {
-    if (p.isMin()) {
+    if (p == UnitFloat::min()) {
       return false;
-    } else if (p.isMax()) {
+    } else if (p == UnitFloat::max()) {
       return true;
     }
     return random() < static_cast<result_type>(p.value() * static_cast<float>(max()));

--- a/include/envoy/common/random_generator.h
+++ b/include/envoy/common/random_generator.h
@@ -6,6 +6,8 @@
 
 #include "envoy/common/pure.h"
 
+#include "common/common/interval_value.h"
+
 namespace Envoy {
 namespace Random {
 
@@ -50,13 +52,13 @@ public:
   /**
    * @return a random boolean value, with probability `p` equaling true.
    */
-  bool bernoulli(float p) {
-    if (p <= 0) {
+  bool bernoulli(UnitFloat p) {
+    if (p == UnitFloat::min()) {
       return false;
-    } else if (p >= 1) {
+    } else if (p == UnitFloat::max()) {
       return true;
     }
-    return random() < static_cast<result_type>(p * static_cast<float>(max()));
+    return random() < static_cast<result_type>(p.value() * static_cast<float>(max()));
   }
 };
 

--- a/include/envoy/event/scaled_range_timer_manager.h
+++ b/include/envoy/event/scaled_range_timer_manager.h
@@ -4,6 +4,8 @@
 #include "envoy/event/scaled_timer_minimum.h"
 #include "envoy/event/timer.h"
 
+#include "common/common/interval_value.h"
+
 #include "absl/types/variant.h"
 
 namespace Envoy {
@@ -36,7 +38,7 @@ public:
    * factor of 0.5 causes firing halfway between min and max, and a factor of 1 causes firing at
    * max.
    */
-  virtual void setScaleFactor(double scale_factor) PURE;
+  virtual void setScaleFactor(UnitFloat scale_factor) PURE;
 };
 
 using ScaledRangeTimerManagerPtr = std::unique_ptr<ScaledRangeTimerManager>;

--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         ":listen_socket_interface",
         ":listener_interface",
         "//include/envoy/ssl:context_interface",
+        "//source/common/common:interval_value",
     ],
 )
 
@@ -172,6 +173,7 @@ envoy_cc_library(
         "//include/envoy/common:resource_interface",
         "//include/envoy/init:manager_interface",
         "//include/envoy/stats:stats_interface",
+        "//source/common/common:interval_value",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -9,6 +9,8 @@
 #include "envoy/network/listener.h"
 #include "envoy/ssl/context.h"
 
+#include "common/common/interval_value.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -98,7 +100,7 @@ public:
    * Set the fraction of connections the listeners should reject.
    * @param reject_fraction a value between 0 (reject none) and 1 (reject all).
    */
-  virtual void setListenerRejectFraction(float reject_fraction) PURE;
+  virtual void setListenerRejectFraction(UnitFloat reject_fraction) PURE;
 
   /**
    * @return the stat prefix used for per-handler stats.

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -16,6 +16,8 @@
 #include "envoy/network/udp_packet_writer_handler.h"
 #include "envoy/stats/scope.h"
 
+#include "common/common/interval_value.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -333,7 +335,7 @@ public:
    * Set the fraction of incoming connections that will be closed immediately
    * after being opened.
    */
-  virtual void setRejectFraction(float reject_fraction) PURE;
+  virtual void setRejectFraction(UnitFloat reject_fraction) PURE;
 };
 
 using ListenerPtr = std::unique_ptr<Listener>;

--- a/include/envoy/server/overload/thread_local_overload_state.h
+++ b/include/envoy/server/overload/thread_local_overload_state.h
@@ -28,7 +28,7 @@ public:
 
   explicit constexpr OverloadActionState(UnitFloat value) : action_value_(value) {}
 
-  float value() const { return action_value_.value(); }
+  UnitFloat value() const { return action_value_; }
   bool isSaturated() const { return action_value_.value() == UnitFloat::max().value(); }
 
 private:

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -25,10 +25,11 @@ public:
   // Returns a value that is as far from max as the original value is from min.
   // This guarantees that max().invert() == min() and min().invert() == max().
   ClosedIntervalValue invert() const {
-    return ClosedIntervalValue(value_ == Interval::max_value ? Interval::min_value
-                               : value_ == Interval::min_value
-                                   ? Interval::max_value
-                                   : Interval::max_value - (value_ - Interval::min_value));
+    return ClosedIntervalValue(value_ == Interval::max_value
+                                   ? Interval::min_value
+                                   : value_ == Interval::min_value
+                                         ? Interval::max_value
+                                         : Interval::max_value - (value_ - Interval::min_value));
   }
 
   // Comparisons are performed using the same operators on the underlying value

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -22,6 +22,13 @@ public:
 
   T value() const { return value_; }
 
+  ClosedIntervalValue invert() const {
+    return ClosedIntervalValue(value_ == Interval::max_value ? Interval::min_value
+                               : value_ == Interval::min_value
+                                   ? Interval::max_value
+                                   : Interval::max_value - (value_ - Interval::min_value));
+  }
+
   // Comparisons are performed using the same operators on the underlying value
   // type, with the same exactness guarantees.
 

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -22,6 +22,13 @@ public:
 
   T value() const { return value_; }
 
+  bool operator==(ClosedIntervalValue<T, Interval> other) const { return value_ == other.value(); }
+  bool operator!=(ClosedIntervalValue<T, Interval> other) const { return value_ != other.value(); }
+  bool operator<(ClosedIntervalValue<T, Interval> other) const { return value_ < other.value(); }
+  bool operator<=(ClosedIntervalValue<T, Interval> other) const { return value_ <= other.value(); }
+  bool operator>=(ClosedIntervalValue<T, Interval> other) const { return value_ >= other.value(); }
+  bool operator>(ClosedIntervalValue<T, Interval> other) const { return value_ > other.value(); }
+
 private:
   T value_;
 };

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -22,8 +22,9 @@ public:
 
   T value() const { return value_; }
 
-  bool operator==(ClosedIntervalValue<T, Interval> other) const { return value_ == other.value(); }
-  bool operator!=(ClosedIntervalValue<T, Interval> other) const { return value_ != other.value(); }
+  bool isMin() const { return value_ == Interval::min_value; }
+  bool isMax() const { return value_ == Interval::max_value; }
+
   bool operator<(ClosedIntervalValue<T, Interval> other) const { return value_ < other.value(); }
   bool operator<=(ClosedIntervalValue<T, Interval> other) const { return value_ <= other.value(); }
   bool operator>=(ClosedIntervalValue<T, Interval> other) const { return value_ >= other.value(); }

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -22,6 +22,8 @@ public:
 
   T value() const { return value_; }
 
+  // Returns a value that is as far from max as the original value is from min.
+  // This guarantees that max().invert() == min() and min().invert() == max().
   ClosedIntervalValue invert() const {
     return ClosedIntervalValue(value_ == Interval::max_value ? Interval::min_value
                                : value_ == Interval::min_value

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -22,6 +22,9 @@ public:
 
   T value() const { return value_; }
 
+  // Comparisons are performed using the same operators on the underlying value
+  // type, with the same exactness guarantees.
+
   bool operator==(ClosedIntervalValue<T, Interval> other) const { return value_ == other.value(); }
   bool operator!=(ClosedIntervalValue<T, Interval> other) const { return value_ != other.value(); }
   bool operator<(ClosedIntervalValue<T, Interval> other) const { return value_ < other.value(); }

--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -22,9 +22,8 @@ public:
 
   T value() const { return value_; }
 
-  bool isMin() const { return value_ == Interval::min_value; }
-  bool isMax() const { return value_ == Interval::max_value; }
-
+  bool operator==(ClosedIntervalValue<T, Interval> other) const { return value_ == other.value(); }
+  bool operator!=(ClosedIntervalValue<T, Interval> other) const { return value_ != other.value(); }
   bool operator<(ClosedIntervalValue<T, Interval> other) const { return value_ < other.value(); }
   bool operator<=(ClosedIntervalValue<T, Interval> other) const { return value_ <= other.value(); }
   bool operator>=(ClosedIntervalValue<T, Interval> other) const { return value_ >= other.value(); }

--- a/source/common/event/scaled_range_timer_manager_impl.cc
+++ b/source/common/event/scaled_range_timer_manager_impl.cc
@@ -150,9 +150,9 @@ TimerPtr ScaledRangeTimerManagerImpl::createTimer(ScaledTimerMinimum minimum, Ti
   return std::make_unique<RangeTimerImpl>(minimum, callback, *this);
 }
 
-void ScaledRangeTimerManagerImpl::setScaleFactor(double scale_factor) {
+void ScaledRangeTimerManagerImpl::setScaleFactor(UnitFloat scale_factor) {
   const MonotonicTime now = dispatcher_.approximateMonotonicTime();
-  scale_factor_ = UnitFloat(scale_factor);
+  scale_factor_ = scale_factor;
   for (auto& queue : queues_) {
     resetQueueTimer(*queue, now);
   }

--- a/source/common/event/scaled_range_timer_manager_impl.h
+++ b/source/common/event/scaled_range_timer_manager_impl.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <chrono>
 #include <stack>
 
@@ -26,7 +28,7 @@ public:
 
   // ScaledRangeTimerManager impl
   TimerPtr createTimer(ScaledTimerMinimum minimum, TimerCb callback) override;
-  void setScaleFactor(double scale_factor) override;
+  void setScaleFactor(UnitFloat scale_factor) override;
 
 private:
   class RangeTimerImpl;

--- a/source/common/network/tcp_listener_impl.cc
+++ b/source/common/network/tcp_listener_impl.cc
@@ -124,8 +124,7 @@ void TcpListenerImpl::enable() { socket_->ioHandle().enableFileEvents(Event::Fil
 
 void TcpListenerImpl::disable() { socket_->ioHandle().enableFileEvents(0); }
 
-void TcpListenerImpl::setRejectFraction(const float reject_fraction) {
-  ASSERT(0 <= reject_fraction && reject_fraction <= 1);
+void TcpListenerImpl::setRejectFraction(const UnitFloat reject_fraction) {
   reject_fraction_ = reject_fraction;
 }
 

--- a/source/common/network/tcp_listener_impl.h
+++ b/source/common/network/tcp_listener_impl.h
@@ -3,6 +3,8 @@
 #include "envoy/common/random_generator.h"
 #include "envoy/runtime/runtime.h"
 
+#include "common/common/interval_value.h"
+
 #include "absl/strings/string_view.h"
 #include "base_listener_impl.h"
 
@@ -20,7 +22,7 @@ public:
   ~TcpListenerImpl() override { socket_->ioHandle().resetFileEvents(); }
   void disable() override;
   void enable() override;
-  void setRejectFraction(float reject_fraction) override;
+  void setRejectFraction(UnitFloat reject_fraction) override;
 
   static const absl::string_view GlobalMaxCxRuntimeKey;
 
@@ -38,7 +40,7 @@ private:
   static bool rejectCxOverGlobalLimit();
 
   Random::RandomGenerator& random_;
-  float reject_fraction_;
+  UnitFloat reject_fraction_;
 };
 
 } // namespace Network

--- a/source/common/network/udp_listener_impl.h
+++ b/source/common/network/udp_listener_impl.h
@@ -30,7 +30,7 @@ public:
   // Network::Listener Interface
   void disable() override;
   void enable() override;
-  void setRejectFraction(float) override {}
+  void setRejectFraction(UnitFloat) override {}
 
   // Network::UdpListener Interface
   Event::Dispatcher& dispatcher() override;

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -153,7 +153,7 @@ void ConnectionHandlerImpl::enableListeners() {
   }
 }
 
-void ConnectionHandlerImpl::setListenerRejectFraction(float reject_fraction) {
+void ConnectionHandlerImpl::setListenerRejectFraction(UnitFloat reject_fraction) {
   listener_reject_fraction_ = reject_fraction;
   for (auto& listener : listeners_) {
     listener.second.listener_->listener()->setRejectFraction(reject_fraction);

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -83,7 +83,7 @@ public:
   void stopListeners() override;
   void disableListeners() override;
   void enableListeners() override;
-  void setListenerRejectFraction(float reject_fraction) override;
+  void setListenerRejectFraction(UnitFloat reject_fraction) override;
   const std::string& statPrefix() const override { return per_handler_stat_prefix_; }
 
   /**
@@ -363,7 +363,7 @@ private:
   std::list<std::pair<Network::Address::InstanceConstSharedPtr, ActiveListenerDetails>> listeners_;
   std::atomic<uint64_t> num_handler_connections_{};
   bool disable_listeners_;
-  float listener_reject_fraction_{0};
+  UnitFloat listener_reject_fraction_{UnitFloat::min()};
 };
 
 class ActiveUdpListenerBase : public ConnectionHandlerImpl::ActiveListenerImplBase,

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -60,7 +60,11 @@ public:
   void setState(NamedOverloadActionSymbolTable::Symbol action, OverloadActionState state) {
     actions_[action.index()] = state;
     if (scaled_timer_action_.has_value() && scaled_timer_action_.value() == action) {
-      scaled_timer_manager_->setScaleFactor(UnitFloat(1 - state.value().value()));
+      scaled_timer_manager_->setScaleFactor(
+          // The action state is 0 for no overload up to 1 for maximal overload,
+          // but the scale factor for timers is 1 for no scaling and 0 for
+          // maximal scaling, so invert the value to pass in (1-value).
+          UnitFloat(1 - state.value().value()));
     }
   }
 
@@ -86,6 +90,8 @@ public:
     const OverloadActionState state = actionState();
     state_ =
         value >= threshold_ ? OverloadActionState::saturated() : OverloadActionState::inactive();
+    // This is a floating point comparision, though state_ is always either
+    // saturated or inactive so there's no risk due to floating point precision.
     return state.value() != actionState().value();
   }
 
@@ -117,6 +123,9 @@ public:
       state_ = OverloadActionState(
           UnitFloat((value - scaling_threshold_) / (saturated_threshold_ - scaling_threshold_)));
     }
+    // All values of state_ are produced via this same code path. Even if
+    // old_state and state_ should be approximately equal, there's no harm in
+    // signalling for a small change if they're not float::operator== equal.
     return state_.value() != old_state.value();
   }
 

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -86,7 +86,7 @@ public:
     const OverloadActionState state = actionState();
     state_ =
         value >= threshold_ ? OverloadActionState::saturated() : OverloadActionState::inactive();
-    return state.value().value() != actionState().value().value();
+    return state.value() != actionState().value();
   }
 
   OverloadActionState actionState() const override { return state_; }
@@ -117,7 +117,7 @@ public:
       state_ = OverloadActionState(
           UnitFloat((value - scaling_threshold_) / (saturated_threshold_ - scaling_threshold_)));
     }
-    return state_.value().value() != old_state.value().value();
+    return state_.value() != old_state.value();
   }
 
   OverloadActionState actionState() const override { return state_; }
@@ -272,7 +272,7 @@ bool OverloadAction::updateResourcePressure(const std::string& name, double pres
     state_ = new_state;
   }
 
-  return state_.value().value() != old_state.value().value();
+  return state_.value() != old_state.value();
 }
 
 OverloadActionState OverloadAction::getState() const { return state_; }

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -86,7 +86,7 @@ public:
     const OverloadActionState state = actionState();
     state_ =
         value >= threshold_ ? OverloadActionState::saturated() : OverloadActionState::inactive();
-    return state.value() != actionState().value();
+    return state.value().value() != actionState().value().value();
   }
 
   OverloadActionState actionState() const override { return state_; }
@@ -117,7 +117,7 @@ public:
       state_ = OverloadActionState(
           UnitFloat((value - scaling_threshold_) / (saturated_threshold_ - scaling_threshold_)));
     }
-    return state_.value() != old_state.value();
+    return state_.value().value() != old_state.value().value();
   }
 
   OverloadActionState actionState() const override { return state_; }
@@ -272,7 +272,7 @@ bool OverloadAction::updateResourcePressure(const std::string& name, double pres
     state_ = new_state;
   }
 
-  return state_.value() != old_state.value();
+  return state_.value().value() != old_state.value().value();
 }
 
 OverloadActionState OverloadAction::getState() const { return state_; }

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -60,7 +60,7 @@ public:
   void setState(NamedOverloadActionSymbolTable::Symbol action, OverloadActionState state) {
     actions_[action.index()] = state;
     if (scaled_timer_action_.has_value() && scaled_timer_action_.value() == action) {
-      scaled_timer_manager_->setScaleFactor(UnitFloat(1 - state.value()));
+      scaled_timer_manager_->setScaleFactor(UnitFloat(1 - state.value().value()));
     }
   }
 
@@ -258,7 +258,7 @@ bool OverloadAction::updateResourcePressure(const std::string& name, double pres
   }
   const auto trigger_new_state = it->second->actionState();
   active_gauge_.set(trigger_new_state.isSaturated() ? 1 : 0);
-  scale_percent_gauge_.set(trigger_new_state.value() * 100);
+  scale_percent_gauge_.set(trigger_new_state.value().value() * 100);
 
   {
     // Compute the new state as the maximum over all trigger states.

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -64,7 +64,7 @@ public:
           // The action state is 0 for no overload up to 1 for maximal overload,
           // but the scale factor for timers is 1 for no scaling and 0 for
           // maximal scaling, so invert the value to pass in (1-value).
-          UnitFloat(1 - state.value().value()));
+          state.value().invert());
     }
   }
 

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -60,7 +60,7 @@ public:
   void setState(NamedOverloadActionSymbolTable::Symbol action, OverloadActionState state) {
     actions_[action.index()] = state;
     if (scaled_timer_action_.has_value() && scaled_timer_action_.value() == action) {
-      scaled_timer_manager_->setScaleFactor(1 - state.value());
+      scaled_timer_manager_->setScaleFactor(UnitFloat(1 - state.value()));
     }
   }
 

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -90,7 +90,7 @@ public:
     const OverloadActionState state = actionState();
     state_ =
         value >= threshold_ ? OverloadActionState::saturated() : OverloadActionState::inactive();
-    // This is a floating point comparision, though state_ is always either
+    // This is a floating point comparison, though state_ is always either
     // saturated or inactive so there's no risk due to floating point precision.
     return state.value() != actionState().value();
   }
@@ -125,7 +125,7 @@ public:
     }
     // All values of state_ are produced via this same code path. Even if
     // old_state and state_ should be approximately equal, there's no harm in
-    // signalling for a small change if they're not float::operator== equal.
+    // signaling for a small change if they're not float::operator== equal.
     return state_.value() != old_state.value();
   }
 

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -152,7 +152,7 @@ void WorkerImpl::stopAcceptingConnectionsCb(OverloadActionState state) {
 }
 
 void WorkerImpl::rejectIncomingConnectionsCb(OverloadActionState state) {
-  handler_->setListenerRejectFraction(static_cast<float>(state.value()));
+  handler_->setListenerRejectFraction(state.value());
 }
 
 } // namespace Server

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -196,6 +196,7 @@ envoy_cc_test(
     name = "random_generator_test",
     srcs = ["random_generator_test.cc"],
     deps = [
+        "//source/common/common:interval_value",
         "//source/common/common:random_generator_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/test_common:environment_lib",

--- a/test/common/common/random_generator_test.cc
+++ b/test/common/common/random_generator_test.cc
@@ -1,5 +1,6 @@
 #include <numeric>
 
+#include "common/common/interval_value.h"
 #include "common/common/random_generator.h"
 
 #include "gmock/gmock.h"
@@ -70,15 +71,13 @@ TEST(UUID, SanityCheckOfUniqueness) {
 TEST(Random, Bernoilli) {
   Random::RandomGeneratorImpl random;
 
-  EXPECT_FALSE(random.bernoulli(0));
-  EXPECT_FALSE(random.bernoulli(-1));
-  EXPECT_TRUE(random.bernoulli(1));
-  EXPECT_TRUE(random.bernoulli(2));
+  EXPECT_FALSE(random.bernoulli(UnitFloat(0.0f)));
+  EXPECT_TRUE(random.bernoulli(UnitFloat(1.0f)));
 
   int true_count = 0;
   static const auto num_rolls = 100000;
   for (size_t i = 0; i < num_rolls; ++i) {
-    if (random.bernoulli(0.4)) {
+    if (random.bernoulli(UnitFloat(0.4f))) {
       ++true_count;
     }
   }

--- a/test/common/event/scaled_range_timer_manager_impl_test.cc
+++ b/test/common/event/scaled_range_timer_manager_impl_test.cc
@@ -280,7 +280,7 @@ TEST_P(ScaledRangeTimerManagerTestWithScope, ScheduleWithScalingFactorZero) {
   MockFunction<TimerCb> callback;
   auto timer =
       manager.createTimer(AbsoluteMinimum(std::chrono::seconds(0)), callback.AsStdFunction());
-  manager.setScaleFactor(0);
+  manager.setScaleFactor(UnitFloat(0));
 
   EXPECT_CALL(callback, Call).WillOnce([&] { EXPECT_EQ(dispatcher_.scope_, getScope()); });
 
@@ -394,7 +394,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithScaling) {
   timers[1].timer->enableTimer(std::chrono::seconds(6));
   timers[2].timer->enableTimer(std::chrono::seconds(10));
 
-  manager.setScaleFactor(0.5);
+  manager.setScaleFactor(UnitFloat(0.5));
 
   // Advance time to start = 1 second, so timers[0] hits its min.
   simTime().advanceTimeAndRun(std::chrono::seconds(1), dispatcher_, Dispatcher::RunType::Block);
@@ -403,7 +403,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithScaling) {
   simTime().advanceTimeAndRun(std::chrono::seconds(1), dispatcher_, Dispatcher::RunType::Block);
 
   // At 4x speed, timers[1] will fire in only 1 second.
-  manager.setScaleFactor(0.25);
+  manager.setScaleFactor(UnitFloat(0.25));
 
   // Advance time to start = 3, which should make timers[1] hit its scaled max.
   simTime().advanceTimeAndRun(std::chrono::seconds(1), dispatcher_, Dispatcher::RunType::Block);
@@ -411,7 +411,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithScaling) {
   // Advance time to start = 6, which is the minimum required for timers[2] to fire.
   simTime().advanceTimeAndRun(std::chrono::seconds(3), dispatcher_, Dispatcher::RunType::Block);
 
-  manager.setScaleFactor(0);
+  manager.setScaleFactor(UnitFloat(0));
   // With a scale factor of 0, timers[2] should be ready to be fired immediately.
   dispatcher_.run(Dispatcher::RunType::Block);
 
@@ -464,7 +464,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersSameTimesFastClock) {
 
 TEST_F(ScaledRangeTimerManagerTest, ScheduledWithScalingFactorZero) {
   ScaledRangeTimerManagerImpl manager(dispatcher_);
-  manager.setScaleFactor(0);
+  manager.setScaleFactor(UnitFloat(0));
 
   TrackedRangeTimer timer(AbsoluteMinimum(std::chrono::seconds(4)), manager, simTime());
 
@@ -566,7 +566,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithChangeInScalingFactor) {
   timers[0].timer->enableTimer(std::chrono::seconds(15));
   timers[1].timer->enableTimer(std::chrono::seconds(14));
 
-  manager.setScaleFactor(0.1);
+  manager.setScaleFactor(UnitFloat(0.1));
 
   timers[2].timer->enableTimer(std::chrono::seconds(21));
   timers[3].timer->enableTimer(std::chrono::seconds(16));
@@ -574,7 +574,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithChangeInScalingFactor) {
   // Advance to timer 0's min.
   simTime().advanceTimeAndRun(std::chrono::seconds(5), dispatcher_, Dispatcher::RunType::Block);
 
-  manager.setScaleFactor(0.5);
+  manager.setScaleFactor(UnitFloat(0.5));
 
   // Now that the scale factor is 0.5, fire times are 0: start+10, 1: start+13, 2: start+14, 3:
   // start+13. Advance to timer 2's min.
@@ -583,7 +583,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithChangeInScalingFactor) {
   // Advance to time start+9.
   simTime().advanceTimeAndRun(std::chrono::seconds(2), dispatcher_, Dispatcher::RunType::Block);
 
-  manager.setScaleFactor(0.1);
+  manager.setScaleFactor(UnitFloat(0.1));
   // Now that the scale factor is reduced, fire times are 0: start+6, 1: start+12.2,
   // 2: start+8.4, 3: start+10.6. Timers 0 and 2 should fire immediately since their
   // trigger times are in the past.
@@ -598,7 +598,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithChangeInScalingFactor) {
   timers[0].timer->enableTimer(std::chrono::seconds(13));
 
   // Fire times are now 0: start+19, 1: start+13, 2: none, 3: start+13.
-  manager.setScaleFactor(0.5);
+  manager.setScaleFactor(UnitFloat(0.5));
 
   // Advance to timer 1's min.
   simTime().advanceTimeAndRun(std::chrono::seconds(2), dispatcher_, Dispatcher::RunType::Block);
@@ -611,7 +611,7 @@ TEST_F(ScaledRangeTimerManagerTest, MultipleTimersWithChangeInScalingFactor) {
   simTime().advanceTimeAndRun(std::chrono::seconds(3), dispatcher_, Dispatcher::RunType::Block);
 
   // The time is now start+16. Setting the scale factor to 0 should make timer 0 fire immediately.
-  manager.setScaleFactor(0);
+  manager.setScaleFactor(UnitFloat(0));
   dispatcher_.run(Dispatcher::RunType::Block);
   EXPECT_THAT(*timers[0].trigger_times,
               ElementsAre(start + std::chrono::seconds(9), start + std::chrono::seconds(16)));

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -352,7 +352,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionZero) {
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks,
                                true);
 
-  listener.setRejectFraction(0);
+  listener.setRejectFraction(UnitFloat(0));
 
   // This connection will be accepted and not rejected.
   {
@@ -383,7 +383,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionIntermediate) {
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks,
                                true);
 
-  listener.setRejectFraction(0.5f);
+  listener.setRejectFraction(UnitFloat(0.5f));
 
   // The first connection will be rejected because the random value is too small.
   {
@@ -446,7 +446,7 @@ TEST_P(TcpListenerImplTest, SetListenerRejectFractionAll) {
   TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket, listener_callbacks,
                                true);
 
-  listener.setRejectFraction(1);
+  listener.setRejectFraction(UnitFloat(1));
 
   {
     testing::InSequence s1;

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -185,7 +185,7 @@ public:
     return TimerPtr{createTimer_(minimum, std::move(callback))};
   }
   MOCK_METHOD(Timer*, createTimer_, (ScaledTimerMinimum, TimerCb));
-  MOCK_METHOD(void, setScaleFactor, (double), (override));
+  MOCK_METHOD(void, setScaleFactor, (UnitFloat), (override));
 };
 
 class MockSchedulableCallback : public SchedulableCallback {

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -394,7 +394,7 @@ public:
   MOCK_METHOD(void, onDestroy, ());
   MOCK_METHOD(void, enable, ());
   MOCK_METHOD(void, disable, ());
-  MOCK_METHOD(void, setRejectFraction, (float));
+  MOCK_METHOD(void, setRejectFraction, (UnitFloat));
 };
 
 class MockConnectionHandler : public ConnectionHandler {
@@ -416,7 +416,7 @@ public:
   MOCK_METHOD(void, stopListeners, ());
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());
-  MOCK_METHOD(void, setListenerRejectFraction, (float), (override));
+  MOCK_METHOD(void, setListenerRejectFraction, (UnitFloat), (override));
   MOCK_METHOD(const std::string&, statPrefix, (), (const));
 };
 
@@ -506,7 +506,7 @@ public:
   MOCK_METHOD(void, onDestroy, ());
   MOCK_METHOD(void, enable, ());
   MOCK_METHOD(void, disable, ());
-  MOCK_METHOD(void, setRejectFraction, (float), (override));
+  MOCK_METHOD(void, setRejectFraction, (UnitFloat), (override));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(Address::InstanceConstSharedPtr&, localAddress, (), (const));
   MOCK_METHOD(Api::IoCallUint64Result, send, (const UdpSendData&));

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -32,7 +32,6 @@ using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
-using testing::Property;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
@@ -469,7 +468,7 @@ TEST_F(ConnectionHandlerTest, SetListenerRejectFraction) {
   EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
   handler_->addListener(absl::nullopt, *test_listener);
 
-  EXPECT_CALL(*listener, setRejectFraction(Property(&UnitFloat::value, 0.1234f)));
+  EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.1234f)));
   EXPECT_CALL(*listener, onDestroy());
 
   handler_->setListenerRejectFraction(UnitFloat(0.1234f));
@@ -482,7 +481,7 @@ TEST_F(ConnectionHandlerTest, AddListenerSetRejectFraction) {
   auto listener = new NiceMock<Network::MockListener>();
   TestListener* test_listener =
       addListener(1, false, false, "test_listener", listener, &listener_callbacks);
-  EXPECT_CALL(*listener, setRejectFraction(Property(&UnitFloat::value, 0.12345f)));
+  EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.12345f)));
   EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
   EXPECT_CALL(*listener, onDestroy());
 

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -32,6 +32,7 @@ using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;
+using testing::Property;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
@@ -468,7 +469,7 @@ TEST_F(ConnectionHandlerTest, SetListenerRejectFraction) {
   EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
   handler_->addListener(absl::nullopt, *test_listener);
 
-  EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.1234f)));
+  EXPECT_CALL(*listener, setRejectFraction(Property(&UnitFloat::value, 0.1234f)));
   EXPECT_CALL(*listener, onDestroy());
 
   handler_->setListenerRejectFraction(UnitFloat(0.1234f));
@@ -481,7 +482,7 @@ TEST_F(ConnectionHandlerTest, AddListenerSetRejectFraction) {
   auto listener = new NiceMock<Network::MockListener>();
   TestListener* test_listener =
       addListener(1, false, false, "test_listener", listener, &listener_callbacks);
-  EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.12345f)));
+  EXPECT_CALL(*listener, setRejectFraction(Property(&UnitFloat::value, 0.12345f)));
   EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
   EXPECT_CALL(*listener, onDestroy());
 

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -182,7 +182,7 @@ public:
 
     MOCK_METHOD(void, enable, (), (override));
     MOCK_METHOD(void, disable, (), (override));
-    MOCK_METHOD(void, setRejectFraction, (float));
+    MOCK_METHOD(void, setRejectFraction, (UnitFloat));
     MOCK_METHOD(Event::Dispatcher&, dispatcher, (), (override));
     MOCK_METHOD(Network::Address::InstanceConstSharedPtr&, localAddress, (), (const, override));
     MOCK_METHOD(Api::IoCallUint64Result, send, (const Network::UdpSendData&), (override));
@@ -468,10 +468,10 @@ TEST_F(ConnectionHandlerTest, SetListenerRejectFraction) {
   EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
   handler_->addListener(absl::nullopt, *test_listener);
 
-  EXPECT_CALL(*listener, setRejectFraction(0.1234f));
+  EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.1234f)));
   EXPECT_CALL(*listener, onDestroy());
 
-  handler_->setListenerRejectFraction(0.1234f);
+  handler_->setListenerRejectFraction(UnitFloat(0.1234f));
 }
 
 TEST_F(ConnectionHandlerTest, AddListenerSetRejectFraction) {
@@ -481,11 +481,11 @@ TEST_F(ConnectionHandlerTest, AddListenerSetRejectFraction) {
   auto listener = new NiceMock<Network::MockListener>();
   TestListener* test_listener =
       addListener(1, false, false, "test_listener", listener, &listener_callbacks);
-  EXPECT_CALL(*listener, setRejectFraction(0.12345f));
+  EXPECT_CALL(*listener, setRejectFraction(UnitFloat(0.12345f)));
   EXPECT_CALL(*socket_factory_, localAddress()).WillOnce(ReturnRef(local_address_));
   EXPECT_CALL(*listener, onDestroy());
 
-  handler_->setListenerRejectFraction(0.12345f);
+  handler_->setListenerRejectFraction(UnitFloat(0.12345f));
   handler_->addListener(absl::nullopt, *test_listener);
 }
 

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -235,9 +235,8 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   factory1_.monitor_->setPressure(0.5);
   timer_cb_();
   EXPECT_FALSE(is_active);
-  EXPECT_THAT(action_state,
-              AllOf(Property(&OverloadActionState::isSaturated, false),
-                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
   EXPECT_EQ(0, cb_count);
   EXPECT_EQ(0, active_gauge.value());
   EXPECT_EQ(0, scale_percent_gauge.value());
@@ -282,9 +281,8 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   factory2_.monitor_->setPressure(0.3);
   timer_cb_();
   EXPECT_FALSE(is_active);
-  EXPECT_THAT(action_state,
-              AllOf(Property(&OverloadActionState::isSaturated, false),
-                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
   EXPECT_EQ(2, cb_count);
   EXPECT_EQ(30, pressure_gauge2.value());
 
@@ -303,9 +301,8 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   factory2_.monitor_->setPressure(0.42);
   timer_cb_();
   EXPECT_FALSE(is_active);
-  EXPECT_THAT(action_state,
-              AllOf(Property(&OverloadActionState::isSaturated, false),
-                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
   EXPECT_EQ(4, cb_count);
   EXPECT_EQ(41, pressure_gauge1.value());
   EXPECT_EQ(42, pressure_gauge2.value());
@@ -329,9 +326,8 @@ TEST_F(OverloadManagerImplTest, ScaledTrigger) {
   factory3_.monitor_->setPressure(0.5);
   timer_cb_();
 
-  EXPECT_THAT(action_state,
-              AllOf(Property(&OverloadActionState::isSaturated, false),
-                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
+  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
+                                  Property(&OverloadActionState::value, UnitFloat::min())));
   EXPECT_EQ(0, active_gauge.value());
   EXPECT_EQ(0, scale_percent_gauge.value());
 
@@ -340,7 +336,7 @@ TEST_F(OverloadManagerImplTest, ScaledTrigger) {
   factory3_.monitor_->setPressure(0.65);
   timer_cb_();
 
-  EXPECT_EQ(action_state.value().value(), 0.5 /* = 0.65 / (0.8 - 0.5) */);
+  EXPECT_EQ(action_state.value(), UnitFloat(0.5) /* = 0.65 / (0.8 - 0.5) */);
   EXPECT_EQ(0, active_gauge.value());
   EXPECT_EQ(50, scale_percent_gauge.value());
 
@@ -412,13 +408,13 @@ TEST_F(OverloadManagerImplTest, DelayedUpdatesAreCoalesced) {
   // When monitor 3 publishes its update, the action won't be visible to the thread-local state
   factory3_.monitor_->setPressure(0.6);
   factory3_.monitor_->publishUpdate();
-  EXPECT_THAT(action_state.value(), Property(&UnitFloat::isMin, true));
+  EXPECT_EQ(action_state.value(), UnitFloat::min());
 
   // Now when monitor 4 publishes a larger value, the update from monitor 3 is skipped.
   EXPECT_FALSE(action_state.isSaturated());
   factory4_.monitor_->setPressure(0.65);
   factory4_.monitor_->publishUpdate();
-  EXPECT_EQ(action_state.value().value(), 0.5 /* = (0.65 - 0.5) / (0.8 - 0.5) */);
+  EXPECT_EQ(action_state.value(), UnitFloat(0.5) /* = (0.65 - 0.5) / (0.8 - 0.5) */);
 }
 
 TEST_F(OverloadManagerImplTest, FlushesUpdatesEvenWithOneUnresponsive) {

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -25,7 +25,7 @@ using testing::_;
 using testing::AllOf;
 using testing::AnyNumber;
 using testing::ByMove;
-using testing::DoubleNear;
+using testing::FloatNear;
 using testing::Invoke;
 using testing::MockFunction;
 using testing::NiceMock;
@@ -504,7 +504,7 @@ TEST_F(OverloadManagerImplTest, AdjustScaleFactor) {
 
   // The scaled trigger has range [0.5, 1.0] so 0.6 should map to a scale value of 0.2, which means
   // a timer scale factor of 0.8 (1 - 0.2).
-  EXPECT_CALL(*scaled_timer_manager, setScaleFactor(DoubleNear(0.8, 0.00001)));
+  EXPECT_CALL(*scaled_timer_manager, setScaleFactor(Property(&UnitFloat::value, FloatNear(0.8, 0.00001))));
   factory1_.monitor_->setPressure(0.6);
 
   timer_cb_();

--- a/test/server/overload_manager_impl_test.cc
+++ b/test/server/overload_manager_impl_test.cc
@@ -235,8 +235,9 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   factory1_.monitor_->setPressure(0.5);
   timer_cb_();
   EXPECT_FALSE(is_active);
-  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
-                                  Property(&OverloadActionState::value, UnitFloat::min())));
+  EXPECT_THAT(action_state,
+              AllOf(Property(&OverloadActionState::isSaturated, false),
+                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
   EXPECT_EQ(0, cb_count);
   EXPECT_EQ(0, active_gauge.value());
   EXPECT_EQ(0, scale_percent_gauge.value());
@@ -281,8 +282,9 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   factory2_.monitor_->setPressure(0.3);
   timer_cb_();
   EXPECT_FALSE(is_active);
-  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
-                                  Property(&OverloadActionState::value, UnitFloat::min())));
+  EXPECT_THAT(action_state,
+              AllOf(Property(&OverloadActionState::isSaturated, false),
+                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
   EXPECT_EQ(2, cb_count);
   EXPECT_EQ(30, pressure_gauge2.value());
 
@@ -301,8 +303,9 @@ TEST_F(OverloadManagerImplTest, CallbackOnlyFiresWhenStateChanges) {
   factory2_.monitor_->setPressure(0.42);
   timer_cb_();
   EXPECT_FALSE(is_active);
-  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
-                                  Property(&OverloadActionState::value, UnitFloat::min())));
+  EXPECT_THAT(action_state,
+              AllOf(Property(&OverloadActionState::isSaturated, false),
+                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
   EXPECT_EQ(4, cb_count);
   EXPECT_EQ(41, pressure_gauge1.value());
   EXPECT_EQ(42, pressure_gauge2.value());
@@ -326,8 +329,9 @@ TEST_F(OverloadManagerImplTest, ScaledTrigger) {
   factory3_.monitor_->setPressure(0.5);
   timer_cb_();
 
-  EXPECT_THAT(action_state, AllOf(Property(&OverloadActionState::isSaturated, false),
-                                  Property(&OverloadActionState::value, UnitFloat::min())));
+  EXPECT_THAT(action_state,
+              AllOf(Property(&OverloadActionState::isSaturated, false),
+                    Property(&OverloadActionState::value, Property(&UnitFloat::isMin, true))));
   EXPECT_EQ(0, active_gauge.value());
   EXPECT_EQ(0, scale_percent_gauge.value());
 
@@ -336,7 +340,7 @@ TEST_F(OverloadManagerImplTest, ScaledTrigger) {
   factory3_.monitor_->setPressure(0.65);
   timer_cb_();
 
-  EXPECT_EQ(action_state.value(), UnitFloat(0.5) /* = 0.65 / (0.8 - 0.5) */);
+  EXPECT_EQ(action_state.value().value(), 0.5 /* = 0.65 / (0.8 - 0.5) */);
   EXPECT_EQ(0, active_gauge.value());
   EXPECT_EQ(50, scale_percent_gauge.value());
 
@@ -408,13 +412,13 @@ TEST_F(OverloadManagerImplTest, DelayedUpdatesAreCoalesced) {
   // When monitor 3 publishes its update, the action won't be visible to the thread-local state
   factory3_.monitor_->setPressure(0.6);
   factory3_.monitor_->publishUpdate();
-  EXPECT_EQ(action_state.value(), UnitFloat::min());
+  EXPECT_THAT(action_state.value(), Property(&UnitFloat::isMin, true));
 
   // Now when monitor 4 publishes a larger value, the update from monitor 3 is skipped.
   EXPECT_FALSE(action_state.isSaturated());
   factory4_.monitor_->setPressure(0.65);
   factory4_.monitor_->publishUpdate();
-  EXPECT_EQ(action_state.value(), UnitFloat(0.5) /* = (0.65 - 0.5) / (0.8 - 0.5) */);
+  EXPECT_EQ(action_state.value().value(), 0.5 /* = (0.65 - 0.5) / (0.8 - 0.5) */);
 }
 
 TEST_F(OverloadManagerImplTest, FlushesUpdatesEvenWithOneUnresponsive) {


### PR DESCRIPTION
Commit Message: Use UnitFloat in place of float in more locations
Additional Description:
UnitFloat represents a floating point value that is guaranteed to be in the range [0, 1]. Use
it in place of floats that also have the same expectation in OverloadActionState and
connection listeners.

This PR introduces no functional changes.

Risk Level: low
Testing: ran affected tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

/assign @KBaichoo 