### PR TITLE
upstream: clean up feature parsing code

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -727,8 +727,8 @@ ClusterInfoImpl::ClusterInfoImpl(
                                   ? std::make_unique<OptionalClusterStats>(
                                         config, *stats_scope_, factory_context.clusterManager())
                                   : nullptr),
-      features_(
-          ClusterInfoImpl::HttpProtocolOptionsConfigImpl::parseFeatures(*http_protocol_options_)),
+      features_(ClusterInfoImpl::HttpProtocolOptionsConfigImpl::parseFeatures(
+          config, *http_protocol_options_)),
       resource_managers_(config, runtime, name_, *stats_scope_,
                          factory_context.clusterManager().clusterCircuitBreakersStatNames()),
       maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -727,8 +727,8 @@ ClusterInfoImpl::ClusterInfoImpl(
                                   ? std::make_unique<OptionalClusterStats>(
                                         config, *stats_scope_, factory_context.clusterManager())
                                   : nullptr),
-      features_(ClusterInfoImpl::HttpProtocolOptionsConfigImpl::parseFeatures(
-          config, http_protocol_options_)),
+      features_(
+          ClusterInfoImpl::HttpProtocolOptionsConfigImpl::parseFeatures(*http_protocol_options_)),
       resource_managers_(config, runtime, name_, *stats_scope_,
                          factory_context.clusterManager().clusterCircuitBreakersStatNames()),
       maintenance_mode_runtime_key_(absl::StrCat("upstream.maintenance_mode.", name_)),

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -43,7 +43,9 @@ getHttp2Options(const envoy::extensions::upstreams::http::v3::HttpProtocolOption
 
 } // namespace
 
-uint64_t ProtocolOptionsConfigImpl::parseFeatures(const ProtocolOptionsConfigImpl& options) {
+uint64_t
+ProtocolOptionsConfigImpl::parseFeatures(const envoy::config::cluster::v3::Cluster& config,
+                                         const ProtocolOptionsConfigImpl& options) {
   uint64_t features = 0;
 
   if (options.use_http2_) {
@@ -56,6 +58,9 @@ uint64_t ProtocolOptionsConfigImpl::parseFeatures(const ProtocolOptionsConfigImp
     features |= Upstream::ClusterInfo::Features::USE_ALPN;
   }
 
+  if (config.close_connections_on_host_health_failure()) {
+    features |= Upstream::ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE;
+  }
   return features;
 }
 

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -43,33 +43,19 @@ getHttp2Options(const envoy::extensions::upstreams::http::v3::HttpProtocolOption
 
 } // namespace
 
-uint64_t
-ProtocolOptionsConfigImpl::parseFeatures(const envoy::config::cluster::v3::Cluster& config,
-                                         std::shared_ptr<const ProtocolOptionsConfigImpl> options) {
+uint64_t ProtocolOptionsConfigImpl::parseFeatures(const ProtocolOptionsConfigImpl& options) {
   uint64_t features = 0;
 
-  if (options) {
-    if (options->use_http2_) {
-      features |= Upstream::ClusterInfo::Features::HTTP2;
-    }
-    if (options->use_downstream_protocol_) {
-      features |= Upstream::ClusterInfo::Features::USE_DOWNSTREAM_PROTOCOL;
-    }
-  } else {
-    if (config.has_http2_protocol_options()) {
-      features |= Upstream::ClusterInfo::Features::HTTP2;
-    }
-    if (config.protocol_selection() ==
-        envoy::config::cluster::v3::Cluster::USE_DOWNSTREAM_PROTOCOL) {
-      features |= Upstream::ClusterInfo::Features::USE_DOWNSTREAM_PROTOCOL;
-    }
+  if (options.use_http2_) {
+    features |= Upstream::ClusterInfo::Features::HTTP2;
   }
-  if (config.close_connections_on_host_health_failure()) {
-    features |= Upstream::ClusterInfo::Features::CLOSE_CONNECTIONS_ON_HOST_HEALTH_FAILURE;
+  if (options.use_downstream_protocol_) {
+    features |= Upstream::ClusterInfo::Features::USE_DOWNSTREAM_PROTOCOL;
   }
-  if (options->use_alpn_) {
+  if (options.use_alpn_) {
     features |= Upstream::ClusterInfo::Features::USE_ALPN;
   }
+
   return features;
 }
 

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -43,9 +43,8 @@ getHttp2Options(const envoy::extensions::upstreams::http::v3::HttpProtocolOption
 
 } // namespace
 
-uint64_t
-ProtocolOptionsConfigImpl::parseFeatures(const envoy::config::cluster::v3::Cluster& config,
-                                         const ProtocolOptionsConfigImpl& options) {
+uint64_t ProtocolOptionsConfigImpl::parseFeatures(const envoy::config::cluster::v3::Cluster& config,
+                                                  const ProtocolOptionsConfigImpl& options) {
   uint64_t features = 0;
 
   if (options.use_http2_) {

--- a/source/extensions/upstreams/http/config.h
+++ b/source/extensions/upstreams/http/config.h
@@ -34,10 +34,9 @@ public:
       const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions> upstream_options,
       bool use_downstream_protocol, bool use_http2);
 
-  // Given the supplied cluster config, and protocol options configuration,
-  // returns a unit64_t representing the enabled Upstream::ClusterInfo::Features.
-  static uint64_t parseFeatures(const envoy::config::cluster::v3::Cluster& config,
-                                std::shared_ptr<const ProtocolOptionsConfigImpl> options);
+  // Given the supplied protocol options configuration, returns a unit64_t representing the enabled
+  // Upstream::ClusterInfo::Features.
+  static uint64_t parseFeatures(const ProtocolOptionsConfigImpl& options);
 
   const Envoy::Http::Http1Settings http1_settings_;
   const envoy::config::core::v3::Http2ProtocolOptions http2_options_;

--- a/source/extensions/upstreams/http/config.h
+++ b/source/extensions/upstreams/http/config.h
@@ -34,9 +34,10 @@ public:
       const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions> upstream_options,
       bool use_downstream_protocol, bool use_http2);
 
-  // Given the supplied protocol options configuration, returns a unit64_t representing the enabled
-  // Upstream::ClusterInfo::Features.
-  static uint64_t parseFeatures(const ProtocolOptionsConfigImpl& options);
+  // Given the supplied cluster config, and protocol options configuration,
+  // returns a unit64_t representing the enabled Upstream::ClusterInfo::Features.
+  static uint64_t parseFeatures(const envoy::config::cluster::v3::Cluster& config,
+                                const ProtocolOptionsConfigImpl& options);
 
   const Envoy::Http::Http1Settings http1_settings_;
   const envoy::config::core::v3::Http2ProtocolOptions http2_options_;

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -237,6 +237,10 @@ TEST_F(ClusterManagerImplTest, MultipleProtocolCluster) {
       protocol_selection: USE_DOWNSTREAM_PROTOCOL
   )EOF";
   create(parseBootstrapFromV3Yaml(yaml));
+  auto info =
+      cluster_manager_->clusters().active_clusters_.find("http12_cluster")->second.get().info();
+  EXPECT_NE(0, info->features() & Upstream::ClusterInfo::Features::USE_DOWNSTREAM_PROTOCOL);
+
   checkConfigDump(R"EOF(
 static_clusters:
   - cluster:


### PR DESCRIPTION
Additional Description:
Fixing a perfectly safe and fairly terrible version merge in the ALPN pr the "refactor all upstream config" PRs.
the original code created the new options for new config, and parseFeatures handled parsing features from either the new options, or the old config.  I decided that was too complicated, changed the code to always create the new options struct and forgot to clean up parseFeatures to assume the presence of the new options struct and remove handling things the old style way.

Risk Level: low (clean up inaccessible code)
Testing: added one extra unit test just because
Docs Changes: n/a
Release Notes:  n/a
