### PR TITLE
test: fix FUZZ_ASSERT triggered by double-counting length in ASSERT computation in StringBuffer::commit

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-4767917877100544
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-buffer_fuzz_test-4767917877100544
@@ -1,0 +1,1 @@
+actions { reserve_commit { reserve_length: 60000 commit_length: 40000 } }

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -167,8 +167,8 @@ public:
 
   void commit(uint64_t length, absl::Span<Buffer::RawSlice>,
               Buffer::ReservationSlicesOwnerPtr) override {
-    size_ += length;
     FUZZ_ASSERT(start_ + size_ + length <= data_.size());
+    size_ += length;
   }
 
   ssize_t search(const void* data, uint64_t size, size_t start, size_t length) const override {


### PR DESCRIPTION
Commit Message:
test: fix FUZZ_ASSERT triggered by double-counting length in ASSERT computation in StringBuffer::commit

length was added to size_ before the FUZZ_ASSERT, but also added inside the FUZZ_ASSERT. Update size_ after doing the ASSERT instead.

Risk Level: n/a, test-only changes
Testing: n/a
Docs Changes: n/a
Release Notes: n/a