### PR TITLE
Remove printers_include with printers_lib

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -209,10 +209,6 @@ def envoy_cc_test_library(
         copts = [],
         alwayslink = 1,
         **kargs):
-    deps = deps + [
-        repository + "//test/test_common:printers_includes",
-    ]
-
     _envoy_cc_test_infrastructure_library(
         name,
         srcs,

--- a/test/config/BUILD
+++ b/test/config/BUILD
@@ -25,6 +25,7 @@ envoy_cc_test_library(
         "//test/integration:server_stats_interface",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
+        "//test/test_common:printers_lib",
         "//test/test_common:resources_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/extensions/filters/network/common/redis/BUILD
+++ b/test/extensions/filters/network/common/redis/BUILD
@@ -18,6 +18,7 @@ envoy_cc_mock(
         "//source/common/common:assert_lib",
         "//source/extensions/filters/network/common/redis:client_lib",
         "//source/extensions/filters/network/common/redis:codec_lib",
+        "//test/test_common:printers_lib",
     ],
 )
 

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -99,6 +99,7 @@ envoy_cc_mock(
         "//source/extensions/filters/network/redis_proxy:command_splitter_interface",
         "//source/extensions/filters/network/redis_proxy:conn_pool_interface",
         "//source/extensions/filters/network/redis_proxy:router_interface",
+        "//test/test_common:printers_lib",
     ],
 )
 

--- a/test/mocks/buffer/BUILD
+++ b/test/mocks/buffer/BUILD
@@ -15,6 +15,7 @@ envoy_cc_mock(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/buffer:watermark_buffer_lib",
+        "//test/test_common:printers_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -11,15 +11,6 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_basic_cc_library(
-    name = "printers_includes",
-    hdrs = ["printers.h"],
-    deps = [
-        ":printers_lib",
-        "//include/envoy/network:address_interface",
-    ],
-)
-
 envoy_cc_test_library(
     name = "environment_lib",
     srcs = ["environment.cc"],
@@ -87,10 +78,8 @@ envoy_cc_test_library(
 
 envoy_cc_library(
     name = "printers_lib",
-    srcs = [
-        "printers.cc",
-        "printers.h",
-    ],
+    srcs = ["printers.cc"],
+    hdrs = ["printers.h"],
     deps = [
         "//include/envoy/network:address_interface",
         "//source/common/buffer:buffer_lib",
@@ -121,6 +110,7 @@ envoy_cc_test_library(
     ],
     deps = [
         ":file_system_for_test_lib",
+        ":printers_lib",
         ":resources_lib",
         ":test_time_lib",
         ":thread_factory_for_test_lib",


### PR DESCRIPTION
Commit Message: Remove the "printers_include" library in favour of "printers_lib".

Additional Description: The partial, header-only library :printers_include provided no service that wasn't already subsumed by :printers_lib.

Risk Level: low

Testing: in progress

Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
