### PR TITLE
grpc-json-transcoder: fix test flake 

### DIFF
--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -996,7 +996,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, EnableStrictRequestValidation) {
                                      {":path", "/unknown/path"},
                                      {":authority", "host"},
                                      {"content-type", "application/json"}},
-      R"({ "theme" : "Children")", {}, {}, Status(),
+      "", {}, {}, Status(),
       Http::TestResponseHeaderMapImpl{{":status", "400"}},
       "Bad request: Could not resolve /unknown/path to a method.", true, false, "", false);
 
@@ -1007,7 +1007,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, EnableStrictRequestValidation) {
                                      {":path", "/shelves/100?unknown=1"},
                                      {":authority", "host"},
                                      {"content-type", "application/json"}},
-      R"({ "theme" : "Children")", {}, {}, Status(),
+      "", {}, {}, Status(),
       Http::TestResponseHeaderMapImpl{{":status", "400"}},
       "Bad request: Could not find field \"unknown\" in the type \"bookstore.GetShelfRequest\".",
       true, false, "", false);

--- a/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/grpc_json_transcoder_integration_test.cc
@@ -996,8 +996,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, EnableStrictRequestValidation) {
                                      {":path", "/unknown/path"},
                                      {":authority", "host"},
                                      {"content-type", "application/json"}},
-      "", {}, {}, Status(),
-      Http::TestResponseHeaderMapImpl{{":status", "400"}},
+      "", {}, {}, Status(), Http::TestResponseHeaderMapImpl{{":status", "400"}},
       "Bad request: Could not resolve /unknown/path to a method.", true, false, "", false);
 
   // Transcoding does not occur when unknown query param is included.
@@ -1007,8 +1006,7 @@ TEST_P(GrpcJsonTranscoderIntegrationTest, EnableStrictRequestValidation) {
                                      {":path", "/shelves/100?unknown=1"},
                                      {":authority", "host"},
                                      {"content-type", "application/json"}},
-      "", {}, {}, Status(),
-      Http::TestResponseHeaderMapImpl{{":status", "400"}},
+      "", {}, {}, Status(), Http::TestResponseHeaderMapImpl{{":status", "400"}},
       "Bad request: Could not find field \"unknown\" in the type \"bookstore.GetShelfRequest\".",
       true, false, "", false);
 }


### PR DESCRIPTION
Envoy will reset the stream when issuing a local reply, which seems to
cause the test client to segfault when sending the body (since the local
reply is triggered during headers). This avoids sending a body in the
case where we expect a local reply during headers.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low 
Testing: Ran the test >100 times, no failures with dbg and/or asan
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
