### PR TITLE
lua: Add setting to skip sampling HTTP call trace span

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -390,16 +390,48 @@ httpCall()
 
 .. code-block:: lua
 
-  local headers, body = handle:httpCall(cluster, headers, body, timeout, asynchronous)
+  local headers, body = handle:httpCall(cluster, headers, body, timeout_ms, asynchronous)
+
+  -- Alternative function signature.
+  local headers, body = handle:httpCall(cluster, headers, body, request_options)
 
 Makes an HTTP call to an upstream host. *cluster* is a string which maps to a configured cluster manager cluster. *headers*
 is a table of key/value pairs to send (the value can be a string or table of strings). Note that
 the *:method*, *:path*, and *:authority* headers must be set. *body* is an optional string of body
-data to send. *timeout* is an integer that specifies the call timeout in milliseconds.
+data to send. *timeout_ms* is an integer that specifies the call timeout in milliseconds.
 
 *asynchronous* is a boolean flag. If asynchronous is set to true, Envoy will make the HTTP request and continue,
 regardless of the response success or failure. If this is set to false, or not set, Envoy will suspend executing the script
 until the call completes or has an error.
+
+The alternative function signature allows caller to specify *request_options* as a table. Currently,
+the supported keys are:
+
+- *asynchronous* is a boolean flag that controls the asynchronicity of the HTTP call.
+  It refers to the same *asynchronous* flag as the first function signature.
+- *timeout_ms* is an integer that specifies the call timeout in milliseconds.
+  It refers to the same *timeout_ms* argument as the first function signature.
+- *sampled* is a boolean flag that decides whether the produced trace span will be sampled or not.
+
+Some examples of specifying *request_options* are shown below:
+
+.. code-block:: lua
+
+  -- Create a fire-and-forget HTTP call.
+  local request_options = {["asynchronous"] = true}
+
+  -- Create a synchronous HTTP call with 1000 ms timeout.
+  local request_options = {["timeout_ms"] = 1000}
+
+  -- Create a synchronous HTTP call, but do not sample the trace span.
+  local request_options = {["sampled"] = false}
+
+  -- The same as above, but explicitly set the "asynchronous" flag to false.
+  local request_options = {["asynchronous"] = false, ["sampled"] = false }
+
+  -- The same as above, but with 1000 ms timeout.
+  local request_options = {["asynchronous"] = false, ["sampled"] = false }
+
 
 Returns *headers* which is a table of response headers. Returns *body* which is the string response
 body. May be nil if there is no body.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -125,6 +125,7 @@ New Features
 * json: introduced new JSON parser (https://github.com/nlohmann/json) to replace RapidJSON. The new parser is disabled by default. To test the new RapidJSON parser, enable the runtime feature `envoy.reloadable_features.remove_legacy_json`.
 * kill_request: :ref:`Kill Request <config_http_filters_kill_request>` Now supports bidirection killing.
 * log: added a new custom flag ``%j`` to the log pattern to print the actual message to log as JSON escaped string.
+* lua filter: added an alternative function signature to `httpCall()` with `request_options` as an argument. This allows to skip sampling the produced trace span by setting `{["sampled"] = false}` as the `request_options`.
 * oauth filter: added the optional parameter :ref:`resources <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.resources>`. Set this value to add multiple "resource" parameters in the Authorization request sent to the OAuth provider. This acts as an identifier representing the protected resources the client is requesting a token for.
 * original_dst: added support for :ref:`Original Destination <config_listener_filters_original_dst>` on Windows. This enables the use of Envoy as a sidecar proxy on Windows.
 * overload: add support for scaling :ref:`transport connection timeouts<envoy_v3_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.TRANSPORT_SOCKET_CONNECT>`. This can be used to reduce the TLS handshake timeout in response to overload.

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -277,8 +277,10 @@ private:
    */
   DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBase64Escape);
 
-  int doSynchronousHttpCall(lua_State* state, Tracing::Span& span);
-  int doAsynchronousHttpCall(lua_State* state, Tracing::Span& span);
+  int doSynchronousHttpCall(lua_State* state, Tracing::Span& span,
+                            Http::AsyncClient::RequestOptions& request_options);
+  int doAsynchronousHttpCall(lua_State* state, Tracing::Span& span,
+                             Http::AsyncClient::RequestOptions& request_options);
 
   // Filters::Common::Lua::BaseLuaObject
   void onMarkDead() override {


### PR DESCRIPTION
Commit Message: This patch allows skipping sampling of the `httpCall()` produced trace span by accepting a table as the last argument of an `httpCall()`. Therefore, `httpCall()` last argument can be omitted, provided with a boolean value, or a table. A sample of a table to be supplied as an arg to `httpCall()` is as follows:

```lua
{
  ["asynchronous"] = false,
  ["sampled"] = false,
  ["timeout_ms"] = 1000
}
``` 


Risk Level: Low, since the current behavior is preserved.
Testing: Added.
Docs Changes: Updated.
Release Notes: Added
Platform-Specific Features: N/A
Fixes #14785

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>
