### PR TITLE
listener: undeprecate use_original_dst

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -93,9 +93,7 @@ message Listener {
     }
   }
 
-  reserved 14, 4;
-
-  reserved "use_original_dst";
+  reserved 14;
 
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -115,6 +113,13 @@ message Listener {
   // Example using SNI for filter chain selection can be found in the
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
   repeated FilterChain filter_chains = 3;
+
+  // If a connection is redirected using *iptables*, the port on which the proxy
+  // receives it might be different from the original destination address. When this flag is set to
+  // true, the listener hands off redirected connections to the listener associated with the
+  // original destination address. If there is no listener associated with the original destination
+  // address, the connection is handled by the listener that receives it. Defaults to false.
+  google.protobuf.BoolValue use_original_dst = 4;
 
   // The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
   // the connection will be closed. The filter chain match is ignored in this field.

--- a/api/envoy/config/listener/v4alpha/listener.proto
+++ b/api/envoy/config/listener/v4alpha/listener.proto
@@ -96,9 +96,7 @@ message Listener {
     }
   }
 
-  reserved 14, 4;
-
-  reserved "use_original_dst";
+  reserved 14;
 
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -118,6 +116,13 @@ message Listener {
   // Example using SNI for filter chain selection can be found in the
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
   repeated FilterChain filter_chains = 3;
+
+  // If a connection is redirected using *iptables*, the port on which the proxy
+  // receives it might be different from the original destination address. When this flag is set to
+  // true, the listener hands off redirected connections to the listener associated with the
+  // original destination address. If there is no listener associated with the original destination
+  // address, the connection is handled by the listener that receives it. Defaults to false.
+  google.protobuf.BoolValue use_original_dst = 4;
 
   // The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
   // the connection will be closed. The filter chain match is ignored in this field.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -67,6 +67,7 @@ New Features
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
+* listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.
 * log: added a new custom flag ``%_`` to the log pattern to print the actual message to log, but with escaped newlines.
 * lua: added `downstreamDirectRemoteAddress()` and `downstreamLocalAddress()` APIs to :ref:`streamInfo() <config_http_filters_lua_stream_info_wrapper>`.
 * mongo_proxy: the list of commands to produce metrics for is now :ref:`configurable <envoy_v3_api_field_extensions.filters.network.mongo_proxy.v3.MongoProxy.commands>`.

--- a/generated_api_shadow/envoy/config/listener/v3/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/listener.proto
@@ -114,6 +114,13 @@ message Listener {
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
   repeated FilterChain filter_chains = 3;
 
+  // If a connection is redirected using *iptables*, the port on which the proxy
+  // receives it might be different from the original destination address. When this flag is set to
+  // true, the listener hands off redirected connections to the listener associated with the
+  // original destination address. If there is no listener associated with the original destination
+  // address, the connection is handled by the listener that receives it. Defaults to false.
+  google.protobuf.BoolValue use_original_dst = 4;
+
   // The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
   // the connection will be closed. The filter chain match is ignored in this field.
   FilterChain default_filter_chain = 25;
@@ -265,6 +272,4 @@ message Listener {
   // The maximum length a tcp listener's pending connections queue can grow to. If no value is
   // provided net.core.somaxconn will be used on Linux and 128 otherwise.
   google.protobuf.UInt32Value tcp_backlog_size = 24;
-
-  google.protobuf.BoolValue hidden_envoy_deprecated_use_original_dst = 4 [deprecated = true];
 }

--- a/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
@@ -96,9 +96,7 @@ message Listener {
     }
   }
 
-  reserved 14, 4;
-
-  reserved "use_original_dst";
+  reserved 14;
 
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -118,6 +116,13 @@ message Listener {
   // Example using SNI for filter chain selection can be found in the
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
   repeated FilterChain filter_chains = 3;
+
+  // If a connection is redirected using *iptables*, the port on which the proxy
+  // receives it might be different from the original destination address. When this flag is set to
+  // true, the listener hands off redirected connections to the listener associated with the
+  // original destination address. If there is no listener associated with the original destination
+  // address, the connection is handled by the listener that receives it. Defaults to false.
+  google.protobuf.BoolValue use_original_dst = 4;
 
   // The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
   // the connection will be closed. The filter chain match is ignored in this field.

--- a/include/envoy/network/listener.h
+++ b/include/envoy/network/listener.h
@@ -94,8 +94,7 @@ public:
   /**
    * @return bool if a connection should be handed off to another Listener after the original
    *         destination address has been restored. 'true' when 'use_original_dst' flag in listener
-   *         configuration is set, false otherwise. Note that this flag is deprecated and will be
-   *         removed from the v2 API.
+   *         configuration is set, false otherwise.
    */
   virtual bool handOffRestoredDestinationConnections() const PURE;
 

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -245,7 +245,7 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
     : parent_(parent), address_(Network::Address::resolveProtoAddress(config.address())),
       bind_to_port_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.deprecated_v1(), bind_to_port, true)),
       hand_off_restored_destination_connections_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, hidden_envoy_deprecated_use_original_dst, false)),
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_original_dst, false)),
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       listener_tag_(parent_.factory_.nextListenerTag()), name_(name), added_via_api_(added_via_api),
@@ -324,7 +324,7 @@ ListenerImpl::ListenerImpl(ListenerImpl& origin,
     : parent_(parent), address_(origin.address_),
       bind_to_port_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.deprecated_v1(), bind_to_port, true)),
       hand_off_restored_destination_connections_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, hidden_envoy_deprecated_use_original_dst, false)),
+          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_original_dst, false)),
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       listener_tag_(origin.listener_tag_), name_(name), added_via_api_(added_via_api),
@@ -529,7 +529,7 @@ void ListenerImpl::buildSocketOptions() {
 
 void ListenerImpl::buildOriginalDstListenerFilter() {
   // Add original dst listener filter if 'use_original_dst' flag is set.
-  if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config_, hidden_envoy_deprecated_use_original_dst, false)) {
+  if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config_, use_original_dst, false)) {
     auto& factory =
         Config::Utility::getAndCheckFactoryByName<Configuration::NamedListenerFilterConfigFactory>(
             Extensions::ListenerFilters::ListenerFilterNames::get().OriginalDst);


### PR DESCRIPTION
Commit Message:

listener: undeprecate use_original_dst

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description: See https://github.com/envoyproxy/envoy/issues/5355#issuecomment-742905855 and above for context
Risk Level: Low
Testing: Listener unit tests, grep
Docs Changes: Generated documentation for the proto field
Release Notes:
#5355