### PR TITLE
event: Extract DispatcherBase interface

### DIFF
--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -52,12 +52,67 @@ using PostCb = std::function<void()>;
 using PostCbSharedPtr = std::shared_ptr<PostCb>;
 
 /**
+ * Minimal interface to the disptching loop used to create low-level primitives. See Dispatcher below for the
+ * full interface.
+ */
+class DispatcherBase {
+ public:
+  virtual ~DispatcherBase() = default;
+
+  /**
+   * Creates a file event that will signal when a file is readable or writable. On UNIX systems this
+   * can be used for any file like interface (files, sockets, etc.).
+   * @param fd supplies the fd to watch.
+   * @param cb supplies the callback to fire when the file is ready.
+   * @param trigger specifies whether to edge or level trigger.
+   * @param events supplies a logical OR of FileReadyType events that the file event should
+   *               initially listen on.
+   */
+  virtual FileEventPtr createFileEvent(os_fd_t fd, FileReadyCb cb, FileTriggerType trigger,
+                                       uint32_t events) PURE;
+
+  /**
+   * Allocates a timer. @see Timer for docs on how to use the timer.
+   * @param cb supplies the callback to invoke when the timer fires.
+   */
+  virtual Event::TimerPtr createTimer(TimerCb cb) PURE;
+
+  /**
+   * Allocates a schedulable callback. @see SchedulableCallback for docs on how to use the wrapped
+   * callback.
+   * @param cb supplies the callback to invoke when the SchedulableCallback is triggered on the
+   * event loop.
+   */
+  virtual Event::SchedulableCallbackPtr createSchedulableCallback(std::function<void()> cb) PURE;
+
+  /**
+   * Sets a tracked object, which is currently operating in this Dispatcher.
+   * This should be cleared with another call to setTrackedObject() when the object is done doing
+   * work. Calling setTrackedObject(nullptr) results in no object being tracked.
+   *
+   * This is optimized for performance, to avoid allocation where we do scoped object tracking.
+   *
+   * @return The previously tracked object or nullptr if there was none.
+   */
+  virtual const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) PURE;
+
+  /**
+   * Validates that an operation is thread-safe with respect to this dispatcher; i.e. that the
+   * current thread of execution is on the same thread upon which the dispatcher loop is running.
+   */
+  virtual bool isThreadSafe() const PURE;
+
+  /**
+   * Returns a recently cached MonotonicTime value.
+   */
+  virtual MonotonicTime approximateMonotonicTime() const PURE;
+};
+
+/**
  * Abstract event dispatching loop.
  */
-class Dispatcher {
+class Dispatcher : public DispatcherBase {
 public:
-  virtual ~Dispatcher() = default;
-
   /**
    * Returns the name that identifies this dispatcher, such as "worker_2" or "main_thread".
    * @return const std::string& the name that identifies this dispatcher.
@@ -137,18 +192,6 @@ public:
                     bool use_tcp_for_dns_lookups) PURE;
 
   /**
-   * Creates a file event that will signal when a file is readable or writable. On UNIX systems this
-   * can be used for any file like interface (files, sockets, etc.).
-   * @param fd supplies the fd to watch.
-   * @param cb supplies the callback to fire when the file is ready.
-   * @param trigger specifies whether to edge or level trigger.
-   * @param events supplies a logical OR of FileReadyType events that the file event should
-   *               initially listen on.
-   */
-  virtual FileEventPtr createFileEvent(os_fd_t fd, FileReadyCb cb, FileTriggerType trigger,
-                                       uint32_t events) PURE;
-
-  /**
    * @return Filesystem::WatcherPtr a filesystem watcher owned by the caller.
    */
   virtual Filesystem::WatcherPtr createFilesystemWatcher() PURE;
@@ -173,20 +216,6 @@ public:
    */
   virtual Network::UdpListenerPtr createUdpListener(Network::SocketSharedPtr socket,
                                                     Network::UdpListenerCallbacks& cb) PURE;
-  /**
-   * Allocates a timer. @see Timer for docs on how to use the timer.
-   * @param cb supplies the callback to invoke when the timer fires.
-   */
-  virtual Event::TimerPtr createTimer(TimerCb cb) PURE;
-
-  /**
-   * Allocates a schedulable callback. @see SchedulableCallback for docs on how to use the wrapped
-   * callback.
-   * @param cb supplies the callback to invoke when the SchedulableCallback is triggered on the
-   * event loop.
-   */
-  virtual Event::SchedulableCallbackPtr createSchedulableCallback(std::function<void()> cb) PURE;
-
   /**
    * Submits an item for deferred delete. @see DeferredDeletable.
    */
@@ -235,28 +264,6 @@ public:
    * @return the watermark buffer factory for this dispatcher.
    */
   virtual Buffer::WatermarkFactory& getWatermarkFactory() PURE;
-
-  /**
-   * Sets a tracked object, which is currently operating in this Dispatcher.
-   * This should be cleared with another call to setTrackedObject() when the object is done doing
-   * work. Calling setTrackedObject(nullptr) results in no object being tracked.
-   *
-   * This is optimized for performance, to avoid allocation where we do scoped object tracking.
-   *
-   * @return The previously tracked object or nullptr if there was none.
-   */
-  virtual const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) PURE;
-
-  /**
-   * Validates that an operation is thread-safe with respect to this dispatcher; i.e. that the
-   * current thread of execution is on the same thread upon which the dispatcher loop is running.
-   */
-  virtual bool isThreadSafe() const PURE;
-
-  /**
-   * Returns a recently cached MonotonicTime value.
-   */
-  virtual MonotonicTime approximateMonotonicTime() const PURE;
 
   /**
    * Updates approximate monotonic time to current value.

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -52,11 +52,11 @@ using PostCb = std::function<void()>;
 using PostCbSharedPtr = std::shared_ptr<PostCb>;
 
 /**
- * Minimal interface to the disptching loop used to create low-level primitives. See Dispatcher below for the
- * full interface.
+ * Minimal interface to the disptching loop used to create low-level primitives. See Dispatcher
+ * below for the full interface.
  */
 class DispatcherBase {
- public:
+public:
   virtual ~DispatcherBase() = default;
 
   /**

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -52,7 +52,7 @@ using PostCb = std::function<void()>;
 using PostCbSharedPtr = std::shared_ptr<PostCb>;
 
 /**
- * Minimal interface to the disptching loop used to create low-level primitives. See Dispatcher
+ * Minimal interface to the dispatching loop used to create low-level primitives. See Dispatcher
  * below for the full interface.
  */
 class DispatcherBase {


### PR DESCRIPTION
Commit Message:
event: Extract DispatcherBase interface

This new interface allows us to more safely build primitives like ScaledTimers which are themselves built on top of low-level 
event loop primitives like Timers which are themselves created via the dispatcher interface.
Additional Description:
Risk Level: n/a interface only change
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Issue #14401