### PR TITLE
[docs] Add guidance on ENVOY_BUG in STYLE.md

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -159,17 +159,17 @@ A few general notes on our error handling philosophy:
   
 # Macro Usage
 
-The following macros are available:
-    - `RELEASE_ASSERT`: fatal check.
-    - `ASSERT`: fatal check in debug-only builds. These should be used to document (and check in
-      debug-only builds) program invariants.
-    - `ENVOY_BUG`: logs and increments a stat in release mode, fatal check in debug builds. These
-      should be used where it may be useful to detect if an efficient condition is violated in
-      production (and check in debug-only builds).
-    
-Sub-macros alias the macros above and can be used to annotate specific situations:
-    - `ENVOY_BUG_ALPHA` (alias `ENVOY_BUG`): Used for alpha or rapidly changing protocols that need
-      detectability on probable or changing invariants.
+* The following macros are available:
+  - `RELEASE_ASSERT`: fatal check.
+  - `ASSERT`: fatal check in debug-only builds. These should be used to document (and check in
+    debug-only builds) program invariants.
+  - `ENVOY_BUG`: logs and increments a stat in release mode, fatal check in debug builds. These
+    should be used where it may be useful to detect if an efficient condition is violated in
+    production (and check in debug-only builds).
+
+* Sub-macros alias the macros above and can be used to annotate specific situations:
+  - `ENVOY_BUG_ALPHA` (alias `ENVOY_BUG`): Used for alpha or rapidly changing protocols that need
+  detectability on probable or changing invariants.
 
 * Per above it's acceptable to turn failures into crash semantics via `RELEASE_ASSERT(condition)` or
   `PANIC(message)` if there is no other sensible behavior, e.g.  in OOM (memory/FD) scenarios.

--- a/STYLE.md
+++ b/STYLE.md
@@ -192,10 +192,10 @@ A few general notes on our error handling philosophy:
   general we view `ASSERT` as the common case and `RELEASE_ASSERT` as the uncommon case, but
   experience and judgment may dictate a particular approach depending on the situation.
 
-Below is a guideline for macro usage. On the left side are invariants and the right side is for
-error conditions that can be triggered. `ENVOY_BUG` represents a middle ground that can be used for
-uncertain conditions that need detectability. `ENVOY_BUG`s can also be added for errors if they need
-detection.
+Below is a guideline for macro usage. The left side of the table has invariants and the right side
+has error conditions that can be triggered and should be gracefully handled. `ENVOY_BUG` represents
+a middle ground that can be used for uncertain conditions that need detectability. `ENVOY_BUG`s can
+also be added for errors if they warrant detection.
 
 | `ASSERT`/`RELEASE_ASSERT` | `ENVOY_BUG` | Error handling and Testing |
 | --- | --- | --- |

--- a/STYLE.md
+++ b/STYLE.md
@@ -160,17 +160,15 @@ A few general notes on our error handling philosophy:
 # Macro Usage
 
 The following macros are available:
-
-    * `RELEASE_ASSERT`: fatal check.
-    * `ASSERT`: fatal check in debug-only builds. These should be used to document (and check in
+    - `RELEASE_ASSERT`: fatal check.
+    - `ASSERT`: fatal check in debug-only builds. These should be used to document (and check in
       debug-only builds) program invariants.
-    * `ENVOY_BUG`: logs and increments a stat in release mode, fatal check in debug builds. These
+    - `ENVOY_BUG`: logs and increments a stat in release mode, fatal check in debug builds. These
       should be used where it may be useful to detect if an efficient condition is violated in
       production (and check in debug-only builds).
     
 Sub-macros alias the macros above and can be used to annotate specific situations:
-
-    * `ENVOY_BUG_ALPHA` (alias `ENVOY_BUG`): Used for alpha or rapidly changing protocols that need
+    - `ENVOY_BUG_ALPHA` (alias `ENVOY_BUG`): Used for alpha or rapidly changing protocols that need
       detectability on probable or changing invariants.
 
 * Per above it's acceptable to turn failures into crash semantics via `RELEASE_ASSERT(condition)` or

--- a/STYLE.md
+++ b/STYLE.md
@@ -172,7 +172,7 @@ A few general notes on our error handling philosophy:
   detectability on probable or changing invariants.
 
 * Per above it's acceptable to turn failures into crash semantics via `RELEASE_ASSERT(condition)` or
-  `PANIC(message)` if there is no other sensible behavior, e.g.  in OOM (memory/FD) scenarios.
+  `PANIC(message)` if there is no other sensible behavior, e.g. in OOM (memory/FD) scenarios.
 * Only `RELEASE_ASSERT(condition)` should be used to validate conditions that might be imposed by
   the external environment.
 * Annotate macro usage with comments on belief (probable or provable condition).
@@ -201,7 +201,7 @@ also be added for errors if they warrant detection.
 | --- | --- | --- |
 | Low level invariants in data structures | | |
 | Simple, provable internal class invariants | Complex, uncertain internal class invariants (e.g. need detectability if violated) | |
-| Provable (pre/post)-conditions | Complicated but likely (pre-/post-) conditions that are low-risk (Envoy can continue safely) | Triggerable or uncertain conditions, may be based on untrusted data plane traffic or an extensions’ contract.  |
+| Provable (pre/post)-conditions | Complicated but likely (pre-/post-) conditions that are low-risk (Envoy can continue safely) | Triggerable or uncertain conditions, may be based on untrusted data plane traffic or an extensions’ contract. |
 |                                                                                     | Conditions in alpha or changing extensions that need detectability. (`ENVOY_BUG_ALPHA`) | |
 | Unlikely environment errors after process initialization that would otherwise crash | | Likely environment errors, e.g. return codes from untrusted extensions, dependencies or system calls, network error, bad data read, permission based errors, etc. |
 | Fatal crashing events. e.g. OOMs, deadlocks, no process recovery possible | | |

--- a/STYLE.md
+++ b/STYLE.md
@@ -160,6 +160,7 @@ A few general notes on our error handling philosophy:
 # Macro Usage
 
 The following macros are available:
+
     * `RELEASE_ASSERT`: fatal check.
     * `ASSERT`: fatal check in debug-only builds. These should be used to document (and check in
       debug-only builds) program invariants.
@@ -168,8 +169,7 @@ The following macros are available:
       production (and check in debug-only builds).
     
 Sub-macros alias the macros above and can be used to annotate specific situations:
-    * `ASSERT_INTERNAL` (by default compiles to `ASSERT` but can be built to behave like
-      `ENVOY_BUG`). Used for provable, internal class invariants. No error handling is needed.
+
     * `ENVOY_BUG_ALPHA` (alias `ENVOY_BUG`): Used for alpha or rapidly changing protocols that need
       detectability on probable or changing invariants.
 
@@ -199,14 +199,14 @@ error conditions that can be triggered. `ENVOY_BUG` represents a middle ground t
 uncertain conditions that need detectability. `ENVOY_BUG`s can also be added for errors if they need
 detection.
 
-| ASSERT/RELEASE_ASSERT                                                               | ENVOY_BUG                                                                                    | Error handling and Testing                                                                                                                                        |
-| ---                                                                                 | ---                                                                                          | ---                                                                                                                                                               |
-| Low level invariants in data structures                                             |                                                                                              |                                                                                                                                                                   |
-| Simple, provable internal class invariants (denote ASSERT_INVARIANT                 | Complex, uncertain internal class invariants (e.g. need detectability if violated)           |                                                                                                                                                                   |
-| Provable (pre/post)-conditions                                                      | Complicated but likely (pre-/post-) conditions that are low-risk (Envoy can continue safely) | Triggerable or uncertain conditions, may be based on untrusted data plane traffic or an extensions’ contract.                                                     |
-|                                                                                     | Conditions in alpha or changing extensions that need detectability. (ENVOY_BUG_ALPHA)        |                                                                                                                                                                   |
-| Unlikely environment errors after process initialization that would otherwise crash |                                                                                              | Likely environment errors, e.g. return codes from untrusted extensions, dependencies or system calls, network error, bad data read, permission based errors, etc. |
-| Fatal crashing events. e.g. OOMs, deadlocks, no process recovery possible           |                                                                                              |                                                                                                                                                                   |
+| `ASSERT`/`RELEASE_ASSERT` | `ENVOY_BUG` | Error handling and Testing |
+| --- | --- | --- |
+| Low level invariants in data structures | | |
+| Simple, provable internal class invariants | Complex, uncertain internal class invariants (e.g. need detectability if violated) | |
+| Provable (pre/post)-conditions | Complicated but likely (pre-/post-) conditions that are low-risk (Envoy can continue safely) | Triggerable or uncertain conditions, may be based on untrusted data plane traffic or an extensions’ contract.  |
+|                                                                                     | Conditions in alpha or changing extensions that need detectability. (`ENVOY_BUG_ALPHA`) | |
+| Unlikely environment errors after process initialization that would otherwise crash | | Likely environment errors, e.g. return codes from untrusted extensions, dependencies or system calls, network error, bad data read, permission based errors, etc. |
+| Fatal crashing events. e.g. OOMs, deadlocks, no process recovery possible | | |
 
 # Hermetic and deterministic tests
 


### PR DESCRIPTION
Commit Message: Adds guidance on ENVOY_BUG per https://github.com/envoyproxy/envoy/issues/14190
Risk Level: Low
Docs Changes: Updates to STYLE.md
Part of https://github.com/envoyproxy/envoy/issues/14190

TODOs (part of issue):
   - add macro for internal class invariants
