### PR TITLE
dependencies: update cve_scan.py for some libcurl 7.74.0 false positives

### DIFF
--- a/tools/dependency/cve_scan.py
+++ b/tools/dependency/cve_scan.py
@@ -42,6 +42,11 @@ IGNORES_CVES = set([
     # Node.js issue unrelated to http-parser, see
     # https://github.com/mhart/StringStream/issues/7.
     'CVE-2018-21270',
+    # These should not affect Curl 7.74.0, but we see false positives due to the
+    # relative release date and CPE wildcard.
+    'CVE-2020-8169',
+    'CVE-2020-8177',
+    'CVE-2020-8284',
 ])
 
 # Subset of CVE fields that are useful below.


### PR DESCRIPTION
Needed since the CVE scan heuristics use relative release data /
CVE publish dates, and these CVEs were published after the 7.74.0
release.

Signed-off-by: Harvey Tuch <htuch@google.com>