### PR TITLE
docs: Clarify Consecutive Gateway Failure docs

### DIFF
--- a/docs/root/intro/arch_overview/upstream/outlier.rst
+++ b/docs/root/intro/arch_overview/upstream/outlier.rst
@@ -110,8 +110,9 @@ the :ref:`outlier_detection.consecutive_5xx<envoy_v3_api_field_config.cluster.v3
 Consecutive Gateway Failure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This detection type takes into account a subset of 5xx errors, called "gateway errors" (502, 503 or 504 status code)
-and is supported only by the :ref:`http router <config_http_filters_router>`.
+In the default mode (:ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>` is *false*) this detection type takes into account a subset of 5xx errors, called "gateway errors" (502, 503 or 504 status code) and local origin failures, such as timeout, TCP reset etc.
+
+In split mode (:ref:`outlier_detection.split_external_local_origin_errors<envoy_v3_api_field_config.cluster.v3.OutlierDetection.split_external_local_origin_errors>` is *true*) this detection type takes into account a subset of 5xx errors, called "gateway errors" (502, 503 or 504 status code) and is supported only by the :ref:`http router <config_http_filters_router>`.
 
 If an upstream host returns some number of consecutive "gateway errors" (502, 503 or 504 status
 code), it will be ejected.


### PR DESCRIPTION
Commit Message: It was initially unclear to me that when
split_external_local_origin_errors is in the default setting of false
that local origin failures will be counted as Consecutive Gateway
Failures. It is clear above that they are counted by the Consecutive 5xx
detection type but since I had that disabled I was surprised to find
them counted in Consecutive Gateway Failure. I think the logic makes
sense though so just attempting to clarify the docs here.
Risk Level: Low
Docs Changes: outlier detection clarification
