### PR TITLE
http: add support for skipping any port from host header

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -35,7 +35,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -552,6 +552,14 @@ message HttpConnectionManager {
   // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
   bool strip_matching_host_port = 39;
+
+  // Determines if the port part should be removed from host/authority header before any processing
+  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+  // This affects the upstream host header as well.
+  // Without setting this option, incoming requests with host `example:443` will not match against
+  // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+  bool strip_any_host_port = 42;
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -555,14 +555,14 @@ message HttpConnectionManager {
   bool strip_matching_host_port = 39
       [(udpa.annotations.field_migrate).oneof_promotion = "strip_port_mode"];
 
-  // Determines if the port part should be removed from host/authority header before any processing
-  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
-  // This affects the upstream host header as well.
-  // Without setting this option, incoming requests with host `example:443` will not match against
-  // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
-  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
   oneof strip_port_mode {
+    // Determines if the port part should be removed from host/authority header before any processing
+    // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+    // This affects the upstream host header as well.
+    // Without setting this option, incoming requests with host `example:443` will not match against
+    // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+    // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+    // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
     bool strip_any_host_port = 42;
   }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -551,7 +551,9 @@ message HttpConnectionManager {
   // Without setting this option, incoming requests with host `example:443` will not match against
   // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_matching_host_port = 39;
+  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+  bool strip_matching_host_port = 39
+      [(udpa.annotations.field_migrate).oneof_promotion = "strip_port_mode"];
 
   // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
@@ -559,7 +561,10 @@ message HttpConnectionManager {
   // Without setting this option, incoming requests with host `example:443` will not match against
   // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_any_host_port = 42;
+  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+  oneof strip_port_mode {
+    bool strip_any_host_port = 42;
+  }
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -545,20 +545,24 @@ message HttpConnectionManager {
   LocalReplyConfig local_reply_config = 38;
 
   // Determines if the port part should be removed from host/authority header before any processing
-  // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
-  // local port and request method is not CONNECT. This affects the upstream host header as well.
-  // Without setting this option, incoming requests with host `example:443` will not match against
-  // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
-  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_matching_host_port = 39;
-
-  // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
   // This affects the upstream host header as well.
   // Without setting this option, incoming requests with host `example:443` will not match against
   // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_any_host_port = 42;
+  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+  oneof strip_port_mode {
+    // Determines if the port part should be removed from host/authority header before any processing
+    // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
+    // local port and request method is not CONNECT. This affects the upstream host header as well.
+    // Without setting this option, incoming requests with host `example:443` will not match against
+    // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+    // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+    // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+    bool strip_matching_host_port = 39;
+
+    bool strip_any_host_port = 42;
+  }
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -544,13 +544,6 @@ message HttpConnectionManager {
   // coded in Envoy, the response content type is plain text.
   LocalReplyConfig local_reply_config = 38;
 
-  // Determines if the port part should be removed from host/authority header before any processing
-  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
-  // This affects the upstream host header as well.
-  // Without setting this option, incoming requests with host `example:443` will not match against
-  // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
-  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
   oneof strip_port_mode {
     // Determines if the port part should be removed from host/authority header before any processing
     // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
@@ -561,6 +554,13 @@ message HttpConnectionManager {
     // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
     bool strip_matching_host_port = 39;
 
+    // Determines if the port part should be removed from host/authority header before any processing
+    // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+    // This affects the upstream host header as well.
+    // Without setting this option, incoming requests with host `example:443` will not match against
+    // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+    // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+    // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
     bool strip_any_host_port = 42;
   }
 

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -34,7 +34,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager";
@@ -551,6 +551,14 @@ message HttpConnectionManager {
   // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
   bool strip_matching_host_port = 39;
+
+  // Determines if the port part should be removed from host/authority header before any processing
+  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+  // This affects the upstream host header as well.
+  // Without setting this option, incoming requests with host `example:443` will not match against
+  // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+  bool strip_any_host_port = 42;
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -73,6 +73,7 @@ New Features
 * health_check: added option to use :ref:`no_traffic_healthy_interval <envoy_v3_api_field_config.core.v3.HealthCheck.no_traffic_healthy_interval>` which allows a different no traffic interval when the host is healthy.
 * http: added HCM :ref:`timeout config field <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.request_headers_timeout>` to control how long a downstream has to finish sending headers before the stream is cancelled.
 * http: added frame flood and abuse checks to the upstream HTTP/2 codec. This check is off by default and can be enabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to true.
+* http: added :ref:`stripping any port from host header <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.strip_any_host_port>` support.
 * http: clusters now support selecting HTTP/1 or HTTP/2 based on ALPN, configurable via :ref:`alpn_config <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.auto_config>` in the :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` message.
 * jwt_authn: added support for :ref:`per-route config <envoy_v3_api_msg_extensions.filters.http.jwt_authn.v3.PerRouteConfig>`.
 * kill_request: added new :ref:`HTTP kill request filter <config_http_filters_kill_request>`.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -557,14 +557,14 @@ message HttpConnectionManager {
   bool strip_matching_host_port = 39
       [(udpa.annotations.field_migrate).oneof_promotion = "strip_port_mode"];
 
-  // Determines if the port part should be removed from host/authority header before any processing
-  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
-  // This affects the upstream host header as well.
-  // Without setting this option, incoming requests with host `example:443` will not match against
-  // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
-  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
   oneof strip_port_mode {
+    // Determines if the port part should be removed from host/authority header before any processing
+    // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+    // This affects the upstream host header as well.
+    // Without setting this option, incoming requests with host `example:443` will not match against
+    // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+    // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+    // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
     bool strip_any_host_port = 42;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -35,7 +35,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -554,6 +554,14 @@ message HttpConnectionManager {
   // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
   bool strip_matching_host_port = 39;
+
+  // Determines if the port part should be removed from host/authority header before any processing
+  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+  // This affects the upstream host header as well.
+  // Without setting this option, incoming requests with host `example:443` will not match against
+  // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+  bool strip_any_host_port = 42;
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -553,7 +553,9 @@ message HttpConnectionManager {
   // Without setting this option, incoming requests with host `example:443` will not match against
   // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_matching_host_port = 39;
+  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+  bool strip_matching_host_port = 39
+      [(udpa.annotations.field_migrate).oneof_promotion = "strip_port_mode"];
 
   // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
@@ -561,7 +563,10 @@ message HttpConnectionManager {
   // Without setting this option, incoming requests with host `example:443` will not match against
   // route with :ref:`domains<envoy_api_field_config.route.v3.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_any_host_port = 42;
+  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+  oneof strip_port_mode {
+    bool strip_any_host_port = 42;
+  }
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -545,20 +545,24 @@ message HttpConnectionManager {
   LocalReplyConfig local_reply_config = 38;
 
   // Determines if the port part should be removed from host/authority header before any processing
-  // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
-  // local port and request method is not CONNECT. This affects the upstream host header as well.
-  // Without setting this option, incoming requests with host `example:443` will not match against
-  // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
-  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_matching_host_port = 39;
-
-  // Determines if the port part should be removed from host/authority header before any processing
   // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
   // This affects the upstream host header as well.
   // Without setting this option, incoming requests with host `example:443` will not match against
   // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  bool strip_any_host_port = 42;
+  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+  oneof strip_port_mode {
+    // Determines if the port part should be removed from host/authority header before any processing
+    // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
+    // local port and request method is not CONNECT. This affects the upstream host header as well.
+    // Without setting this option, incoming requests with host `example:443` will not match against
+    // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+    // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+    // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
+    bool strip_matching_host_port = 39;
+
+    bool strip_any_host_port = 42;
+  }
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -544,13 +544,6 @@ message HttpConnectionManager {
   // coded in Envoy, the response content type is plain text.
   LocalReplyConfig local_reply_config = 38;
 
-  // Determines if the port part should be removed from host/authority header before any processing
-  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
-  // This affects the upstream host header as well.
-  // Without setting this option, incoming requests with host `example:443` will not match against
-  // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
-  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
-  // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
   oneof strip_port_mode {
     // Determines if the port part should be removed from host/authority header before any processing
     // of request by HTTP filters or routing. The port would be removed only if it is equal to the :ref:`listener's<envoy_api_field_config.listener.v4alpha.Listener.address>`
@@ -561,6 +554,13 @@ message HttpConnectionManager {
     // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
     bool strip_matching_host_port = 39;
 
+    // Determines if the port part should be removed from host/authority header before any processing
+    // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+    // This affects the upstream host header as well.
+    // Without setting this option, incoming requests with host `example:443` will not match against
+    // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+    // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+    // Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.
     bool strip_any_host_port = 42;
   }
 

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -34,7 +34,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager";
@@ -551,6 +551,14 @@ message HttpConnectionManager {
   // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
   // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
   bool strip_matching_host_port = 39;
+
+  // Determines if the port part should be removed from host/authority header before any processing
+  // of request by HTTP filters or routing. The port would be removed only if request method is not CONNECT.
+  // This affects the upstream host header as well.
+  // Without setting this option, incoming requests with host `example:443` will not match against
+  // route with :ref:`domains<envoy_api_field_config.route.v4alpha.VirtualHost.domains>` match set to `example`. Defaults to `false`. Note that port removal is not part
+  // of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
+  bool strip_any_host_port = 42;
 
   // Governs Envoy's behavior when receiving invalid HTTP from downstream.
   // If this option is false (default), Envoy will err on the conservative side handling HTTP

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -168,6 +168,11 @@ enum class ForwardClientCertType {
 enum class ClientCertDetailsType { Cert, Chain, Subject, URI, DNS };
 
 /**
+ * Type that indicates how port should be stripped from Host header.
+ */
+enum class StripPortType { MatchingHost, Any, None };
+
+/**
  * Configuration for what addresses should be considered internal beyond the defaults.
  */
 class InternalAddressConfig {
@@ -439,14 +444,9 @@ public:
   virtual bool shouldMergeSlashes() const PURE;
 
   /**
-   * @return if the HttpConnectionManager should remove the matching port from host/authority header
+   * @return port strip type from host/authority header.
    */
-  virtual bool shouldStripMatchingPort() const PURE;
-
-  /**
-   * @return if the HttpConnectionManager should remove the port from host/authority header
-   */
-  virtual bool shouldStripAnyPort() const PURE;
+  virtual StripPortType stripPortType() const PURE;
 
   /**
    * @return the action HttpConnectionManager should take when receiving client request

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -439,9 +439,14 @@ public:
   virtual bool shouldMergeSlashes() const PURE;
 
   /**
-   * @return if the HttpConnectionManager should remove the port from host/authority header
+   * @return if the HttpConnectionManager should remove the matching port from host/authority header
    */
   virtual bool shouldStripMatchingPort() const PURE;
+
+  /**
+   * @return if the HttpConnectionManager should remove the port from host/authority header
+   */
+  virtual bool shouldStripAnyPort() const PURE;
 
   /**
    * @return the action HttpConnectionManager should take when receiving client request

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -169,11 +169,15 @@ enum class ClientCertDetailsType { Cert, Chain, Subject, URI, DNS };
 
 /**
  * Type that indicates how port should be stripped from Host header.
- * MatchingHost will remove the port from host/authority header only if the port matches with the
- * listener port. Any will just remove the port from host/authority header. None will keep the port
- * in host/authority header as is.
  */
-enum class StripPortType { MatchingHost, Any, None };
+enum class StripPortType {
+  // Removes the port from host/authority header only if the port matches with the listener port.
+  MatchingHost,
+  // Removes any port from host/authority header.
+  Any,
+  // Keeps the port in host/authority header as is.
+  None
+};
 
 /**
  * Configuration for what addresses should be considered internal beyond the defaults.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -169,6 +169,9 @@ enum class ClientCertDetailsType { Cert, Chain, Subject, URI, DNS };
 
 /**
  * Type that indicates how port should be stripped from Host header.
+ * MatchingHost will remove the port from host/authority header only if the port matches with the
+ * listener port. Any will just remove the port from host/authority header. None will keep the port
+ * in host/authority header as is.
  */
 enum class StripPortType { MatchingHost, Any, None };
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -4,11 +4,11 @@
 #include <cstdint>
 #include <string>
 
-#include "common/http/conn_manager_config.h"
 #include "envoy/type/v3/percent.pb.h"
 
 #include "common/common/empty_string.h"
 #include "common/common/utility.h"
+#include "common/http/conn_manager_config.h"
 #include "common/http/header_utility.h"
 #include "common/http/headers.h"
 #include "common/http/http1/codec_impl.h"

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -427,6 +427,10 @@ bool ConnectionManagerUtility::maybeNormalizePath(RequestHeaderMap& request_head
 void ConnectionManagerUtility::maybeNormalizeHost(RequestHeaderMap& request_headers,
                                                   const ConnectionManagerConfig& config,
                                                   uint32_t port) {
+  if (config.shouldStripAnyPort()) {
+    HeaderUtility::stripPortFromHost(request_headers, 0);
+    return;
+  }
   if (config.shouldStripMatchingPort()) {
     HeaderUtility::stripPortFromHost(request_headers, port);
   }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <string>
 
+#include "common/http/conn_manager_config.h"
 #include "envoy/type/v3/percent.pb.h"
 
 #include "common/common/empty_string.h"
@@ -427,11 +428,9 @@ bool ConnectionManagerUtility::maybeNormalizePath(RequestHeaderMap& request_head
 void ConnectionManagerUtility::maybeNormalizeHost(RequestHeaderMap& request_headers,
                                                   const ConnectionManagerConfig& config,
                                                   uint32_t port) {
-  if (config.shouldStripAnyPort()) {
+  if (config.stripPortType() == Http::StripPortType::Any) {
     HeaderUtility::stripPortFromHost(request_headers, 0);
-    return;
-  }
-  if (config.shouldStripMatchingPort()) {
+  } else if (config.stripPortType() == Http::StripPortType::MatchingHost) {
     HeaderUtility::stripPortFromHost(request_headers, port);
   }
 }

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -429,7 +429,7 @@ void ConnectionManagerUtility::maybeNormalizeHost(RequestHeaderMap& request_head
                                                   const ConnectionManagerConfig& config,
                                                   uint32_t port) {
   if (config.stripPortType() == Http::StripPortType::Any) {
-    HeaderUtility::stripPortFromHost(request_headers, 0);
+    HeaderUtility::stripPortFromHost(request_headers, absl::nullopt);
   } else if (config.stripPortType() == Http::StripPortType::MatchingHost) {
     HeaderUtility::stripPortFromHost(request_headers, port);
   }

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -239,8 +239,9 @@ void HeaderUtility::stripPortFromHost(RequestHeaderMap& headers, uint32_t listen
     if (!absl::SimpleAtoi(port_str, &port)) {
       return;
     }
-    if (port != listener_port) {
-      // We would strip ports only if they are the same, as local port of the listener.
+    if (listener_port != 0 && port != listener_port) {
+      // We would strip ports only if they are the same, as local port of the listener or it is
+      // zero.
       return;
     }
     const absl::string_view host = original_host.substr(0, port_start);

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -216,7 +216,8 @@ bool HeaderUtility::isEnvoyInternalRequest(const RequestHeaderMap& headers) {
          internal_request_header->value() == Headers::get().EnvoyInternalRequestValues.True;
 }
 
-void HeaderUtility::stripPortFromHost(RequestHeaderMap& headers, uint32_t listener_port) {
+void HeaderUtility::stripPortFromHost(RequestHeaderMap& headers,
+                                      absl::optional<uint32_t> listener_port) {
 
   if (headers.getMethodValue() == Http::Headers::get().MethodValues.Connect) {
     // According to RFC 2817 Connect method should have port part in host header.
@@ -239,9 +240,9 @@ void HeaderUtility::stripPortFromHost(RequestHeaderMap& headers, uint32_t listen
     if (!absl::SimpleAtoi(port_str, &port)) {
       return;
     }
-    if (listener_port != 0 && port != listener_port) {
-      // We would strip ports only if they are the same, as local port of the listener or it is
-      // zero.
+    if (listener_port.has_value() && port != listener_port) {
+      // We would strip ports only if it is specified and they are the same, as local port of the
+      // listener.
       return;
     }
     const absl::string_view host = original_host.substr(0, port_start);

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -177,7 +177,7 @@ public:
    * @brief Remove the port part from host/authority header if it is equal to provided port or
    * provided port is 0.
    */
-  static void stripPortFromHost(RequestHeaderMap& headers, uint32_t listener_port);
+  static void stripPortFromHost(RequestHeaderMap& headers, absl::optional<uint32_t> listener_port);
 
   /* Does a common header check ensuring required headers are present.
    * Required request headers include :method header, :path for non-CONNECT requests, and

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -174,8 +174,8 @@ public:
                                     const RequestOrResponseHeaderMap& headers);
 
   /**
-   * @brief Remove the port part from host/authority header if it is equal to provided port or
-   * provided port is 0.
+   * @brief Remove the port part from host/authority header if it is equal to provided port.
+   * If port is not passed, port part from host/authority header is removed.
    */
   static void stripPortFromHost(RequestHeaderMap& headers, absl::optional<uint32_t> listener_port);
 

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -174,7 +174,8 @@ public:
                                     const RequestOrResponseHeaderMap& headers);
 
   /**
-   * @brief Remove the port part from host/authority header if it is equal to provided port
+   * @brief Remove the port part from host/authority header if it is equal to provided port or
+   * provided port is 0.
    */
   static void stripPortFromHost(RequestHeaderMap& headers, uint32_t listener_port);
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -249,6 +249,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
 #endif
       merge_slashes_(config.merge_slashes()),
       strip_matching_port_(config.strip_matching_host_port()),
+      strip_any_port_(config.strip_any_host_port()),
       headers_with_underscores_action_(
           config.common_http_protocol_options().headers_with_underscores_action()),
       local_reply_(LocalReply::Factory::create(config.local_reply_config(), context)) {

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -264,6 +264,11 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     idle_timeout_ = absl::nullopt;
   }
 
+  if (config.strip_any_host_port() && config.strip_matching_host_port()) {
+    throw EnvoyException(fmt::format(
+        "Error: Only one of `strip_matching_host_port` or `strip_any_host_port` can be set."));
+  }
+
   if (config.strip_any_host_port()) {
     strip_port_type_ = Http::StripPortType::Any;
   } else if (config.strip_matching_host_port()) {

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -5,7 +5,6 @@
 #include <string>
 #include <vector>
 
-#include "common/http/conn_manager_config.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.validate.h"
@@ -20,6 +19,7 @@
 #include "common/common/fmt.h"
 #include "common/config/utility.h"
 #include "common/filter/http/filter_config_discovery_impl.h"
+#include "common/http/conn_manager_config.h"
 #include "common/http/conn_manager_utility.h"
 #include "common/http/default_server_string.h"
 #include "common/http/http1/codec_impl.h"
@@ -272,13 +272,12 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     strip_port_type_ = Http::StripPortType::None;
   }
 
-      // If we are provided a different request_id_extension implementation to use try and create a
-      // new instance of it, otherwise use default one.
-      if (config.request_id_extension().has_typed_config()) {
+  // If we are provided a different request_id_extension implementation to use try and create a
+  // new instance of it, otherwise use default one.
+  if (config.request_id_extension().has_typed_config()) {
     request_id_extension_ =
         Http::RequestIDExtensionFactory::fromProto(config.request_id_extension(), context_);
-  }
-  else {
+  } else {
     request_id_extension_ =
         Http::RequestIDExtensionFactory::defaultInstance(context_.api().randomGenerator());
   }

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -7,7 +7,6 @@
 #include <map>
 #include <string>
 
-#include "common/http/conn_manager_config.h"
 #include "envoy/config/config_provider_manager.h"
 #include "envoy/config/core/v3/extension.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
@@ -19,6 +18,7 @@
 #include "envoy/tracing/http_tracer_manager.h"
 
 #include "common/common/logger.h"
+#include "common/http/conn_manager_config.h"
 #include "common/http/conn_manager_impl.h"
 #include "common/http/date_provider_impl.h"
 #include "common/http/http1/codec_stats.h"

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -170,6 +170,7 @@ public:
   bool shouldNormalizePath() const override { return normalize_path_; }
   bool shouldMergeSlashes() const override { return merge_slashes_; }
   bool shouldStripMatchingPort() const override { return strip_matching_port_; }
+  bool shouldStripAnyPort() const override { return strip_any_port_; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
     return headers_with_underscores_action_;
@@ -251,6 +252,7 @@ private:
   const bool normalize_path_;
   const bool merge_slashes_;
   const bool strip_matching_port_;
+  const bool strip_any_port_;
   const envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_;
   const LocalReply::LocalReplyPtr local_reply_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 
+#include "common/http/conn_manager_config.h"
 #include "envoy/config/config_provider_manager.h"
 #include "envoy/config/core/v3/extension.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
@@ -169,8 +170,7 @@ public:
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return normalize_path_; }
   bool shouldMergeSlashes() const override { return merge_slashes_; }
-  bool shouldStripMatchingPort() const override { return strip_matching_port_; }
-  bool shouldStripAnyPort() const override { return strip_any_port_; }
+  Http::StripPortType stripPortType() const override { return strip_port_type_; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
     return headers_with_underscores_action_;
@@ -251,8 +251,7 @@ private:
   std::chrono::milliseconds delayed_close_timeout_;
   const bool normalize_path_;
   const bool merge_slashes_;
-  const bool strip_matching_port_;
-  const bool strip_any_port_;
+  Http::StripPortType strip_port_type_;
   const envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_;
   const LocalReply::LocalReplyPtr local_reply_;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -7,7 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include "common/http/conn_manager_config.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/request_id_extension.h"
 #include "envoy/network/filter.h"
@@ -24,6 +23,7 @@
 #include "common/common/empty_string.h"
 #include "common/common/logger.h"
 #include "common/common/macros.h"
+#include "common/http/conn_manager_config.h"
 #include "common/http/conn_manager_impl.h"
 #include "common/http/date_provider_impl.h"
 #include "common/http/default_server_string.h"

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/http/conn_manager_config.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/request_id_extension.h"
 #include "envoy/network/filter.h"
@@ -173,8 +174,7 @@ public:
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return true; }
   bool shouldMergeSlashes() const override { return true; }
-  bool shouldStripMatchingPort() const override { return false; }
-  bool shouldStripAnyPort() const override { return false; }
+  Http::StripPortType stripPortType() const override { return Http::StripPortType::None; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
     return envoy::config::core::v3::HttpProtocolOptions::ALLOW;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -174,6 +174,7 @@ public:
   bool shouldNormalizePath() const override { return true; }
   bool shouldMergeSlashes() const override { return true; }
   bool shouldStripMatchingPort() const override { return false; }
+  bool shouldStripAnyPort() const override { return false; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
     return envoy::config::core::v3::HttpProtocolOptions::ALLOW;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -201,6 +201,7 @@ public:
   bool shouldNormalizePath() const override { return false; }
   bool shouldMergeSlashes() const override { return false; }
   bool shouldStripMatchingPort() const override { return false; }
+  bool shouldStripAnyPort() const override { return false; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
     return envoy::config::core::v3::HttpProtocolOptions::ALLOW;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -200,8 +200,7 @@ public:
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return false; }
   bool shouldMergeSlashes() const override { return false; }
-  bool shouldStripMatchingPort() const override { return false; }
-  bool shouldStripAnyPort() const override { return false; }
+  Http::StripPortType stripPortType() const override { return Http::StripPortType::None; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
     return envoy::config::core::v3::HttpProtocolOptions::ALLOW;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -723,7 +723,7 @@ TEST_F(HttpConnectionManagerImplTest, RouteOverride) {
 TEST_F(HttpConnectionManagerImplTest, FilterShouldUseNormalizedHost) {
   setup(false, "");
   // Enable port removal
-  strip_matching_port_ = true;
+  strip_port_type_ = Http::StripPortType::MatchingHost;
   const std::string original_host = "host:443";
   const std::string normalized_host = "host";
 
@@ -765,7 +765,7 @@ TEST_F(HttpConnectionManagerImplTest, FilterShouldUseNormalizedHost) {
 TEST_F(HttpConnectionManagerImplTest, RouteShouldUseNormalizedHost) {
   setup(false, "");
   // Enable port removal
-  strip_matching_port_ = true;
+  strip_port_type_ = Http::StripPortType::MatchingHost;
   const std::string original_host = "host:443";
   const std::string normalized_host = "host";
 

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -133,8 +133,7 @@ public:
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return normalize_path_; }
   bool shouldMergeSlashes() const override { return merge_slashes_; }
-  bool shouldStripMatchingPort() const override { return strip_matching_port_; }
-  bool shouldStripAnyPort() const override { return strip_any_port_; }
+  Http::StripPortType stripPortType() const override { return Http::StripPortType::None; }
   RequestIDExtensionSharedPtr requestIDExtension() override { return request_id_extension_; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
@@ -200,8 +199,6 @@ public:
   Http::Http1Settings http1_settings_;
   bool normalize_path_ = false;
   bool merge_slashes_ = false;
-  bool strip_matching_port_ = false;
-  bool strip_any_port_ = false;
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_ = envoy::config::core::v3::HttpProtocolOptions::ALLOW;
   NiceMock<Network::MockClientConnection> upstream_conn_; // for websocket tests

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -134,6 +134,7 @@ public:
   bool shouldNormalizePath() const override { return normalize_path_; }
   bool shouldMergeSlashes() const override { return merge_slashes_; }
   bool shouldStripMatchingPort() const override { return strip_matching_port_; }
+  bool shouldStripAnyPort() const override { return strip_any_port_; }
   RequestIDExtensionSharedPtr requestIDExtension() override { return request_id_extension_; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
@@ -200,6 +201,7 @@ public:
   bool normalize_path_ = false;
   bool merge_slashes_ = false;
   bool strip_matching_port_ = false;
+  bool strip_any_port_ = false;
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_ = envoy::config::core::v3::HttpProtocolOptions::ALLOW;
   NiceMock<Network::MockClientConnection> upstream_conn_; // for websocket tests

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -133,7 +133,7 @@ public:
   const Http::Http1Settings& http1Settings() const override { return http1_settings_; }
   bool shouldNormalizePath() const override { return normalize_path_; }
   bool shouldMergeSlashes() const override { return merge_slashes_; }
-  Http::StripPortType stripPortType() const override { return Http::StripPortType::None; }
+  Http::StripPortType stripPortType() const override { return strip_port_type_; }
   RequestIDExtensionSharedPtr requestIDExtension() override { return request_id_extension_; }
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
   headersWithUnderscoresAction() const override {
@@ -199,6 +199,7 @@ public:
   Http::Http1Settings http1_settings_;
   bool normalize_path_ = false;
   bool merge_slashes_ = false;
+  Http::StripPortType strip_port_type_ = Http::StripPortType::None;
   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
       headers_with_underscores_action_ = envoy::config::core::v3::HttpProtocolOptions::ALLOW;
   NiceMock<Network::MockClientConnection> upstream_conn_; // for websocket tests

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -1427,7 +1427,7 @@ TEST_F(ConnectionManagerUtilityTest, MergeSlashesWithoutNormalization) {
 
 // maybeNormalizeHost() removes port part from host header.
 TEST_F(ConnectionManagerUtilityTest, RemovePort) {
-  ON_CALL(config_, shouldStripMatchingPort()).WillByDefault(Return(true));
+  ON_CALL(config_, stripPortType()).WillByDefault(Return(Http::StripPortType::MatchingHost));
   TestRequestHeaderMapImpl original_headers;
   original_headers.setHost("host:443");
 
@@ -1435,13 +1435,21 @@ TEST_F(ConnectionManagerUtilityTest, RemovePort) {
   ConnectionManagerUtility::maybeNormalizeHost(header_map, config_, 443);
   EXPECT_EQ(header_map.getHostValue(), "host");
 
-  ON_CALL(config_, shouldStripAnyPort()).WillByDefault(Return(true));
+  ON_CALL(config_, stripPortType()).WillByDefault(Return(Http::StripPortType::Any));
   TestRequestHeaderMapImpl original_headers_any;
   original_headers_any.setHost("host:9999");
 
   TestRequestHeaderMapImpl header_map_any(original_headers_any);
   ConnectionManagerUtility::maybeNormalizeHost(header_map_any, config_, 7777);
   EXPECT_EQ(header_map_any.getHostValue(), "host");
+
+  ON_CALL(config_, stripPortType()).WillByDefault(Return(Http::StripPortType::None));
+  TestRequestHeaderMapImpl original_headers_none;
+  original_headers_none.setHost("host:9999");
+
+  TestRequestHeaderMapImpl header_map_none(original_headers_none);
+  ConnectionManagerUtility::maybeNormalizeHost(header_map_none, config_, 0);
+  EXPECT_EQ(header_map_none.getHostValue(), "host:9999");
 }
 
 // test preserve_external_request_id true does not reset the passed requestId if passed

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -1434,6 +1434,14 @@ TEST_F(ConnectionManagerUtilityTest, RemovePort) {
   TestRequestHeaderMapImpl header_map(original_headers);
   ConnectionManagerUtility::maybeNormalizeHost(header_map, config_, 443);
   EXPECT_EQ(header_map.getHostValue(), "host");
+
+  ON_CALL(config_, shouldStripAnyPort()).WillByDefault(Return(true));
+  TestRequestHeaderMapImpl original_headers_any;
+  original_headers_any.setHost("host:9999");
+
+  TestRequestHeaderMapImpl header_map_any(original_headers_any);
+  ConnectionManagerUtility::maybeNormalizeHost(header_map_any, config_, 7777);
+  EXPECT_EQ(header_map_any.getHostValue(), "host");
 }
 
 // test preserve_external_request_id true does not reset the passed requestId if passed

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -64,7 +64,7 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHost) {
   }
   for (const auto& host_pair : any_host_headers) {
     auto& host_header = hostHeaderEntry(host_pair.first);
-    HeaderUtility::stripPortFromHost(headers_, 0);
+    HeaderUtility::stripPortFromHost(headers_, absl::nullopt);
     EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
   }
 }

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -53,7 +53,7 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHost) {
       {"[fc00::1]:80", "[fc00::1]:80"}      // port not matching w/ ipv6
   };
 
-    const std::vector<std::pair<std::string, std::string>> any_host_headers{
+  const std::vector<std::pair<std::string, std::string>> any_host_headers{
       {"localhost:9999", "localhost"},       // name any port
   };
 

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -55,7 +55,7 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHost) {
 
   for (const auto& host_pair : host_headers) {
     auto& host_header = hostHeaderEntry(host_pair.first);
-    HeaderUtility::stripPortFromHost(headers_, 443);
+    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::MatchingHost, 443);
     EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
   }
 }
@@ -67,7 +67,31 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHostConnect) {
   };
   for (const auto& host_pair : host_headers) {
     auto& host_header = hostHeaderEntry(host_pair.first, true);
-    HeaderUtility::stripPortFromHost(headers_, 443);
+    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::MatchingHost, 443);
+    EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
+  }
+}
+
+// Port's part from host header won't be removed if StripPortType is None
+TEST_F(HeaderUtilityTest, RemovePortsFromHostNoneStripType) {
+  const std::vector<std::pair<std::string, std::string>> host_headers{
+      {"localhost:443", "localhost:443"},
+  };
+  for (const auto& host_pair : host_headers) {
+    auto& host_header = hostHeaderEntry(host_pair.first, true);
+    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::None, 443);
+    EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
+  }
+}
+
+// Port's part from host header will get removed even if port does not natch if StripPortType is Any
+TEST_F(HeaderUtilityTest, RemovePortsFromHostAnyStripType) {
+  const std::vector<std::pair<std::string, std::string>> host_headers{
+      {"localhost:443", "localhost"},
+  };
+  for (const auto& host_pair : host_headers) {
+    auto& host_header = hostHeaderEntry(host_pair.first, true);
+    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::Any, 9999);
     EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
   }
 }

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -53,9 +53,18 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHost) {
       {"[fc00::1]:80", "[fc00::1]:80"}      // port not matching w/ ipv6
   };
 
+    const std::vector<std::pair<std::string, std::string>> any_host_headers{
+      {"localhost:9999", "localhost"},       // name any port
+  };
+
   for (const auto& host_pair : host_headers) {
     auto& host_header = hostHeaderEntry(host_pair.first);
-    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::MatchingHost, 443);
+    HeaderUtility::stripPortFromHost(headers_, 443);
+    EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
+  }
+  for (const auto& host_pair : any_host_headers) {
+    auto& host_header = hostHeaderEntry(host_pair.first);
+    HeaderUtility::stripPortFromHost(headers_, 0);
     EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
   }
 }
@@ -67,31 +76,7 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHostConnect) {
   };
   for (const auto& host_pair : host_headers) {
     auto& host_header = hostHeaderEntry(host_pair.first, true);
-    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::MatchingHost, 443);
-    EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
-  }
-}
-
-// Port's part from host header won't be removed if StripPortType is None
-TEST_F(HeaderUtilityTest, RemovePortsFromHostNoneStripType) {
-  const std::vector<std::pair<std::string, std::string>> host_headers{
-      {"localhost:443", "localhost:443"},
-  };
-  for (const auto& host_pair : host_headers) {
-    auto& host_header = hostHeaderEntry(host_pair.first, true);
-    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::None, 443);
-    EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
-  }
-}
-
-// Port's part from host header will get removed even if port does not natch if StripPortType is Any
-TEST_F(HeaderUtilityTest, RemovePortsFromHostAnyStripType) {
-  const std::vector<std::pair<std::string, std::string>> host_headers{
-      {"localhost:443", "localhost"},
-  };
-  for (const auto& host_pair : host_headers) {
-    auto& host_header = hostHeaderEntry(host_pair.first, true);
-    HeaderUtility::stripPortFromHost(headers_, Http::StripPortType::Any, 9999);
+    HeaderUtility::stripPortFromHost(headers_, 443);
     EXPECT_EQ(host_header.value().getStringView(), host_pair.second);
   }
 }

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -54,7 +54,7 @@ TEST_F(HeaderUtilityTest, RemovePortsFromHost) {
   };
 
   const std::vector<std::pair<std::string, std::string>> any_host_headers{
-      {"localhost:9999", "localhost"},       // name any port
+      {"localhost:9999", "localhost"}, // name any port
   };
 
   for (const auto& host_pair : host_headers) {

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1041,7 +1041,7 @@ TEST_F(HttpConnectionManagerConfigTest, RemovePortDefault) {
                                      date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_,
                                      filter_config_provider_manager_);
-  EXPECT_FALSE(config.shouldStripMatchingPort());
+  EXPECT_EQ(Http::StripPortType::None, config.stripPortType());
 }
 
 // Validated that when configured, we remove port.
@@ -1059,7 +1059,7 @@ TEST_F(HttpConnectionManagerConfigTest, RemovePortTrue) {
                                      date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_,
                                      filter_config_provider_manager_);
-  EXPECT_TRUE(config.shouldStripMatchingPort());
+  EXPECT_EQ(Http::StripPortType::MatchingHost, config.stripPortType());
 }
 
 // Validated that when explicitly set false, we don't remove port.
@@ -1077,7 +1077,7 @@ TEST_F(HttpConnectionManagerConfigTest, RemovePortFalse) {
                                      date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_,
                                      filter_config_provider_manager_);
-  EXPECT_FALSE(config.shouldStripMatchingPort());
+  EXPECT_EQ(Http::StripPortType::None, config.stripPortType());
 }
 
 // Validated that when configured, we remove any port.
@@ -1095,7 +1095,7 @@ TEST_F(HttpConnectionManagerConfigTest, RemoveAnyPortTrue) {
                                      date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_,
                                      filter_config_provider_manager_);
-  EXPECT_TRUE(config.shouldStripAnyPort());
+  EXPECT_EQ(Http::StripPortType::Any, config.stripPortType());
 }
 
 // Validated that when explicitly set false, we don't remove any port.
@@ -1113,7 +1113,7 @@ TEST_F(HttpConnectionManagerConfigTest, RemoveAnyPortFalse) {
                                      date_provider_, route_config_provider_manager_,
                                      scoped_routes_config_provider_manager_, http_tracer_manager_,
                                      filter_config_provider_manager_);
-  EXPECT_FALSE(config.shouldStripAnyPort());
+  EXPECT_EQ(Http::StripPortType::None, config.stripPortType());
 }
 
 // Validated that by default we allow requests with header names containing underscores.

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1080,6 +1080,42 @@ TEST_F(HttpConnectionManagerConfigTest, RemovePortFalse) {
   EXPECT_FALSE(config.shouldStripMatchingPort());
 }
 
+// Validated that when configured, we remove any port.
+TEST_F(HttpConnectionManagerConfigTest, RemoveAnyPortTrue) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  strip_any_host_port: true
+  http_filters:
+  - name: envoy.filters.http.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_, http_tracer_manager_,
+                                     filter_config_provider_manager_);
+  EXPECT_TRUE(config.shouldStripAnyPort());
+}
+
+// Validated that when explicitly set false, we don't remove any port.
+TEST_F(HttpConnectionManagerConfigTest, RemoveAnyPortFalse) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  strip_any_host_port: false
+  http_filters:
+  - name: envoy.filters.http.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_, http_tracer_manager_,
+                                     filter_config_provider_manager_);
+  EXPECT_FALSE(config.shouldStripAnyPort());
+}
+
 // Validated that by default we allow requests with header names containing underscores.
 TEST_F(HttpConnectionManagerConfigTest, HeadersWithUnderscoresAllowedByDefault) {
   const std::string yaml_string = R"EOF(

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1062,6 +1062,27 @@ TEST_F(HttpConnectionManagerConfigTest, RemovePortTrue) {
   EXPECT_EQ(Http::StripPortType::MatchingHost, config.stripPortType());
 }
 
+// Validated that when both strip options are configured, we throw exception.
+TEST_F(HttpConnectionManagerConfigTest, BothStripOptionsAreSet) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  strip_matching_host_port: true
+  strip_any_host_port: true
+  http_filters:
+  - name: envoy.filters.http.router
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(
+      HttpConnectionManagerConfig(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                  date_provider_, route_config_provider_manager_,
+                                  scoped_routes_config_provider_manager_, http_tracer_manager_,
+                                  filter_config_provider_manager_),
+      EnvoyException,
+      "Error: Only one of `strip_matching_host_port` or `strip_any_host_port` can be set.");
+}
+
 // Validated that when explicitly set false, we don't remove port.
 TEST_F(HttpConnectionManagerConfigTest, RemovePortFalse) {
   const std::string yaml_string = R"EOF(

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -555,6 +555,7 @@ public:
   MOCK_METHOD(bool, shouldNormalizePath, (), (const));
   MOCK_METHOD(bool, shouldMergeSlashes, (), (const));
   MOCK_METHOD(bool, shouldStripMatchingPort, (), (const));
+  MOCK_METHOD(bool, shouldStripAnyPort, (), (const));
   MOCK_METHOD(envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction,
               headersWithUnderscoresAction, (), (const));
   MOCK_METHOD(const LocalReply::LocalReply&, localReply, (), (const));

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -554,8 +554,7 @@ public:
   MOCK_METHOD(const Http::Http1Settings&, http1Settings, (), (const));
   MOCK_METHOD(bool, shouldNormalizePath, (), (const));
   MOCK_METHOD(bool, shouldMergeSlashes, (), (const));
-  MOCK_METHOD(bool, shouldStripMatchingPort, (), (const));
-  MOCK_METHOD(bool, shouldStripAnyPort, (), (const));
+  MOCK_METHOD(Http::StripPortType, stripPortType, (), (const));
   MOCK_METHOD(envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction,
               headersWithUnderscoresAction, (), (const));
   MOCK_METHOD(const LocalReply::LocalReply&, localReply, (), (const));


### PR DESCRIPTION
Commit Message: add support for skipping any port from host header
Additional Description: Adds a new config to HCM to skip any port in the host header similar to strip_matching_host_port.
Risk Level: Low
Testing: Added
Docs Changes: Updated
Release Notes: Added
Fixes https://github.com/envoyproxy/envoy/issues/12647
