### PR TITLE
test: replace mock_methodn macros with mock_method

### DIFF
--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -1155,7 +1155,7 @@ class MockDestructSchedulableCallback : public Event::MockSchedulableCallback {
 public:
   MockDestructSchedulableCallback(Event::MockDispatcher* dispatcher)
       : Event::MockSchedulableCallback(dispatcher) {}
-  MOCK_METHOD0(Die, void());
+  MOCK_METHOD(void, Die, ());
 
   ~MockDestructSchedulableCallback() override { Die(); }
 };

--- a/test/extensions/bootstrap/wasm/wasm_speed_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_speed_test.cc
@@ -37,7 +37,7 @@ public:
     log_(static_cast<spdlog::level::level_enum>(level), message);
     return proxy_wasm::WasmResult::Ok;
   }
-  MOCK_METHOD2(log_, void(spdlog::level::level_enum level, absl::string_view message));
+  MOCK_METHOD(void, log_, (spdlog::level::level_enum level, absl::string_view message));
 };
 
 static void bmWasmSimpleCallSpeedTest(benchmark::State& state, std::string test,

--- a/test/extensions/bootstrap/wasm/wasm_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_test.cc
@@ -32,7 +32,7 @@ public:
     log_(static_cast<spdlog::level::level_enum>(level), message);
     return proxy_wasm::WasmResult::Ok;
   }
-  MOCK_METHOD2(log_, void(spdlog::level::level_enum level, absl::string_view message));
+  MOCK_METHOD(void, log_, (spdlog::level::level_enum level, absl::string_view message));
 };
 
 class WasmTestBase {

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -79,7 +79,7 @@ public:
     Extensions::Common::Wasm::Context::log(static_cast<spdlog::level::level_enum>(level), message);
     return proxy_wasm::WasmResult::Ok;
   }
-  MOCK_METHOD2(log_, void(spdlog::level::level_enum level, absl::string_view message));
+  MOCK_METHOD(void, log_, (spdlog::level::level_enum level, absl::string_view message));
 };
 
 class WasmCommonTest : public testing::TestWithParam<std::string> {

--- a/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
+++ b/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
@@ -28,7 +28,7 @@ public:
     Extensions::Common::Wasm::Context::log(static_cast<spdlog::level::level_enum>(level), message);
     return proxy_wasm::WasmResult::Ok;
   }
-  MOCK_METHOD2(log_, void(spdlog::level::level_enum level, absl::string_view message));
+  MOCK_METHOD(void, log_, (spdlog::level::level_enum level, absl::string_view message));
 };
 
 class WasmCommonContextTest

--- a/test/test_common/wasm_base.h
+++ b/test/test_common/wasm_base.h
@@ -37,7 +37,7 @@ namespace Wasm {
     log_(static_cast<spdlog::level::level_enum>(level), message);                                  \
     return proxy_wasm::WasmResult::Ok;                                                             \
   }                                                                                                \
-  MOCK_METHOD2(log_, void(spdlog::level::level_enum level, absl::string_view message))
+  MOCK_METHOD(void, log_, (spdlog::level::level_enum level, absl::string_view message))
 
 class DeferredRunner {
 public:

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -153,6 +153,7 @@ VERSION_HISTORY_NEW_LINE_REGEX = re.compile("\* ([a-z \-_]+): ([a-z:`]+)")
 VERSION_HISTORY_SECTION_NAME = re.compile("^[A-Z][A-Za-z ]*$")
 RELOADABLE_FLAG_REGEX = re.compile(".*(..)(envoy.reloadable_features.[^ ]*)\s.*")
 INVALID_REFLINK = re.compile(".* ref:.*")
+OLD_MOCK_METHOD_REGEX = re.compile("MOCK_METHOD\d")
 # Check for punctuation in a terminal ref clause, e.g.
 # :ref:`panic mode. <arch_overview_load_balancing_panic_threshold>`
 REF_WITH_PUNCTUATION_REGEX = re.compile(".*\. <[^<]*>`\s*")
@@ -773,6 +774,9 @@ class FormatChecker:
       # Matches variants of TEST(), TEST_P(), TEST_F() etc. where the test name begins
       # with a lowercase letter.
       reportError("Test names should be CamelCase, starting with a capital letter")
+    if OLD_MOCK_METHOD_REGEX.search(line):
+      reportError("The MOCK_METHODn() macros should not be used, use MOCK_METHOD() instead")
+
     if not self.allowlistedForSerializeAsString(file_path) and "SerializeAsString" in line:
       # The MessageLite::SerializeAsString doesn't generate deterministic serialization,
       # use MessageUtil::hash instead.

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -230,6 +230,7 @@ def runChecks():
                                 "Don't use mangled Protobuf names for enum constants")
   errors += checkUnfixableError("test_naming.cc",
                                 "Test names should be CamelCase, starting with a capital letter")
+  errors += checkUnfixableError("mock_method_n.cc", "use MOCK_METHOD() instead")
   errors += checkUnfixableError(
       "test/register_factory.cc",
       "Don't use Registry::RegisterFactory or REGISTER_FACTORY in tests, use "

--- a/tools/testdata/check_format/mock_method_n.cc
+++ b/tools/testdata/check_format/mock_method_n.cc
@@ -1,0 +1,7 @@
+namespace Envoy {
+
+struct Class {
+  MOCK_METHOD1(name, void());
+};
+
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: Replace MOCK_METHODn with MOCK_METHOD
Additional Description:
This is a continuation of #13186, but with an additional format check to prevent
additions of MOCK_METHODn invocations in the future.
Risk Level: low
Testing: built affected targets
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: none