### PR TITLE
preconnect: rename

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -584,9 +584,9 @@ message Cluster {
   }
 
   // [#not-implemented-hide:]
-  message PrefetchPolicy {
+  message PreconnectPolicy {
     // Indicates how many streams (rounded up) can be anticipated per-upstream for each
-    // incoming stream. This is useful for high-QPS or latency-sensitive services. Prefetching
+    // incoming stream. This is useful for high-QPS or latency-sensitive services. Preconnecting
     // will only be done if the upstream is healthy.
     //
     // For example if this is 2, for an incoming HTTP/1.1 stream, 2 connections will be
@@ -595,46 +595,46 @@ message Cluster {
     // serve both the original and presumed follow-up stream.
     //
     // In steady state for non-multiplexed connections a value of 1.5 would mean if there were 100
-    // active streams, there would be 100 connections in use, and 50 connections prefetched.
+    // active streams, there would be 100 connections in use, and 50 connections preconnected.
     // This might be a useful value for something like short lived single-use connections,
     // for example proxying HTTP/1.1 if keep-alive were false and each stream resulted in connection
     // termination. It would likely be overkill for long lived connections, such as TCP proxying SMTP
     // or regular HTTP/1.1 with keep-alive. For long lived traffic, a value of 1.05 would be more
-    // reasonable, where for every 100 connections, 5 prefetched connections would be in the queue
+    // reasonable, where for every 100 connections, 5 preconnected connections would be in the queue
     // in case of unexpected disconnects where the connection could not be reused.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight. This means in steady state if a connection is torn down,
     // a subsequent streams will pay an upstream-rtt latency penalty waiting for streams to be
-    // prefetched.
+    // preconnected.
     //
-    // This is limited somewhat arbitrarily to 3 because prefetching connections too aggressively can
-    // harm latency more than the prefetching helps.
-    google.protobuf.DoubleValue per_upstream_prefetch_ratio = 1
+    // This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
+    // harm latency more than the preconnecting helps.
+    google.protobuf.DoubleValue per_upstream_preconnect_ratio = 1
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
 
     // Indicates how many many streams (rounded up) can be anticipated across a cluster for each
     // stream, useful for low QPS services. This is currently supported for a subset of
     // deterministic non-hash-based load-balancing algorithms (weighted round robin, random).
-    // Unlike per_upstream_prefetch_ratio this prefetches across the upstream instances in a
+    // Unlike per_upstream_preconnect_ratio this preconnects across the upstream instances in a
     // cluster, doing best effort predictions of what upstream would be picked next and
     // pre-establishing a connection.
     //
-    // For example if prefetching is set to 2 for a round robin HTTP/2 cluster, on the first
-    // incoming stream, 2 connections will be prefetched - one to the first upstream for this
+    // For example if preconnecting is set to 2 for a round robin HTTP/2 cluster, on the first
+    // incoming stream, 2 connections will be preconnected - one to the first upstream for this
     // cluster, one to the second on the assumption there will be a follow-up stream.
     //
-    // Prefetching will be limited to one prefetch per configured upstream in the cluster.
+    // Preconnecting will be limited to one preconnect per configured upstream in the cluster.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight, so during warm up and in steady state if a connection
-    // is closed (and per_upstream_prefetch_ratio is not set), there will be a latency hit for
+    // is closed (and per_upstream_preconnect_ratio is not set), there will be a latency hit for
     // connection establishment.
     //
-    // If both this and prefetch_ratio are set, Envoy will make sure both predicted needs are met,
-    // basically prefetching max(predictive-prefetch, per-upstream-prefetch), for each upstream.
+    // If both this and preconnect_ratio are set, Envoy will make sure both predicted needs are met,
+    // basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each upstream.
     // TODO(alyssawilk) per LB docs and LB overview docs when unhiding.
-    google.protobuf.DoubleValue predictive_prefetch_ratio = 2
+    google.protobuf.DoubleValue predictive_preconnect_ratio = 2
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
@@ -1029,8 +1029,8 @@ message Cluster {
   TrackClusterStats track_cluster_stats = 49;
 
   // [#not-implemented-hide:]
-  // Prefetch configuration for this cluster.
-  PrefetchPolicy prefetch_policy = 50;
+  // Preconnect configuration for this cluster.
+  PreconnectPolicy preconnect_policy = 50;
 
   // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
   // connection pool for every downstream connection

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -589,12 +589,12 @@ message Cluster {
   }
 
   // [#not-implemented-hide:]
-  message PrefetchPolicy {
+  message PreconnectPolicy {
     option (udpa.annotations.versioning).previous_message_type =
-        "envoy.config.cluster.v3.Cluster.PrefetchPolicy";
+        "envoy.config.cluster.v3.Cluster.PreconnectPolicy";
 
     // Indicates how many streams (rounded up) can be anticipated per-upstream for each
-    // incoming stream. This is useful for high-QPS or latency-sensitive services. Prefetching
+    // incoming stream. This is useful for high-QPS or latency-sensitive services. Preconnecting
     // will only be done if the upstream is healthy.
     //
     // For example if this is 2, for an incoming HTTP/1.1 stream, 2 connections will be
@@ -603,46 +603,46 @@ message Cluster {
     // serve both the original and presumed follow-up stream.
     //
     // In steady state for non-multiplexed connections a value of 1.5 would mean if there were 100
-    // active streams, there would be 100 connections in use, and 50 connections prefetched.
+    // active streams, there would be 100 connections in use, and 50 connections preconnected.
     // This might be a useful value for something like short lived single-use connections,
     // for example proxying HTTP/1.1 if keep-alive were false and each stream resulted in connection
     // termination. It would likely be overkill for long lived connections, such as TCP proxying SMTP
     // or regular HTTP/1.1 with keep-alive. For long lived traffic, a value of 1.05 would be more
-    // reasonable, where for every 100 connections, 5 prefetched connections would be in the queue
+    // reasonable, where for every 100 connections, 5 preconnected connections would be in the queue
     // in case of unexpected disconnects where the connection could not be reused.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight. This means in steady state if a connection is torn down,
     // a subsequent streams will pay an upstream-rtt latency penalty waiting for streams to be
-    // prefetched.
+    // preconnected.
     //
-    // This is limited somewhat arbitrarily to 3 because prefetching connections too aggressively can
-    // harm latency more than the prefetching helps.
-    google.protobuf.DoubleValue per_upstream_prefetch_ratio = 1
+    // This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
+    // harm latency more than the preconnecting helps.
+    google.protobuf.DoubleValue per_upstream_preconnect_ratio = 1
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
 
     // Indicates how many many streams (rounded up) can be anticipated across a cluster for each
     // stream, useful for low QPS services. This is currently supported for a subset of
     // deterministic non-hash-based load-balancing algorithms (weighted round robin, random).
-    // Unlike per_upstream_prefetch_ratio this prefetches across the upstream instances in a
+    // Unlike per_upstream_preconnect_ratio this preconnects across the upstream instances in a
     // cluster, doing best effort predictions of what upstream would be picked next and
     // pre-establishing a connection.
     //
-    // For example if prefetching is set to 2 for a round robin HTTP/2 cluster, on the first
-    // incoming stream, 2 connections will be prefetched - one to the first upstream for this
+    // For example if preconnecting is set to 2 for a round robin HTTP/2 cluster, on the first
+    // incoming stream, 2 connections will be preconnected - one to the first upstream for this
     // cluster, one to the second on the assumption there will be a follow-up stream.
     //
-    // Prefetching will be limited to one prefetch per configured upstream in the cluster.
+    // Preconnecting will be limited to one preconnect per configured upstream in the cluster.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight, so during warm up and in steady state if a connection
-    // is closed (and per_upstream_prefetch_ratio is not set), there will be a latency hit for
+    // is closed (and per_upstream_preconnect_ratio is not set), there will be a latency hit for
     // connection establishment.
     //
-    // If both this and prefetch_ratio are set, Envoy will make sure both predicted needs are met,
-    // basically prefetching max(predictive-prefetch, per-upstream-prefetch), for each upstream.
+    // If both this and preconnect_ratio are set, Envoy will make sure both predicted needs are met,
+    // basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each upstream.
     // TODO(alyssawilk) per LB docs and LB overview docs when unhiding.
-    google.protobuf.DoubleValue predictive_prefetch_ratio = 2
+    google.protobuf.DoubleValue predictive_preconnect_ratio = 2
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
@@ -969,8 +969,8 @@ message Cluster {
   TrackClusterStats track_cluster_stats = 49;
 
   // [#not-implemented-hide:]
-  // Prefetch configuration for this cluster.
-  PrefetchPolicy prefetch_policy = 50;
+  // Preconnect configuration for this cluster.
+  PreconnectPolicy preconnect_policy = 50;
 
   // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
   // connection pool for every downstream connection

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -584,9 +584,9 @@ message Cluster {
   }
 
   // [#not-implemented-hide:]
-  message PrefetchPolicy {
+  message PreconnectPolicy {
     // Indicates how many streams (rounded up) can be anticipated per-upstream for each
-    // incoming stream. This is useful for high-QPS or latency-sensitive services. Prefetching
+    // incoming stream. This is useful for high-QPS or latency-sensitive services. Preconnecting
     // will only be done if the upstream is healthy.
     //
     // For example if this is 2, for an incoming HTTP/1.1 stream, 2 connections will be
@@ -595,46 +595,46 @@ message Cluster {
     // serve both the original and presumed follow-up stream.
     //
     // In steady state for non-multiplexed connections a value of 1.5 would mean if there were 100
-    // active streams, there would be 100 connections in use, and 50 connections prefetched.
+    // active streams, there would be 100 connections in use, and 50 connections preconnected.
     // This might be a useful value for something like short lived single-use connections,
     // for example proxying HTTP/1.1 if keep-alive were false and each stream resulted in connection
     // termination. It would likely be overkill for long lived connections, such as TCP proxying SMTP
     // or regular HTTP/1.1 with keep-alive. For long lived traffic, a value of 1.05 would be more
-    // reasonable, where for every 100 connections, 5 prefetched connections would be in the queue
+    // reasonable, where for every 100 connections, 5 preconnected connections would be in the queue
     // in case of unexpected disconnects where the connection could not be reused.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight. This means in steady state if a connection is torn down,
     // a subsequent streams will pay an upstream-rtt latency penalty waiting for streams to be
-    // prefetched.
+    // preconnected.
     //
-    // This is limited somewhat arbitrarily to 3 because prefetching connections too aggressively can
-    // harm latency more than the prefetching helps.
-    google.protobuf.DoubleValue per_upstream_prefetch_ratio = 1
+    // This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
+    // harm latency more than the preconnecting helps.
+    google.protobuf.DoubleValue per_upstream_preconnect_ratio = 1
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
 
     // Indicates how many many streams (rounded up) can be anticipated across a cluster for each
     // stream, useful for low QPS services. This is currently supported for a subset of
     // deterministic non-hash-based load-balancing algorithms (weighted round robin, random).
-    // Unlike per_upstream_prefetch_ratio this prefetches across the upstream instances in a
+    // Unlike per_upstream_preconnect_ratio this preconnects across the upstream instances in a
     // cluster, doing best effort predictions of what upstream would be picked next and
     // pre-establishing a connection.
     //
-    // For example if prefetching is set to 2 for a round robin HTTP/2 cluster, on the first
-    // incoming stream, 2 connections will be prefetched - one to the first upstream for this
+    // For example if preconnecting is set to 2 for a round robin HTTP/2 cluster, on the first
+    // incoming stream, 2 connections will be preconnected - one to the first upstream for this
     // cluster, one to the second on the assumption there will be a follow-up stream.
     //
-    // Prefetching will be limited to one prefetch per configured upstream in the cluster.
+    // Preconnecting will be limited to one preconnect per configured upstream in the cluster.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight, so during warm up and in steady state if a connection
-    // is closed (and per_upstream_prefetch_ratio is not set), there will be a latency hit for
+    // is closed (and per_upstream_preconnect_ratio is not set), there will be a latency hit for
     // connection establishment.
     //
-    // If both this and prefetch_ratio are set, Envoy will make sure both predicted needs are met,
-    // basically prefetching max(predictive-prefetch, per-upstream-prefetch), for each upstream.
+    // If both this and preconnect_ratio are set, Envoy will make sure both predicted needs are met,
+    // basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each upstream.
     // TODO(alyssawilk) per LB docs and LB overview docs when unhiding.
-    google.protobuf.DoubleValue predictive_prefetch_ratio = 2
+    google.protobuf.DoubleValue predictive_preconnect_ratio = 2
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
@@ -1027,8 +1027,8 @@ message Cluster {
   TrackClusterStats track_cluster_stats = 49;
 
   // [#not-implemented-hide:]
-  // Prefetch configuration for this cluster.
-  PrefetchPolicy prefetch_policy = 50;
+  // Preconnect configuration for this cluster.
+  PreconnectPolicy preconnect_policy = 50;
 
   // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
   // connection pool for every downstream connection

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -590,12 +590,12 @@ message Cluster {
   }
 
   // [#not-implemented-hide:]
-  message PrefetchPolicy {
+  message PreconnectPolicy {
     option (udpa.annotations.versioning).previous_message_type =
-        "envoy.config.cluster.v3.Cluster.PrefetchPolicy";
+        "envoy.config.cluster.v3.Cluster.PreconnectPolicy";
 
     // Indicates how many streams (rounded up) can be anticipated per-upstream for each
-    // incoming stream. This is useful for high-QPS or latency-sensitive services. Prefetching
+    // incoming stream. This is useful for high-QPS or latency-sensitive services. Preconnecting
     // will only be done if the upstream is healthy.
     //
     // For example if this is 2, for an incoming HTTP/1.1 stream, 2 connections will be
@@ -604,46 +604,46 @@ message Cluster {
     // serve both the original and presumed follow-up stream.
     //
     // In steady state for non-multiplexed connections a value of 1.5 would mean if there were 100
-    // active streams, there would be 100 connections in use, and 50 connections prefetched.
+    // active streams, there would be 100 connections in use, and 50 connections preconnected.
     // This might be a useful value for something like short lived single-use connections,
     // for example proxying HTTP/1.1 if keep-alive were false and each stream resulted in connection
     // termination. It would likely be overkill for long lived connections, such as TCP proxying SMTP
     // or regular HTTP/1.1 with keep-alive. For long lived traffic, a value of 1.05 would be more
-    // reasonable, where for every 100 connections, 5 prefetched connections would be in the queue
+    // reasonable, where for every 100 connections, 5 preconnected connections would be in the queue
     // in case of unexpected disconnects where the connection could not be reused.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight. This means in steady state if a connection is torn down,
     // a subsequent streams will pay an upstream-rtt latency penalty waiting for streams to be
-    // prefetched.
+    // preconnected.
     //
-    // This is limited somewhat arbitrarily to 3 because prefetching connections too aggressively can
-    // harm latency more than the prefetching helps.
-    google.protobuf.DoubleValue per_upstream_prefetch_ratio = 1
+    // This is limited somewhat arbitrarily to 3 because preconnecting too aggressively can
+    // harm latency more than the preconnecting helps.
+    google.protobuf.DoubleValue per_upstream_preconnect_ratio = 1
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
 
     // Indicates how many many streams (rounded up) can be anticipated across a cluster for each
     // stream, useful for low QPS services. This is currently supported for a subset of
     // deterministic non-hash-based load-balancing algorithms (weighted round robin, random).
-    // Unlike per_upstream_prefetch_ratio this prefetches across the upstream instances in a
+    // Unlike per_upstream_preconnect_ratio this preconnects across the upstream instances in a
     // cluster, doing best effort predictions of what upstream would be picked next and
     // pre-establishing a connection.
     //
-    // For example if prefetching is set to 2 for a round robin HTTP/2 cluster, on the first
-    // incoming stream, 2 connections will be prefetched - one to the first upstream for this
+    // For example if preconnecting is set to 2 for a round robin HTTP/2 cluster, on the first
+    // incoming stream, 2 connections will be preconnected - one to the first upstream for this
     // cluster, one to the second on the assumption there will be a follow-up stream.
     //
-    // Prefetching will be limited to one prefetch per configured upstream in the cluster.
+    // Preconnecting will be limited to one preconnect per configured upstream in the cluster.
     //
     // If this value is not set, or set explicitly to one, Envoy will fetch as many connections
     // as needed to serve streams in flight, so during warm up and in steady state if a connection
-    // is closed (and per_upstream_prefetch_ratio is not set), there will be a latency hit for
+    // is closed (and per_upstream_preconnect_ratio is not set), there will be a latency hit for
     // connection establishment.
     //
-    // If both this and prefetch_ratio are set, Envoy will make sure both predicted needs are met,
-    // basically prefetching max(predictive-prefetch, per-upstream-prefetch), for each upstream.
+    // If both this and preconnect_ratio are set, Envoy will make sure both predicted needs are met,
+    // basically preconnecting max(predictive-preconnect, per-upstream-preconnect), for each upstream.
     // TODO(alyssawilk) per LB docs and LB overview docs when unhiding.
-    google.protobuf.DoubleValue predictive_prefetch_ratio = 2
+    google.protobuf.DoubleValue predictive_preconnect_ratio = 2
         [(validate.rules).double = {lte: 3.0 gte: 1.0}];
   }
 
@@ -1041,8 +1041,8 @@ message Cluster {
   TrackClusterStats track_cluster_stats = 49;
 
   // [#not-implemented-hide:]
-  // Prefetch configuration for this cluster.
-  PrefetchPolicy prefetch_policy = 50;
+  // Preconnect configuration for this cluster.
+  PreconnectPolicy preconnect_policy = 50;
 
   // If `connection_pool_per_downstream_connection` is true, the cluster will use a separate
   // connection pool for every downstream connection

--- a/include/envoy/common/conn_pool.h
+++ b/include/envoy/common/conn_pool.h
@@ -70,12 +70,12 @@ public:
   virtual Upstream::HostDescriptionConstSharedPtr host() const PURE;
 
   /**
-   * Prefetches an upstream connection, if existing connections do not meet both current and
+   * Creates an upstream connection, if existing connections do not meet both current and
    * anticipated load.
    *
-   * @return true if a connection was prefetched, false otherwise.
+   * @return true if a connection was preconnected, false otherwise.
    */
-  virtual bool maybePrefetch(float prefetch_ratio) PURE;
+  virtual bool maybePreconnect(float preconnect_ratio) PURE;
 };
 
 enum class PoolFailureReason {

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -743,7 +743,7 @@ public:
   /**
    * @return how many streams should be anticipated per each current stream.
    */
-  virtual float perUpstreamPrefetchRatio() const PURE;
+  virtual float perUpstreamPreconnectRatio() const PURE;
 
   /**
    * @return how many streams should be anticipated per each current stream.

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -35,49 +35,49 @@ void ConnPoolImplBase::destructAllConnections() {
   dispatcher_.clearDeferredDeleteList();
 }
 
-bool ConnPoolImplBase::shouldCreateNewConnection(float global_prefetch_ratio) const {
+bool ConnPoolImplBase::shouldCreateNewConnection(float global_preconnect_ratio) const {
   // If the host is not healthy, don't make it do extra work, especially as
   // upstream selection logic may result in bypassing this upstream entirely.
-  // If an Envoy user wants prefetching for degraded upstreams this could be
-  // added later via extending the prefetch config.
+  // If an Envoy user wants preconnecting for degraded upstreams this could be
+  // added later via extending the preconnect config.
   if (host_->health() != Upstream::Host::Health::Healthy) {
     return pending_streams_.size() > connecting_stream_capacity_;
   }
 
-  // If global prefetching is on, and this connection is within the global
-  // prefetch limit, prefetch.
-  // We may eventually want to track prefetch_attempts to allow more prefetching for
+  // If global preconnecting is on, and this connection is within the global
+  // preconnect limit, preconnect.
+  // We may eventually want to track preconnect_attempts to allow more preconnecting for
   // heavily weighted upstreams or sticky picks.
-  if (global_prefetch_ratio > 1.0 &&
-      ((pending_streams_.size() + 1 + num_active_streams_) * global_prefetch_ratio >
+  if (global_preconnect_ratio > 1.0 &&
+      ((pending_streams_.size() + 1 + num_active_streams_) * global_preconnect_ratio >
        (connecting_stream_capacity_ + num_active_streams_))) {
     return true;
   }
 
   // The number of streams we want to be provisioned for is the number of
-  // pending and active streams times the prefetch ratio.
+  // pending and active streams times the preconnect ratio.
   // The number of streams we are (theoretically) provisioned for is the
   // connecting stream capacity plus the number of active streams.
   //
-  // If prefetch ratio is not set, it defaults to 1, and this simplifies to the
+  // If preconnect ratio is not set, it defaults to 1, and this simplifies to the
   // legacy value of pending_streams_.size() > connecting_stream_capacity_
-  return (pending_streams_.size() + num_active_streams_) * perUpstreamPrefetchRatio() >
+  return (pending_streams_.size() + num_active_streams_) * perUpstreamPreconnectRatio() >
          (connecting_stream_capacity_ + num_active_streams_);
 }
 
-float ConnPoolImplBase::perUpstreamPrefetchRatio() const {
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_prefetch")) {
-    return host_->cluster().perUpstreamPrefetchRatio();
+float ConnPoolImplBase::perUpstreamPreconnectRatio() const {
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.allow_preconnect")) {
+    return host_->cluster().perUpstreamPreconnectRatio();
   } else {
     return 1.0;
   }
 }
 
 void ConnPoolImplBase::tryCreateNewConnections() {
-  // Somewhat arbitrarily cap the number of connections prefetched due to new
-  // incoming connections. The prefetch ratio is capped at 3, so in steady
-  // state, no more than 3 connections should be prefetched. If hosts go
-  // unhealthy, and connections are not immediately prefetched, it could be that
+  // Somewhat arbitrarily cap the number of connections preconnected due to new
+  // incoming connections. The preconnect ratio is capped at 3, so in steady
+  // state, no more than 3 connections should be preconnected. If hosts go
+  // unhealthy, and connections are not immediately preconnected, it could be that
   // many connections are desired when the host becomes healthy again, but
   // overwhelming it with connections is not desirable.
   for (int i = 0; i < 3; ++i) {
@@ -87,9 +87,9 @@ void ConnPoolImplBase::tryCreateNewConnections() {
   }
 }
 
-bool ConnPoolImplBase::tryCreateNewConnection(float global_prefetch_ratio) {
+bool ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
   // There are already enough CONNECTING connections for the number of queued streams.
-  if (!shouldCreateNewConnection(global_prefetch_ratio)) {
+  if (!shouldCreateNewConnection(global_preconnect_ratio)) {
     return false;
   }
 
@@ -189,7 +189,7 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStream(AttachContext& context)
     ActiveClient& client = *ready_clients_.front();
     ENVOY_CONN_LOG(debug, "using existing connection", client);
     attachStreamToClient(client, context);
-    // Even if there's a ready client, we may want to prefetch a new connection
+    // Even if there's a ready client, we may want to preconnect a new connection
     // to handle the next incoming stream.
     tryCreateNewConnections();
     return nullptr;
@@ -211,8 +211,8 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStream(AttachContext& context)
   }
 }
 
-bool ConnPoolImplBase::maybePrefetch(float global_prefetch_ratio) {
-  return tryCreateNewConnection(global_prefetch_ratio);
+bool ConnPoolImplBase::maybePreconnect(float global_preconnect_ratio) {
+  return tryCreateNewConnection(global_preconnect_ratio);
 }
 
 void ConnPoolImplBase::scheduleOnUpstreamReady() {
@@ -368,7 +368,7 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
       // NOTE: We move the existing pending streams to a temporary list. This is done so that
       //       if retry logic submits a new stream to the pool, we don't fail it inline.
       purgePendingStreams(client.real_host_description_, failure_reason, reason);
-      // See if we should prefetch another connection based on active connections.
+      // See if we should preconnect another connection based on active connections.
       tryCreateNewConnections();
     }
 
@@ -436,14 +436,14 @@ void ConnPoolImplBase::purgePendingStreams(
 bool ConnPoolImplBase::connectingConnectionIsExcess() const {
   ASSERT(connecting_stream_capacity_ >=
          connecting_clients_.front()->effectiveConcurrentStreamLimit());
-  // If perUpstreamPrefetchRatio is one, this simplifies to checking if there would still be
+  // If perUpstreamPreconnectRatio is one, this simplifies to checking if there would still be
   // sufficient connecting stream capacity to serve all pending streams if the most recent client
   // were removed from the picture.
   //
-  // If prefetch ratio is set, it also factors in the anticipated load based on both queued streams
-  // and active streams, and makes sure the connecting capacity would still be sufficient to serve
-  // that even with the most recent client removed.
-  return (pending_streams_.size() + num_active_streams_) * perUpstreamPrefetchRatio() <=
+  // If preconnect ratio is set, it also factors in the anticipated load based on both queued
+  // streams and active streams, and makes sure the connecting capacity would still be sufficient to
+  // serve that even with the most recent client removed.
+  return (pending_streams_.size() + num_active_streams_) * perUpstreamPreconnectRatio() <=
          (connecting_stream_capacity_ -
           connecting_clients_.front()->effectiveConcurrentStreamLimit() + num_active_streams_);
 }

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -159,8 +159,8 @@ public:
   void scheduleOnUpstreamReady();
   ConnectionPool::Cancellable* newStream(AttachContext& context);
   // Called if this pool is likely to be picked soon, to determine if it's worth
-  // prefetching a connection.
-  bool maybePrefetch(float global_prefetch_ratio);
+  // preconnecting a connection.
+  bool maybePreconnect(float global_preconnect_ratio);
 
   virtual ConnectionPool::Cancellable* newPendingStream(AttachContext& context) PURE;
 
@@ -187,24 +187,24 @@ public:
 protected:
   virtual void onConnected(Envoy::ConnectionPool::ActiveClient&) {}
 
-  // Creates up to 3 connections, based on the prefetch ratio.
+  // Creates up to 3 connections, based on the preconnect ratio.
   void tryCreateNewConnections();
 
   // Creates a new connection if there is sufficient demand, it is allowed by resourceManager, or
   // to avoid starving this pool.
-  // Demand is determined either by perUpstreamPrefetchRatio() or global_prefetch_ratio
-  // if this is called by maybePrefetch()
-  bool tryCreateNewConnection(float global_prefetch_ratio = 0);
+  // Demand is determined either by perUpstreamPreconnectRatio() or global_preconnect_ratio
+  // if this is called by maybePreconnect()
+  bool tryCreateNewConnection(float global_preconnect_ratio = 0);
 
   // A helper function which determines if a canceled pending connection should
   // be closed as excess or not.
   bool connectingConnectionIsExcess() const;
 
   // A helper function which determines if a new incoming stream should trigger
-  // connection prefetch.
-  bool shouldCreateNewConnection(float global_prefetch_ratio) const;
+  // connection preconnect.
+  bool shouldCreateNewConnection(float global_preconnect_ratio) const;
 
-  float perUpstreamPrefetchRatio() const;
+  float perUpstreamPreconnectRatio() const;
 
   ConnectionPool::Cancellable*
   addPendingStream(Envoy::ConnectionPool::PendingStreamPtr&& pending_stream) {

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -61,8 +61,8 @@ public:
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
                                          Http::ConnectionPool::Callbacks& callbacks) override;
-  bool maybePrefetch(float ratio) override {
-    return Envoy::ConnectionPool::ConnPoolImplBase::maybePrefetch(ratio);
+  bool maybePreconnect(float ratio) override {
+    return Envoy::ConnectionPool::ConnPoolImplBase::maybePreconnect(ratio);
   }
   bool hasActiveConnections() const override;
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -59,7 +59,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.always_apply_route_header_rules",
     "envoy.reloadable_features.activate_timers_next_event_loop",
     "envoy.reloadable_features.allow_500_after_100",
-    "envoy.reloadable_features.allow_prefetch",
+    "envoy.reloadable_features.allow_preconnect",
     "envoy.reloadable_features.allow_response_for_timeout",
     "envoy.reloadable_features.consume_all_retry_headers",
     "envoy.reloadable_features.check_ocsp_policy",

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -157,8 +157,8 @@ public:
     TcpAttachContext context(&callbacks);
     return Envoy::ConnectionPool::ConnPoolImplBase::newStream(context);
   }
-  bool maybePrefetch(float prefetch_ratio) override {
-    return Envoy::ConnectionPool::ConnPoolImplBase::maybePrefetch(prefetch_ratio);
+  bool maybePreconnect(float preconnect_ratio) override {
+    return Envoy::ConnectionPool::ConnPoolImplBase::maybePreconnect(preconnect_ratio);
   }
 
   ConnectionPool::Cancellable*

--- a/source/common/tcp/original_conn_pool.h
+++ b/source/common/tcp/original_conn_pool.h
@@ -33,8 +33,8 @@ public:
   void drainConnections() override;
   void closeConnections() override;
   ConnectionPool::Cancellable* newConnection(ConnectionPool::Callbacks& callbacks) override;
-  // The old pool does not implement prefetching.
-  bool maybePrefetch(float) override { return false; }
+  // The old pool does not implement preconnecting.
+  bool maybePreconnect(float) override { return false; }
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
 
 protected:

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -562,8 +562,8 @@ private:
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
   void updateClusterCounts();
   void clusterWarmingToActive(const std::string& cluster_name);
-  static void maybePrefetch(ThreadLocalClusterManagerImpl::ClusterEntry& cluster_entry,
-                            std::function<ConnectionPool::Instance*()> prefetch_pool);
+  static void maybePreconnect(ThreadLocalClusterManagerImpl::ClusterEntry& cluster_entry,
+                              std::function<ConnectionPool::Instance*()> preconnect_pool);
 
   ClusterManagerFactory& factory_;
   Runtime::Loader& runtime_;

--- a/source/common/upstream/load_balancer_impl.cc
+++ b/source/common/upstream/load_balancer_impl.cc
@@ -829,8 +829,8 @@ HostConstSharedPtr EdfLoadBalancerBase::chooseHostOnce(LoadBalancerContext* cont
 
 HostConstSharedPtr LeastRequestLoadBalancer::unweightedHostPeek(const HostVector&,
                                                                 const HostsSource&) {
-  // LeastRequestLoadBalancer can not do deterministic prefetching, because
-  // any other thread might select the least-requested-host between prefetch and
+  // LeastRequestLoadBalancer can not do deterministic preconnecting, because
+  // any other thread might select the least-requested-host between preconnect and
   // host-pick, and change the rq_active checks.
   return nullptr;
 }

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -56,7 +56,7 @@ public:
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
-    // Prefetching is not implemented for OriginalDstCluster
+    // Preconnecting is not implemented for OriginalDstCluster
     HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
 
   private:

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -73,7 +73,7 @@ public:
   HostConstSharedPtr chooseHostOnce(LoadBalancerContext*) override {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
-  // Prefetch not implemented for hash based load balancing
+  // Preconnect not implemented for hash based load balancing
   HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
 
 protected:
@@ -97,7 +97,7 @@ private:
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
-    // Prefetch not implemented for hash based load balancing
+    // Preconnect not implemented for hash based load balancing
     HostConstSharedPtr peekAnotherHost(LoadBalancerContext*) override { return nullptr; }
 
     ClusterStats& stats_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -743,10 +743,10 @@ ClusterInfoImpl::ClusterInfoImpl(
                                          Http::DEFAULT_MAX_HEADERS_COUNT))),
       connect_timeout_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(config, connect_timeout))),
-      per_upstream_prefetch_ratio_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          config.prefetch_policy(), per_upstream_prefetch_ratio, 1.0)),
-      peekahead_ratio_(
-          PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.prefetch_policy(), predictive_prefetch_ratio, 0)),
+      per_upstream_preconnect_ratio_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          config.preconnect_policy(), per_upstream_preconnect_ratio, 1.0)),
+      peekahead_ratio_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.preconnect_policy(),
+                                                       predictive_preconnect_ratio, 0)),
       per_connection_buffer_limit_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, per_connection_buffer_limit_bytes, 1024 * 1024)),
       socket_matcher_(std::move(socket_matcher)), stats_scope_(std::move(stats_scope)),

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -548,7 +548,7 @@ public:
   const absl::optional<std::chrono::milliseconds> idleTimeout() const override {
     return idle_timeout_;
   }
-  float perUpstreamPrefetchRatio() const override { return per_upstream_prefetch_ratio_; }
+  float perUpstreamPreconnectRatio() const override { return per_upstream_preconnect_ratio_; }
   float peekaheadRatio() const override { return peekahead_ratio_; }
   uint32_t perConnectionBufferLimitBytes() const override {
     return per_connection_buffer_limit_bytes_;
@@ -683,7 +683,7 @@ private:
   const uint32_t max_response_headers_count_;
   const std::chrono::milliseconds connect_timeout_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
-  const float per_upstream_prefetch_ratio_;
+  const float per_upstream_preconnect_ratio_;
   const float peekahead_ratio_;
   const uint32_t per_connection_buffer_limit_bytes_;
   TransportSocketMatcherPtr socket_matcher_;

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -78,7 +78,7 @@ public:
 
   // Upstream::LoadBalancer
   Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override;
-  // Prefetching not yet implemented for extensions.
+  // Preconnecting not yet implemented for extensions.
   Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
     return nullptr;
   }
@@ -97,7 +97,7 @@ private:
 
     // Upstream::LoadBalancer
     Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override;
-    // Prefetching not yet implemented for extensions.
+    // Preconnecting not yet implemented for extensions.
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -58,7 +58,7 @@ private:
 
     // Upstream::LoadBalancer
     Upstream::HostConstSharedPtr chooseHost(Upstream::LoadBalancerContext* context) override;
-    // Prefetching not implemented.
+    // Preconnecting not implemented.
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -90,9 +90,9 @@ public:
   std::vector<ActiveClient*> clients_;
 };
 
-TEST_F(ConnPoolImplBaseTest, BasicPrefetch) {
+TEST_F(ConnPoolImplBaseTest, BasicPreconnect) {
   // Create more than one connection per new stream.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
   // On new stream, create 2 connections.
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*connecting capacity*/);
@@ -105,11 +105,11 @@ TEST_F(ConnPoolImplBaseTest, BasicPrefetch) {
   pool_.destructAllConnections();
 }
 
-TEST_F(ConnPoolImplBaseTest, PrefetchOnDisconnect) {
+TEST_F(ConnPoolImplBaseTest, PreconnectOnDisconnect) {
   testing::InSequence s;
 
   // Create more than one connection per new stream.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
   // On new stream, create 2 connections.
   EXPECT_CALL(pool_, instantiateActiveClient).Times(2);
@@ -129,9 +129,9 @@ TEST_F(ConnPoolImplBaseTest, PrefetchOnDisconnect) {
   pool_.destructAllConnections();
 }
 
-TEST_F(ConnPoolImplBaseTest, NoPrefetchIfUnhealthy) {
+TEST_F(ConnPoolImplBaseTest, NoPreconnectIfUnhealthy) {
   // Create more than one connection per new stream.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
   host_->healthFlagSet(Upstream::Host::HealthFlag::FAILED_ACTIVE_HC);
   EXPECT_EQ(host_->health(), Upstream::Host::Health::Unhealthy);
@@ -145,9 +145,9 @@ TEST_F(ConnPoolImplBaseTest, NoPrefetchIfUnhealthy) {
   pool_.destructAllConnections();
 }
 
-TEST_F(ConnPoolImplBaseTest, NoPrefetchIfDegraded) {
+TEST_F(ConnPoolImplBaseTest, NoPreconnectIfDegraded) {
   // Create more than one connection per new stream.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
   EXPECT_EQ(host_->health(), Upstream::Host::Health::Healthy);
   host_->healthFlagSet(Upstream::Host::HealthFlag::DEGRADED_EDS_HEALTH);
@@ -161,34 +161,34 @@ TEST_F(ConnPoolImplBaseTest, NoPrefetchIfDegraded) {
   pool_.destructAllConnections();
 }
 
-TEST_F(ConnPoolImplBaseTest, ExplicitPrefetch) {
+TEST_F(ConnPoolImplBaseTest, ExplicitPreconnect) {
   // Create more than one connection per new stream.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
   EXPECT_CALL(pool_, instantiateActiveClient).Times(AnyNumber());
 
-  // With global prefetch off, we won't prefetch.
-  EXPECT_FALSE(pool_.maybePrefetch(0));
+  // With global preconnect off, we won't preconnect.
+  EXPECT_FALSE(pool_.maybePreconnect(0));
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*connecting capacity*/);
-  // With prefetch ratio of 1.1, we'll prefetch two connections.
-  // Currently, no number of subsequent calls to prefetch will increase that.
-  EXPECT_TRUE(pool_.maybePrefetch(1.1));
-  EXPECT_TRUE(pool_.maybePrefetch(1.1));
-  EXPECT_FALSE(pool_.maybePrefetch(1.1));
+  // With preconnect ratio of 1.1, we'll preconnect two connections.
+  // Currently, no number of subsequent calls to preconnect will increase that.
+  EXPECT_TRUE(pool_.maybePreconnect(1.1));
+  EXPECT_TRUE(pool_.maybePreconnect(1.1));
+  EXPECT_FALSE(pool_.maybePreconnect(1.1));
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 2 /*connecting capacity*/);
 
-  // With a higher prefetch ratio, more connections may be prefetched.
-  EXPECT_TRUE(pool_.maybePrefetch(3));
+  // With a higher preconnect ratio, more connections may be preconnected.
+  EXPECT_TRUE(pool_.maybePreconnect(3));
 
   pool_.destructAllConnections();
 }
 
-TEST_F(ConnPoolImplBaseTest, ExplicitPrefetchNotHealthy) {
+TEST_F(ConnPoolImplBaseTest, ExplicitPreconnectNotHealthy) {
   // Create more than one connection per new stream.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
-  // Prefetch won't occur if the host is not healthy.
+  // Preconnect won't occur if the host is not healthy.
   host_->healthFlagSet(Upstream::Host::HealthFlag::DEGRADED_EDS_HEALTH);
-  EXPECT_FALSE(pool_.maybePrefetch(1));
+  EXPECT_FALSE(pool_.maybePreconnect(1));
 }
 
 } // namespace ConnectionPool

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -1399,11 +1399,11 @@ TEST_F(Http2ConnPoolImplTest, DrainedConnectionsNotActive) {
   closeClient(0);
 }
 
-TEST_F(Http2ConnPoolImplTest, PrefetchWithoutMultiplexing) {
+TEST_F(Http2ConnPoolImplTest, PreconnectWithoutMultiplexing) {
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
-  // With one request per connection, and prefetch 1.5, the first request will
+  // With one request per connection, and preconnect 1.5, the first request will
   // kick off 2 connections.
   expectClientsCreate(2);
   ActiveTestRequest r1(*this, 0, false);
@@ -1429,14 +1429,14 @@ TEST_F(Http2ConnPoolImplTest, PrefetchWithoutMultiplexing) {
   closeAllClients();
 }
 
-TEST_F(Http2ConnPoolImplTest, PrefetchOff) {
+TEST_F(Http2ConnPoolImplTest, PreconnectOff) {
   TestScopedRuntime scoped_runtime;
   Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.reloadable_features.allow_prefetch", "false"}});
+      {{"envoy.reloadable_features.allow_preconnect", "false"}});
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
-  // Despite the prefetch ratio, no prefetch will happen due to the runtime
+  // Despite the preconnect ratio, no preconnect will happen due to the runtime
   // disable.
   expectClientsCreate(1);
   ActiveTestRequest r1(*this, 0, false);
@@ -1447,11 +1447,11 @@ TEST_F(Http2ConnPoolImplTest, PrefetchOff) {
   closeAllClients();
 }
 
-TEST_F(Http2ConnPoolImplTest, PrefetchWithMultiplexing) {
+TEST_F(Http2ConnPoolImplTest, PreconnectWithMultiplexing) {
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(2);
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
-  // With two requests per connection, and prefetch 1.5, the first request will
+  // With two requests per connection, and preconnect 1.5, the first request will
   // only kick off 1 connection.
   expectClientsCreate(1);
   ActiveTestRequest r1(*this, 0, false);
@@ -1470,11 +1470,11 @@ TEST_F(Http2ConnPoolImplTest, PrefetchWithMultiplexing) {
   closeAllClients();
 }
 
-TEST_F(Http2ConnPoolImplTest, PrefetchEvenWhenReady) {
+TEST_F(Http2ConnPoolImplTest, PreconnectEvenWhenReady) {
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
-  // With one request per connection, and prefetch 1.5, the first request will
+  // With one request per connection, and preconnect 1.5, the first request will
   // kick off 2 connections.
   expectClientsCreate(2);
   ActiveTestRequest r1(*this, 0, false);
@@ -1485,7 +1485,7 @@ TEST_F(Http2ConnPoolImplTest, PrefetchEvenWhenReady) {
   expectClientConnect(1);
 
   // The next incoming request will immediately be assigned a stream, and also
-  // kick off a prefetch.
+  // kick off a preconnect.
   expectClientsCreate(1);
   ActiveTestRequest r2(*this, 1, true);
 
@@ -1496,9 +1496,9 @@ TEST_F(Http2ConnPoolImplTest, PrefetchEvenWhenReady) {
   closeAllClients();
 }
 
-TEST_F(Http2ConnPoolImplTest, PrefetchAfterTimeout) {
+TEST_F(Http2ConnPoolImplTest, PreconnectAfterTimeout) {
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
   expectClientsCreate(2);
   ActiveTestRequest r1(*this, 0, false);
@@ -1506,7 +1506,7 @@ TEST_F(Http2ConnPoolImplTest, PrefetchAfterTimeout) {
   // When the first client connects, r1 will be assigned.
   expectClientConnect(0, r1);
 
-  // Now cause the prefetched connection to fail. We should try to create
+  // Now cause the preconnected connection to fail. We should try to create
   // another in its place.
   expectClientsCreate(1);
   test_clients_[1].connect_timer_->invokeCallback();
@@ -1517,20 +1517,20 @@ TEST_F(Http2ConnPoolImplTest, PrefetchAfterTimeout) {
   closeAllClients();
 }
 
-TEST_F(Http2ConnPoolImplTest, CloseExcessWithPrefetch) {
+TEST_F(Http2ConnPoolImplTest, CloseExcessWithPreconnect) {
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.00));
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.00));
 
-  // First request prefetches an additional connection.
+  // First request preconnects an additional connection.
   expectClientsCreate(1);
   ActiveTestRequest r1(*this, 0, false);
 
-  // Second request does not prefetch.
+  // Second request does not preconnect.
   expectClientsCreate(1);
   ActiveTestRequest r2(*this, 0, false);
 
-  // Change the prefetch ratio to force the connection to no longer be excess.
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(2));
+  // Change the preconnect ratio to force the connection to no longer be excess.
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(2));
   // Closing off the second request should bring us back to 1 request in queue,
   // desired capacity 2, so will not close the connection.
   EXPECT_CALL(*this, onClientDestroy()).Times(0);
@@ -1542,14 +1542,14 @@ TEST_F(Http2ConnPoolImplTest, CloseExcessWithPrefetch) {
   closeAllClients();
 }
 
-// Test that maybePrefetch is passed up to the base class implementation.
-TEST_F(Http2ConnPoolImplTest, MaybePrefetch) {
-  ON_CALL(*cluster_, perUpstreamPrefetchRatio).WillByDefault(Return(1.5));
+// Test that maybePreconnect is passed up to the base class implementation.
+TEST_F(Http2ConnPoolImplTest, MaybePreconnect) {
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
 
-  EXPECT_FALSE(pool_->maybePrefetch(0));
+  EXPECT_FALSE(pool_->maybePreconnect(0));
 
   expectClientsCreate(1);
-  EXPECT_TRUE(pool_->maybePrefetch(2));
+  EXPECT_TRUE(pool_->maybePreconnect(2));
 
   pool_->drainConnections();
   closeAllClients();

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -110,12 +110,12 @@ public:
 
   MOCK_METHOD(void, onConnReleasedForTest, ());
   MOCK_METHOD(void, onConnDestroyedForTest, ());
-  bool maybePrefetch(float ratio) override {
+  bool maybePreconnect(float ratio) override {
     if (!test_new_connection_pool_) {
       return false;
     }
     ASSERT(dynamic_cast<ConnPoolImplForTest*>(conn_pool_.get()) != nullptr);
-    return dynamic_cast<ConnPoolImplForTest*>(conn_pool_.get())->maybePrefetch(ratio);
+    return dynamic_cast<ConnPoolImplForTest*>(conn_pool_.get())->maybePreconnect(ratio);
   }
 
   struct TestConnection {
@@ -1092,16 +1092,16 @@ TEST_P(TcpConnPoolImplTest, RequestCapacity) {
   conn_pool_->test_conns_[2].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
-// Test that maybePrefetch is passed up to the base class implementation.
-TEST_P(TcpConnPoolImplTest, TestPrefetch) {
+// Test that maybePreconnect is passed up to the base class implementation.
+TEST_P(TcpConnPoolImplTest, TestPreconnect) {
   initialize();
   if (!test_new_connection_pool_) {
     return;
   }
-  EXPECT_FALSE(conn_pool_->maybePrefetch(0));
+  EXPECT_FALSE(conn_pool_->maybePreconnect(0));
 
   conn_pool_->expectConnCreate();
-  ASSERT_TRUE(conn_pool_->maybePrefetch(2));
+  ASSERT_TRUE(conn_pool_->maybePreconnect(2));
 
   conn_pool_->test_conns_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
 }

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -4179,7 +4179,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
                 ->httpConnPool(ResourcePriority::Default, Http::Protocol::Http11, &lb_context));
 }
 
-class PrefetchTest : public ClusterManagerImplTest {
+class PreconnectTest : public ClusterManagerImplTest {
 public:
   void initialize(float ratio) {
     const std::string yaml = R"EOF(
@@ -4197,8 +4197,8 @@ public:
     if (ratio != 0) {
       config.mutable_static_resources()
           ->mutable_clusters(0)
-          ->mutable_prefetch_policy()
-          ->mutable_predictive_prefetch_ratio()
+          ->mutable_preconnect_policy()
+          ->mutable_predictive_preconnect_ratio()
           ->set_value(ratio);
     }
     create(config);
@@ -4231,8 +4231,8 @@ public:
   HostSharedPtr host2_;
 };
 
-TEST_F(PrefetchTest, PrefetchOff) {
-  // With prefetch set to 0, each request for a connection pool will only
+TEST_F(PreconnectTest, PreconnectOff) {
+  // With preconnect set to 0, each request for a connection pool will only
   // allocate that conn pool.
   initialize(0);
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _))
@@ -4248,9 +4248,9 @@ TEST_F(PrefetchTest, PrefetchOff) {
       ->tcpConnPool(ResourcePriority::Default, nullptr);
 }
 
-TEST_F(PrefetchTest, PrefetchOn) {
-  // With prefetch set to 1.1, each request for a connection pool will kick off
-  // prefetching, so create the pool for both the current connection and the
+TEST_F(PreconnectTest, PreconnectOn) {
+  // With preconnect set to 1.1, each request for a connection pool will kick off
+  // preconnecting, so create the pool for both the current connection and the
   // anticipated one.
   initialize(1.1);
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _))

--- a/test/common/upstream/least_request_load_balancer_corpus/least_request-high-number-of-hosts
+++ b/test/common/upstream/least_request_load_balancer_corpus/least_request-high-number-of-hosts
@@ -16,12 +16,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/least_request_load_balancer_corpus/least_request-no-config
+++ b/test/common/upstream/least_request_load_balancer_corpus/least_request-no-config
@@ -12,12 +12,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/least_request_load_balancer_corpus/least_request-no-hosts
+++ b/test/common/upstream/least_request_load_balancer_corpus/least_request-no-hosts
@@ -4,7 +4,7 @@ common_lb_config {
 
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/least_request_load_balancer_corpus/least_request-normal
+++ b/test/common/upstream/least_request_load_balancer_corpus/least_request-normal
@@ -12,12 +12,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/least_request_load_balancer_corpus/least_request-with-locality-high-number-of-hosts
+++ b/test/common/upstream/least_request_load_balancer_corpus/least_request-with-locality-high-number-of-hosts
@@ -16,12 +16,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/load_balancer_fuzz.proto
+++ b/test/common/upstream/load_balancer_fuzz.proto
@@ -27,8 +27,8 @@ message LbAction {
     // This updates the health flags of hosts at a certain priority level. The number of hosts in each priority level/in localities is static,
     // as untrusted upstreams cannot change that, and can only change their health flags.
     UpdateHealthFlags update_health_flags = 1;
-    // Prefetches a host using the encapsulated specific load balancer.
-    google.protobuf.Empty prefetch = 2;
+    // Preconnects a host using the encapsulated specific load balancer.
+    google.protobuf.Empty preconnect = 2;
     // Chooses a host using the encapsulated specific load balancer.
     google.protobuf.Empty choose_host = 3;
   }

--- a/test/common/upstream/load_balancer_fuzz_base.cc
+++ b/test/common/upstream/load_balancer_fuzz_base.cc
@@ -214,7 +214,7 @@ void LoadBalancerFuzzBase::updateHealthFlagsForAHostSet(
   host_set.runCallbacks({}, {});
 }
 
-void LoadBalancerFuzzBase::prefetch() {
+void LoadBalancerFuzzBase::preconnect() {
   // TODO: context, could generate it in proto action
   lb_->peekAnotherHost(nullptr);
 }
@@ -239,8 +239,8 @@ void LoadBalancerFuzzBase::replay(
                                    event.update_health_flags().random_bytestring());
       break;
     }
-    case test::common::upstream::LbAction::kPrefetch:
-      prefetch();
+    case test::common::upstream::LbAction::kPreconnect:
+      preconnect();
       break;
     case test::common::upstream::LbAction::kChooseHost:
       chooseHost();

--- a/test/common/upstream/load_balancer_fuzz_base.h
+++ b/test/common/upstream/load_balancer_fuzz_base.h
@@ -33,7 +33,7 @@ public:
   // balancer needs to run its algorithm is already encapsulated within the load balancer. Thus,
   // once the load balancer is constructed, all this class has to do is call lb_->peekAnotherHost()
   // and lb_->chooseHost().
-  void prefetch();
+  void preconnect();
   void chooseHost();
   void replay(const Protobuf::RepeatedPtrField<test::common::upstream::LbAction>& actions);
 

--- a/test/common/upstream/random_load_balancer_corpus/random_256_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_256_ports
@@ -10,12 +10,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_NoHosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_NoHosts
@@ -3,7 +3,7 @@ common_lb_config {
 
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_Normal
+++ b/test/common/upstream/random_load_balancer_corpus/random_Normal
@@ -13,12 +13,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-55abbf82c64b5a62e299b93d7b254045471199c9
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-55abbf82c64b5a62e299b93d7b254045471199c9
@@ -10,12 +10,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_crash-ba5efdfd9c412a8507087120783fe6529b1ac0cb
+++ b/test/common/upstream/random_load_balancer_corpus/random_crash-ba5efdfd9c412a8507087120783fe6529b1ac0cb
@@ -11,11 +11,11 @@ actions {
   }
 }
 actions {
-  prefetch {
+  preconnect {
   }
 }
 actions {
-  prefetch {
+  preconnect {
   }
 }
 actions {

--- a/test/common/upstream/random_load_balancer_corpus/random_largest-port-value
+++ b/test/common/upstream/random_load_balancer_corpus/random_largest-port-value
@@ -7,11 +7,11 @@ actions {
   }
 }
 actions {
-  prefetch {
+  preconnect {
   }
 }
 actions {
-  prefetch {
+  preconnect {
   }
 }
 actions {

--- a/test/common/upstream/random_load_balancer_corpus/random_many_choose_hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_many_choose_hosts
@@ -10,12 +10,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_max_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_max_ports
@@ -13,12 +13,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_overflowing_ports
+++ b/test/common/upstream/random_load_balancer_corpus/random_overflowing_ports
@@ -13,12 +13,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_slow-unit-eed4596101efb3e737f736c8d5bcd4f0815a8728
+++ b/test/common/upstream/random_load_balancer_corpus/random_slow-unit-eed4596101efb3e737f736c8d5bcd4f0815a8728
@@ -14,11 +14,11 @@ load_balancer_test_case {
     }
   }
   actions {
-    prefetch {
+    preconnect {
     }
   }
   actions {
-    prefetch {
+    preconnect {
     }
   }
   actions {

--- a/test/common/upstream/random_load_balancer_corpus/random_slow-unit-test
+++ b/test/common/upstream/random_load_balancer_corpus/random_slow-unit-test
@@ -14,11 +14,11 @@ load_balancer_test_case {
     }
   }
   actions {
-    prefetch {
+    preconnect {
     }
   }
   actions {
-    prefetch {
+    preconnect {
     }
   }
   actions {

--- a/test/common/upstream/random_load_balancer_corpus/random_test_something
+++ b/test/common/upstream/random_load_balancer_corpus/random_test_something
@@ -13,12 +13,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with-locality
+++ b/test/common/upstream/random_load_balancer_corpus/random_with-locality
@@ -15,12 +15,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with-locality-high-number-of-hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_with-locality-high-number-of-hosts
@@ -15,12 +15,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/random_load_balancer_corpus/random_with_locality-50000-hosts
+++ b/test/common/upstream/random_load_balancer_corpus/random_with_locality-50000-hosts
@@ -15,12 +15,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/round_robin_load_balancer_corpus/round_robin-high-number-of-hosts
+++ b/test/common/upstream/round_robin_load_balancer_corpus/round_robin-high-number-of-hosts
@@ -16,12 +16,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/round_robin_load_balancer_corpus/round_robin-with-locality-high-number-of-hosts
+++ b/test/common/upstream/round_robin_load_balancer_corpus/round_robin-with-locality-high-number-of-hosts
@@ -16,12 +16,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/round_robin_load_balancer_corpus/round_robin_local_priority
+++ b/test/common/upstream/round_robin_load_balancer_corpus/round_robin_local_priority
@@ -12,12 +12,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/round_robin_load_balancer_corpus/round_robin_local_priority_update_hosts
+++ b/test/common/upstream/round_robin_load_balancer_corpus/round_robin_local_priority_update_hosts
@@ -12,12 +12,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/round_robin_load_balancer_corpus/round_robin_no_hosts
+++ b/test/common/upstream/round_robin_load_balancer_corpus/round_robin_no_hosts
@@ -4,7 +4,7 @@ common_lb_config {
 
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/common/upstream/round_robin_load_balancer_corpus/round_robin_normal
+++ b/test/common/upstream/round_robin_load_balancer_corpus/round_robin_normal
@@ -11,12 +11,12 @@ actions {
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }
 actions {
-    prefetch {
+    preconnect {
 
     }
 }

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1993,10 +1993,10 @@ TEST_P(ProtocolIntegrationTest, ConnDurationTimeoutNoHttpRequest) {
   test_server_->waitForCounterGe("http.config_test.downstream_cx_max_duration_reached", 1);
 }
 
-TEST_P(DownstreamProtocolIntegrationTest, TestPrefetch) {
+TEST_P(DownstreamProtocolIntegrationTest, TestPreconnect) {
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
-    cluster->mutable_prefetch_policy()->mutable_per_upstream_prefetch_ratio()->set_value(1.5);
+    cluster->mutable_preconnect_policy()->mutable_per_upstream_preconnect_ratio()->set_value(1.5);
   });
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -2004,7 +2004,7 @@ TEST_P(DownstreamProtocolIntegrationTest, TestPrefetch) {
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
   FakeHttpConnectionPtr fake_upstream_connection_two;
   if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
-    // For HTTP/1.1 there should be a prefetched connection.
+    // For HTTP/1.1 there should be a preconnected connection.
     ASSERT_TRUE(
         fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_two));
   } else {

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -266,7 +266,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSize) {
   // 2020/07/31  12035    37114       38000   Init manager store unready targets in hash map.
   // 2020/08/10  12275    37061       38000   Re-organize tls histogram maps to improve continuity.
   // 2020/08/11  12202    37061       38500   router: add new retry back-off strategy
-  // 2020/09/11  12973                38993   upstream: predictive prefetch
+  // 2020/09/11  12973                38993   upstream: predictive preconnect
   // 2020/10/02  13251                39326   switch to google tcmalloc
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -24,7 +24,7 @@ public:
   MOCK_METHOD(void, drainConnections, ());
   MOCK_METHOD(bool, hasActiveConnections, (), (const));
   MOCK_METHOD(Cancellable*, newStream, (ResponseDecoder & response_decoder, Callbacks& callbacks));
-  MOCK_METHOD(bool, maybePrefetch, (float));
+  MOCK_METHOD(bool, maybePreconnect, (float));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_;

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -55,7 +55,7 @@ public:
   MOCK_METHOD(void, drainConnections, ());
   MOCK_METHOD(void, closeConnections, ());
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
-  MOCK_METHOD(bool, maybePrefetch, (float), ());
+  MOCK_METHOD(bool, maybePreconnect, (float), ());
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
 
   Envoy::ConnectionPool::MockCancellable* newConnectionImpl(Callbacks& cb);

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -62,7 +62,7 @@ MockClusterInfo::MockClusterInfo()
           circuit_breakers_stats_, absl::nullopt, absl::nullopt)) {
   ON_CALL(*this, connectTimeout()).WillByDefault(Return(std::chrono::milliseconds(1)));
   ON_CALL(*this, idleTimeout()).WillByDefault(Return(absl::optional<std::chrono::milliseconds>()));
-  ON_CALL(*this, perUpstreamPrefetchRatio()).WillByDefault(Return(1.0));
+  ON_CALL(*this, perUpstreamPreconnectRatio()).WillByDefault(Return(1.0));
   ON_CALL(*this, name()).WillByDefault(ReturnRef(name_));
   ON_CALL(*this, edsServiceName()).WillByDefault(ReturnPointee(&eds_service_name_));
   ON_CALL(*this, http1Settings()).WillByDefault(ReturnRef(http1_settings_));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -93,7 +93,7 @@ public:
   MOCK_METHOD(const absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderMax, (), (const));
   MOCK_METHOD(const absl::optional<std::chrono::milliseconds>, grpcTimeoutHeaderOffset, (),
               (const));
-  MOCK_METHOD(float, perUpstreamPrefetchRatio, (), (const));
+  MOCK_METHOD(float, perUpstreamPreconnectRatio, (), (const));
   MOCK_METHOD(float, peekaheadRatio, (), (const));
   MOCK_METHOD(uint32_t, perConnectionBufferLimitBytes, (), (const));
   MOCK_METHOD(uint64_t, features, (), (const));

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -30,6 +30,7 @@ DSR
 HEXDIG
 HEXDIGIT
 OWS
+Preconnecting
 STATNAME
 SkyWalking
 TIDs
@@ -897,6 +898,10 @@ precompile
 precompiled
 precompute
 precomputed
+preconnect
+preconnected
+preconnecting
+preconnects
 predeclared
 prefetch
 prefetched


### PR DESCRIPTION
Splitting the rename out of https://github.com/envoyproxy/envoy/pull/14143

Risk Level: low (renaming hidden config, and API functions)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
