### PR TITLE
proto: hash protos piece by piece

### DIFF
--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -166,6 +166,7 @@ proto_library(
         "//envoy/extensions/common/tap/v3:pkg",
         "//envoy/extensions/compression/gzip/compressor/v3:pkg",
         "//envoy/extensions/compression/gzip/decompressor/v3:pkg",
+        "//envoy/extensions/filters/common/dependency/v3:pkg",
         "//envoy/extensions/filters/common/fault/v3:pkg",
         "//envoy/extensions/filters/common/matcher/action/v3:pkg",
         "//envoy/extensions/filters/http/adaptive_concurrency/v3:pkg",

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -106,8 +106,8 @@ envoy_cc_library(
     name = "hash_lib",
     srcs = ["hash.cc"],
     hdrs = ["hash.h"],
-    deps = [":assert_lib"],
     external_deps = ["xxhash"],
+    deps = [":assert_lib"],
 )
 
 envoy_cc_library(

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -106,6 +106,7 @@ envoy_cc_library(
     name = "hash_lib",
     srcs = ["hash.cc"],
     hdrs = ["hash.h"],
+    deps = [":assert_lib"],
     external_deps = ["xxhash"],
 )
 

--- a/source/common/common/hash.cc
+++ b/source/common/common/hash.cc
@@ -1,8 +1,24 @@
 #include "common/common/hash.h"
 
+#include "common/common/assert.h"
+
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
+
+HashUtil::XxHash64::XxHash64(uint64_t seed) {
+  xx_state_.reset(XXH64_createState());
+  XXH64_reset(xx_state_.get(), seed);
+}
+
+HashUtil::XxHash64& HashUtil::XxHash64::update(absl::string_view data) {
+  XXH64_update(xx_state_.get(), data.data(), data.length());
+  return *this;
+}
+
+uint64_t HashUtil::XxHash64::digest() const { return XXH64_digest(xx_state_.get()); }
+
+void HashUtil::XxHash64::XxDeleter::operator()(XXH64_state_t* state) { XXH64_freeState(state); }
 
 // Computes a 64-bit murmur hash 2, only works with 64-bit platforms. Revisit if support for 32-bit
 // platforms are needed.

--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -37,6 +37,31 @@ public:
     };
     return hash;
   }
+
+  /**
+   * Class for producing 64-bit hashes for xxHash from streaming data.
+   */
+  class XxHash64 {
+  public:
+    /**
+     * Construct a new hash with no data and the given seed
+     */
+    explicit XxHash64(uint64_t seed = 0);
+    /**
+     * Add data to be hashed.
+     */
+    XxHash64& update(absl::string_view input);
+    /**
+     * Return the 64-bit hash of all data previously passed to update()
+     */
+    uint64_t digest() const;
+
+  private:
+    struct XxDeleter {
+      void operator()(XXH64_state_t* state);
+    };
+    std::unique_ptr<XXH64_state_t, XxDeleter> xx_state_;
+  };
 };
 
 /**

--- a/test/common/common/hash_test.cc
+++ b/test/common/common/hash_test.cc
@@ -11,6 +11,14 @@ TEST(Hash, xxHash) {
   EXPECT_EQ(17241709254077376921U, HashUtil::xxHash64(""));
 }
 
+TEST(Hash, xxHashStreaming) {
+  EXPECT_EQ(HashUtil::xxHash64("foo"), HashUtil::XxHash64().update("foo").digest());
+  EXPECT_EQ(HashUtil::xxHash64("bar"), HashUtil::XxHash64().update("b").update("ar").digest());
+  EXPECT_EQ(HashUtil::xxHash64("foo\nbar"),
+            HashUtil::XxHash64().update("foo").update("\n").update("bar").digest());
+  EXPECT_EQ(HashUtil::xxHash64(""), HashUtil::XxHash64().update("").update("").update("").digest());
+}
+
 TEST(Hash, djb2CaseInsensitiveHash) {
   EXPECT_EQ(211616621U, HashUtil::djb2CaseInsensitiveHash("foo"));
   EXPECT_EQ(211611524U, HashUtil::djb2CaseInsensitiveHash("bar"));

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -1,10 +1,10 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
-    "envoy_benchmark_test",
-    "envoy_cc_benchmark_binary",
 )
 
 licenses(["notice"])  # Apache 2
@@ -26,7 +26,10 @@ envoy_cc_benchmark_binary(
     name = "utility_speed_test",
     srcs = ["utility_speed_test.cc"],
     external_deps = ["benchmark"],
-    deps = ["//source/common/common:minimal_logger_lib"],
+    deps = [
+        "//source/common/common:minimal_logger_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+    ],
 )
 
 envoy_benchmark_test(

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -34,7 +34,7 @@ envoy_cc_benchmark_binary(
 
 envoy_benchmark_test(
     name = "utility_speed_benchmark_test",
-    benchmark_binary = "utilty_speed_test",
+    benchmark_binary = "utility_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -29,6 +29,8 @@ envoy_cc_benchmark_binary(
     deps = [
         "//source/common/common:minimal_logger_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/protobuf/BUILD
+++ b/test/common/protobuf/BUILD
@@ -3,6 +3,8 @@ load(
     "envoy_cc_fuzz_test",
     "envoy_cc_test",
     "envoy_package",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
 )
 
 licenses(["notice"])  # Apache 2
@@ -18,6 +20,18 @@ envoy_cc_test(
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
     ],
+)
+
+envoy_cc_benchmark_binary(
+    name = "utility_speed_test",
+    srcs = ["utility_speed_test.cc"],
+    external_deps = ["benchmark"],
+    deps = ["//source/common/common:minimal_logger_lib"],
+)
+
+envoy_benchmark_test(
+    name = "utility_speed_benchmark_test",
+    benchmark_binary = "utilty_speed_test",
 )
 
 envoy_cc_test(

--- a/test/common/protobuf/utility_speed_test.cc
+++ b/test/common/protobuf/utility_speed_test.cc
@@ -1,0 +1,61 @@
+#include "common/protobuf/utility.h"
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+#include "benchmark/benchmark.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+
+static void BM_ProtobufMessageHash(benchmark::State& state) {
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  TestUtility::loadFromYaml(R"EOF(
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 127.0.0.1, port_value: 10000 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: some_service }
+          http_filters:
+          - name: envoy.filters.http.router
+  clusters:
+  - name: some_service
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: some_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 1234
+  )EOF",
+                            bootstrap);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(MessageUtil::hash(bootstrap));
+  }
+}
+BENCHMARK(BM_ProtobufMessageHash);
+
+} // namespace Envoy

--- a/test/common/protobuf/utility_speed_test.cc
+++ b/test/common/protobuf/utility_speed_test.cc
@@ -1,8 +1,10 @@
-#include "common/protobuf/utility.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 
-#include "benchmark/benchmark.h"
+#include "common/protobuf/utility.h"
+
 #include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
 
 namespace Envoy {
 

--- a/test/common/protobuf/utility_speed_test.cc
+++ b/test/common/protobuf/utility_speed_test.cc
@@ -1,9 +1,9 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/service/discovery/v3/discovery.pb.h"
 
 #include "common/protobuf/utility.h"
 
-#include "envoy/config/cluster/v3/cluster.pb.h"
-#include "envoy/service/discovery/v3/discovery.pb.h"
 #include "test/test_common/utility.h"
 
 #include "benchmark/benchmark.h"
@@ -76,7 +76,8 @@ static void bmProtobufMessageHashLarge(benchmark::State& state) {
       "some.really.long.resolver.name");
 
   for (int j = 0; j < 10; ++j) {
-    auto& filter_metadata = (*cluster.mutable_metadata()->mutable_filter_metadata())[absl::StrCat("KEY_NAME_", j)];
+    auto& filter_metadata =
+        (*cluster.mutable_metadata()->mutable_filter_metadata())[absl::StrCat("KEY_NAME_", j)];
     for (int k = 0; k < 5; ++k) {
       (*filter_metadata.mutable_fields())[absl::StrCat("key_number_", k)].set_string_value(
           std::string('b', 30));


### PR DESCRIPTION
Commit Message: Hash protos one piece at a time
Additional Description:
Use an implementation of ZeroCopyOutputStream that sends the results to
a hasher object instead of to a string, producing a hash inline with the
printing instead of first constructing and then hashing the entire string.

Risk Level: low
Testing: added unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
