### PR TITLE
backport to 1.13: http: fix datadog and squash handling of responses without body (#13328)

### DIFF
--- a/source/extensions/filters/http/squash/squash_filter.cc
+++ b/source/extensions/filters/http/squash/squash_filter.cc
@@ -307,16 +307,7 @@ void SquashFilter::cleanup() {
 }
 
 Json::ObjectSharedPtr SquashFilter::getJsonBody(Http::MessagePtr&& m) {
-  Buffer::InstancePtr& data = m->body();
-  uint64_t num_slices = data->getRawSlices(nullptr, 0);
-  STACK_ARRAY(slices, Buffer::RawSlice, num_slices);
-  data->getRawSlices(slices.begin(), num_slices);
-  std::string jsonbody;
-  for (const Buffer::RawSlice& slice : slices) {
-    jsonbody += std::string(static_cast<const char*>(slice.mem_), slice.len_);
-  }
-
-  return Json::Factory::loadFromString(jsonbody);
+  return Json::Factory::loadFromString(m->bodyAsString());
 }
 
 } // namespace Squash

--- a/source/extensions/tracers/datadog/datadog_tracer_impl.cc
+++ b/source/extensions/tracers/datadog/datadog_tracer_impl.cc
@@ -123,7 +123,7 @@ void TraceReporter::onSuccess(Http::MessagePtr&& http_response) {
   } else {
     ENVOY_LOG(debug, "traces successfully submitted to datadog agent");
     driver_.tracerStats().reports_sent_.inc();
-    encoder_->handleResponse(http_response->body()->toString());
+    encoder_->handleResponse(http_response->bodyAsString());
   }
 }
 

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -408,6 +408,19 @@ TEST_F(SquashFilterTest, InvalidJsonForGetAttachment) {
   completeRequest("200", "This is not a JSON object");
 }
 
+TEST_F(SquashFilterTest, InvalidResponseWithNoBody) {
+  doDownstreamRequest();
+  // Expect the get attachment request
+  expectAsyncClientSend();
+  completeCreateRequest();
+
+  auto retry_timer = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
+  EXPECT_CALL(*retry_timer, enableTimer(config_->attachmentPollPeriod(), _));
+  Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
+      new Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-length", "0"}}}));
+  popPendingCallback()->onSuccess(request_, std::move(msg));
+}
+
 TEST_F(SquashFilterTest, DestroyedInFlight) {
   doDownstreamRequest();
 

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -416,9 +416,9 @@ TEST_F(SquashFilterTest, InvalidResponseWithNoBody) {
 
   auto retry_timer = new NiceMock<Envoy::Event::MockTimer>(&filter_callbacks_.dispatcher_);
   EXPECT_CALL(*retry_timer, enableTimer(config_->attachmentPollPeriod(), _));
-  Http::ResponseMessagePtr msg(new Http::ResponseMessageImpl(Http::ResponseHeaderMapPtr{
-      new Http::TestResponseHeaderMapImpl{{":status", "200"}, {"content-length", "0"}}}));
-  popPendingCallback()->onSuccess(request_, std::move(msg));
+  Http::MessagePtr msg(new Http::ResponseMessageImpl(Http::HeaderMapPtr{
+      new Http::TestHeaderMapImpl{{":status", "200"}, {"content-length", "0"}}}));
+  popPendingCallback()->onSuccess(std::move(msg));
 }
 
 TEST_F(SquashFilterTest, DestroyedInFlight) {


### PR DESCRIPTION
Commit Message: Fixing bugs in datadog and squash where unexpected bodyless responses would crash Envoy
Risk Level: low
Testing: new unit tests
Docs Changes: n/a
Release Notes: inline