### PR TITLE
backport 1.16: scaled range timer: guard against queue deletion during timer fire (#…

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -15,6 +15,7 @@ Bug Fixes
 
 * aggregate cluster: fixed a crash due to a TLS initialization issue.
 * lua: fixed crash when Lua script contains streamInfo():downstreamSslConnection().
+* overload: fix a bug that can cause use-after-free when one scaled timer disables another one with the same duration.
 * tls: fix detection of the upstream connection close event.
 
 Removed Config or Runtime

--- a/source/common/event/scaled_range_timer_manager.cc
+++ b/source/common/event/scaled_range_timer_manager.cc
@@ -208,7 +208,11 @@ void ScaledRangeTimerManager::removeTimer(ScalingTimerHandle handle) {
   handle.queue_.range_timers_.erase(handle.iterator_);
   // Don't keep around empty queues
   if (handle.queue_.range_timers_.empty()) {
-    queues_.erase(handle.queue_);
+    // Skip erasing the queue if we're in the middle of processing timers for the queue. The
+    // queue will be erased in `onQueueTimerFired` after the queue entries have been processed.
+    if (!handle.queue_.processing_timers_) {
+      queues_.erase(handle.queue_);
+    }
     return;
   }
 
@@ -238,12 +242,14 @@ void ScaledRangeTimerManager::onQueueTimerFired(Queue& queue) {
 
   // Pop and trigger timers until the one at the front isn't supposed to have expired yet (given the
   // current scale factor).
+  queue.processing_timers_ = true;
   while (!timers.empty() &&
          computeTriggerTime(timers.front(), queue.duration_, scale_factor_) <= now) {
     auto item = std::move(queue.range_timers_.front());
     queue.range_timers_.pop_front();
     item.timer_.trigger();
   }
+  queue.processing_timers_ = false;
 
   if (queue.range_timers_.empty()) {
     // Maintain the invariant that queues are never empty.

--- a/source/common/event/scaled_range_timer_manager.h
+++ b/source/common/event/scaled_range_timer_manager.h
@@ -81,6 +81,10 @@ private:
     //   2) on expiration
     //   3) when the scale factor changes
     const TimerPtr timer_;
+
+    // A flag indicating whether the queue is currently processing timers. Used to guard against
+    // queue deletion during timer processing.
+    bool processing_timers_{false};
   };
 
   /**

--- a/test/common/event/scaled_range_timer_manager_test.cc
+++ b/test/common/event/scaled_range_timer_manager_test.cc
@@ -148,17 +148,15 @@ TEST_F(ScaledRangeTimerManagerTest, DisableWhileScalingMax) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, InCallbackDisableLastTimerInSameQueue) {
-  ScaledRangeTimerManagerImpl manager(dispatcher_);
+  ScaledRangeTimerManager manager(dispatcher_);
 
   MockFunction<TimerCb> callback1;
-  auto timer1 =
-      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(0)), callback1.AsStdFunction());
+  auto timer1 = manager.createTimer(callback1.AsStdFunction());
   MockFunction<TimerCb> callback2;
-  auto timer2 =
-      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(5)), callback2.AsStdFunction());
+  auto timer2 = manager.createTimer(callback2.AsStdFunction());
 
-  timer1->enableTimer(std::chrono::seconds(95));
-  timer2->enableTimer(std::chrono::seconds(100));
+  timer1->enableTimer(std::chrono::seconds(0), std::chrono::seconds(95));
+  timer2->enableTimer(std::chrono::seconds(5), std::chrono::seconds(100));
 
   simTime().advanceTimeAndRun(std::chrono::seconds(5), dispatcher_, Dispatcher::RunType::Block);
 
@@ -175,17 +173,15 @@ TEST_F(ScaledRangeTimerManagerTest, InCallbackDisableLastTimerInSameQueue) {
 }
 
 TEST_F(ScaledRangeTimerManagerTest, InCallbackDisableTimerInOtherQueue) {
-  ScaledRangeTimerManagerImpl manager(dispatcher_);
+  ScaledRangeTimerManager manager(dispatcher_);
 
   MockFunction<TimerCb> callback1;
-  auto timer1 =
-      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(5)), callback1.AsStdFunction());
+  auto timer1 = manager.createTimer(callback1.AsStdFunction());
   MockFunction<TimerCb> callback2;
-  auto timer2 =
-      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(5)), callback2.AsStdFunction());
+  auto timer2 = manager.createTimer(callback2.AsStdFunction());
 
-  timer1->enableTimer(std::chrono::seconds(95));
-  timer2->enableTimer(std::chrono::seconds(100));
+  timer1->enableTimer(std::chrono::seconds(5), std::chrono::seconds(95));
+  timer2->enableTimer(std::chrono::seconds(5), std::chrono::seconds(100));
 
   simTime().advanceTimeAndRun(std::chrono::seconds(5), dispatcher_, Dispatcher::RunType::Block);
 

--- a/test/common/event/scaled_range_timer_manager_test.cc
+++ b/test/common/event/scaled_range_timer_manager_test.cc
@@ -147,6 +147,60 @@ TEST_F(ScaledRangeTimerManagerTest, DisableWhileScalingMax) {
   simTime().advanceTimeAndRun(std::chrono::seconds(100), dispatcher_, Dispatcher::RunType::Block);
 }
 
+TEST_F(ScaledRangeTimerManagerTest, InCallbackDisableLastTimerInSameQueue) {
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
+
+  MockFunction<TimerCb> callback1;
+  auto timer1 =
+      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(0)), callback1.AsStdFunction());
+  MockFunction<TimerCb> callback2;
+  auto timer2 =
+      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(5)), callback2.AsStdFunction());
+
+  timer1->enableTimer(std::chrono::seconds(95));
+  timer2->enableTimer(std::chrono::seconds(100));
+
+  simTime().advanceTimeAndRun(std::chrono::seconds(5), dispatcher_, Dispatcher::RunType::Block);
+
+  EXPECT_TRUE(timer1->enabled());
+  EXPECT_TRUE(timer2->enabled());
+
+  EXPECT_CALL(callback1, Call).WillOnce(Invoke([&]() {
+    timer2->disableTimer();
+    timer2.reset();
+  }));
+
+  // Run the dispatcher to make sure nothing happens when it's not supposed to.
+  simTime().advanceTimeAndRun(std::chrono::seconds(100), dispatcher_, Dispatcher::RunType::Block);
+}
+
+TEST_F(ScaledRangeTimerManagerTest, InCallbackDisableTimerInOtherQueue) {
+  ScaledRangeTimerManagerImpl manager(dispatcher_);
+
+  MockFunction<TimerCb> callback1;
+  auto timer1 =
+      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(5)), callback1.AsStdFunction());
+  MockFunction<TimerCb> callback2;
+  auto timer2 =
+      manager.createTimer(AbsoluteMinimum(std::chrono::seconds(5)), callback2.AsStdFunction());
+
+  timer1->enableTimer(std::chrono::seconds(95));
+  timer2->enableTimer(std::chrono::seconds(100));
+
+  simTime().advanceTimeAndRun(std::chrono::seconds(5), dispatcher_, Dispatcher::RunType::Block);
+
+  EXPECT_TRUE(timer1->enabled());
+  EXPECT_TRUE(timer2->enabled());
+
+  EXPECT_CALL(callback1, Call).WillOnce(Invoke([&]() {
+    timer2->disableTimer();
+    timer2.reset();
+  }));
+
+  // Run the dispatcher to make sure nothing happens when it's not supposed to.
+  simTime().advanceTimeAndRun(std::chrono::seconds(100), dispatcher_, Dispatcher::RunType::Block);
+}
+
 TEST_F(ScaledRangeTimerManagerTest, DisableWithZeroMinTime) {
   ScaledRangeTimerManager manager(dispatcher_);
 


### PR DESCRIPTION
…14799)

Fix a potential use-after-free error in ScaledRangeTimerManagerImpl by adding a processing_timers_ flag to the timer queues that is set during onQueueTimerFired processing. This flag is checked when a timer is removed to ensure that the timer's queue isn't deleted while it is in a callback triggered by onQueueTimerFired.

Signed-off-by: Craig Radcliffe <craig.radcliffe@broadcom.com>
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
