### PR TITLE
docs: update redis_cluster example use v3 api 

### DIFF
--- a/api/envoy/extensions/clusters/redis/v3/redis_cluster.proto
+++ b/api/envoy/extensions/clusters/redis/v3/redis_cluster.proto
@@ -30,18 +30,26 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // :ref:`enable_redirection<envoy_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.ConnPoolSettings.enable_redirection>`
 // is true, then moved and ask redirection errors from upstream servers will trigger a topology
 // refresh when they exceed a user-configured error threshold.
+// 
+// Cluster's lbPolicy should be CLUSTER_PROVIDED.
 //
 // Example:
 //
 // .. code-block:: yaml
 //
 //     name: name
+//     lb_policy: CLUSTER_PROVIDED
 //     connect_timeout: 0.25s
 //     dns_lookup_family: V4_ONLY
-//     hosts:
-//     - socket_address:
-//       address: foo.bar.com
-//       port_value: 22120
+//     loadAssignment: 
+//       clusterName: name
+//       endpoints: 
+//        - lbEndpoints: 
+//          - endpoint: 
+//              address: 
+//               socketAddress: 
+//                 address: foo.bar.com
+//                   portValue: 22120
 //     cluster_type:
 //     name: envoy.clusters.redis
 //     typed_config:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: update redis_cluster example use v3 api 
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes: update redis_cluster example use v3 api 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
