### PR TITLE
Add a cluster metadata access logger formatter

### DIFF
--- a/docs/root/configuration/observability/access_log/usage.rst
+++ b/docs/root/configuration/observability/access_log/usage.rst
@@ -456,6 +456,34 @@ The following command operators are supported:
     JSON struct or list is rendered. Structs and lists may be nested. In any event, the maximum
     length is ignored
 
+%CLUSTER_METADATA(NAMESPACE:KEY*):Z%
+  HTTP
+    :ref:`Upstream cluster Metadata <envoy_v3_api_msg_config.core.v3.Metadata>` info,
+    where NAMESPACE is the filter namespace used when setting the metadata, KEY is an optional
+    lookup up key in the namespace with the option of specifying nested keys separated by ':',
+    and Z is an optional parameter denoting string truncation up to Z characters long. The data
+    will be logged as a JSON string. For example, for the following dynamic metadata:
+
+    ``com.test.my_filter: {"test_key": "foo", "test_object": {"inner_key": "bar"}}``
+
+    * %CLUSTER_METADATA(com.test.my_filter)% will log: ``{"test_key": "foo", "test_object": {"inner_key": "bar"}}``
+    * %CLUSTER_METADATA(com.test.my_filter:test_key)% will log: ``"foo"``
+    * %CLUSTER_METADATA(com.test.my_filter:test_object)% will log: ``{"inner_key": "bar"}``
+    * %CLUSTER_METADATA(com.test.my_filter:test_object:inner_key)% will log: ``"bar"``
+    * %CLUSTER_METADATA(com.unknown_filter)% will log: ``-``
+    * %CLUSTER_METADATA(com.test.my_filter:unknown_key)% will log: ``-``
+    * %CLUSTER_METADATA(com.test.my_filter):25% will log (truncation at 25 characters): ``{"test_key": "foo", "test``
+
+  TCP
+    Not implemented ("-").
+
+  .. note::
+
+    For typed JSON logs, this operator renders a single value with string, numeric, or boolean type
+    when the referenced key is a simple value. If the referenced key is a struct or list value, a
+    JSON struct or list is rendered. Structs and lists may be nested. In any event, the maximum
+    length is ignored
+
 .. _config_access_log_format_filter_state:
 
 %FILTER_STATE(KEY:F):Z%
@@ -464,8 +492,8 @@ The following command operators are supported:
     look up the filter state object. The serialized proto will be logged as JSON string if possible.
     If the serialized proto is unknown to Envoy it will be logged as protobuf debug string.
     Z is an optional parameter denoting string truncation up to Z characters long.
-    F is an optional parameter used to indicate which method FilterState uses for serialization. 
-    If 'PLAIN' is set, the filter state object will be serialized as an unstructured string. 
+    F is an optional parameter used to indicate which method FilterState uses for serialization.
+    If 'PLAIN' is set, the filter state object will be serialized as an unstructured string.
     If 'TYPED' is set or no F provided, the filter state object will be serialized as an JSON string.
 
   TCP

--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
         "//include/envoy/api:api_interface",
         "//include/envoy/formatter:substitution_formatter_interface",
         "//include/envoy/stream_info:stream_info_interface",
+        "//include/envoy/upstream:upstream_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:datasource_lib",

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1182,8 +1182,8 @@ absl::optional<std::string> ClusterMetadataFormatter::format(
     const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
     const StreamInfo::StreamInfo& stream_info, absl::string_view) const {
   auto cluster_info = stream_info.upstreamClusterInfo();
-  if (!cluster_info.has_value()) {
-    return {};
+  if (!cluster_info.has_value() || cluster_info.value().get() == nullptr) {
+    return absl::nullopt;
   }
   return MetadataFormatter::formatMetadata(cluster_info.value()->metadata());
 }
@@ -1194,8 +1194,9 @@ ProtobufWkt::Value ClusterMetadataFormatter::formatValue(const Http::RequestHead
                                                          const StreamInfo::StreamInfo& stream_info,
                                                          absl::string_view) const {
   auto cluster_info = stream_info.upstreamClusterInfo();
-  if (!cluster_info.has_value()) {
-    return {};
+  if (!cluster_info.has_value() || cluster_info.value().get() == nullptr) {
+    // Let the formatter do its thing with empty metadata.
+    return MetadataFormatter::formatMetadataValue(envoy::config::core::v3::Metadata());
   }
   return MetadataFormatter::formatMetadataValue(cluster_info.value()->metadata());
 }

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -1182,7 +1182,7 @@ absl::optional<std::string> ClusterMetadataFormatter::format(
     const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
     const StreamInfo::StreamInfo& stream_info, absl::string_view) const {
   auto cluster_info = stream_info.upstreamClusterInfo();
-  if (!cluster_info.has_value() || cluster_info.value().get() == nullptr) {
+  if (!cluster_info.has_value() || cluster_info.value() == nullptr) {
     return absl::nullopt;
   }
   return MetadataFormatter::formatMetadata(cluster_info.value()->metadata());
@@ -1194,7 +1194,7 @@ ProtobufWkt::Value ClusterMetadataFormatter::formatValue(const Http::RequestHead
                                                          const StreamInfo::StreamInfo& stream_info,
                                                          absl::string_view) const {
   auto cluster_info = stream_info.upstreamClusterInfo();
-  if (!cluster_info.has_value() || cluster_info.value().get() == nullptr) {
+  if (!cluster_info.has_value() || cluster_info.value() == nullptr) {
     // Let the formatter do its thing with empty metadata.
     return MetadataFormatter::formatMetadataValue(envoy::config::core::v3::Metadata());
   }

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/upstream/upstream.h"
 
 #include "common/api/os_sys_calls_impl.h"
 #include "common/common/assert.h"
@@ -361,6 +362,7 @@ std::vector<FormatterProviderPtr> SubstitutionFormatParser::parse(const std::str
 
 FormatterProviderPtr SubstitutionFormatParser::parseBuiltinCommand(const std::string& token) {
   static constexpr absl::string_view DYNAMIC_META_TOKEN{"DYNAMIC_METADATA("};
+  static constexpr absl::string_view CLUSTER_META_TOKEN{"CLUSTER_METADATA("};
   static constexpr absl::string_view FILTER_STATE_TOKEN{"FILTER_STATE("};
   static constexpr absl::string_view PLAIN_SERIALIZATION{"PLAIN"};
   static constexpr absl::string_view TYPED_SERIALIZATION{"TYPED"};
@@ -396,6 +398,14 @@ FormatterProviderPtr SubstitutionFormatParser::parseBuiltinCommand(const std::st
 
     parseCommand(token, start, ":", filter_namespace, path, max_length);
     return std::make_unique<DynamicMetadataFormatter>(filter_namespace, path, max_length);
+  } else if (absl::StartsWith(token, CLUSTER_META_TOKEN)) {
+    std::string filter_namespace;
+    absl::optional<size_t> max_length;
+    std::vector<std::string> path;
+    const size_t start = CLUSTER_META_TOKEN.size();
+
+    parseCommand(token, start, ":", filter_namespace, path, max_length);
+    return std::make_unique<ClusterMetadataFormatter>(filter_namespace, path, max_length);
   } else if (absl::StartsWith(token, FILTER_STATE_TOKEN)) {
     std::string key;
     absl::optional<size_t> max_length;
@@ -1161,6 +1171,33 @@ ProtobufWkt::Value DynamicMetadataFormatter::formatValue(const Http::RequestHead
                                                          const StreamInfo::StreamInfo& stream_info,
                                                          absl::string_view) const {
   return MetadataFormatter::formatMetadataValue(stream_info.dynamicMetadata());
+}
+
+ClusterMetadataFormatter::ClusterMetadataFormatter(const std::string& filter_namespace,
+                                                   const std::vector<std::string>& path,
+                                                   absl::optional<size_t> max_length)
+    : MetadataFormatter(filter_namespace, path, max_length) {}
+
+absl::optional<std::string> ClusterMetadataFormatter::format(
+    const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&, const Http::ResponseTrailerMap&,
+    const StreamInfo::StreamInfo& stream_info, absl::string_view) const {
+  auto cluster_info = stream_info.upstreamClusterInfo();
+  if (!cluster_info.has_value()) {
+    return {};
+  }
+  return MetadataFormatter::formatMetadata(cluster_info.value()->metadata());
+}
+
+ProtobufWkt::Value ClusterMetadataFormatter::formatValue(const Http::RequestHeaderMap&,
+                                                         const Http::ResponseHeaderMap&,
+                                                         const Http::ResponseTrailerMap&,
+                                                         const StreamInfo::StreamInfo& stream_info,
+                                                         absl::string_view) const {
+  auto cluster_info = stream_info.upstreamClusterInfo();
+  if (!cluster_info.has_value()) {
+    return {};
+  }
+  return MetadataFormatter::formatMetadataValue(cluster_info.value()->metadata());
 }
 
 FilterStateFormatter::FilterStateFormatter(const std::string& key,

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -431,6 +431,23 @@ public:
 };
 
 /**
+ * FormatterProvider for ClusterMetadata from StreamInfo.
+ */
+class ClusterMetadataFormatter : public FormatterProvider, MetadataFormatter {
+public:
+  ClusterMetadataFormatter(const std::string& filter_namespace,
+                           const std::vector<std::string>& path, absl::optional<size_t> max_length);
+
+  // FormatterProvider
+  absl::optional<std::string> format(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                     const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&,
+                                     absl::string_view) const override;
+  ProtobufWkt::Value formatValue(const Http::RequestHeaderMap&, const Http::ResponseHeaderMap&,
+                                 const Http::ResponseTrailerMap&, const StreamInfo::StreamInfo&,
+                                 absl::string_view) const override;
+};
+
+/**
  * FormatterProvider for FilterState from StreamInfo.
  */
 class FilterStateFormatter : public FormatterProvider {

--- a/test/common/formatter/BUILD
+++ b/test/common/formatter/BUILD
@@ -59,6 +59,7 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
+        "//test/mocks/upstream:cluster_info_mocks",
         "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -2005,7 +2005,7 @@ TEST(SubstitutionFormatterTest, StructFormatterClusterMetadataTest) {
     test_key: '%CLUSTER_METADATA(com.test:test_key)%'
     test_obj: '%CLUSTER_METADATA(com.test:test_obj)%'
     test_obj.inner_key: '%CLUSTER_METADATA(com.test:test_obj:inner_key)%'
-    test_obj.non_key: '%CLUSTER_METADATA(com.test:test_obj:non_existing_key)%'
+    test_obj.non_existing_key: '%CLUSTER_METADATA(com.test:test_obj:non_existing_key)%'
   )EOF",
                             key_mapping);
   StructFormatter formatter(key_mapping, false, false);
@@ -2013,6 +2013,72 @@ TEST(SubstitutionFormatterTest, StructFormatterClusterMetadataTest) {
   verifyStructOutput(
       formatter.format(request_header, response_header, response_trailer, stream_info, body),
       expected_json_map);
+}
+
+TEST(SubstitutionFormatterTest, StructFormatterTypedClusterMetadataTest) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
+  Http::TestResponseTrailerMapImpl response_trailer{{"third", "POST"}, {"test-2", "test-2"}};
+  std::string body;
+
+  envoy::config::core::v3::Metadata metadata;
+  populateMetadataTestData(metadata);
+  absl::optional<std::shared_ptr<NiceMock<Upstream::MockClusterInfo>>> cluster =
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  EXPECT_CALL(**cluster, metadata()).WillRepeatedly(ReturnRef(metadata));
+  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
+  EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
+
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%CLUSTER_METADATA(com.test:test_key)%'
+    test_obj: '%CLUSTER_METADATA(com.test:test_obj)%'
+    test_obj.inner_key: '%CLUSTER_METADATA(com.test:test_obj:inner_key)%'
+  )EOF",
+                            key_mapping);
+  StructFormatter formatter(key_mapping, true, false);
+
+  ProtobufWkt::Struct output =
+      formatter.format(request_header, response_header, response_trailer, stream_info, body);
+
+  const auto& fields = output.fields();
+  EXPECT_EQ("test_value", fields.at("test_key").string_value());
+  EXPECT_EQ("inner_value", fields.at("test_obj.inner_key").string_value());
+  EXPECT_EQ("inner_value",
+            fields.at("test_obj").struct_value().fields().at("inner_key").string_value());
+}
+
+TEST(SubstitutionFormatterTest, StructFormatterClusterMetadataNoClusterInfoTest) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
+  Http::TestResponseTrailerMapImpl response_trailer{{"third", "POST"}, {"test-2", "test-2"}};
+  std::string body;
+
+  absl::node_hash_map<std::string, std::string> expected_json_map = {{"test_key", "-"}};
+
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%CLUSTER_METADATA(com.test:test_key)%'
+  )EOF",
+                            key_mapping);
+  StructFormatter formatter(key_mapping, false, false);
+
+  // Empty optional (absl::nullopt)
+  {
+    EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
+    verifyStructOutput(
+        formatter.format(request_header, response_header, response_trailer, stream_info, body),
+        expected_json_map);
+  }
+  // Empty cluster info (nullptr)
+  {
+    EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillOnce(Return(nullptr));
+    verifyStructOutput(
+        formatter.format(request_header, response_header, response_trailer, stream_info, body),
+        expected_json_map);
+  }
 }
 
 TEST(SubstitutionFormatterTest, StructFormatterFilterStateTest) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -14,11 +14,13 @@
 #include "common/protobuf/utility.h"
 #include "common/router/string_accessor_impl.h"
 
+#include "envoy/stream_info/stream_info.h"
 #include "test/common/formatter/command_extension.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/upstream/cluster_info.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
@@ -30,6 +32,7 @@ using testing::Const;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
+using testing::ReturnPointee;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -1973,6 +1976,43 @@ TEST(SubstitutionFormatterTest, StructFormatterTypedDynamicMetadataTest) {
   EXPECT_EQ("inner_value", fields.at("test_obj.inner_key").string_value());
   EXPECT_EQ("inner_value",
             fields.at("test_obj").struct_value().fields().at("inner_key").string_value());
+}
+
+TEST(SubstitutionFormatterTest, StructFormatterClusterMetadataTest) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
+  Http::TestResponseTrailerMapImpl response_trailer{{"third", "POST"}, {"test-2", "test-2"}};
+  std::string body;
+
+  envoy::config::core::v3::Metadata metadata;
+  populateMetadataTestData(metadata);
+  absl::optional<std::shared_ptr<NiceMock<Upstream::MockClusterInfo>>> cluster =
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  EXPECT_CALL(**cluster, metadata()).WillRepeatedly(ReturnRef(metadata));
+  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
+  EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
+
+  absl::node_hash_map<std::string, std::string> expected_json_map = {
+      {"test_key", "\"test_value\""},
+      {"test_obj", "{\"inner_key\":\"inner_value\"}"},
+      {"test_obj.inner_key", "\"inner_value\""},
+      {"test_obj.non_existing_key", "-"},
+  };
+
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    test_key: '%CLUSTER_METADATA(com.test:test_key)%'
+    test_obj: '%CLUSTER_METADATA(com.test:test_obj)%'
+    test_obj.inner_key: '%CLUSTER_METADATA(com.test:test_obj:inner_key)%'
+    test_obj.non_key: '%CLUSTER_METADATA(com.test:test_obj:non_existing_key)%'
+  )EOF",
+                            key_mapping);
+  StructFormatter formatter(key_mapping, false, false);
+
+  verifyStructOutput(
+      formatter.format(request_header, response_header, response_trailer, stream_info, body),
+      expected_json_map);
 }
 
 TEST(SubstitutionFormatterTest, StructFormatterFilterStateTest) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/stream_info/stream_info.h"
 
 #include "common/common/logger.h"
 #include "common/common/utility.h"
@@ -14,7 +15,6 @@
 #include "common/protobuf/utility.h"
 #include "common/router/string_accessor_impl.h"
 
-#include "envoy/stream_info/stream_info.h"
 #include "test/common/formatter/command_extension.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"


### PR DESCRIPTION
Commit Message: Add cluster metadata access logger formatter
Additional Description: Allows logging cluster metadata by using CLUSTER_METADATA(...)
Risk Level: Low (adding a new feature)
Testing: Unit tests
Docs Changes: Added documentation in docs/root/configuration/observability/access_log/usage.rst (very similar to the DYNAMIC_METADATA)
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]

@omriz 