### PR TITLE
[test_common/BUILD] Start dissolving :printers_include rule.

### DIFF
--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -15,6 +15,7 @@ envoy_basic_cc_library(
     name = "printers_includes",
     hdrs = ["printers.h"],
     deps = [
+        ":printers_lib",
         "//include/envoy/network:address_interface",
     ],
 )
@@ -86,9 +87,12 @@ envoy_cc_test_library(
 
 envoy_cc_library(
     name = "printers_lib",
-    srcs = ["printers.cc"],
+    srcs = [
+        "printers.cc",
+        "printers.h",
+    ],
     deps = [
-        ":printers_includes",
+        "//include/envoy/network:address_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",
     ],


### PR DESCRIPTION
Commit Message:
[test_common/BUILD] Start dissolving :printers_include rule.

Additional Description:
A rule that exports a header without defining all the symbols declared
by that header causes ODR violations. Basically, Bazel rules should
never contain "include" rules like this. Rather, printer.h and
printer.cc should be served from the same library.

This change is a cautious, local first step. A second step can later
remove the printer_include rule and replace its uses with printer_lib.

Risk Level: low(?)

Testing:

Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
