### PR TITLE
[fuzz] Fix bugs in HPACK fuzz test

### DIFF
--- a/test/common/http/http2/hpack_corpus/use_after_free
+++ b/test/common/http/http2/hpack_corpus/use_after_free
@@ -1,0 +1,1 @@
+headers {   headers {     key: ":path"     value: "  "   }   headers {     key: "       "         e: "       "   } } 

--- a/test/common/http/http2/hpack_corpus/whitespace
+++ b/test/common/http/http2/hpack_corpus/whitespace
@@ -1,0 +1,26 @@
+headers {
+  headers {
+    key: ":path"
+    value: ":path"
+  }
+  headers {
+    key: "GET"
+    value: "\364\214\214\214\364\214\214\214\364\214\214\214\364\214\214\214\364\214\214\214tqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\361\214\214\214\364\214\214\214\354\214\214"
+  }
+  headers {
+    key: "YYYYYYYYYYYYYYY"
+    value: "htvp"
+  }
+  headers {
+    key: "x-envoy"
+    value: "    "
+  }
+  headers {
+    key: ":status"
+    value: "a    "
+  }
+  headers {
+    key: "header"
+    value: "    a"
+  }
+}

--- a/test/common/http/http2/hpack_fuzz_test.cc
+++ b/test/common/http/http2/hpack_fuzz_test.cc
@@ -2,7 +2,6 @@
 // TODO(asraa): Speed up by using raw byte input and separators rather than protobuf input.
 
 #include <algorithm>
-#include <ostream>
 
 #include "test/common/http/http2/hpack_fuzz.pb.validate.h"
 #include "test/fuzz/fuzz_runner.h"

--- a/test/common/http/http2/hpack_fuzz_test.cc
+++ b/test/common/http/http2/hpack_fuzz_test.cc
@@ -104,7 +104,7 @@ struct NvComparator {
     }
     absl::string_view a_val(reinterpret_cast<char*>(a.value), a.valuelen);
     absl::string_view b_val(reinterpret_cast<char*>(b.value), b.valuelen);
-    return b_val > a_val;
+    return a_val < b_val;
   }
 };
 


### PR DESCRIPTION
Signed-off-by: Asra Ali asraa@google.com

Commit Message: Fixes test issues in HPACK fuzz test
Additional Message:
* Use after free because nghttp2_nv object has pointers to the underlying strings and copying them resulted in a use after free when the copy was used after the original was destroyed
* Fixed sorting issues and tested leading/trailing whitespace headers (I can no longer reproduce an issue I saw where a null byte appeared after decoding whitespace, maybe the former fix fixed this)

Risk Level: Low
Testing: Added regression tests and cases for whitespace headers
Fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28880
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28869