### PR TITLE
router: Increase the maximum direct response body size to 1MiB

### DIFF
--- a/docs/root/intro/arch_overview/http/http_routing.rst
+++ b/docs/root/intro/arch_overview/http/http_routing.rst
@@ -186,9 +186,9 @@ upon configuration load and cache the contents.
 
 .. attention::
 
-   If a response body is specified, it must be no more than 4KB in size, regardless of
+   If a response body is specified, it must be no more than 1MiB in size, regardless of
    whether it is provided inline or in a file. Envoy currently holds the entirety of the
-   body in memory, so the 4KB limit is intended to keep the proxy's memory footprint
+   body in memory, so the 1MiB limit is intended to keep the proxy's memory footprint
    from growing too large.
 
 If **response_headers_to_add** has been set for the Route or the enclosing Virtual Host,

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -16,6 +16,7 @@ Minor Behavior Changes
   are very frequent. This change can be disabled by setting the `envoy.reloadable_features.upstream_host_weight_change_causes_rebuild`
   feature flag to false. If setting this flag to false is required in a deployment please open an
   issue against the project.
+* router: Increase the maximum size of a direct response body from 4KiB to 1MiB.
 
 Bug Fixes
 ---------

--- a/source/common/router/config_utility.cc
+++ b/source/common/router/config_utility.cc
@@ -119,7 +119,7 @@ ConfigUtility::parseDirectResponseCode(const envoy::config::route::v3::Route& ro
 
 std::string ConfigUtility::parseDirectResponseBody(const envoy::config::route::v3::Route& route,
                                                    Api::Api& api) {
-  static const ssize_t MaxBodySize = 4096;
+  static const ssize_t MaxBodySize = 1024 * 1024;
   if (!route.has_direct_response() || !route.direct_response().has_body()) {
     return EMPTY_STRING;
   }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6170,11 +6170,11 @@ TEST_F(ConfigUtilityTest, ParseDirectResponseBody) {
   EXPECT_THROW_WITH_MESSAGE(ConfigUtility::parseDirectResponseBody(route, *api_), EnvoyException,
                             "response body file missing_file does not exist");
 
-  std::string body(4097, '*');
+  std::string body(1024 * 1024 + 1, '*');
   auto filename = TestEnvironment::writeStringToFileForTest("body", body);
   route.mutable_direct_response()->mutable_body()->set_filename(filename);
   std::string expected_message("response body file " + filename +
-                               " size is 4097 bytes; maximum is 4096");
+                               " size is 1048577 bytes; maximum is 1048576");
   EXPECT_THROW_WITH_MESSAGE(ConfigUtility::parseDirectResponseBody(route, *api_), EnvoyException,
                             expected_message);
 }


### PR DESCRIPTION
Commit Message: Increase the maximum direct response body size to 1MiB
Risk Level: Low
Testing: Unit test
Docs Changes: Update maximum body size in bytes
Release Notes: docs/root/version_history/current.rst
