### PR TITLE
filter manager: drop assert

### DIFF
--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -611,7 +611,6 @@ public:
 
   void setDownstreamRemoteAddress(
       const Network::Address::InstanceConstSharedPtr& downstream_remote_address) {
-    ASSERT(overridden_downstream_remote_address_ == nullptr);
     overridden_downstream_remote_address_ = downstream_remote_address;
   }
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -611,6 +611,10 @@ public:
 
   void setDownstreamRemoteAddress(
       const Network::Address::InstanceConstSharedPtr& downstream_remote_address) {
+    // TODO(rgs1): we should assert overridden_downstream_remote_address_ is nullptr,
+    // but we are currently relaxing this as a workaround to:
+    //
+    // https://github.com/envoyproxy/envoy/pull/14432#issuecomment-758167614
     overridden_downstream_remote_address_ = downstream_remote_address;
   }
 


### PR DESCRIPTION
This allows us to do a `dynamic_cast<Http::OverridableRemoteSocketAddressSetterStreamInfo>`
and be able to call `setDownstreamRemoteAddress()` from our filter.

See:

https://github.com/envoyproxy/envoy/pull/14432#issuecomment-758004199

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
