### PR TITLE
[fuzz] add fixes to buffer fuzz test

### DIFF
--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-4923810761539584
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-4923810761539584
@@ -1,0 +1,14 @@
+actions {
+  target_index: 16
+  reserve_commit {
+    reserve_length: 65536
+    commit_length: 65536
+  }
+}
+actions {
+  target_index: 6512896
+  reserve_commit {
+    reserve_length: 3
+    commit_length: 6512896
+  }
+}

--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-6365038174666752
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-6365038174666752
@@ -1,0 +1,1 @@
+actions {   reserve_commit {     reserve_length:  31072     commit_length: 65536   } } actions {   add_buffer_fragment: 1 } 

--- a/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-6672326676578304
+++ b/test/common/buffer/buffer_corpus/clusterfuzz-testcase-minimized-6672326676578304
@@ -1,0 +1,7 @@
+actions {
+  target_index: 16809984
+  reserve_commit {
+    reserve_length: 8388608
+    commit_length: 16809984
+  }
+}

--- a/test/common/buffer/buffer_fuzz.cc
+++ b/test/common/buffer/buffer_fuzz.cc
@@ -457,23 +457,26 @@ void executeActions(const test::common::buffer::BufferFuzzTestCase& input, Buffe
       // return the pointer to its std::string array, we can avoid the
       // toString() copy here.
       const uint64_t linear_buffer_length = linear_buffers[j]->length();
-      if (buffers[j]->toString() !=
-          absl::string_view(
+      // We may have spilled over TotalMaxAllocation at this point. Only compare up to
+      // TotalMaxAllocation.
+      if (absl::string_view(
               static_cast<const char*>(linear_buffers[j]->linearize(linear_buffer_length)),
-              linear_buffer_length)) {
+              linear_buffer_length)
+              .compare(buffers[j]->toString().substr(0, TotalMaxAllocation)) != 0) {
         ENVOY_LOG_MISC(debug, "Mismatched buffers at index {}", j);
         ENVOY_LOG_MISC(debug, "B: {}", buffers[j]->toString());
         ENVOY_LOG_MISC(debug, "L: {}", linear_buffers[j]->toString());
         FUZZ_ASSERT(false);
       }
-      FUZZ_ASSERT(buffers[j]->length() == linear_buffer_length);
+      FUZZ_ASSERT(std::min(TotalMaxAllocation, static_cast<uint32_t>(buffers[j]->length())) ==
+                  linear_buffer_length);
       current_allocated_bytes += linear_buffer_length;
     }
     ENVOY_LOG_MISC(debug, "[{} MB allocated total]", current_allocated_bytes / (1024.0 * 1024));
     // We bail out if buffers get too big, otherwise we will OOM the sanitizer.
     // We can't use Memory::Stats::totalCurrentlyAllocated() here as we don't
     // have tcmalloc in ASAN builds, so just do a simple count.
-    if (current_allocated_bytes > TotalMaxAllocation) {
+    if (current_allocated_bytes >= TotalMaxAllocation) {
       ENVOY_LOG_MISC(debug, "Terminating early with total buffer length {} to avoid OOM",
                      current_allocated_bytes);
       break;


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Add fixes to buffer fuzz test:
Additional Description:
* The last action may have gone over `TotalMaxAllocation`, so when comparing the contents of the buffer, only compare up to that point.
* Exit when we hit `TotalMaxAllocation` to prevent the next action from overflowing.

Risk Level: Low
Testing: Added corpus entries
Fixes:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30548
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30437
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30326
