### PR TITLE
CI: chown ENVOY_DOCKER_BUILD_DIR in docker container

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -43,6 +43,7 @@ else
   START_COMMAND=("/bin/bash" "-lc" "groupadd --gid $(id -g) -f envoygroup \
     && useradd -o --uid $(id -u) --gid $(id -g) --no-create-home --home-dir /build envoybuild \
     && usermod -a -G pcap envoybuild \
+    && chown envoybuild:envoygroup /build \
     && sudo -EHs -u envoybuild bash -c 'cd /source && $*'")
 fi
 


### PR DESCRIPTION
Commit Message:

Enable `ENVOY_DOCKER_BUILD_DIR=/tmp/build ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.coverage'`

Additional Description:

`ci/run_envoy_docker.sh` run docker cmd below.
```
docker run --rm -u root:root 
-v /var/run/docker.sock:/var/run/docker.sock --cap-add SYS_PTRACE --cap-add NET_RAW --cap-add NET_ADMIN -it \
-v ${ENVOY_DOCKER_BUILD_DIR}:/build
blablabla
```
The `-u root:root` with `-v ${ENVOY_DOCKER_BUILD_DIR}:/build` sometimes see the /build as root:root in the container.

Surprisingly ENVOY_DOCKER_BUILD_DIR=**$HOME**/build ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.coverage' works but
ENVOY_DOCKER_BUILD_DIR=**/tmp/**/build ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.coverage'

Signed-off-by: Yuchen Dai <silentdai@gmail.com>


Risk Level: LOW
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
