### PR TITLE
stats: Fix zone stats when service_zone runtime flag is not set

### DIFF
--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -32,6 +32,14 @@ const envoy::config::core::v3::Node buildLocalNode(const envoy::config::core::v3
   return local_node;
 }
 
+const absl::string_view getZoneName(const envoy::config::core::v3::Node& node,
+                                    absl::string_view zone_name) {
+  if (zone_name.empty()) {
+    return node.locality().zone();
+  }
+  return zone_name;
+}
+
 } // namespace
 
 class LocalInfoImpl : public LocalInfo {
@@ -43,7 +51,7 @@ public:
                 absl::string_view node_name)
       : node_(buildLocalNode(node, zone_name, cluster_name, node_name)), address_(address),
         context_provider_(node_, node_context_params),
-        zone_stat_name_storage_(zone_name, symbol_table),
+        zone_stat_name_storage_(getZoneName(node_, zone_name), symbol_table),
         zone_stat_name_(zone_stat_name_storage_.statName()) {}
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -775,6 +775,21 @@ TEST_P(ServerInstanceImplTest, BootstrapNode) {
   expectCorrectBuildVersion(server_->localInfo().node().user_agent_build_version());
 }
 
+// Validate server localInfo().zoneStatName() is set from bootstrap config
+TEST_P(ServerInstanceImplTest, ZoneStatNameFromBootstrap) {
+  initialize("test/server/test_data/server/node_bootstrap.yaml");
+  EXPECT_EQ("bootstrap_zone",
+            stats_store_.symbolTable().toString(server_->localInfo().zoneStatName()));
+}
+
+// Validate server localInfo().zoneStatName() can by overridden by option
+TEST_P(ServerInstanceImplTest, ZoneStatNameFromOption) {
+  options_.service_zone_name_ = "bootstrap_zone_override";
+  initialize("test/server/test_data/server/node_bootstrap.yaml");
+  EXPECT_EQ("bootstrap_zone_override",
+            stats_store_.symbolTable().toString(server_->localInfo().zoneStatName()));
+}
+
 // Validate that bootstrap with v2 dynamic transport is rejected when --bootstrap-version is not
 // set.
 TEST_P(ServerInstanceImplTest,


### PR DESCRIPTION
Signed-off-by: Jacky Tian <jtian@lyft.com>

Commit Message: per-zone stats weren't working when zone was set from the node bootstrap config instead of --service-zone runtime flag. this change pulls the zone stat name from the node locality when the service zone option is empty.
Additional Description:
Risk Level: low
Testing: New tests pass with `bazel test //test/server:server_test`
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
