### PR TITLE
network: Enable the Kill Request filter to honor Route-level configur…

### DIFF
--- a/source/extensions/filters/http/kill_request/BUILD
+++ b/source/extensions/filters/http/kill_request/BUILD
@@ -21,6 +21,7 @@ envoy_cc_library(
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/extensions/filters/http:well_known_names",
         "@envoy_api//envoy/extensions/filters/http/kill_request/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/kill_request/kill_request_config.h
+++ b/source/extensions/filters/http/kill_request/kill_request_config.h
@@ -25,6 +25,38 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };
 
+/**
+ * Generic configuration for a kill request.
+ */
+class KillRequestConfig {
+public:
+  KillRequestConfig(
+      const envoy::extensions::filters::http::kill_request::v3::KillRequest& kill_request);
+
+  envoy::type::v3::FractionalPercent
+  probability(const Http::RequestHeaderMap* request_headers) const {
+    return provider_->probability(request_headers);
+  }
+
+private:
+  // Abstract kill provider.
+  class KillProvider {
+  public:
+    virtual ~KillProvider() = default;
+
+    // Return what probability of requests kill should be applied to.
+    virtual envoy::type::v3::FractionalPercent
+    probability(const Http::RequestHeaderMap* request_headers) const PURE;
+  };
+
+  using KillProviderPtr = std::unique_ptr<KillProvider>;
+
+  KillProviderPtr provider_;
+};
+
+using KillRequestConfigPtr = std::unique_ptr<KillRequestConfig>;
+using KillRequestConfigSharedPtr = std::shared_ptr<KillRequestConfig>;
+
 } // namespace KillRequest
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -1,13 +1,21 @@
 #include "extensions/filters/http/kill_request/kill_request_filter.h"
 
 #include <csignal>
+#include <string>
 
 #include "common/protobuf/utility.h"
+
+#include "extensions/filters/http/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace KillRequest {
+
+using ::envoy::extensions::filters::http::kill_request::v3::KillRequest;
+
+KillSettings::KillSettings(const KillRequest& kill_request)
+    : kill_probability_(kill_request.probability()) {}
 
 bool KillRequestFilter::isKillRequestEnabled() {
   return ProtobufPercentHelper::evaluateFractionalPercent(kill_request_.probability(),
@@ -27,6 +35,20 @@ Http::FilterHeadersStatus KillRequestFilter::decodeHeaders(Http::RequestHeaderMa
   if (kill_request_header.empty() ||
       !absl::SimpleAtob(kill_request_header[0]->value().getStringView(), &is_kill_request)) {
     return Http::FilterHeadersStatus::Continue;
+  }
+
+  // Route-level configuration overrides filter-level configuration.
+  if (decoder_callbacks_->route() && decoder_callbacks_->route()->routeEntry()) {
+    const std::string& name = Extensions::HttpFilters::HttpFilterNames::get().KillRequest;
+    const auto* route_entry = decoder_callbacks_->route()->routeEntry();
+
+    const auto* per_route_kill_settings =
+        route_entry->mostSpecificPerFilterConfigTyped<KillSettings>(name);
+
+    if (per_route_kill_settings) {
+      envoy::type::v3::FractionalPercent probability = per_route_kill_settings->getProbability();
+      kill_request_.set_allocated_probability(&probability);
+    }
   }
 
   if (is_kill_request && isKillRequestEnabled()) {

--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "common/protobuf/utility.h"
+
 #include "extensions/filters/http/well_known_names.h"
 
 namespace Envoy {

--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "common/protobuf/utility.h"
+#include "extensions/filters/http/well_known_names.h"
 
 #include "extensions/filters/http/well_known_names.h"
 

--- a/source/extensions/filters/http/kill_request/kill_request_filter.h
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.h
@@ -7,6 +7,7 @@
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 
+#include "common/http/header_utility.h"
 #include "common/http/headers.h"
 
 namespace Envoy {
@@ -52,7 +53,9 @@ public:
     return Http::FilterTrailersStatus::Continue;
   }
 
-  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks&) override {}
+  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override {
+    decoder_callbacks_ = &callbacks;
+  }
 
   // Http::StreamEncoderFilter
   Http::FilterHeadersStatus encode100ContinueHeaders(Http::ResponseHeaderMap&) override {
@@ -82,8 +85,29 @@ private:
   // equaling true.
   bool isKillRequestEnabled();
 
-  const envoy::extensions::filters::http::kill_request::v3::KillRequest kill_request_;
+  envoy::extensions::filters::http::kill_request::v3::KillRequest kill_request_;
   Random::RandomGenerator& random_generator_;
+  Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
+};
+
+/**
+ * Configuration for fault injection.
+ */
+class KillSettings : public Router::RouteSpecificFilterConfig {
+public:
+  KillSettings(const envoy::extensions::filters::http::kill_request::v3::KillRequest& kill_request);
+
+  const std::vector<Http::HeaderUtility::HeaderDataPtr>& filterHeaders() const {
+    return kill_request_filter_headers_;
+  }
+
+  const envoy::type::v3::FractionalPercent getProbability() const {
+    return std::move(kill_probability_);
+  }
+
+private:
+  envoy::type::v3::FractionalPercent kill_probability_;
+  const std::vector<Http::HeaderUtility::HeaderDataPtr> kill_request_filter_headers_;
 };
 
 } // namespace KillRequest

--- a/test/extensions/filters/http/kill_request/BUILD
+++ b/test/extensions/filters/http/kill_request/BUILD
@@ -18,8 +18,10 @@ envoy_extension_cc_test(
     deps = [
         "//include/envoy/http:metadata_interface",
         "//source/common/buffer:buffer_lib",
+        "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/kill_request:kill_request_filter_lib",
         "//test/mocks:common_lib",
+        "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/kill_request/v3:pkg_cc_proto",
         "@envoy_api//envoy/type/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -4,6 +4,7 @@
 
 #include "common/buffer/buffer_impl.h"
 
+#include "extensions/filters/http/well_known_names.h"
 #include "extensions/filters/http/kill_request/kill_request_filter.h"
 #include "extensions/filters/http/well_known_names.h"
 

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -5,8 +5,10 @@
 #include "common/buffer/buffer_impl.h"
 
 #include "extensions/filters/http/kill_request/kill_request_filter.h"
+#include "extensions/filters/http/well_known_names.h"
 
 #include "test/mocks/common.h"
+#include "test/mocks/http/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -18,6 +20,7 @@ namespace HttpFilters {
 namespace KillRequest {
 namespace {
 
+using ::testing::AnyNumber;
 using ::testing::Return;
 
 class KillRequestFilterTest : public testing::Test {
@@ -25,10 +28,15 @@ protected:
   void
   setUpTest(const envoy::extensions::filters::http::kill_request::v3::KillRequest& kill_request) {
     filter_ = std::make_unique<KillRequestFilter>(kill_request, random_generator_);
+
+    filter_->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+    EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
+    EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, popTrackedObject(_)).Times(AnyNumber());
   }
 
   std::unique_ptr<KillRequestFilter> filter_;
   testing::NiceMock<Random::MockRandomGenerator> random_generator_;
+  testing::NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_filter_callbacks_;
   Http::TestRequestHeaderMapImpl request_headers_;
 };
 
@@ -72,6 +80,26 @@ TEST_F(KillRequestFilterTest, KillRequestDisabledWhenIsKillRequestEnabledReturns
 
   ON_CALL(random_generator_, random()).WillByDefault(Return(1));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+}
+
+TEST_F(KillRequestFilterTest,
+       KillRequestDisabledWhenIsKillRequestEnabledReturnsTrueFromRouteLevelConfiguration) {
+  envoy::extensions::filters::http::kill_request::v3::KillRequest kill_request;
+  kill_request.mutable_probability()->set_numerator(0);
+  setUpTest(kill_request);
+  request_headers_.addCopy("x-envoy-kill-request", "true");
+
+  envoy::extensions::filters::http::kill_request::v3::KillRequest route_level_kill_request;
+  route_level_kill_request.mutable_probability()->set_numerator(1);
+  route_level_kill_request.set_kill_request_header("x-custom-kill-request");
+
+  KillSettings kill_settings = KillSettings(route_level_kill_request);
+
+  ON_CALL(random_generator_, random()).WillByDefault(Return(0));
+  ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
+          perFilterConfig(Extensions::HttpFilters::HttpFilterNames::get().KillRequest))
+      .WillByDefault(Return(&kill_settings));
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
 }
 
 TEST_F(KillRequestFilterTest, KillRequestDisabledWhenHeaderIsMissing) {

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -4,7 +4,6 @@
 
 #include "common/buffer/buffer_impl.h"
 
-#include "extensions/filters/http/well_known_names.h"
 #include "extensions/filters/http/kill_request/kill_request_filter.h"
 #include "extensions/filters/http/well_known_names.h"
 


### PR DESCRIPTION
network: Enable the Kill Request filter to honor Route-level configuration. (#14929)

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
