### PR TITLE
Introduce runtime guard to preserve the x-request-id header

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -24,6 +24,7 @@ Bug Fixes
 * active http health checks: properly handles HTTP/2 GOAWAY frames from the upstream. Previously a GOAWAY frame due to a graceful listener drain could cause improper failed health checks due to streams being refused by the upstream on a connection that is going away. To revert to old GOAWAY handling behavior, set the runtime feature `envoy.reloadable_features.health_check.graceful_goaway_handling` to false.
 * buffer: tighten network connection read and write buffer high watermarks in preparation to more careful enforcement of read limits. Buffer high-watermark is now set to the exact configured value; previously it was set to value + 1.
 * http: reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure` to false.
+* tracing: envoy will modify the `x-request-id` header to indicate the tracing decision made on a given request. To prevent this behavior, set the new runtime feature `envoy.reloadable_features.http_omit_tracing_decsion_from_request_id` to true, so that the Request ID header remains unmodified.
 * upstream: fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
 
 Removed Config or Runtime

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -264,6 +264,11 @@ void ConnectionManagerUtility::mutateTracingRequestHeader(RequestHeaderMap& requ
     overall_sampling = &route->tracingConfig()->getOverallSampling();
   }
 
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.http_omit_tracing_decsion_from_request_id")) {
+    return;
+  }
+
   // Do not apply tracing transformations if we are currently tracing.
   if (TraceStatus::NoTrace == rid_extension->getTraceStatus(request_headers)) {
     if (request_headers.ClientTraceId() &&

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -107,6 +107,8 @@ constexpr const char* disabled_runtime_features[] = {
     // Allow Envoy to upgrade or downgrade version of type url, should be removed when support for
     // v2 url is removed from codebase.
     "envoy.reloadable_features.enable_type_url_downgrade_and_upgrade",
+    // Do not modify the externally set x-request-id header to include the tracing decision
+    "envoy.reloadable_features.http_omit_tracing_decsion_from_request_id",
     // TODO(alyssawilk) flip true after the release.
     "envoy.reloadable_features.new_tcp_connection_pool",
     // Sentinel and test flag.


### PR DESCRIPTION
This change adds a new runtime guard to prevent envoy from modifying the `x-request-id` header.  We chose to add a runtime guard so that we do not overload the HTTP Connection Manager's `preserve_external_request_id` directive to achieve the desired behavior.


Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>


Commit Message: Introduce a runtime guard to prevent any modification to x-request-id header
Additional Description: Envoy uses the 14th byte of a UUID in the x-request-id header to indicate a tracing decision.   For cases where the `x-request-id` header is externally injected, this modification can create issues for customers due to the altered header.  With this runtime guard, the behavior can be disabled to ensure that the injected header remains consistent in its path through Envoy.
Risk Level:  Low
Testing: 2 new unit tests, manual header verification, full unit test suite
Docs Changes: N/A
Release Notes: 
Platform Specific Features:
[Optional Runtime guard:]  `envoy.reloadable_features.http_omit_tracing_decsion_from_request_id`
[Optional #Issue] https://github.com/envoyproxy/envoy/issues/11532
