### PR TITLE
process: reinstating the prior 2 week window for stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
     - name: Prune Stale
-      uses: actions/stale@v3.0.14
+      uses: actions/stale@v3.0.15
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # Different amounts of days for issues/PRs are not currently supported but there is a PR
-        # open for it: https://github.com/actions/stale/issues/214
-        days-before-stale: 30
-        days-before-close: 7
+        days-before-issue-stale: 30
+        days-before-issue-close: 7
+        days-before-pr-stale: 10
+        days-before-pr-close: 4
         stale-issue-message: >
           This issue has been automatically marked as stale because it has not had activity in the
           last 30 days. It will be closed in the next 7 days unless it is tagged "help wanted" or "no stalebot" or other activity
@@ -27,12 +27,12 @@ jobs:
           Thank you for your contributions.
         stale-pr-message: >
           This pull request has been automatically marked as stale because it has not had
-          activity in the last 30 days. It will be closed in 7 days if no further activity occurs. Please
+          activity in the last 10 days. It will be closed in 4 days if no further activity occurs. Please
           feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         close-pr-message: >
           This pull request has been automatically closed because it has not had
-          activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+          activity in the last 14 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
           Thank you for your contributions!
         stale-issue-label: 'stale'
         exempt-issue-labels: 'no stalebot,help wanted'


### PR DESCRIPTION
third time's the charm!
They've tagged and released https://github.com/actions/stale/tags which should have https://github.com/actions/stale/pull/224

Risk Level: low
Testing: none
Docs Changes: n/a
Release Notes: n/a