### PR TITLE
docs: Give a hint to specify type_url instead

### DIFF
--- a/docs/root/configuration/listeners/listener_filters/tls_inspector.rst
+++ b/docs/root/configuration/listeners/listener_filters/tls_inspector.rst
@@ -31,7 +31,7 @@ A sample filter configuration could be:
   - name: "envoy.filters.listener.tls_inspector"
     typed_config: {}
 
-Or by specifying the `type_url <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Any.FIELDS.string.google.protobuf.Any.type_url>`_.
+Or by specifying the `type_url <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Any.FIELDS.string.google.protobuf.Any.type_url>`_
 of the *typed_config*:
 
 .. code-block:: yaml

--- a/docs/root/configuration/listeners/listener_filters/tls_inspector.rst
+++ b/docs/root/configuration/listeners/listener_filters/tls_inspector.rst
@@ -15,8 +15,10 @@ from the client. This can be used to select a
 of a :ref:`FilterChainMatch <envoy_v3_api_msg_config.listener.v3.FilterChainMatch>`.
 
 * :ref:`SNI <faq_how_to_setup_sni>`
-* :ref:`v2 API reference <envoy_v3_api_field_config.listener.v3.ListenerFilter.name>`
-* This filter should be configured with the name *envoy.filters.listener.tls_inspector*.
+* :ref:`v3 API reference <envoy_v3_api_field_config.listener.v3.ListenerFilter.name>`
+* This filter may be configured with the name *envoy.filters.listener.tls_inspector* or
+  *type.googleapis.com/envoy.extensions.listeners.tls_inspector.v3.TlsInspector* as the
+  `type_url <https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/src/google/protobuf/any.proto#L154>`_.
 
 Example
 -------
@@ -29,10 +31,20 @@ A sample filter configuration could be:
   - name: "envoy.filters.listener.tls_inspector"
     typed_config: {}
 
+Or by specifying the `type_url <https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/src/google/protobuf/any.proto#L154>`_.
+of the *typed_config*:
+
+.. code-block:: yaml
+
+  listener_filters:
+  - name: "tls_inspector"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.listeners.tls_inspector.v3.TlsInspector
+
 Statistics
 ----------
 
-This filter has a statistics tree rooted at *tls_inspector* with the following statistics: 
+This filter has a statistics tree rooted at *tls_inspector* with the following statistics:
 
 .. csv-table::
   :header: Name, Type, Description

--- a/docs/root/configuration/listeners/listener_filters/tls_inspector.rst
+++ b/docs/root/configuration/listeners/listener_filters/tls_inspector.rst
@@ -18,7 +18,7 @@ of a :ref:`FilterChainMatch <envoy_v3_api_msg_config.listener.v3.FilterChainMatc
 * :ref:`v3 API reference <envoy_v3_api_field_config.listener.v3.ListenerFilter.name>`
 * This filter may be configured with the name *envoy.filters.listener.tls_inspector* or
   *type.googleapis.com/envoy.extensions.listeners.tls_inspector.v3.TlsInspector* as the
-  `type_url <https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/src/google/protobuf/any.proto#L154>`_.
+  `type_url <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Any.FIELDS.string.google.protobuf.Any.type_url>`_.
 
 Example
 -------
@@ -31,7 +31,7 @@ A sample filter configuration could be:
   - name: "envoy.filters.listener.tls_inspector"
     typed_config: {}
 
-Or by specifying the `type_url <https://github.com/protocolbuffers/protobuf/blob/9647a7c2356a9529754c07235a2877ee676c2fd0/src/google/protobuf/any.proto#L154>`_.
+Or by specifying the `type_url <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Any.FIELDS.string.google.protobuf.Any.type_url>`_.
 of the *typed_config*:
 
 .. code-block:: yaml


### PR DESCRIPTION
Commit Message: This gives a hint when configuring TLS Inspector listener filter; users can reference the config by specifying `type_url` instead of `name`.
Risk Level: N/A
Testing: N/A
Docs Changes: This is a docs change.
Release Notes: N/A
Platform-Specific Features: N/A

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>


