### PR TITLE
Fix flaky test script bug

### DIFF
--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -190,11 +190,15 @@ def getGitInfo(CI_TARGET):
 
   ret += "\n"
 
-  output = subprocess.check_output(['git', 'remote', 'get-url', 'origin'], encoding='utf-8')
-  ret += "Origin:\t\t{}".format(output.replace('.git', ''))
+  remotes = subprocess.check_output(['git', 'remote'], encoding='utf-8').splitlines()
 
-  output = subprocess.check_output(['git', 'remote', 'get-url', 'upstream'], encoding='utf-8')
-  ret += "Upstream:\t{}".format(output.replace('.git', ''))
+  if ("origin" in remotes):
+    output = subprocess.check_output(['git', 'remote', 'get-url', 'origin'], encoding='utf-8')
+    ret += "Origin:\t\t{}".format(output.replace('.git', ''))
+
+  if ("upstream" in remotes):
+    output = subprocess.check_output(['git', 'remote', 'get-url', 'upstream'], encoding='utf-8')
+    ret += "Upstream:\t{}".format(output.replace('.git', ''))
 
   output = subprocess.check_output(['git', 'describe', '--all'], encoding='utf-8')
   ret += "Latest ref:\t{}".format(output)


### PR DESCRIPTION
Commit Message:
#14731 introduced a bug where the script tried to dump the URL of a remote that might not be present.  This PR fixes that bug.

Signed-off-by: Randy Miller <rmiller14@gmail.com>

Risk Level: Low
Testing: Ran the script locally multiple times