### PR TITLE
[tls] Expose ServerContextImpl::selectTlsContext

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -251,7 +251,8 @@ public:
                     const std::vector<std::string>& server_names, TimeSource& time_source);
 
   // Select the TLS certificate context in SSL_CTX_set_select_certificate_cb() callback with
-  // ClientHello details.
+  // ClientHello details. This is made public for use by custom TLS extensions who want to
+  // manually create and use this as a client hello callback.
   enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
 
 private:

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -250,6 +250,10 @@ public:
   ServerContextImpl(Stats::Scope& scope, const Envoy::Ssl::ServerContextConfig& config,
                     const std::vector<std::string>& server_names, TimeSource& time_source);
 
+  // Select the TLS certificate context in SSL_CTX_set_select_certificate_cb() callback with
+  // ClientHello details.
+  enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
+
 private:
   using SessionContextID = std::array<uint8_t, SSL_MAX_SSL_SESSION_ID_LENGTH>;
 
@@ -259,9 +263,6 @@ private:
                            HMAC_CTX* hmac_ctx, int encrypt);
   bool isClientEcdsaCapable(const SSL_CLIENT_HELLO* ssl_client_hello);
   bool isClientOcspCapable(const SSL_CLIENT_HELLO* ssl_client_hello);
-  // Select the TLS certificate context in SSL_CTX_set_select_certificate_cb() callback with
-  // ClientHello details.
-  enum ssl_select_cert_result_t selectTlsContext(const SSL_CLIENT_HELLO* ssl_client_hello);
   OcspStapleAction ocspStapleAction(const ServerContextImpl::TlsContext& ctx,
                                     bool client_ocsp_capable);
 


### PR DESCRIPTION
Commit Message: [tls] Expose ServerContextImpl::selectTlsContext

Additional Description:

This simply increases the visiblity to `public` for `ServerContextImpl::selectTlsContext`. For some context, my company has a custom transport socket extension which will dynamically select one of many thousands of certificates based on SNI for the single transport socket. We still load all of the contexts via `ServerContextImpl` and leverage the logic within to apply to the SSL object.

I tried reaching out on Slack. If this is unwelcome, there are potential alternatives such as a more centralized or API-friendly place to use contexts by other extensions w/ custom handshakers and/or socket factories.

Also, if welcomed, we can see about potentially contributing our "dynamic TLS" extension which leverages a grpc-based update mechanism (but not full xDS of course).  Our use case is potentially hundreds of thousands of certs on a single listener which is why existing solutions did not work for us.

Risk Level: Low

Testing: N/A

Docs Changes: N/A

Release Notes: N/A

Platform Specific Features: N/A