### PR TITLE
fix new/free mismatch in Mainthread utility

### DIFF
--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -174,7 +174,7 @@ struct MainThread {
   bool inMainThread() const { return main_thread_id_ == std::this_thread::get_id(); }
   static void init() { MainThreadSingleton::initialize(new MainThread()); }
   static void clear() {
-    free(MainThreadSingleton::getExisting());
+    delete MainThreadSingleton::getExisting();
     MainThreadSingleton::clear();
   }
   static bool isMainThread() { return MainThreadSingleton::get().inMainThread(); }


### PR DESCRIPTION
Signed-off-by: chaoqin-li1123 <chaoqin@uchicago.edu>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Fix the new/free mismatch in main thread singleton.
Additional Description: fix the bug of using free in a object created by new introduced by (https://github.com/envoyproxy/envoy/pull/14457).
Risk Level: Low
Testing: No testing added.
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
