### PR TITLE
buffer impl: add cast for android compilation

### DIFF
--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -206,7 +206,8 @@ RawSlice OwnedImpl::frontSlice() const {
   // Ignore zero-size slices and return the first slice with data.
   for (const auto& slice : slices_) {
     if (slice.dataSize() > 0) {
-      return RawSlice{const_cast<uint8_t*>(slice.data()), slice.dataSize()};
+      return RawSlice{const_cast<uint8_t*>(slice.data()),
+                      static_cast<absl::Span<uint8_t>::size_type>(slice.dataSize())};
     }
   }
 

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -326,7 +326,7 @@ public:
   // SliceData
   absl::Span<uint8_t> getMutableData() override {
     RELEASE_ASSERT(slice_.isMutable(), "Not allowed to call getMutableData if slice is immutable");
-    return {slice_.data(), slice_.dataSize()};
+    return {slice_.data(), static_cast<absl::Span<uint8_t>::size_type>(slice_.dataSize())};
   }
 
 private:


### PR DESCRIPTION
Commit Message: add cast for android compilation
Additional Description: https://github.com/envoyproxy/envoy/pull/14282 added return values that have issues with implicit narrowing when building envoy mobile for android. This explicit cast fixes the build issues.
Risk Level: low using the expected type for the constructor as the static_cast type.
Testing: local build of envoy mobile for android. CI

Signed-off-by: Jingwei Hao <jingwei@lyft.com>
