### PR TITLE
ext-proc: Support "immediate_response" options for request headers 

### DIFF
--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -22,6 +22,7 @@ envoy_cc_library(
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@com_google_absl//absl/strings:str_format",
         "@envoy_api//envoy/extensions/filters/http/ext_proc/v3alpha:pkg_cc_proto",
+        "@envoy_api//envoy/service/ext_proc/v3alpha:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -6,6 +6,7 @@
 #include "envoy/extensions/filters/http/ext_proc/v3alpha/ext_proc.pb.h"
 #include "envoy/grpc/async_client.h"
 #include "envoy/http/filter.h"
+#include "envoy/service/ext_proc/v3alpha/external_processor.pb.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 
@@ -100,6 +101,7 @@ public:
 
 private:
   void closeStream();
+  void sendImmediateResponse(const envoy::service::ext_proc::v3alpha::ImmediateResponse& response);
 
   const FilterConfigSharedPtr config_;
   const ExternalProcessorClientPtr client_;

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -19,6 +19,10 @@ using Extensions::HttpFilters::ExternalProcessing::ExtProcTestUtility;
 
 using Http::LowerCaseString;
 
+// These tests exercise the ext_proc filter through Envoy's integration test
+// environment by configuring an instance of the Envoy server and driving it
+// through the mock network stack.
+
 class ExtProcIntegrationTest : public HttpIntegrationTest,
                                public Grpc::GrpcClientIntegrationParamTest {
 protected:
@@ -76,6 +80,9 @@ protected:
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, ExtProcIntegrationTest,
                          GRPC_CLIENT_INTEGRATION_PARAMS);
 
+// Test the filter using the default configuration by connecting to
+// an ext_proc server that responds to the request_headers message
+// by immediately closing the stream.
 TEST_P(ExtProcIntegrationTest, GetAndCloseStream) {
   initializeConfig();
   HttpIntegrationTest::initialize();
@@ -109,6 +116,9 @@ TEST_P(ExtProcIntegrationTest, GetAndCloseStream) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Test the filter using the default configuration by connecting to
+// an ext_proc server that responds to the request_headers message
+// by returning a failure before the first stream response can be sent.
 TEST_P(ExtProcIntegrationTest, GetAndFailStream) {
   initializeConfig();
   HttpIntegrationTest::initialize();
@@ -129,6 +139,9 @@ TEST_P(ExtProcIntegrationTest, GetAndFailStream) {
   EXPECT_EQ("500", response->headers().getStatusValue());
 }
 
+// Test the filter using the default configuration by connecting to
+// an ext_proc server that responds to the request_headers message
+// by requesting to modify the request headers.
 TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
   initializeConfig();
   HttpIntegrationTest::initialize();
@@ -186,6 +199,10 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Test the filter using the default configuration by connecting to
+// an ext_proc server that responds to the request_headers message
+// by sending back an immediate_response message, which should be
+// returned directly to the downstream.
 TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
   initializeConfig();
   HttpIntegrationTest::initialize();

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -35,6 +35,9 @@ using testing::Unused;
 
 using namespace std::chrono_literals;
 
+// These tests are all unit tests that directly drive an instance of the
+// ext_proc filter and verify the behavior using mocks.
+
 class HttpFilterTest : public testing::Test {
 protected:
   void initialize(std::string&& yaml) {
@@ -92,6 +95,8 @@ protected:
   Buffer::OwnedImpl data_;
 };
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message with an empty response
 TEST_F(HttpFilterTest, SimplestPost) {
   initialize(R"EOF(
   grpc_service:
@@ -153,6 +158,9 @@ TEST_F(HttpFilterTest, SimplestPost) {
   EXPECT_EQ(1, config_->stats().streams_closed_.value());
 }
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message with a message that modifies the request
+// headers.
 TEST_F(HttpFilterTest, PostAndChangeHeaders) {
   initialize(R"EOF(
   grpc_service:
@@ -215,6 +223,10 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
   EXPECT_EQ(1, config_->stats().streams_closed_.value());
 }
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message with an "immediate response" message
+// that should result in a response being directly sent downstream with
+// custom headers.
 TEST_F(HttpFilterTest, PostAndRespondImmediately) {
   initialize(R"EOF(
   grpc_service:
@@ -279,6 +291,8 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
   EXPECT_EQ(1, config_->stats().streams_closed_.value());
 }
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message with an empty immediate_response message
 TEST_F(HttpFilterTest, RespondImmediatelyDefault) {
   initialize(R"EOF(
   grpc_service:
@@ -321,6 +335,9 @@ TEST_F(HttpFilterTest, RespondImmediatelyDefault) {
   EXPECT_TRUE(stream_close_sent_);
 }
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message with an immediate response message
+// that contains a non-default gRPC status.
 TEST_F(HttpFilterTest, RespondImmediatelyGrpcError) {
   initialize(R"EOF(
   grpc_service:
@@ -365,6 +382,8 @@ TEST_F(HttpFilterTest, RespondImmediatelyGrpcError) {
   EXPECT_TRUE(stream_close_sent_);
 }
 
+// Using the default configuration, test the filter with a processor that
+// returns an error from from the gRPC stream.
 TEST_F(HttpFilterTest, PostAndFail) {
   initialize(R"EOF(
   grpc_service:
@@ -407,6 +426,9 @@ TEST_F(HttpFilterTest, PostAndFail) {
   EXPECT_EQ(1, config_->stats().streams_failed_.value());
 }
 
+// Using the default configuration, test the filter with a processor that
+// returns an error from the gRPC stream that is ignored because the
+// failure_mode_allow parameter is set.
 TEST_F(HttpFilterTest, PostAndIgnoreFailure) {
   initialize(R"EOF(
   grpc_service:
@@ -447,6 +469,8 @@ TEST_F(HttpFilterTest, PostAndIgnoreFailure) {
   EXPECT_EQ(1, config_->stats().failure_mode_allowed_.value());
 }
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message by closing the gRPC stream.
 TEST_F(HttpFilterTest, PostAndClose) {
   initialize(R"EOF(
   grpc_service:
@@ -489,6 +513,10 @@ TEST_F(HttpFilterTest, PostAndClose) {
   EXPECT_EQ(1, config_->stats().streams_closed_.value());
 }
 
+// Using the default configuration, test the filter with a processor that
+// replies to the request_headers message incorrectly by sending a
+// request_body message, which should result in the stream being closed
+// and ignored.
 TEST_F(HttpFilterTest, OutOfOrder) {
   initialize(R"EOF(
   grpc_service:


### PR DESCRIPTION
This lets ext_proc servers return an immediate HTTP response (such as to indicate an error) in response to a request_headers message.

Signed-off-by: Gregory Brail <gregbrail@google.com>
