### PR TITLE
Fix starttls_integration_test flakiness on Windows

### DIFF
--- a/test/extensions/transport_sockets/starttls/BUILD
+++ b/test/extensions/transport_sockets/starttls/BUILD
@@ -40,8 +40,6 @@ envoy_extension_cc_test(
         "//test/config/integration/certs",
     ],
     extension_name = "envoy.transport_sockets.starttls",
-    # TODO(envoyproxy/windows-dev): Investigate timeout
-    tags = ["flaky_on_windows"],
     deps = [
         ":starttls_integration_proto_cc_proto",
         "//source/extensions/filters/network/tcp_proxy:config",

--- a/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
@@ -272,15 +272,13 @@ TEST_P(StartTlsIntegrationTest, SwitchToTlsFromClient) {
 
   // Send a message to switch to tls on the receiver side.
   // StartTlsSwitchFilter will switch transport socket on the
-  // receiver side upon receiving "switch" message.
+  // receiver side upon receiving "switch" message and send
+  // back the message "usetls".
+  payload_reader_->set_data_to_wait_for("usetls");
   buffer.add("switch");
   conn_->write(buffer, false);
-  while (client_write_buffer_->bytesDrained() != 11) {
-    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-  }
 
   // Wait for confirmation
-  payload_reader_->set_data_to_wait_for("usetls");
   dispatcher_->run(Event::Dispatcher::RunType::Block);
 
   // Without closing the connection, switch to tls.


### PR DESCRIPTION
Commit Message:
Fix starttls_integration_test flakiness on Windows by removing a race condition.

Additional Description:
On Windows, the starttls_integration_test can time out right before switching to TLS in the SwitchToTlsFromClient test case.  The test case sends a "switch" message to the receiver, waits for the receiver to read the message and drain the queue (who then starts up the switch to TLS), creates a signal to wait for a "usetls" message (payload_reader_->set_data_to_wait_for), then blocks until it receives back "usetls".  On Windows, the sender may block on the queue drain longer than usual, particularly until after the receiver has already sent back the "usetls" message.  This can result in the sender's payload_reader thread reading the "usetls" message before it has a chance to create the signal, ultimately leaving the sender blocking on a signal that already occurred.

This PR gets rid of the queue drain wait loop and sets the signal before sending the "switch" message, ensuring the correct order of operations.  Removing the loop has no effect in terms of verifying correctness, as the sender can't receive the "usetls" message if the receiver didn't drain the queue.

Risk Level: Low
Testing: Ran starttls_integration_test 2000 times on Windows.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A