### PR TITLE
stats: Fix the link printed during an assertion to match the doc it points to.

### DIFF
--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -247,12 +247,12 @@ void SymbolTableImpl::incRefCount(const StatName& stat_name) {
     ASSERT(decode_search != decode_map_.end(),
            "Please see "
            "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
-           "debugging-symbol-table-asserts");
+           "debugging-symbol-table-assertions");
     auto encode_search = encode_map_.find(decode_search->second->toStringView());
     ASSERT(encode_search != encode_map_.end(),
            "Please see "
            "https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#"
-           "debugging-symbol-table-asserts");
+           "debugging-symbol-table-assertions");
 
     ++encode_search->second.ref_count_;
   }

--- a/source/docs/stats.md
+++ b/source/docs/stats.md
@@ -276,7 +276,7 @@ If you are visiting this section because you saw a message like:
 ```bash
 [...][16][critical][assert] [source/common/stats/symbol_table_impl.cc:251] assert failure:
 decode_search != decode_map_.end(). Details: Please see 
-https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#debugging-symbol-table-asserts
+https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#debugging-symbol-table-assertions
 ```
 then you have come to the right place.
 


### PR DESCRIPTION
Commit Message:: I managed to slightly mismatch a reference to a stats.md section in an assertion message. This changes the assert message to match the ID in the .md file.
Additional Description:
Risk Level: low
Testing: none
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
