### PR TITLE
api/style: encourage WKT wrappers for any field with default subject to change

### DIFF
--- a/api/STYLE.md
+++ b/api/STYLE.md
@@ -25,11 +25,10 @@ In addition, the following conventions should be followed:
 
 * Use [wrapped scalar
   types](https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto)
-  where there is a real need for the field to have a default value that does not
-  match the proto3 defaults (0/false/""). This should not be done for fields
-  where the proto3 defaults make sense. All things being equal, pick appropriate
-  logic, e.g. enable vs. disable for a `bool` field, such that the proto3
-  defaults work, but only where this doesn't result in API gymnastics.
+  if there is any potential need for a field to have a default value that does not
+  match the proto3 defaults (0/false/""). For example, new features whose
+  default value may change in the future or security mitigations that should be
+  default safe in the future but are temporarily not enabled.
 
 * Use a `[#not-implemented-hide:]` `protodoc` annotation in comments for fields that lack Envoy
   implementation. These indicate that the entity is not implemented in Envoy and the entity

--- a/api/review_checklist.md
+++ b/api/review_checklist.md
@@ -26,6 +26,9 @@ consider the answers to these questions before sending a PR.
     "Genericness" below -- if this is not part of the API, will every xDS
     client need to add a different knob?  Is consistency across clients
     important for this?)
+- If the feature is modeled as a proto3 scalar, is it plausible that its
+  default value may change in the future? If so, it should be wrapped with
+  a Well-Known Type (WKT), e.g. `bool` becomes `google.protobuf.BoolValue`.
 
 ## Style
 - Is the PR aligned with the [API style guidelines](STYLE.md)?


### PR DESCRIPTION
For various features or security fixes, we have used proto3 fields to
control enablement. These have often been scalar fields and default
disabled due to potential data plane breakages. When the time comes for
these to be default enabled, there is no way to do this client-side
without API breaking changes.

This change to API style encourages use of WKTs for scalars in this
situation, since they can have defaults changes on a per-xDS client
basis without any API breaking change.

Signed-off-by: Harvey Tuch <htuch@google.com>