### PR TITLE
test: Add coverage on checking IP version when the local address is null

### DIFF
--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -165,6 +165,13 @@ TEST_P(ListenSocketImplTestTcp, SetLocalAddress) {
   EXPECT_EQ(socket.localAddress(), address);
 }
 
+TEST_P(ListenSocketImplTestTcp, CheckIpVersionWithNullLocalAddress) {
+  TestListenSocket socket(Utility::getIpv4AnyAddress());
+
+  EXPECT_EQ(version_ == Address::IpVersion::v6 ? Address::IpVersion::v4 : Address::IpVersion::v4,
+            socket.ipVersion());
+}
+
 TEST_P(ListenSocketImplTestUdp, BindSpecificPort) { testBindSpecificPort(); }
 
 // Validate that we get port allocation when binding to port zero.

--- a/test/common/network/listen_socket_impl_test.cc
+++ b/test/common/network/listen_socket_impl_test.cc
@@ -167,9 +167,7 @@ TEST_P(ListenSocketImplTestTcp, SetLocalAddress) {
 
 TEST_P(ListenSocketImplTestTcp, CheckIpVersionWithNullLocalAddress) {
   TestListenSocket socket(Utility::getIpv4AnyAddress());
-
-  EXPECT_EQ(version_ == Address::IpVersion::v6 ? Address::IpVersion::v4 : Address::IpVersion::v4,
-            socket.ipVersion());
+  EXPECT_EQ(Address::IpVersion::v4, socket.ipVersion());
 }
 
 TEST_P(ListenSocketImplTestUdp, BindSpecificPort) { testBindSpecificPort(); }

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -446,6 +446,9 @@ TEST_P(WasmCommonTest, Utilities) {
 }
 
 TEST_P(WasmCommonTest, Stats) {
+  // We set logger level to critical here to gain more coverage.
+  Logger::Registry::getLog(Logger::Id::wasm).set_level(spdlog::level::critical);
+
   Stats::IsolatedStoreImpl stats_store;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   Upstream::MockClusterManager cluster_manager;


### PR DESCRIPTION
Commit Message: This adds coverage on checking IP version when the local address is null
Risk Level: N/A, test only
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform-Specific Features: N/A

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>