### PR TITLE
docs: elaborate on behavior of scheme for ext_authz

### DIFF
--- a/api/envoy/service/auth/v2/attribute_context.proto
+++ b/api/envoy/service/auth/v2/attribute_context.proto
@@ -110,7 +110,9 @@ message AttributeContext {
     // The HTTP request `Host` or 'Authority` header value.
     string host = 5;
 
-    // The HTTP URL scheme, such as `http` and `https`.
+    // The HTTP URL scheme, such as `http` and `https`. This is set for HTTP/2
+    // requests only. For HTTP/1.1, use "x-forwarded-for" header value to lookup
+    // the scheme of the request.
     string scheme = 6;
 
     // This field is always empty, and exists for compatibility reasons. The HTTP URL query is

--- a/api/envoy/service/auth/v3/attribute_context.proto
+++ b/api/envoy/service/auth/v3/attribute_context.proto
@@ -123,7 +123,9 @@ message AttributeContext {
     // The HTTP request `Host` or 'Authority` header value.
     string host = 5;
 
-    // The HTTP URL scheme, such as `http` and `https`.
+    // The HTTP URL scheme, such as `http` and `https`. This is set for HTTP/2
+    // requests only. For HTTP/1.1, use "x-forwarded-for" header value to lookup
+    // the scheme of the request.
     string scheme = 6;
 
     // This field is always empty, and exists for compatibility reasons. The HTTP URL query is

--- a/api/envoy/service/auth/v4alpha/attribute_context.proto
+++ b/api/envoy/service/auth/v4alpha/attribute_context.proto
@@ -123,7 +123,9 @@ message AttributeContext {
     // The HTTP request `Host` or 'Authority` header value.
     string host = 5;
 
-    // The HTTP URL scheme, such as `http` and `https`.
+    // The HTTP URL scheme, such as `http` and `https`. This is set for HTTP/2
+    // requests only. For HTTP/1.1, use "x-forwarded-for" header value to lookup
+    // the scheme of the request.
     string scheme = 6;
 
     // This field is always empty, and exists for compatibility reasons. The HTTP URL query is

--- a/generated_api_shadow/envoy/service/auth/v2/attribute_context.proto
+++ b/generated_api_shadow/envoy/service/auth/v2/attribute_context.proto
@@ -110,7 +110,9 @@ message AttributeContext {
     // The HTTP request `Host` or 'Authority` header value.
     string host = 5;
 
-    // The HTTP URL scheme, such as `http` and `https`.
+    // The HTTP URL scheme, such as `http` and `https`. This is set for HTTP/2
+    // requests only. For HTTP/1.1, use "x-forwarded-for" header value to lookup
+    // the scheme of the request.
     string scheme = 6;
 
     // This field is always empty, and exists for compatibility reasons. The HTTP URL query is

--- a/generated_api_shadow/envoy/service/auth/v3/attribute_context.proto
+++ b/generated_api_shadow/envoy/service/auth/v3/attribute_context.proto
@@ -123,7 +123,9 @@ message AttributeContext {
     // The HTTP request `Host` or 'Authority` header value.
     string host = 5;
 
-    // The HTTP URL scheme, such as `http` and `https`.
+    // The HTTP URL scheme, such as `http` and `https`. This is set for HTTP/2
+    // requests only. For HTTP/1.1, use "x-forwarded-for" header value to lookup
+    // the scheme of the request.
     string scheme = 6;
 
     // This field is always empty, and exists for compatibility reasons. The HTTP URL query is

--- a/generated_api_shadow/envoy/service/auth/v4alpha/attribute_context.proto
+++ b/generated_api_shadow/envoy/service/auth/v4alpha/attribute_context.proto
@@ -123,7 +123,9 @@ message AttributeContext {
     // The HTTP request `Host` or 'Authority` header value.
     string host = 5;
 
-    // The HTTP URL scheme, such as `http` and `https`.
+    // The HTTP URL scheme, such as `http` and `https`. This is set for HTTP/2
+    // requests only. For HTTP/1.1, use "x-forwarded-for" header value to lookup
+    // the scheme of the request.
     string scheme = 6;
 
     // This field is always empty, and exists for compatibility reasons. The HTTP URL query is


### PR DESCRIPTION
Scheme is populated for h2 and not for h1.1.
Advise accordingly in documentation.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->

Commit Message: docs: elaborate on behavior of scheme for ext_authz
Additional Description: I spent quite some time to debug and test why scheme was not being populated for my requests. I finally figured out that it only works for h2. This is not obvious from the docs so I think this addition will help.
Risk Level: N/A
Testing: N/A
Docs Changes: Explain when scheme is populated for ext_authz filter and how to get the scheme when the variable is not set.
Release Notes: N/A
Platform Specific Features: N/A
