### PR TITLE
grpc_json_transcoder: Pass through requests when methods not found

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -71,13 +71,15 @@ public:
       Api::Api& api);
 
   /**
-   * Create an instance of Transcoder interface based on incoming request
-   * @param headers headers received from decoder
-   * @param request_input a ZeroCopyInputStream reading from downstream request body
-   * @param response_input a TranscoderInputStream reading from upstream response body
-   * @param transcoder output parameter for the instance of Transcoder interface
-   * @param method_descriptor output parameter for the method looked up from config
-   * @return status whether the Transcoder instance are successfully created or not
+   * Create an instance of Transcoder interface based on incoming request.
+   * @param headers headers received from decoder.
+   * @param request_input a ZeroCopyInputStream reading from downstream request body.
+   * @param response_input a TranscoderInputStream reading from upstream response body.
+   * @param transcoder output parameter for the instance of Transcoder interface.
+   * @param method_descriptor output parameter for the method looked up from config.
+   * @return status whether the Transcoder instance are successfully created or not. If the method
+   *         is found, status with Code::NOT_FOUND is returned. If the method is found, but fields
+   *         cannot be resolved, status with Code::INVALID_ARGUMENT is returned.
    */
   ProtobufUtil::Status
   createTranscoder(const Http::RequestHeaderMap& headers,


### PR DESCRIPTION
Commit Message:

strict_http_request_validation (commit 6ce641f) introduced an
unexpected behavior when the option is turned on.

Before the change (commit 6ce641f), if an url cannot be
matched/recognized by the grpc_json_transcoder, it will pass
through to the filters in the chain, for example, http routers.
This allows the http router to continue to route the request to
other clusters.

After the change (commit 6ce641f), any unmatched/recognized url
will cause a 400 BAD REQUEST.  This is unexpected behavior.

The fix is, if the url can be matched by the transcoder, it means
it is inteneded to be a gRPC transcoding request.  Otherwise, it
should just pass through because at that moment, it's unclear to
the transcoder logic if this unmatched url is supposed to be a
gRPC method or not.

The param validation/resolve continues once the method is matched.

Additional Description:
Risk Level: Low.
Testing: Manual and integration.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
