### PR TITLE
stats: make the title of a section match the link to it in code

### DIFF
--- a/source/docs/stats.md
+++ b/source/docs/stats.md
@@ -269,7 +269,7 @@ Developers trying to can iterate through changes in these tests locally with:
       test/integration:stats_integration_test
 ```
 
-## Debugging Symbol Table Assertions
+## Debugging Symbol Table Asserts
 
 If you are visiting this section because you saw a message like:
 


### PR DESCRIPTION
Commit Message: I managed to slightly mismatch a reference to a stats.md section in an assertion message. This just changes the section-name to match what we print in the assert, so the link works.
Additional Description: n/a
Risk Level: low
Testing: none - doc only
Docs Changes: this is a doc change
Release Notes: n/a
Platform Specific Features: n/a
