### PR TITLE
Local reply and upstream response rewrites using the FilterManager

### DIFF
--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -384,7 +384,7 @@ private:
     }
     Utility::sendLocalReply(
         remote_closed_,
-        Utility::EncodeFunctions{nullptr, nullptr,
+        Utility::EncodeFunctions{nullptr, nullptr, nullptr,
                                  [this, modify_headers, &details](ResponseHeaderMapPtr&& headers,
                                                                   bool end_stream) -> void {
                                    if (modify_headers != nullptr) {

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -884,9 +884,10 @@ void FilterManager::sendLocalReplyViaFilterChain(
                 *this, code, body, content_type);
             local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), response_headers,
                                  stream_info_, code, body, content_type);
-            // Note that we did a local reply rewrite so that we don't try to do it again in encodeHeaders.
-            // This isn't very clean but we're trying to support local reply rewrites as well as upstream
-            // rewrites, where the match + rewrite logic makes the most sense in encodeHeaders/Data.
+            // Note that we did a local reply rewrite so that we don't try to do it again in
+            // encodeHeaders. This isn't very clean but we're trying to support local reply rewrites
+            // as well as upstream rewrites, where the match + rewrite logic makes the most sense in
+            // encodeHeaders/Data.
             did_rewrite_ = true;
           },
           [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
@@ -1054,15 +1055,16 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
   // See if the response would be written by local_reply_.
   if (!did_rewrite_) {
     do_rewrite_ =
-        local_reply_.match(filter_manager_callbacks_.requestHeaders().ptr(), *filter_manager_callbacks_.responseHeaders(),
-                          filter_manager_callbacks_.responseTrailers().ptr(),
-                          stream_info_);
+        local_reply_.match(filter_manager_callbacks_.requestHeaders().ptr(),
+                           *filter_manager_callbacks_.responseHeaders(),
+                           filter_manager_callbacks_.responseTrailers().ptr(), stream_info_);
   }
 
   bool modified_end_stream = (end_stream && continue_data_entry == encoder_filters_.end());
   const bool original_modified_end_stream = modified_end_stream;
-  ENVOY_STREAM_LOG(debug, "FilterManager::encodeHeaders: end_stream={}, modified_end_stream={}, do_rewrite_={}",
-                   *this, end_stream, modified_end_stream, do_rewrite_);
+  ENVOY_STREAM_LOG(
+      debug, "FilterManager::encodeHeaders: end_stream={}, modified_end_stream={}, do_rewrite_={}",
+      *this, end_stream, modified_end_stream, do_rewrite_);
   if (do_rewrite_) {
     // _This_ actually sets buffered_response_data_ internally.
     rewriteResponse();
@@ -1299,8 +1301,9 @@ void FilterManager::rewriteResponse() {
                    rewritten_code);
   local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), *response_headers,
                        stream_info_, rewritten_code, rewritten_body, rewritten_content_type);
-  ENVOY_STREAM_LOG(trace, "rewriteResponse: local_reply_.rewrite returned body=\"{}\", content_type={}, code={}", *this,
-                   rewritten_body, rewritten_content_type, rewritten_code);
+  ENVOY_STREAM_LOG(
+      trace, "rewriteResponse: local_reply_.rewrite returned body=\"{}\", content_type={}, code={}",
+      *this, rewritten_body, rewritten_content_type, rewritten_code);
 
   buffered_response_data_ = std::make_unique<Buffer::OwnedImpl>(rewritten_body);
   if (!rewritten_body.empty()) {

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -862,6 +862,12 @@ void FilterManager::sendLocalReplyViaFilterChain(
   // a no-op.
   createFilterChain();
 
+  // A bit awkward, but save the local reply data for later. This will come in handy.
+  // When this pointer is non-null, it means a local reply has been initiated, which
+  // is important later on.
+  local_reply_data_ = std::make_unique<Utility::LocalReplyData>(
+      Utility::LocalReplyData{is_grpc_request, code, body, grpc_status, is_head_request});
+
   Utility::sendLocalReply(
       state_.destroyed_,
       Utility::EncodeFunctions{
@@ -875,21 +881,14 @@ void FilterManager::sendLocalReplyViaFilterChain(
               modify_headers(headers);
             }
           },
-          [this](ResponseHeaderMap& response_headers, Code& code, std::string& body,
-                 absl::string_view& content_type) -> void {
-            // TODO(snowp): This &get() business isn't nice, rework LocalReply and others to accept
-            // opt refs.
-            ENVOY_STREAM_LOG(
-                trace, "sendLocalReply local_reply_.rewrite code={}, body={}, content_type={}",
-                *this, code, body, content_type);
-            local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), response_headers,
-                                 stream_info_, code, body, content_type);
-            // Note that we did a local reply rewrite so that we don't try to do it again in
-            // encodeHeaders. This isn't very clean but we're trying to support local reply rewrites
-            // as well as upstream rewrites, where the match + rewrite logic makes the most sense in
-            // encodeHeaders/Data.
-            did_rewrite_ = true;
-          },
+          // Local reply rewrites (and upstream rewrites, for that matter) happen on the filter
+          // chain now, so we do not need to do any additional rewriting here.
+          /*rewrite_=*/nullptr,
+          // Local gRPC replies are encoded as trailers-only responses on the filter chain,
+          // so we don't need to any additional encoding of the gRPC response here. This
+          // is different from the direct local reply case, where we do encode the gRPC
+          // reply as a headers-only response using an encoder callback.
+          /*encode_grpc_=*/nullptr,
           [this, modify_headers](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
             filter_manager_callbacks_.setResponseHeaders(std::move(headers));
             // TODO: Start encoding from the last decoder filter that saw the
@@ -926,8 +925,17 @@ void FilterManager::sendDirectLocalReply(
           },
           [&](ResponseHeaderMap& response_headers, Code& code, std::string& body,
               absl::string_view& content_type) -> void {
+            /* Direct local reply rewrites happen here since we are not going through the filter
+             * chain. */
             local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), response_headers,
                                  stream_info_, code, body, content_type);
+          },
+          [&](ResponseHeaderMap& headers, Code& code, std::string& body,
+              const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+              bool is_head_request) -> void {
+            /* Direct local reply gRPC encoding happens here since we are not going through the
+             * filter chain. */
+            Utility::toGrpcTrailersOnlyResponse(headers, code, body, grpc_status, is_head_request);
           },
           [&](ResponseHeaderMapPtr&& response_headers, bool end_stream) -> void {
             // Move the response headers into the FilterManager to make sure they're visible to
@@ -1052,24 +1060,35 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
     }
   }
 
-  // See if the response would be written by local_reply_.
-  if (!did_rewrite_) {
-    do_rewrite_ =
-        local_reply_.match(filter_manager_callbacks_.requestHeaders().ptr(),
-                           *filter_manager_callbacks_.responseHeaders(),
-                           filter_manager_callbacks_.responseTrailers().ptr(), stream_info_);
-  }
-
   bool modified_end_stream = (end_stream && continue_data_entry == encoder_filters_.end());
+
+  // Capture the original modified_end_stream value. We may modify it again below if we add
+  // a response body.
   const bool original_modified_end_stream = modified_end_stream;
-  ENVOY_STREAM_LOG(
-      debug, "FilterManager::encodeHeaders: end_stream={}, modified_end_stream={}, do_rewrite_={}",
-      *this, end_stream, modified_end_stream, do_rewrite_);
-  if (do_rewrite_) {
-    // _This_ actually sets buffered_response_data_ internally.
+
+  // See if we should do an upstream rewrite. For local replies, always try to do a rewrite.
+  // For upstream replies, only try to do a rewrite if some filter rule actually applies.
+  // The rewrite config supports unconditional rewrites with no filter rules. This makes sense
+  // for local reply rewrites (e.g. one consistent format for all responses generated at Envoy)
+  // but makes a lot less sense for all responses upstream.
+  state_.do_response_rewrite_ =
+      local_reply_data_ != nullptr ||
+      local_reply_.matchesAnyMapper(filter_manager_callbacks_.requestHeaders().ptr(),
+                                    *filter_manager_callbacks_.responseHeaders(),
+                                    filter_manager_callbacks_.responseTrailers().ptr(),
+                                    stream_info_);
+  ENVOY_STREAM_LOG(debug,
+                   "FilterManager::encodeHeaders: end_stream={}, modified_end_stream={}, "
+                   "state_.do_response_rewrite_={}",
+                   *this, end_stream, modified_end_stream, state_.do_response_rewrite_);
+
+  if (state_.do_response_rewrite_) {
+    // Try to rewrite the response. This may end up not doing any actual rewrite if this is
+    // a local reply and there is no matching rule. If it's not a local reply, we know there's
+    // a match at this point since that's a condition for state_.do_response_rewrite_ above.
     rewriteResponse();
 
-    if (buffered_response_data_->length() > 0) {
+    if (buffered_response_data_) {
       // If we're going to rewrite the response here, then modified_end_stream can no longer be true
       // because we have a body now.
       modified_end_stream = false;
@@ -1082,8 +1101,7 @@ void FilterManager::encodeHeaders(ActiveStreamEncoderFilter* filter, ResponseHea
   // Encode the rewritten response right away if the original `modified_end_stream` was true.
   // If it wasn't, then we know a body will be encoded later, and we'll let that function
   // take care of encoding the rewritten response.
-  if (do_rewrite_ && original_modified_end_stream && buffered_response_data_->length() > 0) {
-    ASSERT(!did_rewrite_);
+  if (state_.do_response_rewrite_ && original_modified_end_stream && buffered_response_data_) {
     ENVOY_STREAM_LOG(trace,
                      "FilterManager::encodeData calling filter_manager_callbacks_ with {} bytes "
                      "from buffered_response_data and modified_end_stream={}",
@@ -1224,7 +1242,7 @@ void FilterManager::encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instan
   }
 
   const bool modified_end_stream = end_stream && trailers_added_entry == encoder_filters_.end();
-  if (do_rewrite_ && buffered_response_data_->length() > 0) {
+  if (state_.do_response_rewrite_ && buffered_response_data_) {
     // If we're doing a rewrite and modified_end_stream=true, encode the buffered_response_data_
     // that was set by rewriteResponse() earlier in encodeHeaders().
     if (modified_end_stream) {
@@ -1235,11 +1253,6 @@ void FilterManager::encodeData(ActiveStreamEncoderFilter* filter, Buffer::Instan
       filter_manager_callbacks_.encodeData(*buffered_response_data_, modified_end_stream);
     }
   } else {
-    // We're not rewriting the response, so encode the data as is.
-    ENVOY_STREAM_LOG(trace,
-                     "FilterManager::encodeData calling filter_manager_callbacks_.encodeData with "
-                     "{} bytes and modified_end_stream={}",
-                     *this, data.length(), modified_end_stream);
     filter_manager_callbacks_.encodeData(data, modified_end_stream);
   }
   maybeEndEncode(modified_end_stream);
@@ -1287,9 +1300,6 @@ void FilterManager::maybeEndEncode(bool end_stream) {
 }
 
 void FilterManager::rewriteResponse() {
-  ASSERT(do_rewrite_);
-  ASSERT(!did_rewrite_);
-
   auto response_headers = filter_manager_callbacks_.responseHeaders();
   ASSERT(response_headers.ptr() != nullptr);
 
@@ -1297,16 +1307,34 @@ void FilterManager::rewriteResponse() {
   absl::string_view rewritten_content_type{};
   Http::Code rewritten_code{static_cast<Http::Code>(Utility::getResponseStatus(*response_headers))};
 
-  ENVOY_STREAM_LOG(trace, "rewriteResponse: calling local_reply_.rewrite with code={}", *this,
-                   rewritten_code);
-  local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), *response_headers,
-                       stream_info_, rewritten_code, rewritten_body, rewritten_content_type);
+  // Start with the local reply body, if we have it.
+  if (local_reply_data_) {
+    rewritten_body = local_reply_data_->body_text_;
+  }
+
+  ENVOY_STREAM_LOG(trace, "rewriteResponse: calling local_reply_.rewrite with body=\"{}\", code={}",
+                   *this, rewritten_body, rewritten_code);
+  const bool did_rewrite =
+      local_reply_.rewrite(filter_manager_callbacks_.requestHeaders().ptr(), *response_headers,
+                           stream_info_, rewritten_code, rewritten_body, rewritten_content_type);
   ENVOY_STREAM_LOG(
       trace, "rewriteResponse: local_reply_.rewrite returned body=\"{}\", content_type={}, code={}",
       *this, rewritten_body, rewritten_content_type, rewritten_code);
 
-  buffered_response_data_ = std::make_unique<Buffer::OwnedImpl>(rewritten_body);
-  if (!rewritten_body.empty()) {
+  if (local_reply_data_ && local_reply_data_->is_grpc_) {
+    // Send a trailers-only grpc response
+    Utility::toGrpcTrailersOnlyResponse(*response_headers, rewritten_code, rewritten_body,
+                                        local_reply_data_->grpc_status_,
+                                        local_reply_data_->is_head_request_);
+    // We're sending a trailers-only response with no body. Make sure there's no buffered
+    // response data nor a content length header.
+    buffered_response_data_ = nullptr;
+    return;
+  }
+
+  buffered_response_data_ =
+      did_rewrite ? std::make_unique<Buffer::OwnedImpl>(rewritten_body) : nullptr;
+  if (buffered_response_data_) {
     // Since we overwrote the response body, we need to set the content-length too.
     response_headers->setContentLength(buffered_response_data_->length());
   }

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -909,6 +909,11 @@ public:
    */
   void maybeEndEncode(bool end_stream);
 
+  /**
+   * Rewrite the response headers and body using local_reply_.
+   */
+  void rewriteResponse();
+
   void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
                       const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
@@ -1076,6 +1081,8 @@ private:
 
   FilterChainFactory& filter_chain_factory_;
   const LocalReply::LocalReply& local_reply_;
+  bool do_rewrite_{};
+  bool did_rewrite_{};
   OverridableRemoteSocketAddressSetterStreamInfo stream_info_;
   // TODO(snowp): Once FM has been moved to its own file we'll make these private classes of FM,
   // at which point they no longer need to be friends.

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -152,7 +152,8 @@ using ResponseMapperPtr = std::unique_ptr<ResponseMapper>;
 
 class LocalReplyImpl : public LocalReply {
 public:
-  LocalReplyImpl() : body_formatter_(std::make_unique<BodyFormatter>()) {}
+  LocalReplyImpl()
+      : body_formatter_(std::make_unique<BodyFormatter>()), has_configured_body_formatter_(false) {}
 
   LocalReplyImpl(
       const envoy::extensions::filters::network::http_connection_manager::v3::LocalReplyConfig&

--- a/source/common/local_reply/local_reply.h
+++ b/source/common/local_reply/local_reply.h
@@ -21,16 +21,25 @@ public:
    * @param code status code.
    * @param body response body.
    * @param content_type response content_type.
+   * @return whether the local reply used a non-default body formatter to populate `body`
    */
-  virtual void rewrite(const Http::RequestHeaderMap* request_headers,
+  virtual bool rewrite(const Http::RequestHeaderMap* request_headers,
                        Http::ResponseHeaderMap& response_headers,
                        StreamInfo::StreamInfo& stream_info, Http::Code& code, std::string& body,
                        absl::string_view& content_type) const PURE;
 
-  virtual bool match(const Http::RequestHeaderMap* request_headers,
-                     const Http::ResponseHeaderMap& response_headers,
-                     const Http::ResponseTrailerMap* response_trailers,
-                     StreamInfo::StreamInfo& stream_info) const PURE;
+  /**
+   * decide if any mapper matches the request/response.
+   * @param request_headers the request headers.
+   * @param response_headers the response headers.
+   * @param response_trailers the response trailers, if any.
+   * @param stream_info the stream info.
+   * @return whether any mapper is a match
+   */
+  virtual bool matchesAnyMapper(const Http::RequestHeaderMap* request_headers,
+                                const Http::ResponseHeaderMap& response_headers,
+                                const Http::ResponseTrailerMap* response_trailers,
+                                StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
 using LocalReplyPtr = std::unique_ptr<LocalReply>;

--- a/source/common/local_reply/local_reply.h
+++ b/source/common/local_reply/local_reply.h
@@ -26,6 +26,11 @@ public:
                        Http::ResponseHeaderMap& response_headers,
                        StreamInfo::StreamInfo& stream_info, Http::Code& code, std::string& body,
                        absl::string_view& content_type) const PURE;
+
+  virtual bool match(const Http::RequestHeaderMap* request_headers,
+                     const Http::ResponseHeaderMap& response_headers,
+                     const Http::ResponseTrailerMap* response_trailers,
+                     StreamInfo::StreamInfo& stream_info) const PURE;
 };
 
 using LocalReplyPtr = std::unique_ptr<LocalReply>;

--- a/test/common/local_reply/local_reply_test.cc
+++ b/test/common/local_reply/local_reply_test.cc
@@ -52,7 +52,8 @@ TEST_F(LocalReplyTest, TestEmptyConfig) {
   // Empty LocalReply config.
   auto local = Factory::create(config_, context_);
 
-  EXPECT_EQ(false, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(false,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
   EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
@@ -66,7 +67,8 @@ TEST_F(LocalReplyTest, TestDefaultLocalReply) {
   // Default LocalReply should be the same as empty config.
   auto local = Factory::createDefault();
 
-  EXPECT_EQ(false, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(false,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
   EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
@@ -117,7 +119,8 @@ TEST_F(LocalReplyTest, TestDefaultTextFormatter) {
   TestUtility::loadFromYaml(yaml, config_);
   auto local = Factory::create(config_, context_);
 
-  EXPECT_EQ(false, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(false,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
   EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
@@ -140,7 +143,8 @@ TEST_F(LocalReplyTest, TestDefaultJsonFormatter) {
   TestUtility::loadFromYaml(yaml, config_);
   auto local = Factory::create(config_, context_);
 
-  EXPECT_EQ(false, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(false,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
   EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
@@ -210,7 +214,8 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
 
   // code=400 matches the first filter; rewrite code and body
   resetData(400);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(401));
   EXPECT_EQ(stream_info_.response_code_, 401U);
@@ -221,7 +226,8 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
   // code=403 matches the second filter; does not rewrite code, sets an empty body and content_type.
   resetData(403);
   body_ = "original body text";
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(403));
   EXPECT_EQ(stream_info_.response_code_, 403U);
@@ -231,7 +237,8 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
 
   // code=410 matches the third filter; rewrite body only
   resetData(410);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(410));
   EXPECT_EQ(stream_info_.response_code_, 410U);
@@ -241,7 +248,8 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
 
   // code=420 matches the fourth filter; rewrite code only
   resetData(420);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(421));
   EXPECT_EQ(stream_info_.response_code_, 421U);
@@ -251,7 +259,8 @@ TEST_F(LocalReplyTest, TestMapperRewrite) {
 
   // code=430 matches the fifth filter; rewrite nothing
   resetData(430);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(430));
   EXPECT_EQ(stream_info_.response_code_, 430U);
@@ -283,7 +292,8 @@ TEST_F(LocalReplyTest, DEPRECATED_FEATURE_TEST(TestMapperRewriteDeprecatedTextFo
   // code=404 matches the only filter; does not rewrite code, sets an empty body and content_type.
   resetData(404);
   body_ = "original body text";
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(404));
   EXPECT_EQ(stream_info_.response_code_, 404U);
@@ -332,7 +342,8 @@ TEST_F(LocalReplyTest, TestMapperFormat) {
   // code=400 matches the first filter; rewrite code and body
   // has its own formatter
   resetData(400);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(401));
   EXPECT_EQ(stream_info_.response_code_, 401U);
@@ -350,7 +361,8 @@ TEST_F(LocalReplyTest, TestMapperFormat) {
   // code=410 matches the second filter; rewrite code and body
   // but using default formatter
   resetData(410);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(411));
   EXPECT_EQ(stream_info_.response_code_, 411U);
@@ -389,7 +401,8 @@ TEST_F(LocalReplyTest, TestHeaderAddition) {
 
   response_headers_.addCopy("foo-2", "bar2");
   response_headers_.addCopy("foo-3", "bar3");
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(nullptr, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, TestInitCode);
   EXPECT_EQ(stream_info_.response_code_, static_cast<uint32_t>(TestInitCode));
@@ -456,7 +469,8 @@ TEST_F(LocalReplyTest, TestMapperWithContentType) {
   // has its own formatter.
   // content-type is explicitly set to text/html; charset=UTF-8.
   resetData(400);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(401));
   EXPECT_EQ(stream_info_.response_code_, 401U);
@@ -468,7 +482,8 @@ TEST_F(LocalReplyTest, TestMapperWithContentType) {
   // but using default formatter.
   // content-type is explicitly set to text/html; charset=UTF-8.
   resetData(410);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
   local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_);
   EXPECT_EQ(code_, static_cast<Http::Code>(411));
   EXPECT_EQ(stream_info_.response_code_, 411U);
@@ -480,8 +495,10 @@ TEST_F(LocalReplyTest, TestMapperWithContentType) {
   // has its own formatter.
   // default content-type is set based on reply format type.
   resetData(420);
-  EXPECT_EQ(true, local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
-  EXPECT_EQ(true, local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_, content_type_));
+  EXPECT_EQ(true,
+            local->matchesAnyMapper(&request_headers_, response_headers_, nullptr, stream_info_));
+  EXPECT_EQ(true, local->rewrite(&request_headers_, response_headers_, stream_info_, code_, body_,
+                                 content_type_));
   EXPECT_EQ(code_, static_cast<Http::Code>(421));
   EXPECT_EQ(stream_info_.response_code_, 421U);
   EXPECT_EQ(response_headers_.Status()->value().getStringView(), "421");

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -105,7 +105,7 @@ public:
     Http::Utility::sendLocalReply(
         false,
         Http::Utility::EncodeFunctions(
-            {nullptr, nullptr,
+            {nullptr, nullptr, nullptr,
              [&](Http::ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
                encoder_.encodeHeaders(*headers, end_stream);
              },

--- a/test/integration/local_reply_integration_test.cc
+++ b/test/integration/local_reply_integration_test.cc
@@ -487,11 +487,8 @@ body_format:
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                     {":path", "/"},
-                                     {":scheme", "http"},
-                                     {":authority", "host"}});
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "429"}}, true);
   response->waitForHeaders();
@@ -522,11 +519,8 @@ body_format:
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                     {":path", "/"},
-                                     {":scheme", "http"},
-                                     {":authority", "host"}});
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "429"}}, false);
   upstream_request_->encodeData(512, true);

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -90,7 +90,7 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
   Utility::sendLocalReply(
       stream_destroyed_,
       Utility::EncodeFunctions{
-          nullptr, nullptr,
+          nullptr, nullptr, nullptr,
           [this, modify_headers, details](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
             if (modify_headers != nullptr) {
               modify_headers(*headers);

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -92,8 +92,8 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
       Utility::EncodeFunctions{
           nullptr, nullptr,
           [](ResponseHeaderMap& headers, Code& code, std::string& body,
-                 const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
-                 bool is_head_request) -> void {
+             const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+             bool is_head_request) -> void {
             Utility::toGrpcTrailersOnlyResponse(headers, code, body, grpc_status, is_head_request);
           },
           [this, modify_headers, details](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -90,7 +90,12 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
   Utility::sendLocalReply(
       stream_destroyed_,
       Utility::EncodeFunctions{
-          nullptr, nullptr, nullptr,
+          nullptr, nullptr,
+          [this](ResponseHeaderMap& headers, Code& code, std::string& body,
+                 const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                 bool is_head_request) -> void {
+            Utility::toGrpcTrailersOnlyResponse(headers, code, body, grpc_status, is_head_request);
+          },
           [this, modify_headers, details](ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
             if (modify_headers != nullptr) {
               modify_headers(*headers);

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -91,7 +91,7 @@ void MockStreamDecoderFilterCallbacks::sendLocalReply_(
       stream_destroyed_,
       Utility::EncodeFunctions{
           nullptr, nullptr,
-          [this](ResponseHeaderMap& headers, Code& code, std::string& body,
+          [](ResponseHeaderMap& headers, Code& code, std::string& body,
                  const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                  bool is_head_request) -> void {
             Utility::toGrpcTrailersOnlyResponse(headers, code, body, grpc_status, is_head_request);

--- a/test/mocks/local_reply/mocks.h
+++ b/test/mocks/local_reply/mocks.h
@@ -14,6 +14,13 @@ public:
                Http::ResponseHeaderMap& response_headers, StreamInfo::StreamInfo& stream_info,
                Http::Code& code, std::string& body, absl::string_view& content_type),
               (const));
+
+  MOCK_METHOD(bool, match,
+              (const Http::RequestHeaderMap* request_headers,
+               const Http::ResponseHeaderMap& response_headers,
+               const Http::ResponseTrailerMap* response_trailers,
+               StreamInfo::StreamInfo& stream_info),
+              (const));
 };
 } // namespace LocalReply
 } // namespace Envoy

--- a/test/mocks/local_reply/mocks.h
+++ b/test/mocks/local_reply/mocks.h
@@ -9,7 +9,7 @@ public:
   MockLocalReply();
   ~MockLocalReply() override;
 
-  MOCK_METHOD(void, rewrite,
+  MOCK_METHOD(bool, rewrite,
               (const Http::RequestHeaderMap* request_headers,
                Http::ResponseHeaderMap& response_headers, StreamInfo::StreamInfo& stream_info,
                Http::Code& code, std::string& body, absl::string_view& content_type),

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -182,9 +182,8 @@ void RouterCheckTool::sendLocalReply(ToolConfig& tool_config,
 
   bool is_grpc = false;
   bool is_head_request = false;
-  Envoy::Http::Utility::LocalReplyData local_reply_data{is_direct_local_reply, is_grpc,
-                                                        entry.responseCode(),  entry.responseBody(),
-                                                        absl::nullopt,         is_head_request};
+  Envoy::Http::Utility::LocalReplyData local_reply_data{
+      is_grpc, entry.responseCode(), entry.responseBody(), absl::nullopt, is_head_request};
 
   Envoy::Http::Utility::sendLocalReply(false, encode_functions, local_reply_data);
 }

--- a/test/tools/router_check/router.cc
+++ b/test/tools/router_check/router.cc
@@ -170,7 +170,7 @@ void RouterCheckTool::finalizeHeaders(ToolConfig& tool_config,
 void RouterCheckTool::sendLocalReply(ToolConfig& tool_config,
                                      const Router::DirectResponseEntry& entry) {
   auto encode_functions = Envoy::Http::Utility::EncodeFunctions{
-      nullptr, nullptr,
+      nullptr, nullptr, nullptr,
       [&](Envoy::Http::ResponseHeaderMapPtr&& headers, bool end_stream) -> void {
         UNREFERENCED_PARAMETER(end_stream);
         Http::HeaderMapImpl::copyFrom(*tool_config.response_headers_->header_map_, *headers);
@@ -182,8 +182,9 @@ void RouterCheckTool::sendLocalReply(ToolConfig& tool_config,
 
   bool is_grpc = false;
   bool is_head_request = false;
-  Envoy::Http::Utility::LocalReplyData local_reply_data{
-      is_grpc, entry.responseCode(), entry.responseBody(), absl::nullopt, is_head_request};
+  Envoy::Http::Utility::LocalReplyData local_reply_data{is_direct_local_reply, is_grpc,
+                                                        entry.responseCode(),  entry.responseBody(),
+                                                        absl::nullopt,         is_head_request};
 
   Envoy::Http::Utility::sendLocalReply(false, encode_functions, local_reply_data);
 }


### PR DESCRIPTION
Work in progress converting https://github.com/envoyproxy/envoy/pull/14221 to behavior in the filter manager.

We'll probably want to tease apart the LocalReply case and the upstream rewrite case, perhaps by renaming some of the variables/objects. Feedback welcome.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
