### PR TITLE
router: extract interface for UpstreamRequest

### DIFF
--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -193,14 +193,14 @@ void UpstreamRequest::onUpstreamHostSelected(Upstream::HostDescriptionConstShare
   parent_.onUpstreamHostSelected(host);
 }
 
-void UpstreamRequest::encodeHeaders(bool end_stream) {
+void UpstreamRequest::encodeUpstreamHeaders(bool end_stream) {
   ASSERT(!encode_complete_);
   encode_complete_ = end_stream;
 
   conn_pool_->newStream(this);
 }
 
-void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
+void UpstreamRequest::encodeUpstreamData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!encode_complete_);
   encode_complete_ = end_stream;
 
@@ -227,7 +227,7 @@ void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
   }
 }
 
-void UpstreamRequest::encodeTrailers(const Http::RequestTrailerMap& trailers) {
+void UpstreamRequest::encodeUpstreamTrailers(const Http::RequestTrailerMap& trailers) {
   ASSERT(!encode_complete_);
   encode_complete_ = true;
   encode_trailers_ = true;
@@ -243,7 +243,7 @@ void UpstreamRequest::encodeTrailers(const Http::RequestTrailerMap& trailers) {
   }
 }
 
-void UpstreamRequest::encodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) {
+void UpstreamRequest::encodeUpstreamMetadata(Http::MetadataMapPtr&& metadata_map_ptr) {
   if (!upstream_) {
     ENVOY_STREAM_LOG(trace, "upstream_ not ready. Store metadata_map to encode later: {}",
                      *parent_.callbacks(), *metadata_map_ptr);

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -33,7 +33,8 @@ class UpstreamRequest;
 /**
  * Interface to allow for switching between new and old UpstreamRequest implementation.
  */
-class RouterUpstreamRequest : public LinkedObject<RouterUpstreamRequest> {
+class RouterUpstreamRequest : public LinkedObject<RouterUpstreamRequest>,
+                              public UpstreamToDownstream {
 public:
   virtual ~RouterUpstreamRequest() = default;
 
@@ -66,7 +67,6 @@ public:
 // The base request for Upstream.
 class UpstreamRequest : public Logger::Loggable<Logger::Id::router>,
                         public RouterUpstreamRequest,
-                        public UpstreamToDownstream,
                         public GenericConnectionPoolCallbacks {
 public:
   UpstreamRequest(RouterFilterInterface& parent, std::unique_ptr<GenericConnPool>&& conn_pool);

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -36,8 +36,6 @@ class UpstreamRequest;
 class RouterUpstreamRequest : public LinkedObject<RouterUpstreamRequest>,
                               public UpstreamToDownstream {
 public:
-  virtual ~RouterUpstreamRequest() = default;
-
   virtual void encodeUpstreamHeaders(bool end_stream) PURE;
   virtual void encodeUpstreamData(Buffer::Instance& data, bool end_stream) PURE;
   virtual void encodeUpstreamTrailers(const Http::RequestTrailerMap& trailers) PURE;

--- a/test/mocks/router/router_filter_interface.h
+++ b/test/mocks/router/router_filter_interface.h
@@ -17,21 +17,23 @@ public:
   ~MockRouterFilterInterface() override;
 
   MOCK_METHOD(void, onUpstream100ContinueHeaders,
-              (Envoy::Http::ResponseHeaderMapPtr && headers, UpstreamRequest& upstream_request));
+              (Envoy::Http::ResponseHeaderMapPtr && headers,
+               RouterUpstreamRequest& upstream_request));
   MOCK_METHOD(void, onUpstreamHeaders,
               (uint64_t response_code, Envoy::Http::ResponseHeaderMapPtr&& headers,
-               UpstreamRequest& upstream_request, bool end_stream));
+               RouterUpstreamRequest& upstream_request, bool end_stream));
   MOCK_METHOD(void, onUpstreamData,
-              (Buffer::Instance & data, UpstreamRequest& upstream_request, bool end_stream));
+              (Buffer::Instance & data, RouterUpstreamRequest& upstream_request, bool end_stream));
   MOCK_METHOD(void, onUpstreamTrailers,
-              (Envoy::Http::ResponseTrailerMapPtr && trailers, UpstreamRequest& upstream_request));
+              (Envoy::Http::ResponseTrailerMapPtr && trailers,
+               RouterUpstreamRequest& upstream_request));
   MOCK_METHOD(void, onUpstreamMetadata, (Envoy::Http::MetadataMapPtr && metadata_map));
   MOCK_METHOD(void, onUpstreamReset,
               (Envoy::Http::StreamResetReason reset_reason, absl::string_view transport_failure,
-               UpstreamRequest& upstream_request));
+               RouterUpstreamRequest& upstream_request));
   MOCK_METHOD(void, onUpstreamHostSelected, (Upstream::HostDescriptionConstSharedPtr host));
-  MOCK_METHOD(void, onPerTryTimeout, (UpstreamRequest & upstream_request));
-  MOCK_METHOD(void, onStreamMaxDurationReached, (UpstreamRequest & upstream_request));
+  MOCK_METHOD(void, onPerTryTimeout, (RouterUpstreamRequest & upstream_request));
+  MOCK_METHOD(void, onStreamMaxDurationReached, (RouterUpstreamRequest & upstream_request));
 
   MOCK_METHOD(Envoy::Http::StreamDecoderFilterCallbacks*, callbacks, ());
   MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, cluster, ());


### PR DESCRIPTION
This extracts an interface for UpstreamRequest, which should allow us to
instantiate either one that makes use of upstream filters or the
original one as part of rolling out support for upstream filters.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, refactor only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
