### PR TITLE
Maglev Shuffle Shard

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -481,6 +481,11 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
+      enum LbPolicy {
+        LEAST_REQUEST = 0;
+        RANDOM = 1;
+      }
+
       // If set to `true`, the cluster will use hostname instead of the resolved
       // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
       bool use_hostname_for_hashing = 1;
@@ -504,6 +509,10 @@ message Cluster {
       // This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
       // being probed, so use a higher value if you require better performance.
       google.protobuf.UInt32Value hash_balance_factor = 2 [(validate.rules).uint32 = {gte: 100}];
+
+      google.protobuf.UInt32Value shard_size = 3 [(validate.rules).uint32 = {lte: 5 gte: 1}];
+
+      LbPolicy lb_policy = 4;
     }
 
     // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -485,6 +485,11 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.cluster.v3.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
+      enum LbPolicy {
+        LEAST_REQUEST = 0;
+        RANDOM = 1;
+      }
+
       // If set to `true`, the cluster will use hostname instead of the resolved
       // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
       bool use_hostname_for_hashing = 1;
@@ -508,6 +513,10 @@ message Cluster {
       // This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
       // being probed, so use a higher value if you require better performance.
       google.protobuf.UInt32Value hash_balance_factor = 2 [(validate.rules).uint32 = {gte: 100}];
+
+      google.protobuf.UInt32Value shard_size = 3 [(validate.rules).uint32 = {lte: 5 gte: 1}];
+
+      LbPolicy lb_policy = 4;
     }
 
     // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.

--- a/examples/shuffle-shard/docker-compose.yaml
+++ b/examples/shuffle-shard/docker-compose.yaml
@@ -1,0 +1,58 @@
+version: '3.7'
+services:
+
+  # proxy:
+  #   image: envoyproxy/envoy:v1.15.1
+  #   depends_on:
+  #     - service-http
+  #     - service-http-2
+  #   networks:
+  #     - envoymesh
+  #   ports:
+  #     - "8000:8000"
+  #   volumes:
+  #     - "./envoy.yaml:/etc/envoy.yaml"
+  #   command: "/usr/local/bin/envoy -c /etc/envoy.yaml --concurrency 1"
+
+
+  service-http:
+    image: mendhak/http-https-echo
+    hostname: service-http
+    ports:
+      - "8001:80"
+    environment:
+      - HTTPS_PORT=0
+    networks:
+      - envoymesh
+
+  service-http-2:
+    image: mendhak/http-https-echo
+    hostname: service-http-2
+    ports:
+      - "8002:80"
+    environment:
+      - HTTPS_PORT=0
+    networks:
+      - envoymesh
+
+  service-http-3:
+    image: mendhak/http-https-echo
+    hostname: service-http-3
+    ports:
+      - "8003:80"
+    environment:
+      - HTTPS_PORT=0
+    networks:
+      - envoymesh
+
+  service-http-4:
+    image: mendhak/http-https-echo
+    hostname: service-http-4
+    ports:
+      - "8004:80"
+    environment:
+      - HTTPS_PORT=0
+    networks:
+      - envoymesh
+networks:
+  envoymesh: {}

--- a/examples/shuffle-shard/envoy.yaml
+++ b/examples/shuffle-shard/envoy.yaml
@@ -1,0 +1,95 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: app
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: service-http
+                  hash_policy:
+                    header: 
+                      header_name: charlie
+          http_filters:
+          - name: envoy.filters.http.router
+
+  clusters:
+  - name: service-http
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: maglev
+    common_lb_config:
+      consistent_hashing_lb_config:
+        use_hostname_for_hashing: true
+        shard_size: 3
+        lb_policy: random
+    health_checks:
+    - timeout: 1s
+      interval: 5s
+      interval_jitter: 1s
+      unhealthy_threshold: 1
+      healthy_threshold: 3
+      http_health_check:
+        host: "servicehost"
+        path: "/health"
+
+    load_assignment:
+      cluster_name: service-http
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8001
+          metadata:
+            filter_metadata:
+              envoy.lb:
+                region: us-east-1
+                az: a
+        - endpoint:
+            health_check_config:
+              port_value: 8002
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8002
+          metadata:
+            filter_metadata:
+              envoy.lb:
+                region: us-east-1
+                az: b
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8003
+          metadata:
+            filter_metadata:
+              envoy.lb:
+                region: us-east-2
+                az: c
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8004

--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -166,6 +166,7 @@ proto_library(
         "//envoy/extensions/common/tap/v3:pkg",
         "//envoy/extensions/compression/gzip/compressor/v3:pkg",
         "//envoy/extensions/compression/gzip/decompressor/v3:pkg",
+        "//envoy/extensions/filters/common/dependency/v3:pkg",
         "//envoy/extensions/filters/common/fault/v3:pkg",
         "//envoy/extensions/filters/common/matcher/action/v3:pkg",
         "//envoy/extensions/filters/http/adaptive_concurrency/v3:pkg",

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -481,6 +481,11 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.api.v2.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
+      enum LbPolicy {
+        LEAST_REQUEST = 0;
+        RANDOM = 1;
+      }
+
       // If set to `true`, the cluster will use hostname instead of the resolved
       // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
       bool use_hostname_for_hashing = 1;
@@ -504,6 +509,10 @@ message Cluster {
       // This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
       // being probed, so use a higher value if you require better performance.
       google.protobuf.UInt32Value hash_balance_factor = 2 [(validate.rules).uint32 = {gte: 100}];
+
+      google.protobuf.UInt32Value shard_size = 3 [(validate.rules).uint32 = {lte: 5 gte: 1}];
+
+      LbPolicy lb_policy = 4;
     }
 
     // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -486,6 +486,11 @@ message Cluster {
       option (udpa.annotations.versioning).previous_message_type =
           "envoy.config.cluster.v3.Cluster.CommonLbConfig.ConsistentHashingLbConfig";
 
+      enum LbPolicy {
+        LEAST_REQUEST = 0;
+        RANDOM = 1;
+      }
+
       // If set to `true`, the cluster will use hostname instead of the resolved
       // address as the key to consistently hash to an upstream host. Only valid for StrictDNS clusters with hostnames which resolve to a single IP address.
       bool use_hostname_for_hashing = 1;
@@ -509,6 +514,10 @@ message Cluster {
       // This is an O(N) algorithm, unlike other load balancers. Using a lower `hash_balance_factor` results in more hosts
       // being probed, so use a higher value if you require better performance.
       google.protobuf.UInt32Value hash_balance_factor = 2 [(validate.rules).uint32 = {gte: 100}];
+
+      google.protobuf.UInt32Value shard_size = 3 [(validate.rules).uint32 = {lte: 5 gte: 1}];
+
+      LbPolicy lb_policy = 4;
     }
 
     // Configures the :ref:`healthy panic threshold <arch_overview_load_balancing_panic_threshold>`.

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -86,6 +86,7 @@ void MaglevTable::chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t
   std::mt19937 random(seed);
   bool unique;
 
+  // Generate shard, regardless of health
   for (uint8_t i = 0; i < shard_size_; i++) {
     unique = false;
     for(uint64_t c = 0; !unique && c < table_size_; c++) {
@@ -102,6 +103,7 @@ void MaglevTable::chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t
     hash = random();
   }
 
+  // Find the max health
   Envoy::Upstream::Host::Health max_health = Envoy::Upstream::Host::Health::Unhealthy;
   for (uint8_t i = 0; i < shard_size_; i++) {
     max_health = std::max(max_health, hosts[i]->health());
@@ -110,6 +112,7 @@ void MaglevTable::chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t
   }
   ENVOY_LOG(info, "maglev: health={}", max_health);
 
+  // Remove all hosts that aren't at max health
   uint8_t c = 0;
   for (uint8_t i = 0; i < shard_size_; i++) {
     if (hosts[i]->health() == max_health) {

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -1,8 +1,9 @@
 #include "common/upstream/maglev_lb.h"
 
-#include "envoy/config/cluster/v3/cluster.pb.h"
-#include <random>
 #include <algorithm>
+#include <random>
+
+#include "envoy/config/cluster/v3/cluster.pb.h"
 
 namespace Envoy {
 namespace Upstream {
@@ -76,7 +77,7 @@ MaglevTable::MaglevTable(const NormalizedHostWeightVector& normalized_host_weigh
   }
 }
 
-void MaglevTable::chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t * max_hosts) const {
+void MaglevTable::chooseHosts(uint64_t hash, HostConstSharedPtr* hosts, uint8_t* max_hosts) const {
   if (table_.empty()) {
     return;
   }
@@ -89,7 +90,7 @@ void MaglevTable::chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t
   // Generate shard, regardless of health
   for (uint8_t i = 0; i < shard_size_; i++) {
     unique = false;
-    for(uint64_t c = 0; !unique && c < table_size_; c++) {
+    for (uint64_t c = 0; !unique && c < table_size_; c++) {
       unique = true;
       for (uint8_t j = 0; j < i; j++) {
         if (hosts[j] == table_[hash % table_size_]) {
@@ -160,8 +161,8 @@ MaglevLoadBalancer::MaglevLoadBalancer(
               : false),
       hash_balance_factor_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           common_config.consistent_hashing_lb_config(), hash_balance_factor, 0)),
-      shard_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          common_config.consistent_hashing_lb_config(), shard_size, 1)) {
+      shard_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(common_config.consistent_hashing_lb_config(),
+                                                  shard_size, 1)) {
   ENVOY_LOG(debug, "maglev table size: {}", table_size_);
   // The table size must be prime number.
   if (!Primes::isPrime(table_size_)) {

--- a/source/common/upstream/maglev_lb.h
+++ b/source/common/upstream/maglev_lb.h
@@ -36,10 +36,11 @@ class MaglevTable : public ThreadAwareLoadBalancerBase::HashingLoadBalancer,
 public:
   MaglevTable(const NormalizedHostWeightVector& normalized_host_weights,
               double max_normalized_weight, uint64_t table_size, bool use_hostname_for_hashing,
-              MaglevLoadBalancerStats& stats);
+              uint32_t shard_size, MaglevLoadBalancerStats& stats);
 
   // ThreadAwareLoadBalancerBase::HashingLoadBalancer
   HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
+  void chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t * max_hosts) const override;
 
   // Recommended table size in section 5.3 of the paper.
   static const uint64_t DefaultTableSize = 65537;
@@ -61,6 +62,7 @@ private:
   uint64_t permutation(const TableBuildEntry& entry);
 
   const uint64_t table_size_;
+  const uint64_t shard_size_;
   std::vector<HostConstSharedPtr> table_;
   MaglevLoadBalancerStats& stats_;
 };
@@ -87,7 +89,7 @@ private:
                      double /* min_normalized_weight */, double max_normalized_weight) override {
     HashingLoadBalancerSharedPtr maglev_lb =
         std::make_shared<MaglevTable>(normalized_host_weights, max_normalized_weight, table_size_,
-                                      use_hostname_for_hashing_, stats_);
+                                      use_hostname_for_hashing_, shard_size_, stats_);
 
     if (hash_balance_factor_ == 0) {
       return maglev_lb;
@@ -104,6 +106,7 @@ private:
   const uint64_t table_size_;
   const bool use_hostname_for_hashing_;
   const uint32_t hash_balance_factor_;
+  const uint32_t shard_size_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/maglev_lb.h
+++ b/source/common/upstream/maglev_lb.h
@@ -40,7 +40,7 @@ public:
 
   // ThreadAwareLoadBalancerBase::HashingLoadBalancer
   HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
-  void chooseHosts(uint64_t hash, HostConstSharedPtr * hosts, uint8_t * max_hosts) const override;
+  void chooseHosts(uint64_t hash, HostConstSharedPtr* hosts, uint8_t* max_hosts) const override;
 
   // Recommended table size in section 5.3 of the paper.
   static const uint64_t DefaultTableSize = 65537;

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -63,6 +63,8 @@ private:
 
     // ThreadAwareLoadBalancerBase::HashingLoadBalancer
     HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
+    // HostConstSharedPtr * chooseHosts(uint64_t /*hash*/, uint32_t /*attempt*/) const override {
+    void chooseHosts(uint64_t /*hash*/, HostConstSharedPtr * /*hosts*/, uint8_t * /* max_hosts */ ) const override { }
 
     std::vector<RingEntry> ring_;
 

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -63,7 +63,8 @@ private:
 
     // ThreadAwareLoadBalancerBase::HashingLoadBalancer
     HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
-    void chooseHosts(uint64_t /*hash*/, HostConstSharedPtr * /*hosts*/, uint8_t * /* max_hosts */ ) const override { }
+    void chooseHosts(uint64_t /*hash*/, HostConstSharedPtr* /*hosts*/,
+                     uint8_t* /* max_hosts */) const override {}
 
     std::vector<RingEntry> ring_;
 

--- a/source/common/upstream/ring_hash_lb.h
+++ b/source/common/upstream/ring_hash_lb.h
@@ -63,7 +63,6 @@ private:
 
     // ThreadAwareLoadBalancerBase::HashingLoadBalancer
     HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const override;
-    // HostConstSharedPtr * chooseHosts(uint64_t /*hash*/, uint32_t /*attempt*/) const override {
     void chooseHosts(uint64_t /*hash*/, HostConstSharedPtr * /*hosts*/, uint8_t * /* max_hosts */ ) const override { }
 
     std::vector<RingEntry> ring_;

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -94,7 +94,8 @@ void ThreadAwareLoadBalancerBase::initialize() {
   // I will look into doing this in a follow up. Doing everything using a background thread heavily
   // complicated initialization as the load balancer would need its own initialized callback. I
   // think the synchronous/asynchronous split is probably the best option.
-  priority_set_.addPriorityUpdateCb(
+  if (update_)
+    priority_set_.addPriorityUpdateCb(
       [this](uint32_t, const HostVector&, const HostVector&) -> void { refresh(); });
 
   refresh();
@@ -158,6 +159,13 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
     stats_.lb_healthy_panic_.inc();
   }
 
+  if (shard_size_ > 1) {
+    HostConstSharedPtr hosts [5] = { };
+    uint8_t max_hosts = 0;
+    per_priority_state->current_lb_->chooseHosts(h, hosts, &max_hosts);
+    return (this->*load_balancer_)(hosts, max_hosts);
+  }
+
   HostConstSharedPtr host;
   const uint32_t max_attempts = context ? context->hostSelectionRetryCount() + 1 : 1;
   for (uint32_t i = 0; i < max_attempts; ++i) {
@@ -173,7 +181,7 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
 }
 
 LoadBalancerPtr ThreadAwareLoadBalancerBase::LoadBalancerFactoryImpl::create() {
-  auto lb = std::make_unique<LoadBalancerImpl>(stats_, random_);
+  auto lb = std::make_unique<LoadBalancerImpl>(stats_, random_, common_config_);
 
   // We must protect current_lb_ via a RW lock since it is accessed and written to by multiple
   // threads. All complex processing has already been precalculated however.

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -96,7 +96,7 @@ void ThreadAwareLoadBalancerBase::initialize() {
   // think the synchronous/asynchronous split is probably the best option.
   if (update_)
     priority_set_.addPriorityUpdateCb(
-      [this](uint32_t, const HostVector&, const HostVector&) -> void { refresh(); });
+        [this](uint32_t, const HostVector&, const HostVector&) -> void { refresh(); });
 
   refresh();
 }
@@ -160,7 +160,7 @@ ThreadAwareLoadBalancerBase::LoadBalancerImpl::chooseHost(LoadBalancerContext* c
   }
 
   if (shard_size_ > 1) {
-    HostConstSharedPtr hosts [5] = { };
+    HostConstSharedPtr hosts[5] = {};
     uint8_t max_hosts = 0;
     per_priority_state->current_lb_->chooseHosts(h, hosts, &max_hosts);
     return (this->*load_balancer_)(hosts, max_hosts);

--- a/test/common/upstream/bounded_load_hlb_test.cc
+++ b/test/common/upstream/bounded_load_hlb_test.cc
@@ -20,6 +20,8 @@ public:
     }
     return ring_.at(hash).first;
   }
+  void chooseHosts(uint64_t /* hash */, HostConstSharedPtr* /* hosts */,
+                   uint8_t* /* max_hosts */) const override{};
 
 private:
   const NormalizedHostWeightVector ring_;


### PR DESCRIPTION
***Draft***

Issue: https://github.com/envoyproxy/envoy/issues/14663

This implements option 2 of the google doc.

Some choices that were made:
- Shard generation could be done with [hash, hash+1, ...], or seeding random with (hash % table_size) and using [hash, hash+rand(), ...] or seeding random with hash and using [hash, hash+rand(), ...]. This implementation uses the third option.
- Turned off priority_set callbacks when shuffle sharding is in place. Without turning this off, a client can make their shard unhealthy and slowly consume all backends. Are there other implications to turning this off?
- No shard state. This limits the inner LB method to random or least requests, and limits host weight to only the maglev table.