### PR TITLE
The first working draft of the rules_fuzzing integration in Envoy.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,7 +52,6 @@ build:asan --config=sanitizer
 # ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
 build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
-build:asan --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 build:asan --copt -fsanitize=address,undefined
 build:asan --linkopt -fsanitize=address,undefined
 # vptr and function sanitizer are enabled in clang-asan if it is set up via bazel/setup_clang.sh.
@@ -282,8 +281,12 @@ build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define=ENVOY_CONFIG_ASAN=1
-build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
-build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
+# The fuzzing rules provide their own instrumentation, but it is currently
+# disabled due to bazelbuild/bazel#12888. Instead, the rules are configured
+# to assume external instrumentation through these options.
+build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
+build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
+build:plain-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
 build:asan-fuzzer --config=plain-fuzzer
 build:asan-fuzzer --config=asan
@@ -292,6 +295,9 @@ build:asan-fuzzer --copt=-fno-omit-frame-pointer
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 
 build:oss-fuzz --define=FUZZING_ENGINE=oss-fuzz
+# These options currently have no effect, since rule instrumentation is
+# disabled due to bazelbuild/bazel#12888. Instead, the options will be computed
+# inside the build.sh OSS-Fuzz script.
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -52,6 +52,7 @@ build:asan --config=sanitizer
 # ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
 build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
+build:asan --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 build:asan --copt -fsanitize=address,undefined
 build:asan --linkopt -fsanitize=address,undefined
 # vptr and function sanitizer are enabled in clang-asan if it is set up via bazel/setup_clang.sh.
@@ -277,18 +278,31 @@ build:remote-ci --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
 # Fuzz builds
+
+# The default fuzzing engine configuration.
+build --@rules_fuzzing//fuzzing:cc_engine=//test/fuzz:fuzz_runner_engine
+
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
-build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
-build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
-build:plain-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
+build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 
 build:asan-fuzzer --config=plain-fuzzer
 build:asan-fuzzer --config=asan
 build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
+
+build:asan-honggfuzz --config=asan
+build:asan-honggfuzz --copt=-fno-omit-frame-pointer
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
+build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
+
+build:oss-fuzz --//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb

--- a/.bazelrc
+++ b/.bazelrc
@@ -291,11 +291,6 @@ build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 
-build:asan-honggfuzz --config=asan
-build:asan-honggfuzz --copt=-fno-omit-frame-pointer
-build:asan-honggfuzz --define=FUZZING_ENGINE=honggfuzz
-build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
-
 build:oss-fuzz --define=FUZZING_ENGINE=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none

--- a/.bazelrc
+++ b/.bazelrc
@@ -279,13 +279,9 @@ build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
 # Fuzz builds
 
-# The default fuzzing engine configuration.
-build --@rules_fuzzing//fuzzing:cc_engine=//test/fuzz:fuzz_runner_engine
-
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
-build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
-build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+build:plain-fuzzer --define=ENVOY_CONFIG_ASAN=1
 build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine_instrumentation=libfuzzer
 build:plain-fuzzer --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 
@@ -297,10 +293,10 @@ build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 
 build:asan-honggfuzz --config=asan
 build:asan-honggfuzz --copt=-fno-omit-frame-pointer
-build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:honggfuzz
+build:asan-honggfuzz --define=FUZZING_ENGINE=honggfuzz
 build:asan-honggfuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=honggfuzz
 
-build:oss-fuzz --//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
+build:oss-fuzz --define=FUZZING_ENGINE=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -469,11 +469,6 @@ config_setting(
 )
 
 config_setting(
-    name = "honggfuzz",
-    define_values = {"FUZZING_ENGINE": "honggfuzz"},
-)
-
-config_setting(
     name = "oss_fuzz",
     define_values = {"FUZZING_ENGINE": "oss-fuzz"},
 )
@@ -482,7 +477,6 @@ alias(
     name = "fuzzing_engine",
     actual = select({
         ":libfuzzer": "@rules_fuzzing//fuzzing/engines:libfuzzer",
-        ":honggfuzz": "@rules_fuzzing//fuzzing/engines:honggfuzz",
         ":oss_fuzz": "@rules_fuzzing_oss_fuzz//:oss_fuzz_engine",
         "//conditions:default": "//test/fuzz:fuzz_runner_engine",
     }),

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -457,21 +457,35 @@ config_setting(
 
 config_setting(
     name = "libfuzzer_coverage",
-    testonly = True,
     define_values = {
+        "FUZZING_ENGINE": "libfuzzer",
         "ENVOY_CONFIG_COVERAGE": "1",
-    },
-    flag_values = {
-        "@rules_fuzzing//fuzzing:cc_engine": "@rules_fuzzing//fuzzing/engines:libfuzzer",
     },
 )
 
 config_setting(
     name = "libfuzzer",
-    testonly = True,
-    flag_values = {
-        "@rules_fuzzing//fuzzing:cc_engine": "@rules_fuzzing//fuzzing/engines:libfuzzer",
-    },
+    define_values = {"FUZZING_ENGINE": "libfuzzer"},
+)
+
+config_setting(
+    name = "honggfuzz",
+    define_values = {"FUZZING_ENGINE": "honggfuzz"},
+)
+
+config_setting(
+    name = "oss_fuzz",
+    define_values = {"FUZZING_ENGINE": "oss-fuzz"},
+)
+
+alias(
+    name = "fuzzing_engine",
+    actual = select({
+        "@envoy//bazel:libfuzzer": "@rules_fuzzing//fuzzing/engines:libfuzzer",
+        "@envoy//bazel:honggfuzz": "@rules_fuzzing//fuzzing/engines:honggfuzz",
+        "@envoy//bazel:oss_fuzz": "@rules_fuzzing_oss_fuzz//:oss_fuzz_engine",
+        "//conditions:default": "//test/fuzz:fuzz_runner_engine",
+    }),
 )
 
 alias(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -481,9 +481,9 @@ config_setting(
 alias(
     name = "fuzzing_engine",
     actual = select({
-        "@envoy//bazel:libfuzzer": "@rules_fuzzing//fuzzing/engines:libfuzzer",
-        "@envoy//bazel:honggfuzz": "@rules_fuzzing//fuzzing/engines:honggfuzz",
-        "@envoy//bazel:oss_fuzz": "@rules_fuzzing_oss_fuzz//:oss_fuzz_engine",
+        ":libfuzzer": "@rules_fuzzing//fuzzing/engines:libfuzzer",
+        ":honggfuzz": "@rules_fuzzing//fuzzing/engines:honggfuzz",
+        ":oss_fuzz": "@rules_fuzzing_oss_fuzz//:oss_fuzz_engine",
         "//conditions:default": "//test/fuzz:fuzz_runner_engine",
     }),
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -457,15 +457,21 @@ config_setting(
 
 config_setting(
     name = "libfuzzer_coverage",
+    testonly = True,
     define_values = {
-        "FUZZING_ENGINE": "libfuzzer",
         "ENVOY_CONFIG_COVERAGE": "1",
+    },
+    flag_values = {
+        "@rules_fuzzing//fuzzing:cc_engine": "@rules_fuzzing//fuzzing/engines:libfuzzer",
     },
 )
 
 config_setting(
     name = "libfuzzer",
-    values = {"define": "FUZZING_ENGINE=libfuzzer"},
+    testonly = True,
+    flag_values = {
+        "@rules_fuzzing//fuzzing:cc_engine": "@rules_fuzzing//fuzzing/engines:libfuzzer",
+    },
 )
 
 alias(

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,8 +4,7 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
-load("@fuzzing_py_deps//:requirements.bzl", fuzzing_pip_install = "pip_install")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies", "oss_fuzz_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")
@@ -14,6 +13,7 @@ load("@headersplit_pip3//:requirements.bzl", headersplit_pip_install = "pip_inst
 load("@kafka_pip3//:requirements.bzl", kafka_pip_install = "pip_install")
 load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
 load("@thrift_pip3//:requirements.bzl", thrift_pip_install = "pip_install")
+load("@fuzzing_pip3//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
 
@@ -32,7 +32,7 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     antlr_dependencies(472)
     proxy_wasm_rust_sdk_dependencies()
     rules_fuzzing_dependencies()
-    fuzzing_pip_install()
+    oss_fuzz_dependencies()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",
@@ -86,3 +86,4 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     kafka_pip_install()
     protodoc_pip_install()
     thrift_pip_install()
+    fuzzing_pip_install()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,6 +4,8 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+load("@fuzzing_py_deps//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")
@@ -29,6 +31,8 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     upb_deps()
     antlr_dependencies(472)
     proxy_wasm_rust_sdk_dependencies()
+    rules_fuzzing_dependencies()
+    fuzzing_pip_install()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,7 +4,7 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies", "oss_fuzz_dependencies")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "oss_fuzz_dependencies", "rules_fuzzing_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -117,7 +117,7 @@ def envoy_cc_fuzz_test(
             "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
             "//conditions:default": [
                 ":" + test_lib_name,
-                "@rules_fuzzing//fuzzing:cc_engine",
+                "@envoy//bazel:fuzzing_engine",
             ],
         }),
         size = size,
@@ -127,7 +127,7 @@ def envoy_cc_fuzz_test(
     fuzzing_decoration(
         base_name = name,
         raw_binary = raw_binary_name,
-        engine = "@rules_fuzzing//fuzzing:cc_engine",
+        engine = "@envoy//bazel:fuzzing_engine",
         corpus = [corpus_name],
         dicts = dictionaries,
         tags = ["fuzz_target"] + tags,

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -1,9 +1,8 @@
-load("@rules_python//python:defs.bzl", "py_binary")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_fuzzing//fuzzing:cc_deps.bzl", "fuzzing_decoration")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
 load(
@@ -80,23 +79,14 @@ def envoy_cc_fuzz_test(
         tags = [],
         **kwargs):
     if not (corpus.startswith("//") or corpus.startswith(":") or corpus.startswith("@")):
-        corpus_name = name + "_corpus"
-        corpus = native.glob([corpus + "/**"])
+        corpus_name = name + "_corpus_files"
         native.filegroup(
             name = corpus_name,
-            srcs = corpus,
+            srcs = native.glob([corpus + "/**"]),
         )
     else:
         corpus_name = corpus
-    tar_src = [corpus_name]
-    if dictionaries:
-        tar_src += dictionaries
-    pkg_tar(
-        name = name + "_corpus_tar",
-        srcs = tar_src,
-        testonly = 1,
-    )
-    fuzz_copts = ["-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"]
+
     test_lib_name = name + "_lib"
     envoy_cc_test_library(
         name = test_lib_name,
@@ -108,13 +98,12 @@ def envoy_cc_fuzz_test(
         tags = tags,
         **kwargs
     )
+
+    raw_binary_name = name + "_raw"
     cc_test(
-        name = name,
-        copts = fuzz_copts + envoy_copts("@envoy", test = True),
-        linkopts = _envoy_test_linkopts() + select({
-            "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
-            "//conditions:default": [],
-        }),
+        name = raw_binary_name,
+        copts = envoy_copts("@envoy", test = True),
+        linkopts = _envoy_test_linkopts(),
         linkstatic = envoy_linkstatic(),
         args = select({
             "@envoy//bazel:libfuzzer_coverage": ["$(locations %s)" % corpus_name],
@@ -126,30 +115,22 @@ def envoy_cc_fuzz_test(
         deps = select({
             "@envoy//bazel:apple": [repository + "//test:dummy_main"],
             "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
-            "@envoy//bazel:libfuzzer": [
-                ":" + test_lib_name,
-            ],
             "//conditions:default": [
                 ":" + test_lib_name,
-                repository + "//test/fuzz:main",
+                "@rules_fuzzing//fuzzing:cc_engine",
             ],
         }),
         size = size,
-        tags = ["fuzz_target"] + tags,
+        tags = ["fuzz_target_binary"] + tags,
     )
 
-    # This target exists only for
-    # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield
-    # anything useful on its own, as it expects to be run in an environment where the linker options
-    # provide a path to FuzzingEngine.
-    cc_binary(
-        name = name + "_driverless",
-        copts = fuzz_copts + envoy_copts("@envoy", test = True),
-        linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
-        linkstatic = 1,
-        testonly = 1,
-        deps = [":" + test_lib_name],
-        tags = ["manual"] + tags,
+    fuzzing_decoration(
+        base_name = name,
+        raw_binary = raw_binary_name,
+        engine = "@rules_fuzzing//fuzzing:cc_engine",
+        corpus = [corpus_name],
+        dicts = dictionaries,
+        tags = ["fuzz_target"] + tags,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -121,7 +121,7 @@ def envoy_cc_fuzz_test(
             ],
         }),
         size = size,
-        tags = ["fuzz_target_binary"] + tags,
+        tags = ["fuzz_target_binary", "manual"] + tags,
     )
 
     fuzzing_decoration(

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -131,6 +131,7 @@ def envoy_cc_fuzz_test(
         corpus = [corpus_name],
         dicts = dictionaries,
         tags = ["fuzz_target"] + tags,
+        external_instrumentation = True,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -883,7 +883,7 @@ def _rules_fuzzing():
         name = "rules_fuzzing",
         repo_mapping = {
             "@fuzzing_py_deps": "@fuzzing_pip3",
-        }
+        },
     )
 
 def _kafka_deps():

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -161,13 +161,13 @@ def envoy_dependencies(skip_targets = []):
     _proxy_wasm_cpp_sdk()
     _proxy_wasm_cpp_host()
     _emscripten_toolchain()
+    _rules_fuzzing()
     external_http_archive("proxy_wasm_rust_sdk")
     external_http_archive("com_googlesource_code_re2")
     _com_google_cel_cpp()
     external_http_archive("com_github_google_flatbuffers")
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
-    external_http_archive("rules_fuzzing")
     external_http_archive("envoy_build_tools")
     external_http_archive("rules_cc")
 
@@ -876,6 +876,14 @@ def _com_github_wasm_c_api():
     external_http_archive(
         name = "com_github_wasm_c_api",
         build_file = "@envoy//bazel/external:wasm-c-api.BUILD",
+    )
+
+def _rules_fuzzing():
+    external_http_archive(
+        name = "rules_fuzzing",
+        repo_mapping = {
+            "@fuzzing_py_deps": "@fuzzing_pip3",
+        }
     )
 
 def _kafka_deps():

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -167,6 +167,7 @@ def envoy_dependencies(skip_targets = []):
     external_http_archive("com_github_google_flatbuffers")
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
+    external_http_archive("rules_fuzzing")
     external_http_archive("envoy_build_tools")
     external_http_archive("rules_cc")
 

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -98,8 +98,14 @@ def _python_deps():
         # use_category = ["test"],
     )
     pip3_import(
-        name = "fuzzing_py_deps",
+        name = "fuzzing_pip3",
         requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+
+        # project_name = "Abseil Python Common Libraries",
+        # project_url = "https://github.com/abseil/abseil-py",
+        # version = "0.11.0",
+        # release_date = "2020-10-27",
+        # use_category = ["test"],
     )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -97,6 +97,10 @@ def _python_deps():
         # release_date = "2020-05-21"
         # use_category = ["test"],
     )
+    pip3_import(
+        name = "fuzzing_py_deps",
+        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+    )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().
 def envoy_dependencies_extra():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -49,8 +49,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Fuzzing Rules for Bazel",
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
-        version = "7ed90b3fee1fd1a754448eecae015130dc0fc06e",
-        sha256 = "5e401a64e90cbcca434d65a4a00b4a226650a87bf992a49852136bc31c789d04",
+        # TODO(sbucur): DO NOT SUBMIT before updating to versioned release.
+        version = "90b718226a217739683ef91cede4304ab375c2d2",
+        sha256 = "ffe8a5b886b22ccb4ef3a56977b54c50889df61e48a1e8c959f358b3567999d3",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
         release_date = "2021-01-11",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -54,7 +54,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         sha256 = "28079db0a4aa660b4d99423695c3d8fdf73bed42873a36616bb72049256ce6e3",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-23",
+        release_date = "2021-01-24",
         use_category = ["test_only"],
         implied_untracked_deps = [
             "rules_fuzzing_oss_fuzz",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -50,8 +50,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
         # TODO(sbucur): DO NOT SUBMIT before updating to versioned release.
-        version = "8dcdb86f367d5c98b0d7182f5267e66885f9609b",
-        sha256 = "28079db0a4aa660b4d99423695c3d8fdf73bed42873a36616bb72049256ce6e3",
+        version = "5d3f1d06334fa39cf2bcb6d3d64d660b3de6afe9",
+        sha256 = "44af7162d85259683b24cba69c56c013b0fae8054c568c08b342394abe303be0",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
         release_date = "2021-01-24",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -50,8 +50,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
         # TODO(sbucur): DO NOT SUBMIT before updating to versioned release.
-        version = "f5add01c7764e2c39cb03abf4c0b8dccb6e7e660",
-        sha256 = "af283f0703f42b54e11fc3824ad9adebf8639b90fb6fac5e83c1e82ab72b7260",
+        version = "4841822d1098048baf48088fe3e01c184284a483",
+        sha256 = "6230a8692fe6c863a78368bcadf132de5bdbad66f673b0a53f8fb36e9ac917c4",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
         release_date = "2021-01-25",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -50,8 +50,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
         # TODO(sbucur): DO NOT SUBMIT before updating to versioned release.
-        version = "90b718226a217739683ef91cede4304ab375c2d2",
-        sha256 = "ffe8a5b886b22ccb4ef3a56977b54c50889df61e48a1e8c959f358b3567999d3",
+        version = "5ea191be65ba41eee3a83aadc1b8bd8b4562a81d",
+        sha256 = "07f67909bf4cb07b740c78346c304ab41c6e2a56b977e1a267a261bc19dd6e4e",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
         release_date = "2021-01-11",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -54,7 +54,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         sha256 = "07f67909bf4cb07b740c78346c304ab41c6e2a56b977e1a267a261bc19dd6e4e",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-11",
+        release_date = "2021-01-19",
         use_category = ["test_only"],
         implied_untracked_deps = [
             "rules_fuzzing_oss_fuzz",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -45,6 +45,17 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2019-10-10",
         use_category = ["build"],
     ),
+    rules_fuzzing = dict(
+        project_name = "Fuzzing Rules for Bazel",
+        project_desc = "Bazel rules for fuzz tests",
+        project_url = "https://github.com/bazelbuild/rules_fuzzing",
+        version = "7ed90b3fee1fd1a754448eecae015130dc0fc06e",
+        sha256 = "5e401a64e90cbcca434d65a4a00b4a226650a87bf992a49852136bc31c789d04",
+        strip_prefix = "rules_fuzzing-{version}",
+        urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
+        release_date = "2021-01-11",
+        use_category = ["test_only"],
+    ),
     envoy_build_tools = dict(
         project_name = "envoy-build-tools",
         project_desc = "Common build tools shared by the Envoy/UDPA ecosystem",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -56,6 +56,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
         release_date = "2021-01-11",
         use_category = ["test_only"],
+        implied_untracked_deps = [
+            "rules_fuzzing_oss_fuzz",
+        ],
     ),
     envoy_build_tools = dict(
         project_name = "envoy-build-tools",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -50,11 +50,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
         # TODO(sbucur): DO NOT SUBMIT before updating to versioned release.
-        version = "5ea191be65ba41eee3a83aadc1b8bd8b4562a81d",
-        sha256 = "07f67909bf4cb07b740c78346c304ab41c6e2a56b977e1a267a261bc19dd6e4e",
+        version = "8dcdb86f367d5c98b0d7182f5267e66885f9609b",
+        sha256 = "28079db0a4aa660b4d99423695c3d8fdf73bed42873a36616bb72049256ce6e3",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-19",
+        release_date = "2021-01-23",
         use_category = ["test_only"],
         implied_untracked_deps = [
             "rules_fuzzing_oss_fuzz",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -50,11 +50,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
         # TODO(sbucur): DO NOT SUBMIT before updating to versioned release.
-        version = "5d3f1d06334fa39cf2bcb6d3d64d660b3de6afe9",
-        sha256 = "44af7162d85259683b24cba69c56c013b0fae8054c568c08b342394abe303be0",
+        version = "f5add01c7764e2c39cb03abf4c0b8dccb6e7e660",
+        sha256 = "af283f0703f42b54e11fc3824ad9adebf8639b90fb6fac5e83c1e82ab72b7260",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-24",
+        release_date = "2021-01-25",
         use_category = ["test_only"],
         implied_untracked_deps = [
             "rules_fuzzing_oss_fuzz",

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -5,6 +5,10 @@ load(
     "envoy_package",
     "envoy_proto_library",
 )
+load(
+    "@rules_fuzzing//fuzzing:cc_deps.bzl",
+    "cc_fuzzing_engine",
+)
 
 licenses(["notice"])  # Apache 2
 
@@ -86,4 +90,12 @@ envoy_cc_test(
     deps = [
         "//test/fuzz:random_lib",
     ],
+)
+
+cc_fuzzing_engine(
+    name = "fuzz_runner_engine",
+    testonly = True,
+    display_name = "Fuzz Test Runner",
+    launcher = "fuzz_runner_launcher.sh",
+    library = ":main",
 )

--- a/test/fuzz/fuzz_runner_launcher.sh
+++ b/test/fuzz/fuzz_runner_launcher.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Launcher for the fuzz runner engine.
+
+if (( ! FUZZER_IS_REGRESSION )); then
+    echo "NOTE: Non-regression mode is not supported by this engine."
+fi
+
+command_line=("${FUZZER_BINARY}")
+if [[ -n "${FUZZER_SEED_CORPUS_DIR}" ]]; then
+    command_line+=("${FUZZER_SEED_CORPUS_DIR}")
+fi
+
+exec "${command_line[@]}"


### PR DESCRIPTION
Commit Message: Use the new rules_fuzzing Bazel repository for fuzzing support.

Additional Description: The new fuzzing rules provide an improved fuzzing development experience and simplifies a number of tasks, such as OSS-Fuzz integration.

Risk Level: High

Testing: Used RBE to test the changes on all fuzz tests: `bazel test --config=remote --config=asan-fuzzer -c opt $(bazel query 'let all_fuzz_tests = attr(tags, "fuzz_target", "...") in $all_fuzz_tests - attr(tags, "no_fuzz", $all_fuzz_tests)')`

Docs Changes: None yet.

Release Notes: N/A

Platform Specific Features: Fuzz tests run on Linux platforms only.
