### PR TITLE
overload: remove createScaledTimer with OverloadTimerType

### DIFF
--- a/include/envoy/event/scaled_timer_minimum.h
+++ b/include/envoy/event/scaled_timer_minimum.h
@@ -13,7 +13,11 @@ namespace Event {
  * Describes a minimum timer value that is equal to a scale factor applied to the maximum.
  */
 struct ScaledMinimum {
-  explicit ScaledMinimum(UnitFloat scale_factor) : scale_factor_(scale_factor) {}
+  explicit constexpr ScaledMinimum(UnitFloat scale_factor) : scale_factor_(scale_factor) {}
+  inline bool operator==(const ScaledMinimum& other) const {
+    return other.scale_factor_.value() == scale_factor_.value();
+  }
+
   const UnitFloat scale_factor_;
 };
 
@@ -21,7 +25,8 @@ struct ScaledMinimum {
  * Describes a minimum timer value that is an absolute duration.
  */
 struct AbsoluteMinimum {
-  explicit AbsoluteMinimum(std::chrono::milliseconds value) : value_(value) {}
+  explicit constexpr AbsoluteMinimum(std::chrono::milliseconds value) : value_(value) {}
+  inline bool operator==(const AbsoluteMinimum& other) const { return other.value_ == value_; }
   const std::chrono::milliseconds value_;
 };
 
@@ -29,10 +34,10 @@ struct AbsoluteMinimum {
  * Class that describes how to compute a minimum timeout given a maximum timeout value. It wraps
  * ScaledMinimum and AbsoluteMinimum and provides a single computeMinimum() method.
  */
-class ScaledTimerMinimum : private absl::variant<ScaledMinimum, AbsoluteMinimum> {
+class ScaledTimerMinimum {
 public:
-  // Use base class constructor.
-  using absl::variant<ScaledMinimum, AbsoluteMinimum>::variant;
+  constexpr ScaledTimerMinimum(ScaledMinimum arg) : impl_(arg) {}
+  constexpr ScaledTimerMinimum(AbsoluteMinimum arg) : impl_(arg) {}
 
   // Computes the minimum value for a given maximum timeout. If this object was constructed with a
   // - ScaledMinimum value:
@@ -51,9 +56,13 @@ public:
       }
       const std::chrono::milliseconds value_;
     };
-    return absl::visit<Visitor, const absl::variant<ScaledMinimum, AbsoluteMinimum>&>(
-        Visitor(maximum), *this);
+    return absl::visit(Visitor(maximum), impl_);
   }
+
+  inline bool operator==(const ScaledTimerMinimum& other) const { return impl_ == other.impl_; }
+
+private:
+  absl::variant<ScaledMinimum, AbsoluteMinimum> impl_;
 };
 
 } // namespace Event

--- a/include/envoy/server/overload/thread_local_overload_state.h
+++ b/include/envoy/server/overload/thread_local_overload_state.h
@@ -40,17 +40,6 @@ private:
  */
 using OverloadActionCb = std::function<void(OverloadActionState)>;
 
-enum class OverloadTimerType {
-  // Timers created with this type will never be scaled. This should only be used for testing.
-  UnscaledRealTimerForTest,
-  // The amount of time an HTTP connection to a downstream client can remain idle (no streams). This
-  // corresponds to the HTTP_DOWNSTREAM_CONNECTION_IDLE TimerType in overload.proto.
-  HttpDownstreamIdleConnectionTimeout,
-  // The amount of time an HTTP stream from a downstream client can remain idle. This corresponds to
-  // the HTTP_DOWNSTREAM_STREAM_IDLE TimerType in overload.proto.
-  HttpDownstreamIdleStreamTimeout,
-};
-
 /**
  * Thread-local copy of the state of each configured overload action.
  */
@@ -58,10 +47,6 @@ class ThreadLocalOverloadState : public ThreadLocal::ThreadLocalObject {
 public:
   // Get a thread-local reference to the value for the given action key.
   virtual const OverloadActionState& getState(const std::string& action) PURE;
-
-  // Get a scaled timer whose minimum corresponds to the configured value for the given timer type.
-  virtual Event::TimerPtr createScaledTimer(OverloadTimerType timer_type,
-                                            Event::TimerCb callback) PURE;
 
   // Get a scaled timer whose minimum is determined by the given scaling rule.
   virtual Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum,

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -440,6 +440,9 @@ private:
   // map lookup in the hot path of processing each request.
   const Server::OverloadActionState& overload_stop_accepting_requests_ref_;
   const Server::OverloadActionState& overload_disable_keepalive_ref_;
+  // Timer scaling factors.
+  const Event::ScaledTimerMinimum downstream_idle_connection_scaled_timeout_;
+  const Event::ScaledTimerMinimum downstream_idle_stream_scaled_timeout_;
   TimeSource& time_source_;
   bool remote_close_{};
 };

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -255,9 +255,6 @@ private:
     struct NullThreadLocalOverloadState : public ThreadLocalOverloadState {
       NullThreadLocalOverloadState(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
       const OverloadActionState& getState(const std::string&) override { return inactive_; }
-      Event::TimerPtr createScaledTimer(OverloadTimerType, Event::TimerCb callback) override {
-        return dispatcher_.createTimer(callback);
-      }
       Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum,
                                         Event::TimerCb callback) override {
         return dispatcher_.createTimer(callback);
@@ -284,6 +281,10 @@ private:
       // This method shouldn't be called by the admin listener
       NOT_REACHED_GCOVR_EXCL_LINE;
       return false;
+    }
+
+    Event::ScaledTimerMinimum getConfiguredTimerMinimum(OverloadTimerType) const override {
+      return Event::ScaledMinimum(UnitFloat::max());
     }
 
     ThreadLocal::SlotPtr tls_;

--- a/source/server/overload_manager_impl.h
+++ b/source/server/overload_manager_impl.h
@@ -114,6 +114,7 @@ public:
   bool registerForAction(const std::string& action, Event::Dispatcher& dispatcher,
                          OverloadActionCb callback) override;
   ThreadLocalOverloadState& getThreadLocalOverloadState() override;
+  Event::ScaledTimerMinimum getConfiguredTimerMinimum(OverloadTimerType timer_type) const override;
 
   // Stop the overload manager timer and wait for any pending resource updates to complete.
   // After this returns, overload manager clients should not receive any more callbacks

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -53,7 +53,7 @@ void HttpConnectionManagerImplTest::setup(bool ssl, const std::string& server_na
   server_name_ = server_name;
   ON_CALL(filter_callbacks_.connection_, ssl()).WillByDefault(Return(ssl_connection_));
   ON_CALL(Const(filter_callbacks_.connection_), ssl()).WillByDefault(Return(ssl_connection_));
-  ON_CALL(overload_manager_.overload_state_, createScaledTypedTimer_)
+  ON_CALL(overload_manager_.overload_state_, createScaledMinimumTimer_)
       .WillByDefault([&](auto, auto callback) {
         return filter_callbacks_.connection_.dispatcher_.createTimer(callback).release();
       });

--- a/test/mocks/server/overload_manager.cc
+++ b/test/mocks/server/overload_manager.cc
@@ -11,19 +11,14 @@ namespace Envoy {
 namespace Server {
 
 using ::testing::NiceMock;
+using ::testing::Return;
 using ::testing::ReturnNew;
 using ::testing::ReturnRef;
 
 MockThreadLocalOverloadState::MockThreadLocalOverloadState()
     : disabled_state_(OverloadActionState::inactive()) {
   ON_CALL(*this, getState).WillByDefault(ReturnRef(disabled_state_));
-  ON_CALL(*this, createScaledTypedTimer_).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
   ON_CALL(*this, createScaledMinimumTimer_).WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
-}
-
-Event::TimerPtr MockThreadLocalOverloadState::createScaledTimer(OverloadTimerType timer_type,
-                                                                Event::TimerCb callback) {
-  return Event::TimerPtr{createScaledTypedTimer_(timer_type, std::move(callback))};
 }
 
 Event::TimerPtr MockThreadLocalOverloadState::createScaledTimer(Event::ScaledTimerMinimum minimum,
@@ -33,6 +28,8 @@ Event::TimerPtr MockThreadLocalOverloadState::createScaledTimer(Event::ScaledTim
 
 MockOverloadManager::MockOverloadManager() {
   ON_CALL(*this, getThreadLocalOverloadState()).WillByDefault(ReturnRef(overload_state_));
+  ON_CALL(*this, getConfiguredTimerMinimum)
+      .WillByDefault(Return(Event::ScaledMinimum(UnitFloat::max())));
 }
 
 MockOverloadManager::~MockOverloadManager() = default;

--- a/test/mocks/server/overload_manager.h
+++ b/test/mocks/server/overload_manager.h
@@ -14,10 +14,8 @@ class MockThreadLocalOverloadState : public ThreadLocalOverloadState {
 public:
   MockThreadLocalOverloadState();
   MOCK_METHOD(const OverloadActionState&, getState, (const std::string&), (override));
-  Event::TimerPtr createScaledTimer(OverloadTimerType timer_type, Event::TimerCb callback) override;
   Event::TimerPtr createScaledTimer(Event::ScaledTimerMinimum minimum,
                                     Event::TimerCb callback) override;
-  MOCK_METHOD(Event::Timer*, createScaledTypedTimer_, (OverloadTimerType, Event::TimerCb));
   MOCK_METHOD(Event::Timer*, createScaledMinimumTimer_,
               (Event::ScaledTimerMinimum, Event::TimerCb));
 
@@ -36,6 +34,8 @@ public:
               (const std::string& action, Event::Dispatcher& dispatcher,
                OverloadActionCb callback));
   MOCK_METHOD(ThreadLocalOverloadState&, getThreadLocalOverloadState, ());
+  MOCK_METHOD(Event::ScaledTimerMinimum, getConfiguredTimerMinimum, (OverloadTimerType timer_type),
+              (const));
 
   testing::NiceMock<MockThreadLocalOverloadState> overload_state_;
 };


### PR DESCRIPTION
Commit Message: Remove createScaledTimer method that takes OverloadTimerType
Additional Description:
Require that callers of ThreadLocalOverloadState::createScaledTimer know
their timer scaling factor instead of looking it up by well-known type.
This makes timer creation more efficient since the lookup is performed
at most once instead of on every call to createScaledTimer, and will
make it easier to add scaled timers in other places without threading
the entire ThreadLocalOverloadState there.

Risk Level: low
Testing: ran affected tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a