### PR TITLE
brotoli: fix CI by adding category field to bazel BUILD files

### DIFF
--- a/source/extensions/compression/brotli/compressor/BUILD
+++ b/source/extensions/compression/brotli/compressor/BUILD
@@ -25,6 +25,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    category = "envoy.compression.compressor",
     security_posture = "robust_to_untrusted_downstream",
     deps = [
         ":compressor_lib",

--- a/source/extensions/compression/brotli/decompressor/BUILD
+++ b/source/extensions/compression/brotli/decompressor/BUILD
@@ -27,6 +27,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    category = "envoy.compression.decompressor",
     security_posture = "robust_to_untrusted_downstream",
     deps = [
         ":decompressor_lib",


### PR DESCRIPTION
Commit Message: brotoli: fix CI by adding category field to bazel BUILD files
Additional Description:
Risk Level: low
Testing: ci/run_envoy_docker.sh 'ci/do_ci.sh deps'
Docs Changes: none
Release Notes: none