### PR TITLE
tls: improve TLS handshake/read/write error log

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -210,7 +210,11 @@ ParseState Filter::parseClientHello(const void* data, size_t len) {
 
   // This should never succeed because an error is always returned from the SNI callback.
   ASSERT(ret <= 0);
-  switch (SSL_get_error(ssl_.get(), ret)) {
+  int err = SSL_get_error(ssl_.get(), ret);
+  ENVOY_LOG(trace, "tls inspector error while client hello parsing: {}",
+            SSL_error_description(err));
+
+  switch (err) {
   case SSL_ERROR_WANT_READ:
     if (read_ == config_->maxClientHelloSize()) {
       // We've hit the specified size limit. This is an unreasonably large ClientHello;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -210,12 +210,7 @@ ParseState Filter::parseClientHello(const void* data, size_t len) {
 
   // This should never succeed because an error is always returned from the SNI callback.
   ASSERT(ret <= 0);
-  int err = SSL_get_error(ssl_.get(), ret);
-#ifndef BORINGSSL_FIPS
-  ENVOY_LOG(trace, "tls inspector error while client hello parsing: {}",
-            SSL_error_description(err));
-#endif
-  switch (err) {
+  switch (SSL_get_error(ssl_.get(), ret)) {
   case SSL_ERROR_WANT_READ:
     if (read_ == config_->maxClientHelloSize()) {
       // We've hit the specified size limit. This is an unreasonably large ClientHello;

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -211,9 +211,10 @@ ParseState Filter::parseClientHello(const void* data, size_t len) {
   // This should never succeed because an error is always returned from the SNI callback.
   ASSERT(ret <= 0);
   int err = SSL_get_error(ssl_.get(), ret);
+#ifndef BORINGSSL_FIPS
   ENVOY_LOG(trace, "tls inspector error while client hello parsing: {}",
             SSL_error_description(err));
-
+#endif
   switch (err) {
   case SSL_ERROR_WANT_READ:
     if (read_ == config_->maxClientHelloSize()) {

--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -177,6 +177,7 @@ envoy_cc_library(
     ],
     deps = [
         "//source/common/common:assert_lib",
+        "//source/common/common:empty_string",
         "//source/common/common:utility_lib",
         "//source/common/network:address_lib",
     ],

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -233,7 +233,7 @@ Network::PostIoAction SslHandshakerImpl::doHandshake() {
                : PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl(), rc);
-    ENVOY_CONN_LOG(trace, "ssl error occured while read: {}", handshake_callbacks_->connection(),
+    ENVOY_CONN_LOG(trace, "ssl error occurred while read: {}", handshake_callbacks_->connection(),
                    SSL_error_description(err));
     switch (err) {
     case SSL_ERROR_WANT_READ:

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -233,6 +233,8 @@ Network::PostIoAction SslHandshakerImpl::doHandshake() {
                : PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl(), rc);
+    ENVOY_CONN_LOG(trace, "ssl error occured while read: {}", handshake_callbacks_->connection(),
+                   SSL_error_description(err));
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -233,10 +233,8 @@ Network::PostIoAction SslHandshakerImpl::doHandshake() {
                : PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl(), rc);
-#ifndef BORINGSSL_FIPS
     ENVOY_CONN_LOG(trace, "ssl error occurred while read: {}", handshake_callbacks_->connection(),
-                   SSL_error_description(err));
-#endif
+                   Utility::getErrorDescription(err));
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.cc
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.cc
@@ -233,8 +233,10 @@ Network::PostIoAction SslHandshakerImpl::doHandshake() {
                : PostIoAction::Close;
   } else {
     int err = SSL_get_error(ssl(), rc);
+#ifndef BORINGSSL_FIPS
     ENVOY_CONN_LOG(trace, "ssl error occurred while read: {}", handshake_callbacks_->connection(),
                    SSL_error_description(err));
+#endif
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:

--- a/source/extensions/transport_sockets/tls/ssl_handshaker.h
+++ b/source/extensions/transport_sockets/tls/ssl_handshaker.h
@@ -37,7 +37,9 @@ private:
       Envoy::Ssl::ClientValidationStatus::NotValidated};
 };
 
-class SslHandshakerImpl : public Ssl::ConnectionInfo, public Ssl::Handshaker {
+class SslHandshakerImpl : public Ssl::ConnectionInfo,
+                          public Ssl::Handshaker,
+                          protected Logger::Loggable<Logger::Id::connection> {
 public:
   SslHandshakerImpl(bssl::UniquePtr<SSL> ssl, int ssl_extended_socket_info_index,
                     Ssl::HandshakeCallbacks* handshake_callbacks);

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -137,8 +137,10 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       if (result.error_.has_value()) {
         keep_reading = false;
         int err = SSL_get_error(rawSsl(), result.error_.value());
+#ifndef BORINGSSL_FIPS
         ENVOY_CONN_LOG(trace, "ssl error occurred while read: {}", callbacks_->connection(),
                        SSL_error_description(err));
+#endif
         switch (err) {
         case SSL_ERROR_WANT_READ:
           break;
@@ -265,8 +267,10 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
     } else {
       int err = SSL_get_error(rawSsl(), rc);
+#ifndef BORINGSSL_FIPS
       ENVOY_CONN_LOG(trace, "ssl error occurred while write: {}", callbacks_->connection(),
                      SSL_error_description(err));
+#endif
       switch (err) {
       case SSL_ERROR_WANT_WRITE:
         bytes_to_retry_ = bytes_to_write;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -137,6 +137,8 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       if (result.error_.has_value()) {
         keep_reading = false;
         int err = SSL_get_error(rawSsl(), result.error_.value());
+        ENVOY_CONN_LOG(trace, "ssl error occured while read: {}", callbacks_->connection(),
+                       SSL_error_description(err));
         switch (err) {
         case SSL_ERROR_WANT_READ:
           break;
@@ -263,6 +265,8 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
     } else {
       int err = SSL_get_error(rawSsl(), rc);
+      ENVOY_CONN_LOG(trace, "ssl error occured while write: {}", callbacks_->connection(),
+                     SSL_error_description(err));
       switch (err) {
       case SSL_ERROR_WANT_WRITE:
         bytes_to_retry_ = bytes_to_write;

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -137,7 +137,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       if (result.error_.has_value()) {
         keep_reading = false;
         int err = SSL_get_error(rawSsl(), result.error_.value());
-        ENVOY_CONN_LOG(trace, "ssl error occured while read: {}", callbacks_->connection(),
+        ENVOY_CONN_LOG(trace, "ssl error occurred while read: {}", callbacks_->connection(),
                        SSL_error_description(err));
         switch (err) {
         case SSL_ERROR_WANT_READ:
@@ -265,7 +265,7 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
     } else {
       int err = SSL_get_error(rawSsl(), rc);
-      ENVOY_CONN_LOG(trace, "ssl error occured while write: {}", callbacks_->connection(),
+      ENVOY_CONN_LOG(trace, "ssl error occurred while write: {}", callbacks_->connection(),
                      SSL_error_description(err));
       switch (err) {
       case SSL_ERROR_WANT_WRITE:

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -137,10 +137,8 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
       if (result.error_.has_value()) {
         keep_reading = false;
         int err = SSL_get_error(rawSsl(), result.error_.value());
-#ifndef BORINGSSL_FIPS
         ENVOY_CONN_LOG(trace, "ssl error occurred while read: {}", callbacks_->connection(),
-                       SSL_error_description(err));
-#endif
+                       Utility::getErrorDescription(err));
         switch (err) {
         case SSL_ERROR_WANT_READ:
           break;
@@ -267,10 +265,8 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
       bytes_to_write = std::min(write_buffer.length(), static_cast<uint64_t>(16384));
     } else {
       int err = SSL_get_error(rawSsl(), rc);
-#ifndef BORINGSSL_FIPS
       ENVOY_CONN_LOG(trace, "ssl error occurred while write: {}", callbacks_->connection(),
-                     SSL_error_description(err));
-#endif
+                     Utility::getErrorDescription(err));
       switch (err) {
       case SSL_ERROR_WANT_WRITE:
         bytes_to_retry_ = bytes_to_write;

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -1,6 +1,7 @@
 #include "extensions/transport_sockets/tls/utility.h"
 
 #include "common/common/assert.h"
+#include "common/common/empty_string.h"
 #include "common/network/address_impl.h"
 
 #include "absl/strings/str_join.h"
@@ -212,6 +213,49 @@ absl::optional<std::string> Utility::getLastCryptoError() {
   }
 
   return absl::nullopt;
+}
+
+std::string Utility::getErrorDescription(int err) {
+  switch (err) {
+  case SSL_ERROR_NONE:
+    return "NONE";
+  case SSL_ERROR_SSL:
+    return "SSL";
+  case SSL_ERROR_WANT_READ:
+    return "WANT_READ";
+  case SSL_ERROR_WANT_WRITE:
+    return "WANT_WRITE";
+  case SSL_ERROR_WANT_X509_LOOKUP:
+    return "WANT_X509_LOOKUP";
+  case SSL_ERROR_SYSCALL:
+    return "SYSCALL";
+  case SSL_ERROR_ZERO_RETURN:
+    return "ZERO_RETURN";
+  case SSL_ERROR_WANT_CONNECT:
+    return "WANT_CONNECT";
+  case SSL_ERROR_WANT_ACCEPT:
+    return "WANT_ACCEPT";
+  case SSL_ERROR_WANT_CHANNEL_ID_LOOKUP:
+    return "WANT_CHANNEL_ID_LOOKUP";
+  case SSL_ERROR_PENDING_SESSION:
+    return "PENDING_SESSION";
+  case SSL_ERROR_PENDING_CERTIFICATE:
+    return "PENDING_CERTIFICATE";
+  case SSL_ERROR_WANT_PRIVATE_KEY_OPERATION:
+    return "WANT_PRIVATE_KEY_OPERATION";
+  case SSL_ERROR_PENDING_TICKET:
+    return "PENDING_TICKET";
+  case SSL_ERROR_EARLY_DATA_REJECTED:
+    return "EARLY_DATA_REJECTED";
+  case SSL_ERROR_WANT_CERTIFICATE_VERIFY:
+    return "WANT_CERTIFICATE_VERIFY";
+  case SSL_ERROR_HANDOFF:
+    return "HANDOFF";
+  case SSL_ERROR_HANDBACK:
+    return "HANDBACK";
+  default:
+    return EMPTY_STRING;
+  }
 }
 
 } // namespace Tls

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -215,46 +215,47 @@ absl::optional<std::string> Utility::getLastCryptoError() {
   return absl::nullopt;
 }
 
-std::string Utility::getErrorDescription(int err) {
+absl::string_view Utility::getErrorDescription(int err) {
   switch (err) {
   case SSL_ERROR_NONE:
-    return "NONE";
+    return SSL_ERROR_NONE_MESSAGE;
   case SSL_ERROR_SSL:
-    return "SSL";
+    return SSL_ERROR_SSL_MESSAGE;
   case SSL_ERROR_WANT_READ:
-    return "WANT_READ";
+    return SSL_ERROR_WANT_READ_MESSAGE;
   case SSL_ERROR_WANT_WRITE:
-    return "WANT_WRITE";
+    return SSL_ERROR_WANT_WRITE_MESSAGE;
   case SSL_ERROR_WANT_X509_LOOKUP:
-    return "WANT_X509_LOOKUP";
+    return SSL_ERROR_WANT_X509_LOOPUP_MESSAGE;
   case SSL_ERROR_SYSCALL:
-    return "SYSCALL";
+    return SSL_ERROR_SYSCALL_MESSAGE;
   case SSL_ERROR_ZERO_RETURN:
-    return "ZERO_RETURN";
+    return SSL_ERROR_ZERO_RETURN_MESSAGE;
   case SSL_ERROR_WANT_CONNECT:
-    return "WANT_CONNECT";
+    return SSL_ERROR_WANT_CONNECT_MESSAGE;
   case SSL_ERROR_WANT_ACCEPT:
-    return "WANT_ACCEPT";
+    return SSL_ERROR_WANT_ACCEPT_MESSAGE;
   case SSL_ERROR_WANT_CHANNEL_ID_LOOKUP:
-    return "WANT_CHANNEL_ID_LOOKUP";
+    return SSL_ERROR_WANT_CHANNEL_ID_LOOKUP_MESSAGE;
   case SSL_ERROR_PENDING_SESSION:
-    return "PENDING_SESSION";
+    return SSL_ERROR_PENDING_SESSION_MESSAGE;
   case SSL_ERROR_PENDING_CERTIFICATE:
-    return "PENDING_CERTIFICATE";
+    return SSL_ERROR_PENDING_CERTIFICATE_MESSAGE;
   case SSL_ERROR_WANT_PRIVATE_KEY_OPERATION:
-    return "WANT_PRIVATE_KEY_OPERATION";
+    return SSL_ERROR_WANT_PRIVATE_KEY_OPERATION_MESSAGE;
   case SSL_ERROR_PENDING_TICKET:
-    return "PENDING_TICKET";
+    return SSL_ERROR_PENDING_TICKET_MESSAGE;
   case SSL_ERROR_EARLY_DATA_REJECTED:
-    return "EARLY_DATA_REJECTED";
+    return SSL_ERROR_EARLY_DATA_REJECTED_MESSAGE;
   case SSL_ERROR_WANT_CERTIFICATE_VERIFY:
-    return "WANT_CERTIFICATE_VERIFY";
+    return SSL_ERROR_WANT_CERTIFICATE_VERIFY_MESSAGE;
   case SSL_ERROR_HANDOFF:
-    return "HANDOFF";
+    return SSL_ERROR_HANDOFF_MESSAGE;
   case SSL_ERROR_HANDBACK:
-    return "HANDBACK";
+    return SSL_ERROR_HANDBACK_MESSAGE;
   default:
-    return EMPTY_STRING;
+    ENVOY_BUG(false, "Unknown BoringSSL error had occurred");
+    return SSL_ERROR_UNKNOWN_ERROR_MESSAGE;
   }
 }
 

--- a/source/extensions/transport_sockets/tls/utility.h
+++ b/source/extensions/transport_sockets/tls/utility.h
@@ -89,6 +89,13 @@ SystemTime getExpirationTime(const X509& cert);
  */
 absl::optional<std::string> getLastCryptoError();
 
+/**
+ * Returns error string corresponding error code derived from OpenSSL.
+ * @param err error code
+ * @return string message corresponding error code.
+ */
+std::string getErrorDescription(int err);
+
 } // namespace Utility
 } // namespace Tls
 } // namespace TransportSockets

--- a/source/extensions/transport_sockets/tls/utility.h
+++ b/source/extensions/transport_sockets/tls/utility.h
@@ -15,6 +15,29 @@ namespace TransportSockets {
 namespace Tls {
 namespace Utility {
 
+static constexpr absl::string_view SSL_ERROR_NONE_MESSAGE = "NONE";
+static constexpr absl::string_view SSL_ERROR_SSL_MESSAGE = "SSL";
+static constexpr absl::string_view SSL_ERROR_WANT_READ_MESSAGE = "WANT_READ";
+static constexpr absl::string_view SSL_ERROR_WANT_WRITE_MESSAGE = "WANT_WRITE";
+static constexpr absl::string_view SSL_ERROR_WANT_X509_LOOPUP_MESSAGE = "WANT_X509_LOOKUP";
+static constexpr absl::string_view SSL_ERROR_SYSCALL_MESSAGE = "SYSCALL";
+static constexpr absl::string_view SSL_ERROR_ZERO_RETURN_MESSAGE = "ZERO_RETURN";
+static constexpr absl::string_view SSL_ERROR_WANT_CONNECT_MESSAGE = "WANT_CONNECT";
+static constexpr absl::string_view SSL_ERROR_WANT_ACCEPT_MESSAGE = "WANT_ACCEPT";
+static constexpr absl::string_view SSL_ERROR_WANT_CHANNEL_ID_LOOKUP_MESSAGE =
+    "WANT_CHANNEL_ID_LOOKUP";
+static constexpr absl::string_view SSL_ERROR_PENDING_SESSION_MESSAGE = "PENDING_SESSION";
+static constexpr absl::string_view SSL_ERROR_PENDING_CERTIFICATE_MESSAGE = "PENDING_CERTIFICATE";
+static constexpr absl::string_view SSL_ERROR_WANT_PRIVATE_KEY_OPERATION_MESSAGE =
+    "WANT_PRIVATE_KEY_OPERATION";
+static constexpr absl::string_view SSL_ERROR_PENDING_TICKET_MESSAGE = "PENDING_TICKET";
+static constexpr absl::string_view SSL_ERROR_EARLY_DATA_REJECTED_MESSAGE = "EARLY_DATA_REJECTED";
+static constexpr absl::string_view SSL_ERROR_WANT_CERTIFICATE_VERIFY_MESSAGE =
+    "WANT_CERTIFICATE_VERIFY";
+static constexpr absl::string_view SSL_ERROR_HANDOFF_MESSAGE = "HANDOFF";
+static constexpr absl::string_view SSL_ERROR_HANDBACK_MESSAGE = "HANDBACK";
+static constexpr absl::string_view SSL_ERROR_UNKNOWN_ERROR_MESSAGE = "UNKNOWN_ERROR";
+
 /**
  * Retrieves the serial number of a certificate.
  * @param cert the certificate
@@ -94,7 +117,7 @@ absl::optional<std::string> getLastCryptoError();
  * @param err error code
  * @return string message corresponding error code.
  */
-std::string getErrorDescription(int err);
+absl::string_view getErrorDescription(int err);
 
 } // namespace Utility
 } // namespace Tls

--- a/test/extensions/transport_sockets/tls/handshaker_test.cc
+++ b/test/extensions/transport_sockets/tls/handshaker_test.cc
@@ -153,10 +153,10 @@ TEST_F(HandshakerTest, ErrorCbOnAbnormalOperation) {
   BIO* bio = BIO_new(BIO_s_socket());
   SSL_set_bio(client_ssl_.get(), bio, bio);
 
-  StrictMock<MockHandshakeCallbacks> handshake_callbacks;
+  NiceMock<MockHandshakeCallbacks> handshake_callbacks;
   NiceMock<Network::MockConnection> mock_connection;
 
-  EXPECT_CALL(handshake_callbacks, connection).WillOnce(ReturnRef(mock_connection));
+  ON_CALL(handshake_callbacks, connection).WillByDefault(ReturnRef(mock_connection));
   EXPECT_CALL(handshake_callbacks, onFailure);
 
   SslHandshakerImpl handshaker(std::move(server_ssl_), 0, &handshake_callbacks);

--- a/test/extensions/transport_sockets/tls/handshaker_test.cc
+++ b/test/extensions/transport_sockets/tls/handshaker_test.cc
@@ -154,6 +154,9 @@ TEST_F(HandshakerTest, ErrorCbOnAbnormalOperation) {
   SSL_set_bio(client_ssl_.get(), bio, bio);
 
   StrictMock<MockHandshakeCallbacks> handshake_callbacks;
+  NiceMock<Network::MockConnection> mock_connection;
+
+  EXPECT_CALL(handshake_callbacks, connection).WillOnce(ReturnRef(mock_connection));
   EXPECT_CALL(handshake_callbacks, onFailure);
 
   SslHandshakerImpl handshaker(std::move(server_ssl_), 0, &handshake_callbacks);

--- a/test/extensions/transport_sockets/tls/utility_test.cc
+++ b/test/extensions/transport_sockets/tls/utility_test.cc
@@ -138,6 +138,34 @@ TEST(UtilityTest, TestGetCertificationExtensionValue) {
   EXPECT_EQ("", Utility::getCertificateExtensionValue(*cert, "foo"));
 }
 
+TEST(UtilityTest, SslErrorDescriptionTest) {
+  const std::vector<std::pair<int, std::string>> test_set = {
+      {0, "NONE"},
+      {1, "SSL"},
+      {2, "WANT_READ"},
+      {3, "WANT_WRITE"},
+      {4, "WANT_X509_LOOKUP"},
+      {5, "SYSCALL"},
+      {6, "ZERO_RETURN"},
+      {7, "WANT_CONNECT"},
+      {8, "WANT_ACCEPT"},
+      {9, "WANT_CHANNEL_ID_LOOKUP"},
+      {11, "PENDING_SESSION"},
+      {12, "PENDING_CERTIFICATE"},
+      {13, "WANT_PRIVATE_KEY_OPERATION"},
+      {14, "PENDING_TICKET"},
+      {15, "EARLY_DATA_REJECTED"},
+      {16, "WANT_CERTIFICATE_VERIFY"},
+      {17, "HANDOFF"},
+      {18, "HANDBACK"},
+      {19, ""},
+  };
+
+  for (const auto& test_data : test_set) {
+    EXPECT_EQ(test_data.second, Utility::getErrorDescription(test_data.first));
+  }
+}
+
 } // namespace
 } // namespace Tls
 } // namespace TransportSockets

--- a/test/extensions/transport_sockets/tls/utility_test.cc
+++ b/test/extensions/transport_sockets/tls/utility_test.cc
@@ -158,12 +158,17 @@ TEST(UtilityTest, SslErrorDescriptionTest) {
       {16, "WANT_CERTIFICATE_VERIFY"},
       {17, "HANDOFF"},
       {18, "HANDBACK"},
-      {19, ""},
   };
 
   for (const auto& test_data : test_set) {
     EXPECT_EQ(test_data.second, Utility::getErrorDescription(test_data.first));
   }
+
+#if defined(NDEBUG)
+  EXPECT_EQ(Utility::getErrorDescription(19), "UNKNOWN_ERROR");
+#else
+  EXPECT_DEATH(Utility::getErrorDescription(19), "Unknown BoringSSL error had occurred");
+#endif
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Shikugawa <Shikugawa@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: This commit includes improvements of TLS handshake, read and write and tls_inspector error log.
Additional Description: `SSL_error_description` on BoringSSL can't be utilized when BORINGSSL_FIPS. So we introduced the conversion feature from error code.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
