### PR TITLE
Request headers to add

### DIFF
--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -479,7 +479,7 @@ Custom request/response headers can be added to a request/response at the weight
 route, virtual host, and/or global route configuration level. See the
 :ref:`v3 <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` API documentation.
 
-No *:-prefixed* pseudo-header may be modified via this mechanism. The *:path*
+Neither *:-prefixed* pseudo-headers nor the Host: header may be modified via this mechanism. The *:path*
 and *:authority* headers may instead be modified via mechanisms such as
 :ref:`prefix_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.prefix_rewrite>`,
 :ref:`regex_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.regex_rewrite>`, and

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -23,6 +23,7 @@ Bug Fixes
 
 * active http health checks: properly handles HTTP/2 GOAWAY frames from the upstream. Previously a GOAWAY frame due to a graceful listener drain could cause improper failed health checks due to streams being refused by the upstream on a connection that is going away. To revert to old GOAWAY handling behavior, set the runtime feature `envoy.reloadable_features.health_check.graceful_goaway_handling` to false.
 * buffer: tighten network connection read and write buffer high watermarks in preparation to more careful enforcement of read limits. Buffer high-watermark is now set to the exact configured value; previously it was set to value + 1.
+* http: disallowing "host:" in request_headers_to_add for behavioral consistency with rejecting :authority header. This behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_host_like_authority` to false.
 * http: reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure` to false.
 * upstream: fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
 

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -314,5 +314,11 @@ bool HeaderUtility::isRemovableHeader(absl::string_view header) {
          !absl::EqualsIgnoreCase(header, Headers::get().HostLegacy.get());
 }
 
+bool HeaderUtility::isModifiableHeader(absl::string_view header) {
+  return (header.empty() || header[0] != ':') &&
+         (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.treat_host_like_authority") ||
+          !absl::EqualsIgnoreCase(header, Headers::get().HostLegacy.get()));
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -193,6 +193,13 @@ public:
    * may not be removed.
    */
   static bool isRemovableHeader(absl::string_view header);
+
+  /**
+   * Returns true if a header may be safely modified without causing additional
+   * problems. Currently header names beginning with ":" and the "host" header
+   * may not be modified.
+   */
+  static bool isModifiableHeader(absl::string_view header);
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -47,8 +47,10 @@ HeaderFormatterPtr parseInternal(const envoy::config::core::v3::HeaderValue& hea
   // will cause us to have to worry about interaction with other aspects of the
   // RouteAction, e.g. prefix rewriting. We also reject other :-prefixed
   // headers, since it seems dangerous and there doesn't appear a use case.
-  if (key[0] == ':') {
-    throw EnvoyException(":-prefixed headers may not be modified");
+  // Host is disallowed as it created confusing and inconsistent behaviors for
+  // HTTP/1 and HTTP/1. It could arugably be allowed on the response path.
+  if (!Http::HeaderUtility::isModifiableHeader(key)) {
+    throw EnvoyException(":-prefixed or host headers may not be modified");
   }
 
   absl::string_view format(header_value.value());

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -48,7 +48,7 @@ HeaderFormatterPtr parseInternal(const envoy::config::core::v3::HeaderValue& hea
   // RouteAction, e.g. prefix rewriting. We also reject other :-prefixed
   // headers, since it seems dangerous and there doesn't appear a use case.
   // Host is disallowed as it created confusing and inconsistent behaviors for
-  // HTTP/1 and HTTP/1. It could arugably be allowed on the response path.
+  // HTTP/1 and HTTP/2. It could arguably be allowed on the response path.
   if (!Http::HeaderUtility::isModifiableHeader(key)) {
     throw EnvoyException(":-prefixed or host headers may not be modified");
   }

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -86,6 +86,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.stop_faking_paths",
     "envoy.reloadable_features.strict_1xx_and_204_response_headers",
     "envoy.reloadable_features.tls_use_io_handle_bio",
+    "envoy.reloadable_features.treat_host_like_authority",
     "envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure",
     "envoy.reloadable_features.upstream_host_weight_change_causes_rebuild",
     "envoy.reloadable_features.vhds_heartbeats",

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -701,5 +701,14 @@ TEST(RequiredHeaders, IsRemovableHeader) {
   EXPECT_TRUE(HeaderUtility::isRemovableHeader("Content-Type"));
 }
 
+TEST(RequiredHeaders, IsModifiableHeader) {
+  EXPECT_FALSE(HeaderUtility::isRemovableHeader(":path"));
+  EXPECT_FALSE(HeaderUtility::isRemovableHeader("host"));
+  EXPECT_FALSE(HeaderUtility::isRemovableHeader("Host"));
+  EXPECT_TRUE(HeaderUtility::isRemovableHeader(""));
+  EXPECT_TRUE(HeaderUtility::isRemovableHeader("hostname"));
+  EXPECT_TRUE(HeaderUtility::isRemovableHeader("Content-Type"));
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -57,6 +57,11 @@ route_config:
         - header:
             key: "x-vhost-request"
             value: "vhost"
+      request_headers_to_add:
+        - header:
+            key: "host"
+            value: "FOO"
+          append: false
       request_headers_to_remove: ["x-vhost-request-remove"]
       response_headers_to_add:
         - header:
@@ -444,6 +449,8 @@ protected:
     headers.remove(Envoy::Http::LowerCaseString{"x-request-id"});
     headers.remove(Envoy::Http::LowerCaseString{"x-envoy-internal"});
 
+    std::cerr << expected_headers;
+    std::cerr << headers;
     EXPECT_EQ(expected_headers, headers);
   }
 

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -57,11 +57,6 @@ route_config:
         - header:
             key: "x-vhost-request"
             value: "vhost"
-      request_headers_to_add:
-        - header:
-            key: "host"
-            value: "FOO"
-          append: false
       request_headers_to_remove: ["x-vhost-request-remove"]
       response_headers_to_add:
         - header:
@@ -449,8 +444,6 @@ protected:
     headers.remove(Envoy::Http::LowerCaseString{"x-request-id"});
     headers.remove(Envoy::Http::LowerCaseString{"x-envoy-internal"});
 
-    std::cerr << expected_headers;
-    std::cerr << headers;
     EXPECT_EQ(expected_headers, headers);
   }
 


### PR DESCRIPTION
Being consistent about treating Host: and :authority the same way in Envoy header modification.

Risk Level: Medium (changes allowed modifiable headers)
Testing: new unit tests
Docs Changes: yes
Release Notes: inline
Platform Specific Features:

@markdroth interestingly the :-prefixed headers weren't mentioned in the API protos, so I don't think this will trigger API shepherds checks. Tagging you as a reviewer as I think it merits an API shepherd pass, and I don't know if we want  enforcement inline for API consistency (it'd need to be copy pasted a bunch of places) or if this is fine by you.

cc @wlhee as I think I'd like this not-yet-landed utility in your PR.
