### PR TITLE
[fuzz] fix minor fuzz bugs

### DIFF
--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -22,8 +22,8 @@ Http::FilterFactoryCb AdmissionControlFilterFactory::createFilterFactoryFromProt
     const envoy::extensions::filters::http::admission_control::v3alpha::AdmissionControl& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
 
-  if (config.has_sr_threshold() && config.sr_threshold().default_value().value() == 0) {
-    throw EnvoyException("Success Rate Threshold cannot be zero percent");
+  if (config.has_sr_threshold() && config.sr_threshold().default_value().value() < 1) {
+    throw EnvoyException("Success Rate Threshold cannot be less than one.");
   }
 
   const std::string prefix = stats_prefix + "admission_control.";

--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -22,8 +22,8 @@ Http::FilterFactoryCb AdmissionControlFilterFactory::createFilterFactoryFromProt
     const envoy::extensions::filters::http::admission_control::v3alpha::AdmissionControl& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
 
-  if (config.has_sr_threshold() && config.sr_threshold().default_value().value() < 1) {
-    throw EnvoyException("Success Rate Threshold cannot be less than one.");
+  if (config.has_sr_threshold() && config.sr_threshold().default_value().value() < 1.0) {
+    throw EnvoyException("Success rate threshold cannot be less than 1.0%.");
   }
 
   const std::string prefix = stats_prefix + "admission_control.";

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -75,7 +75,7 @@ success_criteria:
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(admission_control_filter_factory.createFilterFactoryFromProtoTyped(
                                 proto, "whatever", factory_context),
-                            EnvoyException, "Success Rate Threshold cannot be less than one.");
+                            EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }
 
 TEST_F(AdmissionControlConfigTest, SmallSuccessRateThreshold) {
@@ -102,7 +102,7 @@ success_criteria:
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   EXPECT_THROW_WITH_MESSAGE(admission_control_filter_factory.createFilterFactoryFromProtoTyped(
                                 proto, "whatever", factory_context),
-                            EnvoyException, "Success Rate Threshold cannot be less than one.");
+                            EnvoyException, "Success rate threshold cannot be less than 1.0%.");
 }
 
 // Verify the configuration when all fields are set.

--- a/test/extensions/filters/http/common/fuzz/BUILD
+++ b/test/extensions/filters/http/common/fuzz/BUILD
@@ -55,6 +55,7 @@ envoy_cc_test_library(
         "//test/mocks/http:http_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/proto:bookstore_proto_cc_proto",
+        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/squash/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-4784906297278464
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-4784906297278464
@@ -1,0 +1,23 @@
+config {
+  name: "envoy.filters.http.admission_control"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.admission_control.v3alpha.AdmissionControl"
+    value: "\022\000\032\002\020\002*\016\n\t\t+\000\000\000\000\000\000\000\022\001$"
+  }
+}
+data {
+  headers {
+  }
+  http_body {
+    data: "\037\000\000\000\000\000\000\000"
+  }
+}
+upstream_data {
+  headers {
+  }
+  http_body {
+    data: "="
+    data: "="
+    data: "?"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6484279454466048
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6484279454466048
@@ -1,0 +1,13 @@
+config {
+  name: "envoy.filters.http.ratelimit"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit"
+    value: "\n\001\021(\0010\001:\376\001\022\373\001\022\370\001\n\001T\022\002\n\000\032\003\n\001~\032\256\0012\253\001\032\250\001\nHtype.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit\022\\\n\001\021(\0010\001:Q\022O\022M\n\001T\022\002\n\000\032\005\"\003\n\001!\032\0022\000\032\005\"\003\n\001>\032\007\032\005\"003\n\032\002\022\000\032\n\"\010\n\001>\020\200\200\254\001\"\027envoy\000\000\000\027ters.http.rbac2\000H\001\032\005\"\003\n\001>\032\007\032\005\"003\n\032\002\022\000\032\n\"\010\n\001>\020\200\200\254\001\"\027envoy\000\000\000\027ters.http.rbac2\000H\001"
+  }
+}
+data {
+  http_body {
+    data: "\021"
+    data: "!"
+  }
+}

--- a/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6550085676695552
+++ b/test/extensions/filters/http/common/fuzz/filter_corpus/clusterfuzz-testcase-minimized-filter_fuzz_test-6550085676695552
@@ -1,0 +1,1 @@
+config {   name: "envoy.filters.http.wasm" } 

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -48,7 +48,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& i
   try {
     // Catch invalid header characters.
     TestUtility::validate(input);
-    ENVOY_LOG_MISC(info, "{}", input.config().DebugString());
+    ENVOY_LOG_MISC(debug, "Filter configuration: {}", input.config().DebugString());
     // Fuzz filter.
     static UberFilterFuzzer fuzzer;
     fuzzer.fuzz(input.config(), input.data(), input.upstream_data());

--- a/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
+++ b/test/extensions/filters/http/common/fuzz/filter_fuzz_test.cc
@@ -48,6 +48,7 @@ DEFINE_PROTO_FUZZER(const test::extensions::filters::http::FilterFuzzTestCase& i
   try {
     // Catch invalid header characters.
     TestUtility::validate(input);
+    ENVOY_LOG_MISC(info, "{}", input.config().DebugString());
     // Fuzz filter.
     static UberFilterFuzzer fuzzer;
     fuzzer.fuzz(input.config(), input.data(), input.upstream_data());

--- a/test/extensions/filters/http/common/fuzz/uber_filter.h
+++ b/test/extensions/filters/http/common/fuzz/uber_filter.h
@@ -4,6 +4,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/test_runtime.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -39,7 +40,9 @@ private:
   Network::Address::InstanceConstSharedPtr addr_;
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
   NiceMock<Http::MockAsyncClientRequest> async_request_;
+  envoy::config::core::v3::Metadata listener_metadata_;
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info_;
+  TestScopedRuntime scoped_runtime_;
 
   // Filter constructed from the config.
   Http::StreamDecoderFilterSharedPtr decoder_filter_;

--- a/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
+++ b/test/extensions/filters/http/common/fuzz/uber_per_filter.cc
@@ -148,6 +148,10 @@ void UberFilterFuzzer::perFilterSetup() {
   ON_CALL(factory_context_, admin()).WillByDefault(testing::ReturnRef(factory_context_.admin_));
   ON_CALL(factory_context_.admin_, addHandler(_, _, _, _, _)).WillByDefault(testing::Return(true));
   ON_CALL(factory_context_.admin_, removeHandler(_)).WillByDefault(testing::Return(true));
+
+  // Prepare expectations for WASM filter.
+  ON_CALL(factory_context_, listenerMetadata())
+      .WillByDefault(testing::ReturnRef(listener_metadata_));
 }
 
 } // namespace HttpFilters


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Fixes minor fuzz bugs.
 - Add runtime loader 
 - Add listenerMetadata() to context for WASM filter
 - Fix divide by zero bug caused by a runtime percent < 1 in admission control filter

Risk Level: Low
Testing: Added unit test for admission control fix
Fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28401
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28696
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29233