### PR TITLE
tcp_proxy: explicitly supporting upstream-write-first semantics in the new pool

### DIFF
--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -197,7 +197,8 @@ public:
     const char* spaces = spacesForLevel(indent_level);
     os << spaces << "ConnPoolImplBase " << this << DUMP_MEMBER(ready_clients_.size())
        << DUMP_MEMBER(busy_clients_.size()) << DUMP_MEMBER(connecting_clients_.size())
-       << DUMP_MEMBER(connecting_stream_capacity_) << DUMP_MEMBER(num_active_streams_);
+       << DUMP_MEMBER(connecting_stream_capacity_) << DUMP_MEMBER(num_active_streams_)
+       << DUMP_MEMBER(pending_streams_.size());
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ConnPoolImplBase& s) {
@@ -206,7 +207,6 @@ public:
   }
 
 protected:
-  // Creates up to 3 connections, based on the preconnect ratio.
   virtual void onConnected(Envoy::ConnectionPool::ActiveClient&) {}
 
   enum class ConnectionResult {

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -50,6 +50,7 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
 
   Upstream::Host::CreateConnectionData data{std::move(tcp_client->connection_),
                                             client.real_host_description_};
+  data.connection_->readDisable(false);
   data.connection_->removeConnectionCallbacks(*tcp_client);
   data.connection_->removeReadFilter(tcp_client->read_filter_handle_);
   dispatcher_.deferredDelete(client.removeFromList(owningList(client.state_)));

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -50,6 +50,9 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
 
   Upstream::Host::CreateConnectionData data{std::move(tcp_client->connection_),
                                             client.real_host_description_};
+  // As this connection comes from the tcp connection pool, it will be
+  // read-disabled to handle TCP traffic where upstream sends data first. Undo
+  // this as it is not necessary for HTTP/HTTPS.
   data.connection_->readDisable(false);
   data.connection_->removeConnectionCallbacks(*tcp_client);
   data.connection_->removeReadFilter(tcp_client->read_filter_handle_);

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -24,7 +24,6 @@ ActiveTcpClient::ActiveTcpClient(Envoy::ConnectionPool::ConnPoolImplBase& parent
   real_host_description_ = data.host_description_;
   connection_ = std::move(data.connection_);
   connection_->addConnectionCallbacks(*this);
-  connection_->detectEarlyCloseWhenReadDisabled(false);
   read_filter_handle_ = std::make_shared<ConnReadFilter>(*this);
   connection_->addReadFilter(read_filter_handle_);
   connection_->setConnectionStats({host->cluster().stats().upstream_cx_rx_bytes_total_,
@@ -63,6 +62,13 @@ void ActiveTcpClient::clearCallbacks() {
 }
 
 void ActiveTcpClient::onEvent(Network::ConnectionEvent event) {
+  // If this is a newly established TCP connection, readDisable. This is to handle a race condition
+  // for TCP for protocols like MySQL where the upstream writes first, and the data needs to be
+  // preserved until a downstream connection is associated.
+  // This is also necessary for prefetch to be used with such protocols.
+  if (event == Network::ConnectionEvent::Connected) {
+    connection_->readDisable(true);
+  }
   Envoy::ConnectionPool::ActiveClient::onEvent(event);
   if (callbacks_) {
     // Do not pass the Connected event to any session which registered during onEvent above.

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -97,6 +97,9 @@ public:
   // Undo the readDisable done in onEvent(Connected) - now that there is an associated connection,
   // drain any data.
   void readEnableIfNew() {
+    // It is expected for Envoy use of ActiveTcpClient this function only be
+    // called once. Other users of the TcpConnPool may recycle Tcp connections,
+    // and this safeguards them against read-enabling too many times.
     if (!associated_before_) {
       associated_before_ = true;
       connection_->readDisable(false);

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -128,7 +128,6 @@ public:
   ConnectionPool::ConnectionStatePtr connection_state_;
   TcpConnectionData* tcp_connection_data_{};
   bool associated_before_{};
-
 };
 
 class ConnPoolImpl : public Envoy::ConnectionPool::ConnPoolImplBase,

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -321,6 +321,7 @@ public:
     EXPECT_CALL(*connection_, setConnectionStats(_));
     EXPECT_CALL(*connection_, streamInfo()).Times(2);
     EXPECT_CALL(*connection_, id()).Times(AnyNumber());
+    EXPECT_CALL(*connection_, readDisable(_)).Times(AnyNumber());
 
     connect_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
     EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillOnce(Return(connection_));

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -633,7 +633,7 @@ AssertionResult FakeUpstream::waitForRawConnection(FakeRawConnectionPtr& connect
 
   return runOnDispatcherThreadAndWait([&]() {
     absl::MutexLock lock(&lock_);
-    connection = std::make_unique<FakeRawConnection>(consumeConnection(), timeSystem());
+    connection = makeRawConnection(consumeConnection(), timeSystem());
     connection->initialize();
     // Skip enableHalfClose if the connection is already disconnected.
     if (connection->connected()) {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -579,6 +579,11 @@ public:
     return socket_->addressProvider().localAddress();
   }
 
+  virtual std::unique_ptr<FakeRawConnection> makeRawConnection(
+      SharedConnectionWrapper& shared_connection, Event::TestTimeSystem& time_system){
+    return std::make_unique<FakeRawConnection>(shared_connection, time_system);
+  }
+
   // Wait for one of the upstreams to receive a connection
   ABSL_MUST_USE_RESULT
   static testing::AssertionResult

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -579,8 +579,9 @@ public:
     return socket_->addressProvider().localAddress();
   }
 
-  virtual std::unique_ptr<FakeRawConnection> makeRawConnection(
-      SharedConnectionWrapper& shared_connection, Event::TestTimeSystem& time_system){
+  virtual std::unique_ptr<FakeRawConnection>
+  makeRawConnection(SharedConnectionWrapper& shared_connection,
+                    Event::TestTimeSystem& time_system) {
     return std::make_unique<FakeRawConnection>(shared_connection, time_system);
   }
 

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1404,6 +1404,8 @@ TEST_P(MysqlIntegrationTest, UpstreamWritesFirst) {
 
 // Make sure that with the connection read disabled, that disconnect detection
 // works.
+// Early close notification does not work for OSX
+#if !defined(__APPLE__)
 TEST_P(MysqlIntegrationTest, DisconnectDetected) {
   // Switch to per-upstream preconnect.
   perUpstreamPreconnect();
@@ -1422,6 +1424,7 @@ TEST_P(MysqlIntegrationTest, DisconnectDetected) {
 
   tcp_client->close();
 }
+#endif
 
 void MysqlIntegrationTest::testPreconnect() {
   globalPreconnect();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1381,7 +1381,7 @@ public:
   void testPreconnect();
 };
 
-// This just verifies that FakeMysqlUpstream works as advertized, and the early data
+// This just verifies that FakeMysqlUpstream works as advertised, and the early data
 // makes it to the client.
 TEST_P(MysqlIntegrationTest, UpstreamWritesFirst) {
   globalPreconnect();

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1312,7 +1312,7 @@ class FakeMysqlUpstream : public FakeUpstream {
   using FakeUpstream::FakeUpstream;
 
   bool createNetworkFilterChain(Network::Connection& connection,
-                                const std::vector<Network::FilterFactoryCb>& cb) {
+                                const std::vector<Network::FilterFactoryCb>& cb) override {
     Buffer::OwnedImpl to_write("P");
     connection.write(to_write, false);
     return FakeUpstream::createNetworkFilterChain(connection, cb);


### PR DESCRIPTION
Additional Description:
Both the old and the new TCP proxy pools register for "unexpected data" and disconnect when receiving it.  It appears that generally the timing works out in the old pool that the connection gets assigned right away, but the new pool doesn't pass the race deterministically.  Fixing this by read-disabling, so data will be associated with the downstream connection as it is associated.
Risk Level: Medium (new pool is still off by default, but affects ALPN as well)
Testing: new integration tests
Docs Changes: n/a
Release Notes: n/a