### PR TITLE
stats: Symbolize zone_name on initialization

### DIFF
--- a/include/envoy/local_info/BUILD
+++ b/include/envoy/local_info/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     hdrs = ["local_info.h"],
     deps = [
         "//include/envoy/network:address_interface",
+        "//include/envoy/stats:symbol_table_interface",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -30,7 +30,7 @@ public:
   /**
    * @return the zone name as a stat name.
    */
-  virtual Stats::StatName zoneStatName() const PURE;
+  virtual const Stats::StatName& zoneStatName() const PURE;
 
   /**
    * @return the human readable cluster name. E.g., "eta".

--- a/include/envoy/local_info/local_info.h
+++ b/include/envoy/local_info/local_info.h
@@ -5,6 +5,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/network/address.h"
+#include "envoy/stats/symbol_table.h"
 
 namespace Envoy {
 namespace LocalInfo {
@@ -25,6 +26,11 @@ public:
    * @return the human readable zone name. E.g., "us-east-1a".
    */
   virtual const std::string& zoneName() const PURE;
+
+  /**
+   * @return the zone name as a stat name.
+   */
+  virtual Stats::StatName zoneStatName() const PURE;
 
   /**
    * @return the human readable cluster name. E.g., "eta".

--- a/source/common/local_info/BUILD
+++ b/source/common/local_info/BUILD
@@ -14,7 +14,7 @@ envoy_cc_library(
     deps = [
         "//include/envoy/local_info:local_info_interface",
         "//source/common/config:version_converter_lib",
-        "//source/common/envoy/stats:symbol_table_lib",
+        "//source/common/stats:symbol_table_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/local_info/BUILD
+++ b/source/common/local_info/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     hdrs = ["local_info_impl.h"],
     deps = [
         "//include/envoy/local_info:local_info_interface",
+        "//include/envoy/stats:symbol_table_interface",
         "//source/common/config:version_converter_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/source/common/local_info/BUILD
+++ b/source/common/local_info/BUILD
@@ -13,8 +13,8 @@ envoy_cc_library(
     hdrs = ["local_info_impl.h"],
     deps = [
         "//include/envoy/local_info:local_info_interface",
-        "//include/envoy/stats:symbol_table_interface",
         "//source/common/config:version_converter_lib",
+        "//source/common/envoy/stats:symbol_table_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -4,9 +4,9 @@
 
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/local_info/local_info.h"
-#include "envoy/stats/symbol_table.h"
 
 #include "common/config/version_converter.h"
+#include "common/stats/symbol_table_impl.h"
 
 namespace Envoy {
 namespace LocalInfo {

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -17,7 +17,8 @@ public:
                 const Network::Address::InstanceConstSharedPtr& address,
                 absl::string_view zone_name, absl::string_view cluster_name,
                 absl::string_view node_name)
-      : node_(node), address_(address), zone_stat_name_(zone_name, symbol_table) {
+      : node_(node), address_(address), zone_stat_name_storage_(zone_name, symbol_table),
+        zone_stat_name_(zone_stat_name_storage_.statName()) {
     if (!zone_name.empty()) {
       node_.mutable_locality()->set_zone(std::string(zone_name));
     }
@@ -31,7 +32,7 @@ public:
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
   const std::string& zoneName() const override { return node_.locality().zone(); }
-  Stats::StatName zoneStatName() const override { return zone_stat_name_.statName(); }
+  const Stats::StatName& zoneStatName() const override { return zone_stat_name_; }
   const std::string& clusterName() const override { return node_.cluster(); }
   const std::string& nodeName() const override { return node_.id(); }
   const envoy::config::core::v3::Node& node() const override { return node_; }
@@ -39,7 +40,8 @@ public:
 private:
   envoy::config::core::v3::Node node_;
   Network::Address::InstanceConstSharedPtr address_;
-  Stats::StatNameManagedStorage zone_stat_name_;
+  const Stats::StatNameManagedStorage zone_stat_name_storage_;
+  const Stats::StatName zone_stat_name_;
 };
 
 } // namespace LocalInfo

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -173,9 +173,8 @@ public:
         emit_dynamic_stats_(emit_dynamic_stats), start_child_span_(start_child_span),
         suppress_envoy_headers_(suppress_envoy_headers),
         respect_expected_rq_timeout_(respect_expected_rq_timeout), http_context_(http_context),
-        stat_name_pool_(scope_.symbolTable()),
-        zone_name_(stat_name_pool_.add(local_info_.zoneName())),
-        shadow_writer_(std::move(shadow_writer)), time_source_(time_source) {
+        zone_name_(local_info_.zoneStatName()), shadow_writer_(std::move(shadow_writer)),
+        time_source_(time_source) {
     if (!strict_check_headers.empty()) {
       strict_check_headers_ = std::make_unique<HeaderVector>();
       for (const auto& header : strict_check_headers) {
@@ -217,8 +216,6 @@ public:
   HeaderVectorPtr strict_check_headers_;
   std::list<AccessLog::InstanceSharedPtr> upstream_logs_;
   Http::Context& http_context_;
-  Stats::StatNamePool
-      stat_name_pool_; // TODO(#14242): use dynamic name for zone_name and drop pool.
   Stats::StatName zone_name_;
   Stats::StatName empty_stat_name_;
 

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -85,8 +85,8 @@ void ValidationInstance::initialize(const Options& options,
   bootstrap.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
 
   local_info_ = std::make_unique<LocalInfo::LocalInfoImpl>(
-      bootstrap.node(), local_address, options.serviceZone(), options.serviceClusterName(),
-      options.serviceNodeName());
+      stats().symbolTable(), bootstrap.node(), local_address, options.serviceZone(),
+      options.serviceClusterName(), options.serviceNodeName());
 
   Configuration::InitialImpl initial_config(bootstrap, options);
   overload_manager_ = std::make_unique<OverloadManagerImpl>(

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -403,8 +403,8 @@ void InstanceImpl::initialize(const Options& options,
   }
 
   local_info_ = std::make_unique<LocalInfo::LocalInfoImpl>(
-      bootstrap_.node(), local_address, options.serviceZone(), options.serviceClusterName(),
-      options.serviceNodeName());
+      stats().symbolTable(), bootstrap_.node(), local_address, options.serviceZone(),
+      options.serviceClusterName(), options.serviceNodeName());
 
   Configuration::InitialImpl initial_config(bootstrap_, options);
 

--- a/test/mocks/local_info/BUILD
+++ b/test/mocks/local_info/BUILD
@@ -15,6 +15,7 @@ envoy_cc_mock(
     deps = [
         "//include/envoy/local_info:local_info_interface",
         "//source/common/network:address_lib",
+        "//test/common/stats:stat_test_utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -17,12 +17,22 @@ MockLocalInfo::MockLocalInfo() : address_(new Network::Address::Ipv4Instance("12
   node_.mutable_locality()->set_zone("zone_name");
   ON_CALL(*this, address()).WillByDefault(Return(address_));
   ON_CALL(*this, zoneName()).WillByDefault(ReturnRef(node_.locality().zone()));
+  ON_CALL(*this, zoneStatName()).WillByDefault(Return(makeZoneStatName()));
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(node_.cluster()));
   ON_CALL(*this, nodeName()).WillByDefault(ReturnRef(node_.id()));
   ON_CALL(*this, node()).WillByDefault(ReturnRef(node_));
 }
 
 MockLocalInfo::~MockLocalInfo() = default;
+
+Stats::StatName MockLocalInfo::makeZoneStatName() const {
+  if (zone_stat_name_ == nullptr ||
+      symbol_table_->toString(zone_stat_name_->statName()) != node_.locality().zone()) {
+    zone_stat_name_ =
+        std::make_unique<Stats::StatNameManagedStorage>(node_.locality().zone(), *symbol_table_);
+  }
+  return zone_stat_name_->statName();
+}
 
 } // namespace LocalInfo
 } // namespace Envoy

--- a/test/mocks/local_info/mocks.cc
+++ b/test/mocks/local_info/mocks.cc
@@ -17,7 +17,7 @@ MockLocalInfo::MockLocalInfo() : address_(new Network::Address::Ipv4Instance("12
   node_.mutable_locality()->set_zone("zone_name");
   ON_CALL(*this, address()).WillByDefault(Return(address_));
   ON_CALL(*this, zoneName()).WillByDefault(ReturnRef(node_.locality().zone()));
-  ON_CALL(*this, zoneStatName()).WillByDefault(Return(makeZoneStatName()));
+  ON_CALL(*this, zoneStatName()).WillByDefault(ReturnRef(makeZoneStatName()));
   ON_CALL(*this, clusterName()).WillByDefault(ReturnRef(node_.cluster()));
   ON_CALL(*this, nodeName()).WillByDefault(ReturnRef(node_.id()));
   ON_CALL(*this, node()).WillByDefault(ReturnRef(node_));
@@ -25,13 +25,14 @@ MockLocalInfo::MockLocalInfo() : address_(new Network::Address::Ipv4Instance("12
 
 MockLocalInfo::~MockLocalInfo() = default;
 
-Stats::StatName MockLocalInfo::makeZoneStatName() const {
-  if (zone_stat_name_ == nullptr ||
-      symbol_table_->toString(zone_stat_name_->statName()) != node_.locality().zone()) {
-    zone_stat_name_ =
+const Stats::StatName& MockLocalInfo::makeZoneStatName() const {
+  if (zone_stat_name_storage_ == nullptr ||
+      symbol_table_->toString(zone_stat_name_) != node_.locality().zone()) {
+    zone_stat_name_storage_ =
         std::make_unique<Stats::StatNameManagedStorage>(node_.locality().zone(), *symbol_table_);
+    zone_stat_name_ = zone_stat_name_storage_->statName();
   }
-  return zone_stat_name_->statName();
+  return zone_stat_name_;
 }
 
 } // namespace LocalInfo

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -5,6 +5,8 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/local_info/local_info.h"
 
+#include "test/common/stats/stat_test_utility.h"
+
 #include "gmock/gmock.h"
 
 namespace Envoy {
@@ -19,12 +21,17 @@ public:
   MOCK_METHOD(const std::string&, zoneName, (), (const));
   MOCK_METHOD(const std::string&, clusterName, (), (const));
   MOCK_METHOD(const std::string&, nodeName, (), (const));
+  MOCK_METHOD(Stats::StatName, zoneStatName, (), (const));
   MOCK_METHOD(envoy::config::core::v3::Node&, node, (), (const));
+
+  Stats::StatName makeZoneStatName() const;
 
   Network::Address::InstanceConstSharedPtr address_;
   // TODO(htuch): Make this behave closer to the real implementation, with the various property
   // methods using node_ as the source of truth.
   envoy::config::core::v3::Node node_;
+  mutable Stats::TestUtil::TestSymbolTable symbol_table_;
+  mutable std::unique_ptr<Stats::StatNameManagedStorage> zone_stat_name_;
 };
 
 } // namespace LocalInfo

--- a/test/mocks/local_info/mocks.h
+++ b/test/mocks/local_info/mocks.h
@@ -21,17 +21,18 @@ public:
   MOCK_METHOD(const std::string&, zoneName, (), (const));
   MOCK_METHOD(const std::string&, clusterName, (), (const));
   MOCK_METHOD(const std::string&, nodeName, (), (const));
-  MOCK_METHOD(Stats::StatName, zoneStatName, (), (const));
+  MOCK_METHOD(const Stats::StatName&, zoneStatName, (), (const));
   MOCK_METHOD(envoy::config::core::v3::Node&, node, (), (const));
 
-  Stats::StatName makeZoneStatName() const;
+  const Stats::StatName& makeZoneStatName() const;
 
   Network::Address::InstanceConstSharedPtr address_;
   // TODO(htuch): Make this behave closer to the real implementation, with the various property
   // methods using node_ as the source of truth.
   envoy::config::core::v3::Node node_;
   mutable Stats::TestUtil::TestSymbolTable symbol_table_;
-  mutable std::unique_ptr<Stats::StatNameManagedStorage> zone_stat_name_;
+  mutable std::unique_ptr<Stats::StatNameManagedStorage> zone_stat_name_storage_;
+  mutable Stats::StatName zone_stat_name_;
 };
 
 } // namespace LocalInfo


### PR DESCRIPTION
Commit Message: zone_name can be symbolized on startup to avoid re-symbolizing when constructing Router::FilterConfig, which (I believe) happens on every request.
Additional Description: 
Risk Level: low
Testing: //test/...
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes: #14242
