### PR TITLE
Optimize LoaderImpl with sharded locks for unregistered threads

### DIFF
--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -247,6 +247,11 @@ public:
 private:
   friend RtdsSubscription;
 
+  struct ThreadSafeSnapshot {
+    absl::Mutex mutex;
+    SnapshotConstSharedPtr snapshot ABSL_GUARDED_BY(mutex);
+  };
+
   // Create a new Snapshot
   SnapshotImplPtr createNewSnapshot();
   // Load a new Snapshot into TLS
@@ -269,8 +274,7 @@ private:
   Upstream::ClusterManager* cm_{};
   Stats::Store& store_;
 
-  absl::Mutex snapshot_mutex_;
-  SnapshotConstSharedPtr thread_safe_snapshot_ ABSL_GUARDED_BY(snapshot_mutex_);
+  std::vector<ThreadSafeSnapshot> thread_safe_snapshots_;
 };
 
 } // namespace Runtime


### PR DESCRIPTION
Signed-off-by: Yasheng Yang <yasheng@google.com>

This change improves the performance of manually created dispatchers
that are not registered to the thread-local-storage.

A total of std:: thread ::hardware_concurrency() snapshot shards are
created with individual locks. When reading, a shard is picked using
the current thread_id.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: Optimize LoaderImpl with sharded locks for unregistered threads
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #14996
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
