### PR TITLE
[fuzz] remove network filters with low security posture

### DIFF
--- a/docs/generate_extension_db.py
+++ b/docs/generate_extension_db.py
@@ -24,12 +24,14 @@ _extensions_build_config_spec = spec_from_loader(
 extensions_build_config = module_from_spec(_extensions_build_config_spec)
 _extensions_build_config_spec.loader.exec_module(extensions_build_config)
 
+
 class ExtensionDbError(Exception):
   pass
 
 
 def IsMissing(value):
   return value == '(missing)'
+
 
 def NumReadFiltersFuzzed():
   f = open('test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc', 'r')
@@ -39,6 +41,7 @@ def NumReadFiltersFuzzed():
     data += f.readline()
   return data.count('NetworkFilterNames::get()')
 
+
 def NumRobustToDownstreamNetworkFilters(db):
   count = 0
   for extension, metadata in db.items():
@@ -46,6 +49,7 @@ def NumRobustToDownstreamNetworkFilters(db):
     if 'network' in extension and metadata['security_posture'] == 'robust_to_untrusted_downstream':
       count += 1
   return count
+
 
 def GetExtensionMetadata(target):
   if not BUILDOZER_PATH:

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -25,16 +25,16 @@ std::vector<absl::string_view> UberFilterFuzzer::filterNames() {
     const auto factories = Registry::FactoryRegistry<
         Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
     const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ExtAuthorization,
-        NetworkFilterNames::get().LocalRateLimit,
         NetworkFilterNames::get().ClientSslAuth,
+        NetworkFilterNames::get().ExtAuthorization,
         // A dedicated http_connection_manager fuzzer can be found in
         // test/common/http/conn_manager_impl_fuzz_test.cc
         NetworkFilterNames::get().HttpConnectionManager,
+        NetworkFilterNames::get().LocalRateLimit,
         NetworkFilterNames::get().RateLimit,
         NetworkFilterNames::get().Rbac,
         NetworkFilterNames::get().TcpProxy,
-        NetworkFilterNames::get().Echo,
+
     };
     // Check whether each filter is loaded into Envoy.
     // Some customers build Envoy without some filters. When they run fuzzing, the use of a filter

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -18,27 +18,23 @@ namespace {
 static const int SecondsPerDay = 86400;
 } // namespace
 std::vector<absl::string_view> UberFilterFuzzer::filterNames() {
-  // These filters have already been covered by this fuzzer.
-  // Will extend to cover other network filters one by one.
+  // Add filters that are in the process of being or are robust against untrusted downstream
+  // traffic.
   static std::vector<absl::string_view> filter_names;
   if (filter_names.empty()) {
     const auto factories = Registry::FactoryRegistry<
         Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
     const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ExtAuthorization, NetworkFilterNames::get().LocalRateLimit,
-        NetworkFilterNames::get().RedisProxy, NetworkFilterNames::get().ClientSslAuth,
-        NetworkFilterNames::get().Echo, NetworkFilterNames::get().DirectResponse,
-        NetworkFilterNames::get().DubboProxy, NetworkFilterNames::get().SniCluster,
+        NetworkFilterNames::get().ExtAuthorization,
+        NetworkFilterNames::get().LocalRateLimit,
+        NetworkFilterNames::get().ClientSslAuth,
         // A dedicated http_connection_manager fuzzer can be found in
         // test/common/http/conn_manager_impl_fuzz_test.cc
-        NetworkFilterNames::get().HttpConnectionManager, NetworkFilterNames::get().ThriftProxy,
-        NetworkFilterNames::get().ZooKeeperProxy, NetworkFilterNames::get().SniDynamicForwardProxy,
-        NetworkFilterNames::get().KafkaBroker, NetworkFilterNames::get().RocketmqProxy,
-        NetworkFilterNames::get().RateLimit, NetworkFilterNames::get().Rbac,
-        NetworkFilterNames::get().MongoProxy, NetworkFilterNames::get().MySQLProxy
-        // TODO(jianwendong): add "NetworkFilterNames::get().Postgres" after it supports untrusted
-        // data.
-        // TODO(jianwendong): add fuzz test for "NetworkFilterNames::get().TcpProxy".
+        NetworkFilterNames::get().HttpConnectionManager,
+        NetworkFilterNames::get().RateLimit,
+        NetworkFilterNames::get().Rbac,
+        NetworkFilterNames::get().TcpProxy,
+        NetworkFilterNames::get().Echo,
     };
     // Check whether each filter is loaded into Envoy.
     // Some customers build Envoy without some filters. When they run fuzzing, the use of a filter


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Removes network filters whose security posture is unknown from fuzzing. This should be a requirement to change their posture, but for now it adds too much noise for unmaintained filters.
Risk Level: Low
Testing: n/a