### PR TITLE
stream_info: add setResponseCode and update local_reply to take a normal StreamInfo

### DIFF
--- a/include/envoy/stream_info/stream_info.h
+++ b/include/envoy/stream_info/stream_info.h
@@ -237,6 +237,11 @@ public:
   virtual void setResponseFlag(ResponseFlag response_flag) PURE;
 
   /**
+   * @param code the HTTP response code to set for this request.
+   */
+  virtual void setResponseCode(uint32_t code) PURE;
+
+  /**
    * @param rc_details the response code details string to set for this request.
    * See ResponseCodeDetailValues above for well-known constants.
    */

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -74,7 +74,7 @@ public:
   bool matchAndRewrite(const Http::RequestHeaderMap& request_headers,
                        Http::ResponseHeaderMap& response_headers,
                        const Http::ResponseTrailerMap& response_trailers,
-                       StreamInfo::StreamInfol& stream_info, Http::Code& code, std::string& body,
+                       StreamInfo::StreamInfo& stream_info, Http::Code& code, std::string& body,
                        BodyFormatter*& final_formatter) const {
     // If not matched, just bail out.
     if (!filter_->evaluate(stream_info, request_headers, response_headers, response_trailers)) {

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -74,7 +74,7 @@ public:
   bool matchAndRewrite(const Http::RequestHeaderMap& request_headers,
                        Http::ResponseHeaderMap& response_headers,
                        const Http::ResponseTrailerMap& response_trailers,
-                       StreamInfo::StreamInfoImpl& stream_info, Http::Code& code, std::string& body,
+                       StreamInfo::StreamInfol& stream_info, Http::Code& code, std::string& body,
                        BodyFormatter*& final_formatter) const {
     // If not matched, just bail out.
     if (!filter_->evaluate(stream_info, request_headers, response_headers, response_trailers)) {
@@ -90,7 +90,7 @@ public:
     if (status_code_.has_value() && code != status_code_.value()) {
       code = status_code_.value();
       response_headers.setStatus(std::to_string(enumToInt(code)));
-      stream_info.response_code_ = static_cast<uint32_t>(code);
+      stream_info.setResponseCode(static_cast<uint32_t>(code));
     }
 
     if (body_formatter_) {
@@ -126,14 +126,14 @@ public:
   }
 
   void rewrite(const Http::RequestHeaderMap* request_headers,
-               Http::ResponseHeaderMap& response_headers, StreamInfo::StreamInfoImpl& stream_info,
+               Http::ResponseHeaderMap& response_headers, StreamInfo::StreamInfo& stream_info,
                Http::Code& code, std::string& body,
                absl::string_view& content_type) const override {
     // Set response code to stream_info and response_headers due to:
     // 1) StatusCode filter is using response_code from stream_info,
     // 2) %RESP(:status)% is from Status() in response_headers.
     response_headers.setStatus(std::to_string(enumToInt(code)));
-    stream_info.response_code_ = static_cast<uint32_t>(code);
+    stream_info.setResponseCode(static_cast<uint32_t>(code));
 
     if (request_headers == nullptr) {
       request_headers = Http::StaticEmptyHeaders::get().request_headers.get();

--- a/source/common/local_reply/local_reply.h
+++ b/source/common/local_reply/local_reply.h
@@ -24,7 +24,7 @@ public:
    */
   virtual void rewrite(const Http::RequestHeaderMap* request_headers,
                        Http::ResponseHeaderMap& response_headers,
-                       StreamInfo::StreamInfoImpl& stream_info, Http::Code& code, std::string& body,
+                       StreamInfo::StreamInfo& stream_info, Http::Code& code, std::string& body,
                        absl::string_view& content_type) const PURE;
 };
 

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -131,6 +131,8 @@ struct StreamInfoImpl : public StreamInfo {
     return response_code_details_;
   }
 
+  void setResponseCode(uint32_t code) override { response_code_ = code; }
+
   void setResponseCodeDetails(absl::string_view rc_details) override {
     response_code_details_.emplace(absl::StrReplaceAll(rc_details, emptySpaceReplacement()));
   }

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -38,6 +38,7 @@ public:
   const absl::optional<std::string>& responseCodeDetails() const override {
     return response_code_details_;
   }
+  void setResponseCode(uint32_t code) override { response_code_ = code; }
   void setResponseCodeDetails(absl::string_view rc_details) override {
     response_code_details_.emplace(rc_details);
   }

--- a/test/mocks/local_reply/mocks.h
+++ b/test/mocks/local_reply/mocks.h
@@ -11,7 +11,7 @@ public:
 
   MOCK_METHOD(void, rewrite,
               (const Http::RequestHeaderMap* request_headers,
-               Http::ResponseHeaderMap& response_headers, StreamInfo::StreamInfoImpl& stream_info,
+               Http::ResponseHeaderMap& response_headers, StreamInfo::StreamInfo& stream_info,
                Http::Code& code, std::string& body, absl::string_view& content_type),
               (const));
 };

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -24,6 +24,9 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, setResponseFlag(_)).WillByDefault(Invoke([this](ResponseFlag response_flag) {
     response_flags_ |= response_flag;
   }));
+  ON_CALL(*this, setResponseCode(_)).WillByDefault(Invoke([this](uint32_t code) {
+    response_code_ = code;
+  }));
   ON_CALL(*this, setResponseCodeDetails(_)).WillByDefault(Invoke([this](absl::string_view details) {
     response_code_details_ = std::string(details);
   }));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -21,6 +21,7 @@ public:
 
   // StreamInfo::StreamInfo
   MOCK_METHOD(void, setResponseFlag, (ResponseFlag response_flag));
+  MOCK_METHOD(void, setResponseCode, (uint32_t));
   MOCK_METHOD(void, setResponseCodeDetails, (absl::string_view));
   MOCK_METHOD(void, setConnectionTerminationDetails, (absl::string_view));
   MOCK_METHOD(bool, intersectResponseFlags, (uint64_t), (const));


### PR DESCRIPTION
Commit Message: stream_info: add setResponseCode and update local_reply to take a normal StreamInfo
Additional Description: This makes local_reply a little cleaner by removing a small implementation detail and adding a new setter function to StreamInfo.
Risk Level: medium (refactors existing code)
Testing: No new tests
Docs Changes: None
Release Notes: None
