### PR TITLE
tracing: add API to retrieve trace id from span

### DIFF
--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -174,6 +174,14 @@ public:
    * @param key baggage value
    */
   virtual void setBaggage(absl::string_view key, absl::string_view value) PURE;
+
+  /**
+   * Retrieve the trace ID associated with this span.
+   * The trace id may be created for this span, propagated by parent spans, or
+   * not created yet.
+   * @return trace ID
+   */
+  virtual std::string getTraceId() const PURE;
 };
 
 /**

--- a/include/envoy/tracing/http_tracer.h
+++ b/include/envoy/tracing/http_tracer.h
@@ -177,11 +177,11 @@ public:
 
   /**
    * Retrieve the trace ID associated with this span.
-   * The trace id may be created for this span, propagated by parent spans, or
+   * The trace id may be generated for this span, propagated by parent spans, or
    * not created yet.
-   * @return trace ID
+   * @return trace ID as a hex string
    */
-  virtual std::string getTraceId() const PURE;
+  virtual std::string getTraceIdAsHex() const PURE;
 };
 
 /**

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -13,6 +13,7 @@
 #include "envoy/type/tracing/v3/custom_tag.pb.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/common/empty_string.h"
 #include "common/config/metadata.h"
 #include "common/http/header_map_impl.h"
 #include "common/json/json_loader.h"
@@ -170,8 +171,8 @@ public:
   void finishSpan() override {}
   void injectContext(Http::RequestHeaderMap&) override {}
   void setBaggage(absl::string_view, absl::string_view) override {}
-  std::string getBaggage(absl::string_view) override { return std::string(); }
-  std::string getTraceId() const override { return std::string(); }
+  std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
+  std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }

--- a/source/common/tracing/http_tracer_impl.h
+++ b/source/common/tracing/http_tracer_impl.h
@@ -171,6 +171,7 @@ public:
   void injectContext(Http::RequestHeaderMap&) override {}
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return std::string(); }
+  std::string getTraceId() const override { return std::string(); }
   SpanPtr spawnChild(const Config&, const std::string&, SystemTime) override {
     return SpanPtr{new NullSpan()};
   }

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -5,6 +5,7 @@
 #include "envoy/stats/scope.h"
 #include "envoy/tracing/http_tracer.h"
 
+#include "common/common/empty_string.h"
 #include "common/common/logger.h"
 #include "common/singleton/const_singleton.h"
 
@@ -44,7 +45,7 @@ public:
   void setBaggage(absl::string_view key, absl::string_view value) override;
 
   // TODO: This method is unimplemented for OpenTracing.
-  std::string getTraceId() const override { return std::string(); };
+  std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -43,6 +43,9 @@ public:
   std::string getBaggage(absl::string_view key) override;
   void setBaggage(absl::string_view key, absl::string_view value) override;
 
+  // TODO: This method is unimplemented for OpenTracing.
+  std::string getTraceId() const override { return std::string(); };
+
 private:
   OpenTracingDriver& driver_;
   opentracing::FinishSpanOptions finish_options_;

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -77,6 +77,8 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override{};
   std::string getBaggage(absl::string_view) override { return std::string(); };
 
+  std::string getTraceId() const override;
+
 private:
   ::opencensus::trace::Span span_;
   const envoy::config::trace::v3::OpenCensusConfig& oc_config_;
@@ -241,6 +243,11 @@ void Span::injectContext(Http::RequestHeaderMap& request_headers) {
       break;
     }
   }
+}
+
+std::string Span::getTraceId() const {
+  const auto& ctx = span_.context();
+  return ctx.trace_id().ToHex();
 }
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config& /*config*/, const std::string& name,

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -6,6 +6,7 @@
 #include "envoy/http/header_map.h"
 
 #include "common/common/base64.h"
+#include "common/common/empty_string.h"
 
 #include "absl/strings/str_cat.h"
 #include "google/devtools/cloudtrace/v2/tracing.grpc.pb.h"
@@ -75,9 +76,9 @@ public:
 
   // OpenCensus doesn't support baggage, so noop these OpenTracing functions.
   void setBaggage(absl::string_view, absl::string_view) override{};
-  std::string getBaggage(absl::string_view) override { return std::string(); };
+  std::string getBaggage(absl::string_view) override { return EMPTY_STRING; };
 
-  std::string getTraceId() const override;
+  std::string getTraceIdAsHex() const override;
 
 private:
   ::opencensus::trace::Span span_;
@@ -245,7 +246,7 @@ void Span::injectContext(Http::RequestHeaderMap& request_headers) {
   }
 }
 
-std::string Span::getTraceId() const {
+std::string Span::getTraceIdAsHex() const {
   const auto& ctx = span_.context();
   return ctx.trace_id().ToHex();
 }

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -5,6 +5,7 @@
 
 #include "envoy/common/pure.h"
 
+#include "common/common/empty_string.h"
 #include "common/tracing/http_tracer_impl.h"
 
 #include "extensions/tracers/skywalking/skywalking_types.h"
@@ -89,7 +90,7 @@ public:
   void setBaggage(absl::string_view key, absl::string_view value) override;
 
   // TODO: This method is unimplemented for OpenTracing.
-  std::string getTraceId() const override { return std::string(); };
+  std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
   /*
    * Get pointer to corresponding SpanStore object. This method is mainly used in testing. Used to

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -88,6 +88,9 @@ public:
   std::string getBaggage(absl::string_view key) override;
   void setBaggage(absl::string_view key, absl::string_view value) override;
 
+  // TODO: This method is unimplemented for OpenTracing.
+  std::string getTraceId() const override { return std::string(); };
+
   /*
    * Get pointer to corresponding SpanStore object. This method is mainly used in testing. Used to
    * check the internal data of the span.

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -156,6 +156,9 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return std::string(); }
 
+  // TODO: This method is unimplemented for X-Ray.
+  std::string getTraceId() const override { return std::string(); };
+
   /**
    * Creates a child span.
    * In X-Ray terms this creates a sub-segment and sets its parent ID to the current span's ID.

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -7,6 +7,7 @@
 #include "envoy/common/time.h"
 #include "envoy/tracing/http_tracer.h"
 
+#include "common/common/empty_string.h"
 #include "common/common/hex.h"
 #include "common/common/random_generator.h"
 #include "common/protobuf/utility.h"
@@ -154,10 +155,10 @@ public:
 
   // X-Ray doesn't support baggage, so noop these OpenTracing functions.
   void setBaggage(absl::string_view, absl::string_view) override {}
-  std::string getBaggage(absl::string_view) override { return std::string(); }
+  std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
 
   // TODO: This method is unimplemented for X-Ray.
-  std::string getTraceId() const override { return std::string(); };
+  std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
   /**
    * Creates a child span.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/config/trace/v3/zipkin.pb.h"
 
+#include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/common/fmt.h"
 #include "common/common/utility.h"
@@ -37,7 +38,7 @@ void ZipkinSpan::log(SystemTime timestamp, const std::string& event) {
 
 // TODO(#11622): Implement baggage storage for zipkin spans
 void ZipkinSpan::setBaggage(absl::string_view, absl::string_view) {}
-std::string ZipkinSpan::getBaggage(absl::string_view) { return std::string(); }
+std::string ZipkinSpan::getBaggage(absl::string_view) { return EMPTY_STRING; }
 
 void ZipkinSpan::injectContext(Http::RequestHeaderMap& request_headers) {
   // Set the trace-id and span-id headers properly, based on the newly-created span structure.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -80,6 +80,9 @@ public:
   void setBaggage(absl::string_view, absl::string_view) override;
   std::string getBaggage(absl::string_view) override;
 
+  // TODO: This method is unimplemented for Zipkin.
+  std::string getTraceId() const override { return std::string(); };
+
   /**
    * @return a reference to the Zipkin::Span object.
    */

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -8,6 +8,7 @@
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "common/common/empty_string.h"
 #include "common/http/async_client_utility.h"
 #include "common/http/header_map_impl.h"
 #include "common/json/json_loader.h"
@@ -81,7 +82,7 @@ public:
   std::string getBaggage(absl::string_view) override;
 
   // TODO: This method is unimplemented for Zipkin.
-  std::string getTraceId() const override { return std::string(); };
+  std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
   /**
    * @return a reference to the Zipkin::Span object.

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -746,6 +746,7 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
   span_ptr->setTag("foo", "bar");
   span_ptr->setBaggage("key", "value");
   ASSERT_EQ("", span_ptr->getBaggage("baggage_key"));
+  ASSERT_EQ(span_ptr->getTraceId(), "");
   span_ptr->injectContext(request_headers);
 
   EXPECT_NE(nullptr, span_ptr->spawnChild(config, "foo", SystemTime()));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -746,7 +746,7 @@ TEST(HttpNullTracerTest, BasicFunctionality) {
   span_ptr->setTag("foo", "bar");
   span_ptr->setBaggage("key", "value");
   ASSERT_EQ("", span_ptr->getBaggage("baggage_key"));
-  ASSERT_EQ(span_ptr->getTraceId(), "");
+  ASSERT_EQ(span_ptr->getTraceIdAsHex(), "");
   span_ptr->injectContext(request_headers);
 
   EXPECT_NE(nullptr, span_ptr->spawnChild(config, "foo", SystemTime()));

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -215,6 +215,18 @@ TEST_F(OpenTracingDriverTest, ExtractWithUnindexedHeader) {
   EXPECT_EQ(spans.at(1).span_context.span_id, spans.at(0).references.at(0).span_id);
 }
 
+TEST_F(OpenTracingDriverTest, GetTraceId) {
+  setupValidDriver();
+
+  Tracing::SpanPtr first_span = driver_->startSpan(config_, request_headers_, operation_name_,
+                                                   start_time_, {Tracing::Reason::Sampling, true});
+  first_span->setTag("abc", "123");
+  first_span->finishSpan();
+
+  // This method is unimplemented and a noop.
+  ASSERT_EQ(first_span->getTraceId(), "");
+}
+
 } // namespace
 } // namespace Ot
 } // namespace Common

--- a/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
+++ b/test/extensions/tracers/common/ot/opentracing_driver_impl_test.cc
@@ -224,7 +224,7 @@ TEST_F(OpenTracingDriverTest, GetTraceId) {
   first_span->finishSpan();
 
   // This method is unimplemented and a noop.
-  ASSERT_EQ(first_span->getTraceId(), "");
+  ASSERT_EQ(first_span->getTraceIdAsHex(), "");
 }
 
 } // namespace

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -729,7 +729,7 @@ TEST_F(LightStepDriverTest, GetTraceId) {
                                              start_time_, {Tracing::Reason::Sampling, true});
 
   // This method is unimplemented and a noop.
-  ASSERT_EQ(span->getTraceId(), "");
+  ASSERT_EQ(span->getTraceIdAsHex(), "");
 }
 
 } // namespace

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -723,6 +723,15 @@ TEST_F(LightStepDriverTest, GetAndSetBaggage) {
   EXPECT_EQ(span->getBaggage(key), value);
 }
 
+TEST_F(LightStepDriverTest, GetTraceId) {
+  setupValidDriver();
+  Tracing::SpanPtr span = driver_->startSpan(config_, request_headers_, operation_name_,
+                                             start_time_, {Tracing::Reason::Sampling, true});
+
+  // This method is unimplemented and a noop.
+  ASSERT_EQ(span->getTraceId(), "");
+}
+
 } // namespace
 } // namespace Lightstep
 } // namespace Tracers

--- a/test/extensions/tracers/opencensus/tracer_test.cc
+++ b/test/extensions/tracers/opencensus/tracer_test.cc
@@ -129,7 +129,7 @@ TEST(OpenCensusTracerTest, Span) {
     ASSERT_EQ("", span->getBaggage("baggage_key"));
 
     // Trace id is automatically created when no parent context exists.
-    ASSERT_NE(span->getTraceId(), "");
+    ASSERT_NE(span->getTraceIdAsHex(), "");
   }
 
   // Retrieve SpanData from the OpenCensus trace exporter.
@@ -223,7 +223,7 @@ void testIncomingHeaders(
 
     // Check contents via public API.
     // Trace id is set via context propagation headers.
-    EXPECT_EQ(span->getTraceId(), "404142434445464748494a4b4c4d4e4f");
+    EXPECT_EQ(span->getTraceIdAsHex(), "404142434445464748494a4b4c4d4e4f");
   }
 
   // Retrieve SpanData from the OpenCensus trace exporter.

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -97,6 +97,9 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   EXPECT_EQ("", span->getBaggage("FakeStringAndNothingToDo"));
   span->setBaggage("FakeStringAndNothingToDo", "FakeStringAndNothingToDo");
 
+  // This method is unimplemented and a noop.
+  ASSERT_EQ(span->getTraceId(), "");
+
   // Test whether the basic functions of Span are normal.
 
   span->setSampled(false);

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -98,7 +98,7 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
   span->setBaggage("FakeStringAndNothingToDo", "FakeStringAndNothingToDo");
 
   // This method is unimplemented and a noop.
-  ASSERT_EQ(span->getTraceId(), "");
+  ASSERT_EQ(span->getTraceIdAsHex(), "");
 
   // Test whether the basic functions of Span are normal.
 

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -127,7 +127,7 @@ TEST_F(XRayTracerTest, GetTraceId) {
   span->finishSpan();
 
   // This method is unimplemented and a noop.
-  ASSERT_EQ(span->getTraceId(), "");
+  ASSERT_EQ(span->getTraceIdAsHex(), "");
 }
 
 TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {

--- a/test/extensions/tracers/xray/tracer_test.cc
+++ b/test/extensions/tracers/xray/tracer_test.cc
@@ -120,6 +120,16 @@ TEST_F(XRayTracerTest, BaggageNotImplemented) {
   ASSERT_EQ("", span->getBaggage("baggage_key"));
 }
 
+TEST_F(XRayTracerTest, GetTraceId) {
+  Tracer tracer{"" /*span name*/,   "" /*origin*/,        aws_metadata_,
+                std::move(broker_), server_.timeSource(), server_.api().randomGenerator()};
+  auto span = tracer.createNonSampledSpan();
+  span->finishSpan();
+
+  // This method is unimplemented and a noop.
+  ASSERT_EQ(span->getTraceId(), "");
+}
+
 TEST_F(XRayTracerTest, ChildSpanHasParentInfo) {
   NiceMock<Tracing::MockConfig> config;
   constexpr auto expected_span_name = "Service 1";

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -709,6 +709,13 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
                                               start_time_, {Tracing::Reason::Sampling, true});
   span5->setBaggage("baggage_key", "baggage_value");
   EXPECT_EQ("", span5->getBaggage("baggage_key"));
+
+  // ====
+  // Test trace id noop
+  // ====
+  Tracing::SpanPtr span6 = driver_->startSpan(config_, request_headers_, operation_name_,
+                                              start_time_, {Tracing::Reason::Sampling, true});
+  EXPECT_EQ(span6->getTraceId(), "");
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersTest) {

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -715,7 +715,7 @@ TEST_F(ZipkinDriverTest, ZipkinSpanTest) {
   // ====
   Tracing::SpanPtr span6 = driver_->startSpan(config_, request_headers_, operation_name_,
                                               start_time_, {Tracing::Reason::Sampling, true});
-  EXPECT_EQ(span6->getTraceId(), "");
+  EXPECT_EQ(span6->getTraceIdAsHex(), "");
 }
 
 TEST_F(ZipkinDriverTest, ZipkinSpanContextFromB3HeadersTest) {

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -39,7 +39,7 @@ public:
   MOCK_METHOD(void, setSampled, (const bool sampled));
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
-  MOCK_METHOD(std::string, getTraceId, (), (const));
+  MOCK_METHOD(std::string, getTraceIdAsHex, (), (const));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -39,6 +39,7 @@ public:
   MOCK_METHOD(void, setSampled, (const bool sampled));
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
+  MOCK_METHOD(std::string, getTraceId, (), (const));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {


### PR DESCRIPTION
Commit Message:
tracing: add API to retrieve trace id from span

Additional Description:
Currently, access loggers and tracers are only connected by Envoy's request id. We would like to associate access log entries with trace ids as well.
For now, accessing trace ID is only implemented in the OpenCensus tracer extension. I am not familiar with the other tracers to understand how to retrieve the trace ID, so they return empty string.

Risk Level:
Low. Just adding a new method, not used anywhere.

Testing: Unit tests

Docs Changes: None
Release Notes: None
Platform Specific Features: None

Ref: GoogleCloudPlatform/esp-v2#431

Signed-off-by: Teju Nareddy <nareddyt@google.com>