### PR TITLE
tcp_proxy: switching to the new pool

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -9,6 +9,8 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* tcp: switched to the new TCP connection pool by default. This behavior can be temporarily reverted by setting `envoy.reloadable_features.new_tcp_connection_pool` to false.
+
 Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -78,6 +78,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.http_upstream_wait_connect_response",
     "envoy.reloadable_features.http2_skip_encoding_empty_trailers",
     "envoy.reloadable_features.listener_in_place_filterchain_update",
+    "envoy.reloadable_features.new_tcp_connection_pool",
     "envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2",
     "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing",
     "envoy.reloadable_features.preserve_query_string_in_path_redirects",
@@ -105,8 +106,6 @@ constexpr const char* disabled_runtime_features[] = {
     // Allow Envoy to upgrade or downgrade version of type url, should be removed when support for
     // v2 url is removed from codebase.
     "envoy.reloadable_features.enable_type_url_downgrade_and_upgrade",
-    // TODO(alyssawilk) flip true after the release.
-    "envoy.reloadable_features.new_tcp_connection_pool",
     // TODO(yanavlasov) flip true after all tests for upstream flood checks are implemented
     "envoy.reloadable_features.upstream_http2_flood_checks",
     // Sentinel and test flag.


### PR DESCRIPTION
Switching to the new pool by default after a successful canary and global rollout by our awesome Pinterest smoke testers :-)

Risk Level: Medium (even with canary)
Testing: lots of tests of the new pool
Docs Changes: n/a
Release Notes: inline
Fixes #3818
