### PR TITLE
Revert "network filters: avoid unnecessary std::shared_ptrs (#14711)"

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -245,7 +245,7 @@ class Filter : public Network::ReadFilter,
                protected Logger::Loggable<Logger::Id::filter>,
                public GenericConnectionPoolCallbacks {
 public:
-  Filter(Config& config, Upstream::ClusterManager& cluster_manager);
+  Filter(ConfigSharedPtr config, Upstream::ClusterManager& cluster_manager);
   ~Filter() override;
 
   // Network::ReadFilter
@@ -264,7 +264,7 @@ public:
   // Upstream::LoadBalancerContext
   const Router::MetadataMatchCriteria* metadataMatchCriteria() override;
   absl::optional<uint64_t> computeHashKey() override {
-    auto hash_policy = config_.hashPolicy();
+    auto hash_policy = config_->hashPolicy();
     if (hash_policy) {
       return hash_policy->generateHash(
           downstreamConnection()->addressProvider().remoteAddress().get(),
@@ -337,7 +337,7 @@ protected:
 
   // Callbacks for different error and success states during connection establishment
   virtual RouteConstSharedPtr pickRoute() {
-    return config_.getRouteFromEntries(read_callbacks_->connection());
+    return config_->getRouteFromEntries(read_callbacks_->connection());
   }
 
   virtual void onInitFailure(UpstreamFailureReason) {
@@ -357,7 +357,7 @@ protected:
   void disableIdleTimer();
   void onMaxDownstreamConnectionDuration();
 
-  Config& config_;
+  const ConfigSharedPtr config_;
   Upstream::ClusterManager& cluster_manager_;
   Network::ReadFilterCallbacks* read_callbacks_{};
 

--- a/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
+++ b/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.cc
@@ -53,7 +53,7 @@ ClientSslAuthConfigSharedPtr ClientSslAuthConfig::create(
   return new_config;
 }
 
-const AllowedPrincipals& ClientSslAuthConfig::allowedPrincipals() const {
+const AllowedPrincipals& ClientSslAuthConfig::allowedPrincipals() {
   return tls_->getTyped<AllowedPrincipals>();
 }
 
@@ -98,7 +98,7 @@ Network::FilterStatus ClientSslAuthFilter::onNewConnection() {
   // If this is not an SSL connection, do no further checking. High layers should redirect, etc.
   // if SSL is required.
   if (!read_callbacks_->connection().ssl()) {
-    config_.stats().auth_no_ssl_.inc();
+    config_->stats().auth_no_ssl_.inc();
     return Network::FilterStatus::Continue;
   } else {
     // Otherwise we need to wait for handshake to be complete before proceeding.
@@ -112,21 +112,21 @@ void ClientSslAuthFilter::onEvent(Network::ConnectionEvent event) {
   }
 
   ASSERT(read_callbacks_->connection().ssl());
-  if (config_.ipAllowlist().contains(
+  if (config_->ipAllowlist().contains(
           *read_callbacks_->connection().addressProvider().remoteAddress())) {
-    config_.stats().auth_ip_allowlist_.inc();
+    config_->stats().auth_ip_allowlist_.inc();
     read_callbacks_->continueReading();
     return;
   }
 
-  if (!config_.allowedPrincipals().allowed(
+  if (!config_->allowedPrincipals().allowed(
           read_callbacks_->connection().ssl()->sha256PeerCertificateDigest())) {
-    config_.stats().auth_digest_no_match_.inc();
+    config_->stats().auth_digest_no_match_.inc();
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     return;
   }
 
-  config_.stats().auth_digest_match_.inc();
+  config_->stats().auth_digest_match_.inc();
   read_callbacks_->continueReading();
 }
 

--- a/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.h
+++ b/source/extensions/filters/network/client_ssl_auth/client_ssl_auth.h
@@ -80,8 +80,8 @@ public:
          ThreadLocal::SlotAllocator& tls, Upstream::ClusterManager& cm,
          Event::Dispatcher& dispatcher, Stats::Scope& scope, Random::RandomGenerator& random);
 
-  const AllowedPrincipals& allowedPrincipals() const;
-  const Network::Address::IpList& ipAllowlist() const { return ip_allowlist_; }
+  const AllowedPrincipals& allowedPrincipals();
+  const Network::Address::IpList& ipAllowlist() { return ip_allowlist_; }
   GlobalStats& stats() { return stats_; }
 
 private:
@@ -108,7 +108,7 @@ private:
  */
 class ClientSslAuthFilter : public Network::ReadFilter, public Network::ConnectionCallbacks {
 public:
-  ClientSslAuthFilter(ClientSslAuthConfig& config) : config_(config) {}
+  ClientSslAuthFilter(ClientSslAuthConfigSharedPtr config) : config_(config) {}
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
@@ -124,7 +124,7 @@ public:
   void onBelowWriteBufferLowWatermark() override {}
 
 private:
-  ClientSslAuthConfig& config_;
+  ClientSslAuthConfigSharedPtr config_;
   Network::ReadFilterCallbacks* read_callbacks_{};
 };
 

--- a/source/extensions/filters/network/client_ssl_auth/config.cc
+++ b/source/extensions/filters/network/client_ssl_auth/config.cc
@@ -22,7 +22,7 @@ Network::FilterFactoryCb ClientSslAuthConfigFactory::createFilterFactoryFromProt
       proto_config, context.threadLocal(), context.clusterManager(), context.dispatcher(),
       context.scope(), context.api().randomGenerator()));
   return [filter_config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(std::make_shared<ClientSslAuthFilter>(*filter_config));
+    filter_manager.addReadFilter(std::make_shared<ClientSslAuthFilter>(filter_config));
   };
 }
 

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -38,7 +38,7 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
         async_client_factory->create(), std::chrono::milliseconds(timeout_ms),
         transport_api_version);
     filter_manager.addReadFilter(Network::ReadFilterSharedPtr{
-        std::make_shared<Filter>(*ext_authz_config, std::move(client))});
+        std::make_shared<Filter>(ext_authz_config, std::move(client))});
   };
 }
 

--- a/source/extensions/filters/network/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/network/ext_authz/ext_authz.cc
@@ -23,11 +23,11 @@ InstanceStats Config::generateStats(const std::string& name, Stats::Scope& scope
 
 void Filter::callCheck() {
   Filters::Common::ExtAuthz::CheckRequestUtils::createTcpCheck(filter_callbacks_, check_request_,
-                                                               config_.includePeerCertificate());
+                                                               config_->includePeerCertificate());
 
   status_ = Status::Calling;
-  config_.stats().active_.inc();
-  config_.stats().total_.inc();
+  config_->stats().active_.inc();
+  config_->stats().total_.inc();
 
   calling_check_ = true;
   client_->check(*this, check_request_, Tracing::NullSpan::instance(),
@@ -37,7 +37,7 @@ void Filter::callCheck() {
 
 Network::FilterStatus Filter::onData(Buffer::Instance&, bool /* end_stream */) {
   if (!filterEnabled(filter_callbacks_->connection().streamInfo().dynamicMetadata())) {
-    config_.stats().disabled_.inc();
+    config_->stats().disabled_.inc();
     return Network::FilterStatus::Continue;
   }
 
@@ -62,40 +62,40 @@ void Filter::onEvent(Network::ConnectionEvent event) {
       // Make sure that any pending request in the client is cancelled. This will be NOP if the
       // request already completed.
       client_->cancel();
-      config_.stats().active_.dec();
+      config_->stats().active_.dec();
     }
   }
 }
 
 void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
   status_ = Status::Complete;
-  config_.stats().active_.dec();
+  config_->stats().active_.dec();
 
   switch (response->status) {
   case Filters::Common::ExtAuthz::CheckStatus::OK:
-    config_.stats().ok_.inc();
+    config_->stats().ok_.inc();
     break;
   case Filters::Common::ExtAuthz::CheckStatus::Error:
-    config_.stats().error_.inc();
+    config_->stats().error_.inc();
     break;
   case Filters::Common::ExtAuthz::CheckStatus::Denied:
-    config_.stats().denied_.inc();
+    config_->stats().denied_.inc();
     break;
   }
 
   // Fail open only if configured to do so and if the check status was a error.
   if (response->status == Filters::Common::ExtAuthz::CheckStatus::Denied ||
       (response->status == Filters::Common::ExtAuthz::CheckStatus::Error &&
-       !config_.failureModeAllow())) {
-    config_.stats().cx_closed_.inc();
+       !config_->failureModeAllow())) {
+    config_->stats().cx_closed_.inc();
     filter_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
   } else {
     // Let the filter chain continue.
     filter_return_ = FilterReturn::Continue;
-    if (config_.failureModeAllow() &&
+    if (config_->failureModeAllow() &&
         response->status == Filters::Common::ExtAuthz::CheckStatus::Error) {
       // Status is Error and yet we are configured to allow traffic. Click a counter.
-      config_.stats().failure_mode_allowed_.inc();
+      config_->stats().failure_mode_allowed_.inc();
     }
 
     if (!response->dynamic_metadata.fields().empty()) {

--- a/source/extensions/filters/network/ext_authz/ext_authz.h
+++ b/source/extensions/filters/network/ext_authz/ext_authz.h
@@ -87,7 +87,7 @@ class Filter : public Network::ReadFilter,
                public Network::ConnectionCallbacks,
                public Filters::Common::ExtAuthz::RequestCallbacks {
 public:
-  Filter(Config& config, Filters::Common::ExtAuthz::ClientPtr&& client)
+  Filter(ConfigSharedPtr config, Filters::Common::ExtAuthz::ClientPtr&& client)
       : config_(config), client_(std::move(client)) {}
   ~Filter() override = default;
 
@@ -119,10 +119,10 @@ private:
   void callCheck();
 
   bool filterEnabled(const envoy::config::core::v3::Metadata& metadata) {
-    return config_.filterEnabledMetadata(metadata);
+    return config_->filterEnabledMetadata(metadata);
   }
 
-  Config& config_;
+  ConfigSharedPtr config_;
   Filters::Common::ExtAuthz::ClientPtr client_;
   Network::ReadFilterCallbacks* filter_callbacks_{};
   Status status_{Status::NotStarted};

--- a/source/extensions/filters/network/local_ratelimit/config.cc
+++ b/source/extensions/filters/network/local_ratelimit/config.cc
@@ -16,7 +16,7 @@ Network::FilterFactoryCb LocalRateLimitConfigFactory::createFilterFactoryFromPro
   ConfigSharedPtr filter_config(
       new Config(proto_config, context.dispatcher(), context.scope(), context.runtime()));
   return [filter_config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(std::make_shared<Filter>(*filter_config));
+    filter_manager.addReadFilter(std::make_shared<Filter>(filter_config));
   };
 }
 

--- a/source/extensions/filters/network/local_ratelimit/local_ratelimit.cc
+++ b/source/extensions/filters/network/local_ratelimit/local_ratelimit.cc
@@ -32,13 +32,13 @@ LocalRateLimitStats Config::generateStats(const std::string& prefix, Stats::Scop
 bool Config::canCreateConnection() { return rate_limiter_.requestAllowed(descriptors_); }
 
 Network::FilterStatus Filter::onNewConnection() {
-  if (!config_.enabled()) {
+  if (!config_->enabled()) {
     ENVOY_CONN_LOG(trace, "local_rate_limit: runtime disabled", read_callbacks_->connection());
     return Network::FilterStatus::Continue;
   }
 
-  if (!config_.canCreateConnection()) {
-    config_.stats().rate_limited_.inc();
+  if (!config_->canCreateConnection()) {
+    config_->stats().rate_limited_.inc();
     ENVOY_CONN_LOG(trace, "local_rate_limit: rate limiting connection",
                    read_callbacks_->connection());
     read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);

--- a/source/extensions/filters/network/local_ratelimit/local_ratelimit.h
+++ b/source/extensions/filters/network/local_ratelimit/local_ratelimit.h
@@ -60,7 +60,7 @@ using ConfigSharedPtr = std::shared_ptr<Config>;
  */
 class Filter : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  Filter(Config& config) : config_(config) {}
+  Filter(const ConfigSharedPtr& config) : config_(config) {}
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance&, bool) override {
@@ -72,7 +72,7 @@ public:
   }
 
 private:
-  Config& config_;
+  const ConfigSharedPtr config_;
   Network::ReadFilterCallbacks* read_callbacks_{};
 };
 

--- a/source/extensions/filters/network/mongo_proxy/config.cc
+++ b/source/extensions/filters/network/mongo_proxy/config.cc
@@ -46,7 +46,7 @@ Network::FilterFactoryCb MongoProxyFilterConfigFactory::createFilterFactoryFromP
           stats](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<ProdProxyFilter>(
         stat_prefix, context.scope(), context.runtime(), access_log, fault_config,
-        context.drainDecision(), context.dispatcher().timeSource(), emit_dynamic_metadata, *stats));
+        context.drainDecision(), context.dispatcher().timeSource(), emit_dynamic_metadata, stats));
   };
 }
 

--- a/source/extensions/filters/network/mongo_proxy/proxy.h
+++ b/source/extensions/filters/network/mongo_proxy/proxy.h
@@ -110,7 +110,7 @@ public:
               AccessLogSharedPtr access_log,
               const Filters::Common::Fault::FaultDelayConfigSharedPtr& fault_config,
               const Network::DrainDecision& drain_decision, TimeSource& time_system,
-              bool emit_dynamic_metadata, MongoStats& stats);
+              bool emit_dynamic_metadata, const MongoStatsSharedPtr& stats);
   ~ProxyFilter() override;
 
   virtual DecoderPtr createDecoder(DecoderCallbacks& callbacks) PURE;
@@ -197,7 +197,7 @@ private:
   Event::TimerPtr drain_close_timer_;
   TimeSource& time_source_;
   const bool emit_dynamic_metadata_;
-  MongoStats& mongo_stats_;
+  MongoStatsSharedPtr mongo_stats_;
 };
 
 class ProdProxyFilter : public ProxyFilter {

--- a/source/extensions/filters/network/mysql_proxy/mysql_config.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_config.cc
@@ -31,7 +31,7 @@ NetworkFilters::MySQLProxy::MySQLConfigFactory::createFilterFactoryFromProtoType
   MySQLFilterConfigSharedPtr filter_config(
       std::make_shared<MySQLFilterConfig>(stat_prefix, context.scope()));
   return [filter_config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addFilter(std::make_shared<MySQLFilter>(*filter_config));
+    filter_manager.addFilter(std::make_shared<MySQLFilter>(filter_config));
   };
 }
 

--- a/source/extensions/filters/network/mysql_proxy/mysql_filter.h
+++ b/source/extensions/filters/network/mysql_proxy/mysql_filter.h
@@ -69,7 +69,7 @@ using MySQLFilterConfigSharedPtr = std::shared_ptr<MySQLFilterConfig>;
  */
 class MySQLFilter : public Network::Filter, DecoderCallbacks, Logger::Loggable<Logger::Id::filter> {
 public:
-  MySQLFilter(MySQLFilterConfig& config);
+  MySQLFilter(MySQLFilterConfigSharedPtr config);
   ~MySQLFilter() override = default;
 
   // Network::ReadFilter
@@ -97,7 +97,7 @@ public:
 
 private:
   Network::ReadFilterCallbacks* read_callbacks_{};
-  MySQLFilterConfig& config_;
+  MySQLFilterConfigSharedPtr config_;
   Buffer::OwnedImpl read_buffer_;
   Buffer::OwnedImpl write_buffer_;
   std::unique_ptr<Decoder> decoder_;

--- a/source/extensions/filters/network/postgres_proxy/config.cc
+++ b/source/extensions/filters/network/postgres_proxy/config.cc
@@ -20,7 +20,7 @@ NetworkFilters::PostgresProxy::PostgresConfigFactory::createFilterFactoryFromPro
   PostgresFilterConfigSharedPtr filter_config(
       std::make_shared<PostgresFilterConfig>(stat_prefix, enable_sql, context.scope()));
   return [filter_config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addFilter(std::make_shared<PostgresFilter>(*filter_config));
+    filter_manager.addFilter(std::make_shared<PostgresFilter>(filter_config));
   };
 }
 

--- a/source/extensions/filters/network/postgres_proxy/postgres_filter.h
+++ b/source/extensions/filters/network/postgres_proxy/postgres_filter.h
@@ -81,7 +81,7 @@ class PostgresFilter : public Network::Filter,
                        DecoderCallbacks,
                        Logger::Loggable<Logger::Id::filter> {
 public:
-  PostgresFilter(PostgresFilterConfig& config);
+  PostgresFilter(PostgresFilterConfigSharedPtr config);
   ~PostgresFilter() override = default;
 
   // Network::ReadFilter
@@ -114,13 +114,13 @@ public:
   // Routines used during integration and unit tests
   uint32_t getFrontendBufLength() const { return frontend_buffer_.length(); }
   uint32_t getBackendBufLength() const { return backend_buffer_.length(); }
-  const PostgresProxyStats& getStats() const { return config_.stats_; }
+  const PostgresProxyStats& getStats() const { return config_->stats_; }
   Network::Connection& connection() const { return read_callbacks_->connection(); }
-  PostgresFilterConfig& getConfig() const { return config_; }
+  const PostgresFilterConfigSharedPtr& getConfig() const { return config_; }
 
 private:
   Network::ReadFilterCallbacks* read_callbacks_{};
-  PostgresFilterConfig& config_;
+  PostgresFilterConfigSharedPtr config_;
   Buffer::OwnedImpl frontend_buffer_;
   Buffer::OwnedImpl backend_buffer_;
   std::unique_ptr<Decoder> decoder_;

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -33,10 +33,10 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
   return [proto_config, &context, timeout,
           filter_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(std::make_shared<Filter>(
-        *filter_config, Filters::Common::RateLimit::rateLimitClient(
-                            context, proto_config.rate_limit_service().grpc_service(), timeout,
-                            Envoy::Config::Utility::getAndCheckTransportVersion(
-                                proto_config.rate_limit_service()))));
+        filter_config, Filters::Common::RateLimit::rateLimitClient(
+                           context, proto_config.rate_limit_service().grpc_service(), timeout,
+                           Envoy::Config::Utility::getAndCheckTransportVersion(
+                               proto_config.rate_limit_service()))));
   };
 }
 

--- a/source/extensions/filters/network/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/ratelimit/ratelimit.cc
@@ -42,16 +42,16 @@ Network::FilterStatus Filter::onData(Buffer::Instance&, bool) {
 
 Network::FilterStatus Filter::onNewConnection() {
   if (status_ == Status::NotStarted &&
-      !config_.runtime().snapshot().featureEnabled("ratelimit.tcp_filter_enabled", 100)) {
+      !config_->runtime().snapshot().featureEnabled("ratelimit.tcp_filter_enabled", 100)) {
     status_ = Status::Complete;
   }
 
   if (status_ == Status::NotStarted) {
     status_ = Status::Calling;
-    config_.stats().active_.inc();
-    config_.stats().total_.inc();
+    config_->stats().active_.inc();
+    config_->stats().total_.inc();
     calling_limit_ = true;
-    client_->limit(*this, config_.domain(), config_.descriptors(), Tracing::NullSpan::instance(),
+    client_->limit(*this, config_->domain(), config_->descriptors(), Tracing::NullSpan::instance(),
                    filter_callbacks_->connection().streamInfo());
     calling_limit_ = false;
   }
@@ -67,7 +67,7 @@ void Filter::onEvent(Network::ConnectionEvent event) {
       event == Network::ConnectionEvent::LocalClose) {
     if (status_ == Status::Calling) {
       client_->cancel();
-      config_.stats().active_.dec();
+      config_->stats().active_.dec();
     }
   }
 }
@@ -82,32 +82,32 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
   }
 
   status_ = Status::Complete;
-  config_.stats().active_.dec();
+  config_->stats().active_.dec();
 
   switch (status) {
   case Filters::Common::RateLimit::LimitStatus::OK:
-    config_.stats().ok_.inc();
+    config_->stats().ok_.inc();
     break;
   case Filters::Common::RateLimit::LimitStatus::Error:
-    config_.stats().error_.inc();
+    config_->stats().error_.inc();
     break;
   case Filters::Common::RateLimit::LimitStatus::OverLimit:
-    config_.stats().over_limit_.inc();
+    config_->stats().over_limit_.inc();
     break;
   }
 
   if (status == Filters::Common::RateLimit::LimitStatus::OverLimit &&
-      config_.runtime().snapshot().featureEnabled("ratelimit.tcp_filter_enforcing", 100)) {
-    config_.stats().cx_closed_.inc();
+      config_->runtime().snapshot().featureEnabled("ratelimit.tcp_filter_enforcing", 100)) {
+    config_->stats().cx_closed_.inc();
     filter_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
   } else if (status == Filters::Common::RateLimit::LimitStatus::Error) {
-    if (config_.failureModeAllow()) {
-      config_.stats().failure_mode_allowed_.inc();
+    if (config_->failureModeAllow()) {
+      config_->stats().failure_mode_allowed_.inc();
       if (!calling_limit_) {
         filter_callbacks_->continueReading();
       }
     } else {
-      config_.stats().cx_closed_.inc();
+      config_->stats().cx_closed_.inc();
       filter_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
     }
   } else {

--- a/source/extensions/filters/network/ratelimit/ratelimit.h
+++ b/source/extensions/filters/network/ratelimit/ratelimit.h
@@ -74,7 +74,7 @@ class Filter : public Network::ReadFilter,
                public Network::ConnectionCallbacks,
                public Filters::Common::RateLimit::RequestCallbacks {
 public:
-  Filter(Config& config, Filters::Common::RateLimit::ClientPtr&& client)
+  Filter(ConfigSharedPtr config, Filters::Common::RateLimit::ClientPtr&& client)
       : config_(config), client_(std::move(client)) {}
 
   // Network::ReadFilter
@@ -101,7 +101,7 @@ public:
 private:
   enum class Status { NotStarted, Calling, Complete };
 
-  Config& config_;
+  ConfigSharedPtr config_;
   Filters::Common::RateLimit::ClientPtr client_;
   Network::ReadFilterCallbacks* filter_callbacks_{};
   Status status_{Status::NotStarted};

--- a/source/extensions/filters/network/rbac/config.cc
+++ b/source/extensions/filters/network/rbac/config.cc
@@ -81,7 +81,7 @@ RoleBasedAccessControlNetworkFilterConfigFactory::createFilterFactoryFromProtoTy
   RoleBasedAccessControlFilterConfigSharedPtr config(
       std::make_shared<RoleBasedAccessControlFilterConfig>(proto_config, context.scope()));
   return [config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(std::make_shared<RoleBasedAccessControlFilter>(*config));
+    filter_manager.addReadFilter(std::make_shared<RoleBasedAccessControlFilter>(config));
   };
 }
 

--- a/source/extensions/filters/network/rbac/rbac_filter.cc
+++ b/source/extensions/filters/network/rbac/rbac_filter.cc
@@ -47,7 +47,7 @@ Network::FilterStatus RoleBasedAccessControlFilter::onData(Buffer::Instance&, bo
   std::string log_policy_id = "none";
   // When the enforcement type is continuous always do the RBAC checks. If it is a one time check,
   // run the check once and skip it for subsequent onData calls.
-  if (config_.enforcementType() ==
+  if (config_->enforcementType() ==
       envoy::extensions::filters::network::rbac::v3::RBAC::CONTINUOUS) {
     shadow_engine_result_ =
         checkEngine(Filters::Common::RBAC::EnforcementMode::Shadow).engine_result_;
@@ -95,7 +95,7 @@ void RoleBasedAccessControlFilter::setDynamicMetadata(std::string shadow_engine_
 }
 
 Result RoleBasedAccessControlFilter::checkEngine(Filters::Common::RBAC::EnforcementMode mode) {
-  const auto engine = config_.engine(mode);
+  const auto engine = config_->engine(mode);
   std::string effective_policy_id;
   if (engine != nullptr) {
     // Check authorization decision and do Action operations
@@ -105,25 +105,25 @@ Result RoleBasedAccessControlFilter::checkEngine(Filters::Common::RBAC::Enforcem
     if (allowed) {
       if (mode == Filters::Common::RBAC::EnforcementMode::Shadow) {
         ENVOY_LOG(debug, "shadow allowed, matched policy {}", log_policy_id);
-        config_.stats().shadow_allowed_.inc();
+        config_->stats().shadow_allowed_.inc();
         setDynamicMetadata(
             Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().EngineResultAllowed,
             effective_policy_id);
       } else if (mode == Filters::Common::RBAC::EnforcementMode::Enforced) {
         ENVOY_LOG(debug, "enforced allowed, matched policy {}", log_policy_id);
-        config_.stats().allowed_.inc();
+        config_->stats().allowed_.inc();
       }
       return Result{Allow, effective_policy_id};
     } else {
       if (mode == Filters::Common::RBAC::EnforcementMode::Shadow) {
         ENVOY_LOG(debug, "shadow denied, matched policy {}", log_policy_id);
-        config_.stats().shadow_denied_.inc();
+        config_->stats().shadow_denied_.inc();
         setDynamicMetadata(
             Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().EngineResultDenied,
             effective_policy_id);
       } else if (mode == Filters::Common::RBAC::EnforcementMode::Enforced) {
         ENVOY_LOG(debug, "enforced denied, matched policy {}", log_policy_id);
-        config_.stats().denied_.inc();
+        config_->stats().denied_.inc();
       }
       return Result{Deny, log_policy_id};
     }

--- a/source/extensions/filters/network/rbac/rbac_filter.h
+++ b/source/extensions/filters/network/rbac/rbac_filter.h
@@ -60,7 +60,8 @@ class RoleBasedAccessControlFilter : public Network::ReadFilter,
                                      public Logger::Loggable<Logger::Id::rbac> {
 
 public:
-  RoleBasedAccessControlFilter(RoleBasedAccessControlFilterConfig& config) : config_(config) {}
+  RoleBasedAccessControlFilter(RoleBasedAccessControlFilterConfigSharedPtr config)
+      : config_(config) {}
   ~RoleBasedAccessControlFilter() override = default;
 
   // Network::ReadFilter
@@ -73,7 +74,7 @@ public:
   void setDynamicMetadata(std::string shadow_engine_result, std::string shadow_policy_id);
 
 private:
-  RoleBasedAccessControlFilterConfig& config_;
+  RoleBasedAccessControlFilterConfigSharedPtr config_;
   Network::ReadFilterCallbacks* callbacks_{};
   EngineResult engine_result_{Unknown};
   EngineResult shadow_engine_result_{Unknown};

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -98,7 +98,7 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
     Common::Redis::DecoderFactoryImpl factory;
     filter_manager.addReadFilter(std::make_shared<ProxyFilter>(
         factory, Common::Redis::EncoderPtr{new Common::Redis::EncoderImpl()}, *splitter,
-        *filter_config));
+        filter_config));
   };
 }
 

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -75,7 +75,7 @@ class ProxyFilter : public Network::ReadFilter,
                     public Network::ConnectionCallbacks {
 public:
   ProxyFilter(Common::Redis::DecoderFactory& factory, Common::Redis::EncoderPtr&& encoder,
-              CommandSplitter::Instance& splitter, ProxyFilterConfig& config);
+              CommandSplitter::Instance& splitter, ProxyFilterConfigSharedPtr config);
   ~ProxyFilter() override;
 
   // Network::ReadFilter
@@ -122,7 +122,7 @@ private:
   Common::Redis::DecoderPtr decoder_;
   Common::Redis::EncoderPtr encoder_;
   CommandSplitter::Instance& splitter_;
-  ProxyFilterConfig& config_;
+  ProxyFilterConfigSharedPtr config_;
   Buffer::OwnedImpl encoder_buffer_;
   Network::ReadFilterCallbacks* callbacks_{};
   std::list<PendingRequest> pending_requests_;

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/config.cc
@@ -25,7 +25,7 @@ SniDynamicForwardProxyNetworkFilterConfigFactory::createFilterFactoryFromProtoTy
       proto_config, cache_manager_factory, context.clusterManager()));
 
   return [filter_config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(std::make_shared<ProxyFilter>(*filter_config));
+    filter_manager.addReadFilter(std::make_shared<ProxyFilter>(filter_config));
   };
 }
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -20,7 +20,7 @@ ProxyFilterConfig::ProxyFilterConfig(
       dns_cache_manager_(cache_manager_factory.get()),
       dns_cache_(dns_cache_manager_->getCache(proto_config.dns_cache_config())) {}
 
-ProxyFilter::ProxyFilter(ProxyFilterConfig& config) : config_(config) {}
+ProxyFilter::ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)) {}
 
 using LoadDnsCacheEntryStatus = Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus;
 
@@ -33,7 +33,7 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
     return Network::FilterStatus::Continue;
   }
 
-  circuit_breaker_ = config_.cache().canCreateDnsRequest();
+  circuit_breaker_ = config_->cache().canCreateDnsRequest();
 
   if (circuit_breaker_ == nullptr) {
     ENVOY_CONN_LOG(debug, "pending request overflow", read_callbacks_->connection());
@@ -41,9 +41,9 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
     return Network::FilterStatus::StopIteration;
   }
 
-  uint32_t default_port = config_.port();
+  uint32_t default_port = config_->port();
 
-  auto result = config_.cache().loadDnsCacheEntry(sni, default_port, *this);
+  auto result = config_->cache().loadDnsCacheEntry(sni, default_port, *this);
 
   cache_load_handle_ = std::move(result.handle_);
   if (cache_load_handle_ == nullptr) {

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
@@ -39,7 +39,7 @@ class ProxyFilter
       public Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks,
       Logger::Loggable<Logger::Id::forward_proxy> {
 public:
-  ProxyFilter(ProxyFilterConfig& config);
+  ProxyFilter(ProxyFilterConfigSharedPtr config);
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance&, bool) override {
@@ -54,7 +54,7 @@ public:
   void onLoadDnsCacheComplete() override;
 
 private:
-  ProxyFilterConfig& config_;
+  const ProxyFilterConfigSharedPtr config_;
   Upstream::ResourceAutoIncDecPtr circuit_breaker_;
   Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryHandlePtr cache_load_handle_;
   Network::ReadFilterCallbacks* read_callbacks_{};

--- a/source/extensions/filters/network/tcp_proxy/config.cc
+++ b/source/extensions/filters/network/tcp_proxy/config.cc
@@ -23,7 +23,7 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
       std::make_shared<Envoy::TcpProxy::Config>(proto_config, context));
   return [filter_config, &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(
-        std::make_shared<Envoy::TcpProxy::Filter>(*filter_config, context.clusterManager()));
+        std::make_shared<Envoy::TcpProxy::Filter>(filter_config, context.clusterManager()));
   };
 }
 

--- a/source/extensions/filters/network/zookeeper_proxy/config.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/config.cc
@@ -34,7 +34,7 @@ Network::FilterFactoryCb ZooKeeperConfigFactory::createFilterFactoryFromProtoTyp
   auto& time_source = context.dispatcher().timeSource();
 
   return [filter_config, &time_source](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addFilter(std::make_shared<ZooKeeperFilter>(*filter_config, time_source));
+    filter_manager.addFilter(std::make_shared<ZooKeeperFilter>(filter_config, time_source));
   };
 }
 

--- a/source/extensions/filters/network/zookeeper_proxy/filter.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.cc
@@ -68,8 +68,8 @@ void ZooKeeperFilterConfig::initOpCode(OpCodes opcode, Stats::Counter& counter,
   opcode_info.latency_name_ = stat_name_set_->add(absl::StrCat(name, "_latency"));
 }
 
-ZooKeeperFilter::ZooKeeperFilter(ZooKeeperFilterConfig& config, TimeSource& time_source)
-    : config_(config), decoder_(createDecoder(*this, time_source)) {}
+ZooKeeperFilter::ZooKeeperFilter(ZooKeeperFilterConfigSharedPtr config, TimeSource& time_source)
+    : config_(std::move(config)), decoder_(createDecoder(*this, time_source)) {}
 
 void ZooKeeperFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
@@ -90,7 +90,7 @@ Network::FilterStatus ZooKeeperFilter::onWrite(Buffer::Instance& data, bool) {
 Network::FilterStatus ZooKeeperFilter::onNewConnection() { return Network::FilterStatus::Continue; }
 
 DecoderPtr ZooKeeperFilter::createDecoder(DecoderCallbacks& callbacks, TimeSource& time_source) {
-  return std::make_unique<DecoderImpl>(callbacks, config_.maxPacketBytes(), time_source);
+  return std::make_unique<DecoderImpl>(callbacks, config_->maxPacketBytes(), time_source);
 }
 
 void ZooKeeperFilter::setDynamicMetadata(const std::string& key, const std::string& value) {
@@ -125,45 +125,45 @@ void ZooKeeperFilter::setDynamicMetadata(
 
 void ZooKeeperFilter::onConnect(const bool readonly) {
   if (readonly) {
-    config_.stats_.connect_readonly_rq_.inc();
+    config_->stats_.connect_readonly_rq_.inc();
     setDynamicMetadata("opname", "connect_readonly");
   } else {
-    config_.stats_.connect_rq_.inc();
+    config_->stats_.connect_rq_.inc();
     setDynamicMetadata("opname", "connect");
   }
 }
 
 void ZooKeeperFilter::onDecodeError() {
-  config_.stats_.decoder_error_.inc();
+  config_->stats_.decoder_error_.inc();
   setDynamicMetadata("opname", "error");
 }
 
 void ZooKeeperFilter::onRequestBytes(const uint64_t bytes) {
-  config_.stats_.request_bytes_.add(bytes);
+  config_->stats_.request_bytes_.add(bytes);
   setDynamicMetadata("bytes", std::to_string(bytes));
 }
 
 void ZooKeeperFilter::onResponseBytes(const uint64_t bytes) {
-  config_.stats_.response_bytes_.add(bytes);
+  config_->stats_.response_bytes_.add(bytes);
   setDynamicMetadata("bytes", std::to_string(bytes));
 }
 
 void ZooKeeperFilter::onPing() {
-  config_.stats_.ping_rq_.inc();
+  config_->stats_.ping_rq_.inc();
   setDynamicMetadata("opname", "ping");
 }
 
 void ZooKeeperFilter::onAuthRequest(const std::string& scheme) {
   Stats::Counter& counter = Stats::Utility::counterFromStatNames(
-      config_.scope_, {config_.stat_prefix_, config_.auth_,
-                       config_.stat_name_set_->getBuiltin(absl::StrCat(scheme, "_rq"),
-                                                          config_.unknown_scheme_rq_)});
+      config_->scope_, {config_->stat_prefix_, config_->auth_,
+                        config_->stat_name_set_->getBuiltin(absl::StrCat(scheme, "_rq"),
+                                                            config_->unknown_scheme_rq_)});
   counter.inc();
   setDynamicMetadata("opname", "auth");
 }
 
 void ZooKeeperFilter::onGetDataRequest(const std::string& path, const bool watch) {
-  config_.stats_.getdata_rq_.inc();
+  config_->stats_.getdata_rq_.inc();
   setDynamicMetadata({{"opname", "getdata"}, {"path", path}, {"watch", watch ? "true" : "false"}});
 }
 
@@ -174,19 +174,19 @@ void ZooKeeperFilter::onCreateRequest(const std::string& path, const CreateFlags
   switch (opcode) {
   case OpCodes::Create:
     opname = "create";
-    config_.stats_.create_rq_.inc();
+    config_->stats_.create_rq_.inc();
     break;
   case OpCodes::Create2:
     opname = "create2";
-    config_.stats_.create2_rq_.inc();
+    config_->stats_.create2_rq_.inc();
     break;
   case OpCodes::CreateContainer:
     opname = "createcontainer";
-    config_.stats_.createcontainer_rq_.inc();
+    config_->stats_.createcontainer_rq_.inc();
     break;
   case OpCodes::CreateTtl:
     opname = "createttl";
-    config_.stats_.createttl_rq_.inc();
+    config_->stats_.createttl_rq_.inc();
     break;
   default:
     throw EnvoyException(fmt::format("Unknown opcode: {}", enumToSignedInt(opcode)));
@@ -198,7 +198,7 @@ void ZooKeeperFilter::onCreateRequest(const std::string& path, const CreateFlags
 }
 
 void ZooKeeperFilter::onSetRequest(const std::string& path) {
-  config_.stats_.setdata_rq_.inc();
+  config_->stats_.setdata_rq_.inc();
   setDynamicMetadata({{"opname", "setdata"}, {"path", path}});
 }
 
@@ -207,91 +207,91 @@ void ZooKeeperFilter::onGetChildrenRequest(const std::string& path, const bool w
   std::string opname = "getchildren";
 
   if (v2) {
-    config_.stats_.getchildren2_rq_.inc();
+    config_->stats_.getchildren2_rq_.inc();
     opname = "getchildren2";
   } else {
-    config_.stats_.getchildren_rq_.inc();
+    config_->stats_.getchildren_rq_.inc();
   }
 
   setDynamicMetadata({{"opname", opname}, {"path", path}, {"watch", watch ? "true" : "false"}});
 }
 
 void ZooKeeperFilter::onDeleteRequest(const std::string& path, const int32_t version) {
-  config_.stats_.delete_rq_.inc();
+  config_->stats_.delete_rq_.inc();
   setDynamicMetadata({{"opname", "delete"}, {"path", path}, {"version", std::to_string(version)}});
 }
 
 void ZooKeeperFilter::onExistsRequest(const std::string& path, const bool watch) {
-  config_.stats_.exists_rq_.inc();
+  config_->stats_.exists_rq_.inc();
   setDynamicMetadata({{"opname", "exists"}, {"path", path}, {"watch", watch ? "true" : "false"}});
 }
 
 void ZooKeeperFilter::onGetAclRequest(const std::string& path) {
-  config_.stats_.getacl_rq_.inc();
+  config_->stats_.getacl_rq_.inc();
   setDynamicMetadata({{"opname", "getacl"}, {"path", path}});
 }
 
 void ZooKeeperFilter::onSetAclRequest(const std::string& path, const int32_t version) {
-  config_.stats_.setacl_rq_.inc();
+  config_->stats_.setacl_rq_.inc();
   setDynamicMetadata({{"opname", "setacl"}, {"path", path}, {"version", std::to_string(version)}});
 }
 
 void ZooKeeperFilter::onSyncRequest(const std::string& path) {
-  config_.stats_.sync_rq_.inc();
+  config_->stats_.sync_rq_.inc();
   setDynamicMetadata({{"opname", "sync"}, {"path", path}});
 }
 
 void ZooKeeperFilter::onCheckRequest(const std::string&, const int32_t) {
-  config_.stats_.check_rq_.inc();
+  config_->stats_.check_rq_.inc();
 }
 
 void ZooKeeperFilter::onCheckWatchesRequest(const std::string& path, const int32_t) {
-  config_.stats_.checkwatches_rq_.inc();
+  config_->stats_.checkwatches_rq_.inc();
   setDynamicMetadata({{"opname", "checkwatches"}, {"path", path}});
 }
 
 void ZooKeeperFilter::onRemoveWatchesRequest(const std::string& path, const int32_t) {
-  config_.stats_.removewatches_rq_.inc();
+  config_->stats_.removewatches_rq_.inc();
   setDynamicMetadata({{"opname", "removewatches"}, {"path", path}});
 }
 
 void ZooKeeperFilter::onMultiRequest() {
-  config_.stats_.multi_rq_.inc();
+  config_->stats_.multi_rq_.inc();
   setDynamicMetadata("opname", "multi");
 }
 
 void ZooKeeperFilter::onReconfigRequest() {
-  config_.stats_.reconfig_rq_.inc();
+  config_->stats_.reconfig_rq_.inc();
   setDynamicMetadata("opname", "reconfig");
 }
 
 void ZooKeeperFilter::onSetWatchesRequest() {
-  config_.stats_.setwatches_rq_.inc();
+  config_->stats_.setwatches_rq_.inc();
   setDynamicMetadata("opname", "setwatches");
 }
 
 void ZooKeeperFilter::onGetEphemeralsRequest(const std::string& path) {
-  config_.stats_.getephemerals_rq_.inc();
+  config_->stats_.getephemerals_rq_.inc();
   setDynamicMetadata({{"opname", "getephemerals"}, {"path", path}});
 }
 
 void ZooKeeperFilter::onGetAllChildrenNumberRequest(const std::string& path) {
-  config_.stats_.getallchildrennumber_rq_.inc();
+  config_->stats_.getallchildrennumber_rq_.inc();
   setDynamicMetadata({{"opname", "getallchildrennumber"}, {"path", path}});
 }
 
 void ZooKeeperFilter::onCloseRequest() {
-  config_.stats_.close_rq_.inc();
+  config_->stats_.close_rq_.inc();
   setDynamicMetadata("opname", "close");
 }
 
 void ZooKeeperFilter::onConnectResponse(const int32_t proto_version, const int32_t timeout,
                                         const bool readonly,
                                         const std::chrono::milliseconds& latency) {
-  config_.stats_.connect_resp_.inc();
+  config_->stats_.connect_resp_.inc();
 
   Stats::Histogram& histogram = Stats::Utility::histogramFromElements(
-      config_.scope_, {config_.stat_prefix_, config_.connect_latency_},
+      config_->scope_, {config_->stat_prefix_, config_->connect_latency_},
       Stats::Histogram::Unit::Milliseconds);
   histogram.recordValue(latency.count());
 
@@ -303,10 +303,10 @@ void ZooKeeperFilter::onConnectResponse(const int32_t proto_version, const int32
 
 void ZooKeeperFilter::onResponse(const OpCodes opcode, const int32_t xid, const int64_t zxid,
                                  const int32_t error, const std::chrono::milliseconds& latency) {
-  Stats::StatName opcode_latency = config_.unknown_opcode_latency_;
-  auto iter = config_.op_code_map_.find(opcode);
+  Stats::StatName opcode_latency = config_->unknown_opcode_latency_;
+  auto iter = config_->op_code_map_.find(opcode);
   std::string opname = "";
-  if (iter != config_.op_code_map_.end()) {
+  if (iter != config_->op_code_map_.end()) {
     const ZooKeeperFilterConfig::OpCodeInfo& opcode_info = iter->second;
     opcode_info.counter_->inc();
     opname = opcode_info.opname_;
@@ -314,7 +314,8 @@ void ZooKeeperFilter::onResponse(const OpCodes opcode, const int32_t xid, const 
   }
 
   Stats::Histogram& histogram = Stats::Utility::histogramFromStatNames(
-      config_.scope_, {config_.stat_prefix_, opcode_latency}, Stats::Histogram::Unit::Milliseconds);
+      config_->scope_, {config_->stat_prefix_, opcode_latency},
+      Stats::Histogram::Unit::Milliseconds);
   histogram.recordValue(latency.count());
 
   setDynamicMetadata({{"opname", opname},
@@ -326,7 +327,7 @@ void ZooKeeperFilter::onResponse(const OpCodes opcode, const int32_t xid, const 
 void ZooKeeperFilter::onWatchEvent(const int32_t event_type, const int32_t client_state,
                                    const std::string& path, const int64_t zxid,
                                    const int32_t error) {
-  config_.stats_.watch_event_.inc();
+  config_->stats_.watch_event_.inc();
   setDynamicMetadata({{"opname", "watch_event"},
                       {"event_type", std::to_string(event_type)},
                       {"client_state", std::to_string(client_state)},

--- a/source/extensions/filters/network/zookeeper_proxy/filter.h
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.h
@@ -138,7 +138,7 @@ class ZooKeeperFilter : public Network::Filter,
                         DecoderCallbacks,
                         Logger::Loggable<Logger::Id::filter> {
 public:
-  ZooKeeperFilter(ZooKeeperFilterConfig& config, TimeSource& time_source);
+  ZooKeeperFilter(ZooKeeperFilterConfigSharedPtr config, TimeSource& time_source);
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
@@ -187,7 +187,7 @@ public:
 
 private:
   Network::ReadFilterCallbacks* read_callbacks_{};
-  ZooKeeperFilterConfig& config_;
+  ZooKeeperFilterConfigSharedPtr config_;
   std::unique_ptr<Decoder> decoder_;
 };
 

--- a/test/common/network/filter_manager_impl_test.cc
+++ b/test/common/network/filter_manager_impl_test.cc
@@ -363,6 +363,7 @@ TEST_F(NetworkFilterManagerTest, RateLimitAndTcpProxy) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   NiceMock<MockClientConnection> upstream_connection;
   NiceMock<Tcp::ConnectionPool::MockInstance> conn_pool;
+  FilterManagerImpl manager(connection_);
 
   std::string rl_yaml = R"EOF(
 domain: foo
@@ -388,18 +389,16 @@ stat_prefix: name
                                                               factory_context.runtime_loader_));
   Extensions::Filters::Common::RateLimit::MockClient* rl_client =
       new Extensions::Filters::Common::RateLimit::MockClient();
+  manager.addReadFilter(std::make_shared<Extensions::NetworkFilters::RateLimitFilter::Filter>(
+      rl_config, Extensions::Filters::Common::RateLimit::ClientPtr{rl_client}));
+
+  factory_context.cluster_manager_.initializeThreadLocalClusters({"fake_cluster"});
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy tcp_proxy;
   tcp_proxy.set_stat_prefix("name");
   tcp_proxy.set_cluster("fake_cluster");
-  factory_context.cluster_manager_.initializeThreadLocalClusters({"fake_cluster"});
   TcpProxy::ConfigSharedPtr tcp_proxy_config(new TcpProxy::Config(tcp_proxy, factory_context));
-
-  FilterManagerImpl manager(connection_);
-
-  manager.addReadFilter(std::make_shared<Extensions::NetworkFilters::RateLimitFilter::Filter>(
-      *rl_config, Extensions::Filters::Common::RateLimit::ClientPtr{rl_client}));
   manager.addReadFilter(
-      std::make_shared<TcpProxy::Filter>(*tcp_proxy_config, factory_context.cluster_manager_));
+      std::make_shared<TcpProxy::Filter>(tcp_proxy_config, factory_context.cluster_manager_));
 
   Extensions::Filters::Common::RateLimit::RequestCallbacks* request_callbacks{};
   EXPECT_CALL(*rl_client, limit(_, "foo",

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -955,7 +955,7 @@ public:
     }
 
     {
-      filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+      filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
       EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
       EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
       filter_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -1108,7 +1108,7 @@ TEST_F(TcpProxyTest, BadFactory) {
   EXPECT_CALL(*upstream_connections_.at(0), dispatcher())
       .WillRepeatedly(ReturnRef(filter_callbacks_.connection_.dispatcher_));
 
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
   EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -1368,7 +1368,7 @@ TEST_F(TcpProxyTest, RouteWithMetadataMatch) {
       {Envoy::Config::MetadataFilters::get().ENVOY_LB, metadata_struct});
 
   configure(config);
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
@@ -1417,7 +1417,7 @@ TEST_F(TcpProxyTest, WeightedClusterWithMetadataMatch) {
   v2.set_string_value("v2");
   HashedValue hv0(v0), hv1(v1), hv2(v2);
 
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
   // Expect filter to try to open a connection to cluster1.
@@ -1483,7 +1483,7 @@ TEST_F(TcpProxyTest, StreamInfoDynamicMetadata) {
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_, dynamicMetadata())
       .WillOnce(ReturnRef(metadata));
 
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
   Upstream::LoadBalancerContext* context;
@@ -1537,7 +1537,7 @@ TEST_F(TcpProxyTest, StreamInfoDynamicMetadataAndConfigMerged) {
   EXPECT_CALL(filter_callbacks_.connection_.stream_info_, dynamicMetadata())
       .WillOnce(ReturnRef(metadata));
 
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
   Upstream::LoadBalancerContext* context;
@@ -1566,7 +1566,7 @@ TEST_F(TcpProxyTest, StreamInfoDynamicMetadataAndConfigMerged) {
 
 TEST_F(TcpProxyTest, DisconnectBeforeData) {
   configure(defaultConfig());
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
@@ -1604,7 +1604,7 @@ TEST_F(TcpProxyTest, UpstreamConnectionLimit) {
       0, 0, 0, 0, 0);
 
   // setup sets up expectation for tcpConnForCluster but this test is expected to NOT call that
-  filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+  filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
   // The downstream connection closes if the proxy can't make an upstream connection.
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::NoFlush));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
@@ -1963,7 +1963,7 @@ public:
   void initializeFilter() {
     EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
 
-    filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+    filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
 
@@ -2165,7 +2165,7 @@ public:
   void initializeFilter() {
     EXPECT_CALL(filter_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
 
-    filter_ = std::make_unique<Filter>(*config_, factory_context_.cluster_manager_);
+    filter_ = std::make_unique<Filter>(config_, factory_context_.cluster_manager_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
 

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -87,7 +87,7 @@ ip_white_list:
 
   void createAuthFilter() {
     filter_callbacks_.connection_.callbacks_.clear();
-    instance_ = std::make_unique<ClientSslAuthFilter>(*config_);
+    instance_ = std::make_unique<ClientSslAuthFilter>(config_);
     instance_->initializeReadFilterCallbacks(filter_callbacks_);
 
     // NOP currently.

--- a/test/extensions/filters/network/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_fuzz_test.cc
@@ -68,7 +68,7 @@ DEFINE_PROTO_FUZZER(const envoy::extensions::filters::network::ext_authz::ExtAut
 
   ConfigSharedPtr config = std::make_shared<Config>(proto_config, stats_store);
   std::unique_ptr<Filter> filter =
-      std::make_unique<Filter>(*config, Filters::Common::ExtAuthz::ClientPtr{client});
+      std::make_unique<Filter>(config, Filters::Common::ExtAuthz::ClientPtr{client});
 
   NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
   filter->initializeReadFilterCallbacks(filter_callbacks);

--- a/test/extensions/filters/network/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_test.cc
@@ -42,7 +42,7 @@ public:
     TestUtility::loadFromYaml(yaml, proto_config);
     config_ = std::make_shared<Config>(proto_config, stats_store_);
     client_ = new Filters::Common::ExtAuthz::MockClient();
-    filter_ = std::make_unique<Filter>(*config_, Filters::Common::ExtAuthz::ClientPtr{client_});
+    filter_ = std::make_unique<Filter>(config_, Filters::Common::ExtAuthz::ClientPtr{client_});
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     addr_ = std::make_shared<Network::Address::PipeInstance>("/test/test.sock");
 

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_fuzz_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_fuzz_test.cc
@@ -22,7 +22,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace LocalRateLimitFilter {
 struct ActiveFilter {
-  ActiveFilter(const ConfigSharedPtr& config) : filter_(*config) {
+  ActiveFilter(const ConfigSharedPtr& config) : filter_(config) {
     filter_.initializeReadFilterCallbacks(read_filter_callbacks_);
   }
 

--- a/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
+++ b/test/extensions/filters/network/local_ratelimit/local_ratelimit_test.cc
@@ -45,7 +45,7 @@ public:
 class LocalRateLimitFilterTest : public LocalRateLimitTestBase {
 public:
   struct ActiveFilter {
-    ActiveFilter(const ConfigSharedPtr& config) : filter_(*config) {
+    ActiveFilter(const ConfigSharedPtr& config) : filter_(config) {
       filter_.initializeReadFilterCallbacks(read_filter_callbacks_);
     }
 

--- a/test/extensions/filters/network/mongo_proxy/proxy_test.cc
+++ b/test/extensions/filters/network/mongo_proxy/proxy_test.cc
@@ -85,7 +85,7 @@ public:
   void initializeFilter(bool emit_dynamic_metadata = false) {
     filter_ = std::make_unique<TestProxyFilter>(
         "test.", store_, runtime_, access_log_, fault_config_, drain_decision_,
-        dispatcher_.timeSource(), emit_dynamic_metadata, *mongo_stats_);
+        dispatcher_.timeSource(), emit_dynamic_metadata, mongo_stats_);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->onNewConnection();
 

--- a/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
@@ -23,7 +23,7 @@ public:
 
   void initialize() {
     config_ = std::make_shared<MySQLFilterConfig>(stat_prefix_, scope_);
-    filter_ = std::make_unique<MySQLFilter>(*config_);
+    filter_ = std::make_unique<MySQLFilter>(config_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
 

--- a/test/extensions/filters/network/postgres_proxy/postgres_filter_test.cc
+++ b/test/extensions/filters/network/postgres_proxy/postgres_filter_test.cc
@@ -32,7 +32,7 @@ class PostgresFilterTest
 public:
   PostgresFilterTest() {
     config_ = std::make_shared<PostgresFilterConfig>(stat_prefix_, true, scope_);
-    filter_ = std::make_unique<PostgresFilter>(*config_);
+    filter_ = std::make_unique<PostgresFilter>(config_);
 
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
@@ -323,7 +323,7 @@ TEST_F(PostgresFilterTest, QueryMessageMetadata) {
   setMetadata();
 
   // Disable creating parsing SQL and creating metadata.
-  filter_->getConfig().enable_sql_parsing_ = false;
+  filter_->getConfig()->enable_sql_parsing_ = false;
   createPostgresMsg(data_, "Q", "SELECT * FROM whatever");
   filter_->onData(data_, false);
 
@@ -334,7 +334,7 @@ TEST_F(PostgresFilterTest, QueryMessageMetadata) {
   ASSERT_THAT(filter_->getStats().statements_parsed_.value(), 0);
 
   // Now enable SQL parsing and creating metadata.
-  filter_->getConfig().enable_sql_parsing_ = true;
+  filter_->getConfig()->enable_sql_parsing_ = true;
   filter_->onData(data_, false);
 
   auto& filter_meta = filter_->connection().streamInfo().dynamicMetadata().filter_metadata().at(

--- a/test/extensions/filters/network/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/ratelimit/ratelimit_test.cc
@@ -45,7 +45,7 @@ public:
     TestUtility::loadFromYaml(yaml, proto_config, false, true);
     config_ = std::make_shared<Config>(proto_config, stats_store_, runtime_);
     client_ = new Filters::Common::RateLimit::MockClient();
-    filter_ = std::make_unique<Filter>(*config_, Filters::Common::RateLimit::ClientPtr{client_});
+    filter_ = std::make_unique<Filter>(config_, Filters::Common::RateLimit::ClientPtr{client_});
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
 
     // NOP currently.

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -59,7 +59,7 @@ public:
     EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
     EXPECT_CALL(callbacks_.connection_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
 
-    filter_ = std::make_unique<RoleBasedAccessControlFilter>(*config_);
+    filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
     filter_->initializeReadFilterCallbacks(callbacks_);
   }
 
@@ -128,7 +128,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithOneTimeEnforcement) {
 
 TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithContinuousEnforcement) {
   config_ = setupConfig(true, true /* continuous enforcement */);
-  filter_ = std::make_unique<RoleBasedAccessControlFilter>(*config_);
+  filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
   filter_->initializeReadFilterCallbacks(callbacks_);
   setDestinationPort(123);
 
@@ -160,7 +160,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, RequestedServerName) {
 
 TEST_F(RoleBasedAccessControlNetworkFilterTest, AllowedWithNoPolicy) {
   config_ = setupConfig(false /* with_policy */);
-  filter_ = std::make_unique<RoleBasedAccessControlFilter>(*config_);
+  filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
   filter_->initializeReadFilterCallbacks(callbacks_);
   setDestinationPort(0);
 
@@ -196,7 +196,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, Denied) {
 // Log Tests
 TEST_F(RoleBasedAccessControlNetworkFilterTest, ShouldLog) {
   config_ = setupConfig(true, false, envoy::config::rbac::v3::RBAC::LOG);
-  filter_ = std::make_unique<RoleBasedAccessControlFilter>(*config_);
+  filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
   filter_->initializeReadFilterCallbacks(callbacks_);
 
   setDestinationPort(123);
@@ -211,7 +211,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, ShouldLog) {
 
 TEST_F(RoleBasedAccessControlNetworkFilterTest, ShouldNotLog) {
   config_ = setupConfig(true, false, envoy::config::rbac::v3::RBAC::LOG);
-  filter_ = std::make_unique<RoleBasedAccessControlFilter>(*config_);
+  filter_ = std::make_unique<RoleBasedAccessControlFilter>(config_);
   filter_->initializeReadFilterCallbacks(callbacks_);
 
   setDestinationPort(456);

--- a/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/redis_proxy/proxy_filter_test.cc
@@ -131,7 +131,7 @@ public:
     config_ =
         std::make_shared<ProxyFilterConfig>(proto_config, store_, drain_decision_, runtime_, api_);
     filter_ = std::make_unique<ProxyFilter>(*this, Common::Redis::EncoderPtr{encoder_}, splitter_,
-                                            *config_);
+                                            config_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
     EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
     EXPECT_EQ(1UL, config_->stats_.downstream_cx_total_.value());

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -36,7 +36,7 @@ public:
     proto_config.set_port_value(443);
     EXPECT_CALL(*dns_cache_manager_, getCache(_));
     filter_config_ = std::make_shared<ProxyFilterConfig>(proto_config, *this, cm_);
-    filter_ = std::make_unique<ProxyFilter>(*filter_config_);
+    filter_ = std::make_unique<ProxyFilter>(filter_config_);
     filter_->initializeReadFilterCallbacks(callbacks_);
 
     // Allow for an otherwise strict mock.

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -32,7 +32,7 @@ public:
 
   void initialize() {
     config_ = std::make_shared<ZooKeeperFilterConfig>(stat_prefix_, 1048576, scope_);
-    filter_ = std::make_unique<ZooKeeperFilter>(*config_, time_system_);
+    filter_ = std::make_unique<ZooKeeperFilter>(config_, time_system_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);
   }
 


### PR DESCRIPTION
This reverts commit 72db81d3e61818012b92fa43d7cdd9ca31c2277e.

Per discussion in #14717 and via Slack, we'll come up with a different
approach since using a std::function to keep state presents a few
challenges.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
