### PR TITLE
[Windows] Improve fileReadToEnd on Windows

### DIFF
--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -124,6 +124,10 @@ std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {
   if (illegalPath(path)) {
     throw EnvoyException(absl::StrCat("Invalid path: ", path));
   }
+
+  // In integration tests (and potentially in production) we rename config files and this creates
+  // sharing violation errors while reading the file from a different thread. This is why we need to
+  // add `FILE_SHARE_DELETE` to the sharing mode.
   auto fd = CreateFileA(path.c_str(), GENERIC_READ,
                         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, 0, OPEN_EXISTING, 0,
                         NULL);

--- a/source/common/filesystem/win32/filesystem_impl.cc
+++ b/source/common/filesystem/win32/filesystem_impl.cc
@@ -142,15 +142,16 @@ std::string InstanceImplWin32::fileReadToEnd(const std::string& path) {
     if (!ReadFile(fd, buffer.data(), buffer_size, &bytes_read, NULL)) {
       auto last_error = ::GetLastError();
       if (last_error == ERROR_FILE_NOT_FOUND) {
+        CloseHandle(fd);
         throw EnvoyException(absl::StrCat("Invalid path: ", path));
       }
+      CloseHandle(fd);
       throw EnvoyException(absl::StrCat("unable to read file: ", path));
     }
     complete_buffer.insert(complete_buffer.end(), buffer.begin(), buffer.begin() + bytes_read);
   } while (bytes_read == buffer_size);
-  auto st = std::string(complete_buffer.begin(), complete_buffer.end());
   CloseHandle(fd);
-  return st;
+  return std::string(complete_buffer.begin(), complete_buffer.end());
 }
 
 PathSplitResult InstanceImplWin32::splitPathFromFilename(absl::string_view path) {

--- a/test/extensions/filters/http/tap/BUILD
+++ b/test/extensions/filters/http/tap/BUILD
@@ -52,9 +52,6 @@ envoy_extension_cc_test(
     name = "tap_filter_integration_test",
     srcs = ["tap_filter_integration_test.cc"],
     extension_name = "envoy.filters.http.tap",
-    # TODO(envoyproxy/windows-dev): Diagnose flake, observed to hang at;
-    # IpVersions/TapIntegrationTest.AdminLdsReload/IPv6
-    tags = ["flaky_on_windows"],
     deps = [
         "//source/extensions/filters/http/tap:config",
         "//test/extensions/common/tap:common",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1322,8 +1322,6 @@ envoy_cc_test(
         "//test/config/integration:server_xds_files",
         "//test/config/integration/certs",
     ],
-    # TODO(envoyproxy/windows-dev): Investigate flakes in #14286.
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         ":http_protocol_integration_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -976,9 +976,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "load_stats_integration_test",
     srcs = ["load_stats_integration_test.cc"],
-    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test, hangs at
-    # IpVersionsClientType/LoadStatsIntegrationTest.NoLocalLocality/3
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         "//test/config:utility_lib",

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -135,8 +135,6 @@ envoy_cc_test(
 envoy_cc_test(
     name = "eds_integration_test",
     srcs = ["eds_integration_test.cc"],
-    # TODO(envoyproxy/windows-dev): Diagnose timeout observed in opt build test
-    tags = ["flaky_on_windows"],
     deps = [
         ":http_integration_lib",
         "//source/common/upstream:load_balancer_lib",

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -158,7 +158,10 @@ void TestEnvironment::renameFile(const std::string& old_name, const std::string&
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rename-wrename?view=vs-2017
   // Note MoveFileEx cannot overwrite a directory as documented, nor a symlink, apparently.
   const BOOL rc = ::MoveFileEx(old_name.c_str(), new_name.c_str(), MOVEFILE_REPLACE_EXISTING);
-  ASSERT_NE(0, rc);
+  if (rc == 0) {
+    PANIC(fmt::format("failed to rename file from  {} to {} with error {}", old_name, new_name,
+                      ::GetLastError()));
+  }
 #else
   const int rc = ::rename(old_name.c_str(), new_name.c_str());
   ASSERT_EQ(0, rc);

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -158,10 +158,8 @@ void TestEnvironment::renameFile(const std::string& old_name, const std::string&
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rename-wrename?view=vs-2017
   // Note MoveFileEx cannot overwrite a directory as documented, nor a symlink, apparently.
   const BOOL rc = ::MoveFileEx(old_name.c_str(), new_name.c_str(), MOVEFILE_REPLACE_EXISTING);
-  if (rc == 0) {
-    PANIC(fmt::format("failed to rename file from  {} to {} with error {}", old_name, new_name,
-                      ::GetLastError()));
-  }
+  ASSERT_NE(0, rc) << fmt::format("failed to rename file from  {} to {} with error {}", old_name,
+                                  new_name, ::GetLastError());
 #else
   const int rc = ::rename(old_name.c_str(), new_name.c_str());
   ASSERT_EQ(0, rc);


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
Commit Message:

See #14413

The problem is demonstrated in `eds_integration_test` but it is actually a production code issue for Windows. The scenario is the following:

Thread 1: `MoveFileEx` from E:\temp/eds.update.pb_text -> E:\temp/eds.pb_text
Thread 2: `ReadDirectoryChangeW` notification triggers and notifies `filesystem_subscription_impl`
Thread 3: `filesystem_subscription_impl` tries to read file `E:\temp/eds.pb_text` and fails
Thread 1: `MoveFileEx` completes

Additional Description:

The way MoveFile is implemented is by opening a handle to the source, issuing a rename command, then closing the handle. 

FILE_SHARE_DELETE is named very badly, but it indicates that the opener is willing to allow the file’s name to change while the handle is open.  It’s named very badly because this can’t happen due to delete, because delete in NT occurs on last handle close, so if you have a handle to a file, the file is going to remain there.  In practice, this flag controls two things: first, it allows the file to be renamed; second, it allows another thread to indicate that it wants to delete the file when the last handle is closed. 

I have tested the following tests before removing the flakes:

1. `tap_filter_integration_test` tested 12k times with no flakes
2. `eds_integration_test` tested 2k times
3. `load_stats_integration_test` tested 300 times

Risk Level: Low
Testing: Existing Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
