### PR TITLE
Add initial support for the rules_fuzzing Bazel library.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -278,15 +278,19 @@ build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
 # Fuzz builds
 
+# Shared fuzzing configuration.
+build:fuzzing --define=ENVOY_CONFIG_ASAN=1
+build:fuzzing --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+build:fuzzing --config=libc++
+
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
+build:plain-fuzzer --config=fuzzing
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
-build:plain-fuzzer --define=ENVOY_CONFIG_ASAN=1
 # The fuzzing rules provide their own instrumentation, but it is currently
 # disabled due to bazelbuild/bazel#12888. Instead, we provide instrumentation at
 # the top level through these options.
 build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
 build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
-build:plain-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
 build:asan-fuzzer --config=plain-fuzzer
 build:asan-fuzzer --config=asan
@@ -294,11 +298,10 @@ build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 
-build:oss-fuzz-base --define=FUZZING_ENGINE=oss-fuzz
-build:oss-fuzz-base --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
-build:oss-fuzz-base --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
-
-build:oss-fuzz --config=oss-fuzz-base
+build:oss-fuzz --config=fuzzing
+build:oss-fuzz --define=FUZZING_ENGINE=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
 build:oss-fuzz --dynamic_mode=off
 build:oss-fuzz --strip=never
 build:oss-fuzz --copt=-fno-sanitize=vptr
@@ -306,7 +309,6 @@ build:oss-fuzz --linkopt=-fno-sanitize=vptr
 build:oss-fuzz --define=tcmalloc=disabled
 build:oss-fuzz --define=signal_trace=disabled
 build:oss-fuzz --define=ENVOY_CONFIG_ASAN=1
-build:oss-fuzz --config=libc++
 build:oss-fuzz --copt=-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
 build:oss-fuzz --define=force_libcpp=enabled
 build:oss-fuzz --linkopt=-lc++

--- a/.bazelrc
+++ b/.bazelrc
@@ -308,7 +308,6 @@ build:oss-fuzz --copt=-fno-sanitize=vptr
 build:oss-fuzz --linkopt=-fno-sanitize=vptr
 build:oss-fuzz --define=tcmalloc=disabled
 build:oss-fuzz --define=signal_trace=disabled
-build:oss-fuzz --define=ENVOY_CONFIG_ASAN=1
 build:oss-fuzz --copt=-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
 build:oss-fuzz --define=force_libcpp=enabled
 build:oss-fuzz --linkopt=-lc++

--- a/.bazelrc
+++ b/.bazelrc
@@ -277,9 +277,13 @@ build:remote-ci --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build:remote-ci --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
 # Fuzz builds
+
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
-build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
+build:plain-fuzzer --define=ENVOY_CONFIG_ASAN=1
+# The fuzzing rules provide their own instrumentation, but it is currently
+# disabled due to bazelbuild/bazel#12888. Instead, we provide instrumentation at
+# the top level through these options.
 build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
 build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
 build:plain-fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -289,6 +293,24 @@ build:asan-fuzzer --config=asan
 build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
+
+build:oss-fuzz-base --define=FUZZING_ENGINE=oss-fuzz
+build:oss-fuzz-base --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
+build:oss-fuzz-base --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
+
+build:oss-fuzz --config=oss-fuzz-base
+build:oss-fuzz --dynamic_mode=off
+build:oss-fuzz --strip=never
+build:oss-fuzz --copt=-fno-sanitize=vptr
+build:oss-fuzz --linkopt=-fno-sanitize=vptr
+build:oss-fuzz --define=tcmalloc=disabled
+build:oss-fuzz --define=signal_trace=disabled
+build:oss-fuzz --define=ENVOY_CONFIG_ASAN=1
+build:oss-fuzz --config=libc++
+build:oss-fuzz --copt=-D_LIBCPP_DISABLE_DEPRECATION_WARNINGS
+build:oss-fuzz --define=force_libcpp=enabled
+build:oss-fuzz --linkopt=-lc++
+build:oss-fuzz --linkopt=-pthread
 
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -465,7 +465,21 @@ config_setting(
 
 config_setting(
     name = "libfuzzer",
-    values = {"define": "FUZZING_ENGINE=libfuzzer"},
+    define_values = {"FUZZING_ENGINE": "libfuzzer"},
+)
+
+config_setting(
+    name = "oss_fuzz",
+    define_values = {"FUZZING_ENGINE": "oss-fuzz"},
+)
+
+alias(
+    name = "fuzzing_engine",
+    actual = select({
+        ":libfuzzer": "@rules_fuzzing//fuzzing/engines:libfuzzer",
+        ":oss_fuzz": "@rules_fuzzing_oss_fuzz//:oss_fuzz_engine",
+        "//conditions:default": "//test/fuzz:fuzz_runner_engine",
+    }),
 )
 
 alias(

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,6 +4,7 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "oss_fuzz_dependencies", "rules_fuzzing_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")
@@ -12,6 +13,7 @@ load("@headersplit_pip3//:requirements.bzl", headersplit_pip_install = "pip_inst
 load("@kafka_pip3//:requirements.bzl", kafka_pip_install = "pip_install")
 load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
 load("@thrift_pip3//:requirements.bzl", thrift_pip_install = "pip_install")
+load("@fuzzing_pip3//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
 
@@ -29,6 +31,8 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     upb_deps()
     antlr_dependencies(472)
     proxy_wasm_rust_sdk_dependencies()
+    rules_fuzzing_dependencies()
+    oss_fuzz_dependencies()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",
@@ -82,3 +86,4 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     kafka_pip_install()
     protodoc_pip_install()
     thrift_pip_install()
+    fuzzing_pip_install()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -161,6 +161,7 @@ def envoy_dependencies(skip_targets = []):
     _proxy_wasm_cpp_sdk()
     _proxy_wasm_cpp_host()
     _emscripten_toolchain()
+    _rules_fuzzing()
     external_http_archive("proxy_wasm_rust_sdk")
     external_http_archive("com_googlesource_code_re2")
     _com_google_cel_cpp()
@@ -875,6 +876,14 @@ def _com_github_wasm_c_api():
     external_http_archive(
         name = "com_github_wasm_c_api",
         build_file = "@envoy//bazel/external:wasm-c-api.BUILD",
+    )
+
+def _rules_fuzzing():
+    external_http_archive(
+        name = "rules_fuzzing",
+        repo_mapping = {
+            "@fuzzing_py_deps": "@fuzzing_pip3",
+        },
     )
 
 def _kafka_deps():

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -97,6 +97,16 @@ def _python_deps():
         # release_date = "2020-05-21"
         # use_category = ["test"],
     )
+    pip3_import(
+        name = "fuzzing_pip3",
+        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+
+        # project_name = "Abseil Python Common Libraries",
+        # project_url = "https://github.com/abseil/abseil-py",
+        # version = "0.11.0",
+        # release_date = "2020-10-27",
+        # use_category = ["test"],
+    )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().
 def envoy_dependencies_extra():

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -100,11 +100,18 @@ def _python_deps():
     pip3_import(
         name = "fuzzing_pip3",
         requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+        extra_pip_args = ["--require-hashes"],
 
         # project_name = "Abseil Python Common Libraries",
         # project_url = "https://github.com/abseil/abseil-py",
         # version = "0.11.0",
         # release_date = "2020-10-27",
+        # use_category = ["test"],
+
+        # project_name = "Six: Python 2 and 3 Compatibility Library",
+        # project_url = "https://six.readthedocs.io/",
+        # version = "1.15.0",
+        # release_date = "2020-05-21"
         # use_category = ["test"],
     )
 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -49,11 +49,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Fuzzing Rules for Bazel",
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
-        version = "2c97fcd74f20dce950c77129b9b9b31cc63a4c8e",
-        sha256 = "6764e198db6f84bd1f6bf9565ebd7bb532a73b5f99cfe19126a279f67cc9b633",
+        version = "f6062a88d83463e2900e47bc218547ba046dad44",
+        sha256 = "9397f26694e0bf8efb1a67a0a88e1770eddeebbb95d0a2cd9d2043b366dc0480",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-28",
+        release_date = "2021-01-29",
         use_category = ["test_only"],
         implied_untracked_deps = [
             # This is a repository rule generated to define an OSS-Fuzz fuzzing

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -53,7 +53,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         sha256 = "6af5cd0207f81d66a1c5ca762d8411c584a2a96d1a35da04410e1e65b414ee5f",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-27",
+        release_date = "2021-01-26",
         use_category = ["test_only"],
         implied_untracked_deps = [
             "rules_fuzzing_oss_fuzz",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -45,6 +45,20 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2019-10-10",
         use_category = ["build"],
     ),
+    rules_fuzzing = dict(
+        project_name = "Fuzzing Rules for Bazel",
+        project_desc = "Bazel rules for fuzz tests",
+        project_url = "https://github.com/bazelbuild/rules_fuzzing",
+        version = "04c6c334bba2142b3165a59ce29f57e057752fcd",
+        sha256 = "6af5cd0207f81d66a1c5ca762d8411c584a2a96d1a35da04410e1e65b414ee5f",
+        strip_prefix = "rules_fuzzing-{version}",
+        urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
+        release_date = "2021-01-25",
+        use_category = ["test_only"],
+        implied_untracked_deps = [
+            "rules_fuzzing_oss_fuzz",
+        ],
+    ),
     envoy_build_tools = dict(
         project_name = "envoy-build-tools",
         project_desc = "Common build tools shared by the Envoy/UDPA ecosystem",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -56,6 +56,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2021-01-26",
         use_category = ["test_only"],
         implied_untracked_deps = [
+            # This is a repository rule generated to define an OSS-Fuzz fuzzing
+            # engine target from the CFLAGS/CXXFLAGS environment.
             "rules_fuzzing_oss_fuzz",
         ],
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -53,7 +53,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         sha256 = "6af5cd0207f81d66a1c5ca762d8411c584a2a96d1a35da04410e1e65b414ee5f",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-25",
+        release_date = "2021-01-27",
         use_category = ["test_only"],
         implied_untracked_deps = [
             "rules_fuzzing_oss_fuzz",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -49,11 +49,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Fuzzing Rules for Bazel",
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
-        version = "04c6c334bba2142b3165a59ce29f57e057752fcd",
-        sha256 = "6af5cd0207f81d66a1c5ca762d8411c584a2a96d1a35da04410e1e65b414ee5f",
+        version = "2c97fcd74f20dce950c77129b9b9b31cc63a4c8e",
+        sha256 = "6764e198db6f84bd1f6bf9565ebd7bb532a73b5f99cfe19126a279f67cc9b633",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-26",
+        release_date = "2021-01-28",
         use_category = ["test_only"],
         implied_untracked_deps = [
             # This is a repository rule generated to define an OSS-Fuzz fuzzing

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -5,6 +5,10 @@ load(
     "envoy_package",
     "envoy_proto_library",
 )
+load(
+    "@rules_fuzzing//fuzzing:cc_deps.bzl",
+    "cc_fuzzing_engine",
+)
 
 licenses(["notice"])  # Apache 2
 
@@ -86,4 +90,12 @@ envoy_cc_test(
     deps = [
         "//test/fuzz:random_lib",
     ],
+)
+
+cc_fuzzing_engine(
+    name = "fuzz_runner_engine",
+    testonly = True,
+    display_name = "Fuzz Test Runner",
+    launcher = "fuzz_runner_launcher.sh",
+    library = ":main",
 )

--- a/test/fuzz/fuzz_runner_launcher.sh
+++ b/test/fuzz/fuzz_runner_launcher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Launcher for the fuzz runner engine.
+# See https://github.com/bazelbuild/rules_fuzzing for more info.
+
+if (( ! FUZZER_IS_REGRESSION )); then
+    echo "NOTE: Non-regression mode is not supported by this engine."
+fi
+
+command_line=("${FUZZER_BINARY}")
+if [[ -n "${FUZZER_SEED_CORPUS_DIR}" ]]; then
+    command_line+=("${FUZZER_SEED_CORPUS_DIR}")
+fi
+
+exec "${command_line[@]}"


### PR DESCRIPTION
_Commit Message:_ Introduce the new https://github.com/bazelbuild/rules_fuzzing library for fuzz testing support. 

_Additional Description:_ The new library provides new functionality (support for testing the fuzz test locally) and simplifies existing fuzzing tasks. This is the first PR in the series. See #14675 for the detailed rollout plan.

_Risk Level:_ High (new dependencies and major change to the existing `envoy_cc_fuzz_test` macro)

_Testing:_ The changes consist of either (a) code that should be a drop-in replacement to the existing functionality, or (b) new targets marked as "manual". For (a), the Envoy regression tests should catch deviations from the original behavior. The new functionality in (b) is either tested manually, or through the OSS-Fuzz integration (changes coming in future PR).

_Docs Changes:_ None (this is test-only functionality).

_Release Notes:_ N/A

_Platform Specific Features:_ The fuzz tests run on Linux platforms only.