### PR TITLE
http: making downstream scheme vs unreliable-:scheme clear

### DIFF
--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -334,7 +334,17 @@ x-forwarded-proto
 
 It is a common case where a service wants to know what the originating protocol (HTTP or HTTPS) was
 of the connection terminated by front/edge Envoy. *x-forwarded-proto* contains this information. It
-will be set to either *http* or *https*.
+will be set to either *http* or *https* based on the downstream scheme or, if scheme was not present,
+the security of the underlying downstream connection.
+
+    .. note::
+
+      The x-forwarded-proto should be used in Envoy filters rather than the :scheme header
+      as :scheme may not be set for HTTP/1.1 requests.
+
+      In future, Envoy may remove the :scheme header entirely during request processing to make
+      the unreliability of the :scheme header crystal clear.
+
 
 .. _config_http_conn_man_headers_x-request-id:
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -292,7 +292,6 @@ private:
   HEADER_FUNC(Method)                                                                              \
   HEADER_FUNC(Path)                                                                                \
   HEADER_FUNC(Protocol)                                                                            \
-  HEADER_FUNC(Scheme)                                                                              \
   HEADER_FUNC(TE)                                                                                  \
   HEADER_FUNC(UserAgent)
 

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -320,5 +320,25 @@ bool HeaderUtility::isModifiableHeader(absl::string_view header) {
           !absl::EqualsIgnoreCase(header, Headers::get().HostLegacy.get()));
 }
 
+absl::string_view HeaderUtility::getDownstreamScheme(const Http::RequestHeaderMap& headers,
+                                                     absl::string_view default_scheme) {
+  if (!headers.getForwardedProtoValue().empty()) {
+    return headers.getForwardedProtoValue();
+  }
+  return default_scheme;
+}
+
+absl::string_view HeaderUtility::getLegacyScheme(const Http::RequestHeaderMap& headers,
+                                                 absl::string_view default_scheme) {
+  const auto header = headers.get(Http::Headers::get().Scheme);
+  if (!header.empty()) {
+    ASSERT(header.size() == 1);
+    if (!header[0]->value().getStringView().empty()) {
+      return header[0]->value().getStringView();
+    }
+  }
+  return default_scheme;
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -200,6 +200,36 @@ public:
    * may not be modified.
    */
   static bool isModifiableHeader(absl::string_view header);
+
+  /**
+   * Returns the downstream scheme.
+   *
+   * The downstream scheme in Envoy is stored in the X-Forwarded-Proto header, not
+   * the :scheme header. The value of the header, and the return value of this function,
+   * is derived from the down :scheme header, if present, or otherwise
+   * will be http or https, infered from the encryption level of the downstream
+   * connection. This function will return default_scheme ifd some filter removed
+   * the X-Forwarded-Proto header entirely.
+   */
+  static absl::string_view getDownstreamScheme(const Http::RequestHeaderMap& headers,
+                                               absl::string_view default_scheme);
+
+  /**
+   * Returns the scheme header, if present, else returns default_scheme.
+   * Use of this function is HIGHLY discouraged.
+   * Code sites should be evaluated to determine what the intended usage is.
+   *
+   * Before request headers are sent upstream, the scheme header will be what
+   * the downstream sent, so present for HTTP/2, and HTTP/1.1 requests with fully qualified URLs,
+   * and absent for most HTTP/1.1 requests and below.
+   *
+   * After request headers are sent upstream, the scheme header will always be
+   * set, and will indicate the encryption level of the upstream connection.
+   *
+   * Generally getDownstreamScheme is preferred.
+   */
+  static absl::string_view getLegacyScheme(const Http::RequestHeaderMap& headers,
+                                           absl::string_view default_scheme = "");
 };
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -76,6 +76,7 @@ public:
   const LowerCaseString OtSpanContext{"x-ot-span-context"};
   const LowerCaseString Pragma{"pragma"};
   const LowerCaseString Referer{"referer"};
+  const LowerCaseString Scheme{":scheme"}; // FIXME
   const LowerCaseString Vary{"vary"};
 
   struct {

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -78,8 +78,10 @@ void HttpGrpcAccessLog::emitLog(const Http::RequestHeaderMap& request_headers,
   // HTTP request properties.
   // TODO(mattklein123): Populate port field.
   auto* request_properties = log_entry.mutable_request();
-  if (request_headers.Scheme() != nullptr) {
-    request_properties->set_scheme(std::string(request_headers.getSchemeValue()));
+  // TODO(#14587) this should probably be getDownstreamScheme()
+  const auto scheme = Http::HeaderUtility::getLegacyScheme(request_headers);
+  if (!scheme.empty()) {
+    request_properties->set_scheme(std::string(scheme));
   }
   if (request_headers.Host() != nullptr) {
     request_properties->set_authority(std::string(request_headers.getHostValue()));

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -2,6 +2,7 @@
 
 #include "common/grpc/common.h"
 #include "common/http/header_map_impl.h"
+#include "common/http/header_utility.h"
 #include "common/http/utility.h"
 
 #include "extensions/filters/common/expr/cel_state.h"
@@ -120,7 +121,8 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
     } else if (value == Host) {
       return convertHeaderEntry(headers_.value_->Host());
     } else if (value == Scheme) {
-      return convertHeaderEntry(headers_.value_->Scheme());
+      // TODO(#14587) determine if this should be getDownstreamScheme
+      return CelValue::CreateStringView(Http::HeaderUtility::getLegacyScheme(*headers_.value_));
     } else if (value == Method) {
       return convertHeaderEntry(headers_.value_->Method());
     } else if (value == Referer) {

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -111,7 +111,8 @@ void CheckRequestUtils::setHttpRequest(
   httpreq.set_method(getHeaderStr(headers.Method()));
   httpreq.set_path(getHeaderStr(headers.Path()));
   httpreq.set_host(getHeaderStr(headers.Host()));
-  httpreq.set_scheme(getHeaderStr(headers.Scheme()));
+  // TODO(#14587) determine if this should be getDownstreamScheme.
+  httpreq.set_scheme(std::string(Http::HeaderUtility::getLegacyScheme(headers)));
   httpreq.set_size(stream_info.bytesReceived());
 
   if (stream_info.protocol()) {

--- a/source/extensions/filters/http/csrf/BUILD
+++ b/source/extensions/filters/http/csrf/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:matchers_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
         "//source/extensions/filters/http:well_known_names",

--- a/source/extensions/filters/http/csrf/csrf_filter.cc
+++ b/source/extensions/filters/http/csrf/csrf_filter.cc
@@ -5,6 +5,7 @@
 
 #include "common/common/empty_string.h"
 #include "common/http/header_map_impl.h"
+#include "common/http/header_utility.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
 
@@ -66,8 +67,10 @@ std::string targetOriginValue(const Http::RequestHeaderMap& headers) {
     return EMPTY_STRING;
   }
 
-  const auto absolute_url = fmt::format(
-      "{}://{}", headers.Scheme() != nullptr ? headers.getSchemeValue() : "http", host_value);
+  auto scheme =
+      Http::HeaderUtility::getLegacyScheme(headers, Http::Headers::get().SchemeValues.Http);
+  // TODO(#14587) determine if this should be getDownstreamScheme.
+  const auto absolute_url = fmt::format("{}://{}", scheme, host_value);
   return hostAndPort(absolute_url);
 }
 

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -278,14 +278,9 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     // Construct the correct scheme. We default to https since this is a requirement for OAuth to
     // succeed. However, if a downstream client explicitly declares the "http" scheme for whatever
     // reason, we also use "http" when constructing our redirect uri to the authorization server.
-    auto scheme = Http::Headers::get().SchemeValues.Https;
-
-    const auto* scheme_header = headers.Scheme();
-    if ((scheme_header != nullptr &&
-         scheme_header->value().getStringView() == Http::Headers::get().SchemeValues.Http)) {
-      scheme = Http::Headers::get().SchemeValues.Http;
-    }
-
+    // TODO(#14587) determine if this should be getDownstreamScheme.
+    absl::string_view scheme =
+        Http::HeaderUtility::getLegacyScheme(headers, Http::Headers::get().SchemeValues.Https);
     const std::string base_path = absl::StrCat(scheme, "://", host_);
     const std::string state_path = absl::StrCat(base_path, headers.Path()->value().getStringView());
     const std::string escaped_state = Http::Utility::PercentEncoding::encode(state_path, ":/=&?");

--- a/test/common/http/common.cc
+++ b/test/common/http/common.cc
@@ -7,7 +7,7 @@
 namespace Envoy {
 void HttpTestUtility::addDefaultHeaders(Http::RequestHeaderMap& headers,
                                         const std::string default_method) {
-  headers.setScheme("http");
+  headers.setReferenceKey(Http::Headers::get().Scheme, Http::Headers::get().SchemeValues.Http);
   headers.setMethod(default_method);
   headers.setHost("host");
   headers.setPath("/");

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -710,5 +710,21 @@ TEST(RequiredHeaders, IsModifiableHeader) {
   EXPECT_TRUE(HeaderUtility::isRemovableHeader("Content-Type"));
 }
 
+TEST(Scheme, GetScheme) {
+  EXPECT_EQ("http", HeaderUtility::getDownstreamScheme(
+                        TestRequestHeaderMapImpl{{"x-forwarded-proto", "http"}}, "asd"));
+  EXPECT_EQ("asd", HeaderUtility::getDownstreamScheme(
+                       TestRequestHeaderMapImpl{{"x-forwarded-proto", ""}}, "asd"));
+  EXPECT_EQ("asd", HeaderUtility::getDownstreamScheme(TestRequestHeaderMapImpl{}, "asd"));
+}
+
+TEST(Scheme, GetLegacyScheme) {
+  EXPECT_EQ("http",
+            HeaderUtility::getLegacyScheme(TestRequestHeaderMapImpl{{":scheme", "http"}}, "asd"));
+  EXPECT_EQ("asd",
+            HeaderUtility::getLegacyScheme(TestRequestHeaderMapImpl{{":scheme", ""}}, "asd"));
+  EXPECT_EQ("asd", HeaderUtility::getLegacyScheme(TestRequestHeaderMapImpl{}, "asd"));
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -6123,8 +6123,9 @@ TEST_F(RouterTest, AutoHostRewriteEnabled) {
 
   // :authority header in the outgoing request should match the DNS name of
   // the selected upstream host
-  EXPECT_CALL(encoder, encodeHeaders(HeaderMapEqualRef(&outgoing_headers), true))
-      .WillOnce(Invoke([&](const Http::HeaderMap&, bool) -> Http::Status {
+  EXPECT_CALL(encoder, encodeHeaders(_, true))
+      .WillOnce(Invoke([&](const Http::HeaderMap& headers, bool) -> Http::Status {
+        EXPECT_TRUE(TestUtility::headerMapEqualIgnoreOrder(headers, outgoing_headers));
         encoder.stream_.resetStream(Http::StreamResetReason::RemoteReset);
         return Http::okStatus();
       }));

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -55,6 +55,10 @@ namespace Envoy {
 namespace Upstream {
 namespace {
 
+absl::string_view getSchemeValue(const Http::RequestHeaderMap& headers) {
+  return Http::HeaderUtility::getLegacyScheme(headers);
+}
+
 envoy::config::core::v3::HealthCheck createGrpcHealthCheckConfig() {
   envoy::config::core::v3::HealthCheck health_check;
   health_check.mutable_timeout()->set_seconds(1);
@@ -1056,7 +1060,7 @@ TEST_F(HttpHealthCheckerImplTest, ZeroRetryInterval) {
       .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
         EXPECT_EQ(headers.getHostValue(), host);
         EXPECT_EQ(headers.getPathValue(), path);
-        EXPECT_EQ(headers.getSchemeValue(), Http::Headers::get().SchemeValues.Http);
+        EXPECT_EQ(getSchemeValue(headers), Http::Headers::get().SchemeValues.Http);
         return Http::okStatus();
       }));
   health_checker_->start();
@@ -1132,7 +1136,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceCheck) {
       .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
         EXPECT_EQ(headers.getHostValue(), host);
         EXPECT_EQ(headers.getPathValue(), path);
-        EXPECT_EQ(headers.getSchemeValue(), Http::Headers::get().SchemeValues.Http);
+        EXPECT_EQ(getSchemeValue(headers), Http::Headers::get().SchemeValues.Http);
         return Http::okStatus();
       }));
   health_checker_->start();
@@ -1167,7 +1171,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServicePrefixPatternCheck) {
       .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
         EXPECT_EQ(headers.getHostValue(), host);
         EXPECT_EQ(headers.getPathValue(), path);
-        EXPECT_EQ(headers.getSchemeValue(), Http::Headers::get().SchemeValues.Http);
+        EXPECT_EQ(getSchemeValue(headers), Http::Headers::get().SchemeValues.Http);
         return Http::okStatus();
       }));
   health_checker_->start();
@@ -1202,7 +1206,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceExactPatternCheck) {
       .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
         EXPECT_EQ(headers.getHostValue(), host);
         EXPECT_EQ(headers.getPathValue(), path);
-        EXPECT_EQ(headers.getSchemeValue(), Http::Headers::get().SchemeValues.Http);
+        EXPECT_EQ(getSchemeValue(headers), Http::Headers::get().SchemeValues.Http);
         return Http::okStatus();
       }));
   health_checker_->start();
@@ -1237,7 +1241,7 @@ TEST_F(HttpHealthCheckerImplTest, SuccessServiceRegexPatternCheck) {
       .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
         EXPECT_EQ(headers.getHostValue(), host);
         EXPECT_EQ(headers.getPathValue(), path);
-        EXPECT_EQ(headers.getSchemeValue(), Http::Headers::get().SchemeValues.Http);
+        EXPECT_EQ(getSchemeValue(headers), Http::Headers::get().SchemeValues.Http);
         return Http::okStatus();
       }));
   health_checker_->start();
@@ -3035,7 +3039,7 @@ TEST_F(HttpHealthCheckerImplTest, DEPRECATED_FEATURE_TEST(ServiceNameMatch)) {
       .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
         EXPECT_EQ(headers.getHostValue(), host);
         EXPECT_EQ(headers.getPathValue(), path);
-        EXPECT_EQ(headers.getSchemeValue(), Http::Headers::get().SchemeValues.Http);
+        EXPECT_EQ(getSchemeValue(headers), Http::Headers::get().SchemeValues.Http);
         return Http::okStatus();
       }));
   health_checker_->start();
@@ -4195,7 +4199,7 @@ public:
         .WillOnce(Invoke([&](const Http::RequestHeaderMap& headers, bool) -> Http::Status {
           EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc, headers.getContentTypeValue());
           EXPECT_EQ(std::string("/grpc.health.v1.Health/Check"), headers.getPathValue());
-          EXPECT_EQ(Http::Headers::get().SchemeValues.Http, headers.getSchemeValue());
+          EXPECT_EQ(Http::Headers::get().SchemeValues.Http, getSchemeValue(headers));
           EXPECT_NE(nullptr, headers.Method());
           EXPECT_EQ(expected_host, headers.getHostValue());
           EXPECT_EQ(std::chrono::milliseconds(1000).count(),

--- a/test/extensions/quic_listeners/quiche/BUILD
+++ b/test/extensions/quic_listeners/quiche/BUILD
@@ -255,6 +255,7 @@ envoy_cc_test(
     tags = ["nofips"],
     deps = [
         ":quic_test_utils_for_envoy_lib",
+        "//source/common/http:header_utility_lib",
         "//source/extensions/quic_listeners/quiche:envoy_quic_utils_lib",
         "//test/mocks/api:api_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",

--- a/test/extensions/quic_listeners/quiche/envoy_quic_utils_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_utils_test.cc
@@ -12,6 +12,7 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include "common/http/header_utility.h"
 #include "test/mocks/api/mocks.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -54,7 +55,10 @@ TEST(EnvoyQuicUtilsTest, HeadersConversion) {
   EXPECT_EQ(headers_block.size(), envoy_headers->size());
   EXPECT_EQ("www.google.com", envoy_headers->getHostValue());
   EXPECT_EQ("/index.hml", envoy_headers->getPathValue());
-  EXPECT_EQ("https", envoy_headers->getSchemeValue());
+  const auto result =
+      Http::HeaderUtility::getAllOfHeaderAsString(*envoy_headers, Http::Headers::get().Scheme);
+  ASSERT_TRUE(result.result().has_value());
+  EXPECT_EQ("https", result.result().value());
 
   quic::QuicHeaderList quic_headers = quic::test::AsHeaderList(headers_block);
   auto envoy_headers2 = quicHeadersToEnvoyHeaders<Http::RequestHeaderMapImpl>(quic_headers);

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -725,6 +725,14 @@ TEST_P(IntegrationTest, BadHeader) {
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 400 Bad Request\r\n"));
 }
 
+TEST_P(IntegrationTest, Http2Scheme) {
+  initialize();
+  std::string response;
+  sendRawHttpAndWaitForResponse(lookupPort("http"),
+                                "GET / HTTP/1.1\r\nHost: host\r\n:scheme: http\r\n\r\n", &response);
+  EXPECT_THAT(response, HasSubstr("HTTP/1.1 400 Bad Request\r\n"));
+}
+
 TEST_P(IntegrationTest, Http10Disabled) {
   initialize();
   std::string response;

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -107,7 +107,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
   headers.setMethod(method);
   headers.setPath(url);
   headers.setHost(host);
-  headers.setReferenceScheme(Http::Headers::get().SchemeValues.Http);
+  headers.setReferenceKey(Http::Headers::get().Scheme, Http::Headers::get().SchemeValues.Http);
   if (!content_type.empty()) {
     headers.setContentType(content_type);
   }

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -69,10 +69,12 @@ void WebsocketIntegrationTest::validateUpgradeRequestHeaders(
   ASSERT_TRUE(proxied_request_headers.EnvoyExpectedRequestTimeoutMs() != nullptr);
   proxied_request_headers.removeEnvoyExpectedRequestTimeoutMs();
 
-  if (proxied_request_headers.Scheme()) {
-    ASSERT_EQ(proxied_request_headers.getSchemeValue(), "http");
+  absl::string_view scheme = Http::HeaderUtility::getLegacyScheme(proxied_request_headers);
+  if (!scheme.empty()) {
+    ASSERT_EQ(scheme, "http");
   } else {
-    proxied_request_headers.setScheme("http");
+    proxied_request_headers.setReferenceKey(Http::Headers::get().Scheme,
+                                            Http::Headers::get().SchemeValues.Http);
   }
 
   // 0 byte content lengths may be stripped on the H2 path - ignore that as a difference by adding


### PR DESCRIPTION
See comments in header_utility.h for details on the difference between 
:scheme (which is functionally a hop by hop header, transitioning from optional downstream scheme to reflecting upstream encryption) and
x-forwarded-proto (which represents the actual downstream scheme)

I set up this PR to address #14587 since folks have been using :scheme when (I believe) they intend to use X-Forwarded-Proto.
I removed the Scheme header key, so Envoy filters would fail to compile until they switched to getDownstreamScheme or getLegacyScheme, docced up the difference, and planned on migrating all the Envoy uses to getDownstreamScheme.

I was tempted to send this out for actual review, when it occurred to me that maybe 
isModifiableHeader should apply to X-Forwarded-Proto since it affects a fundamental component of the request.  And lua filters and wasm filters and ext_foo filters are probably all going to have the same problem, which is that people think :scheme represents the scheme of the request (rather than functionally being hop by hop).  

So then I thought, why not fix it differently.  On header ingress, move :scheme to :scheme-of-last-hop and set the value which currently was in x-forwarded-proto to the :scheme header.  The HTTP/1 codec ignores both headers, and the HTTP/2 codec could do the swap back, addressing my concerns about consistency between regular and upstream filters, and people get what they expect when they reference :scheme.

Unless they're actually familiar with the spec, at which point we'd of course be doing the wrong thing.

Polling wasm/security/http experts for thoughts on which group of people we should confuse :-/

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
