### PR TITLE
http: error handling for bad factory type

### DIFF
--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -599,9 +599,13 @@ std::unique_ptr<GenericConnPool>
 Filter::createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster) {
   GenericConnPoolFactory* factory = nullptr;
   if (cluster_->upstreamConfig().has_value()) {
-    factory = &Envoy::Config::Utility::getAndCheckFactory<GenericConnPoolFactory>(
+    factory = Envoy::Config::Utility::getFactory<GenericConnPoolFactory>(
         cluster_->upstreamConfig().value());
-  } else {
+    ENVOY_BUG(factory != nullptr,
+              fmt::format("invalid factory type '{}', failing over to default upstream",
+                          cluster_->upstreamConfig().value().DebugString()));
+  }
+  if (!factory) {
     factory = &Envoy::Config::Utility::getAndCheckFactoryByName<GenericConnPoolFactory>(
         "envoy.filters.connection_pools.http.generic");
   }

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -310,6 +310,7 @@ envoy_cc_test(
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/upstreams/http/http/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/upstreams/http/tcp/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/upstreams/tcp/generic/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ],
 )


### PR DESCRIPTION
Probably we should eventually split upstream config into explicit tcp_upstream_config and http_upstream_config so we can validate on ingress.  This is at least a step in the right direction.

Commit Message: avoiding a crash on bad http upstream config, mirroring what we do for the tcp path.
Risk Level: Low 
Testing: new unit test
Docs Changes: n/a
Release Notes: n/a