### PR TITLE
configuration impl: mark int as unsigned for ios compilation

### DIFF
--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -192,7 +192,7 @@ WatchdogImpl::WatchdogImpl(const envoy::config::bootstrap::v3::Watchdog& watchdo
 
 InitialImpl::InitialImpl(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,
                          const Options& options)
-    : enable_deprecated_v2_api_(options.bootstrapVersion() == 2) {
+    : enable_deprecated_v2_api_(options.bootstrapVersion() == 2u) {
   const auto& admin = bootstrap.admin();
   admin_.access_log_path_ = admin.access_log_path();
   admin_.profile_path_ =


### PR DESCRIPTION
Commit Message: add `u` suffix to int to explicitly mark as unsigned for ios compilation

Additional Description: https://github.com/envoyproxy/envoy/pull/14223 added a comparison between integers of different signs: 'const unsigned int' and 'const int'. This suffix addition fixes the build issue.

Risk Level: low, explicitly declare int as unsigned.

Testing: local build of envoy mobile for ios. CI.

Signed-off-by: Jingwei Hao <jingwei@lyft.com>