### PR TITLE
Add support for google::protobuf::ListValue formatting

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -149,23 +149,23 @@ StructFormatter::StructFormatter(const ProtobufWkt::Struct& format_mapping, bool
                                  bool omit_empty_values)
     : omit_empty_values_(omit_empty_values), preserve_types_(preserve_types),
       empty_value_(omit_empty_values_ ? EMPTY_STRING : DefaultUnspecifiedValueString),
-      struct_output_format_(toFormatValue(format_mapping)) {}
+      struct_output_format_(toFormatMapValue(format_mapping)) {}
 
 StructFormatter::StructFormatMapWrapper
-StructFormatter::toFormatValue(const ProtobufWkt::Struct& struct_format) const {
+StructFormatter::toFormatMapValue(const ProtobufWkt::Struct& struct_format) const {
   auto output = std::make_unique<StructFormatMap>();
   for (const auto& pair : struct_format.fields()) {
     switch (pair.second.kind_case()) {
     case ProtobufWkt::Value::kStringValue:
-      output->emplace(pair.first, toFormatValue(pair.second.string_value()));
+      output->emplace(pair.first, toFormatStringValue(pair.second.string_value()));
       break;
 
     case ProtobufWkt::Value::kStructValue:
-      output->emplace(pair.first, toFormatValue(pair.second.struct_value()));
+      output->emplace(pair.first, toFormatMapValue(pair.second.struct_value()));
       break;
 
     case ProtobufWkt::Value::kListValue:
-      output->emplace(pair.first, toFormatValue(pair.second.list_value()));
+      output->emplace(pair.first, toFormatListValue(pair.second.list_value()));
       break;
 
     default:
@@ -177,20 +177,20 @@ StructFormatter::toFormatValue(const ProtobufWkt::Struct& struct_format) const {
 };
 
 StructFormatter::StructFormatListWrapper
-StructFormatter::toFormatValue(const ProtobufWkt::ListValue& list_value_format) const {
+StructFormatter::toFormatListValue(const ProtobufWkt::ListValue& list_value_format) const {
   auto output = std::make_unique<StructFormatList>();
   for (const auto& value : list_value_format.values()) {
     switch (value.kind_case()) {
     case ProtobufWkt::Value::kStringValue:
-      output->emplace_back(toFormatValue(value.string_value()));
+      output->emplace_back(toFormatStringValue(value.string_value()));
       break;
 
     case ProtobufWkt::Value::kStructValue:
-      output->emplace_back(toFormatValue(value.struct_value()));
+      output->emplace_back(toFormatMapValue(value.struct_value()));
       break;
 
     case ProtobufWkt::Value::kListValue:
-      output->emplace_back(toFormatValue(value.list_value()));
+      output->emplace_back(toFormatListValue(value.list_value()));
       break;
     default:
       throw EnvoyException("Only string values, nested structs and list values are "
@@ -201,7 +201,7 @@ StructFormatter::toFormatValue(const ProtobufWkt::ListValue& list_value_format) 
 }
 
 std::vector<FormatterProviderPtr>
-StructFormatter::toFormatValue(const std::string& string_format) const {
+StructFormatter::toFormatStringValue(const std::string& string_format) const {
   return SubstitutionFormatParser::parse(string_format);
 };
 

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -166,9 +166,9 @@ private:
       const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatListWrapper&)>>;
 
   // Methods for building the format map.
-  std::vector<FormatterProviderPtr> toFormatValue(const std::string& string_format) const;
-  StructFormatMapWrapper toFormatValue(const ProtobufWkt::Struct& struct_format) const;
-  StructFormatListWrapper toFormatValue(const ProtobufWkt::ListValue& list_value_format) const;
+  std::vector<FormatterProviderPtr> toFormatStringValue(const std::string& string_format) const;
+  StructFormatMapWrapper toFormatMapValue(const ProtobufWkt::Struct& struct_format) const;
+  StructFormatListWrapper toFormatListValue(const ProtobufWkt::ListValue& list_value_format) const;
 
   // Methods for doing the actual formatting.
   ProtobufWkt::Value providersCallback(const std::vector<FormatterProviderPtr>& providers,

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -123,6 +123,10 @@ private:
   std::vector<FormatterProviderPtr> providers_;
 };
 
+// Helper classes for StructFormatter::StructFormatMapVisitor.
+template <class... Ts> struct StructFormatMapVisitorHelper : Ts... { using Ts::operator()...; };
+template <class... Ts> StructFormatMapVisitorHelper(Ts...) -> StructFormatMapVisitorHelper<Ts...>;
+
 /**
  * An formatter for structured log formats, which returns a Struct proto that
  * can be converted easily into multiple formats.
@@ -158,8 +162,6 @@ private:
     StructFormatListPtr value_;
   };
 
-  template <class... Ts> struct StructFormatMapVisitorHelper : Ts... { using Ts::operator()...; };
-  template <class... Ts> StructFormatMapVisitorHelper(Ts...) -> StructFormatMapVisitorHelper<Ts...>;
   using StructFormatMapVisitor = StructFormatMapVisitorHelper<
       const std::function<ProtobufWkt::Value(const std::vector<FormatterProviderPtr>&)>,
       const std::function<ProtobufWkt::Value(const StructFormatter::StructFormatMapWrapper&)>,

--- a/test/common/formatter/substitution_format_string_test.cc
+++ b/test/common/formatter/substitution_format_string_test.cc
@@ -95,7 +95,8 @@ TEST_F(SubstitutionFormatStringUtilsTest, TestInvalidConfigs) {
     TestUtility::loadFromYaml(yaml, config_);
     EXPECT_THROW_WITH_MESSAGE(
         SubstitutionFormatStringUtils::fromProtoConfig(config_, context_.api()), EnvoyException,
-        "Only string values or nested structs are supported in structured access log format.");
+        "Only string values, nested structs and list values are supported in structured access log "
+        "format.");
   }
 }
 

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1624,7 +1624,7 @@ TEST(SubstitutionFormatterTest, StructFormatterPlainStringTest) {
       expected_json_map);
 }
 
-TEST(SubstitutionFormatterTest, StructFormatterNestedObject) {
+TEST(SubstitutionFormatterTest, StructFormatterTypesTest) {
   StreamInfo::MockStreamInfo stream_info;
   Http::TestRequestHeaderMapImpl request_header;
   Http::TestResponseHeaderMapImpl response_header;
@@ -1638,31 +1638,35 @@ TEST(SubstitutionFormatterTest, StructFormatterNestedObject) {
 
   ProtobufWkt::Struct key_mapping;
   TestUtility::loadFromYaml(R"EOF(
-    level_one:
-      level_two:
-        level_three:
-          plain_string: plain_string_value
-          protocol: '%PROTOCOL%'
+    string_type: plain_string_value
+    struct_type:
+      plain_string: plain_string_value
+      protocol: '%PROTOCOL%'
+    list_type:
+      - plain_string_value
+      - '%PROTOCOL%'
   )EOF",
                             key_mapping);
   StructFormatter formatter(key_mapping, false, false);
 
   const ProtobufWkt::Struct expected = TestUtility::jsonToStruct(R"EOF({
-    "level_one": {
-      "level_two": {
-        "level_three": {
-          "plain_string": "plain_string_value",
-          "protocol": "HTTP/1.1"
-        }
-      }
-    }
+    "string_type": "plain_string_value",
+    "struct_type": {
+      "plain_string": "plain_string_value",
+      "protocol": "HTTP/1.1"
+    },
+    "list_type": [
+      "plain_string_value",
+      "HTTP/1.1"
+    ]
   })EOF");
   const ProtobufWkt::Struct out_struct =
       formatter.format(request_header, response_header, response_trailer, stream_info, body);
   EXPECT_TRUE(TestUtility::protoEqual(out_struct, expected));
 }
 
-TEST(SubstitutionFormatterTest, StructFormatterList) {
+// Test that nested values are formatted properly, including inter-type nesting.
+TEST(SubstitutionFormatterTest, StructFormatterNestedObjectsTest) {
   StreamInfo::MockStreamInfo stream_info;
   Http::TestRequestHeaderMapImpl request_header;
   Http::TestResponseHeaderMapImpl response_header;
@@ -1675,19 +1679,110 @@ TEST(SubstitutionFormatterTest, StructFormatterList) {
   EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
 
   ProtobufWkt::Struct key_mapping;
+  // For both struct and list, we test 3 nesting levels of all types (string, struct and list).
   TestUtility::loadFromYaml(R"EOF(
+    struct:
+      struct_string: plain_string_value
+      struct_protocol: '%PROTOCOL%'
+      struct_struct:
+        struct_struct_string: plain_string_value
+        struct_struct_protocol: '%PROTOCOL%'
+        struct_struct_struct:
+          struct_struct_struct_string: plain_string_value
+          struct_struct_struct_protocol: '%PROTOCOL%'
+        struct_struct_list:
+          - struct_struct_list_string
+          - '%PROTOCOL%'
+      struct_list:
+        - struct_list_string
+        - '%PROTOCOL%'
+        # struct_list_struct
+        - struct_list_struct_string: plain_string_value
+          struct_list_struct_protocol: '%PROTOCOL%'
+        # struct_list_list
+        - - struct_list_list_string
+          - '%PROTOCOL%'
     list:
-      - plain_string: plain_string_value
-      - protocol: '%PROTOCOL%'
+      - list_string
+      - '%PROTOCOL%'
+      # list_struct
+      - list_struct_string: plain_string_value
+        list_struct_protocol: '%PROTOCOL%'
+        list_struct_struct:
+          list_struct_struct_string: plain_string_value
+          list_struct_struct_protocol: '%PROTOCOL%'
+        list_struct_list:
+          - list_struct_list_string
+          - '%PROTOCOL%'
+      # list_list
+      - - list_list_string
+        - '%PROTOCOL%'
+        # list_list_struct
+        - list_list_struct_string: plain_string_value
+          list_list_struct_protocol: '%PROTOCOL%'
+        # list_list_list
+        - - list_list_list_string
+          - '%PROTOCOL%'
   )EOF",
                             key_mapping);
   StructFormatter formatter(key_mapping, false, false);
-
   const ProtobufWkt::Struct expected = TestUtility::jsonToStruct(R"EOF({
+    "struct": {
+      "struct_string": "plain_string_value",
+      "struct_protocol": "HTTP/1.1",
+      "struct_struct": {
+        "struct_struct_string": "plain_string_value",
+        "struct_struct_protocol": "HTTP/1.1",
+        "struct_struct_struct": {
+          "struct_struct_struct_string": "plain_string_value",
+          "struct_struct_struct_protocol": "HTTP/1.1",
+        },
+        "struct_struct_list": [
+          "struct_struct_list_string",
+          "HTTP/1.1",
+        ],
+      },
+      "struct_list": [
+        "struct_list_string",
+        "HTTP/1.1",
+        {
+          "struct_list_struct_string": "plain_string_value",
+          "struct_list_struct_protocol": "HTTP/1.1",
+        },
+        [
+          "struct_list_list_string",
+          "HTTP/1.1",
+        ],
+      ],
+    },
     "list": [
-      { "plain_string": "plain_string_value" },
-      { "protocol": "HTTP/1.1" },
-    ]
+      "list_string",
+      "HTTP/1.1",
+      {
+        "list_struct_string": "plain_string_value",
+        "list_struct_protocol": "HTTP/1.1",
+        "list_struct_struct": {
+          "list_struct_struct_string": "plain_string_value",
+          "list_struct_struct_protocol": "HTTP/1.1",
+        },
+        "list_struct_list": [
+          "list_struct_list_string",
+          "HTTP/1.1",
+        ]
+      },
+      [
+        "list_list_string",
+        "HTTP/1.1",
+        {
+          "list_list_struct_string": "plain_string_value",
+          "list_list_struct_protocol": "HTTP/1.1",
+        },
+        [
+          "list_list_list_string",
+          "HTTP/1.1",
+        ],
+      ],
+    ],
   })EOF");
   const ProtobufWkt::Struct out_struct =
       formatter.format(request_header, response_header, response_trailer, stream_info, body);
@@ -1768,10 +1863,14 @@ TEST(SubstitutionFormatterTest, StructFormatterAlternateHeaderTest) {
 
   ProtobufWkt::Struct key_mapping;
   TestUtility::loadFromYaml(R"EOF(
-    request_present_header_or_request_absent_header: '%REQ(request_present_header?request_absent_header)%'
-    request_absent_header_or_request_present_header: '%REQ(request_absent_header?request_present_header)%'
-    response_absent_header_or_response_absent_header: '%RESP(response_absent_header?response_present_header)%'
-    response_present_header_or_response_absent_header: '%RESP(response_present_header?response_absent_header)%'
+    request_present_header_or_request_absent_header:
+    '%REQ(request_present_header?request_absent_header)%'
+    request_absent_header_or_request_present_header:
+    '%REQ(request_absent_header?request_present_header)%'
+    response_absent_header_or_response_absent_header:
+    '%RESP(response_absent_header?response_present_header)%'
+    response_present_header_or_response_absent_header:
+    '%RESP(response_present_header?response_absent_header)%'
   )EOF",
                             key_mapping);
   StructFormatter formatter(key_mapping, false, false);
@@ -1932,7 +2031,7 @@ TEST(SubstitutionFormatterTest, StructFormatterTypedFilterStateTest) {
             fields.at("test_obj").struct_value().fields().at("inner_key").string_value());
 }
 
-// Test new specifier (PLAIN/TYPED) of FilterState. Ensure that after adding additional specifier,
+// Test new specifier (PLAIN/TYPED) of FilterState. Ensure that after adding additiona specifier,
 // the FilterState can call the serializeAsProto or serializeAsString methods correctly.
 TEST(SubstitutionFormatterTest, FilterStateSpeciferTest) {
   Http::TestRequestHeaderMapImpl request_headers;
@@ -2062,7 +2161,8 @@ TEST(SubstitutionFormatterTest, StructFormatterMultiTokenTest) {
 
     ProtobufWkt::Struct key_mapping;
     TestUtility::loadFromYaml(R"EOF(
-      multi_token_field: '%PROTOCOL% plainstring %REQ(some_request_header)% %RESP(some_response_header)%'
+      multi_token_field: '%PROTOCOL% plainstring %REQ(some_request_header)%
+      %RESP(some_response_header)%'
     )EOF",
                               key_mapping);
     for (const bool preserve_types : {false, true}) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1662,6 +1662,38 @@ TEST(SubstitutionFormatterTest, StructFormatterNestedObject) {
   EXPECT_TRUE(TestUtility::protoEqual(out_struct, expected));
 }
 
+TEST(SubstitutionFormatterTest, StructFormatterList) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header;
+  Http::TestResponseHeaderMapImpl response_header;
+  Http::TestResponseTrailerMapImpl response_trailer;
+  std::string body;
+
+  envoy::config::core::v3::Metadata metadata;
+  populateMetadataTestData(metadata);
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    list:
+      - plain_string: plain_string_value
+      - protocol: '%PROTOCOL%'
+  )EOF",
+                            key_mapping);
+  StructFormatter formatter(key_mapping, false, false);
+
+  const ProtobufWkt::Struct expected = TestUtility::jsonToStruct(R"EOF({
+    "list": [
+      { "plain_string": "plain_string_value" },
+      { "protocol": "HTTP/1.1" },
+    ]
+  })EOF");
+  const ProtobufWkt::Struct out_struct =
+      formatter.format(request_header, response_header, response_trailer, stream_info, body);
+  EXPECT_TRUE(TestUtility::protoEqual(out_struct, expected));
+}
+
 TEST(SubstitutionFormatterTest, StructFormatterSingleOperatorTest) {
   StreamInfo::MockStreamInfo stream_info;
   Http::TestRequestHeaderMapImpl request_header;

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2031,7 +2031,7 @@ TEST(SubstitutionFormatterTest, StructFormatterTypedFilterStateTest) {
             fields.at("test_obj").struct_value().fields().at("inner_key").string_value());
 }
 
-// Test new specifier (PLAIN/TYPED) of FilterState. Ensure that after adding additiona specifier,
+// Test new specifier (PLAIN/TYPED) of FilterState. Ensure that after adding additional specifier,
 // the FilterState can call the serializeAsProto or serializeAsString methods correctly.
 TEST(SubstitutionFormatterTest, FilterStateSpeciferTest) {
   Http::TestRequestHeaderMapImpl request_headers;


### PR DESCRIPTION
Commit Message: Add support for (Struct) ListValue formatting
Additional Description: Previously, only string and "Struct" were supported. This change mostly refactors some things in the StructFormatter and adds 2 methods for dealing with ListValues.
Risk Level: Low (new functionality that previously threw an exception).
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
