### PR TITLE
Fix the emsdk patching.

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -784,7 +784,7 @@ def _emscripten_toolchain():
             ".emscripten_sanity",
         ]),
         patch_cmds = [
-            "[[ \"$(uname -m)\" == \"x86_64\" ]] && ./emsdk install 2.0.7 && ./emsdk activate --embedded 2.0.7 || true",
+            "if [[ \"$(uname -m)\" == \"x86_64\" ]]; then ./emsdk install 2.0.7 && ./emsdk activate --embedded 2.0.7; fi",
         ],
     )
 


### PR DESCRIPTION
If the patch fails, because of `|| true`, bazel continues
the build.
