### PR TITLE
listener: allocate UUID for unnamed filter chains

### DIFF
--- a/source/server/filter_chain_manager_impl.cc
+++ b/source/server/filter_chain_manager_impl.cc
@@ -156,20 +156,26 @@ void FilterChainManagerImpl::addFilterChains(
       filter_chains;
   uint32_t new_filter_chain_size = 0;
   for (const auto& filter_chain : filter_chain_span) {
+    std::string fc_name;
+    if (!filter_chain->name().empty()) {
+      fc_name = filter_chain->name();
+    } else {
+      fc_name = parent_context_.api().randomGenerator().uuid();
+    }
+
     const auto& filter_chain_match = filter_chain->filter_chain_match();
     if (!filter_chain_match.address_suffix().empty() || filter_chain_match.has_suffix_len()) {
       throw EnvoyException(fmt::format("error adding listener '{}': filter chain '{}' contains "
                                        "unimplemented fields",
-                                       address_->asString(), filter_chain->name()));
+                                       address_->asString(), fc_name));
     }
     const auto& matching_iter = filter_chains.find(filter_chain_match);
     if (matching_iter != filter_chains.end()) {
       throw EnvoyException(fmt::format("error adding listener '{}': filter chain '{}' has "
                                        "the same matching rules defined as '{}'",
-                                       address_->asString(), filter_chain->name(),
-                                       matching_iter->second));
+                                       address_->asString(), fc_name, matching_iter->second));
     }
-    filter_chains.insert({filter_chain_match, filter_chain->name()});
+    filter_chains.insert({filter_chain_match, fc_name});
 
     // Validate IP addresses.
     std::vector<std::string> destination_ips;

--- a/test/server/filter_chain_manager_impl_test.cc
+++ b/test/server/filter_chain_manager_impl_test.cc
@@ -188,6 +188,25 @@ TEST_F(FilterChainManagerImplTest, LookupFilterChainContextByFilterChainMessage)
       nullptr, filter_chain_factory_builder_, filter_chain_manager_);
 }
 
+TEST_F(FilterChainManagerImplTest, DuplicateUnnamedFilterChainMatchError) {
+  const std::string valid_uuid_regex =
+      "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
+  std::vector<envoy::config::listener::v3::FilterChain> filter_chain_messages;
+
+  for (int i = 0; i < 2; i++) {
+    envoy::config::listener::v3::FilterChain new_filter_chain = filter_chain_template_;
+    filter_chain_messages.push_back(std::move(new_filter_chain));
+  }
+  EXPECT_THROW_WITH_REGEX(
+      filter_chain_manager_.addFilterChains(
+          std::vector<const envoy::config::listener::v3::FilterChain*>{&filter_chain_messages[0],
+                                                                       &filter_chain_messages[1]},
+          nullptr, filter_chain_factory_builder_, filter_chain_manager_),
+      EnvoyException,
+      fmt::format("filter chain '{}' has the same matching rules defined as '{}'", valid_uuid_regex,
+                  valid_uuid_regex));
+}
+
 TEST_F(FilterChainManagerImplTest, DuplicateContextsAreNotBuilt) {
   std::vector<envoy::config::listener::v3::FilterChain> filter_chain_messages;
 


### PR DESCRIPTION
According to the proto desc of `FilterChain` - if no name is provided, Envoy
will allocate an internal UUID for the filter chain.

This patch introduces this function for unnamed filter chains, which can help
some debugging of errors like `error adding listener '0.0.0.0:8443': filter
chain '' has the same matching rules defined as ''`.

Related to:
https://github.com/envoyproxy/envoy/issues/11753
https://github.com/istio/istio/issues/27480

Signed-off-by: Kailun Qin <kailun.qin@intel.com>

Risk Level: N/A
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
