### PR TITLE
api: relax inline_string length limitation in DataSource

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -331,7 +331,7 @@ message DataSource {
     string filename = 1 [(validate.rules).string = {min_len: 1}];
 
     // Bytes inlined in the configuration.
-    bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
+    bytes inline_bytes = 2;
 
     // String inlined in the configuration.
     string inline_string = 3;

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -334,7 +334,7 @@ message DataSource {
     bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
 
     // String inlined in the configuration.
-    string inline_string = 3 [(validate.rules).string = {min_len: 1}];
+    string inline_string = 3;
   }
 }
 

--- a/api/envoy/config/core/v4alpha/base.proto
+++ b/api/envoy/config/core/v4alpha/base.proto
@@ -329,7 +329,7 @@ message DataSource {
     string filename = 1 [(validate.rules).string = {min_len: 1}];
 
     // Bytes inlined in the configuration.
-    bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
+    bytes inline_bytes = 2;
 
     // String inlined in the configuration.
     string inline_string = 3;

--- a/api/envoy/config/core/v4alpha/base.proto
+++ b/api/envoy/config/core/v4alpha/base.proto
@@ -332,7 +332,7 @@ message DataSource {
     bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
 
     // String inlined in the configuration.
-    string inline_string = 3 [(validate.rules).string = {min_len: 1}];
+    string inline_string = 3;
   }
 }
 

--- a/generated_api_shadow/envoy/config/core/v3/base.proto
+++ b/generated_api_shadow/envoy/config/core/v3/base.proto
@@ -329,7 +329,7 @@ message DataSource {
     string filename = 1 [(validate.rules).string = {min_len: 1}];
 
     // Bytes inlined in the configuration.
-    bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
+    bytes inline_bytes = 2;
 
     // String inlined in the configuration.
     string inline_string = 3;

--- a/generated_api_shadow/envoy/config/core/v3/base.proto
+++ b/generated_api_shadow/envoy/config/core/v3/base.proto
@@ -332,7 +332,7 @@ message DataSource {
     bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
 
     // String inlined in the configuration.
-    string inline_string = 3 [(validate.rules).string = {min_len: 1}];
+    string inline_string = 3;
   }
 }
 

--- a/generated_api_shadow/envoy/config/core/v4alpha/base.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/base.proto
@@ -339,7 +339,7 @@ message DataSource {
     bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
 
     // String inlined in the configuration.
-    string inline_string = 3 [(validate.rules).string = {min_len: 1}];
+    string inline_string = 3;
   }
 }
 

--- a/generated_api_shadow/envoy/config/core/v4alpha/base.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/base.proto
@@ -336,7 +336,7 @@ message DataSource {
     string filename = 1 [(validate.rules).string = {min_len: 1}];
 
     // Bytes inlined in the configuration.
-    bytes inline_bytes = 2 [(validate.rules).bytes = {min_len: 1}];
+    bytes inline_bytes = 2;
 
     // String inlined in the configuration.
     string inline_string = 3;

--- a/source/common/config/datasource.cc
+++ b/source/common/config/datasource.cc
@@ -15,20 +15,27 @@ static constexpr uint32_t RetryCount = 1;
 
 std::string read(const envoy::config::core::v3::DataSource& source, bool allow_empty,
                  Api::Api& api) {
+  std::string data;
   switch (source.specifier_case()) {
   case envoy::config::core::v3::DataSource::SpecifierCase::kFilename:
-    return api.fileSystem().fileReadToEnd(source.filename());
+    data = api.fileSystem().fileReadToEnd(source.filename());
+    break;
   case envoy::config::core::v3::DataSource::SpecifierCase::kInlineBytes:
-    return source.inline_bytes();
+    data = source.inline_bytes();
+    break;
   case envoy::config::core::v3::DataSource::SpecifierCase::kInlineString:
-    return source.inline_string();
+    data = source.inline_string();
+    break;
   default:
     if (!allow_empty) {
       throw EnvoyException(
           fmt::format("Unexpected DataSource::specifier_case(): {}", source.specifier_case()));
     }
-    return "";
   }
+  if (!allow_empty && data.empty()) {
+    throw EnvoyException("DataSource cannot be empty");
+  }
+  return data;
 }
 
 absl::optional<std::string> getPath(const envoy::config::core::v3::DataSource& source) {

--- a/test/integration/local_reply_integration_test.cc
+++ b/test/integration/local_reply_integration_test.cc
@@ -411,4 +411,59 @@ body_format:
   EXPECT_EQ(response->body(), "513 - customized body text");
 }
 
+// Should return formatted text/plain response.
+TEST_P(LocalReplyIntegrationTest, ShouldFormatResponseToEmptyBody) {
+  const std::string yaml = R"EOF(
+mappers:
+- filter:
+    status_code_filter:
+      comparison:
+        op: EQ
+        value:
+          default_value: 503
+          runtime_key: key_b
+  status_code: 513
+  body:
+    inline_string: ""
+body_format:
+  text_format_source:
+    inline_string: ""
+)EOF";
+  setLocalReplyConfig(yaml);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"test-header", "exact-match-value-2"}});
+  auto response = std::move(encoder_decoder.second);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  ASSERT_TRUE(fake_upstream_connection_->close());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  response->waitForEndStream();
+
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+  } else {
+    codec_client_->close();
+  }
+
+  EXPECT_FALSE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+
+  EXPECT_EQ("513", response->headers().Status()->value().getStringView());
+
+  EXPECT_EQ(response->body(), "");
+}
+
 } // namespace Envoy


### PR DESCRIPTION
As discussed in #14276, relax the min length requirement of  `inline_string` in DataSource. It should checked after DataSource since an empty file could pass validation.

Risk Level: Low
Testing: integration test
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Lizan Zhou <lizan@tetrate.io>
