### PR TITLE
wasm: cleanup duplicate stats

### DIFF
--- a/source/extensions/common/wasm/ext/BUILD
+++ b/source/extensions/common/wasm/ext/BUILD
@@ -85,11 +85,3 @@ cc_proto_library(
         # "//external:protobuf_clib",
     ],
 )
-
-filegroup(
-    name = "jslib",
-    srcs = [
-        "envoy_wasm_intrinsics.js",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -102,7 +102,7 @@ void Wasm::initializeLifecycle(Server::ServerLifecycleNotifier& lifecycle_notifi
 Wasm::Wasm(absl::string_view runtime, absl::string_view vm_id, absl::string_view vm_configuration,
            absl::string_view vm_key, const Stats::ScopeSharedPtr& scope,
            Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher)
-    : WasmBase(createWasmVm(runtime, scope), vm_id, vm_configuration, vm_key), scope_(scope),
+    : WasmBase(createWasmVm(runtime), vm_id, vm_configuration, vm_key), scope_(scope),
       cluster_manager_(cluster_manager), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()),
       wasm_stats_(WasmStats{
@@ -116,8 +116,7 @@ Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher)
     : WasmBase(base_wasm_handle,
                [&base_wasm_handle]() {
                  return createWasmVm(
-                     getEnvoyWasmIntegration(*base_wasm_handle->wasm()->wasm_vm()).runtime(),
-                     getWasm(base_wasm_handle)->scope_);
+                     getEnvoyWasmIntegration(*base_wasm_handle->wasm()->wasm_vm()).runtime());
                }),
       scope_(getWasm(base_wasm_handle)->scope_),
       cluster_manager_(getWasm(base_wasm_handle)->clusterManager()), dispatcher_(dispatcher),

--- a/source/extensions/common/wasm/wasm_extension.cc
+++ b/source/extensions/common/wasm/wasm_extension.cc
@@ -40,10 +40,8 @@ RegisterWasmExtension::RegisterWasmExtension(WasmExtension* extension) {
 }
 
 std::unique_ptr<EnvoyWasmVmIntegration>
-EnvoyWasm::createEnvoyWasmVmIntegration(const Stats::ScopeSharedPtr& scope,
-                                        absl::string_view runtime,
-                                        absl::string_view short_runtime) {
-  return std::make_unique<EnvoyWasmVmIntegration>(scope, runtime, short_runtime);
+EnvoyWasm::createEnvoyWasmVmIntegration(absl::string_view runtime) {
+  return std::make_unique<EnvoyWasmVmIntegration>(runtime);
 }
 
 PluginHandleExtensionFactory EnvoyWasm::pluginFactory() {

--- a/source/extensions/common/wasm/wasm_extension.h
+++ b/source/extensions/common/wasm/wasm_extension.h
@@ -54,8 +54,7 @@ public:
 
   virtual void initialize() = 0;
   virtual std::unique_ptr<EnvoyWasmVmIntegration>
-  createEnvoyWasmVmIntegration(const Stats::ScopeSharedPtr& scope, absl::string_view runtime,
-                               absl::string_view short_runtime) = 0;
+  createEnvoyWasmVmIntegration(absl::string_view runtime) = 0;
   virtual PluginHandleExtensionFactory pluginFactory() = 0;
   virtual WasmHandleExtensionFactory wasmFactory() = 0;
   virtual WasmHandleExtensionCloneFactory wasmCloneFactory() = 0;
@@ -101,8 +100,7 @@ public:
   ~EnvoyWasm() override = default;
   void initialize() override {}
   std::unique_ptr<EnvoyWasmVmIntegration>
-  createEnvoyWasmVmIntegration(const Stats::ScopeSharedPtr& scope, absl::string_view runtime,
-                               absl::string_view short_runtime) override;
+  createEnvoyWasmVmIntegration(absl::string_view runtime) override;
   PluginHandleExtensionFactory pluginFactory() override;
   WasmHandleExtensionFactory wasmFactory() override;
   WasmHandleExtensionCloneFactory wasmCloneFactory() override;

--- a/source/extensions/common/wasm/wasm_runtime_factory.h
+++ b/source/extensions/common/wasm/wasm_runtime_factory.h
@@ -18,7 +18,6 @@ public:
   virtual WasmVmPtr createWasmVm() PURE;
 
   virtual absl::string_view name() PURE;
-  virtual absl::string_view shortName() PURE;
 
   std::string category() { return "envoy.wasm.runtime"; }
 };

--- a/source/extensions/common/wasm/wasm_vm.cc
+++ b/source/extensions/common/wasm/wasm_vm.cc
@@ -55,7 +55,7 @@ bool EnvoyWasmVmIntegration::getNullVmFunction(absl::string_view function_name, 
   return false;
 }
 
-WasmVmPtr createWasmVm(absl::string_view runtime, const Stats::ScopeSharedPtr& scope) {
+WasmVmPtr createWasmVm(absl::string_view runtime) {
   if (runtime.empty()) {
     ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::wasm), warn,
                         "Failed to create Wasm VM with unspecified runtime");
@@ -72,8 +72,7 @@ WasmVmPtr createWasmVm(absl::string_view runtime, const Stats::ScopeSharedPtr& s
   }
 
   auto wasm = runtime_factory->createWasmVm();
-  wasm->integration() = getWasmExtension()->createEnvoyWasmVmIntegration(
-      scope, runtime_factory->name(), runtime_factory->shortName());
+  wasm->integration() = getWasmExtension()->createEnvoyWasmVmIntegration(runtime_factory->name());
   return wasm;
 }
 

--- a/source/extensions/common/wasm/wasm_vm.h
+++ b/source/extensions/common/wasm/wasm_vm.h
@@ -21,14 +21,10 @@ namespace Wasm {
 class EnvoyWasmVmIntegration : public proxy_wasm::WasmVmIntegration,
                                Logger::Loggable<Logger::Id::wasm> {
 public:
-  EnvoyWasmVmIntegration(const Stats::ScopeSharedPtr& scope, absl::string_view runtime,
-                         absl::string_view short_runtime)
-      : scope_(scope), runtime_(std::string(runtime)), short_runtime_(std::string(short_runtime)) {}
+  EnvoyWasmVmIntegration(absl::string_view runtime) : runtime_(std::string(runtime)) {}
 
   // proxy_wasm::WasmVmIntegration
-  proxy_wasm::WasmVmIntegration* clone() override {
-    return new EnvoyWasmVmIntegration(scope_, runtime_, short_runtime_);
-  }
+  proxy_wasm::WasmVmIntegration* clone() override { return new EnvoyWasmVmIntegration(runtime_); }
   bool getNullVmFunction(absl::string_view function_name, bool returns_word,
                          int number_of_arguments, proxy_wasm::NullPlugin* plugin,
                          void* ptr_to_function_return) override;
@@ -37,9 +33,7 @@ public:
   const std::string& runtime() const { return runtime_; }
 
 protected:
-  const Stats::ScopeSharedPtr scope_;
   const std::string runtime_;
-  const std::string short_runtime_;
 }; // namespace Wasm
 
 inline EnvoyWasmVmIntegration& getEnvoyWasmIntegration(proxy_wasm::WasmVm& wasm_vm) {
@@ -55,7 +49,7 @@ public:
 using WasmVmPtr = std::unique_ptr<proxy_wasm::WasmVm>;
 
 // Create a new low-level Wasm VM using runtime of the given type (e.g. "envoy.wasm.runtime.wavm").
-WasmVmPtr createWasmVm(absl::string_view runtime, const Stats::ScopeSharedPtr& scope);
+WasmVmPtr createWasmVm(absl::string_view runtime);
 
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/wasm_runtime/null/config.cc
+++ b/source/extensions/wasm_runtime/null/config.cc
@@ -14,7 +14,6 @@ public:
   WasmVmPtr createWasmVm() override { return proxy_wasm::createNullVm(); }
 
   absl::string_view name() override { return "envoy.wasm.runtime.null"; }
-  absl::string_view shortName() override { return "null"; }
 };
 
 REGISTER_FACTORY(NullRuntimeFactory, WasmRuntimeFactory);

--- a/source/extensions/wasm_runtime/v8/config.cc
+++ b/source/extensions/wasm_runtime/v8/config.cc
@@ -14,7 +14,6 @@ public:
   WasmVmPtr createWasmVm() override { return proxy_wasm::createV8Vm(); }
 
   absl::string_view name() override { return "envoy.wasm.runtime.v8"; }
-  absl::string_view shortName() override { return "v8"; }
 };
 
 #if defined(ENVOY_WASM_V8)

--- a/source/extensions/wasm_runtime/wasmtime/config.cc
+++ b/source/extensions/wasm_runtime/wasmtime/config.cc
@@ -14,7 +14,6 @@ public:
   WasmVmPtr createWasmVm() override { return proxy_wasm::createWasmtimeVm(); }
 
   absl::string_view name() override { return "envoy.wasm.runtime.wasmtime"; }
-  absl::string_view shortName() override { return "wasmtime"; }
 };
 
 #if defined(ENVOY_WASM_WASMTIME)

--- a/source/extensions/wasm_runtime/wavm/config.cc
+++ b/source/extensions/wasm_runtime/wavm/config.cc
@@ -14,7 +14,6 @@ public:
   WasmVmPtr createWasmVm() override { return proxy_wasm::createWavmVm(); }
 
   absl::string_view name() override { return "envoy.wasm.runtime.wavm"; }
-  absl::string_view shortName() override { return "wavm"; }
 };
 
 #if defined(ENVOY_WASM_WAVM)

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -49,14 +49,12 @@ protected:
   Stats::ScopeSharedPtr scope_;
 };
 
-TEST_F(BaseVmTest, NoRuntime) { EXPECT_EQ(createWasmVm("", scope_), nullptr); }
+TEST_F(BaseVmTest, NoRuntime) { EXPECT_EQ(createWasmVm(""), nullptr); }
 
-TEST_F(BaseVmTest, BadRuntime) {
-  EXPECT_EQ(createWasmVm("envoy.wasm.runtime.invalid", scope_), nullptr);
-}
+TEST_F(BaseVmTest, BadRuntime) { EXPECT_EQ(createWasmVm("envoy.wasm.runtime.invalid"), nullptr); }
 
 TEST_F(BaseVmTest, NullVmStartup) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null");
   EXPECT_TRUE(wasm_vm != nullptr);
   EXPECT_TRUE(wasm_vm->runtime() == "null");
   EXPECT_TRUE(wasm_vm->cloneable() == Cloneable::InstantiatedModule);
@@ -70,7 +68,7 @@ TEST_F(BaseVmTest, NullVmStartup) {
 }
 
 TEST_F(BaseVmTest, NullVmMemory) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.null");
   EXPECT_EQ(wasm_vm->getMemorySize(), std::numeric_limits<uint64_t>::max());
   std::string d = "data";
   auto m = wasm_vm->getMemory(reinterpret_cast<uint64_t>(d.data()), d.size()).value();
@@ -137,14 +135,14 @@ protected:
 INSTANTIATE_TEST_SUITE_P(AllowPrecompiled, WasmVmTest, testing::Values(false, true));
 
 TEST_P(WasmVmTest, V8BadCode) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8");
   ASSERT_TRUE(wasm_vm != nullptr);
 
   EXPECT_FALSE(wasm_vm->load("bad code", GetParam()));
 }
 
 TEST_P(WasmVmTest, V8Code) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8");
   ASSERT_TRUE(wasm_vm != nullptr);
   EXPECT_TRUE(wasm_vm->runtime() == "v8");
 
@@ -163,7 +161,7 @@ TEST_P(WasmVmTest, V8Code) {
 }
 
 TEST_P(WasmVmTest, V8BadHostFunctions) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8");
   ASSERT_TRUE(wasm_vm != nullptr);
 
   auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -184,7 +182,7 @@ TEST_P(WasmVmTest, V8BadHostFunctions) {
 }
 
 TEST_P(WasmVmTest, V8BadModuleFunctions) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8");
   ASSERT_TRUE(wasm_vm != nullptr);
 
   auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -212,7 +210,7 @@ TEST_P(WasmVmTest, V8BadModuleFunctions) {
 }
 
 TEST_P(WasmVmTest, V8FunctionCalls) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8");
   ASSERT_TRUE(wasm_vm != nullptr);
 
   auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -250,7 +248,7 @@ TEST_P(WasmVmTest, V8FunctionCalls) {
 }
 
 TEST_P(WasmVmTest, V8Memory) {
-  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
+  auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8");
   ASSERT_TRUE(wasm_vm != nullptr);
 
   auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Removes stat duplication for `wasm.v8.created` and `wasm_vm.v8.created` which appear to be measuring the same thing. Same for `active`.

Additional Description:
Risk Level: low
Testing:
Docs Changes: none since no docs written yet for wasm
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
