### PR TITLE
event: split dispatcherimpl into two classes

### DIFF
--- a/include/envoy/event/timer.h
+++ b/include/envoy/event/timer.h
@@ -14,7 +14,7 @@ class ScopeTrackedObject;
 
 namespace Event {
 
-class Dispatcher;
+class DispatcherBase;
 
 /**
  * Callback invoked when a timer event fires.
@@ -67,7 +67,7 @@ public:
   /**
    * Creates a timer.
    */
-  virtual TimerPtr createTimer(const TimerCb& cb, Dispatcher& dispatcher) PURE;
+  virtual TimerPtr createTimer(const TimerCb& cb, DispatcherBase& dispatcher) PURE;
 };
 
 using SchedulerPtr = std::unique_ptr<Scheduler>;

--- a/source/common/common/scope_tracker.h
+++ b/source/common/common/scope_tracker.h
@@ -12,7 +12,7 @@ namespace Envoy {
 // dispatcher at the previously tracked object.
 class ScopeTrackerScopeState {
 public:
-  ScopeTrackerScopeState(const ScopeTrackedObject* object, Event::Dispatcher& dispatcher)
+  ScopeTrackerScopeState(const ScopeTrackedObject* object, Event::DispatcherBase& dispatcher)
       : dispatcher_(dispatcher) {
     latched_object_ = dispatcher_.setTrackedObject(object);
   }
@@ -21,7 +21,7 @@ public:
 
 private:
   const ScopeTrackedObject* latched_object_;
-  Event::Dispatcher& dispatcher_;
+  Event::DispatcherBase& dispatcher_;
 };
 
 } // namespace Envoy

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -84,8 +84,7 @@ DispatcherImplBase::createRawSchedulableCallback(std::function<void()> cb) {
 void DispatcherImplBase::registerWatchdog(const Server::WatchDogSharedPtr& watchdog,
                                           std::chrono::milliseconds min_touch_interval) {
   ASSERT(!watchdog_registration_, "Each dispatcher can have at most one registered watchdog.");
-  watchdog_registration_ =
-      std::make_unique<WatchdogRegistration>(watchdog, *scheduler_, min_touch_interval, *this);
+  watchdog_registration_.emplace(watchdog, *scheduler_, min_touch_interval, *this);
 }
 
 void DispatcherImplBase::touchWatchdog() {

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -161,7 +161,7 @@ void DispatcherImpl::initializeStats(Stats::Scope& scope,
     stats_ = std::make_unique<DispatcherStats>(
         DispatcherStats{ALL_DISPATCHER_STATS(POOL_HISTOGRAM_PREFIX(scope, stats_prefix_ + "."))});
     base_.initializeStats(stats_.get());
-    ENVOY_LOG(debug, "running {} on thread {}", stats_prefix_, base_.run_tid().debugString());
+    ENVOY_LOG(debug, "running {} on thread {}", stats_prefix_, base_.runTid().debugString());
   });
 }
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -38,7 +38,10 @@ namespace Envoy {
 namespace Event {
 
 DispatcherImplBase::DispatcherImplBase(Api::Api& api, TimeSystem& time_system)
-    : api_(api), scheduler_(time_system.createScheduler(base_scheduler_, base_scheduler_)) {}
+    : api_(api), scheduler_(time_system.createScheduler(base_scheduler_, base_scheduler_)) {
+  updateApproximateMonotonicTime();
+  registerOnPrepareCallback(std::bind(&DispatcherImplBase::updateApproximateMonotonicTime, this));
+}
 
 FileEventPtr DispatcherImplBase::createFileEvent(os_fd_t fd, FileReadyCb cb,
                                                  FileTriggerType trigger, uint32_t events) {
@@ -141,8 +144,6 @@ DispatcherImpl::DispatcherImpl(const std::string& name, Api::Api& api,
       current_to_delete_(&to_delete_1_) {
   ASSERT(!name_.empty());
   FatalErrorHandler::registerFatalErrorHandler(*this);
-  base_.updateApproximateMonotonicTime();
-  base_.registerOnPrepareCallback(std::bind(&DispatcherImpl::updateApproximateMonotonicTime, this));
 }
 
 DispatcherImpl::~DispatcherImpl() { FatalErrorHandler::removeFatalErrorHandler(*this); }

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -53,9 +53,9 @@ public:
   /**
    * @return Thread::ThreadId the thread ID last set by saveTid().
    */
-  Thread::ThreadId run_tid() const { return run_tid_; }
+  Thread::ThreadId runTid() const { return run_tid_; }
   /**
-   * Saves the ID of the calling thread for later retrieval with run_tid().
+   * Saves the ID of the calling thread for later retrieval with runTid().
    */
   void saveTid() { run_tid_ = api_.threadFactory().currentThreadId(); }
   /**

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -102,10 +102,9 @@ private:
     const std::chrono::milliseconds timer_interval_;
     TimerPtr touch_timer_;
   };
-  using WatchdogRegistrationPtr = std::unique_ptr<WatchdogRegistration>;
 
   LibeventScheduler base_scheduler_;
-  WatchdogRegistrationPtr watchdog_registration_;
+  absl::optional<WatchdogRegistration> watchdog_registration_;
   const ScopeTrackedObject* current_object_{};
   Api::Api& api_;
   SchedulerPtr scheduler_;

--- a/source/common/event/file_event_impl.cc
+++ b/source/common/event/file_event_impl.cc
@@ -10,7 +10,7 @@
 namespace Envoy {
 namespace Event {
 
-FileEventImpl::FileEventImpl(DispatcherImpl& dispatcher, os_fd_t fd, FileReadyCb cb,
+FileEventImpl::FileEventImpl(DispatcherImplBase& dispatcher, os_fd_t fd, FileReadyCb cb,
                              FileTriggerType trigger, uint32_t events)
     : cb_(cb), fd_(fd), trigger_(trigger), enabled_events_(events),
       activation_cb_(dispatcher.createSchedulableCallback([this]() {

--- a/source/common/event/file_event_impl.h
+++ b/source/common/event/file_event_impl.h
@@ -16,7 +16,7 @@ namespace Event {
  */
 class FileEventImpl : public FileEvent, ImplBase {
 public:
-  FileEventImpl(DispatcherImpl& dispatcher, os_fd_t fd, FileReadyCb cb, FileTriggerType trigger,
+  FileEventImpl(DispatcherImplBase& dispatcher, os_fd_t fd, FileReadyCb cb, FileTriggerType trigger,
                 uint32_t events);
 
   // Event::FileEvent

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -35,7 +35,7 @@ LibeventScheduler::LibeventScheduler() {
   RELEASE_ASSERT(Libevent::Global::initialized(), "");
 }
 
-TimerPtr LibeventScheduler::createTimer(const TimerCb& cb, Dispatcher& dispatcher) {
+TimerPtr LibeventScheduler::createTimer(const TimerCb& cb, DispatcherBase& dispatcher) {
   return std::make_unique<TimerImpl>(libevent_, cb, dispatcher);
 };
 

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -62,7 +62,7 @@ public:
   LibeventScheduler();
 
   // Scheduler
-  TimerPtr createTimer(const TimerCb& cb, Dispatcher& dispatcher) override;
+  TimerPtr createTimer(const TimerCb& cb, DispatcherBase& dispatcher) override;
   SchedulableCallbackPtr createSchedulableCallback(const std::function<void()>& cb) override;
 
   /**

--- a/source/common/event/posix/signal_impl.cc
+++ b/source/common/event/posix/signal_impl.cc
@@ -6,7 +6,7 @@
 namespace Envoy {
 namespace Event {
 
-SignalEventImpl::SignalEventImpl(DispatcherImpl& dispatcher, signal_t signal_num, SignalCb cb)
+SignalEventImpl::SignalEventImpl(DispatcherImplBase& dispatcher, signal_t signal_num, SignalCb cb)
     : cb_(cb) {
   evsignal_assign(
       &raw_event_, &dispatcher.base(), signal_num,

--- a/source/common/event/posix/signal_impl.h
+++ b/source/common/event/posix/signal_impl.h
@@ -13,7 +13,7 @@ namespace Event {
  */
 class SignalEventImpl : public SignalEvent, ImplBase {
 public:
-  SignalEventImpl(DispatcherImpl& dispatcher, signal_t signal_num, SignalCb cb);
+  SignalEventImpl(DispatcherImplBase& dispatcher, signal_t signal_num, SignalCb cb);
 
 private:
   SignalCb cb_;

--- a/source/common/event/real_time_system.cc
+++ b/source/common/event/real_time_system.cc
@@ -12,7 +12,7 @@ namespace {
 class RealScheduler : public Scheduler {
 public:
   RealScheduler(Scheduler& base_scheduler) : base_scheduler_(base_scheduler) {}
-  TimerPtr createTimer(const TimerCb& cb, Dispatcher& d) override {
+  TimerPtr createTimer(const TimerCb& cb, DispatcherBase& d) override {
     return base_scheduler_.createTimer(cb, d);
   };
 

--- a/source/common/event/scaled_range_timer_manager_impl.cc
+++ b/source/common/event/scaled_range_timer_manager_impl.cc
@@ -137,7 +137,7 @@ private:
   const ScopeTrackedObject* scope_;
 };
 
-ScaledRangeTimerManagerImpl::ScaledRangeTimerManagerImpl(Dispatcher& dispatcher)
+ScaledRangeTimerManagerImpl::ScaledRangeTimerManagerImpl(DispatcherBase& dispatcher)
     : dispatcher_(dispatcher), scale_factor_(1.0) {}
 
 ScaledRangeTimerManagerImpl::~ScaledRangeTimerManagerImpl() {
@@ -163,7 +163,7 @@ ScaledRangeTimerManagerImpl::Queue::Item::Item(RangeTimerImpl& timer, MonotonicT
 
 ScaledRangeTimerManagerImpl::Queue::Queue(std::chrono::milliseconds duration,
                                           ScaledRangeTimerManagerImpl& manager,
-                                          Dispatcher& dispatcher)
+                                          DispatcherBase& dispatcher)
     : duration_(duration),
       timer_(dispatcher.createTimer([this, &manager] { manager.onQueueTimerFired(*this); })) {}
 

--- a/source/common/event/scaled_range_timer_manager_impl.h
+++ b/source/common/event/scaled_range_timer_manager_impl.h
@@ -21,7 +21,7 @@ namespace Event {
  */
 class ScaledRangeTimerManagerImpl : public ScaledRangeTimerManager {
 public:
-  explicit ScaledRangeTimerManagerImpl(Dispatcher& dispatcher);
+  explicit ScaledRangeTimerManagerImpl(DispatcherBase& dispatcher);
   ~ScaledRangeTimerManagerImpl() override;
 
   // ScaledRangeTimerManager impl
@@ -45,7 +45,7 @@ private:
     using Iterator = std::list<Item>::iterator;
 
     Queue(std::chrono::milliseconds duration, ScaledRangeTimerManagerImpl& manager,
-          Dispatcher& dispatcher);
+          DispatcherBase& dispatcher);
 
     // The (max - min) value for all timers in range_timers_.
     const std::chrono::milliseconds duration_;
@@ -113,7 +113,7 @@ private:
 
   void onQueueTimerFired(Queue& queue);
 
-  Dispatcher& dispatcher_;
+  DispatcherBase& dispatcher_;
   UnitFloat scale_factor_;
   absl::flat_hash_set<std::unique_ptr<Queue>, Hash, Eq> queues_;
 };

--- a/source/common/event/timer_impl.cc
+++ b/source/common/event/timer_impl.cc
@@ -10,7 +10,7 @@
 namespace Envoy {
 namespace Event {
 
-TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Dispatcher& dispatcher)
+TimerImpl::TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, DispatcherBase& dispatcher)
     : cb_(cb), dispatcher_(dispatcher),
       activate_timers_next_event_loop_(
           // Only read the runtime feature if the runtime loader singleton has already been created.

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -52,7 +52,7 @@ public:
  */
 class TimerImpl : public Timer, ImplBase {
 public:
-  TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Event::Dispatcher& dispatcher);
+  TimerImpl(Libevent::BasePtr& libevent, TimerCb cb, Event::DispatcherBase& dispatcher);
 
   // Timer
   void disableTimer() override;
@@ -65,7 +65,7 @@ public:
 private:
   void internalEnableTimer(const timeval& tv, const ScopeTrackedObject* scope);
   TimerCb cb_;
-  Dispatcher& dispatcher_;
+  DispatcherBase& dispatcher_;
   // This has to be atomic for alarms which are handled out of thread, for
   // example if the DispatcherImpl::post is called by two threads, they race to
   // both set this to null.

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -63,7 +63,7 @@ public:
   ~SimulatedScheduler() override { time_system_.unregisterScheduler(this); }
 
   // From Scheduler.
-  TimerPtr createTimer(const TimerCb& cb, Dispatcher& /*dispatcher*/) override;
+  TimerPtr createTimer(const TimerCb& cb, DispatcherBase& /*dispatcher*/) override;
 
   // Implementation of SimulatedTimeSystemHelper::Alarm methods.
   bool isEnabled(Alarm& alarm) ABSL_LOCKS_EXCLUDED(mutex_);
@@ -254,7 +254,7 @@ private:
 };
 
 TimerPtr SimulatedTimeSystemHelper::SimulatedScheduler::createTimer(const TimerCb& cb,
-                                                                    Dispatcher& /*dispatcher*/) {
+                                                                    DispatcherBase& /*dispatcher*/) {
   return std::make_unique<SimulatedTimeSystemHelper::Alarm>(*this, time_system_, cb_scheduler_, cb);
 }
 

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -253,8 +253,9 @@ private:
   SimulatedTimeSystemHelper& time_system_;
 };
 
-TimerPtr SimulatedTimeSystemHelper::SimulatedScheduler::createTimer(const TimerCb& cb,
-                                                                    DispatcherBase& /*dispatcher*/) {
+TimerPtr
+SimulatedTimeSystemHelper::SimulatedScheduler::createTimer(const TimerCb& cb,
+                                                           DispatcherBase& /*dispatcher*/) {
   return std::make_unique<SimulatedTimeSystemHelper::Alarm>(*this, time_system_, cb_scheduler_, cb);
 }
 


### PR DESCRIPTION
Commit Message: Split DispatcherImpl into two classes
Additional Description:
Wrap DispatcherImpl around DispatcherImplBase. This allows writing
low-level stuff like timers and file events in terms of the base
interface.

Risk Level: medium - nontrivial refactor, though no functional changes expected
Testing: ran affected tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

towards #14401
/assign @antoniovicente 