### PR TITLE
streaminfo/mocks: delay filter_state_ dereference

### DIFF
--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -103,7 +103,7 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
-  ON_CALL(Const(*this), filterState()).WillByDefault(ReturnRef(*filter_state_));
+  ON_CALL(Const(*this), filterState()).WillByDefault(Invoke([this]() { return *filter_state_; }));
   ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(upstream_filter_state_));
   ON_CALL(*this, setUpstreamFilterState(_))
       .WillByDefault(Invoke([this](const FilterStateSharedPtr& filter_state) {

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -103,7 +103,9 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(Const(*this), dynamicMetadata()).WillByDefault(ReturnRef(metadata_));
   ON_CALL(*this, filterState()).WillByDefault(ReturnRef(filter_state_));
-  ON_CALL(Const(*this), filterState()).WillByDefault(Invoke([this]() { return *filter_state_; }));
+  ON_CALL(Const(*this), filterState()).WillByDefault(Invoke([this]() -> const FilterState& {
+    return *filter_state_;
+  }));
   ON_CALL(*this, upstreamFilterState()).WillByDefault(ReturnRef(upstream_filter_state_));
   ON_CALL(*this, setUpstreamFilterState(_))
       .WillByDefault(Invoke([this](const FilterStateSharedPtr& filter_state) {


### PR DESCRIPTION
Commit Message:
    streaminfo/mocks: delay filter_state_ dereference

    By dereferencing filter_state_ in the constructor, any test that sets
    filter_state_ will dereference an invalid pointer. This may not be a
    common use-case, but it came up when writing some microbenchmarks for
    a custom filter where I needed to reset the FilterState on each
    iteration of the benchmark.

    Signed-off-by: Brian Wolfe <brian.wolfe@airbnb.com>

Additional Description:

Not sure if this makes sense to include in Envoy, I just was surprised when I got segfaults when writing this benchmark and it took me a while to figure out that this line capturing the instance reference, not the pointer reference.

Risk Level: test-only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
