### PR TITLE
ext_proc: Implement streamed request and response body processing

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3alpha/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3alpha/ext_proc.proto
@@ -23,17 +23,20 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // The External Processing filter allows an external service to act on HTTP traffic in a flexible way.
 
 // **Current Implementation Status:**
-// At this time, the filter will send the "request_headers" and "response_headers" messages
-// to the server when the filter is invoked, and apply any header mutations returned by the
-// server, and respond to "immediate_response" messages. No other parts of the protocol are implemented yet.
+// The filter will send the "request_headers" and "response_headers" messages by default.
+// In addition, if the "processing mode" is set , the "request_body" and "response_body"
+// messages will be sent if the corresponding fields of the "processing_mode" are
+// set to STREAMING. The other body processing modes, and trailer processing, are not
+// implemented yet. The filter will also respond to "immediate_response" messages
+// at any point in the stream.
 
 // As designed, the filter supports up to six different processing steps, which are in the
 // process of being implemented:
 // * Request headers: IMPLEMENTED
-// * Request body: NOT IMPLEMENTED
+// * Request body: Only STREAMED mode is implemented
 // * Request trailers: NOT IMPLEMENTED
 // * Response headers: IMPLEMENTED
-// * Response body: NOT IMPLEMENTED
+// * Response body: Only STREAMED mode is implemented
 // * Response trailers: NOT IMPLEMENTED
 
 // The filter communicates with an external gRPC service that can use it to do a variety of things

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_proc/v3alpha/ext_proc.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_proc/v3alpha/ext_proc.proto
@@ -23,17 +23,20 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // The External Processing filter allows an external service to act on HTTP traffic in a flexible way.
 
 // **Current Implementation Status:**
-// At this time, the filter will send the "request_headers" and "response_headers" messages
-// to the server when the filter is invoked, and apply any header mutations returned by the
-// server, and respond to "immediate_response" messages. No other parts of the protocol are implemented yet.
+// The filter will send the "request_headers" and "response_headers" messages by default.
+// In addition, if the "processing mode" is set , the "request_body" and "response_body"
+// messages will be sent if the corresponding fields of the "processing_mode" are
+// set to STREAMING. The other body processing modes, and trailer processing, are not
+// implemented yet. The filter will also respond to "immediate_response" messages
+// at any point in the stream.
 
 // As designed, the filter supports up to six different processing steps, which are in the
 // process of being implemented:
 // * Request headers: IMPLEMENTED
-// * Request body: NOT IMPLEMENTED
+// * Request body: Only STREAMED mode is implemented
 // * Request trailers: NOT IMPLEMENTED
 // * Response headers: IMPLEMENTED
-// * Response body: NOT IMPLEMENTED
+// * Response body: Only STREAMED mode is implemented
 // * Response trailers: NOT IMPLEMENTED
 
 // The filter communicates with an external gRPC service that can use it to do a variety of things

--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -55,6 +55,7 @@ envoy_cc_library(
     srcs = ["mutation_utils.cc"],
     hdrs = ["mutation_utils.h"],
     deps = [
+        "//include/envoy/buffer:buffer_interface",
         "//include/envoy/http:header_map_interface",
         "//source/common/http:header_utility_lib",
         "//source/common/protobuf:utility_lib",

--- a/source/extensions/filters/http/ext_proc/client.h
+++ b/source/extensions/filters/http/ext_proc/client.h
@@ -17,7 +17,8 @@ public:
   virtual ~ExternalProcessorStream() = default;
   virtual void send(envoy::service::ext_proc::v3alpha::ProcessingRequest&& request,
                     bool end_stream) PURE;
-  virtual void close() PURE;
+  // Idempotent close. Return true if it actually closed.
+  virtual bool close() PURE;
 };
 
 using ExternalProcessorStreamPtr = std::unique_ptr<ExternalProcessorStream>;

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -11,11 +11,13 @@ namespace ExternalProcessing {
 
 using envoy::extensions::filters::http::ext_proc::v3alpha::ProcessingMode;
 
+using envoy::service::ext_proc::v3alpha::BodyResponse;
 using envoy::service::ext_proc::v3alpha::HeadersResponse;
 using envoy::service::ext_proc::v3alpha::ImmediateResponse;
 using envoy::service::ext_proc::v3alpha::ProcessingRequest;
 using envoy::service::ext_proc::v3alpha::ProcessingResponse;
 
+using Http::FilterDataStatus;
 using Http::FilterHeadersStatus;
 using Http::RequestHeaderMap;
 using Http::ResponseHeaderMap;
@@ -30,18 +32,16 @@ void Filter::openStream() {
   }
 }
 
-void Filter::closeStream() {
-  if (!processing_complete_) {
-    if (stream_) {
-      ENVOY_LOG(debug, "Closing gRPC stream to external processor");
-      stream_->close();
+void Filter::onDestroy() {
+  // Make doubly-sure we no longer use the stream, as
+  // per the filter contract.
+  processing_complete_ = true;
+  if (stream_) {
+    if (stream_->close()) {
       stats_.streams_closed_.inc();
     }
-    processing_complete_ = true;
   }
 }
-
-void Filter::onDestroy() { closeStream(); }
 
 FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool end_of_stream) {
   if (processing_mode_.request_header_mode() == ProcessingMode::SKIP) {
@@ -49,6 +49,7 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool end_of
   }
 
   // We're at the start, so start the stream and send a headers message
+  ENVOY_BUG(request_state_ == FilterState::IDLE, "Filter request state should be idle");
   openStream();
   request_headers_ = &headers;
   ProcessingRequest req;
@@ -64,12 +65,46 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool end_of
   return FilterHeadersStatus::StopAllIterationAndWatermark;
 }
 
+FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
+  if (processing_complete_) {
+    return FilterDataStatus::Continue;
+  }
+
+  switch (processing_mode_.request_body_mode()) {
+  case ProcessingMode::BUFFERED:
+  case ProcessingMode::BUFFERED_PARTIAL:
+    ENVOY_LOG(warn, "Ignoring unimplemented request body processing mode BUFFERED");
+    return FilterDataStatus::Continue;
+  case ProcessingMode::STREAMED:
+    return decodeDataStreamed(data, end_stream);
+  case ProcessingMode::NONE:
+  default:
+    return FilterDataStatus::Continue;
+  }
+}
+
+FilterDataStatus Filter::decodeDataStreamed(Buffer::Instance& data, bool end_stream) {
+  ENVOY_BUG(request_state_ == FilterState::IDLE, "Filter request state should be idle");
+  openStream();
+  request_body_chunk_ = &data;
+  ProcessingRequest req;
+  auto* body_req = req.mutable_request_body();
+  body_req->set_end_of_stream(end_stream);
+  body_req->set_body(data.toString());
+  request_state_ = FilterState::BODY;
+  ENVOY_LOG(debug, "Sending request_body message");
+  stream_->send(std::move(req), false);
+  stats_.stream_msgs_sent_.inc();
+  return FilterDataStatus::StopIterationAndWatermark;
+}
+
 FilterHeadersStatus Filter::encodeHeaders(ResponseHeaderMap& headers, bool end_of_stream) {
   if (processing_complete_ || processing_mode_.response_header_mode() == ProcessingMode::SKIP) {
     return FilterHeadersStatus::Continue;
   }
 
   // Depending on processing mode this may or may not be the first message
+  ENVOY_BUG(response_state_ == FilterState::IDLE, "Filter response state should be idle");
   openStream();
   response_headers_ = &headers;
   ProcessingRequest req;
@@ -83,34 +118,83 @@ FilterHeadersStatus Filter::encodeHeaders(ResponseHeaderMap& headers, bool end_o
   return FilterHeadersStatus::StopAllIterationAndWatermark;
 }
 
-void Filter::onReceiveMessage(
-    std::unique_ptr<envoy::service::ext_proc::v3alpha::ProcessingResponse>&& r) {
+FilterDataStatus Filter::encodeData(Buffer::Instance& data, bool end_stream) {
+  if (processing_complete_) {
+    return FilterDataStatus::Continue;
+  }
+
+  switch (processing_mode_.response_body_mode()) {
+  case ProcessingMode::BUFFERED:
+  case ProcessingMode::BUFFERED_PARTIAL:
+    ENVOY_LOG(warn, "Ignoring unimplemented response body processing mode BUFFERED");
+    return FilterDataStatus::Continue;
+  case ProcessingMode::STREAMED:
+    return encodeDataStreamed(data, end_stream);
+  case ProcessingMode::NONE:
+  default:
+    return FilterDataStatus::Continue;
+  }
+}
+
+FilterDataStatus Filter::encodeDataStreamed(Buffer::Instance& data, bool end_stream) {
+  ENVOY_BUG(response_state_ == FilterState::IDLE, "Filter response state should be idle");
+  openStream();
+  response_body_chunk_ = &data;
+  ProcessingRequest req;
+  auto* body_req = req.mutable_response_body();
+  body_req->set_end_of_stream(end_stream);
+  body_req->set_body(data.toString());
+  response_state_ = FilterState::BODY;
+  ENVOY_LOG(debug, "Sending response_body message. end_stream = {}", end_stream);
+  stream_->send(std::move(req), false);
+  stats_.stream_msgs_sent_.inc();
+  return FilterDataStatus::StopIterationAndWatermark;
+}
+
+void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
   auto response = std::move(r);
   bool message_handled = false;
   ENVOY_LOG(debug, "Received gRPC message. State = {}", request_state_);
 
-  if (response->has_request_headers()) {
+  // Update processing mode now because filter callbacks check it
+  // and the various "handle" methods below may result in callbacks
+  // being invoked in line.
+  if (response->has_mode_override()) {
+    ENVOY_LOG(debug, "Processing mode overridden by server for this request");
+    processing_mode_ = response->mode_override();
+  }
+
+  switch (response->response_case()) {
+  case ProcessingResponse::ResponseCase::kRequestHeaders:
     message_handled = handleRequestHeadersResponse(response->request_headers());
-  } else if (response->has_response_headers()) {
+    break;
+  case ProcessingResponse::ResponseCase::kResponseHeaders:
     message_handled = handleResponseHeadersResponse(response->response_headers());
-  } else if (response->has_immediate_response()) {
+    break;
+  case ProcessingResponse::ResponseCase::kRequestBody:
+    message_handled = handleRequestBodyResponse(response->request_body());
+    break;
+  case ProcessingResponse::ResponseCase::kResponseBody:
+    message_handled = handleResponseBodyResponse(response->response_body());
+    break;
+  case ProcessingResponse::ResponseCase::kImmediateResponse:
     handleImmediateResponse(response->immediate_response());
     message_handled = true;
+    break;
+  default:
+    // Any other message is considered spurious
+    break;
   }
 
   if (message_handled) {
-    if (response->has_mode_override()) {
-      ENVOY_LOG(debug, "Processing mode overridden by server for this request");
-      processing_mode_ = response->mode_override();
-    }
     stats_.stream_msgs_received_.inc();
   } else {
     stats_.spurious_msgs_received_.inc();
-    // Ignore messages received out of order. However, close the stream to
+    // Ignore messages received out of order. However, ignore the stream
     // protect ourselves since the server is not following the protocol.
     ENVOY_LOG(warn, "Spurious response message received on gRPC stream");
     cleanupState();
-    closeStream();
+    processing_complete_ = true;
   }
 }
 
@@ -136,13 +220,35 @@ bool Filter::handleResponseHeadersResponse(const HeadersResponse& response) {
   return false;
 }
 
+bool Filter::handleRequestBodyResponse(const BodyResponse& response) {
+  if (request_state_ == FilterState::BODY) {
+    ENVOY_LOG(debug, "Applying request_body response");
+    MutationUtils::applyCommonBodyResponse(response, *request_body_chunk_);
+    request_state_ = FilterState::IDLE;
+    decoder_callbacks_->continueDecoding();
+    return true;
+  }
+  return false;
+}
+
+bool Filter::handleResponseBodyResponse(const BodyResponse& response) {
+  if (response_state_ == FilterState::BODY) {
+    ENVOY_LOG(debug, "Applying response_body response");
+    MutationUtils::applyCommonBodyResponse(response, *response_body_chunk_);
+    response_state_ = FilterState::IDLE;
+    encoder_callbacks_->continueEncoding();
+    return true;
+  }
+  return false;
+}
+
 void Filter::handleImmediateResponse(const ImmediateResponse& response) {
   // We don't want to process any more stream messages after this.
-  // Close the stream before sending because "sendLocalResponse" triggers
+  // Close the stream before sending because "sendLocalResponse" may trigger
   // additional calls to this filter.
   request_state_ = FilterState::IDLE;
   response_state_ = FilterState::IDLE;
-  closeStream();
+  processing_complete_ = true;
   sendImmediateResponse(response);
 }
 

--- a/source/extensions/filters/http/ext_proc/mutation_utils.h
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/buffer/buffer.h"
 #include "envoy/http/header_map.h"
 #include "envoy/service/ext_proc/v3alpha/external_processor.pb.h"
 
@@ -23,6 +24,14 @@ public:
   static void
   applyHeaderMutations(const envoy::service::ext_proc::v3alpha::HeaderMutation& mutation,
                        Http::HeaderMap& headers);
+
+  // Apply mutations that are common to body responses.
+  static void applyCommonBodyResponse(const envoy::service::ext_proc::v3alpha::BodyResponse& body,
+                                      Buffer::Instance& buffer);
+
+  // Modify a buffer based on a set of mutations from a protobuf
+  static void applyBodyMutations(const envoy::service::ext_proc::v3alpha::BodyMutation& mutation,
+                                 Buffer::Instance& buffer);
 
 private:
   static bool isSettableHeader(absl::string_view key);

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -145,8 +145,6 @@ TEST_F(ExtProcStreamTest, StreamClosed) {
   EXPECT_FALSE(last_response_);
   EXPECT_TRUE(grpc_closed_);
   EXPECT_EQ(grpc_status_, 0);
-
-  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 
@@ -160,8 +158,6 @@ TEST_F(ExtProcStreamTest, StreamError) {
   EXPECT_FALSE(last_response_);
   EXPECT_FALSE(grpc_closed_);
   EXPECT_EQ(grpc_status_, 123);
-
-  EXPECT_CALL(stream_, closeStream());
   stream->close();
 }
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -14,6 +14,11 @@
 namespace Envoy {
 
 using envoy::extensions::filters::http::ext_proc::v3alpha::ProcessingMode;
+using envoy::service::ext_proc::v3alpha::BodyResponse;
+using envoy::service::ext_proc::v3alpha::HeadersResponse;
+using envoy::service::ext_proc::v3alpha::HttpBody;
+using envoy::service::ext_proc::v3alpha::HttpHeaders;
+using envoy::service::ext_proc::v3alpha::ImmediateResponse;
 using envoy::service::ext_proc::v3alpha::ProcessingRequest;
 using envoy::service::ext_proc::v3alpha::ProcessingResponse;
 using Extensions::HttpFilters::ExternalProcessing::HasNoHeader;
@@ -69,16 +74,29 @@ protected:
     setDownstreamProtocol(Http::CodecClient::Type::HTTP2);
   }
 
-  IntegrationStreamDecoderPtr
-  sendDownstreamRequest(std::function<void(Http::HeaderMap& headers)> modify_headers) {
+  IntegrationStreamDecoderPtr sendDownstreamRequest(
+      absl::optional<std::function<void(Http::HeaderMap& headers)>> modify_headers) {
     auto conn = makeClientConnection(lookupPort("http"));
     codec_client_ = makeHttpConnection(std::move(conn));
     Http::TestRequestHeaderMapImpl headers;
-    if (modify_headers != nullptr) {
-      modify_headers(headers);
+    if (modify_headers) {
+      (*modify_headers)(headers);
     }
     HttpTestUtility::addDefaultHeaders(headers);
     return codec_client_->makeHeaderOnlyRequest(headers);
+  }
+
+  IntegrationStreamDecoderPtr sendDownstreamRequestWithBody(
+      absl::string_view body,
+      absl::optional<std::function<void(Http::HeaderMap& headers)>> modify_headers) {
+    auto conn = makeClientConnection(lookupPort("http"));
+    codec_client_ = makeHttpConnection(std::move(conn));
+    Http::TestRequestHeaderMapImpl headers;
+    HttpTestUtility::addDefaultHeaders(headers, "POST");
+    if (modify_headers) {
+      (*modify_headers)(headers);
+    }
+    return codec_client_->makeRequestWithBody(headers, std::string(body));
   }
 
   void verifyDownstreamResponse(IntegrationStreamDecoder& response, int status_code) {
@@ -101,6 +119,112 @@ protected:
     ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
   }
 
+  void processRequestHeadersMessage(
+      bool first_message,
+      absl::optional<std::function<void(const HttpHeaders&, HeadersResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(
+          fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_request_headers());
+    if (first_message) {
+      processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    }
+    ProcessingResponse response;
+    auto* headers = response.mutable_request_headers();
+    if (cb) {
+      (*cb)(request.request_headers(), *headers);
+    }
+    processor_stream_->sendGrpcMessage(response);
+  }
+
+  void processResponseHeadersMessage(
+      bool first_message,
+      absl::optional<std::function<void(const HttpHeaders&, HeadersResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(
+          fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_response_headers());
+    if (first_message) {
+      processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    }
+    ProcessingResponse response;
+    auto* headers = response.mutable_response_headers();
+    if (cb) {
+      (*cb)(request.response_headers(), *headers);
+    }
+    processor_stream_->sendGrpcMessage(response);
+  }
+
+  void processRequestBodyMessage(
+      bool first_message, absl::optional<std::function<void(const HttpBody&, BodyResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(
+          fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_request_body());
+    if (first_message) {
+      processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    }
+    ProcessingResponse response;
+    auto* body = response.mutable_request_body();
+    if (cb) {
+      (*cb)(request.request_body(), *body);
+    }
+    processor_stream_->sendGrpcMessage(response);
+  }
+
+  void processResponseBodyMessage(
+      bool first_message, absl::optional<std::function<void(const HttpBody&, BodyResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(
+          fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    ASSERT_TRUE(request.has_response_body());
+    if (first_message) {
+      processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    }
+    ProcessingResponse response;
+    auto* body = response.mutable_response_body();
+    if (cb) {
+      (*cb)(request.response_body(), *body);
+    }
+    processor_stream_->sendGrpcMessage(response);
+  }
+
+  void processAndRespondImmediately(bool first_message,
+                                    absl::optional<std::function<void(ImmediateResponse&)>> cb) {
+    ProcessingRequest request;
+    if (first_message) {
+      ASSERT_TRUE(
+          fake_upstreams_.back()->waitForHttpConnection(*dispatcher_, processor_connection_));
+      ASSERT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    }
+    ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, request));
+    if (first_message) {
+      processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+    }
+    ProcessingResponse response;
+    auto* immediate = response.mutable_immediate_response();
+    if (cb) {
+      (*cb)(*immediate);
+    }
+    processor_stream_->sendGrpcMessage(response);
+  }
+
   envoy::extensions::filters::http::ext_proc::v3alpha::ExternalProcessor proto_config_{};
   FakeHttpConnectionPtr processor_connection_;
   FakeStreamPtr processor_stream_;
@@ -115,7 +239,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, ExtProcIntegrationTest,
 TEST_P(ExtProcIntegrationTest, GetAndCloseStream) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
   ProcessingRequest request_headers_msg;
   waitForFirstMessage(request_headers_msg);
@@ -133,7 +257,7 @@ TEST_P(ExtProcIntegrationTest, GetAndCloseStream) {
 TEST_P(ExtProcIntegrationTest, GetAndFailStream) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
   ProcessingRequest request_headers_msg;
   waitForFirstMessage(request_headers_msg);
@@ -148,7 +272,7 @@ TEST_P(ExtProcIntegrationTest, GetAndFailStream) {
 TEST_P(ExtProcIntegrationTest, GetAndFailStreamOutOfLine) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
   ProcessingRequest request_headers_msg;
   waitForFirstMessage(request_headers_msg);
@@ -169,7 +293,7 @@ TEST_P(ExtProcIntegrationTest, GetAndFailStreamOutOfLine) {
 TEST_P(ExtProcIntegrationTest, GetAndFailStreamOutOfLineLater) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
   ProcessingRequest request_headers_msg;
   waitForFirstMessage(request_headers_msg);
@@ -190,7 +314,7 @@ TEST_P(ExtProcIntegrationTest, GetAndFailStreamOutOfLineLater) {
 TEST_P(ExtProcIntegrationTest, GetAndCloseStreamOnResponse) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
   ProcessingRequest request_headers_msg;
   waitForFirstMessage(request_headers_msg);
@@ -214,7 +338,7 @@ TEST_P(ExtProcIntegrationTest, GetAndCloseStreamOnResponse) {
 TEST_P(ExtProcIntegrationTest, GetAndFailStreamOnResponse) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
   ProcessingRequest request_headers_msg;
   waitForFirstMessage(request_headers_msg);
@@ -241,29 +365,20 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
   auto response = sendDownstreamRequest(
       [](Http::HeaderMap& headers) { headers.addCopy(LowerCaseString("x-remove-this"), "yes"); });
 
-  ProcessingRequest request_headers_msg;
-  waitForFirstMessage(request_headers_msg);
+  processRequestHeadersMessage(true, [](const HttpHeaders& headers, HeadersResponse& headers_resp) {
+    Http::TestRequestHeaderMapImpl expected_request_headers{{":scheme", "http"},
+                                                            {":method", "GET"},
+                                                            {"host", "host"},
+                                                            {":path", "/"},
+                                                            {"x-remove-this", "yes"}};
+    EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_request_headers));
 
-  ASSERT_TRUE(request_headers_msg.has_request_headers());
-  const auto request_headers = request_headers_msg.request_headers();
-  Http::TestRequestHeaderMapImpl expected_request_headers{{":scheme", "http"},
-                                                          {":method", "GET"},
-                                                          {"host", "host"},
-                                                          {":path", "/"},
-                                                          {"x-remove-this", "yes"}};
-  EXPECT_THAT(request_headers.headers(), HeaderProtosEqual(expected_request_headers));
-
-  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-
-  // Ask to change the headers
-  ProcessingResponse response_msg;
-  auto response_header_mutation =
-      response_msg.mutable_request_headers()->mutable_response()->mutable_header_mutation();
-  auto mut1 = response_header_mutation->add_set_headers();
-  mut1->mutable_header()->set_key("x-new-header");
-  mut1->mutable_header()->set_value("new");
-  response_header_mutation->add_remove_headers("x-remove-this");
-  processor_stream_->sendGrpcMessage(response_msg);
+    auto response_header_mutation = headers_resp.mutable_response()->mutable_header_mutation();
+    auto* mut1 = response_header_mutation->add_set_headers();
+    mut1->mutable_header()->set_key("x-new-header");
+    mut1->mutable_header()->set_value("new");
+    response_header_mutation->add_remove_headers("x-remove-this");
+  });
 
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
@@ -275,18 +390,10 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(100, true);
 
-  // Now expect a message for the response path
-  ProcessingRequest response_headers_msg;
-  ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, response_headers_msg));
-  ASSERT_TRUE(response_headers_msg.has_response_headers());
-  const auto response_headers = response_headers_msg.response_headers();
-  Http::TestRequestHeaderMapImpl expected_response_headers{{":status", "200"}};
-  EXPECT_THAT(response_headers.headers(), HeaderProtosEqual(expected_response_headers));
-
-  // Send back a response but don't do anything
-  ProcessingResponse response_2;
-  response_2.mutable_response_headers();
-  processor_stream_->sendGrpcMessage(response_2);
+  processResponseHeadersMessage(false, [](const HttpHeaders& headers, HeadersResponse&) {
+    Http::TestRequestHeaderMapImpl expected_response_headers{{":status", "200"}};
+    EXPECT_THAT(headers.headers(), HeaderProtosEqual(expected_response_headers));
+  });
 
   verifyDownstreamResponse(*response, 200);
 }
@@ -297,32 +404,109 @@ TEST_P(ExtProcIntegrationTest, GetAndSetHeaders) {
 TEST_P(ExtProcIntegrationTest, GetAndSetHeadersOnResponse) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
-
-  ProcessingRequest request_headers_msg;
-  waitForFirstMessage(request_headers_msg);
-
-  ASSERT_TRUE(request_headers_msg.has_request_headers());
-  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-  ProcessingResponse resp1;
-  resp1.mutable_request_headers();
-  processor_stream_->sendGrpcMessage(resp1);
-
+  auto response = sendDownstreamRequest(absl::nullopt);
+  processRequestHeadersMessage(true, absl::nullopt);
   handleUpstreamRequest();
 
-  ProcessingRequest response_headers_msg;
-  ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, response_headers_msg));
-  ASSERT_TRUE(response_headers_msg.has_response_headers());
-  ProcessingResponse resp2;
-  auto* headers2 = resp2.mutable_response_headers();
-  auto* response_mutation = headers2->mutable_response()->mutable_header_mutation();
-  auto* add1 = response_mutation->add_set_headers();
-  add1->mutable_header()->set_key("x-response-processed");
-  add1->mutable_header()->set_value("1");
-  processor_stream_->sendGrpcMessage(resp2);
+  processResponseHeadersMessage(false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+    auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
+    auto* add1 = response_mutation->add_set_headers();
+    add1->mutable_header()->set_key("x-response-processed");
+    add1->mutable_header()->set_value("1");
+  });
 
   verifyDownstreamResponse(*response, 200);
   EXPECT_THAT(response->headers(), SingleHeaderValueIs("x-response-processed", "1"));
+}
+
+// Test the filter with a response body callback enabled using an
+// an ext_proc server that responds to the response_body message
+// by requesting to modify the response body.
+TEST_P(ExtProcIntegrationTest, GetAndSetBodyOnResponse) {
+  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+  processRequestHeadersMessage(true, absl::nullopt);
+  handleUpstreamRequest();
+
+  processResponseHeadersMessage(false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+    auto* content_length =
+        headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+    content_length->mutable_header()->set_key("content-length");
+    content_length->mutable_header()->set_value("13");
+  });
+
+  bool last_chunk = false;
+  do {
+    processResponseBodyMessage(false, [&last_chunk](const HttpBody& body, BodyResponse& body_resp) {
+      auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
+      // Replace the last chunk of the body in case there were many chunks
+      if (body.end_of_stream()) {
+        last_chunk = true;
+        body_mut->set_body("Hello, World!");
+      } else {
+        body_mut->set_clear_body(true);
+      }
+    });
+  } while (!last_chunk);
+
+  verifyDownstreamResponse(*response, 200);
+  EXPECT_THAT(response->headers(), SingleHeaderValueIs("content-length", "13"));
+  EXPECT_EQ("Hello, World!", response->body());
+}
+
+// Test the filter with both body callbacks enabled and have the
+// ext_proc server change both of them.
+TEST_P(ExtProcIntegrationTest, GetAndSetBodyOnBoth) {
+  // Logger::Registry::getLog(Logger::Id::filter).set_level(spdlog::level::trace);
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  auto response = sendDownstreamRequestWithBody("Replace this!", absl::nullopt);
+
+  processRequestHeadersMessage(true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+    auto* content_length =
+        headers_resp.mutable_response()->mutable_header_mutation()->add_set_headers();
+    content_length->mutable_header()->set_key("content-length");
+    content_length->mutable_header()->set_value("13");
+  });
+
+  bool last_chunk = false;
+  do {
+    processRequestBodyMessage(false, [&last_chunk](const HttpBody& body, BodyResponse& body_resp) {
+      auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
+      // Replace the last chunk of the body in case there were many chunks
+      if (body.end_of_stream()) {
+        last_chunk = true;
+        body_mut->set_body("Hello, World!");
+      } else {
+        body_mut->set_clear_body(true);
+      }
+    });
+  } while (!last_chunk);
+
+  handleUpstreamRequest();
+
+  processResponseHeadersMessage(false, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+    headers_resp.mutable_response()->mutable_header_mutation()->add_remove_headers(
+        "content-length");
+  });
+
+  last_chunk = false;
+  do {
+    processResponseBodyMessage(false, [&last_chunk](const HttpBody& body, BodyResponse& body_resp) {
+      if (body.end_of_stream()) {
+        last_chunk = true;
+      }
+      body_resp.mutable_response()->mutable_body_mutation()->set_body("123");
+    });
+  } while (!last_chunk);
+
+  verifyDownstreamResponse(*response, 200);
+  EXPECT_EQ("123", response->body());
 }
 
 // Test the filter using a configuration that uses the processing mode to
@@ -331,20 +515,15 @@ TEST_P(ExtProcIntegrationTest, ProcessingModeResponseOnly) {
   proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SKIP);
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
   handleUpstreamRequest();
 
-  ProcessingRequest response_headers_msg;
-  waitForFirstMessage(response_headers_msg);
-  ASSERT_TRUE(response_headers_msg.has_response_headers());
-  ProcessingResponse resp2;
-  auto* headers2 = resp2.mutable_response_headers();
-  auto* response_mutation = headers2->mutable_response()->mutable_header_mutation();
-  auto* add1 = response_mutation->add_set_headers();
-  add1->mutable_header()->set_key("x-response-processed");
-  add1->mutable_header()->set_value("1");
-  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-  processor_stream_->sendGrpcMessage(resp2);
+  processResponseHeadersMessage(true, [](const HttpHeaders&, HeadersResponse& headers_resp) {
+    auto* response_mutation = headers_resp.mutable_response()->mutable_header_mutation();
+    auto* add1 = response_mutation->add_set_headers();
+    add1->mutable_header()->set_key("x-response-processed");
+    add1->mutable_header()->set_value("1");
+  });
 
   verifyDownstreamResponse(*response, 200);
   EXPECT_THAT(response->headers(), SingleHeaderValueIs("x-response-processed", "1"));
@@ -359,27 +538,19 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
 
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
+  auto response = sendDownstreamRequest(absl::nullopt);
 
-  ProcessingRequest request_headers_msg;
-  waitForFirstMessage(request_headers_msg);
-
-  EXPECT_TRUE(request_headers_msg.has_request_headers());
-  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-
-  // Produce an immediate response
-  ProcessingResponse response_msg;
-  auto* immediate_response = response_msg.mutable_immediate_response();
-  immediate_response->mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
-  immediate_response->set_body("{\"reason\": \"Not authorized\"}");
-  immediate_response->set_details("Failed because you are not authorized");
-  auto* hdr1 = immediate_response->mutable_headers()->add_set_headers();
-  hdr1->mutable_header()->set_key("x-failure-reason");
-  hdr1->mutable_header()->set_value("testing");
-  auto* hdr2 = immediate_response->mutable_headers()->add_set_headers();
-  hdr2->mutable_header()->set_key("content-type");
-  hdr2->mutable_header()->set_value("application/json");
-  processor_stream_->sendGrpcMessage(response_msg);
+  processAndRespondImmediately(true, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    immediate.set_body("{\"reason\": \"Not authorized\"}");
+    immediate.set_details("Failed because you are not authorized");
+    auto* hdr1 = immediate.mutable_headers()->add_set_headers();
+    hdr1->mutable_header()->set_key("x-failure-reason");
+    hdr1->mutable_header()->set_value("testing");
+    auto* hdr2 = immediate.mutable_headers()->add_set_headers();
+    hdr2->mutable_header()->set_key("content-type");
+    hdr2->mutable_header()->set_value("application/json");
+  });
 
   verifyDownstreamResponse(*response, 401);
   EXPECT_THAT(response->headers(), SingleHeaderValueIs("x-failure-reason", "testing"));
@@ -394,36 +565,63 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediately) {
 TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyOnResponse) {
   initializeConfig();
   HttpIntegrationTest::initialize();
-  auto response = sendDownstreamRequest(nullptr);
-
-  // request_headers message to processor
-  ProcessingRequest request_headers_msg;
-  waitForFirstMessage(request_headers_msg);
-  EXPECT_TRUE(request_headers_msg.has_request_headers());
-  processor_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
-
-  // Response to request_headers
-  ProcessingResponse resp1;
-  resp1.mutable_request_headers();
-  processor_stream_->sendGrpcMessage(resp1);
-
+  auto response = sendDownstreamRequest(absl::nullopt);
+  processRequestHeadersMessage(true, absl::nullopt);
   handleUpstreamRequest();
 
-  // response_headers message to processor
-  ProcessingRequest response_headers_msg;
-  ASSERT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, response_headers_msg));
-  ASSERT_TRUE(response_headers_msg.has_response_headers());
-
-  // Response to response_headers
-  ProcessingResponse resp2;
-  auto* immediate_response = resp2.mutable_immediate_response();
-  immediate_response->mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
-  immediate_response->set_body("{\"reason\": \"Not authorized\"}");
-  immediate_response->set_details("Failed because you are not authorized");
-  processor_stream_->sendGrpcMessage(resp2);
+  processAndRespondImmediately(false, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    immediate.set_body("{\"reason\": \"Not authorized\"}");
+    immediate.set_details("Failed because you are not authorized");
+  });
 
   verifyDownstreamResponse(*response, 401);
   EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
+}
+
+// Test the filter with request body streaming enabled using
+// an ext_proc server that responds to the request_body message
+// by sending back an immediate_response message
+TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyOnRequestBody) {
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequestWithBody("Replace this!", absl::nullopt);
+  processRequestHeadersMessage(true, absl::nullopt);
+  processAndRespondImmediately(false, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    immediate.set_body("{\"reason\": \"Not authorized\"}");
+    immediate.set_details("Failed because you are not authorized");
+  });
+
+  verifyDownstreamResponse(*response, 401);
+  EXPECT_EQ("{\"reason\": \"Not authorized\"}", response->body());
+}
+
+// Test the filter with body streaming enabled using
+// an ext_proc server that responds to the response_body message
+// by sending back an immediate_response message. Since this
+// happens after the response headers have been sent, as a result
+// Envoy should just reset the stream.
+TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyOnResponseBody) {
+  Logger::Registry::getLog(Logger::Id::filter).set_level(spdlog::level::trace);
+  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::STREAMED);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+  auto response = sendDownstreamRequest(absl::nullopt);
+  processRequestHeadersMessage(true, absl::nullopt);
+  handleUpstreamRequest();
+  processResponseHeadersMessage(false, absl::nullopt);
+
+  processAndRespondImmediately(false, [](ImmediateResponse& immediate) {
+    immediate.mutable_status()->set_code(envoy::type::v3::StatusCode::Unauthorized);
+    immediate.set_body("{\"reason\": \"Not authorized\"}");
+    immediate.set_details("Failed because you are not authorized");
+  });
+
+  // The stream should have been reset here before the complete
+  // response was received.
+  response->waitForReset();
 }
 
 } // namespace Envoy

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -22,6 +22,10 @@ namespace ExternalProcessing {
 namespace {
 
 using envoy::extensions::filters::http::ext_proc::v3alpha::ProcessingMode;
+using envoy::service::ext_proc::v3alpha::BodyResponse;
+using envoy::service::ext_proc::v3alpha::HeadersResponse;
+using envoy::service::ext_proc::v3alpha::HttpBody;
+using envoy::service::ext_proc::v3alpha::HttpHeaders;
 using envoy::service::ext_proc::v3alpha::ProcessingRequest;
 using envoy::service::ext_proc::v3alpha::ProcessingResponse;
 
@@ -61,31 +65,96 @@ protected:
     stream_timeout_ = timeout;
 
     auto stream = std::make_unique<MockStream>();
-    EXPECT_CALL(*stream, send(_, _)).WillRepeatedly(Invoke(this, &HttpFilterTest::doSend));
-    EXPECT_CALL(*stream, close()).WillRepeatedly(Invoke(this, &HttpFilterTest::doSendClose));
+    // We never send with the "close" flag set
+    EXPECT_CALL(*stream, send(_, false)).WillRepeatedly(Invoke(this, &HttpFilterTest::doSend));
+    // close is idempotent and only called once per filter
+    EXPECT_CALL(*stream, close()).WillOnce(Invoke(this, &HttpFilterTest::doSendClose));
     return stream;
   }
 
-  void doSend(ProcessingRequest&& request, bool end_stream) {
-    ASSERT_FALSE(stream_close_sent_);
+  void doSend(ProcessingRequest&& request, Unused) {
     ASSERT_TRUE(last_request_processed_);
     last_request_ = std::move(request);
     last_request_processed_ = false;
-    if (end_stream) {
-      stream_close_sent_ = true;
-    }
   }
 
-  void doSendClose() {
-    ASSERT_FALSE(stream_close_sent_);
-    stream_close_sent_ = true;
+  bool doSendClose() { return !server_closed_stream_; }
+
+  // Expect a request_headers request, and send back a valid response.
+  void processRequestHeaders(
+      absl::optional<std::function<void(const HttpHeaders&, ProcessingResponse&, HeadersResponse&)>>
+          cb) {
+    ASSERT_FALSE(last_request_processed_);
+    EXPECT_FALSE(last_request_.async_mode());
+    ASSERT_TRUE(last_request_.has_request_headers());
+    const auto& headers = last_request_.request_headers();
+    auto response = std::make_unique<ProcessingResponse>();
+    auto* headers_response = response->mutable_request_headers();
+    if (cb) {
+      (*cb)(headers, *response, *headers_response);
+    }
+    last_request_processed_ = true;
+    EXPECT_CALL(decoder_callbacks_, continueDecoding());
+    stream_callbacks_->onReceiveMessage(std::move(response));
+  }
+
+  // Expect a response_headers request, and send back a valid response
+  void processResponseHeaders(
+      absl::optional<std::function<void(const HttpHeaders&, ProcessingResponse&, HeadersResponse&)>>
+          cb) {
+    ASSERT_FALSE(last_request_processed_);
+    EXPECT_FALSE(last_request_.async_mode());
+    ASSERT_TRUE(last_request_.has_response_headers());
+    const auto& headers = last_request_.response_headers();
+    auto response = std::make_unique<ProcessingResponse>();
+    auto* headers_response = response->mutable_response_headers();
+    if (cb) {
+      (*cb)(headers, *response, *headers_response);
+    }
+    last_request_processed_ = true;
+    EXPECT_CALL(encoder_callbacks_, continueEncoding());
+    stream_callbacks_->onReceiveMessage(std::move(response));
+  }
+
+  // Expect a request_body request, and send back a valid response
+  void processRequestBody(
+      absl::optional<std::function<void(const HttpBody&, ProcessingResponse&, BodyResponse&)>> cb) {
+    ASSERT_FALSE(last_request_processed_);
+    EXPECT_FALSE(last_request_.async_mode());
+    ASSERT_TRUE(last_request_.has_request_body());
+    const auto& body = last_request_.request_body();
+    auto response = std::make_unique<ProcessingResponse>();
+    auto* body_response = response->mutable_request_body();
+    if (cb) {
+      (*cb)(body, *response, *body_response);
+    }
+    last_request_processed_ = true;
+    EXPECT_CALL(decoder_callbacks_, continueDecoding());
+    stream_callbacks_->onReceiveMessage(std::move(response));
+  }
+
+  // Expect a request_body request, and send back a valid response
+  void processResponseBody(
+      absl::optional<std::function<void(const HttpBody&, ProcessingResponse&, BodyResponse&)>> cb) {
+    ASSERT_FALSE(last_request_processed_);
+    EXPECT_FALSE(last_request_.async_mode());
+    ASSERT_TRUE(last_request_.has_response_body());
+    const auto& body = last_request_.response_body();
+    auto response = std::make_unique<ProcessingResponse>();
+    auto* body_response = response->mutable_response_body();
+    if (cb) {
+      (*cb)(body, *response, *body_response);
+    }
+    last_request_processed_ = true;
+    EXPECT_CALL(encoder_callbacks_, continueEncoding());
+    stream_callbacks_->onReceiveMessage(std::move(response));
   }
 
   std::unique_ptr<MockClient> client_;
   ExternalProcessorCallbacks* stream_callbacks_ = nullptr;
   ProcessingRequest last_request_;
   bool last_request_processed_ = true;
-  bool stream_close_sent_ = false;
+  bool server_closed_stream_ = false;
   std::chrono::milliseconds stream_timeout_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   FilterConfigSharedPtr config_;
@@ -120,28 +189,17 @@ TEST_F(HttpFilterTest, SimplestPost) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
-  // Verify that call was received by mock gRPC server
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_request_headers());
-  const auto request_headers = last_request_.request_headers();
-  EXPECT_FALSE(request_headers.end_of_stream());
-
-  Http::TestRequestHeaderMapImpl expected{{":path", "/"},
-                                          {":method", "POST"},
-                                          {":scheme", "http"},
-                                          {"host", "host"},
-                                          {"content-type", "text/plain"},
-                                          {"content-length", "10"},
-                                          {"x-some-other-header", "yes"}};
-  EXPECT_THAT(request_headers.headers(), HeaderProtosEqual(expected));
-  last_request_processed_ = true;
-
-  // Send back a response
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  std::unique_ptr<ProcessingResponse> resp1 = std::make_unique<ProcessingResponse>();
-  resp1->mutable_request_headers();
-  stream_callbacks_->onReceiveMessage(std::move(resp1));
+  processRequestHeaders([](const HttpHeaders& header_req, ProcessingResponse&, HeadersResponse&) {
+    EXPECT_FALSE(header_req.end_of_stream());
+    Http::TestRequestHeaderMapImpl expected{{":path", "/"},
+                                            {":method", "POST"},
+                                            {":scheme", "http"},
+                                            {"host", "host"},
+                                            {"content-type", "text/plain"},
+                                            {"content-length", "10"},
+                                            {"x-some-other-header", "yes"}};
+    EXPECT_THAT(header_req.headers(), HeaderProtosEqual(expected));
+  });
 
   data_.add("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, true));
@@ -154,30 +212,18 @@ TEST_F(HttpFilterTest, SimplestPost) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->encodeHeaders(response_headers_, false));
 
-  // Expect another stream message
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_response_headers());
-  const auto response_headers = last_request_.response_headers();
-  EXPECT_FALSE(response_headers.end_of_stream());
-
-  Http::TestRequestHeaderMapImpl expected_response{
-      {":status", "200"}, {"content-type", "text/plain"}, {"content-length", "3"}};
-  EXPECT_THAT(response_headers.headers(), HeaderProtosEqual(expected_response));
-  last_request_processed_ = true;
-
-  // Send back a response
-  EXPECT_CALL(encoder_callbacks_, continueEncoding());
-  std::unique_ptr<ProcessingResponse> resp2 = std::make_unique<ProcessingResponse>();
-  resp2->mutable_response_headers();
-  stream_callbacks_->onReceiveMessage(std::move(resp2));
+  processResponseHeaders([](const HttpHeaders& header_resp, ProcessingResponse&, HeadersResponse&) {
+    EXPECT_FALSE(header_resp.end_of_stream());
+    Http::TestRequestHeaderMapImpl expected_response{
+        {":status", "200"}, {"content-type", "text/plain"}, {"content-length", "3"}};
+    EXPECT_THAT(header_resp.headers(), HeaderProtosEqual(expected_response));
+  });
 
   data_.add("bar");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, false));
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(2, config_->stats().stream_msgs_sent_.value());
@@ -202,24 +248,18 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_request_headers());
-
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  std::unique_ptr<ProcessingResponse> resp1 = std::make_unique<ProcessingResponse>();
-  auto req_headers_response = resp1->mutable_request_headers();
-  auto headers_mut = req_headers_response->mutable_response()->mutable_header_mutation();
-  auto add1 = headers_mut->add_set_headers();
-  add1->mutable_header()->set_key("x-new-header");
-  add1->mutable_header()->set_value("new");
-  add1->mutable_append()->set_value(false);
-  auto add2 = headers_mut->add_set_headers();
-  add2->mutable_header()->set_key("x-some-other-header");
-  add2->mutable_header()->set_value("no");
-  add2->mutable_append()->set_value(true);
-  *headers_mut->add_remove_headers() = "x-do-we-want-this";
-  stream_callbacks_->onReceiveMessage(std::move(resp1));
+  processRequestHeaders([](const HttpHeaders&, ProcessingResponse&, HeadersResponse& header_resp) {
+    auto headers_mut = header_resp.mutable_response()->mutable_header_mutation();
+    auto add1 = headers_mut->add_set_headers();
+    add1->mutable_header()->set_key("x-new-header");
+    add1->mutable_header()->set_value("new");
+    add1->mutable_append()->set_value(false);
+    auto add2 = headers_mut->add_set_headers();
+    add2->mutable_header()->set_key("x-some-other-header");
+    add2->mutable_header()->set_value("no");
+    add2->mutable_append()->set_value(true);
+    *headers_mut->add_remove_headers() = "x-do-we-want-this";
+  });
 
   // We should now have changed the original header a bit
   Http::TestRequestHeaderMapImpl expected{{":path", "/"},
@@ -230,7 +270,6 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
                                           {"x-some-other-header", "yes"},
                                           {"x-some-other-header", "no"}};
   EXPECT_THAT(&request_headers_, HeaderMapEqualIgnoreOrder(&expected));
-  last_request_processed_ = true;
 
   data_.add("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, true));
@@ -243,28 +282,18 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->encodeHeaders(response_headers_, false));
 
-  // Expect another stream message
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_response_headers());
-  const auto response_headers = last_request_.response_headers();
-  EXPECT_FALSE(response_headers.end_of_stream());
+  processResponseHeaders(
+      [](const HttpHeaders& response_headers, ProcessingResponse&, HeadersResponse& header_resp) {
+        EXPECT_FALSE(response_headers.end_of_stream());
+        Http::TestRequestHeaderMapImpl expected_response{
+            {":status", "200"}, {"content-type", "text/plain"}, {"content-length", "3"}};
+        EXPECT_THAT(response_headers.headers(), HeaderProtosEqual(expected_response));
 
-  Http::TestRequestHeaderMapImpl expected_response{
-      {":status", "200"}, {"content-type", "text/plain"}, {"content-length", "3"}};
-  EXPECT_TRUE(ExtProcTestUtility::headerProtosEqualIgnoreOrder(expected_response,
-                                                               response_headers.headers()));
-  last_request_processed_ = true;
-
-  // Send back a response
-  EXPECT_CALL(encoder_callbacks_, continueEncoding());
-  std::unique_ptr<ProcessingResponse> resp2 = std::make_unique<ProcessingResponse>();
-  auto resp_headers = resp2->mutable_response_headers();
-  auto resp_headers_mut = resp_headers->mutable_response()->mutable_header_mutation();
-  auto resp_add1 = resp_headers_mut->add_set_headers();
-  resp_add1->mutable_header()->set_key("x-new-header");
-  resp_add1->mutable_header()->set_value("new");
-  stream_callbacks_->onReceiveMessage(std::move(resp2));
+        auto* resp_headers_mut = header_resp.mutable_response()->mutable_header_mutation();
+        auto* resp_add1 = resp_headers_mut->add_set_headers();
+        resp_add1->mutable_header()->set_key("x-new-header");
+        resp_add1->mutable_header()->set_value("new");
+      });
 
   // We should now have changed the original header a bit
   Http::TestRequestHeaderMapImpl final_expected_response{{":status", "200"},
@@ -278,7 +307,6 @@ TEST_F(HttpFilterTest, PostAndChangeHeaders) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(2, config_->stats().stream_msgs_sent_.value());
@@ -342,7 +370,6 @@ TEST_F(HttpFilterTest, PostAndRespondImmediately) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
@@ -366,15 +393,7 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyOnResponse) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_request_headers());
-  last_request_processed_ = true;
-
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  std::unique_ptr<ProcessingResponse> resp1 = std::make_unique<ProcessingResponse>();
-  resp1->mutable_request_headers();
-  stream_callbacks_->onReceiveMessage(std::move(resp1));
+  processRequestHeaders(absl::nullopt);
 
   data_.add("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, true));
@@ -384,7 +403,6 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyOnResponse) {
             filter_->encodeHeaders(response_headers_, false));
 
   EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
   ASSERT_TRUE(last_request_.has_response_headers());
   last_request_processed_ = true;
 
@@ -408,7 +426,190 @@ TEST_F(HttpFilterTest, PostAndRespondImmediatelyOnResponse) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
+
+  EXPECT_EQ(1, config_->stats().streams_started_.value());
+  EXPECT_EQ(2, config_->stats().stream_msgs_sent_.value());
+  EXPECT_EQ(2, config_->stats().stream_msgs_received_.value());
+  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+}
+
+// Using a configuration with streaming set for the request body,
+// test the filter with a processor that changes the request body.
+TEST_F(HttpFilterTest, PostAndChangeRequestBodyStreamed) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  processing_mode:
+    request_header_mode: "SEND"
+    response_header_mode: "SEND"
+    request_body_mode: "STREAMED"
+    response_body_mode: "NONE"
+    request_trailer_mode: "SKIP"
+    response_trailer_mode: "SKIP"
+  )EOF");
+
+  // Create synthetic HTTP request
+  HttpTestUtility::addDefaultHeaders(request_headers_, "POST");
+  request_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  request_headers_.addCopy(LowerCaseString("content-length"), 100);
+
+  EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers_, false));
+  processRequestHeaders(absl::nullopt);
+
+  TestUtility::feedBufferWithRandomCharacters(data_, 100);
+  EXPECT_EQ(FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
+
+  processRequestBody([](const HttpBody& req_body, ProcessingResponse&, BodyResponse& body_resp) {
+    EXPECT_FALSE(req_body.end_of_stream());
+    EXPECT_EQ(100, req_body.body().size());
+    auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
+    body_mut->set_body("Replaced!");
+  });
+  EXPECT_EQ("Replaced!", data_.toString());
+
+  // Deliver a second callback with an empty body and the end.
+  data_.drain(data_.length());
+  EXPECT_EQ(FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+  processRequestBody([](const HttpBody& req_body, ProcessingResponse&, BodyResponse&) {
+    EXPECT_TRUE(req_body.end_of_stream());
+    EXPECT_TRUE(req_body.body().empty());
+  });
+  EXPECT_EQ(0, data_.length());
+
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+
+  response_headers_.addCopy(LowerCaseString(":status"), "200");
+  response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  response_headers_.addCopy(LowerCaseString("content-length"), "3");
+
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encode100ContinueHeaders(response_headers_));
+  EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->encodeHeaders(response_headers_, false));
+  processResponseHeaders(absl::nullopt);
+
+  data_.add("bar");
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, false));
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
+  filter_->onDestroy();
+
+  EXPECT_EQ(1, config_->stats().streams_started_.value());
+  EXPECT_EQ(4, config_->stats().stream_msgs_sent_.value());
+  EXPECT_EQ(4, config_->stats().stream_msgs_received_.value());
+  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+}
+
+// Using a configuration with streaming set for the request and
+// response bodies but not the headers,
+// test the filter with a processor that clears the request body
+// and changes the response body.
+TEST_F(HttpFilterTest, PostAndChangeBothBodiesStreamed) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  processing_mode:
+    request_header_mode: "SKIP"
+    response_header_mode: "SKIP"
+    request_body_mode: "STREAMED"
+    response_body_mode: "STREAMED"
+    request_trailer_mode: "SKIP"
+    response_trailer_mode: "SKIP"
+  )EOF");
+
+  // Create synthetic HTTP request
+  HttpTestUtility::addDefaultHeaders(request_headers_, "POST");
+  request_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  request_headers_.addCopy(LowerCaseString("content-length"), 100);
+
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  TestUtility::feedBufferWithRandomCharacters(data_, 100);
+  EXPECT_EQ(FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, true));
+
+  processRequestBody([](const HttpBody& req_body, ProcessingResponse&, BodyResponse& body_resp) {
+    EXPECT_TRUE(req_body.end_of_stream());
+    EXPECT_EQ(100, req_body.body().size());
+    auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
+    body_mut->set_clear_body(true);
+  });
+  EXPECT_EQ(0, data_.length());
+
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+
+  response_headers_.addCopy(LowerCaseString(":status"), "200");
+  response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  response_headers_.addCopy(LowerCaseString("content-length"), "100");
+
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encode100ContinueHeaders(response_headers_));
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+
+  TestUtility::feedBufferWithRandomCharacters(data_, 100);
+  EXPECT_EQ(FilterDataStatus::StopIterationAndWatermark, filter_->encodeData(data_, true));
+
+  processResponseBody([](const HttpBody& req_body, ProcessingResponse&, BodyResponse& body_resp) {
+    EXPECT_TRUE(req_body.end_of_stream());
+    EXPECT_EQ(100, req_body.body().size());
+    auto* body_mut = body_resp.mutable_response()->mutable_body_mutation();
+    body_mut->set_body("Hello, World!");
+  });
+  EXPECT_EQ("Hello, World!", data_.toString());
+
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
+  filter_->onDestroy();
+
+  EXPECT_EQ(1, config_->stats().streams_started_.value());
+  EXPECT_EQ(2, config_->stats().stream_msgs_sent_.value());
+  EXPECT_EQ(2, config_->stats().stream_msgs_received_.value());
+  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+}
+
+// Using a configuration with streaming set for the request and
+// response bodies, we should ignore a "buffered" body mode for now
+// because it is not implemented.
+TEST_F(HttpFilterTest, PostAndIgnoreBufferedBodiesUntilImplemented) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  processing_mode:
+    request_header_mode: "SEND"
+    response_header_mode: "SEND"
+    request_body_mode: "BUFFERED"
+    response_body_mode: "BUFFERED"
+    request_trailer_mode: "SKIP"
+    response_trailer_mode: "SKIP"
+  )EOF");
+
+  // Create synthetic HTTP request
+  HttpTestUtility::addDefaultHeaders(request_headers_, "POST");
+  request_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  request_headers_.addCopy(LowerCaseString("content-length"), 100);
+
+  EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers_, false));
+  processRequestHeaders(absl::nullopt);
+
+  TestUtility::feedBufferWithRandomCharacters(data_, 100);
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(data_, true));
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+
+  response_headers_.addCopy(LowerCaseString(":status"), "200");
+  response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  response_headers_.addCopy(LowerCaseString("content-length"), "100");
+
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encode100ContinueHeaders(response_headers_));
+  EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->encodeHeaders(response_headers_, false));
+  processResponseHeaders(absl::nullopt);
+
+  TestUtility::feedBufferWithRandomCharacters(data_, 100);
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
+
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
+  filter_->onDestroy();
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(2, config_->stats().stream_msgs_sent_.value());
@@ -451,7 +652,6 @@ TEST_F(HttpFilterTest, RespondImmediatelyDefault) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 }
 
 // Using the default configuration, test the filter with a processor that
@@ -492,7 +692,6 @@ TEST_F(HttpFilterTest, RespondImmediatelyGrpcError) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 }
 
 // Using the default configuration, test the filter with a processor that
@@ -510,7 +709,6 @@ TEST_F(HttpFilterTest, PostAndFail) {
   HttpTestUtility::addDefaultHeaders(request_headers_, "POST");
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
-  EXPECT_FALSE(stream_close_sent_);
 
   // Oh no! The remote server had a failure!
   Http::TestResponseHeaderMapImpl immediate_response_headers;
@@ -521,6 +719,7 @@ TEST_F(HttpFilterTest, PostAndFail) {
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            Unused, Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
 
   data_.add("foo");
@@ -533,8 +732,6 @@ TEST_F(HttpFilterTest, PostAndFail) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  // The other side closed the stream
-  EXPECT_FALSE(stream_close_sent_);
   EXPECT_TRUE(immediate_response_headers.empty());
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
@@ -559,7 +756,6 @@ TEST_F(HttpFilterTest, PostAndFailOnResponse) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
   ASSERT_TRUE(last_request_.has_request_headers());
   last_request_processed_ = true;
 
@@ -584,6 +780,7 @@ TEST_F(HttpFilterTest, PostAndFailOnResponse) {
                            Unused, Unused,
                            std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                            Unused, Unused) { modify_headers(immediate_response_headers); }));
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
 
   data_.add("bar");
@@ -592,7 +789,6 @@ TEST_F(HttpFilterTest, PostAndFailOnResponse) {
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
   // The other side closed the stream
-  EXPECT_FALSE(stream_close_sent_);
   EXPECT_TRUE(immediate_response_headers.empty());
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
@@ -618,10 +814,10 @@ TEST_F(HttpFilterTest, PostAndIgnoreFailure) {
   HttpTestUtility::addDefaultHeaders(request_headers_, "POST");
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
-  EXPECT_FALSE(stream_close_sent_);
 
   // Oh no! The remote server had a failure which we will ignore
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcError(Grpc::Status::Internal);
 
   data_.add("foo");
@@ -634,8 +830,6 @@ TEST_F(HttpFilterTest, PostAndIgnoreFailure) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  // The other side closed the stream
-  EXPECT_FALSE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
@@ -660,11 +854,11 @@ TEST_F(HttpFilterTest, PostAndClose) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
   ASSERT_TRUE(last_request_.has_request_headers());
 
   // Close the stream, which should tell the filter to keep on going
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  server_closed_stream_ = true;
   stream_callbacks_->onGrpcClose();
 
   data_.add("foo");
@@ -677,9 +871,6 @@ TEST_F(HttpFilterTest, PostAndClose) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-
-  // The other side closed the stream
-  EXPECT_FALSE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
@@ -707,7 +898,6 @@ TEST_F(HttpFilterTest, ProcessingModeRequestHeadersOnly) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
   ASSERT_TRUE(last_request_.has_request_headers());
   last_request_processed_ = true;
 
@@ -735,7 +925,6 @@ TEST_F(HttpFilterTest, ProcessingModeRequestHeadersOnly) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(empty_chunk, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
@@ -756,16 +945,9 @@ TEST_F(HttpFilterTest, ProcessingModeOverrideResponseHeaders) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->decodeHeaders(request_headers_, false));
 
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_request_headers());
-  last_request_processed_ = true;
-
-  EXPECT_CALL(decoder_callbacks_, continueDecoding());
-  std::unique_ptr<ProcessingResponse> resp1 = std::make_unique<ProcessingResponse>();
-  resp1->mutable_request_headers();
-  resp1->mutable_mode_override()->set_response_header_mode(ProcessingMode::SKIP);
-  stream_callbacks_->onReceiveMessage(std::move(resp1));
+  processRequestHeaders([](const HttpHeaders&, ProcessingResponse& response, HeadersResponse&) {
+    response.mutable_mode_override()->set_response_header_mode(ProcessingMode::SKIP);
+  });
 
   Buffer::OwnedImpl first_chunk("foo");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(first_chunk, true));
@@ -786,7 +968,6 @@ TEST_F(HttpFilterTest, ProcessingModeOverrideResponseHeaders) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(empty_chunk, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
@@ -823,16 +1004,7 @@ TEST_F(HttpFilterTest, ProcessingModeResponseHeadersOnly) {
   EXPECT_EQ(FilterHeadersStatus::StopAllIterationAndWatermark,
             filter_->encodeHeaders(response_headers_, false));
 
-  EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
-  ASSERT_TRUE(last_request_.has_response_headers());
-  last_request_processed_ = true;
-
-  // Send back a response
-  EXPECT_CALL(encoder_callbacks_, continueEncoding());
-  std::unique_ptr<ProcessingResponse> resp2 = std::make_unique<ProcessingResponse>();
-  resp2->mutable_response_headers();
-  stream_callbacks_->onReceiveMessage(std::move(resp2));
+  processResponseHeaders(absl::nullopt);
 
   Http::TestRequestHeaderMapImpl final_expected_response{
       {":status", "200"}, {"content-type", "text/plain"}, {"content-length", "3"}};
@@ -844,7 +1016,6 @@ TEST_F(HttpFilterTest, ProcessingModeResponseHeadersOnly) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(empty_chunk, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());
@@ -868,7 +1039,6 @@ TEST_F(HttpFilterTest, OutOfOrder) {
             filter_->decodeHeaders(request_headers_, false));
 
   EXPECT_FALSE(last_request_.async_mode());
-  EXPECT_FALSE(stream_close_sent_);
   ASSERT_TRUE(last_request_.has_request_headers());
 
   // Return an out-of-order message. The server should close the stream
@@ -888,9 +1058,6 @@ TEST_F(HttpFilterTest, OutOfOrder) {
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(data_, true));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
   filter_->onDestroy();
-
-  // We closed the stream
-  EXPECT_TRUE(stream_close_sent_);
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());
   EXPECT_EQ(1, config_->stats().stream_msgs_sent_.value());

--- a/test/extensions/filters/http/ext_proc/mock_server.h
+++ b/test/extensions/filters/http/ext_proc/mock_server.h
@@ -22,7 +22,7 @@ public:
   MockStream();
   ~MockStream() override;
   MOCK_METHOD(void, send, (envoy::service::ext_proc::v3alpha::ProcessingRequest&&, bool));
-  MOCK_METHOD(void, close, ());
+  MOCK_METHOD(bool, close, ());
 };
 
 } // namespace ExternalProcessing


### PR DESCRIPTION
Commit Message: ext_proc: Implement request and response body processing. Only the STREAMED body mode is supported in this commit. Since the default "processing mode" of an ext_proc filter sends headers only, a server must override the processing mode in a response message, or the configuration must be adjusted in order for this change to take effect. Previously, any changes to the request and response mode in a processing mode setting would have been ignored.

Additional Description: This PR also cleans up handling of the closing of gRPC streams -- we don't close them until "onDestroy" on the theory that this might have a slightly smaller impact on the latency of messages travelling through the filter.

Risk Level: Medium: New functionality for a new filter

Testing: Unit and integration tests, plus some manual testing with a separate filter server.

Docs Changes: Updates to ext_proc.proto to indicate what is supported.

Release Notes: ext_proc: The STREAMED processing mode is implemented for the request_body_mode and response_body_mode of the processing mode.

Platform Specific Features:
