### PR TITLE
WIP [test] fix server not reached

### DIFF
--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -73,8 +73,9 @@ message ApiConfigSource {
     AGGREGATED_DELTA_GRPC = 6;
   }
 
-  // API type (gRPC, REST, delta gRPC)
-  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true}];
+  // API type (gRPC, REST, delta gRPC).
+  // Aggregated gRPC and delta gRPC are not implemented.
+  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true not_in: 5 not_in: 6}];
 
   // API version for xDS transport protocol. This describes the xDS gRPC/REST
   // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -75,8 +75,9 @@ message ApiConfigSource {
     AGGREGATED_DELTA_GRPC = 6;
   }
 
-  // API type (gRPC, REST, delta gRPC)
-  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true}];
+  // API type (gRPC, REST, delta gRPC).
+  // Aggregated gRPC and delta gRPC are not implemented.
+  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true not_in: 5 not_in: 6}];
 
   // API version for xDS transport protocol. This describes the xDS gRPC/REST
   // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.

--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -146,6 +146,7 @@ proto_library(
         "//envoy/config/retry/omit_canary_hosts/v2:pkg",
         "//envoy/config/retry/omit_canary_hosts/v3:pkg",
         "//envoy/config/retry/previous_hosts/v2:pkg",
+        "//envoy/config/retry/previous_hosts/v3:pkg",
         "//envoy/config/route/v3:pkg",
         "//envoy/config/tap/v3:pkg",
         "//envoy/config/trace/v3:pkg",

--- a/generated_api_shadow/envoy/config/core/v3/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v3/config_source.proto
@@ -73,8 +73,9 @@ message ApiConfigSource {
     AGGREGATED_DELTA_GRPC = 6;
   }
 
-  // API type (gRPC, REST, delta gRPC)
-  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true}];
+  // API type (gRPC, REST, delta gRPC).
+  // Aggregated gRPC and delta gRPC are not implemented.
+  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true not_in: 5 not_in: 6}];
 
   // API version for xDS transport protocol. This describes the xDS gRPC/REST
   // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.

--- a/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
@@ -74,8 +74,9 @@ message ApiConfigSource {
     AGGREGATED_DELTA_GRPC = 6;
   }
 
-  // API type (gRPC, REST, delta gRPC)
-  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true}];
+  // API type (gRPC, REST, delta gRPC).
+  // Aggregated gRPC and delta gRPC are not implemented.
+  ApiType api_type = 1 [(validate.rules).enum = {defined_only: true not_in: 5 not_in: 6}];
 
   // API version for xDS transport protocol. This describes the xDS gRPC/REST
   // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -82,6 +82,9 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
           Utility::configSourceInitialFetchTimeout(config), /*is_aggregated*/ false,
           use_namespace_matching);
     }
+    case envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC: {
+      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+    }
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;
     }

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -82,9 +82,6 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
           Utility::configSourceInitialFetchTimeout(config), /*is_aggregated*/ false,
           use_namespace_matching);
     }
-    case envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC: {
-      NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-    }
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;
     }

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-5391772077391872
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-5391772077391872
@@ -1,0 +1,12 @@
+node {
+  id: "`"
+  cluster: "8"
+}
+dynamic_resources {
+  cds_config {
+    api_config_source {
+      api_type: AGGREGATED_DELTA_GRPC
+      transport_api_version: V3
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Aggregated gRPC and delta gRPC are not implemented config sources yet, they panic crash currently. Add API constraint that avoid these fields (and explicitly marks the aggregated gRPC as not implemented crash).
Risk Level: Low
Testing: Added fuzz regression test
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30119
API Considerations: These fields already cause a panic crash. Avoid with PGV calidation.
