### PR TITLE
test: fix race in overload integration test

### DIFF
--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -330,12 +330,11 @@ TEST_P(OverloadScaledTimerIntegrationTest, CloseIdleHttpStream) {
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
   // Create an HTTP connection and start a request.
-  FakeStreamPtr http_stream;
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto response = codec_client_->makeRequestWithBody(request_headers, 10);
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, http_stream));
-  ASSERT_TRUE(http_stream->waitForHeadersComplete());
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
   // At this point, Envoy is waiting for the upstream to respond, but that won't
   // happen before it hits the stream timeout.
 


### PR DESCRIPTION
Commit Message: Fix data race in overload integration test
Additional Description:
When the stream is deleted by the test ending, there is a race with deletion of the fake upstream.
Using the test member variable ensures that the stream isn't deleted until after the destructor
runs and cleans up the fake upstreams.
Risk Level: low - test only
Testing: ran affected test with TSAN 100 times before/after
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a