### PR TITLE
LB: edf by timer wheel

### DIFF
--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -155,18 +155,13 @@ public:
                                                     // has_next guarantee the shared_ptr exists.
                                                     calculate_weight(*(next->entry_.lock()));
       addDeadline(deadline, next->entry_);
+      // Save weak_ptr before pop.
+      auto ret = next->entry_;
       wheel_[offset_].pop_front();
       maybeAdvanceCurrent();
-      return next->entry_.lock();
+      return ret.lock();
     }
     return nullptr;
-  }
-
-  // TODO(lambdai): When is empty called? Consider maintain the current non-empty slot in the rest
-  // of the flow.
-  bool empty() const {
-    return distant_entries_.empty() &&
-           std::all_of(wheel_.begin(), wheel_.end(), [](auto& slot) { return slot.empty(); });
   }
 
 private:

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -138,9 +138,9 @@ public:
         ++offset_;
       }
       // Now offset_ == wheel_size_
-      bool spreaded =
+      bool spread =
           spreadDistantEntries(distant_entries_, wheel_, current_lower_boundary_, per_slot_range_);
-      if (!spreaded) {
+      if (!spread) {
         // FIX-ME: repeatedly spread until distant entries are empty.
         return nullptr;
       }
@@ -188,9 +188,9 @@ private:
         ++offset_;
       }
       // Now offset_ == wheel_size_
-      bool spreaded =
+      bool spread =
           spreadDistantEntries(distant_entries_, wheel_, current_lower_boundary_, per_slot_range_);
-      if (!spreaded) {
+      if (!spread) {
         // FIX-ME: repeatedly spread until distant entries are empty.
         return std::make_pair<bool, EdfEntry*>(false, nullptr);
       }

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -315,8 +315,8 @@ private:
     double deadline_;
     // Tie breaker for entries with the same deadline. This is used to provide FIFO behavior.
     uint64_t order_offset_;
-    // We only hold a weak pointer, since we don't support a remove operator. This allows entries
-    // to be lazily unloaded from the queue.
+    // We only hold a weak pointer, since we don't support a remove operator. This allows entries to
+    // be lazily unloaded from the queue.
     std::weak_ptr<C> entry_;
 
     // Flip < direction to make this a min queue.
@@ -330,8 +330,8 @@ private:
   // TODO(htuch): Is it worth the small extra complexity to use integer time for performance
   // reasons?
   double current_time_{};
-  // Offset used during addition to break ties when entries have the same weight but should
-  // reflect FIFO insertion order in picks.
+  // Offset used during addition to break ties when entries have the same weight but should reflect
+  // FIFO insertion order in picks.
   uint64_t order_offset_{};
   // Min priority queue for EDF.
   std::priority_queue<EdfEntry> queue_;

--- a/source/common/upstream/edf_scheduler.h
+++ b/source/common/upstream/edf_scheduler.h
@@ -2,7 +2,7 @@
 #include <cstdint>
 #include <iostream>
 #include <queue>
-
+#include <list>
 #include "common/common/assert.h"
 
 namespace Envoy {
@@ -18,11 +18,192 @@ namespace Upstream {
 #define EDF_TRACE(...)
 #endif
 
+template <class C> class TimeWheel {
+  struct EdfEntry {
+    double deadline_;
+    // Tie breaker for entries with the same deadline. This is used to provide FIFO behavior.
+    //    uint64_t order_offset_;
+    // We only hold a weak pointer, since we don't support a remove operator. This allows entries
+    // to be lazily unloaded from the queue.
+    std::weak_ptr<C> entry_;
+
+    // Flip < direction to make this a min queue.
+    // bool operator<(const EdfEntry& other) const {
+    //   return deadline_ > other.deadline_ ||
+    //          (deadline_ == other.deadline_ && order_offset_ > other.order_offset_);
+    // }
+  };
+
+public:
+  TimeWheel(int wheel_size = 16) : wheel_size_(wheel_size), wheel_(wheel_size) {}
+  void dump() {
+    FANCY_LOG(trace, "prepick size = {}", prepick_list_.size());
+    FANCY_LOG(trace, "wheel size = {}", std::reduce(wheel_.begin(), wheel_.end(), 0, [](int acc, const auto& l) {return acc + l.size();} ));
+    FANCY_LOG(trace, "distant size = {}", distant_entries_.size());
+  }
+  void maybeAdvanceCurrent() {
+    // There is entry in the current slot regardless the entry is expired or not. Leave it here for
+    // the next pick.
+    while (offset_ < static_cast<decltype(offset_)>(wheel_.size())) {
+      if (!wheel_[offset_].empty()) {
+        return;
+      }
+      // Advance slot by 1.
+      ++offset_;
+      current_lower_boundary_ += per_slot_range_;
+    }
+    // All slots are empty. Roll the wheel.
+    offset_ = 0;
+    spreadDistantEntries(distant_entries_, wheel_, current_lower_boundary_, per_slot_range_);
+  }
+  void addDeadline(double deadline, std::shared_ptr<C> entry) {
+    ASSERT(deadline > current_lower_boundary_);
+    EDF_TRACE("Insertion {} in queue with deadline {}.", static_cast<const void*>(entry.get()),
+              deadline);
+    int offset = static_cast<int>((deadline - current_lower_boundary_) / per_slot_range_);
+    if (offset + offset_ >= static_cast<int>(wheel_.size())) {
+      // add to upper level
+      distant_entries_.push_back({deadline, entry});
+    } else {
+      wheel_[offset + offset_].push_back({deadline, entry});
+    }
+    maybeAdvanceCurrent();
+  }
+  void add(double weight, std::shared_ptr<C> entry) {
+    ASSERT(weight > 0);
+    const double deadline = current_lower_boundary_ + 1.0 / weight;
+    EDF_TRACE("Insertion {} in queue with deadline {} and weight {}.",
+              static_cast<const void*>(entry.get()), deadline, weight);
+    addDeadline(deadline, std::move(entry));
+  }
+  // TODO(lambdai): Currently the code assumes rotate the wheel by 1 is sufficient. It's not always
+  // true. Also need to fix with hierachical wheels.
+  bool spreadDistantEntries(std::list<EdfEntry>& upper, std::vector<std::list<EdfEntry>>& lower,
+                            const double& base, const double& span) {
+    if (upper.empty()) {
+      return false;
+    }
+    int nr_slot = lower.size();
+    double upper_bound = base + nr_slot * span;
+
+    for (auto iter = upper.begin(); iter != upper.end();) {
+      // Unlikely too large.
+      if (iter->deadline_ > upper_bound) {
+        ++iter;
+        continue;
+      }
+      // No precision lost before 2 ^ 53 / (number of slot).
+      int offset = static_cast<int>((iter->deadline_ - base) / span);
+      lower[offset].splice(lower[offset].begin(), upper, iter++);
+    }
+    // FIXME
+    return true;
+  }
+
+  std::shared_ptr<C> pickAndAdd(std::function<double(const C&)> calculate_weight) {
+    while (!prepick_list_.empty()) {
+      // In this case the entry was added back during peekAgain so don't re-add.
+      if (prepick_list_.front().expired()) {
+        prepick_list_.pop();
+        continue;
+      }
+      std::shared_ptr<C> ret{prepick_list_.front()};
+      prepick_list_.pop();
+      return ret;
+    }
+
+    while (true) {
+      while (offset_ < wheel_size_) {
+        auto& current_slot = wheel_[offset_];
+        while (!current_slot.empty()) {
+          const EdfEntry& edf_entry = current_slot.front();
+          // Entry has been removed, let's see if there's another one.
+          if (edf_entry.entry_.expired()) {
+            EDF_TRACE("Entry has expired, repick.");
+            current_slot.pop_front();
+            continue;
+          }
+          std::shared_ptr<C> ret{current_slot.front().entry_};
+          add(calculate_weight(*ret), ret);
+          current_slot.pop_front();
+          maybeAdvanceCurrent();
+          return ret;
+        }
+        ++offset_;
+      }
+      // Now offset_ == wheel_size_
+      bool spreaded =
+          spreadDistantEntries(distant_entries_, wheel_, current_lower_boundary_, per_slot_range_);
+      if (!spreaded) {
+        // FIXME: repeatedly spread until distant entries are empty.
+        return nullptr;
+      }
+    }
+  }
+
+  std::shared_ptr<C> peekAgain(std::function<double(const C&)> calculate_weight) {
+    auto [has_next, next] = nextAvailableInWheel();
+    if (has_next) {
+      prepick_list_.push(next.entry_);
+      const double deadline = next.deadline_ + 1.0 /
+                                                   // has_next guarantee the shared_ptr exists.
+                                                   calculate_weight(*next.entry_.lock());
+      addDeadline(deadline, next.entry_.lock());
+      wheel_[offset_].pop_front();
+      maybeAdvanceCurrent();
+      return next.entry_.lock();
+    }
+    return nullptr;
+  }
+  // TODO(lambdai): When is empty called? Consider maintain the current non-empty slot in the rest
+  // of th flow.
+  bool empty() const {
+    return distant_entries_.empty() &&
+           std::all_of(wheel_.begin(), wheel_.end(), [](auto& slot) { return slot.empty(); });
+  }
+
+private:
+  std::pair<bool, EdfEntry> nextAvailableInWheel() {
+    // TODO(lambdai): dedup with pickAndAdd
+    while (true) {
+      while (offset_ < wheel_size_) {
+        auto& current_slot = wheel_[offset_];
+        while (!current_slot.empty()) {
+          const EdfEntry& edf_entry = current_slot.front();
+          // Entry has been removed, let's see if there's another one.
+          if (edf_entry.entry_.expired()) {
+            EDF_TRACE("Entry has expired, repick.");
+            current_slot.pop_front();
+            continue;
+          }
+          return std::pair<bool, EdfEntry>(true, edf_entry);
+        }
+        ++offset_;
+      }
+      // Now offset_ == wheel_size_
+      bool spreaded =
+          spreadDistantEntries(distant_entries_, wheel_, current_lower_boundary_, per_slot_range_);
+      if (!spreaded) {
+        // FIXME: repeatedly spread until distant entries are empty.
+        return std::make_pair<bool, EdfEntry>(false, EdfEntry());
+      }
+    }
+  }
+  const int wheel_size_;
+  std::vector<std::list<EdfEntry>> wheel_;
+  double current_lower_boundary_{0.0};
+  int offset_{0};
+  double per_slot_range_{1};
+  double current_time_{0.0};
+  std::list<EdfEntry> distant_entries_;
+  std::queue<std::weak_ptr<C>, std::list<std::weak_ptr<C>>> prepick_list_;
+};
+
 // Earliest Deadline First (EDF) scheduler
-// (https://en.wikipedia.org/wiki/Earliest_deadline_first_scheduling) used for weighted round robin.
-// Each pick from the schedule has the earliest deadline entry selected. Entries have deadlines set
-// at current time + 1 / weight, providing weighted round robin behavior with floating point
-// weights and an O(log n) pick time.
+// (https://en.wikipedia.org/wiki/Earliest_deadline_first_scheduling) used for weighted round
+// robin. Each pick from the schedule has the earliest deadline entry selected. Entries have
+// deadlines set at current time + 1 / weight, providing weighted round robin behavior with
+// floating point weights and an O(log n) pick time.
 template <class C> class EdfScheduler {
 public:
   // Each time peekAgain is called, it will return the best-effort subsequent
@@ -118,8 +299,8 @@ private:
     double deadline_;
     // Tie breaker for entries with the same deadline. This is used to provide FIFO behavior.
     uint64_t order_offset_;
-    // We only hold a weak pointer, since we don't support a remove operator. This allows entries to
-    // be lazily unloaded from the queue.
+    // We only hold a weak pointer, since we don't support a remove operator. This allows entries
+    // to be lazily unloaded from the queue.
     std::weak_ptr<C> entry_;
 
     // Flip < direction to make this a min queue.
@@ -133,8 +314,8 @@ private:
   // TODO(htuch): Is it worth the small extra complexity to use integer time for performance
   // reasons?
   double current_time_{};
-  // Offset used during addition to break ties when entries have the same weight but should reflect
-  // FIFO insertion order in picks.
+  // Offset used during addition to break ties when entries have the same weight but should
+  // reflect FIFO insertion order in picks.
   uint64_t order_offset_{};
   // Min priority queue for EDF.
   std::priority_queue<EdfEntry> queue_;

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -113,6 +113,22 @@ envoy_cc_test(
 )
 
 envoy_cc_benchmark_binary(
+    name = "edf_speed_test",
+    srcs = ["edf_speed_test.cc"],
+    external_deps = [
+        "benchmark",
+    ],
+    deps = [
+        "//source/common/upstream:edf_scheduler_lib",
+    ],
+)
+
+envoy_benchmark_test(
+    name = "edf_speed_test_benchmark_test",
+    benchmark_binary = "edf_speed_test",
+)
+
+envoy_cc_benchmark_binary(
     name = "eds_speed_test",
     srcs = ["eds_speed_test.cc"],
     external_deps = [

--- a/test/common/upstream/edf_scheduler_test.cc
+++ b/test/common/upstream/edf_scheduler_test.cc
@@ -6,6 +6,144 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
+TEST(TimeWheelTest, TwEmpty) {
+  TimeWheel<uint32_t> sched;
+  EXPECT_EQ(nullptr, sched.peekAgain([](const double&) { return 0; }));
+  EXPECT_EQ(nullptr, sched.pickAndAdd([](const double&) { return 0; }));
+}
+
+// Validate we get regular RR behavior when all weights are the same.
+TEST(TimeWheelTest, TwUnweighted) {
+  TimeWheel<uint32_t> sched;
+  // FIX: Stablizate the test when increasing `num_entries`. The impl is fine but the double
+  // precision give it the by-1 count error.
+  constexpr uint32_t num_entries = 4;
+  std::shared_ptr<uint32_t> entries[num_entries];
+
+  for (uint32_t i = 0; i < num_entries; ++i) {
+    entries[i] = std::make_shared<uint32_t>(i);
+    sched.add(1, entries[i]);
+  }
+
+  for (uint32_t rounds = 0; rounds < 4; ++rounds) {
+    for (uint32_t i = 0; i < num_entries; ++i) {
+      auto peek = sched.peekAgain([](const double&) { return 1; });
+      auto p = sched.pickAndAdd([](const double&) { return 1; });
+      EXPECT_EQ(i, *p);
+      EXPECT_EQ(*peek, *p);
+    }
+  }
+}
+
+TEST(TimeWheelTest, TwWeighted) {
+  TimeWheel<uint32_t> sched;
+  // FIX: Stablizate the test when increasing `num_entries`. The impl is fine but the double
+  // precision give it the by-1 count error.
+  constexpr uint32_t num_entries = 4;
+  std::shared_ptr<uint32_t> entries[num_entries];
+  uint32_t pick_count[num_entries];
+
+  for (uint32_t i = 0; i < num_entries; ++i) {
+    entries[i] = std::make_shared<uint32_t>(i);
+    pick_count[i] = 0;
+  }
+  // All the scheduable in the same slot are considered as the same deadline when picking. Insert
+  // the highest weight first so it is scheduled first. It's not a problem in the long run but order
+  // matters in this test case.
+  for (uint32_t i = 0; i < num_entries; ++i) {
+    sched.add(num_entries - i, entries[num_entries - i - 1]);
+  }
+  FANCY_LOG(error, "--------------after init------");
+  sched.dump();
+  FANCY_LOG(error, "--------------start test------");
+  for (uint32_t i = 0; i < (num_entries * (1 + num_entries)) / 2; ++i) {
+    auto peek = sched.peekAgain([](const double& orig) { return orig + 1; });
+    sched.dump();
+
+    auto p = sched.pickAndAdd([](const double& orig) { return orig + 1; });
+    sched.dump();
+
+    EXPECT_EQ(*p, *peek);
+    ++pick_count[*p];
+  }
+
+  for (uint32_t i = 0; i < num_entries; ++i) {
+    EXPECT_EQ(i + 1, pick_count[i]);
+  }
+}
+TEST(TimeWheelTest, TwExpired) {
+  TimeWheel<uint32_t> sched;
+
+  auto second_entry = std::make_shared<uint32_t>(42);
+  {
+    auto first_entry = std::make_shared<uint32_t>(37);
+    sched.add(2, first_entry);
+    sched.add(1, second_entry);
+  }
+
+  auto peek = sched.peekAgain([](const double&) { return 1; });
+  auto p = sched.pickAndAdd([](const double&) { return 1; });
+  EXPECT_EQ(*peek, *p);
+  EXPECT_EQ(*second_entry, *p);
+  EXPECT_EQ(*second_entry, *p);
+}
+TEST(TimeWheelTest, TwExpiredPeek) {
+  TimeWheel<uint32_t> sched;
+
+  {
+    auto second_entry = std::make_shared<uint32_t>(42);
+    auto first_entry = std::make_shared<uint32_t>(37);
+    sched.add(2, first_entry);
+    sched.add(1, second_entry);
+  }
+  auto third_entry = std::make_shared<uint32_t>(37);
+  sched.add(3, third_entry);
+
+  EXPECT_EQ(37, *sched.peekAgain([](const double&) { return 1; }));
+}
+
+// Validate that expired entries are ignored.
+TEST(TimeWheelTest, TwExpiredPeekedIsNotPicked) {
+  TimeWheel<uint32_t> sched;
+
+  {
+    auto second_entry = std::make_shared<uint32_t>(42);
+    auto first_entry = std::make_shared<uint32_t>(37);
+    sched.add(2, first_entry);
+    sched.add(1, second_entry);
+    for (int i = 0; i < 3; ++i) {
+      EXPECT_TRUE(sched.peekAgain([](const double&) { return 1; }) != nullptr);
+    }
+  }
+
+  EXPECT_TRUE(sched.peekAgain([](const double&) { return 1; }) == nullptr);
+  EXPECT_TRUE(sched.pickAndAdd([](const double&) { return 1; }) == nullptr);
+}
+
+TEST(TimeWheelTest, TwManyPeekahead) {
+  TimeWheel<uint32_t> sched1;
+  TimeWheel<uint32_t> sched2;
+  constexpr uint32_t num_entries = 128;
+  std::shared_ptr<uint32_t> entries[num_entries];
+
+  for (uint32_t i = 0; i < num_entries; ++i) {
+    entries[i] = std::make_shared<uint32_t>(i);
+    sched1.add(1, entries[i]);
+    sched2.add(1, entries[i]);
+  }
+
+  std::vector<uint32_t> picks;
+  for (uint32_t rounds = 0; rounds < 10; ++rounds) {
+    picks.push_back(*sched1.peekAgain([](const double&) { return 1; }));
+  }
+  for (uint32_t rounds = 0; rounds < 10; ++rounds) {
+    auto p1 = sched1.pickAndAdd([](const double&) { return 1; });
+    auto p2 = sched2.pickAndAdd([](const double&) { return 1; });
+    EXPECT_EQ(picks[rounds], *p1);
+    EXPECT_EQ(*p2, *p1);
+  }
+}
+
 TEST(EdfSchedulerTest, Empty) {
   EdfScheduler<uint32_t> sched;
   EXPECT_EQ(nullptr, sched.peekAgain([](const double&) { return 0; }));

--- a/test/common/upstream/edf_speed_test.cc
+++ b/test/common/upstream/edf_speed_test.cc
@@ -1,0 +1,69 @@
+#include "common/upstream/edf_scheduler.h"
+
+#include "test/benchmark/main.h"
+
+#include "gtest/gtest.h"
+#include "benchmark/benchmark.h"
+
+using ::benchmark::State;
+using Envoy::benchmark::skipExpensiveBenchmarks;
+
+namespace Envoy {
+namespace Upstream {
+
+class EdfSpeedTest {
+public:
+  EdfSpeedTest(State& state) : state_(state) {}
+  State& state_;
+};
+
+static void heap(State& state) {
+  for (auto _ : state) {
+    // Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(0));
+    // if we've been instructed to skip tests, only run once no matter the argument:
+    uint32_t num_entries = skipExpensiveBenchmarks() ? 1 : state.range(0);
+
+    EdfScheduler<uint32_t> sched;
+    std::vector<std::shared_ptr<uint32_t>> entries;
+    entries.reserve(num_entries);
+    for (uint32_t i = 0; i < num_entries; ++i) {
+      entries.push_back(std::make_shared<uint32_t>(i));
+      sched.add(1, entries[i]);
+    }
+    for (uint32_t rounds = 0; rounds < 128; ++rounds) {
+      for (uint32_t i = 0; i < num_entries; ++i) {
+        auto _peek = sched.peekAgain([](const double&) { return 1; });
+        auto _pick = sched.pickAndAdd([](const double&) { return 1; });
+      }
+    }
+  }
+}
+
+
+static void wheel(State& state) {
+  for (auto _ : state) {
+    // Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(0));
+    // if we've been instructed to skip tests, only run once no matter the argument:
+    uint32_t num_entries = skipExpensiveBenchmarks() ? 1 : state.range(0);
+
+    TimeWheel<uint32_t> sched;
+    std::vector<std::shared_ptr<uint32_t>> entries;
+    entries.reserve(num_entries);
+    for (uint32_t i = 0; i < num_entries; ++i) {
+      entries.push_back(std::make_shared<uint32_t>(i));
+      sched.add(1, entries[i]);
+    }
+    for (uint32_t rounds = 0; rounds < 128; ++rounds) {
+      for (uint32_t i = 0; i < num_entries; ++i) {
+        auto _peek = sched.peekAgain([](const double&) { return 1; });
+        auto _pick = sched.pickAndAdd([](const double&) { return 1; });
+      }
+    }
+  }
+}
+
+BENCHMARK(heap)->Ranges({{1, 10000}})->Unit(::benchmark::kMillisecond);
+BENCHMARK(wheel)->Ranges({{1, 10000}})->Unit(::benchmark::kMillisecond);
+
+} // namespace Upstream
+} // namespace Envoy

--- a/test/common/upstream/edf_speed_test.cc
+++ b/test/common/upstream/edf_speed_test.cc
@@ -11,18 +11,12 @@ using Envoy::benchmark::skipExpensiveBenchmarks;
 namespace Envoy {
 namespace Upstream {
 
-class EdfSpeedTest {
-public:
-  EdfSpeedTest(State& state) : state_(state) {}
-  State& state_;
-};
-
-static void heap(State& state) {
+template <class Edf> static void BM_pick_and_add(State& state) {
   for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
     // if we've been instructed to skip tests, only run once no matter the argument:
     uint32_t num_entries = skipExpensiveBenchmarks() ? 1 : state.range(0);
-
-    EdfScheduler<uint32_t> sched;
+    Edf sched;
     std::vector<std::shared_ptr<uint32_t>> entries;
     entries.reserve(num_entries);
     for (uint32_t i = 0; i < num_entries; ++i) {
@@ -35,26 +29,12 @@ static void heap(State& state) {
   }
 }
 
-static void wheel(State& state) {
-  for (auto _ : state) {
-    // if we've been instructed to skip tests, only run once no matter the argument:
-    uint32_t num_entries = skipExpensiveBenchmarks() ? 1 : state.range(0);
-
-    TimeWheel<uint32_t> sched;
-    std::vector<std::shared_ptr<uint32_t>> entries;
-    entries.reserve(num_entries);
-    for (uint32_t i = 0; i < num_entries; ++i) {
-      entries.push_back(std::make_shared<uint32_t>(i));
-      sched.add((i % 2) + 1, entries[i]);
-    }
-    for (uint32_t rounds = 0; rounds < 1000000; ++rounds) {
-      auto _pick = sched.pickAndAdd([](const double&) { return 1; });
-    }
-  }
-}
-
-BENCHMARK(heap)->Ranges({{1, 10000}})->Unit(::benchmark::kMillisecond);
-BENCHMARK(wheel)->Ranges({{1, 10000}})->Unit(::benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_pick_and_add, EdfScheduler<uint32_t>)
+    ->Ranges({{1, 10000}})
+    ->Unit(::benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_pick_and_add, TimeWheel<uint32_t>)
+    ->Ranges({{1, 10000}})
+    ->Unit(::benchmark::kMillisecond);
 
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/edf_speed_test.cc
+++ b/test/common/upstream/edf_speed_test.cc
@@ -11,7 +11,8 @@ using Envoy::benchmark::skipExpensiveBenchmarks;
 namespace Envoy {
 namespace Upstream {
 
-template <class Edf> static void BM_pick_and_add(State& state) {
+// NOLINTNEXTLINE(readability-identifier-naming)
+template <class Edf> static void BM_PickAndAdd(State& state) {
   for (auto _ : state) {
     UNREFERENCED_PARAMETER(_);
     // if we've been instructed to skip tests, only run once no matter the argument:
@@ -29,10 +30,10 @@ template <class Edf> static void BM_pick_and_add(State& state) {
   }
 }
 
-BENCHMARK_TEMPLATE(BM_pick_and_add, EdfScheduler<uint32_t>)
+BENCHMARK_TEMPLATE(BM_PickAndAdd, EdfScheduler<uint32_t>)
     ->Ranges({{1, 10000}})
     ->Unit(::benchmark::kMillisecond);
-BENCHMARK_TEMPLATE(BM_pick_and_add, TimeWheel<uint32_t>)
+BENCHMARK_TEMPLATE(BM_PickAndAdd, TimeWheel<uint32_t>)
     ->Ranges({{1, 10000}})
     ->Unit(::benchmark::kMillisecond);
 

--- a/test/common/upstream/edf_speed_test.cc
+++ b/test/common/upstream/edf_speed_test.cc
@@ -2,8 +2,8 @@
 
 #include "test/benchmark/main.h"
 
-#include "gtest/gtest.h"
 #include "benchmark/benchmark.h"
+#include "gtest/gtest.h"
 
 using ::benchmark::State;
 using Envoy::benchmark::skipExpensiveBenchmarks;
@@ -19,7 +19,6 @@ public:
 
 static void heap(State& state) {
   for (auto _ : state) {
-    // Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(0));
     // if we've been instructed to skip tests, only run once no matter the argument:
     uint32_t num_entries = skipExpensiveBenchmarks() ? 1 : state.range(0);
 
@@ -28,21 +27,16 @@ static void heap(State& state) {
     entries.reserve(num_entries);
     for (uint32_t i = 0; i < num_entries; ++i) {
       entries.push_back(std::make_shared<uint32_t>(i));
-      sched.add(1, entries[i]);
+      sched.add((i % 2) + 1, entries[i]);
     }
-    for (uint32_t rounds = 0; rounds < 128; ++rounds) {
-      for (uint32_t i = 0; i < num_entries; ++i) {
-        auto _peek = sched.peekAgain([](const double&) { return 1; });
-        auto _pick = sched.pickAndAdd([](const double&) { return 1; });
-      }
+    for (uint32_t rounds = 0; rounds < 1000000; ++rounds) {
+      auto _pick = sched.pickAndAdd([](const double&) { return 1; });
     }
   }
 }
 
-
 static void wheel(State& state) {
   for (auto _ : state) {
-    // Envoy::Upstream::EdsSpeedTest speed_test(state, state.range(0));
     // if we've been instructed to skip tests, only run once no matter the argument:
     uint32_t num_entries = skipExpensiveBenchmarks() ? 1 : state.range(0);
 
@@ -51,13 +45,10 @@ static void wheel(State& state) {
     entries.reserve(num_entries);
     for (uint32_t i = 0; i < num_entries; ++i) {
       entries.push_back(std::make_shared<uint32_t>(i));
-      sched.add(1, entries[i]);
+      sched.add((i % 2) + 1, entries[i]);
     }
-    for (uint32_t rounds = 0; rounds < 128; ++rounds) {
-      for (uint32_t i = 0; i < num_entries; ++i) {
-        auto _peek = sched.peekAgain([](const double&) { return 1; });
-        auto _pick = sched.pickAndAdd([](const double&) { return 1; });
-      }
+    for (uint32_t rounds = 0; rounds < 1000000; ++rounds) {
+      auto _pick = sched.pickAndAdd([](const double&) { return 1; });
     }
   }
 }


### PR DESCRIPTION
Commit Message:
Add an experimental edf scheduler powered by timer wheel.
Additional Description:

With the naive timer wheel the cost of pick/peek/add host is reduced.
Almost constant cost regardless of the number of hosts is tens or thousands.  
No bias toward the earlier host because `current_time_` is not bumped when adding new hosts except when the first host is added.
We move unweighted to udf if the timer wheel cost is acceptable.

The trade-off includes 
RR is not that strict. All the entries in the same slot are FIFO when picking(but not adding). Could be mitigated by carefully select the per slot time range.
Sparse slots can hamper the performance. Can be mitigated by a hierarchical time wheel to handle a very low weight host.

Performance: `wheel` is the new and `heap` is the current. The parameter is the number of hosts.
Each iteration in the row runs 1 million `pickAndAdd`. The existing heap or priority queue implementation adds 15-20ms when the hosts are 8x.
``` 
------------------------------------------------------
Benchmark            Time             CPU   Iterations
------------------------------------------------------
heap/1            73.0 ms         73.0 ms           10
heap/8            89.0 ms         89.0 ms            8
heap/64            109 ms          109 ms            6
heap/512           130 ms          130 ms            5
heap/4096          151 ms          151 ms            5
heap/10000         158 ms          158 ms            4
wheel/1           71.5 ms         71.5 ms           10
wheel/8           70.6 ms         70.6 ms           10
wheel/64          70.7 ms         70.7 ms           10
wheel/512         71.4 ms         71.4 ms           10
wheel/4096        77.6 ms         77.6 ms            9
wheel/10000       79.9 ms         79.9 ms            9
```
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
![TimerWheel (1)](https://user-images.githubusercontent.com/209726/104642059-61587100-565f-11eb-90c2-3bb9e280f2f7.png)

