### PR TITLE
network: update network test-coverage expectations and add one simple coverage improvement

### DIFF
--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -24,24 +24,18 @@ void commonHashKey(const TransportSocketOptions& options, std::vector<std::uint8
   }
 
   const auto& verify_san_list = options.verifySubjectAltNameListOverride();
-  if (!verify_san_list.empty()) {
-    for (const auto& san : verify_san_list) {
-      pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(san), key);
-    }
+  for (const auto& san : verify_san_list) {
+    pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(san), key);
   }
 
   const auto& alpn_list = options.applicationProtocolListOverride();
-  if (!alpn_list.empty()) {
-    for (const auto& protocol : alpn_list) {
-      pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(protocol), key);
-    }
+  for (const auto& protocol : alpn_list) {
+    pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(protocol), key);
   }
 
   const auto& alpn_fallback = options.applicationProtocolFallback();
-  if (!alpn_fallback.empty()) {
-    for (const auto& protocol : alpn_fallback) {
-      pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(protocol), key);
-    }
+  for (const auto& protocol : alpn_fallback) {
+    pushScalarToByteVector(StringUtil::CaseInsensitiveHash()(protocol), key);
   }
 
   // Proxy protocol options should only be included in the hash if the upstream

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -14,7 +14,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common/http/http3:50.0"
 "source/common/init:96.4"
 "source/common/json:90.6"
-"source/common/network:95.3"
+"source/common/network:95.1"
 "source/common/protobuf:94.6"
 "source/common/signal:84.5" # Death tests don't report LCOV
 "source/common/singleton:95.1"


### PR DESCRIPTION
Commit Message: It looks like #14472 brought us to the edge of coverage passing for source/common/network, so this reverts the change to that expectation. I also found one easy savings of a few lines of missing coverage by removing some redundant if statements.
Additional Description:
Risk Level: low
Testing: test/common/network/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
