### PR TITLE
[Windows] Race condition with move and directory change2

### DIFF
--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -79,6 +79,9 @@ bazel "${BAZEL_STARTUP_OPTIONS[@]}" test "${BAZEL_BUILD_OPTIONS[@]}" //test/... 
 echo "running flaky test reporting script"
 "${ENVOY_SRCDIR}"/ci/flaky_test/run_process_xml.sh "$CI_TARGET"
 
+echo "verifying flaky test with more datapoints"
+bazel "${BAZEL_STARTUP_OPTIONS[@]}" test "${BAZEL_BUILD_OPTIONS[@]}" //test/integration:eds_integration_test --cache_test_results=no --runs_per_test=1000
+
 # Build tests that are known-flaky or known-failing to ensure no compilation regressions
 bazel "${BAZEL_STARTUP_OPTIONS[@]}" build "${BAZEL_BUILD_OPTIONS[@]}" //test/... --test_tag_filters=-skip_on_windows,fails_on_windows,flaky_on_windows --build_tests_only
 

--- a/include/envoy/filesystem/filesystem.h
+++ b/include/envoy/filesystem/filesystem.h
@@ -112,6 +112,13 @@ public:
   virtual std::string fileReadToEnd(const std::string& path) PURE;
 
   /**
+   * @return full file content as a string.
+   * @throw EnvoyException if the file cannot be read.
+   * Be aware, this is not most highly performing file reading method.
+   */
+  virtual std::string fileReadToEnd(const std::string& path, bool retry_sharing_violations) PURE;
+
+  /**
    * @path file path to split
    * @return PathSplitResult containing the parent directory of the input path and the file name
    * @note will throw an exception if path does not contain any path separator character

--- a/source/common/config/filesystem_subscription_impl.cc
+++ b/source/common/config/filesystem_subscription_impl.cc
@@ -49,7 +49,7 @@ void FilesystemSubscriptionImpl::configRejected(const EnvoyException& e,
 std::string FilesystemSubscriptionImpl::refreshInternal(ProtobufTypes::MessagePtr* config_update) {
   auto owned_message = std::make_unique<envoy::service::discovery::v3::DiscoveryResponse>();
   auto& message = *owned_message;
-  MessageUtil::loadFromFile(path_, message, validation_visitor_, api_);
+  MessageUtil::loadFromFile(path_, message, validation_visitor_, api_, true, true);
   *config_update = std::move(owned_message);
   const auto decoded_resources =
       DecodedResourcesWrapper(resource_decoder_, message.resources(), message.version_info());

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -149,7 +149,8 @@ std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {
   return file_string.str();
 }
 
-std::string InstanceImplWin32::fileReadToEnd(const std::string& path, bool retry_sharing_violations) {
+std::string InstanceImplWin32::fileReadToEnd(const std::string& path,
+                                             bool retry_sharing_violations) {
   std::string out;
   int attempts = 1;
   constexpr int max_attempts = 3;
@@ -157,20 +158,19 @@ std::string InstanceImplWin32::fileReadToEnd(const std::string& path, bool retry
     try {
       out = fileReadToEnd(path);
       return out;
-    }
-    catch (const EnvoyException& e) {
-        if (retry_sharing_violations) {
-          std::string exception_message(e.what());
-            ENVOY_LOG_MISC(warn, "{}", exception_message);
-          if (exception_message.find("Error sharing violation") != std::string::npos) {
-            ENVOY_LOG_MISC(warn, "retrying");
-            ++attempts;
-          } else {
-             throw e;
-          }
+    } catch (const EnvoyException& e) {
+      if (retry_sharing_violations) {
+        std::string exception_message(e.what());
+        ENVOY_LOG_MISC(warn, "{}", exception_message);
+        if (exception_message.find("Error sharing violation") != std::string::npos) {
+          ENVOY_LOG_MISC(warn, "retrying");
+          ++attempts;
         } else {
           throw e;
         }
+      } else {
+        throw e;
+      }
     }
     Sleep(20 * exp2(attempts));
   } while (attempts <= max_attempts && retry_sharing_violations);

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -36,6 +36,7 @@ public:
   bool directoryExists(const std::string& path) override;
   ssize_t fileSize(const std::string& path) override;
   std::string fileReadToEnd(const std::string& path) override;
+  std::string fileReadToEnd(const std::string& path, bool retry_sharing_violations) override;
   PathSplitResult splitPathFromFilename(absl::string_view path) override;
   bool illegalPath(const std::string& path) override;
 };

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -400,8 +400,8 @@ void MessageUtil::loadFromYaml(const std::string& yaml, ProtobufWkt::Struct& mes
 
 void MessageUtil::loadFromFile(const std::string& path, Protobuf::Message& message,
                                ProtobufMessage::ValidationVisitor& validation_visitor,
-                               Api::Api& api, bool do_boosting) {
-  const std::string contents = api.fileSystem().fileReadToEnd(path);
+                               Api::Api& api, bool do_boosting, bool retry_sharing_violations) {
+  const std::string contents = api.fileSystem().fileReadToEnd(path, retry_sharing_violations);
   // If the filename ends with .pb, attempt to parse it as a binary proto.
   if (absl::EndsWith(path, FileExtensions::get().ProtoBinary)) {
     // Attempt to parse the binary format.

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -258,7 +258,7 @@ public:
   static void loadFromYaml(const std::string& yaml, ProtobufWkt::Struct& message);
   static void loadFromFile(const std::string& path, Protobuf::Message& message,
                            ProtobufMessage::ValidationVisitor& validation_visitor, Api::Api& api,
-                           bool do_boosting = true);
+                           bool do_boosting = true, bool retry_sharing_violations = false);
 
   /**
    * Checks for use of deprecated fields in message and all sub-messages.

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -135,8 +135,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "eds_integration_test",
     srcs = ["eds_integration_test.cc"],
-    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/upstream:load_balancer_lib",
@@ -980,7 +978,6 @@ envoy_cc_test(
     srcs = ["load_stats_integration_test.cc"],
     # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test, hangs at
     # IpVersionsClientType/LoadStatsIntegrationTest.NoLocalLocality/3
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/config:utility_lib",

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -52,6 +52,7 @@ public:
   MOCK_METHOD(bool, directoryExists, (const std::string&));
   MOCK_METHOD(ssize_t, fileSize, (const std::string&));
   MOCK_METHOD(std::string, fileReadToEnd, (const std::string&));
+  MOCK_METHOD(std::string, fileReadToEnd, (const std::string&, bool));
   MOCK_METHOD(PathSplitResult, splitPathFromFilename, (absl::string_view));
   MOCK_METHOD(bool, illegalPath, (const std::string&));
 };

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -158,7 +158,7 @@ void TestEnvironment::renameFile(const std::string& old_name, const std::string&
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rename-wrename?view=vs-2017
   // Note MoveFileEx cannot overwrite a directory as documented, nor a symlink, apparently.
   const BOOL rc = ::MoveFileEx(old_name.c_str(), new_name.c_str(), MOVEFILE_REPLACE_EXISTING);
-  ASSERT_NE(0, rc);
+  ASSERT_NE(0, rc) << fmt::format("MoveFileEx failed with error: {}", ::GetLastError());
 #else
   const int rc = ::rename(old_name.c_str(), new_name.c_str());
   ASSERT_EQ(0, rc);


### PR DESCRIPTION
### Commit Message:

There is a weird race condition between `MoveFileEx` and `ReadDirectoryChangeW`.

What happens is the following:

Thread 1: `MoveFileEx` from E:\temp/eds.update.pb_text -> E:\temp/eds.pb_text
Thread 2: `ReadDirectoryChangeW` notification triggers and notifies `filesystem_subscription_impl`
Thread 3: `filesystem_subscription_impl` tries to read file ` E:\temp/eds.pb_text` and fails
Thread 1:  `MoveFileEx` completes

These logs also demonstrate it:

```
❯ ./bazel-bin/test/integration/eds_integration_test.exe --gtest_filter=IpVersions/EdsIntegrationTest.RemoveAfterHcFail/0 -l warn
Note: Google Test filter = IpVersions/EdsIntegrationTest.RemoveAfterHcFail/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from IpVersions/EdsIntegrationTest
[ RUN      ] IpVersions/EdsIntegrationTest.RemoveAfterHcFail/0
[3928][warning][runtime] [source/common/runtime/runtime_features.cc:31] Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size
[3928][warning][runtime] [source/common/runtime/runtime_features.cc:31] Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size
[3928][warning][misc] [test/test_common/environment.cc:160] move started
[3928][warning][misc] [test/test_common/environment.cc:163] move completed E:\temp/eds.update.pb_text -> E:\temp/eds.pb_text
[3928][warning][misc] [test/test_common/environment.cc:160] move started
[3928][warning][misc] [test/test_common/environment.cc:163] move completed E:\temp/cds.update.pb_text -> E:\temp/cds.pb_text
[9244][warning][runtime] [source/common/runtime/runtime_features.cc:31] Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size
[9244][warning][runtime] [source/common/runtime/runtime_features.cc:31] Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size
[9244][warning][runtime] [source/common/runtime/runtime_features.cc:31] Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size
[9244][warning][runtime] [source/common/runtime/runtime_features.cc:31] Unable to use runtime singleton for feature envoy.http.headermap.lazy_map_min_size
[9244][warning][main] [source/server/server.cc:604] there is no configured limit to the number of allowed active connections. Set a limit via the runtime key overload.global_downstream_max_connections
[3928][warning][misc] [test/test_common/environment.cc:160] move started
[1028][warning][misc] [source/common/filesystem/win32/watcher_impl.cc:214] trigger watcher
[9244][warning][misc] [source/common/filesystem/win32/filesystem_impl.cc:139] read failed with le 32
[3928][warning][misc] [test/test_common/environment.cc:163] move completed E:\temp/eds.update.pb_text -> E:\temp/eds.pb_text
[9068][warning][config] [source/common/config/filesystem_subscription_impl.cc:78] Filesystem config update failure: unable to read file: E:\temp/eds.pb_text
```

Additional Description: Solved by retrying
Risk Level: Low
Testing: Existing integration tests
Docs Changes:
Release Notes:
Platform Specific Features:
