### PR TITLE
jwt_authn: make "issuer" field in JwtProvider as optional

### DIFF
--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -68,7 +68,7 @@ message JwtProvider {
   // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
   // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
   // are implemented differently than other *JwtRequirements*. Hence the usage of this field
-  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
+  // is different as follows if *allow_missing* or *allow_missing_or_failed* is used:
   //
   // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
   // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -61,14 +61,19 @@ message JwtProvider {
   // the JWT, usually a URL or an email address.
   //
   // It is optional. If specified, it has to match the *iss* field in JWT.
-  // Its usage implications are following:
   //
-  // * If a JWT has *iss* field and this field is specified, they have to match.
-  // * If a JWT doesn't have *iss* field,  not to check with this field.
-  // * If this field is not specified, the JWT *iss* field is not checked.
-  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
-  //   without this field will be used.
+  // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
+  // JWT *iss* field is not checked.
+  //
+  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
+  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
+  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  //
+  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
+  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
+  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
+  // field is used to list all providers and its type is *map*, its order is nondeterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -73,7 +73,7 @@ message JwtProvider {
   // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
   // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
   // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is nondeterministic.
+  // field is used to list all providers and its type is *map*, its order is non deterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the *iss* field in JWT.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,7 +59,14 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
-  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
+  // It is optional. If specified, it has to match the *iss* field in JWT.
+  // Its usage implications are following:
+  // * If a JWT has *iss* field and this field is specified, they have to match.
+  // * If a JWT doesn't have *iss* field,  not to check with this field.
+  // * If this field is not specified, the JWT *iss* field is not checked.
+  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
+  //   without this field will be used.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -65,15 +65,14 @@ message JwtProvider {
   // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
   // JWT *iss* field is not checked.
   //
-  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
-  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
-  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
+  // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
+  // are implemented differently than other *JwtRequirements*. Hence the usage of this field
+  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
   //
-  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
-  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
-  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is non deterministic.
+  // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
+  // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.
+  // * Multiple *JwtProviders* should not have same value in this field.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -59,8 +59,10 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  //
   // It is optional. If specified, it has to match the *iss* field in JWT.
   // Its usage implications are following:
+  //
   // * If a JWT has *iss* field and this field is specified, they have to match.
   // * If a JWT doesn't have *iss* field,  not to check with this field.
   // * If this field is not specified, the JWT *iss* field is not checked.

--- a/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. It has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,11 +59,12 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com
   //
-  string issuer = 1 [(validate.rules).string = {min_len: 1}];
+  string issuer = 1;
 
   // The list of JWT `audiences <https://tools.ietf.org/html/rfc7519#section-4.1.3>`_ are
   // allowed to access. A JWT containing any of these audiences will be accepted. If not specified,

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -68,7 +68,7 @@ message JwtProvider {
   // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
   // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
   // are implemented differently than other *JwtRequirements*. Hence the usage of this field
-  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
+  // is different as follows if *allow_missing* or *allow_missing_or_failed* is used:
   //
   // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
   // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -61,14 +61,19 @@ message JwtProvider {
   // the JWT, usually a URL or an email address.
   //
   // It is optional. If specified, it has to match the *iss* field in JWT.
-  // Its usage implications are following:
   //
-  // * If a JWT has *iss* field and this field is specified, they have to match.
-  // * If a JWT doesn't have *iss* field,  not to check with this field.
-  // * If this field is not specified, the JWT *iss* field is not checked.
-  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
-  //   without this field will be used.
+  // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
+  // JWT *iss* field is not checked.
+  //
+  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
+  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
+  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  //
+  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
+  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
+  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
+  // field is used to list all providers and its type is *map*, its order is nondeterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -73,7 +73,7 @@ message JwtProvider {
   // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
   // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
   // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is nondeterministic.
+  // field is used to list all providers and its type is *map*, its order is non deterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the *iss* field in JWT.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,7 +59,14 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
-  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
+  // It is optional. If specified, it has to match the *iss* field in JWT.
+  // Its usage implications are following:
+  // * If a JWT has *iss* field and this field is specified, they have to match.
+  // * If a JWT doesn't have *iss* field,  not to check with this field.
+  // * If this field is not specified, the JWT *iss* field is not checked.
+  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
+  //   without this field will be used.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -65,15 +65,14 @@ message JwtProvider {
   // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
   // JWT *iss* field is not checked.
   //
-  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
-  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
-  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
+  // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
+  // are implemented differently than other *JwtRequirements*. Hence the usage of this field
+  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
   //
-  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
-  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
-  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is non deterministic.
+  // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
+  // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.
+  // * Multiple *JwtProviders* should not have same value in this field.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. It has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,11 +59,12 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com
   //
-  string issuer = 1 [(validate.rules).string = {min_len: 1}];
+  string issuer = 1;
 
   // The list of JWT `audiences <https://tools.ietf.org/html/rfc7519#section-4.1.3>`_ are
   // allowed to access. A JWT containing any of these audiences will be accepted. If not specified,

--- a/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/api/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -59,8 +59,10 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  //
   // It is optional. If specified, it has to match the *iss* field in JWT.
   // Its usage implications are following:
+  //
   // * If a JWT has *iss* field and this field is specified, they have to match.
   // * If a JWT doesn't have *iss* field,  not to check with this field.
   // * If this field is not specified, the JWT *iss* field is not checked.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,6 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` from required to optional.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,7 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
-* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT :ref:`RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>` requirements.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT [RFC](https://tools.ietf.org/html/rfc7519#section-4.1.1) requirements.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,7 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
-* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT :ref:`RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>` requirements.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,7 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
-* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT `RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>_` requirements.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT `RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ requirements.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,7 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
-* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` from required to optional.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to optional.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,7 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
-* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to optional.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -75,7 +75,7 @@ New Features
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
-* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT [RFC](https://tools.ietf.org/html/rfc7519#section-4.1.1) requirements.
+* jwt_authn: changed config field :ref:`issuer <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtProvider.issuer>` to be optional to comply with JWT `RFC <https://tools.ietf.org/html/rfc7519#section-4.1.1>_` requirements.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.
 * listener: added an optional :ref:`default filter chain <envoy_v3_api_field_config.listener.v3.Listener.default_filter_chain>`. If this field is supplied, and none of the :ref:`filter_chains <envoy_v3_api_field_config.listener.v3.Listener.filter_chains>` matches, this default filter chain is used to serve the connection.
 * listener: added back the :ref:`use_original_dst field <envoy_v3_api_field_config.listener.v3.Listener.use_original_dst>`.

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -68,7 +68,7 @@ message JwtProvider {
   // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
   // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
   // are implemented differently than other *JwtRequirements*. Hence the usage of this field
-  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
+  // is different as follows if *allow_missing* or *allow_missing_or_failed* is used:
   //
   // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
   // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -61,14 +61,19 @@ message JwtProvider {
   // the JWT, usually a URL or an email address.
   //
   // It is optional. If specified, it has to match the *iss* field in JWT.
-  // Its usage implications are following:
   //
-  // * If a JWT has *iss* field and this field is specified, they have to match.
-  // * If a JWT doesn't have *iss* field,  not to check with this field.
-  // * If this field is not specified, the JWT *iss* field is not checked.
-  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
-  //   without this field will be used.
+  // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
+  // JWT *iss* field is not checked.
+  //
+  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
+  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
+  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  //
+  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
+  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
+  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
+  // field is used to list all providers and its type is *map*, its order is nondeterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -73,7 +73,7 @@ message JwtProvider {
   // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
   // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
   // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is nondeterministic.
+  // field is used to list all providers and its type is *map*, its order is non deterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the *iss* field in JWT.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,7 +59,14 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
-  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
+  // It is optional. If specified, it has to match the *iss* field in JWT.
+  // Its usage implications are following:
+  // * If a JWT has *iss* field and this field is specified, they have to match.
+  // * If a JWT doesn't have *iss* field,  not to check with this field.
+  // * If this field is not specified, the JWT *iss* field is not checked.
+  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
+  //   without this field will be used.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -65,15 +65,14 @@ message JwtProvider {
   // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
   // JWT *iss* field is not checked.
   //
-  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
-  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
-  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
+  // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
+  // are implemented differently than other *JwtRequirements*. Hence the usage of this field
+  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
   //
-  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
-  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
-  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is non deterministic.
+  // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
+  // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.
+  // * Multiple *JwtProviders* should not have same value in this field.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -59,8 +59,10 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  //
   // It is optional. If specified, it has to match the *iss* field in JWT.
   // Its usage implications are following:
+  //
   // * If a JWT has *iss* field and this field is specified, they have to match.
   // * If a JWT doesn't have *iss* field,  not to check with this field.
   // * If this field is not specified, the JWT *iss* field is not checked.

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v3/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. It has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,11 +59,12 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com
   //
-  string issuer = 1 [(validate.rules).string = {min_len: 1}];
+  string issuer = 1;
 
   // The list of JWT `audiences <https://tools.ietf.org/html/rfc7519#section-4.1.3>`_ are
   // allowed to access. A JWT containing any of these audiences will be accepted. If not specified,

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -68,7 +68,7 @@ message JwtProvider {
   // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
   // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
   // are implemented differently than other *JwtRequirements*. Hence the usage of this field
-  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
+  // is different as follows if *allow_missing* or *allow_missing_or_failed* is used:
   //
   // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
   // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -61,14 +61,19 @@ message JwtProvider {
   // the JWT, usually a URL or an email address.
   //
   // It is optional. If specified, it has to match the *iss* field in JWT.
-  // Its usage implications are following:
   //
-  // * If a JWT has *iss* field and this field is specified, they have to match.
-  // * If a JWT doesn't have *iss* field,  not to check with this field.
-  // * If this field is not specified, the JWT *iss* field is not checked.
-  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
-  //   without this field will be used.
+  // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
+  // JWT *iss* field is not checked.
+  //
+  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
+  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
+  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  //
+  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
+  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
+  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
+  // field is used to list all providers and its type is *map*, its order is nondeterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -73,7 +73,7 @@ message JwtProvider {
   // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
   // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
   // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is nondeterministic.
+  // field is used to list all providers and its type is *map*, its order is non deterministic.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the *iss* field in JWT.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,7 +59,14 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
-  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
+  // It is optional. If specified, it has to match the *iss* field in JWT.
+  // Its usage implications are following:
+  // * If a JWT has *iss* field and this field is specified, they have to match.
+  // * If a JWT doesn't have *iss* field,  not to check with this field.
+  // * If this field is not specified, the JWT *iss* field is not checked.
+  // * If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
+  //   JwtProvider to verify the signature. If the JWT doesn't have *iss* field, the first JwtProvider
+  //   without this field will be used.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -65,15 +65,14 @@ message JwtProvider {
   // If a JWT has *iss* field and this field is specified, they have to match, otherwise the
   // JWT *iss* field is not checked.
   //
-  // If *allow_missing* or *allow_missing_or_failed* is used, the JWT *iss* field is used to find
-  // the *first* JwtProvider with the same *issuer*, and use it to verify the signature.
-  // If a JWT doesn't have the *iss* field, the *first* JwtProvider with empty *issuer* will be used.
-  // If all JwtProviders have non empty *issuer*, a JWT without *iss* will be rejected.
+  // Note: *JwtRequirement* :ref:`allow_missing <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing>`
+  // and :ref:`allow_missing_or_failed <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtRequirement.allow_missing_or_failed>`
+  // are implemented differently than other *JwtRequirements*. Hence the usage of this field
+  // is different as followings if *allow_missing* or *allow_missing_or_failed* is used:
   //
-  // Multiple JwtProviders can have same "issuer", but it is not recommended when *allow_missing* or
-  // *allow_missing_or_failed* is used where the JWT *iss* is used to find the *first* JwtProvider.
-  // Since :ref:`providers <envoy_v3_api_field_extensions.filters.http.jwt_authn.v3.JwtAuthentication.providers>`
-  // field is used to list all providers and its type is *map*, its order is non deterministic.
+  // * If a JWT has *iss* field, it needs to be specified by this field in one of *JwtProviders*.
+  // * If a JWT doesn't have *iss* field, one of *JwtProviders* should fill this field empty.
+  // * Multiple *JwtProviders* should not have same value in this field.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 //
 // A JwtProvider message specifies how a JSON Web Token (JWT) can be verified. It specifies:
 //
-// * issuer: the principal that issues the JWT. It has to match the one from the token.
+// * issuer: the principal that issues the JWT. If specified, it has to match the one from the token.
 // * allowed audiences: the ones in the token have to be listed here.
 // * how to fetch public key JWKS to verify the token signature.
 // * how to extract JWT token in the request.
@@ -59,11 +59,12 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  // It is optional. If specified, it has to match with "iss" field in the JWT payload.
   //
   // Example: https://securetoken.google.com
   // Example: 1234567-compute@developer.gserviceaccount.com
   //
-  string issuer = 1 [(validate.rules).string = {min_len: 1}];
+  string issuer = 1;
 
   // The list of JWT `audiences <https://tools.ietf.org/html/rfc7519#section-4.1.3>`_ are
   // allowed to access. A JWT containing any of these audiences will be accepted. If not specified,

--- a/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/jwt_authn/v4alpha/config.proto
@@ -59,8 +59,10 @@ message JwtProvider {
 
   // Specify the `principal <https://tools.ietf.org/html/rfc7519#section-4.1.1>`_ that issued
   // the JWT, usually a URL or an email address.
+  //
   // It is optional. If specified, it has to match the *iss* field in JWT.
   // Its usage implications are following:
+  //
   // * If a JWT has *iss* field and this field is specified, they have to match.
   // * If a JWT doesn't have *iss* field,  not to check with this field.
   // * If this field is not specified, the JWT *iss* field is not checked.

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -160,8 +160,8 @@ void AuthenticatorImpl::startVerify() {
   jwks_data_ = provider_ ? jwks_cache_.findByProvider(provider_.value())
                          : jwks_cache_.findByIssuer(jwt_->iss_);
   // When `provider` is valid, findByProvider should never return nullptr.
-  // Only when `allow_missing` or `allow_missing_or_fail` is used, `provider` may be invalid.
-  // In this case, `iss` from the Jwt token is used to find the first provider with the issuer.
+  // Only when `allow_missing` or `allow_failed` is used, `provider` is invalid,
+  // Jwt `iss` field is used to find the first provider with the issuer.
   // If not found, use the first provider without issuer specified.
   // If still no found, fail the request with UnknownIssuer error.
   if (!jwks_data_) {

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -149,15 +149,8 @@ void AuthenticatorImpl::startVerify() {
 
   ENVOY_LOG(debug, "{}: Verifying JWT token of issuer {}", name(), jwt_->iss_);
   if (!jwt_->iss_.empty()) {
-    // Check if token extracted from the location contains the issuer specified by config.
-    if (!curr_token_->isIssuerSpecified(jwt_->iss_)) {
-      doneWithStatus(Status::JwtUnknownIssuer);
-      return;
-    }
-  } else {
-    // If provider is not specified, in allow_missing_or_failed or allow_missing case,
-    // the issuer specified in "iss" payload is required in order to lookup provider.
-    if (!provider_) {
+    // Check if `iss` is allowed.
+    if (!curr_token_->isIssuerAllowed(jwt_->iss_)) {
       doneWithStatus(Status::JwtUnknownIssuer);
       return;
     }
@@ -166,8 +159,15 @@ void AuthenticatorImpl::startVerify() {
   // Check the issuer is configured or not.
   jwks_data_ = provider_ ? jwks_cache_.findByProvider(provider_.value())
                          : jwks_cache_.findByIssuer(jwt_->iss_);
-  // isIssuerSpecified() check already make sure the issuer is in the cache.
-  ASSERT(jwks_data_ != nullptr);
+  // When `provider` is valid, findByProvider should never return nullptr.
+  // Only when `allow_missing` or `allow_missing_or_fail` is used, `provider` may be invalid.
+  // In this case, `iss` from the Jwt token is used to find the first provider with the issuer.
+  // If not found, use the first provider without issuer specified.
+  // If still no found, fail the request with UnknownIssuer error.
+  if (!jwks_data_) {
+    doneWithStatus(Status::JwtUnknownIssuer);
+    return;
+  }
 
   // Default is 60 seconds
   uint64_t clock_skew_seconds = ::google::jwt_verify::kClockSkewInSecond;

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -161,6 +161,7 @@ void AuthenticatorImpl::startVerify() {
                          : jwks_cache_.findByIssuer(jwt_->iss_);
   // When `provider` is valid, findByProvider should never return nullptr.
   // Only when `allow_missing` or `allow_failed` is used, `provider` is invalid,
+  // and this authenticator is checking tokens from all providers. In this case,
   // Jwt `iss` field is used to find the first provider with the issuer.
   // If not found, use the first provider without issuer specified.
   // If still no found, fail the request with UnknownIssuer error.

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -49,7 +49,7 @@ private:
   // If true, all issuers are ok
   bool allow_all_{false};
   // Only these specified issuers are allowed.
-  absl::node_hash_set<std::string> specified_issuers_;
+  absl::flat_hash_set<std::string> specified_issuers_;
 };
 
 /**

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -23,6 +23,36 @@ namespace JwtAuthn {
 namespace {
 
 /**
+ * Check Issuer specified in Provider
+ */
+class JwtIssuerChecker {
+public:
+  // add a specified issuer from JwtProvider.
+  void add(const std::string& issuer) {
+    // If a specified issuer is empty, it means to allow all issuers.
+    if (issuer.empty()) {
+      allow_all_ = true;
+    } else {
+      specified_issuers_.insert(issuer);
+    }
+  }
+
+  // check if a jwt issuer is allowed
+  bool check(const std::string& jwt_issuer) const {
+    if (allow_all_) {
+      return true;
+    }
+    return specified_issuers_.find(jwt_issuer) != specified_issuers_.end();
+  }
+
+private:
+  // If true, all issuers are ok
+  bool allow_all_{false};
+  // Only these specified issuers are allowed.
+  absl::node_hash_set<std::string> specified_issuers_;
+};
+
+/**
  * Constant values
  */
 struct JwtConstValueStruct {
@@ -37,30 +67,30 @@ using JwtConstValues = ConstSingleton<JwtConstValueStruct>;
 // A base JwtLocation object to store token and specified_issuers.
 class JwtLocationBase : public JwtLocation {
 public:
-  JwtLocationBase(const std::string& token, const absl::node_hash_set<std::string>& issuers)
-      : token_(token), specified_issuers_(issuers) {}
+  JwtLocationBase(const std::string& token, const JwtIssuerChecker& issuer_checker)
+      : token_(token), issuer_checker_(issuer_checker) {}
 
   // Get the token string
   const std::string& token() const override { return token_; }
 
   // Check if an issuer has specified the location.
-  bool isIssuerSpecified(const std::string& issuer) const override {
-    return specified_issuers_.find(issuer) != specified_issuers_.end();
+  bool isIssuerAllowed(const std::string& jwt_issuer) const override {
+    return issuer_checker_.check(jwt_issuer);
   }
 
 private:
   // Extracted token.
   const std::string token_;
-  // Stored issuers specified the location.
-  const absl::node_hash_set<std::string>& specified_issuers_;
+  // Issuer checker
+  const JwtIssuerChecker& issuer_checker_;
 };
 
 // The JwtLocation for header extraction.
 class JwtHeaderLocation : public JwtLocationBase {
 public:
-  JwtHeaderLocation(const std::string& token, const absl::node_hash_set<std::string>& issuers,
+  JwtHeaderLocation(const std::string& token, const JwtIssuerChecker& issuer_checker,
                     const LowerCaseString& header)
-      : JwtLocationBase(token, issuers), header_(header) {}
+      : JwtLocationBase(token, issuer_checker), header_(header) {}
 
   void removeJwt(Http::HeaderMap& headers) const override { headers.remove(header_); }
 
@@ -72,9 +102,9 @@ private:
 // The JwtLocation for param extraction.
 class JwtParamLocation : public JwtLocationBase {
 public:
-  JwtParamLocation(const std::string& token, const absl::node_hash_set<std::string>& issuers,
+  JwtParamLocation(const std::string& token, const JwtIssuerChecker& issuer_checker,
                    const std::string&)
-      : JwtLocationBase(token, issuers) {}
+      : JwtLocationBase(token, issuer_checker) {}
 
   void removeJwt(Http::HeaderMap&) const override {
     // TODO(qiwzhang): remove JWT from parameter.
@@ -120,7 +150,7 @@ private:
     // The value prefix. e.g. for "Bearer <token>", the value_prefix is "Bearer ".
     std::string value_prefix_;
     // Issuers that specified this header.
-    absl::node_hash_set<std::string> specified_issuers_;
+    JwtIssuerChecker issuer_checker_;
   };
   using HeaderLocationSpecPtr = std::unique_ptr<HeaderLocationSpec>;
   // The map of (header + value_prefix) to HeaderLocationSpecPtr
@@ -129,7 +159,7 @@ private:
   // ParamMap value type to store issuers that specified this header.
   struct ParamLocationSpec {
     // Issuers that specified this param.
-    absl::node_hash_set<std::string> specified_issuers_;
+    JwtIssuerChecker issuer_checker_;
   };
   // The map of a parameter key to set of issuers specified the parameter
   std::map<std::string, ParamLocationSpec> param_locations_;
@@ -172,12 +202,12 @@ void ExtractorImpl::addHeaderConfig(const std::string& issuer, const LowerCaseSt
   if (!header_location_spec) {
     header_location_spec = std::make_unique<HeaderLocationSpec>(header_name, value_prefix);
   }
-  header_location_spec->specified_issuers_.insert(issuer);
+  header_location_spec->issuer_checker_.add(issuer);
 }
 
 void ExtractorImpl::addQueryParamConfig(const std::string& issuer, const std::string& param) {
   auto& param_location_spec = param_locations_[param];
-  param_location_spec.specified_issuers_.insert(issuer);
+  param_location_spec.issuer_checker_.add(issuer);
 }
 
 std::vector<JwtLocationConstPtr>
@@ -201,7 +231,7 @@ ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
         value_str = extractJWT(value_str, pos + location_spec->value_prefix_.length());
       }
       tokens.push_back(std::make_unique<const JwtHeaderLocation>(
-          std::string(value_str), location_spec->specified_issuers_, location_spec->header_));
+          std::string(value_str), location_spec->issuer_checker_, location_spec->header_));
     }
   }
 
@@ -218,7 +248,7 @@ ExtractorImpl::extract(const Http::RequestHeaderMap& headers) const {
     const auto& it = params.find(param_key);
     if (it != params.end()) {
       tokens.push_back(std::make_unique<const JwtParamLocation>(
-          it->second, location_spec.specified_issuers_, param_key));
+          it->second, location_spec.issuer_checker_, param_key));
     }
   }
   return tokens;

--- a/source/extensions/filters/http/jwt_authn/extractor.h
+++ b/source/extensions/filters/http/jwt_authn/extractor.h
@@ -29,7 +29,7 @@ public:
   virtual const std::string& token() const PURE;
 
   // Check if an issuer has specified the location.
-  virtual bool isIssuerSpecified(const std::string& issuer) const PURE;
+  virtual bool isIssuerAllowed(const std::string& issuer) const PURE;
 
   // Remove the token from the headers
   virtual void removeJwt(Http::HeaderMap& headers) const PURE;

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -30,9 +30,9 @@ void validateJwtConfig(const JwtAuthentication& proto_config, Api::Api& api) {
     if (!inline_jwks.empty()) {
       auto jwks_obj = Jwks::createFrom(inline_jwks, Jwks::JWKS);
       if (jwks_obj->getStatus() != Status::Ok) {
-        throw EnvoyException(fmt::format(
-            "Issuer '{}' in jwt_authn config has invalid local jwks: {}", provider.issuer(),
-            ::google::jwt_verify::getStatusString(jwks_obj->getStatus())));
+        throw EnvoyException(
+            fmt::format("Provider '{}' in jwt_authn config has invalid local jwks: {}", it.first,
+                        ::google::jwt_verify::getStatusString(jwks_obj->getStatus())));
       }
     }
   }

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -121,7 +121,7 @@ public:
     if (it != jwks_data_map_.end()) {
       return &it->second;
     }
-    // Verififer::innerCreate() makes sure that all provider names are defined.
+    // Verifier::innerCreate function makes sure that all provider names are defined.
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
 

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.h
@@ -63,6 +63,7 @@ public:
   // Lookup issuer cache map. The cache only stores Jwks specified in the config.
   virtual JwksData* findByIssuer(const std::string& issuer) PURE;
 
+  // Lookup provider cache map.
   virtual JwksData* findByProvider(const std::string& provider) PURE;
 
   // Factory function to create an instance.

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -206,6 +206,7 @@ TEST_F(AuthenticatorTest, TestWrongIssuerOKWithProvider) {
 
 // Jwt "iss" is "other.com", "issuer" in JwtProvider is not specified,
 // authenticator doesn't have a valid provider. The verification is OK.
+// When "allow_missing" or "allow_failed" is used, authenticator doesn't have a valid provider.
 TEST_F(AuthenticatorTest, TestWrongIssuerOKWithoutProvider) {
   auto& provider = (*proto_config_.mutable_providers())[std::string(ProviderName)];
   provider.clear_issuer();
@@ -246,6 +247,7 @@ TEST_F(AuthenticatorTest, TestJwtWithoutIssWithValidProvider) {
 // authenticator doesn't have a valid provider.
 // It needs to find the first JwtProvider without "issuer" specified.
 // The verification fails with JwtUnknownIssuer.
+// When "allow_missing" or "allow_failed" is used, authenticator doesn't have a valid provider.
 TEST_F(AuthenticatorTest, TestJwtWithoutIssWithoutValidProvider) {
   createAuthenticator(nullptr, absl::nullopt);
   EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
@@ -279,6 +281,7 @@ TEST_F(AuthenticatorTest, TestJwtWithoutIssWithValidProviderNotIssuer) {
 
 // Not "iss" in Jwt, "issuer" in JwtProvider is not specified,
 // authenticator doesn't have a valid provider. The verification is OK
+// When "allow_missing" or "allow_failed" is used, authenticator doesn't have a valid provider.
 TEST_F(AuthenticatorTest, TestJwtWithoutIssWithoutValidProviderNotIssuer) {
   auto& provider = (*proto_config_.mutable_providers())[std::string(ProviderName)];
   provider.clear_issuer();

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -244,6 +244,7 @@ TEST_F(AuthenticatorTest, TestJwtWithoutIssWithValidProvider) {
 
 // Not "iss" in Jwt, "issuer" in JwtProvider is specified,
 // authenticator doesn't have a valid provider.
+// It needs to find the first JwtProvider without "issuer" specified.
 // The verification fails with JwtUnknownIssuer.
 TEST_F(AuthenticatorTest, TestJwtWithoutIssWithoutValidProvider) {
   createAuthenticator(nullptr, absl::nullopt);

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -174,8 +174,60 @@ TEST_F(AuthenticatorTest, TestJwtWithNonExistKid) {
   expectVerifyStatus(Status::JwtVerificationFail, headers);
 }
 
-// This test verifies the Jwt without "iss" work
-TEST_F(AuthenticatorTest, TestJwtWithoutIss) {
+// Jwt "iss" is "other.com", it doesn't match "issuer" specified in JwtProvider.
+// The verification fails with JwtUnknownIssuer.
+TEST_F(AuthenticatorTest, TestWrongIssuer) {
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
+  // Token with other issuer should fail.
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(OtherGoodToken)}};
+  expectVerifyStatus(Status::JwtUnknownIssuer, headers);
+}
+
+// Jwt "iss" is "other.com", "issuer" in JwtProvider is not specified,
+// authenticator has a valid provider. The verification is OK.
+TEST_F(AuthenticatorTest, TestWrongIssuerOKWithProvider) {
+  auto& provider = (*proto_config_.mutable_providers())[std::string(ProviderName)];
+  provider.clear_issuer();
+  provider.clear_audiences();
+  createAuthenticator();
+
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
+      .WillOnce(Invoke([this](const envoy::config::core::v3::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
+
+  // Token with other issuer is OK since "issuer" is not specified in the provider.
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(OtherGoodToken)}};
+  expectVerifyStatus(Status::Ok, headers);
+}
+
+// Jwt "iss" is "other.com", "issuer" in JwtProvider is not specified,
+// authenticator doesn't have a valid provider. The verification is OK.
+TEST_F(AuthenticatorTest, TestWrongIssuerOKWithoutProvider) {
+  auto& provider = (*proto_config_.mutable_providers())[std::string(ProviderName)];
+  provider.clear_issuer();
+  provider.clear_audiences();
+  // use authenticator without a valid provider
+  createAuthenticator(nullptr, absl::nullopt);
+
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
+      .WillOnce(Invoke([this](const envoy::config::core::v3::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
+
+  // Token with other issuer is OK since issuer is not specified in the provider.
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(OtherGoodToken)}};
+  expectVerifyStatus(Status::Ok, headers);
+}
+
+// Not "iss" in Jwt, "issuer" in JwtProvider is specified,
+// authenticator has a valid provider. The verification is OK.
+TEST_F(AuthenticatorTest, TestJwtWithoutIssWithValidProvider) {
   jwks_ = Jwks::createFrom(ES256PublicKey, Jwks::JWKS);
   EXPECT_TRUE(jwks_->getStatus() == Status::Ok);
 
@@ -185,10 +237,63 @@ TEST_F(AuthenticatorTest, TestJwtWithoutIss) {
         receiver.onJwksSuccess(std::move(jwks_));
       }));
 
-  // Test OK pubkey and its cache
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(ES256WithoutIssToken)}};
+  expectVerifyStatus(Status::Ok, headers);
+}
+
+// Not "iss" in Jwt, "issuer" in JwtProvider is specified,
+// authenticator doesn't have a valid provider.
+// The verification fails with JwtUnknownIssuer.
+TEST_F(AuthenticatorTest, TestJwtWithoutIssWithoutValidProvider) {
+  createAuthenticator(nullptr, absl::nullopt);
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _)).Times(0);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(ES256WithoutIssToken)}};
+  expectVerifyStatus(Status::JwtUnknownIssuer, headers);
+}
+
+// Not "iss" in Jwt, "issuer" in JwtProvider is not specified,
+// authenticator has a valid provider. The verification is OK
+TEST_F(AuthenticatorTest, TestJwtWithoutIssWithValidProviderNotIssuer) {
+  auto& provider = (*proto_config_.mutable_providers())[std::string(ProviderName)];
+  provider.clear_issuer();
+  createAuthenticator();
+
+  jwks_ = Jwks::createFrom(ES256PublicKey, Jwks::JWKS);
+  EXPECT_TRUE(jwks_->getStatus() == Status::Ok);
+
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
+      .WillOnce(Invoke([this](const envoy::config::core::v3::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
+
   Http::TestRequestHeaderMapImpl headers{
       {"Authorization", "Bearer " + std::string(ES256WithoutIssToken)}};
 
+  expectVerifyStatus(Status::Ok, headers);
+}
+
+// Not "iss" in Jwt, "issuer" in JwtProvider is not specified,
+// authenticator doesn't have a valid provider. The verification is OK
+TEST_F(AuthenticatorTest, TestJwtWithoutIssWithoutValidProviderNotIssuer) {
+  auto& provider = (*proto_config_.mutable_providers())[std::string(ProviderName)];
+  provider.clear_issuer();
+  createAuthenticator(nullptr, absl::nullopt);
+
+  jwks_ = Jwks::createFrom(ES256PublicKey, Jwks::JWKS);
+  EXPECT_TRUE(jwks_->getStatus() == Status::Ok);
+
+  EXPECT_CALL(*raw_fetcher_, fetch(_, _, _))
+      .WillOnce(Invoke([this](const envoy::config::core::v3::HttpUri&, Tracing::Span&,
+                              JwksFetcher::JwksReceiver& receiver) {
+        receiver.onJwksSuccess(std::move(jwks_));
+      }));
+
+  Http::TestRequestHeaderMapImpl headers{
+      {"Authorization", "Bearer " + std::string(ES256WithoutIssToken)}};
   expectVerifyStatus(Status::Ok, headers);
 }
 

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -59,8 +59,10 @@ providers:
 
 class ExtractorTest : public testing::Test {
 public:
-  void SetUp() override {
-    TestUtility::loadFromYaml(ExampleConfig, config_);
+  void SetUp() override { setUp(ExampleConfig); }
+
+  void setUp(const std::string& config_str) {
+    TestUtility::loadFromYaml(config_str, config_);
     JwtProviderList providers;
     for (const auto& it : config_.providers()) {
       providers.emplace_back(&it.second);
@@ -101,14 +103,14 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocation) {
 
   // Only the issue1 is using default header location.
   EXPECT_EQ(tokens[0]->token(), "jwt_token");
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer1"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
 
   // Other issuers are using custom locations
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer2"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer3"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer4"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer5"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("unknown_issuer"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer2"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer3"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer4"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer5"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("unknown_issuer"));
 
   // Test token remove
   tokens[0]->removeJwt(headers);
@@ -125,7 +127,7 @@ TEST_F(ExtractorTest, TestDefaultHeaderLocationWithValidJWT) {
 
   // Only the issue1 is using default header location.
   EXPECT_EQ(tokens[0]->token(), GoodToken);
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer1"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
 }
 
 // Test extracting token from the default query parameter: "access_token"
@@ -136,14 +138,14 @@ TEST_F(ExtractorTest, TestDefaultParamLocation) {
 
   // Only the issue1 is using default header location.
   EXPECT_EQ(tokens[0]->token(), "jwt_token");
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer1"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer1"));
 
   // Other issuers are using custom locations
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer2"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer3"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer4"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer5"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("unknown_issuer"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer2"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer3"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer4"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer5"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("unknown_issuer"));
 
   tokens[0]->removeJwt(headers);
 }
@@ -156,14 +158,14 @@ TEST_F(ExtractorTest, TestCustomHeaderToken) {
 
   // Only issuer2 and issuer4 are using "token-header" location
   EXPECT_EQ(tokens[0]->token(), "jwt_token");
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer2"));
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer4"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer2"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer4"));
 
   // Other issuers are not allowed from "token-header"
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer1"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer3"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer5"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("unknown_issuer"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer1"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer3"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer5"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("unknown_issuer"));
 
   // Test token remove
   tokens[0]->removeJwt(headers);
@@ -194,11 +196,11 @@ TEST_F(ExtractorTest, TestPrefixHeaderMatch) {
   EXPECT_EQ(tokens.size(), 2);
 
   // Match issuer 5 with map key as: prefix-header + AAA
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer5"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer5"));
   EXPECT_EQ(tokens[0]->token(), "BBBjwt_token");
 
   // Match issuer 6 with map key as: prefix-header + AAABBB which is after AAA
-  EXPECT_TRUE(tokens[1]->isIssuerSpecified("issuer6"));
+  EXPECT_TRUE(tokens[1]->isIssuerAllowed("issuer6"));
   EXPECT_EQ(tokens[1]->token(), "jwt_token");
 
   // Test token remove
@@ -215,7 +217,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch1) {
   EXPECT_EQ(tokens.size(), 1);
 
   // Match issuer 7 with map key as: prefix-header + 'CCCDDD'
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer7"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer7"));
   EXPECT_EQ(tokens[0]->token(), "jwt_token");
 }
 
@@ -226,7 +228,7 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch2) {
   EXPECT_EQ(tokens.size(), 1);
 
   // Match issuer 7 with map key as: prefix-header + AAA
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer7"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer7"));
   EXPECT_EQ(tokens[0]->token(), "and0X3Rva2Vu");
 }
 
@@ -237,11 +239,11 @@ TEST_F(ExtractorTest, TestPrefixHeaderFlexibleMatch3) {
   EXPECT_EQ(tokens.size(), 2);
 
   // Match issuer 8 with map key as: prefix-header + '"CCCDDD"'
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer8"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer8"));
   EXPECT_EQ(tokens[0]->token(), "and0X3Rva2Vu");
 
   // Match issuer 7 with map key as: prefix-header + 'CCCDDD'
-  EXPECT_TRUE(tokens[1]->isIssuerSpecified("issuer7"));
+  EXPECT_TRUE(tokens[1]->isIssuerAllowed("issuer7"));
   EXPECT_EQ(tokens[1]->token(), "and0X3Rva2Vu");
 }
 
@@ -253,13 +255,13 @@ TEST_F(ExtractorTest, TestCustomParamToken) {
 
   // Both issuer3 and issuer4 have specified this custom query location.
   EXPECT_EQ(tokens[0]->token(), "jwt_token");
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer3"));
-  EXPECT_TRUE(tokens[0]->isIssuerSpecified("issuer4"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer3"));
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer4"));
 
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer1"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer2"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("issuer5"));
-  EXPECT_FALSE(tokens[0]->isIssuerSpecified("unknown_issuer"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer1"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer2"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("issuer5"));
+  EXPECT_FALSE(tokens[0]->isIssuerAllowed("unknown_issuer"));
 
   tokens[0]->removeJwt(headers);
 }
@@ -306,6 +308,37 @@ TEST_F(ExtractorTest, TestExtractParam) {
   EXPECT_EQ(tokens.size(), 2);
   EXPECT_EQ(tokens[0]->token(), "token5");
   EXPECT_EQ(tokens[1]->token(), "token3");
+}
+
+TEST_F(ExtractorTest, TestIssuerNotSpecified) {
+  setUp(R"(
+providers:
+  provider1:
+    from_headers:
+      - name: jwt1
+  provider2:
+    issuer: issuer2
+    from_headers:
+      - name: jwt2
+)");
+
+  auto headers = TestRequestHeaderMapImpl{
+      {":path", "/path"},
+      {"jwt1", "token1"},
+      {"jwt2", "token2"},
+  };
+  auto tokens = extractor_->extract(headers);
+  EXPECT_EQ(tokens.size(), 2);
+
+  EXPECT_EQ(tokens[0]->token(), "token1");
+  EXPECT_EQ(tokens[1]->token(), "token2");
+
+  // Token1 allows any issuers since its provider did not specify "issuer"
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("abc"));
+
+  // Token2 only allows "issuer2"
+  EXPECT_TRUE(tokens[1]->isIssuerAllowed("issuer2"));
+  EXPECT_FALSE(tokens[1]->isIssuerAllowed("abc"));
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/extractor_test.cc
+++ b/test/extensions/filters/http/jwt_authn/extractor_test.cc
@@ -334,6 +334,7 @@ providers:
   EXPECT_EQ(tokens[1]->token(), "token2");
 
   // Token1 allows any issuers since its provider did not specify "issuer"
+  EXPECT_TRUE(tokens[0]->isIssuerAllowed("issuer2"));
   EXPECT_TRUE(tokens[0]->isIssuerAllowed("abc"));
 
   // Token2 only allows "issuer2"

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -62,6 +62,7 @@ TEST(HttpJwtAuthnFilterFactoryTest, BadLocalJwks) {
 TEST(HttpJwtAuthnFilterFactoryTest, ProviderWithoutIssuer) {
   JwtAuthentication proto_config;
   auto& provider = (*proto_config.mutable_providers())["provider"];
+  // This provider did not specify "issuer".
   provider.mutable_local_jwks()->set_inline_string(PublicKey);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;

--- a/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_factory_test.cc
@@ -59,6 +59,19 @@ TEST(HttpJwtAuthnFilterFactoryTest, BadLocalJwks) {
                EnvoyException);
 }
 
+TEST(HttpJwtAuthnFilterFactoryTest, ProviderWithoutIssuer) {
+  JwtAuthentication proto_config;
+  auto& provider = (*proto_config.mutable_providers())["provider"];
+  provider.mutable_local_jwks()->set_inline_string(PublicKey);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  FilterFactory factory;
+  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
 TEST(HttpJwtAuthnFilterFactoryTest, EmptyPerRouteConfig) {
   PerRouteConfig per_route;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix https://github.com/envoyproxy/envoy/issues/12377

According to [rfc](https://tools.ietf.org/html/rfc7519#section-4.1.1), "iss" field should be optional.  But "issuer" in JwtProvider filter_config is marked as required.  

This PR changes it to be optional.  Its usage implications are following:
* If a Jwt has "iss" field and the "issuer" field in JwtProvider config is specified, they have to match. In all other cases,  the JWT "iss" field is not checked.
* If allow_missing or allow_missing_or_fail is used,  the Jwt "iss" field is used to find JwtProvider to verify the signature. If the Jwt doesn't have "iss" field, the first JwtProvider without "issuer" is used.


Commit Message:
Additional Description:
Risk Level: None as new features are added to allow empty issuer in the JwtProvider
Testing: Added unit-tests
Docs Changes: None
Release Notes: Yes
