### PR TITLE
matching: pass FactoryContext to all factories

### DIFF
--- a/include/envoy/matcher/matcher.h
+++ b/include/envoy/matcher/matcher.h
@@ -13,6 +13,12 @@
 #include "absl/types/optional.h"
 
 namespace Envoy {
+
+namespace Server {
+namespace Configuration {
+class FactoryContext;
+}
+} // namespace Server
 namespace Matcher {
 
 // This file describes a MatchTree<DataType>, which traverses a tree of matches until it
@@ -71,7 +77,9 @@ using ActionFactoryCb = std::function<ActionPtr()>;
 
 class ActionFactory : public Config::TypedFactory {
 public:
-  virtual ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config) PURE;
+  virtual ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config,
+                        Server::Configuration::FactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.action"; }
 };
@@ -143,7 +151,9 @@ using InputMatcherPtr = std::unique_ptr<InputMatcher>;
  */
 class InputMatcherFactory : public Config::TypedFactory {
 public:
-  virtual InputMatcherPtr createInputMatcher(const Protobuf::Message& config) PURE;
+  virtual InputMatcherPtr
+  createInputMatcher(const Protobuf::Message& config,
+                     Server::Configuration::FactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.input_matcher"; }
 };
@@ -212,7 +222,7 @@ public:
    */
   virtual DataInputPtr<DataType>
   createDataInput(const Protobuf::Message& config,
-                  ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+                  Server::Configuration::FactoryContext& factory_context) PURE;
 
   /**
    * The category of this factory depends on the DataType, so we require a name() function to exist

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -111,9 +111,9 @@ public:
 
   Matcher::DataInputPtr<HttpMatchingData>
   createDataInput(const Protobuf::Message& config,
-                  ProtobufMessage::ValidationVisitor& validation_visitor) override {
-    const auto& typed_config =
-        MessageUtil::downcastAndValidate<const ProtoType&>(config, validation_visitor);
+                  Server::Configuration::FactoryContext& factory_context) override {
+    const auto& typed_config = MessageUtil::downcastAndValidate<const ProtoType&>(
+        config, factory_context.messageValidationVisitor());
 
     return std::make_unique<DataInputType>(typed_config.header_name());
   };
@@ -186,7 +186,8 @@ using FilterMatchStateSharedPtr = std::shared_ptr<FilterMatchState>;
 class SkipActionFactory : public Matcher::ActionFactory {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&) override {
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&,
+                                                 Server::Configuration::FactoryContext&) override {
     return []() { return std::make_unique<SkipAction>(); };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/common/http/match_wrapper/config.cc
+++ b/source/common/http/match_wrapper/config.cc
@@ -64,9 +64,8 @@ Envoy::Http::FilterFactoryCb MatchWrapperConfig::createFilterFactoryFromProtoTyp
       proto_config.extension_config().typed_config(), context.messageValidationVisitor(), factory);
   auto filter_factory = factory.createFilterFactoryFromProto(*message, prefix, context);
 
-  auto match_tree =
-      Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData>(context.messageValidationVisitor())
-          .create(proto_config.matcher());
+  auto match_tree = Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData>(context).create(
+      proto_config.matcher());
 
   return [filter_factory, match_tree](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
     DelegatingFactoryCallbacks delegated_callbacks(callbacks, match_tree);

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -11,6 +11,7 @@
 #include "common/protobuf/utility.h"
 
 #include "test/common/matcher/test_utility.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
@@ -24,6 +25,7 @@ public:
 
   StringActionFactory action_factory_;
   Registry::InjectFactory<ActionFactory> inject_action_;
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
 };
 
 TEST_F(MatcherTest, TestMatcher) {
@@ -60,7 +62,7 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory(ProtobufMessage::getStrictValidationVisitor());
+  MatchTreeFactory<TestData> factory(factory_context_);
 
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
@@ -99,7 +101,7 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory(ProtobufMessage::getStrictValidationVisitor());
+  MatchTreeFactory<TestData> factory(factory_context_);
 
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
   NeverMatchFactory match_factory;
@@ -154,7 +156,7 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory(ProtobufMessage::getStrictValidationVisitor());
+  MatchTreeFactory<TestData> factory(factory_context_);
 
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
@@ -210,7 +212,7 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory(ProtobufMessage::getStrictValidationVisitor());
+  MatchTreeFactory<TestData> factory(factory_context_);
 
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
@@ -260,7 +262,7 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory(ProtobufMessage::getStrictValidationVisitor());
+  MatchTreeFactory<TestData> factory(factory_context_);
 
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -31,7 +31,7 @@ public:
       : factory_name_(std::string(factory_name)), value_(std::string(data)), injection_(*this) {}
 
   DataInputPtr<TestData> createDataInput(const Protobuf::Message&,
-                                         ProtobufMessage::ValidationVisitor&) override {
+                                         Server::Configuration::FactoryContext&) override {
     return std::make_unique<TestInput>(
         DataInputGetResult{DataInputGetResult::DataAvailability::AllDataAvailable, value_});
   }
@@ -78,7 +78,8 @@ struct StringAction : public ActionBase<ProtobufWkt::StringValue> {
 // Factory for StringAction.
 class StringActionFactory : public ActionFactory {
 public:
-  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config) override {
+  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config,
+                                        Server::Configuration::FactoryContext&) override {
     const auto& string = dynamic_cast<const ProtobufWkt::StringValue&>(config);
     return [string]() { return std::make_unique<StringAction>(string.value()); };
   }
@@ -102,7 +103,8 @@ class NeverMatchFactory : public InputMatcherFactory {
 public:
   NeverMatchFactory() : inject_factory_(*this) {}
 
-  InputMatcherPtr createInputMatcher(const Protobuf::Message&) override {
+  InputMatcherPtr createInputMatcher(const Protobuf::Message&,
+                                     Server::Configuration::FactoryContext&) override {
     return std::make_unique<NeverMatch>();
   }
 


### PR DESCRIPTION
This is more consistent with other factories and allows the factory idiomatic access to stuff like the validation context.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
