### PR TITLE
Removed duplicate entry of response_payload_too_large.

### DIFF
--- a/docs/root/configuration/http/http_conn_man/response_code_details.rst
+++ b/docs/root/configuration/http/http_conn_man/response_code_details.rst
@@ -41,7 +41,6 @@ Below are the list of reasons the HttpConnectionManager or Router filter may sen
    request_payload_exceeded_retry_buffer_limit, Envoy is doing streaming proxying but too much data arrived while waiting to attempt a retry.
    request_payload_too_large, Envoy is doing non-streaming proxying and the request payload exceeded configured limits.
    response_payload_too_large, Envoy is doing non-streaming proxying and the response payload exceeded configured limits.
-   response_payload_too_large, Envoy is doing non-streaming proxying and the response payload exceeded configured limits.
    route_configuration_not_found, The request was rejected because there was no route configuration found.
    route_not_found, The request was rejected because there was no route found.
    stream_idle_timeout, The per-stream keepalive timeout was exceeded.


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>

 
Commit Message: Removed duplicate entry of response_payload_too_large.
Additional Description: Removed duplicate entry of `response_payload_too_large` from `docs/root/configuration/http/http_conn_man/response_code_details.rst`
Risk Level: Low
Testing: 
Docs Changes: 
Release Notes: N/A
Platform Specific Features: N/A
 