### PR TITLE
Temporarily disable wasm example verification on CI as it runs out of disk

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -450,7 +450,7 @@ elif [[ "$CI_TARGET" == "verify_examples" ]]; then
   export DOCKER_NO_PULL=1
   umask 027
   chmod -R o-rwx examples/
-  ci/verify_examples.sh
+  ci/verify_examples.sh "*" wasm-cc
   exit 0
 else
   echo "Invalid do_ci.sh target, see ci/README.md for valid targets."

--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -E
 
 TESTFILTER="${1:-*}"
+TESTEXCLUDES="${2}"
 FAILED=()
 SRCDIR="${SRCDIR:-$(pwd)}"
-
 
 trap_errors () {
     local frame=0 command line sub file
@@ -29,7 +29,7 @@ trap exit 1 INT
 run_examples () {
     local examples example
     cd "${SRCDIR}/examples" || exit 1
-    examples=$(find . -mindepth 1 -maxdepth 1 -type d -name "$TESTFILTER" ! -iname "_*" | sort)
+    examples=$(find . -mindepth 1 -maxdepth 1 -type d -name "$TESTFILTER" ! -iname "_*" ! -name "$TESTEXCLUDES" | sort)
     for example in $examples; do
         pushd "$example" > /dev/null || return 1
         ./verify.sh


### PR DESCRIPTION
Additional Description:
This change is temporary to unblock CI as it fails to test the wasm-cc example due to limited disk space. The test will be enabled when its disk requirements are reduced or CI has a bigger disk or some other content is deleted before running this test.

Temporarily addresses issue #14874

Risk Level: Low (test only)
Testing: test examples
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A


Signed-off-by: Yan Avlasov <yavlasov@google.com>
