### PR TITLE
[tls] add missing built in cipher stat names

### DIFF
--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -472,9 +472,9 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
 
   // Add hardcoded cipher suites from the TLS 1.3 spec:
   // https://tools.ietf.org/html/rfc8446#appendix-B.4
-  stat_name_set_->rememberBuiltins({"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
-                                    "TLS_AES_128_CCM_SHA256", "TLS_AES_256_CCM_8_SHA256",
-                                    "TLS_CHACHA20_POLY1305_SHA256"});
+  // AES-CCM cipher suites are removed (no BoringSSL support).
+  stat_name_set_->rememberBuiltins(
+      {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256"});
 
   // Curves from
   // https://github.com/google/boringssl/blob/f4d8b969200f1ee2dd872ffb85802e6a0976afe7/ssl/ssl_key_share.cc#L384

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -471,7 +471,7 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
   }
 
   // Add hardcoded cipher suites from the TLS 1.3 spec:
-  // https://tools.ietf.org/html/rfc8446
+  // https://tools.ietf.org/html/rfc8446#appendix-B.4
   stat_name_set_->rememberBuiltins({"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
                                     "TLS_AES_128_CCM_SHA256", "TLS_AES_256_CCM_8_SHA256",
                                     "TLS_CHACHA20_POLY1305_SHA256"});

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -472,8 +472,9 @@ ContextImpl::ContextImpl(Stats::Scope& scope, const Envoy::Ssl::ContextConfig& c
 
   // Add hardcoded cipher suites from the TLS 1.3 spec:
   // https://tools.ietf.org/html/rfc8446
-  stat_name_set_->rememberBuiltins(
-      {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"});
+  stat_name_set_->rememberBuiltins({"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384",
+                                    "TLS_AES_128_CCM_SHA256", "TLS_AES_256_CCM_8_SHA256",
+                                    "TLS_CHACHA20_POLY1305_SHA256"});
 
   // Curves from
   // https://github.com/google/boringssl/blob/f4d8b969200f1ee2dd872ffb85802e6a0976afe7/ssl/ssl_key_share.cc#L384

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -2000,7 +2000,7 @@ TEST_F(SslContextStatsTest, IncOnlyKnownCounters) {
   // fallback registration does not occur. So we test for the fallback only in
   // release builds.
 #ifdef NDEBUG
-  stat = store_.findCounterByString("ssl.ciphers.fallback");
+  Stats::CounterOptConstRef stat = store_.findCounterByString("ssl.ciphers.fallback");
   ASSERT_TRUE(stat.has_value());
   EXPECT_EQ(1, stat->get().value());
 #endif

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -1979,7 +1979,8 @@ TEST_F(SslContextStatsTest, IncOnlyKnownCounters) {
   // we'll be able to find the value in the stats store.
   for (const auto& cipher :
        {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256"}) {
-    // Test all built-in TLS v1.3 cipher suites https://tools.ietf.org/html/rfc8446#appendix-B.4.
+    // Test supported built-in TLS v1.3 cipher suites
+    // https://tools.ietf.org/html/rfc8446#appendix-B.4.
     context_->incCounter("ssl.ciphers", cipher);
     Stats::CounterOptConstRef stat =
         store_.findCounterByString(absl::StrCat("ssl.ciphers.", cipher));

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -2000,9 +2000,9 @@ TEST_F(SslContextStatsTest, IncOnlyKnownCounters) {
   // fallback registration does not occur. So we test for the fallback only in
   // release builds.
 #ifdef NDEBUG
-  cipher = store_.findCounterByString("ssl.ciphers.fallback");
-  ASSERT_TRUE(cipher.has_value());
-  EXPECT_EQ(1, cipher->get().value());
+  stat = store_.findCounterByString("ssl.ciphers.fallback");
+  ASSERT_TRUE(stat.has_value());
+  EXPECT_EQ(1, stat->get().value());
 #endif
 }
 

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -1978,8 +1978,7 @@ TEST_F(SslContextStatsTest, IncOnlyKnownCounters) {
   // Incrementing a value for a cipher that is part of the configuration works, and
   // we'll be able to find the value in the stats store.
   for (const auto& cipher :
-       {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_AES_128_CCM_SHA256",
-        "TLS_AES_256_CCM_8_SHA256", "TLS_CHACHA20_POLY1305_SHA256"}) {
+       {"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256"}) {
     // Test all built-in TLS v1.3 cipher suites https://tools.ietf.org/html/rfc8446#appendix-B.4.
     context_->incCounter("ssl.ciphers", cipher);
     Stats::CounterOptConstRef stat =

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -35,6 +35,7 @@ STATNAME
 SkyWalking
 TIDs
 ceil
+CCM
 CHACHA
 CHLO
 CHMOD


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Adds 3 missing (and removes one duplicate) stat name for TLS v1.3 cipher suites. 
Risk Level: Low
Testing: Added unit tests to test all suits in https://tools.ietf.org/html/rfc8446#appendix-B.4
