### PR TITLE
macos build: Fix ninja install

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -6,8 +6,10 @@
 # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md for
 # a list of pre-installed tools in the macOS image.
 
-# https://github.com/actions/virtual-environments/issues/1811
-brew uninstall openssl@1.0.2t
+# https://github.com/actions/virtual-environments/issues/2322
+if command -v 2to3 > /dev/null; then
+    rm -f "$(command -v 2to3)"
+fi
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 HOMEBREW_RETRY_ATTEMPTS=10


### PR DESCRIPTION
Commit Message:
macos build: Fix ninja install

- python@3.9 (dependency of ninja) 2to3 tool conflicting with system python
- remove 2to3 if exists
- remove now unneeded openssl workaround
- See issue: https://github.com/actions/virtual-environments/issues/2322

Additional Description: N/A
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A