### PR TITLE
tcp: extending tcp integration test

### DIFF
--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -21,6 +21,7 @@ const char AutonomousStream::RESPONSE_SIZE_BYTES[] = "response_size_bytes";
 const char AutonomousStream::RESPONSE_DATA_BLOCKS[] = "response_data_blocks";
 const char AutonomousStream::EXPECT_REQUEST_SIZE_BYTES[] = "expect_request_size_bytes";
 const char AutonomousStream::RESET_AFTER_REQUEST[] = "reset_after_request";
+const char AutonomousStream::CLOSE_AFTER_RESPONSE[] = "close_after_response";
 const char AutonomousStream::NO_TRAILERS[] = "no_trailers";
 const char AutonomousStream::NO_END_STREAM[] = "no_end_stream";
 
@@ -83,6 +84,11 @@ void AutonomousStream::sendResponse() {
     if (send_trailers) {
       encodeTrailers(upstream_.responseTrailers());
     }
+  }
+  if (!headers.get_(CLOSE_AFTER_RESPONSE).empty()) {
+    parent_.connection().dispatcher().post(
+        [this]() -> void { parent_.connection().close(Network::ConnectionCloseType::FlushWrite); });
+    return;
   }
 }
 

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -25,6 +25,8 @@ public:
   static const char NO_TRAILERS[];
   // Prevents upstream from finishing response.
   static const char NO_END_STREAM[];
+  // Closes the underlying connection after a given response is sent.
+  static const char CLOSE_AFTER_RESPONSE[];
 
   AutonomousStream(FakeHttpConnection& parent, Http::ResponseEncoder& encoder,
                    AutonomousUpstream& upstream, bool allow_incomplete_streams);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -222,9 +222,9 @@ protected:
   absl::Mutex lock_;
   Http::RequestHeaderMapPtr headers_ ABSL_GUARDED_BY(lock_);
   Buffer::OwnedImpl body_ ABSL_GUARDED_BY(lock_);
+  FakeHttpConnection& parent_;
 
 private:
-  FakeHttpConnection& parent_;
   Http::ResponseEncoder& encoder_;
   Http::RequestTrailerMapPtr trailers_ ABSL_GUARDED_BY(lock_);
   bool end_stream_ ABSL_GUARDED_BY(lock_){};

--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -48,7 +48,12 @@ IntegrationTcpClient::IntegrationTcpClient(
         client_write_buffer_ =
             new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
         return client_write_buffer_;
+      }))
+      .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
+                                std::function<void()> above_overflow) -> Buffer::Instance* {
+        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
+  ;
 
   connection_ = dispatcher.createClientConnection(
       Network::Utility::resolveUrl(


### PR DESCRIPTION
Adding some tests to ensure both the old and the new pool can handle many connections, and regression testing behavior as connections are added/used/removed over time.

Risk Level: n/a (test only)
Testing: yes
Docs Changes: no
Release Notes: no
