### PR TITLE
fix v3 api ref issues in getting started doc

### DIFF
--- a/docs/root/start/start.rst
+++ b/docs/root/start/start.rst
@@ -8,7 +8,7 @@ This section gets you started with a very simple configuration and provides some
 The fastest way to get started using Envoy is :ref:`installing pre-built binaries <install_binaries>`.
 You can also :ref:`build it <building>` from source.
 
-These examples use the :ref:`v3 Envoy API <envoy_api_reference>`.
+These examples use the :ref:`v3 Envoy API <envoy_v3_api_reference>`.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: redirection issues in getting started docs for v3 API reference.
Additional Description: same has been identified in v1.15 and v1.16 as well ( see below urls)
https://www.envoyproxy.io/docs/envoy/v1.15.0/start/start
https://www.envoyproxy.io/docs/envoy/v1.16.0/start/start
https://www.envoyproxy.io/docs/envoy/v1.17.0/start/start
Risk Level: LOW
Testing:
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes:]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
part of #11027