### PR TITLE
listener manager: avoid unique -> shared conversion

### DIFF
--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -1024,7 +1024,7 @@ Network::DrainableFilterChainSharedPtr ListenerFilterChainFactoryBuilder::buildF
   std::vector<std::string> server_names(filter_chain.filter_chain_match().server_names().begin(),
                                         filter_chain.filter_chain_match().server_names().end());
 
-  auto filter_chain_res = std::make_unique<FilterChainImpl>(
+  auto filter_chain_res = std::make_shared<FilterChainImpl>(
       config_factory.createTransportSocketFactory(*message, factory_context_,
                                                   std::move(server_names)),
       listener_component_factory_.createNetworkFilterFactoryList(filter_chain.filters(),


### PR DESCRIPTION
buildFilterChainInternal() returns a shared_ptr, so let's make
that instead of unique_ptr.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
