### PR TITLE
docs: Gzip compressor mention non existing fields

### DIFF
--- a/api/envoy/extensions/filters/http/gzip/v3/gzip.proto
+++ b/api/envoy/extensions/filters/http/gzip/v3/gzip.proto
@@ -72,9 +72,8 @@ message Gzip {
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
 
-  // Set of configuration parameters common for all compression filters. If this field is set then
-  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
-  // `remove_accept_encoding_header` are ignored.
+  // Set of configuration parameters common for all compression filters. You can define
+  // `content_length`, `content_type` and other parameters in this field.
   compressor.v3.Compressor compressor = 10;
 
   // Value for Zlib's next output buffer. If not set, defaults to 4096.

--- a/api/envoy/extensions/filters/http/gzip/v4alpha/gzip.proto
+++ b/api/envoy/extensions/filters/http/gzip/v4alpha/gzip.proto
@@ -72,9 +72,8 @@ message Gzip {
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
 
-  // Set of configuration parameters common for all compression filters. If this field is set then
-  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
-  // `remove_accept_encoding_header` are ignored.
+  // Set of configuration parameters common for all compression filters. You can define
+  // `content_length`, `content_type` and other parameters in this field.
   compressor.v4alpha.Compressor compressor = 10;
 
   // Value for Zlib's next output buffer. If not set, defaults to 4096.

--- a/generated_api_shadow/envoy/extensions/filters/http/gzip/v3/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/gzip/v3/gzip.proto
@@ -67,9 +67,8 @@ message Gzip {
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
 
-  // Set of configuration parameters common for all compression filters. If this field is set then
-  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
-  // `remove_accept_encoding_header` are ignored.
+  // Set of configuration parameters common for all compression filters. You can define
+  // `content_length`, `content_type` and other parameters in this field.
   compressor.v3.Compressor compressor = 10;
 
   // Value for Zlib's next output buffer. If not set, defaults to 4096.

--- a/generated_api_shadow/envoy/extensions/filters/http/gzip/v4alpha/gzip.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/gzip/v4alpha/gzip.proto
@@ -72,9 +72,8 @@ message Gzip {
   // zlib manual > deflateInit2.
   google.protobuf.UInt32Value window_bits = 9 [(validate.rules).uint32 = {lte: 15 gte: 9}];
 
-  // Set of configuration parameters common for all compression filters. If this field is set then
-  // the fields `content_length`, `content_type`, `disable_on_etag_header` and
-  // `remove_accept_encoding_header` are ignored.
+  // Set of configuration parameters common for all compression filters. You can define
+  // `content_length`, `content_type` and other parameters in this field.
   compressor.v4alpha.Compressor compressor = 10;
 
   // Value for Zlib's next output buffer. If not set, defaults to 4096.


### PR DESCRIPTION
Fields `content_length`, `content_type`, `disable_on_etag_header` and
`remove_accept_encoding_header` are valid for APIv2 Gzip filter, not for
APIv3.

-----------------------------------

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: docs: Gzip compressor mention non existing fields
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
