### PR TITLE
http2: Latch envoy.reloadable_features.upstream_http2_flood_checks on connection creation.

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1394,7 +1394,8 @@ ClientConnectionImpl::ClientConnectionImpl(
     Nghttp2SessionFactory& http2_session_factory)
     : ConnectionImpl(connection, stats, random_generator, http2_options, max_response_headers_kb,
                      max_response_headers_count),
-      callbacks_(callbacks) {
+      callbacks_(callbacks), enable_upstream_http2_flood_checks_(Runtime::runtimeFeatureEnabled(
+                                 "envoy.reloadable_features.upstream_http2_flood_checks")) {
   ClientHttp2Options client_http2_options(http2_options);
   session_ = http2_session_factory.create(http2_callbacks_.callbacks(), base(),
                                           client_http2_options.options());
@@ -1442,7 +1443,7 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 Status ClientConnectionImpl::trackInboundFrames(const nghttp2_frame_hd* hd,
                                                 uint32_t padding_length) {
   Status result;
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.upstream_http2_flood_checks")) {
+  if (enable_upstream_http2_flood_checks_) {
     ENVOY_CONN_LOG(trace, "track inbound frame type={} flags={} length={} padding_length={}",
                    connection_, static_cast<uint64_t>(hd->type), static_cast<uint64_t>(hd->flags),
                    static_cast<uint64_t>(hd->length), padding_length);
@@ -1465,7 +1466,7 @@ Status ClientConnectionImpl::trackInboundFrames(const nghttp2_frame_hd* hd,
 // TODO(yanavlasov): move to the base class once the runtime flag is removed.
 ProtocolConstraints::ReleasorProc
 ClientConnectionImpl::trackOutboundFrames(bool is_outbound_flood_monitored_control_frame) {
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.upstream_http2_flood_checks")) {
+  if (enable_upstream_http2_flood_checks_) {
     return protocol_constraints_.incrementOutboundFrameCount(
         is_outbound_flood_monitored_control_frame);
   }

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -572,6 +572,8 @@ private:
   Status trackInboundFrames(const nghttp2_frame_hd*, uint32_t) override;
 
   Http::ConnectionCallbacks& callbacks_;
+  // Latched value of "envoy.reloadable_features.upstream_http2_flood_checks" runtime feature.
+  bool enable_upstream_http2_flood_checks_;
 };
 
 /**


### PR DESCRIPTION
Commit Message:
http2: Latch envoy.reloadable_features.upstream_http2_flood_checks on connection creation.

Checking the runtime feature on every packet sent results in excessive lock contention and
could trigger incorrect termination of HTTP2 upstream connections if the value of the runtime
feature changes halfway through the lifetime of the upstream connection.

Additional Description:
Risk Level: low, latching a runtime feature.  minimal functional change expected.
Testing: covered by existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #14996