### PR TITLE
Windows build: Add repository cache to CI

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -385,6 +385,11 @@ stages:
         pool:
           vmImage: "windows-latest"
         steps:
+          - task: Cache@2
+            inputs:
+              key: '"windows.release" | ./WORKSPACE | **/*.bzl'
+              path: $(Build.StagingDirectory)/repository_cache
+            continueOnError: true
           - bash: ci/run_envoy_docker.sh ci/windows_ci_steps.sh
             displayName: "Run Windows CI"
             env:

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -50,6 +50,7 @@ BAZEL_BUILD_OPTIONS=(
     --show_task_finish
     --verbose_failures
     "--test_output=errors"
+    "--repository_cache=${BUILD_DIR}/repository_cache"
     "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
     "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -50,7 +50,7 @@ BAZEL_BUILD_OPTIONS=(
     --show_task_finish
     --verbose_failures
     "--test_output=errors"
-    "--repository_cache=${BUILD_DIR}/repository_cache"
+    "--repository_cache=${BUILD_DIR/\/c/c:}/repository_cache"
     "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
     "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 


### PR DESCRIPTION
Commit Message: Windows build: Add repository cache to CI
Additional Description: Cached artifacts will help build be less flaky downloading resources
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes https://github.com/envoyproxy/envoy/issues/14566
