### PR TITLE
fix: fill in the required args for Api::Impl

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -42,7 +42,9 @@ envoy_cc_binary(
         "//source/common/common:assert_lib",
         "//source/common/protobuf:message_validator_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/common:random_generator_lib",
         "//source/common/stats:isolated_store_lib",
+        "//test/test_common:test_version_linkstamp",
         "@envoy_api//envoy/config/bootstrap/v2:pkg_cc_proto",
     ] + envoy_cc_platform_dep("//source/exe:platform_impl_lib"),
 )

--- a/tools/bootstrap2pb.cc
+++ b/tools/bootstrap2pb.cc
@@ -13,10 +13,10 @@
 
 #include "common/api/api_impl.h"
 #include "common/common/assert.h"
+#include "common/common/random_generator.h"
 #include "common/event/real_time_system.h"
 #include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/utility.h"
-#include "common/common/random_generator.h"
 #include "common/stats/isolated_store_impl.h"
 
 #include "exe/platform_impl.h"

--- a/tools/bootstrap2pb.cc
+++ b/tools/bootstrap2pb.cc
@@ -16,6 +16,7 @@
 #include "common/event/real_time_system.h"
 #include "common/protobuf/message_validator_impl.h"
 #include "common/protobuf/utility.h"
+#include "common/common/random_generator.h"
 #include "common/stats/isolated_store_impl.h"
 
 #include "exe/platform_impl.h"
@@ -31,8 +32,9 @@ int main(int argc, char** argv) {
   Envoy::PlatformImpl platform_impl_;
   Envoy::Stats::IsolatedStoreImpl stats_store;
   Envoy::Event::RealTimeSystem time_system; // NO_CHECK_FORMAT(real_time)
+  Envoy::Random::RandomGeneratorImpl rand;
   Envoy::Api::Impl api(platform_impl_.threadFactory(), stats_store, time_system,
-                       platform_impl_.fileSystem());
+                       platform_impl_.fileSystem(), rand);
 
   envoy::config::bootstrap::v2::Bootstrap bootstrap;
   Envoy::MessageUtil::loadFromFile(argv[1], bootstrap,


### PR DESCRIPTION
Commit Message: Add `Random::RandomGenerator&` as an argument which is required by `Api::Impl`.
Risk Level: Low