### PR TITLE
lds: ASAN repro of heap-use-after-free in LDS and a single character fix

### DIFF
--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -77,7 +77,7 @@ private:
   Network::Socket::Type socket_type_;
   const Network::Socket::OptionsSharedPtr options_;
   bool bind_to_port_;
-  const std::string& listener_name_;
+  const std::string listener_name_;
   const bool reuse_port_;
   Network::SocketSharedPtr socket_;
   absl::once_flag steal_once_;

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -14,6 +14,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/resources.h"
 
+#include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -255,6 +256,77 @@ TEST_P(ListenerIntegrationTest, BasicSuccess) {
   verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ(request_size, upstream_request_->bodyLength());
+}
+
+// This test updates the same listener multiple times to catch problems that
+// may exist in the shared ListenSocketFactory. e.g. ListenSocketFactory holding
+// stale reference to members of the first listener.
+TEST_P(ListenerIntegrationTest, MultipleLdsUpdatesSharingListenSocketFactory) {
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    // Set reuse_port so that a new socket is created by the
+    // ListenSocketFactory.
+    listener_config_.set_reuse_port(true);
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "1");
+    createRdsStream(route_table_name_);
+  };
+  initialize();
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 1);
+  // testing-listener-0 is not initialized as we haven't pushed any RDS yet.
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
+  // Workers not started, the LDS added listener 0 is in active_listeners_ list.
+  EXPECT_EQ(test_server_->server().listenerManager().listeners().size(), 1);
+  registerTestServerPorts({listener_name_});
+
+  const std::string route_config_tmpl = R"EOF(
+      name: {}
+      virtual_hosts:
+      - name: integration
+        domains: ["*"]
+        routes:
+        - match: {{ prefix: "/" }}
+          route: {{ cluster: {} }}
+)EOF";
+  sendRdsResponse(fmt::format(route_config_tmpl, route_table_name_, "cluster_0"), "1");
+  test_server_->waitForCounterGe(
+      fmt::format("http.config_test.rds.{}.update_success", route_table_name_), 1);
+  // Now testing-listener-0 finishes initialization, Server initManager will be ready.
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initialized);
+
+  test_server_->waitUntilListenersReady();
+  // NOTE: The line above doesn't tell you if listener is up and listening.
+  test_server_->waitForCounterGe("listener_manager.listener_create_success", 1);
+  // Make a connection to the listener from version 1.
+  codec_client_ = makeHttpConnection(lookupPort(listener_name_));
+
+  for (int version = 2; version <= 10; version++) {
+    // Touch the metadata to get a different hash.
+    (*(*listener_config_.mutable_metadata()->mutable_filter_metadata())["random_filter_name"]
+          .mutable_fields())["random_key"]
+        .set_number_value(version);
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)},
+                    absl::StrCat(version));
+    sendRdsResponse(fmt::format(route_config_tmpl, route_table_name_, "cluster_0"),
+                    absl::StrCat(version));
+
+    test_server_->waitForCounterGe("listener_manager.listener_create_success", version);
+
+    // Wait for the client to be disconnected.
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+    // Make a new connection to the new listener.
+    codec_client_ = makeHttpConnection(lookupPort(listener_name_));
+    int response_size = 800;
+    int request_size = 10;
+    Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                     {"server_id", "cluster_0, backend_0"}};
+    auto response = sendRequestAndWaitForResponse(
+        Http::TestResponseHeaderMapImpl{
+            {":method", "GET"}, {":path", "/"}, {":authority", "host"}, {":scheme", "http"}},
+        request_size, response_headers, response_size, /*cluster_0*/ 0);
+    verifyResponse(std::move(response), "200", response_headers, std::string(response_size, 'a'));
+    EXPECT_TRUE(upstream_request_->complete());
+    EXPECT_EQ(request_size, upstream_request_->bodyLength());
+  }
 }
 
 } // namespace

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -315,8 +315,8 @@ TEST_P(ListenerIntegrationTest, MultipleLdsUpdatesSharingListenSocketFactory) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
     // Make a new connection to the new listener.
     codec_client_ = makeHttpConnection(lookupPort(listener_name_));
-    int response_size = 800;
-    int request_size = 10;
+    const uint32_t response_size = 800;
+    const uint32_t request_size = 10;
     Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
                                                      {"server_id", "cluster_0, backend_0"}};
     auto response = sendRequestAndWaitForResponse(


### PR DESCRIPTION
Signed-off-by: pengg <pengg@google.com>

Commit Message: Fix a heap-use-after-free in LDS
Additional Description: ListenSocketFactoryImpl stores a const std::string& to the first Listener, which is destructed upon LDS update. When reuse_port is enabled, ListenSocketFactoryImpl reads the stale reference which may be a huge garbage string depending on where std::string::size() is aligned to the garbage memory region.
Risk Level: Low
Testing: Integration with ASAN to reproduce
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
