### PR TITLE
grpc_stats: switch default of `stats_for_all_methods`

### DIFF
--- a/api/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
+++ b/api/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
@@ -46,10 +46,8 @@ message FilterConfig {
     //
     // .. attention::
     //   If neither `individual_method_stats_allowlist` nor `stats_for_all_methods` is set, the
-    //   behavior will default to `stats_for_all_methods=true`. This default value is deprecated,
-    //   and in a future release, if neither field is set, it will default to
-    //   `stats_for_all_methods=false` in order to be safe by default. This behavior can be
-    //   controlled with runtime override
+    //   behavior will default to `stats_for_all_methods=false`. This default value is changed due
+    //   to the previous value being deprecated. This behavior can be changed with runtime override
     //   `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
     google.protobuf.BoolValue stats_for_all_methods = 3;
   }

--- a/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -47,10 +47,8 @@ message FilterConfig {
     //
     // .. attention::
     //   If neither `individual_method_stats_allowlist` nor `stats_for_all_methods` is set, the
-    //   behavior will default to `stats_for_all_methods=true`. This default value is deprecated,
-    //   and in a future release, if neither field is set, it will default to
-    //   `stats_for_all_methods=false` in order to be safe by default. This behavior can be
-    //   controlled with runtime override
+    //   behavior will default to `stats_for_all_methods=false`. This default value is changed due
+    //   to the previous value being deprecated. This behavior can be changed with runtime override
     //   `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
     google.protobuf.BoolValue stats_for_all_methods = 3;
   }

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -7,8 +7,8 @@ Incompatible Behavior Changes
 
 * grpc_stats: the default value for :ref:`stats_for_all_methods <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_methods>` is switched
   from true to false, in order to avoid possible memory exhaustion due to an untrusted downstream sending a large number of unique method names. The previous
-  default value was deprecated in version 1.14.0. This only changes the behavior when teh value is not set. The previous behavior can be used by setting the value
-  to true. This behavior change by be overriden by setting enabling runtime feature `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
+  default value was deprecated in version 1.14.0. This only changes the behavior when the value is not set. The previous behavior can be used by setting the value
+  to true. This behavior change by be overridden by setting enabling runtime feature `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
 
 Minor Behavior Changes
 ----------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -5,6 +5,11 @@ Incompatible Behavior Changes
 -----------------------------
 *Changes that are expected to cause an incompatibility if applicable; deployment changes are likely required*
 
+* grpc_stats: the default value for :ref:`stats_for_all_methods <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_methods>` is switched
+  from true to false, in order to avoid possible memory exhaustion due to an untrusted downstream sending a large number of unique method names. The previous
+  default value was deprecated in version 1.14.0. This only changes the behavior when teh value is not set. The previous behavior can be used by setting the value
+  to true. This behavior change by be overriden by setting enabling runtime feature `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
+
 Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*

--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -166,6 +166,7 @@ proto_library(
         "//envoy/extensions/common/tap/v3:pkg",
         "//envoy/extensions/compression/gzip/compressor/v3:pkg",
         "//envoy/extensions/compression/gzip/decompressor/v3:pkg",
+        "//envoy/extensions/filters/common/dependency/v3:pkg",
         "//envoy/extensions/filters/common/fault/v3:pkg",
         "//envoy/extensions/filters/common/matcher/action/v3:pkg",
         "//envoy/extensions/filters/http/adaptive_concurrency/v3:pkg",

--- a/generated_api_shadow/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
+++ b/generated_api_shadow/envoy/config/filter/http/grpc_stats/v2alpha/config.proto
@@ -46,10 +46,8 @@ message FilterConfig {
     //
     // .. attention::
     //   If neither `individual_method_stats_allowlist` nor `stats_for_all_methods` is set, the
-    //   behavior will default to `stats_for_all_methods=true`. This default value is deprecated,
-    //   and in a future release, if neither field is set, it will default to
-    //   `stats_for_all_methods=false` in order to be safe by default. This behavior can be
-    //   controlled with runtime override
+    //   behavior will default to `stats_for_all_methods=false`. This default value is changed due
+    //   to the previous value being deprecated. This behavior can be changed with runtime override
     //   `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
     google.protobuf.BoolValue stats_for_all_methods = 3;
   }

--- a/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/grpc_stats/v3/config.proto
@@ -47,10 +47,8 @@ message FilterConfig {
     //
     // .. attention::
     //   If neither `individual_method_stats_allowlist` nor `stats_for_all_methods` is set, the
-    //   behavior will default to `stats_for_all_methods=true`. This default value is deprecated,
-    //   and in a future release, if neither field is set, it will default to
-    //   `stats_for_all_methods=false` in order to be safe by default. This behavior can be
-    //   controlled with runtime override
+    //   behavior will default to `stats_for_all_methods=false`. This default value is changed due
+    //   to the previous value being deprecated. This behavior can be changed with runtime override
     //   `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`.
     google.protobuf.BoolValue stats_for_all_methods = 3;
   }

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -106,7 +106,7 @@ struct Config {
         // set.
         //
         // This will flip to false after one release.
-        const bool runtime_feature_default = true;
+        const bool runtime_feature_default = false;
 
         const char* runtime_key = "envoy.deprecated_features.grpc_stats_filter_enable_"
                                   "stats_for_all_methods_by_default";

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -243,29 +243,25 @@ TEST_F(GrpcStatsFilterConfigTest, StatsForAllMethodsDefaultSetting) {
       deprecatedFeatureEnabled(
           "envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default", _))
       .WillOnce(Invoke([](absl::string_view, bool default_value) { return default_value; }));
-  EXPECT_LOG_CONTAINS("warn",
-                      "Using deprecated default value for "
-                      "'envoy.extensions.filters.http.grpc_stats.v3.FilterConfig.stats_for_all_"
-                      "methods'",
-                      initialize());
+  initialize();
 
   Http::TestRequestHeaderMapImpl request_headers{{"content-type", "application/grpc"},
                                                  {":path", "/BadCompanions/GetBadCompanions"}};
 
   doRequestResponse(request_headers);
 
-  EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
+  EXPECT_EQ(0UL, decoder_callbacks_.clusterInfo()
                      ->statsScope()
                      .counterFromString("grpc.BadCompanions.GetBadCompanions.success")
                      .value());
-  EXPECT_EQ(1UL, decoder_callbacks_.clusterInfo()
+  EXPECT_EQ(0UL, decoder_callbacks_.clusterInfo()
                      ->statsScope()
                      .counterFromString("grpc.BadCompanions.GetBadCompanions.total")
                      .value());
   EXPECT_EQ(
-      0UL,
+      1UL,
       decoder_callbacks_.clusterInfo()->statsScope().counterFromString("grpc.success").value());
-  EXPECT_EQ(0UL,
+  EXPECT_EQ(1UL,
             decoder_callbacks_.clusterInfo()->statsScope().counterFromString("grpc.total").value());
 }
 


### PR DESCRIPTION
Signed-off-by: Greg Greenway <ggreenway@apple.com>

Commit Message: grpc_stats: switch default of `stats_for_all_methods`
Additional Description: This change was announced (and previous value deprecated) in v1.14.0 (#10467).
Risk Level: Low
Testing: Adjusted unittests
Docs Changes: Updated
Release Notes: Added
Platform Specific Features: None
Optional Runtime guard: `envoy.deprecated_features.grpc_stats_filter_enable_stats_for_all_methods_by_default`
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
