### PR TITLE
Fix http2_upstream_integration_test flakiness on Windows 

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -575,6 +575,7 @@ void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(default_response_headers_, false);
+  response->waitForHeaders();
   ASSERT_TRUE(fake_upstream_connection_->close());
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
 


### PR DESCRIPTION
Commit Message:
Fix http2_upstream_integration_test flakiness on Windows by waiting for headers before resetting the connection.

Signed-off-by: Randy Miller <rmiller14@gmail.com>

Additional Description:
The http2_upstream_integration_test's RouterUpstreamDisconnectBeforeResponseComplete test case flakes out on Windows.  The connection might be closed before the SSL handshake is completed, which results in the reset signal not being received by the downstream client.  This PR fixes that by blocking on the downstream client receiving the initial headers before having the upstream client disconnect.

Risk Level: Low
Testing: Ran http2_upstream_integration_test, http_integration, and uds_integration_test at least 1000 times each.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
