### PR TITLE
XDS Connection closure smart logging

### DIFF
--- a/source/common/config/grpc_stream.h
+++ b/source/common/config/grpc_stream.h
@@ -139,6 +139,8 @@ public:
     return false;
   }
 
+  absl::optional<Grpc::Status::GrpcStatus> getCloseStatus() { return close_status_; }
+
 private:
   void setRetryTimer() {
     retry_timer_->enableTimer(std::chrono::milliseconds(backoff_strategy_->nextBackOffMs()));

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -187,6 +187,7 @@ envoy_cc_test(
         "//test/mocks/config:config_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/grpc:grpc_mocks",
+        "//test/test_common:simulated_time_system_lib",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
     ],
 )

--- a/test/mocks/event/BUILD
+++ b/test/mocks/event/BUILD
@@ -26,6 +26,7 @@ envoy_cc_mock(
         "//include/envoy/network:listener_interface",
         "//include/envoy/ssl:context_interface",
         "//test/mocks/buffer:buffer_mocks",
+        "//test/test_common:simulated_time_system_lib",
         "//test/test_common:test_time_lib",
     ],
 )

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -21,6 +21,7 @@
 #include "common/common/scope_tracker.h"
 
 #include "test/mocks/buffer/mocks.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/test_time.h"
 
 #include "gmock/gmock.h"
@@ -137,7 +138,7 @@ public:
   MOCK_METHOD(MonotonicTime, approximateMonotonicTime, (), (const));
   MOCK_METHOD(void, updateApproximateMonotonicTime, ());
 
-  GlobalTimeSystem time_system_;
+  SimulatedTimeSystem time_system_;
   std::list<DeferredDeletablePtr> to_delete_;
   testing::NiceMock<MockBufferFactory> buffer_factory_;
 


### PR DESCRIPTION
XDS connection closures are logged as warnings only for
repeated failures for certain type of status codes.

Fixes #14591 

Signed-off-by: Mandar U Jog <mjog@google.com>

Will follow up with tests if this approach is ok.