### PR TITLE
http: add support for dynamically injecting filters into the chain

### DIFF
--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -570,13 +570,14 @@ public:
    * The filter will be added as a dual filter, e.g. it will serve as both a decoding and encoding
    * filter.
    *
-   * Expected usage of this API is as follows: filters that might want to inject filters should create
-   * the filter factories that are used to provide the filters as part of its own filter factory creation
-   * (this ensures that filter factories consistently created on the main thread), and invoke the filter factories
-   * to create new filters per stream (this ensures that the lifetime of filters matches regular filters).
+   * Expected usage of this API is as follows: filters that might want to inject filters should
+   * create the filter factories that are used to provide the filters as part of its own filter
+   * factory creation (this ensures that filter factories consistently created on the main thread),
+   * and invoke the filter factories to create new filters per stream (this ensures that the
+   * lifetime of filters matches regular filters).
    *
-   * The filter factories may also be created as part of other factory instantiations that occur during HTTP filter
-   * factory creation (e.g. match actions).
+   * The filter factories may also be created as part of other factory instantiations that occur
+   * during HTTP filter factory creation (e.g. match actions).
    */
   virtual void addStreamFilter(StreamFilterSharedPtr filter) PURE;
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -280,8 +280,8 @@ using StreamDecoderFilterSharedPtr = std::shared_ptr<StreamDecoderFilter>;
 class StreamEncoderFilter;
 using StreamEncoderFilterSharedPtr = std::shared_ptr<StreamEncoderFilter>;
 /**
- * Stream decoder filter callbacks add additional callbacks that allow a decoding filter to
- * restart decoding if they decide to hold data (e.g. for buffering or rate limiting).
+ * Stream decoder filter callbacks add additional callbacks that allow a decoding filter to restart
+ * decoding if they decide to hold data (e.g. for buffering or rate limiting).
  */
 class StreamDecoderFilterCallbacks : public virtual StreamFilterCallbacks {
 public:
@@ -327,8 +327,8 @@ public:
    * to further filters (outside of callback context).
    *
    * 4) If additional data needs to be added in the decodeTrailers() callback, this method can be
-   * called in the context of the callback. All further filters will receive decodeData(...,
-   * false) followed by decodeTrailers(). However if the iteration is stopped, the added data will
+   * called in the context of the callback. All further filters will receive decodeData(..., false)
+   * followed by decodeTrailers(). However if the iteration is stopped, the added data will
    * buffered, so that the further filters will not receive decodeData() before decodeHeaders().
    *
    * It is an error to call this method in any other case.
@@ -337,8 +337,7 @@ public:
    * filters and also how the two methods are different.
    *
    * @param data Buffer::Instance supplies the data to be decoded.
-   * @param streaming_filter boolean supplies if this filter streams data or buffers the full
-   * body.
+   * @param streaming_filter boolean supplies if this filter streams data or buffers the full body.
    */
   virtual void addDecodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
@@ -354,16 +353,15 @@ public:
    * from within a filter's decodeData() call.
    *
    * When using this callback, filters should generally only return
-   * FilterDataStatus::StopIterationNoBuffer from their decodeData() call, since use of this
-   * method indicates that a filter does not wish to participate in standard HTTP connection
-   * manager buffering and continuation and will perform any necessary buffering and continuation
-   * on its own.
+   * FilterDataStatus::StopIterationNoBuffer from their decodeData() call, since use of this method
+   * indicates that a filter does not wish to participate in standard HTTP connection manager
+   * buffering and continuation and will perform any necessary buffering and continuation on
+   * its own.
    *
    * This callback is different from addDecodedData() in that the specified data and end_stream
    * status will be propagated directly to further filters in the filter chain. This is different
    * from addDecodedData() where data is added to the HTTP connection manager's buffered data with
-   * the assumption that standard HTTP connection manager buffering and continuation are being
-   * used.
+   * the assumption that standard HTTP connection manager buffering and continuation are being used.
    */
   virtual void injectDecodedDataToFilterChain(Buffer::Instance& data, bool end_stream) PURE;
 
@@ -379,14 +377,13 @@ public:
   virtual RequestTrailerMap& addDecodedTrailers() PURE;
 
   /**
-   * Attempts to create a locally generated response using the provided response_code and
-   * body_text parameters. If the request was a gRPC request the local reply will be encoded as a
-   * gRPC response with a 200 HTTP response code and grpc-status and grpc-message headers mapped
-   * from the provided parameters.
+   * Attempts to create a locally generated response using the provided response_code and body_text
+   * parameters. If the request was a gRPC request the local reply will be encoded as a gRPC
+   * response with a 200 HTTP response code and grpc-status and grpc-message headers mapped from the
+   * provided parameters.
    *
    * If a response has already started (e.g. if the router calls sendSendLocalReply after encoding
-   * headers) this will either ship the reply directly to the downstream codec, or reset the
-   * stream.
+   * headers) this will either ship the reply directly to the downstream codec, or reset the stream.
    *
    * @param response_code supplies the HTTP response code.
    * @param body_text supplies the optional body text which is sent using the text/plain content
@@ -435,8 +432,8 @@ public:
    * The connection manager inspects certain pseudo headers that are not actually sent downstream.
    * - See source/common/http/headers.h
    *
-   * The only 1xx that may be provided to encodeHeaders() is a 101 upgrade, which will be the
-   * final encodeHeaders() for a response.
+   * The only 1xx that may be provided to encodeHeaders() is a 101 upgrade, which will be the final
+   * encodeHeaders() for a response.
    *
    * @param headers supplies the headers to be encoded.
    * @param end_stream supplies whether this is a header only request/response.
@@ -482,9 +479,8 @@ public:
    * their high watermark.
    *
    * In the case of a filter such as the router filter, which spills into multiple buffers (codec,
-   * connection etc.) this may be called multiple times. Any such filter is responsible for
-   * calling the low watermark callbacks an equal number of times as the respective buffers are
-   * drained.
+   * connection etc.) this may be called multiple times. Any such filter is responsible for calling
+   * the low watermark callbacks an equal number of times as the respective buffers are drained.
    */
   virtual void onDecoderFilterAboveWriteBufferHighWatermark() PURE;
 

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -271,9 +271,17 @@ public:
 using RouteConfigUpdatedCallback = std::function<void(bool)>;
 using RouteConfigUpdatedCallbackSharedPtr = std::shared_ptr<RouteConfigUpdatedCallback>;
 
+class StreamFilter;
+using StreamFilterSharedPtr = std::shared_ptr<StreamFilter>;
+
+class StreamDecoderFilter;
+using StreamDecoderFilterSharedPtr = std::shared_ptr<StreamDecoderFilter>;
+
+class StreamEncoderFilter;
+using StreamEncoderFilterSharedPtr = std::shared_ptr<StreamEncoderFilter>;
 /**
- * Stream decoder filter callbacks add additional callbacks that allow a decoding filter to restart
- * decoding if they decide to hold data (e.g. for buffering or rate limiting).
+ * Stream decoder filter callbacks add additional callbacks that allow a decoding filter to
+ * restart decoding if they decide to hold data (e.g. for buffering or rate limiting).
  */
 class StreamDecoderFilterCallbacks : public virtual StreamFilterCallbacks {
 public:
@@ -319,8 +327,8 @@ public:
    * to further filters (outside of callback context).
    *
    * 4) If additional data needs to be added in the decodeTrailers() callback, this method can be
-   * called in the context of the callback. All further filters will receive decodeData(..., false)
-   * followed by decodeTrailers(). However if the iteration is stopped, the added data will
+   * called in the context of the callback. All further filters will receive decodeData(...,
+   * false) followed by decodeTrailers(). However if the iteration is stopped, the added data will
    * buffered, so that the further filters will not receive decodeData() before decodeHeaders().
    *
    * It is an error to call this method in any other case.
@@ -329,7 +337,8 @@ public:
    * filters and also how the two methods are different.
    *
    * @param data Buffer::Instance supplies the data to be decoded.
-   * @param streaming_filter boolean supplies if this filter streams data or buffers the full body.
+   * @param streaming_filter boolean supplies if this filter streams data or buffers the full
+   * body.
    */
   virtual void addDecodedData(Buffer::Instance& data, bool streaming_filter) PURE;
 
@@ -345,15 +354,16 @@ public:
    * from within a filter's decodeData() call.
    *
    * When using this callback, filters should generally only return
-   * FilterDataStatus::StopIterationNoBuffer from their decodeData() call, since use of this method
-   * indicates that a filter does not wish to participate in standard HTTP connection manager
-   * buffering and continuation and will perform any necessary buffering and continuation on its
-   * own.
+   * FilterDataStatus::StopIterationNoBuffer from their decodeData() call, since use of this
+   * method indicates that a filter does not wish to participate in standard HTTP connection
+   * manager buffering and continuation and will perform any necessary buffering and continuation
+   * on its own.
    *
    * This callback is different from addDecodedData() in that the specified data and end_stream
    * status will be propagated directly to further filters in the filter chain. This is different
    * from addDecodedData() where data is added to the HTTP connection manager's buffered data with
-   * the assumption that standard HTTP connection manager buffering and continuation are being used.
+   * the assumption that standard HTTP connection manager buffering and continuation are being
+   * used.
    */
   virtual void injectDecodedDataToFilterChain(Buffer::Instance& data, bool end_stream) PURE;
 
@@ -361,21 +371,22 @@ public:
    * Adds decoded trailers. May only be called in decodeData when end_stream is set to true.
    * If called in any other context, an assertion will be triggered.
    *
-   * When called in decodeData, the trailers map will be initialized to an empty map and returned by
-   * reference. Calling this function more than once is invalid.
+   * When called in decodeData, the trailers map will be initialized to an empty map and returned
+   * by reference. Calling this function more than once is invalid.
    *
    * @return a reference to the newly created trailers map.
    */
   virtual RequestTrailerMap& addDecodedTrailers() PURE;
 
   /**
-   * Attempts to create a locally generated response using the provided response_code and body_text
-   * parameters. If the request was a gRPC request the local reply will be encoded as a gRPC
-   * response with a 200 HTTP response code and grpc-status and grpc-message headers mapped from the
-   * provided parameters.
+   * Attempts to create a locally generated response using the provided response_code and
+   * body_text parameters. If the request was a gRPC request the local reply will be encoded as a
+   * gRPC response with a 200 HTTP response code and grpc-status and grpc-message headers mapped
+   * from the provided parameters.
    *
    * If a response has already started (e.g. if the router calls sendSendLocalReply after encoding
-   * headers) this will either ship the reply directly to the downstream codec, or reset the stream.
+   * headers) this will either ship the reply directly to the downstream codec, or reset the
+   * stream.
    *
    * @param response_code supplies the HTTP response code.
    * @param body_text supplies the optional body text which is sent using the text/plain content
@@ -402,8 +413,9 @@ public:
   /**
    * Called with 100-Continue headers to be encoded.
    *
-   * This is not folded into encodeHeaders because most Envoy users and filters will not be proxying
-   * 100-continue and with it split out, can ignore the complexity of multiple encodeHeaders calls.
+   * This is not folded into encodeHeaders because most Envoy users and filters will not be
+   * proxying 100-continue and with it split out, can ignore the complexity of multiple
+   * encodeHeaders calls.
    *
    * This must not be invoked more than once per request.
    *
@@ -423,8 +435,8 @@ public:
    * The connection manager inspects certain pseudo headers that are not actually sent downstream.
    * - See source/common/http/headers.h
    *
-   * The only 1xx that may be provided to encodeHeaders() is a 101 upgrade, which will be the final
-   * encodeHeaders() for a response.
+   * The only 1xx that may be provided to encodeHeaders() is a 101 upgrade, which will be the
+   * final encodeHeaders() for a response.
    *
    * @param headers supplies the headers to be encoded.
    * @param end_stream supplies whether this is a header only request/response.
@@ -470,8 +482,9 @@ public:
    * their high watermark.
    *
    * In the case of a filter such as the router filter, which spills into multiple buffers (codec,
-   * connection etc.) this may be called multiple times. Any such filter is responsible for calling
-   * the low watermark callbacks an equal number of times as the respective buffers are drained.
+   * connection etc.) this may be called multiple times. Any such filter is responsible for
+   * calling the low watermark callbacks an equal number of times as the respective buffers are
+   * drained.
    */
   virtual void onDecoderFilterAboveWriteBufferHighWatermark() PURE;
 
@@ -554,6 +567,21 @@ public:
    */
   virtual void
   requestRouteConfigUpdate(RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) PURE;
+
+  /**
+   * Adds a new stream filter immediately following the current filter. May not be called after
+   * headers have continued past the current filter.
+   *
+   * The filter will be added as a dual filter, e.g. it will serve as both a decoding and encoding
+   * filter.
+   */
+  virtual void addStreamFilter(StreamFilterSharedPtr filter) PURE;
+
+  /**
+   * Adds a new stream decoder filter immediately following the current filter. May not be called
+   * after headers have continued past the current filter.
+   */
+  virtual void addStreamDecoderFilter(StreamDecoderFilterSharedPtr filter) PURE;
 };
 
 /**
@@ -812,6 +840,12 @@ public:
    * absl::nullopt.
    */
   virtual Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() PURE;
+
+  /**
+   * Adds a new stream encoder filter immediately following the current filter. May not be called
+   * after headers have continued past the current filter.
+   */
+  virtual void addStreamEncoderFilter(StreamEncoderFilterSharedPtr filter) PURE;
 };
 
 /**

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -355,8 +355,8 @@ public:
    * When using this callback, filters should generally only return
    * FilterDataStatus::StopIterationNoBuffer from their decodeData() call, since use of this method
    * indicates that a filter does not wish to participate in standard HTTP connection manager
-   * buffering and continuation and will perform any necessary buffering and continuation on
-   * its own.
+   * buffering and continuation and will perform any necessary buffering and continuation on its
+   * own.
    *
    * This callback is different from addDecodedData() in that the specified data and end_stream
    * status will be propagated directly to further filters in the filter chain. This is different
@@ -369,8 +369,8 @@ public:
    * Adds decoded trailers. May only be called in decodeData when end_stream is set to true.
    * If called in any other context, an assertion will be triggered.
    *
-   * When called in decodeData, the trailers map will be initialized to an empty map and returned
-   * by reference. Calling this function more than once is invalid.
+   * When called in decodeData, the trailers map will be initialized to an empty map and returned by
+   * reference. Calling this function more than once is invalid.
    *
    * @return a reference to the newly created trailers map.
    */
@@ -410,9 +410,8 @@ public:
   /**
    * Called with 100-Continue headers to be encoded.
    *
-   * This is not folded into encodeHeaders because most Envoy users and filters will not be
-   * proxying 100-continue and with it split out, can ignore the complexity of multiple
-   * encodeHeaders calls.
+   * This is not folded into encodeHeaders because most Envoy users and filters will not be proxying
+   * 100-continue and with it split out, can ignore the complexity of multiple encodeHeaders calls.
    *
    * This must not be invoked more than once per request.
    *

--- a/include/envoy/http/filter.h
+++ b/include/envoy/http/filter.h
@@ -569,12 +569,22 @@ public:
    *
    * The filter will be added as a dual filter, e.g. it will serve as both a decoding and encoding
    * filter.
+   *
+   * Expected usage of this API is as follows: filters that might want to inject filters should create
+   * the filter factories that are used to provide the filters as part of its own filter factory creation
+   * (this ensures that filter factories consistently created on the main thread), and invoke the filter factories
+   * to create new filters per stream (this ensures that the lifetime of filters matches regular filters).
+   *
+   * The filter factories may also be created as part of other factory instantiations that occur during HTTP filter
+   * factory creation (e.g. match actions).
    */
   virtual void addStreamFilter(StreamFilterSharedPtr filter) PURE;
 
   /**
    * Adds a new stream decoder filter immediately following the current filter. May not be called
    * after headers have continued past the current filter.
+   *
+   * See addStreamFilter documentation for expected usage.
    */
   virtual void addStreamDecoderFilter(StreamDecoderFilterSharedPtr filter) PURE;
 };
@@ -839,6 +849,8 @@ public:
   /**
    * Adds a new stream encoder filter immediately following the current filter. May not be called
    * after headers have continued past the current filter.
+   *
+   * See StreamDecoderFilterCallbacks::addStreamFilter for expected usage.
    */
   virtual void addStreamEncoderFilter(StreamEncoderFilterSharedPtr filter) PURE;
 };

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -88,6 +88,8 @@ public:
   void requestRouteConfigUpdate(Http::RouteConfigUpdatedCallbackSharedPtr) override {
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
+  void addStreamFilter(StreamFilterSharedPtr) override {}
+  void addStreamDecoderFilter(StreamDecoderFilterSharedPtr) override {}
 
   // Http::AsyncClient::Stream
   void sendHeaders(RequestHeaderMap& headers, bool end_stream) override;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1,5 +1,6 @@
 #include "common/http/filter_manager.h"
 
+#include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/matcher/matcher.h"
 
@@ -9,6 +10,7 @@
 #include "common/http/header_map_impl.h"
 #include "common/http/header_utility.h"
 #include "common/http/utility.h"
+#include "common/matcher/matcher.h"
 #include "common/runtime/runtime_features.h"
 
 namespace Envoy {
@@ -303,6 +305,12 @@ void ActiveStreamDecoderFilter::doTrailers() {
 }
 bool ActiveStreamDecoderFilter::hasTrailers() {
   return parent_.filter_manager_callbacks_.requestTrailers().has_value();
+}
+void ActiveStreamDecoderFilter::addStreamFilter(StreamFilterSharedPtr filter) {
+  parent_.addStreamFilterAfter(filter, *this);
+}
+void ActiveStreamDecoderFilter::addStreamDecoderFilter(StreamDecoderFilterSharedPtr filter) {
+  parent_.addStreamDecoderFilterAfter(filter, *this);
 }
 
 void ActiveStreamDecoderFilter::drainSavedRequestMetadata() {
@@ -1441,6 +1449,9 @@ void ActiveStreamEncoderFilter::doTrailers() {
 }
 bool ActiveStreamEncoderFilter::hasTrailers() {
   return parent_.filter_manager_callbacks_.responseTrailers().has_value();
+}
+void ActiveStreamEncoderFilter::addStreamEncoderFilter(StreamEncoderFilterSharedPtr filter) {
+  parent_.addStreamEncoderFilterAfter(filter, *this);
 }
 void ActiveStreamEncoderFilter::addEncodedData(Buffer::Instance& data, bool streaming) {
   return parent_.addEncodedData(*this, data, streaming);

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -1003,7 +1003,7 @@ public:
     auto itr = encoder_filters_.insert(
         ++wrapper.entry(),
         std::make_unique<ActiveStreamEncoderFilter>(*this, filter, nullptr, false));
-    filter->setEncoderFilterCallbacks(*itr->get());
+    filter->setEncoderFilterCallbacks(**itr);
   }
   /**
    * Marks local processing as complete.

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -978,7 +978,7 @@ public:
         ++wrapper.entry(),
         std::make_unique<ActiveStreamDecoderFilter>(*this, filter, nullptr, true));
 
-    filter->setDecoderFilterCallbacks(*decoder_filter_itr->get());
+    filter->setDecoderFilterCallbacks(**decoder_filter_itr);
 
     ASSERT(wrapper.dual_filter_itr_ != encoder_filters_.end());
     auto encoder_filter_itr = encoder_filters_.insert(
@@ -987,7 +987,7 @@ public:
 
     decoder_filter_itr->get()->dual_filter_itr_ = encoder_filter_itr;
 
-    filter->setEncoderFilterCallbacks(*encoder_filter_itr->get());
+    filter->setEncoderFilterCallbacks(**encoder_filter_itr);
   }
 
   void addStreamDecoderFilterAfter(StreamDecoderFilterSharedPtr filter,
@@ -996,7 +996,7 @@ public:
         ++wrapper.entry(),
         std::make_unique<ActiveStreamDecoderFilter>(*this, filter, nullptr, false));
 
-    filter->setDecoderFilterCallbacks(*itr->get());
+    filter->setDecoderFilterCallbacks(**itr);
   }
   void addStreamEncoderFilterAfter(StreamEncoderFilterSharedPtr filter,
                                    ActiveStreamEncoderFilter& wrapper) {

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -344,6 +344,165 @@ TEST_F(FilterManagerTest, MatchTreeFilterActionDualFilter) {
   filter_manager_->decodeHeaders(*grpc_headers, true);
   filter_manager_->destroyFilters();
 }
+
+// Verifies that a filter can add a stream filter during decodeHeaders and
+// that the injected filter has decodeHeaders invoked.
+TEST_F(FilterManagerTest, InjectStreamFilter) {
+  initialize();
+
+  std::shared_ptr<MockStreamFilter> injected_filter(new MockStreamFilter());
+  std::shared_ptr<MockStreamFilter> filter(new MockStreamFilter());
+  EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, decodeHeaders(_, true))
+      .WillOnce(Invoke([&](auto&, bool) -> FilterHeadersStatus {
+        filter->decoder_callbacks_->addStreamFilter(injected_filter);
+
+        return FilterHeadersStatus::Continue;
+      }));
+  EXPECT_CALL(*injected_filter, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*injected_filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*injected_filter, decodeHeaders(_, true))
+      .WillOnce(Invoke([&](auto&, bool) -> FilterHeadersStatus {
+        ResponseHeaderMapPtr headers{new TestResponseHeaderMapImpl{
+            {":status", "200"}, {"match-header", "match"}, {"content-type", "application/grpc"}}};
+
+        filter->decoder_callbacks_->encodeHeaders(std::move(headers), true, "details");
+
+        return FilterHeadersStatus::StopIteration;
+      }));
+
+  // Note that the injected filter is also on the encoding path.
+  EXPECT_CALL(*injected_filter, encodeHeaders(_, true))
+      .WillOnce(Return(FilterHeadersStatus::Continue));
+  EXPECT_CALL(*filter, onDestroy());
+  EXPECT_CALL(*injected_filter, onDestroy());
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamFilter(filter, nullptr);
+      }));
+
+  RequestHeaderMapPtr grpc_headers{
+      new TestRequestHeaderMapImpl{{":authority", "host"},
+                                   {":path", "/"},
+                                   {":method", "GET"},
+                                   {"match-header", "match"},
+                                   {"content-type", "application/grpc"}}};
+
+  ON_CALL(filter_manager_callbacks_, requestHeaders())
+      .WillByDefault(Return(makeOptRef(*grpc_headers)));
+  filter_manager_->createFilterChain();
+
+  filter_manager_->requestHeadersInitialized();
+  EXPECT_CALL(*filter, encodeHeaders(_, true));
+  filter_manager_->decodeHeaders(*grpc_headers, true);
+  filter_manager_->destroyFilters();
+}
+
+TEST_F(FilterManagerTest, InjectStreamDecoderFilter) {
+  initialize();
+
+  std::shared_ptr<MockStreamDecoderFilter> injected_filter(new MockStreamDecoderFilter());
+  std::shared_ptr<MockStreamFilter> filter(new MockStreamFilter());
+  EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, decodeHeaders(_, true))
+      .WillOnce(Invoke([&](auto&, bool) -> FilterHeadersStatus {
+        filter->decoder_callbacks_->addStreamDecoderFilter(injected_filter);
+
+        return FilterHeadersStatus::Continue;
+      }));
+  EXPECT_CALL(*injected_filter, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*injected_filter, decodeHeaders(_, true))
+      .WillOnce(Invoke([&](auto&, bool) -> FilterHeadersStatus {
+        ResponseHeaderMapPtr headers{new TestResponseHeaderMapImpl{
+            {":status", "200"}, {"match-header", "match"}, {"content-type", "application/grpc"}}};
+
+        filter->decoder_callbacks_->encodeHeaders(std::move(headers), true, "details");
+
+        return FilterHeadersStatus::StopIteration;
+      }));
+
+  // Note that the injected filter is *not* on the encoding path.
+  EXPECT_CALL(*filter, onDestroy());
+  EXPECT_CALL(*injected_filter, onDestroy());
+  EXPECT_CALL(*injected_filter, decodeComplete());
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamFilter(filter, nullptr);
+      }));
+
+  RequestHeaderMapPtr grpc_headers{
+      new TestRequestHeaderMapImpl{{":authority", "host"},
+                                   {":path", "/"},
+                                   {":method", "GET"},
+                                   {"match-header", "match"},
+                                   {"content-type", "application/grpc"}}};
+
+  ON_CALL(filter_manager_callbacks_, requestHeaders())
+      .WillByDefault(Return(makeOptRef(*grpc_headers)));
+  filter_manager_->createFilterChain();
+
+  filter_manager_->requestHeadersInitialized();
+  EXPECT_CALL(*filter, encodeHeaders(_, true));
+  filter_manager_->decodeHeaders(*grpc_headers, true);
+  filter_manager_->destroyFilters();
+}
+
+// Verifies that we can inject a new encoding filter on the encoding path.
+TEST_F(FilterManagerTest, InjectStreamEncoderFilter) {
+  initialize();
+
+  std::shared_ptr<MockStreamEncoderFilter> injected_filter(new MockStreamEncoderFilter());
+  std::shared_ptr<MockStreamFilter> filter(new MockStreamFilter());
+  EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, decodeHeaders(_, true))
+      .WillOnce(Invoke([&](auto&, bool) -> FilterHeadersStatus {
+        ResponseHeaderMapPtr headers{new TestResponseHeaderMapImpl{
+            {":status", "200"}, {"match-header", "match"}, {"content-type", "application/grpc"}}};
+
+        filter->decoder_callbacks_->encodeHeaders(std::move(headers), true, "details");
+
+        return FilterHeadersStatus::StopIteration;
+      }));
+  EXPECT_CALL(*injected_filter, setEncoderFilterCallbacks(_));
+
+  EXPECT_CALL(*filter, onDestroy());
+  EXPECT_CALL(*injected_filter, onDestroy());
+  EXPECT_CALL(*injected_filter, encodeComplete());
+
+  // Note that we inject the filter on the encoding path, resulting in the injected filter seeing
+  // the headers after the original filter.
+  EXPECT_CALL(*filter, encodeHeaders(_, true))
+      .WillOnce(Invoke([&](auto&, bool) -> FilterHeadersStatus {
+        filter->encoder_callbacks_->addStreamEncoderFilter(injected_filter);
+        return FilterHeadersStatus::Continue;
+      }));
+  EXPECT_CALL(*injected_filter, encodeHeaders(_, true));
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillRepeatedly(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamFilter(filter, nullptr);
+      }));
+
+  RequestHeaderMapPtr grpc_headers{
+      new TestRequestHeaderMapImpl{{":authority", "host"},
+                                   {":path", "/"},
+                                   {":method", "GET"},
+                                   {"match-header", "match"},
+                                   {"content-type", "application/grpc"}}};
+
+  ON_CALL(filter_manager_callbacks_, requestHeaders())
+      .WillByDefault(Return(makeOptRef(*grpc_headers)));
+  filter_manager_->createFilterChain();
+
+  filter_manager_->requestHeadersInitialized();
+  filter_manager_->decodeHeaders(*grpc_headers, true);
+  filter_manager_->destroyFilters();
+}
 } // namespace
 } // namespace Http
 } // namespace Envoy

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -216,6 +216,8 @@ public:
                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                        absl::string_view details);
 
+  MOCK_METHOD(void, addStreamFilter, (StreamFilterSharedPtr filter));
+  MOCK_METHOD(void, addStreamDecoderFilter, (StreamDecoderFilterSharedPtr filter));
   void encode100ContinueHeaders(ResponseHeaderMapPtr&& headers) override {
     encode100ContinueHeaders_(*headers);
   }
@@ -293,6 +295,7 @@ public:
   MOCK_METHOD(uint32_t, encoderBufferLimit, ());
 
   // Http::StreamEncoderFilterCallbacks
+  MOCK_METHOD(void, addStreamEncoderFilter, (StreamEncoderFilterSharedPtr filter));
   MOCK_METHOD(void, addEncodedData, (Buffer::Instance & data, bool streaming));
   MOCK_METHOD(void, injectEncodedDataToFilterChain, (Buffer::Instance & data, bool end_stream));
   MOCK_METHOD(ResponseTrailerMap&, addEncodedTrailers, ());


### PR DESCRIPTION
Adds support for a set of new filter callbacks that allows a filter to
inject a filter into the filter chain immediately following itself. This
allows a filter to inspect the incoming headers and dynamically adjust
what filters are being executed.

Filters can only be injected before headers have made it to the next
filter; this ensures that the injected filters will be treated exactly
as any other filter.

See https://github.com/envoyproxy/envoy/compare/master...snowp:composite-filter?expand=1 for a working example of a filter making use of this API.

Part of #12968

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium, new unused feature but changes to FM
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
