### PR TITLE
event: ASSERT that operations on file events and timers are only performed from the dispatcher thread.

### DIFF
--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -47,6 +47,7 @@ AccessLogFileImpl::AccessLogFileImpl(Filesystem::FilePtr&& file, Event::Dispatch
         flush_timer_->enableTimer(flush_interval_msec_);
       })),
       thread_factory_(thread_factory), flush_interval_msec_(flush_interval_msec), stats_(stats) {
+  flush_timer_->enableTimer(flush_interval_msec_);
   open();
 }
 
@@ -205,7 +206,6 @@ void AccessLogFileImpl::write(absl::string_view data) {
 void AccessLogFileImpl::createFlushStructures() {
   flush_thread_ = thread_factory_.createThread([this]() -> void { flushThreadFunc(); },
                                                Thread::Options{"AccessLogFlush"});
-  flush_timer_->enableTimer(flush_interval_msec_);
 }
 
 } // namespace AccessLog

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -12,7 +12,7 @@ namespace Event {
 
 FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, os_fd_t fd, FileReadyCb cb,
                              FileTriggerType trigger, uint32_t events)
-    : cb_(cb), fd_(fd), trigger_(trigger), enabled_events_(events),
+    : dispatcher_(dispatcher), cb_(cb), fd_(fd), trigger_(trigger), enabled_events_(events),
       activation_cb_(dispatcher.createSchedulableCallback([this]() {
         ASSERT(injected_activation_events_ != 0);
         mergeInjectedEventsAndRunCb(0);
@@ -33,6 +33,8 @@ FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, os_fd_t fd, FileReadyCb
 }
 
 void FileEventImpl::activate(uint32_t events) {
+  ASSERT(dispatcher_.isThreadSafe());
+
   // events is not empty.
   ASSERT(events != 0);
   // Only supported event types are set.
@@ -51,6 +53,7 @@ void FileEventImpl::activate(uint32_t events) {
 }
 
 void FileEventImpl::assignEvents(uint32_t events, event_base* base) {
+  ASSERT(dispatcher_.isThreadSafe());
   ASSERT(base != nullptr);
   enabled_events_ = events;
   event_assign(
@@ -81,6 +84,7 @@ void FileEventImpl::assignEvents(uint32_t events, event_base* base) {
 }
 
 void FileEventImpl::updateEvents(uint32_t events) {
+  ASSERT(dispatcher_.isThreadSafe());
   if (events == enabled_events_) {
     return;
   }
@@ -91,6 +95,7 @@ void FileEventImpl::updateEvents(uint32_t events) {
 }
 
 void FileEventImpl::setEnabled(uint32_t events) {
+  ASSERT(dispatcher_.isThreadSafe());
   if (injected_activation_events_ != 0) {
     // Clear pending events on updates to the fd event mask to avoid delivering events that are no
     // longer relevant. Updating the event mask will reset the fd edge trigger state so the proxy
@@ -103,6 +108,7 @@ void FileEventImpl::setEnabled(uint32_t events) {
 }
 
 void FileEventImpl::unregisterEventIfEmulatedEdge(uint32_t event) {
+  ASSERT(dispatcher_.isThreadSafe());
   // This constexpr if allows the compiler to optimize away the function on POSIX
   if constexpr (PlatformDefaultTriggerType == FileTriggerType::EmulatedEdge) {
     ASSERT((event & (FileReadyType::Read | FileReadyType::Write)) == event);
@@ -114,6 +120,7 @@ void FileEventImpl::unregisterEventIfEmulatedEdge(uint32_t event) {
 }
 
 void FileEventImpl::registerEventIfEmulatedEdge(uint32_t event) {
+  ASSERT(dispatcher_.isThreadSafe());
   // This constexpr if allows the compiler to optimize away the function on POSIX
   if constexpr (PlatformDefaultTriggerType == FileTriggerType::EmulatedEdge) {
     ASSERT((event & (FileReadyType::Read | FileReadyType::Write)) == event);
@@ -129,6 +136,7 @@ void FileEventImpl::registerEventIfEmulatedEdge(uint32_t event) {
 }
 
 void FileEventImpl::mergeInjectedEventsAndRunCb(uint32_t events) {
+  ASSERT(dispatcher_.isThreadSafe());
   if (injected_activation_events_ != 0) {
     // TODO(antoniovicente) remove this adjustment to activation events once ConnectionImpl can
     // handle Read and Close events delivered together.

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -30,6 +30,7 @@ private:
   void mergeInjectedEventsAndRunCb(uint32_t events);
   void updateEvents(uint32_t events);
 
+  Dispatcher& dispatcher_;
   FileReadyCb cb_;
   os_fd_t fd_;
   FileTriggerType trigger_;

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -37,7 +37,10 @@ TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Dispatcher& dispat
       this);
 }
 
-void TimerImpl::disableTimer() { event_del(&raw_event_); }
+void TimerImpl::disableTimer() {
+  ASSERT(dispatcher_.isThreadSafe());
+  event_del(&raw_event_);
+}
 
 void TimerImpl::enableTimer(const std::chrono::milliseconds d, const ScopeTrackedObject* object) {
   timeval tv;
@@ -53,6 +56,7 @@ void TimerImpl::enableHRTimer(const std::chrono::microseconds d,
 }
 
 void TimerImpl::internalEnableTimer(const timeval& tv, const ScopeTrackedObject* object) {
+  ASSERT(dispatcher_.isThreadSafe());
   object_ = object;
 
   if (!activate_timers_next_event_loop_ && tv.tv_sec == 0 && tv.tv_usec == 0) {
@@ -62,7 +66,10 @@ void TimerImpl::internalEnableTimer(const timeval& tv, const ScopeTrackedObject*
   }
 }
 
-bool TimerImpl::enabled() { return 0 != evtimer_pending(&raw_event_, nullptr); }
+bool TimerImpl::enabled() {
+  ASSERT(dispatcher_.isThreadSafe());
+  return 0 != evtimer_pending(&raw_event_, nullptr);
+}
 
 } // namespace Event
 } // namespace Envoy

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -218,10 +218,13 @@ void GuardDogImpl::stopWatching(WatchDogSharedPtr wd) {
 void GuardDogImpl::start(Api::Api& api) {
   Thread::LockGuard guard(mutex_);
   // See comments in WorkerImpl::start for the naming convention.
-  loop_timer_->enableTimer(std::chrono::milliseconds(0));
   Thread::Options options{absl::StrCat("dog:", dispatcher_->name())};
   thread_ = api.threadFactory().createThread(
-      [this]() -> void { dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit); }, options);
+      [this]() -> void {
+        loop_timer_->enableTimer(std::chrono::milliseconds(0));
+        dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
+      },
+      options);
 }
 
 void GuardDogImpl::stop() {

--- a/source/server/guarddog_impl.cc
+++ b/source/server/guarddog_impl.cc
@@ -218,10 +218,10 @@ void GuardDogImpl::stopWatching(WatchDogSharedPtr wd) {
 void GuardDogImpl::start(Api::Api& api) {
   Thread::LockGuard guard(mutex_);
   // See comments in WorkerImpl::start for the naming convention.
+  loop_timer_->enableTimer(std::chrono::milliseconds(0));
   Thread::Options options{absl::StrCat("dog:", dispatcher_->name())};
   thread_ = api.threadFactory().createThread(
       [this]() -> void { dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit); }, options);
-  loop_timer_->enableTimer(std::chrono::milliseconds(0));
 }
 
 void GuardDogImpl::stop() {

--- a/source/server/guarddog_impl.h
+++ b/source/server/guarddog_impl.h
@@ -87,7 +87,7 @@ public:
    */
   void forceCheckForTest() {
     Thread::LockGuard guard(mutex_);
-    loop_timer_->enableTimer(std::chrono::milliseconds(0));
+    dispatcher_->post([this]() { loop_timer_->enableTimer(std::chrono::milliseconds(0)); });
     test_interlock_hook_->waitFromTest(mutex_);
   }
 

--- a/test/common/access_log/access_log_manager_impl_test.cc
+++ b/test/common/access_log/access_log_manager_impl_test.cc
@@ -83,6 +83,7 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFilePeriodically) {
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
 
   EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
+  EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
 
   EXPECT_EQ(0UL, store_.counter("filesystem.write_failed").value());
@@ -90,7 +91,6 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFilePeriodically) {
   EXPECT_EQ(0UL, store_.counter("filesystem.flushed_by_timer").value());
   EXPECT_EQ(0UL, store_.counter("filesystem.write_buffered").value());
 
-  EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
   EXPECT_CALL(*file_, write_(_))
       .WillOnce(Invoke([&](absl::string_view data) -> Api::IoCallSizeResult {
         EXPECT_EQ(
@@ -152,11 +152,10 @@ TEST_F(AccessLogManagerImplTest, FlushToLogFileOnDemand) {
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
 
   EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
+  EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
 
   EXPECT_EQ(0UL, store_.counter("filesystem.flushed_by_timer").value());
-
-  EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
 
   // The first write to a given file will start the flush thread. Because AccessManagerImpl::write
   // holds the write_lock_ when the thread is started, the thread will flush on its first loop, once
@@ -224,11 +223,11 @@ TEST_F(AccessLogManagerImplTest, FlushCountsIOErrors) {
   NiceMock<Event::MockTimer>* timer = new NiceMock<Event::MockTimer>(&dispatcher_);
 
   EXPECT_CALL(*file_, open_(_)).WillOnce(Return(ByMove(Filesystem::resultSuccess<bool>(true))));
+  EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
   AccessLogFileSharedPtr log_file = access_log_manager_.createAccessLog("foo");
 
   EXPECT_EQ(0UL, store_.counter("filesystem.write_failed").value());
 
-  EXPECT_CALL(*timer, enableTimer(timeout_40ms_, _));
   EXPECT_CALL(*file_, write_(_))
       .WillOnce(Invoke([](absl::string_view data) -> Api::IoCallSizeResult {
         EXPECT_EQ(0, data.compare("test"));

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -26,7 +26,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions:96.3"
 "source/extensions/common/crypto:91.5"
 "source/extensions/common/tap:95.9"
-"source/extensions/common/wasm:95.4"
+"source/extensions/common/wasm:95.3"
 "source/extensions/common/wasm/null:77.8"
 "source/extensions/common/wasm/v8:85.4"
 "source/extensions/common:94.4"


### PR DESCRIPTION
Commit Message:
event: ASSERT that operations on file events and timers are only performed from the dispatcher thread.

This weakens the thread-safety requirements for dispatcher primitives and may allow us to disable locking in libevent or simplify the switch to a different event loop implementation.

Risk Level: low. Mostly adding ASSERTs. No functional changes expected.
Testing: existing tests.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a