### PR TITLE
remove memory allocation in WatcherImpl for Windows

### DIFF
--- a/source/common/filesystem/win32/watcher_impl.cc
+++ b/source/common/filesystem/win32/watcher_impl.cc
@@ -205,7 +205,7 @@ void WatcherImpl::directoryChangeCompletion(DWORD err, DWORD num_bytes, LPOVERLA
         // this tells the libevent callback to pull this callback off the active_callbacks_
         // queue. We do this so that the callbacks are executed in the main libevent loop,
         // not in this completion routine
-        Buffer::RawSlice buffer{(void *)data.data(), 1};
+        Buffer::RawSlice buffer{(void*)data.data(), 1};
         auto result = watcher->write_handle_->writev(&buffer, 1);
         RELEASE_ASSERT(result.rc_ == 1,
                        fmt::format("failed to write 1 byte: {}", result.err_->getErrorDetails()));

--- a/source/common/filesystem/win32/watcher_impl.cc
+++ b/source/common/filesystem/win32/watcher_impl.cc
@@ -194,7 +194,7 @@ void WatcherImpl::directoryChangeCompletion(DWORD err, DWORD num_bytes, LPOVERLA
       events |= Events::Modified;
     }
 
-    char data[] = {'a'};
+    constexpr absl::string_view data{"a"};
     for (FileWatch& watch : dir_watch->watches_) {
       if (watch.file_ == file && (watch.events_ & events)) {
         ENVOY_LOG(debug, "matched callback: file: {}", watcher->wstring_converter_.to_bytes(file));
@@ -205,7 +205,7 @@ void WatcherImpl::directoryChangeCompletion(DWORD err, DWORD num_bytes, LPOVERLA
         // this tells the libevent callback to pull this callback off the active_callbacks_
         // queue. We do this so that the callbacks are executed in the main libevent loop,
         // not in this completion routine
-        Buffer::RawSlice buffer{data, 1};
+        Buffer::RawSlice buffer{(void *)data.data(), 1};
         auto result = watcher->write_handle_->writev(&buffer, 1);
         RELEASE_ASSERT(result.rc_ == 1,
                        fmt::format("failed to write 1 byte: {}", result.err_->getErrorDetails()));


### PR DESCRIPTION
Signed-off-by: Randy Miller <rmiller14@gmail.com>

Commit Message: Remove memory allocation in WatcherImpl::directoryChangeCompletion for Windows by replacing ioHandle write (which requires Buffer::OwnedImpl) with ioHandle writev.

Risk Level: Low
Testing: Ran the watcher_impl_test filesystem test 1000 times with no regressions.
Issues: Fixes #14307.
