### PR TITLE
server: add FIPS mode statistic indicating FIPS compliance

### DIFF
--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -33,4 +33,5 @@ Server related statistics are rooted at *server.* with following statistics:
   envoy_bug_failures, Counter, Number of envoy bug failures detected in a release build. File or report the issue if this increments as this may be serious.
   static_unknown_fields, Counter, Number of messages in static configuration with unknown fields
   dynamic_unknown_fields, Counter, Number of messages in dynamic configuration with unknown fields
+  fips_mode, Gauge, Integer representing whether the envoy build is FIPS compliant or not
 

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -35,7 +35,7 @@ Server related statistics are rooted at *server.* with following statistics:
   dynamic_unknown_fields, Counter, Number of messages in dynamic configuration with unknown fields
 
 Server Compilation Settings
-------
+---------------------------
 
 Server Compilation Settings related statistics are rooted at *server.compilation_settings.* with following statistics:
 

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -35,3 +35,13 @@ Server related statistics are rooted at *server.* with following statistics:
   dynamic_unknown_fields, Counter, Number of messages in dynamic configuration with unknown fields
   fips_mode, Gauge, Integer representing whether the envoy build is FIPS compliant or not
 
+Server Compilation Settings
+------
+
+Server Compilation Settings related statistics are rooted at *server.compilation_settings.* with following statistics:
+
+.. csv-table::
+  :header: Name, Type, Description
+  :widths: 1, 1, 2
+
+  fips_mode, Gauge, Integer representing whether the envoy build is FIPS compliant or not

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -33,7 +33,6 @@ Server related statistics are rooted at *server.* with following statistics:
   envoy_bug_failures, Counter, Number of envoy bug failures detected in a release build. File or report the issue if this increments as this may be serious.
   static_unknown_fields, Counter, Number of messages in static configuration with unknown fields
   dynamic_unknown_fields, Counter, Number of messages in dynamic configuration with unknown fields
-  fips_mode, Gauge, Integer representing whether the envoy build is FIPS compliant or not
 
 Server Compilation Settings
 ------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -37,8 +37,8 @@ New Features
 * access log: added the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point for custom formatters (command operators).
 * http: added support for :ref:`:ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
 * http: change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to false.
-* tcp_proxy: add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation <tunneling-tcp-over-http>` for details.
 * server: added :ref:`fips_mode <statistics>` statistic.
+* tcp_proxy: add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation <tunneling-tcp-over-http>` for details.
 
 Deprecated
 ----------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,6 +38,7 @@ New Features
 * http: added support for :ref:`:ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
 * http: change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to false.
 * tcp_proxy: add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation <tunneling-tcp-over-http>` for details.
+* server: added :ref:`fips_mode <statistics>` statistic.
 
 Deprecated
 ----------

--- a/source/common/version/version.cc
+++ b/source/common/version/version.cc
@@ -36,6 +36,14 @@ const envoy::config::core::v3::BuildVersion& VersionInfo::buildVersion() {
   return *result;
 }
 
+bool VersionInfo::sslFipsCompliant() {
+  bool fipsCompliant = false;
+#ifdef BORINGSSL_FIPS
+  fipsCompliant = true;
+#endif
+  return fipsCompliant;
+}
+
 const std::string& VersionInfo::buildType() {
 #ifdef NDEBUG
   static const std::string release_type = "RELEASE";

--- a/source/common/version/version.h
+++ b/source/common/version/version.h
@@ -22,7 +22,8 @@ public:
   static const std::string& revisionStatus();
   // Repository information and build type.
   static const std::string& version();
-  static const std::string& sslVersion();
+  // FIPS Compliance of envoy build
+  static bool sslFipsCompliant();
 
   static const envoy::config::core::v3::BuildVersion& buildVersion();
 
@@ -30,6 +31,7 @@ private:
   friend class Envoy::VersionInfoTestPeer;
   // RELEASE or DEBUG
   static const std::string& buildType();
+  static const std::string& sslVersion();
   static envoy::config::core::v3::BuildVersion makeBuildVersion(const char* version);
 };
 

--- a/source/common/version/version.h
+++ b/source/common/version/version.h
@@ -22,6 +22,7 @@ public:
   static const std::string& revisionStatus();
   // Repository information and build type.
   static const std::string& version();
+  static const std::string& sslVersion();
 
   static const envoy::config::core::v3::BuildVersion& buildVersion();
 
@@ -29,7 +30,6 @@ private:
   friend class Envoy::VersionInfoTestPeer;
   // RELEASE or DEBUG
   static const std::string& buildType();
-  static const std::string& sslVersion();
   static envoy::config::core::v3::BuildVersion makeBuildVersion(const char* version);
 };
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -386,7 +386,7 @@ void InstanceImpl::initialize(const Options& options,
   }
   server_stats_->version_.set(version_int);
   const std::string fips_ssl_version = "BoringSSL-FIPS";
-  if(VersionInfo::sslVersion() == fips_ssl_version) {
+  if (VersionInfo::sslVersion() == fips_ssl_version) {
     server_stats_->fips_mode_.set(1);
   }
 

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -385,6 +385,10 @@ void InstanceImpl::initialize(const Options& options,
     }
   }
   server_stats_->version_.set(version_int);
+  const std::string fips_ssl_version = "BoringSSL-FIPS";
+  if(VersionInfo::sslVersion() == fips_ssl_version) {
+    server_stats_->fips_mode_.set(1);
+  }
 
   bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
   bootstrap_.mutable_node()->set_user_agent_name("envoy");

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -358,10 +358,12 @@ void InstanceImpl::initialize(const Options& options,
       ServerStats{ALL_SERVER_STATS(POOL_COUNTER_PREFIX(stats_store_, server_stats_prefix),
                                    POOL_GAUGE_PREFIX(stats_store_, server_stats_prefix),
                                    POOL_HISTOGRAM_PREFIX(stats_store_, server_stats_prefix))});
-  server_compilation_settings_stats_ = std::make_unique<CompilationSettings::ServerCompilationSettingsStats>(
-    CompilationSettings::ServerCompilationSettingsStats{ALL_SERVER_COMPILATION_SETTINGS_STATS(POOL_COUNTER_PREFIX(stats_store_, server_compilation_settings_stats_prefix),
-                                  POOL_GAUGE_PREFIX(stats_store_, server_compilation_settings_stats_prefix),
-                                  POOL_HISTOGRAM_PREFIX(stats_store_, server_compilation_settings_stats_prefix))});
+  server_compilation_settings_stats_ =
+      std::make_unique<CompilationSettings::ServerCompilationSettingsStats>(
+          CompilationSettings::ServerCompilationSettingsStats{ALL_SERVER_COMPILATION_SETTINGS_STATS(
+              POOL_COUNTER_PREFIX(stats_store_, server_compilation_settings_stats_prefix),
+              POOL_GAUGE_PREFIX(stats_store_, server_compilation_settings_stats_prefix),
+              POOL_HISTOGRAM_PREFIX(stats_store_, server_compilation_settings_stats_prefix))});
   validation_context_.staticWarningValidationVisitor().setUnknownCounter(
       server_stats_->static_unknown_fields_);
   validation_context_.dynamicWarningValidationVisitor().setUnknownCounter(

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -50,6 +50,17 @@
 
 namespace Envoy {
 namespace Server {
+  namespace CompilationSettings {
+  /**
+   * All server compilation settings stats. @see stats_macros.h
+   */
+  #define ALL_SERVER_COMPILATION_SETTINGS_STATS(COUNTER, GAUGE, HISTOGRAM)                                                \
+    GAUGE(fips_mode, NeverImport)                                                                    
+
+    struct ServerCompilationSettingsStats {
+      ALL_SERVER_COMPILATION_SETTINGS_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
+    };
+  }
 
 /**
  * All server wide stats. @see stats_macros.h
@@ -74,7 +85,6 @@ namespace Server {
   GAUGE(total_connections, Accumulate)                                                             \
   GAUGE(uptime, Accumulate)                                                                        \
   GAUGE(version, NeverImport)                                                                      \
-  GAUGE(fips_mode, NeverImport)                                                                    \
   HISTOGRAM(initialization_time_ms, Milliseconds)
 
 struct ServerStats {
@@ -323,6 +333,7 @@ private:
   time_t original_start_time_;
   Stats::StoreRoot& stats_store_;
   std::unique_ptr<ServerStats> server_stats_;
+  std::unique_ptr<CompilationSettings::ServerCompilationSettingsStats> server_compilation_settings_stats_;
   Assert::ActionRegistrationPtr assert_action_registration_;
   Assert::ActionRegistrationPtr envoy_bug_action_registration_;
   ThreadLocal::Instance& thread_local_;

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -74,6 +74,7 @@ namespace Server {
   GAUGE(total_connections, Accumulate)                                                             \
   GAUGE(uptime, Accumulate)                                                                        \
   GAUGE(version, NeverImport)                                                                      \
+  GAUGE(fips_mode, NeverImport)                                                                    \
   HISTOGRAM(initialization_time_ms, Milliseconds)
 
 struct ServerStats {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -50,17 +50,18 @@
 
 namespace Envoy {
 namespace Server {
-  namespace CompilationSettings {
-  /**
-   * All server compilation settings stats. @see stats_macros.h
-   */
-  #define ALL_SERVER_COMPILATION_SETTINGS_STATS(COUNTER, GAUGE, HISTOGRAM)                                                \
-    GAUGE(fips_mode, NeverImport)                                                                    
+namespace CompilationSettings {
+/**
+ * All server compilation settings stats. @see stats_macros.h
+ */
+#define ALL_SERVER_COMPILATION_SETTINGS_STATS(COUNTER, GAUGE, HISTOGRAM)                           \
+  GAUGE(fips_mode, NeverImport)
 
-    struct ServerCompilationSettingsStats {
-      ALL_SERVER_COMPILATION_SETTINGS_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
-    };
-  }
+struct ServerCompilationSettingsStats {
+  ALL_SERVER_COMPILATION_SETTINGS_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT,
+                                        GENERATE_HISTOGRAM_STRUCT)
+};
+} // namespace CompilationSettings
 
 /**
  * All server wide stats. @see stats_macros.h
@@ -333,7 +334,8 @@ private:
   time_t original_start_time_;
   Stats::StoreRoot& stats_store_;
   std::unique_ptr<ServerStats> server_stats_;
-  std::unique_ptr<CompilationSettings::ServerCompilationSettingsStats> server_compilation_settings_stats_;
+  std::unique_ptr<CompilationSettings::ServerCompilationSettingsStats>
+      server_compilation_settings_stats_;
   Assert::ActionRegistrationPtr assert_action_registration_;
   Assert::ActionRegistrationPtr envoy_bug_action_registration_;
   ThreadLocal::Instance& thread_local_;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -367,12 +367,11 @@ TEST_P(ServerInstanceImplTest, ValidateFIPSModeStat) {
   auto server_thread =
       startTestServer("test/server/test_data/server/proxy_version_bootstrap.yaml", true);
 
-  const std::string fips_ssl_version = "BoringSSL-FIPS";
-  if (VersionInfo::sslVersion() == fips_ssl_version) {
-    EXPECT_EQ(1L, TestUtility::findGauge(stats_store_, "server.fips_mode")->value());
-  } else {
-    EXPECT_EQ(0L, TestUtility::findGauge(stats_store_, "server.fips_mode")->value());
-  }
+#ifdef BORINGSSL_FIPS
+  EXPECT_EQ(1L, TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
+#else
+  EXPECT_EQ(0L, TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
+#endif
 
   server_->dispatcher().post([&] { server_->shutdown(); });
   server_thread->join();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -368,9 +368,11 @@ TEST_P(ServerInstanceImplTest, ValidateFIPSModeStat) {
       startTestServer("test/server/test_data/server/proxy_version_bootstrap.yaml", true);
 
 #ifdef BORINGSSL_FIPS
-  EXPECT_EQ(1L, TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
+  EXPECT_EQ(1L,
+            TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
 #else
-  EXPECT_EQ(0L, TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
+  EXPECT_EQ(0L,
+            TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
 #endif
 
   server_->dispatcher().post([&] { server_->shutdown(); });

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -367,13 +367,13 @@ TEST_P(ServerInstanceImplTest, ValidateFIPSModeStat) {
   auto server_thread =
       startTestServer("test/server/test_data/server/proxy_version_bootstrap.yaml", true);
 
-#ifdef BORINGSSL_FIPS
-  EXPECT_EQ(1L,
-            TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
-#else
-  EXPECT_EQ(0L,
-            TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
-#endif
+  if (VersionInfo::sslFipsCompliant()) {
+    EXPECT_EQ(
+        1L, TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
+  } else {
+    EXPECT_EQ(
+        0L, TestUtility::findGauge(stats_store_, "server.compilation_settings.fips_mode")->value());
+  }
 
   server_->dispatcher().post([&] { server_->shutdown(); });
   server_thread->join();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -362,6 +362,17 @@ TEST_P(ServerInstanceImplTest, ProxyVersionOveridesFromBootstrap) {
   server_thread->join();
 }
 
+// Validates that the "server.fips_mode" indicates the FIPS compliance from the Envoy Build
+TEST_P(ServerInstanceImplTest, ValidateFIPSModeForNonFIPSBuild) {
+  auto server_thread =
+      startTestServer("test/server/test_data/server/proxy_version_bootstrap.yaml", true);
+
+  EXPECT_EQ(0L, TestUtility::findGauge(stats_store_, "server.fips_mode")->value());
+
+  server_->dispatcher().post([&] { server_->shutdown(); });
+  server_thread->join();
+}
+
 TEST_P(ServerInstanceImplTest, EmptyShutdownLifecycleNotifications) {
   auto server_thread = startTestServer("test/server/test_data/server/node_bootstrap.yaml", false);
   server_->dispatcher().post([&] { server_->shutdown(); });


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Added a new stat(server.fips_mode) to indicate FIPS Compliance
Additional Description:
Emit 0 if Envoy build is not FIPS compliant
Emit 1 if Envoy is FIPS compliant.
Risk Level:
Low
Testing:
Unit Tests
Docs Changes:
Yes
Release Notes:
Yes
Platform Specific Features:
No
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
