### PR TITLE
stats: Symbolize routher's VirtualCluster StatNames in Router::ContextImpl.

### DIFF
--- a/include/envoy/router/context.h
+++ b/include/envoy/router/context.h
@@ -6,6 +6,7 @@ namespace Envoy {
 namespace Router {
 
 struct StatNames;
+struct VirtualClusterStatNames;
 
 class Context {
 public:
@@ -15,6 +16,11 @@ public:
    * @return a struct containing StatNames for router stats.
    */
   virtual const StatNames& statNames() const PURE;
+
+  /**
+   * @return a struct containing StatNames for virtual cluster stats.
+   */
+  virtual const VirtualClusterStatNames& virtualClusterStatNames() const PURE;
 };
 
 } // namespace Router

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -453,20 +453,20 @@ using ShadowPolicyPtr = std::unique_ptr<ShadowPolicy>;
 /**
  * All virtual cluster stats. @see stats_macro.h
  */
-#define ALL_VIRTUAL_CLUSTER_STATS(COUNTER)                                                         \
+#define ALL_VIRTUAL_CLUSTER_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)               \
   COUNTER(upstream_rq_retry)                                                                       \
   COUNTER(upstream_rq_retry_limit_exceeded)                                                        \
   COUNTER(upstream_rq_retry_overflow)                                                              \
   COUNTER(upstream_rq_retry_success)                                                               \
   COUNTER(upstream_rq_timeout)                                                                     \
-  COUNTER(upstream_rq_total)
+  COUNTER(upstream_rq_total)                                                                       \
+  STATNAME(other)
 
 /**
  * Struct definition for all virtual cluster stats. @see stats_macro.h
  */
-struct VirtualClusterStats {
-  ALL_VIRTUAL_CLUSTER_STATS(GENERATE_COUNTER_STRUCT)
-};
+MAKE_STAT_NAMES_STRUCT(VirtualClusterStatNames, ALL_VIRTUAL_CLUSTER_STATS);
+MAKE_STATS_STRUCT(VirtualClusterStats, VirtualClusterStatNames, ALL_VIRTUAL_CLUSTER_STATS);
 
 /**
  * Virtual cluster definition (allows splitting a virtual host into virtual clusters orthogonal to
@@ -486,8 +486,9 @@ public:
    */
   virtual VirtualClusterStats& stats() const PURE;
 
-  static VirtualClusterStats generateStats(Stats::Scope& scope) {
-    return {ALL_VIRTUAL_CLUSTER_STATS(POOL_COUNTER(scope))};
+  static VirtualClusterStats generateStats(Stats::Scope& scope,
+                                           const VirtualClusterStatNames& stat_names) {
+    return VirtualClusterStats(stat_names, scope);
   }
 };
 

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -97,6 +97,7 @@ envoy_cc_library(
     hdrs = ["context_impl.h"],
     deps = [
         "//include/envoy/router:context_interface",
+        "//include/envoy/router:router_interface",
         "//include/envoy/stats:stats_macros",
     ],
 )

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -196,8 +196,10 @@ private:
 
   struct VirtualClusterBase : public VirtualCluster {
   public:
-    VirtualClusterBase(Stats::StatName stat_name, Stats::ScopePtr&& scope)
-        : stat_name_(stat_name), scope_(std::move(scope)), stats_(generateStats(*scope_)) {}
+    VirtualClusterBase(Stats::StatName stat_name, Stats::ScopePtr&& scope,
+                       const VirtualClusterStatNames& stat_names)
+        : stat_name_(stat_name), scope_(std::move(scope)),
+          stats_(generateStats(*scope_, stat_names)) {}
 
     // Router::VirtualCluster
     Stats::StatName statName() const override { return stat_name_; }
@@ -211,14 +213,15 @@ private:
 
   struct VirtualClusterEntry : public VirtualClusterBase {
     VirtualClusterEntry(const envoy::config::route::v3::VirtualCluster& virtual_cluster,
-                        Stats::StatNamePool& pool, Stats::Scope& scope);
+                        Stats::StatNamePool& pool, Stats::Scope& scope,
+                        const VirtualClusterStatNames& stat_names);
 
     std::vector<Http::HeaderUtility::HeaderDataPtr> headers_;
   };
 
   struct CatchAllVirtualCluster : public VirtualClusterBase {
-    explicit CatchAllVirtualCluster(Stats::StatNamePool& pool, Stats::Scope& scope)
-        : VirtualClusterBase(pool.add("other"), scope.createScope("other")) {}
+    explicit CatchAllVirtualCluster(Stats::Scope& scope, const VirtualClusterStatNames& stat_names)
+        : VirtualClusterBase(stat_names.other_, scope.createScope("other"), stat_names) {}
   };
 
   static const std::shared_ptr<const SslRedirectRoute> SSL_REDIRECT_ROUTE;

--- a/source/common/router/context_impl.cc
+++ b/source/common/router/context_impl.cc
@@ -3,7 +3,8 @@
 namespace Envoy {
 namespace Router {
 
-ContextImpl::ContextImpl(Stats::SymbolTable& symbol_table) : stat_names_(symbol_table) {}
+ContextImpl::ContextImpl(Stats::SymbolTable& symbol_table)
+    : stat_names_(symbol_table), virtual_cluster_stat_names_(symbol_table) {}
 
 } // namespace Router
 } // namespace Envoy

--- a/source/common/router/context_impl.h
+++ b/source/common/router/context_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/router/context.h"
+#include "envoy/router/router.h"
 #include "envoy/stats/stats_macros.h"
 
 namespace Envoy {
@@ -34,9 +35,13 @@ public:
   ~ContextImpl() override = default;
 
   const StatNames& statNames() const override { return stat_names_; }
+  const VirtualClusterStatNames& virtualClusterStatNames() const override {
+    return virtual_cluster_stat_names_;
+  }
 
 private:
   const StatNames stat_names_;
+  const VirtualClusterStatNames virtual_cluster_stat_names_;
 };
 
 } // namespace Router

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -256,7 +256,8 @@ public:
   Stats::TestSymbolTable symbol_table_;
   Stats::StatNameManagedStorage stat_name_{"fake_virtual_cluster", *symbol_table_};
   Stats::IsolatedStoreImpl stats_store_;
-  mutable VirtualClusterStats stats_{generateStats(stats_store_)};
+  VirtualClusterStatNames stat_names_{stats_store_.symbolTable()};
+  mutable VirtualClusterStats stats_{generateStats(stats_store_, stat_names_)};
 };
 
 class MockVirtualHost : public VirtualHost {


### PR DESCRIPTION
Commit Message: One more incidence was found where counterFromString can be called from worker threads during control-plane updates: VirtualClusters. This simply captures those in Router::ContextImpl to avoid taking symbol-table locks curing control-plane updates.
Additional Description:
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
