### PR TITLE
adaptive concurrency: Fix race condition during minRTT update

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -48,6 +48,7 @@ Bug Fixes
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
 * active http health checks: properly handles HTTP/2 GOAWAY frames from the upstream. Previously a GOAWAY frame due to a graceful listener drain could cause improper failed health checks due to streams being refused by the upstream on a connection that is going away. To revert to old GOAWAY handling behavior, set the runtime feature `envoy.reloadable_features.health_check.graceful_goaway_handling` to false.
+* adaptive concurrency: fixed a bug where concurrent requests on different worker threads could update minRTT back-to-back.
 * buffer: tighten network connection read and write buffer high watermarks in preparation to more careful enforcement of read limits. Buffer high-watermark is now set to the exact configured value; previously it was set to value + 1.
 * fault injection: stop counting as active fault after delay elapsed. Previously fault injection filter continues to count the injected delay as an active fault even after it has elapsed. This produces incorrect output statistics and impacts the max number of consecutive faults allowed (e.g., for long-lived streams). This change decreases the active fault count when the delay fault is the only active and has gone finished.
 * grpc-web: fix local reply and non-proto-encoded gRPC response handling for small response bodies. This fix can be temporarily reverted by setting `envoy.reloadable_features.grpc_web_fix_non_proto_encoded_response_handling` to false.
@@ -55,21 +56,6 @@ Bug Fixes
 * http: reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure` to false.
 * listener: prevent crashing when an unknown listener config proto is received and debug logging is enabled.
 * upstream: fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
-* adaptive concurrency: fixed a bug where concurrent requests on different worker threads could update minRTT back-to-back.
-* config: validate that upgrade configs have a non-empty :ref:`upgrade_type <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.UpgradeConfig.upgrade_type>`, fixing a bug where an errant "-" could result in unexpected behavior.
-* dns: fix a bug where custom resolvers provided in configuration were not preserved after network issues.
-* dns_filter: correctly associate DNS response IDs when multiple queries are received.
-* grpc mux: fix sending node again after stream is reset when ::ref:`set_node_on_first_message_only <envoy_api_field_core.ApiConfigSource.set_node_on_first_message_only>` is set.
-* http: fixed URL parsing for HTTP/1.1 fully qualified URLs and connect requests containing IPv6 addresses.
-* http: reject requests with missing required headers after filter chain processing.
-* http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
-* proxy_proto: fixed a bug where the wrong downstream address got sent to upstream connections.
-* proxy_proto: fixed a bug where network filters would not have the correct downstreamRemoteAddress() when accessed from the StreamInfo. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.
-* sds: fix a bug that clusters sharing same sds target are marked active immediately.
-* tls: fix detection of the upstream connection close event.
-* tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
-* udp: fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.
-* watchdog: touch the watchdog before most event loop operations to avoid misses when handling bursts of callbacks.
 
 Removed Config or Runtime
 -------------------------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -55,6 +55,21 @@ Bug Fixes
 * http: reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure` to false.
 * listener: prevent crashing when an unknown listener config proto is received and debug logging is enabled.
 * upstream: fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
+* adaptive concurrency: fixed a bug where concurrent requests on different worker threads could update minRTT back-to-back.
+* config: validate that upgrade configs have a non-empty :ref:`upgrade_type <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.UpgradeConfig.upgrade_type>`, fixing a bug where an errant "-" could result in unexpected behavior.
+* dns: fix a bug where custom resolvers provided in configuration were not preserved after network issues.
+* dns_filter: correctly associate DNS response IDs when multiple queries are received.
+* grpc mux: fix sending node again after stream is reset when ::ref:`set_node_on_first_message_only <envoy_api_field_core.ApiConfigSource.set_node_on_first_message_only>` is set.
+* http: fixed URL parsing for HTTP/1.1 fully qualified URLs and connect requests containing IPv6 addresses.
+* http: reject requests with missing required headers after filter chain processing.
+* http: sending CONNECT_ERROR for HTTP/2 where appropriate during CONNECT requests.
+* proxy_proto: fixed a bug where the wrong downstream address got sent to upstream connections.
+* proxy_proto: fixed a bug where network filters would not have the correct downstreamRemoteAddress() when accessed from the StreamInfo. This could result in incorrect enforcement of RBAC rules in the RBAC network filter (but not in the RBAC HTTP filter), or incorrect access log addresses from tcp_proxy.
+* sds: fix a bug that clusters sharing same sds target are marked active immediately.
+* tls: fix detection of the upstream connection close event.
+* tls: fix read resumption after triggering buffer high-watermark and all remaining request/response bytes are stored in the SSL connection's internal buffers.
+* udp: fixed issue in which receiving truncated UDP datagrams would cause Envoy to crash.
+* watchdog: touch the watchdog before most event loop operations to avoid misses when handling bursts of callbacks.
 
 Removed Config or Runtime
 -------------------------

--- a/source/extensions/filters/http/adaptive_concurrency/controller/BUILD
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     ],
     deps = [
         "//include/envoy/common:time_interface",
+        "//source/common/common:thread_synchronizer_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/protobuf",
         "//source/common/runtime:runtime_lib",

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -215,10 +215,12 @@ void GradientController::recordLatencySample(MonotonicTime rq_send_time) {
     sample_count = hist_sample_count(latency_sample_hist_.get());
   }
 
-  if (inMinRTTSamplingWindow() && sample_count >= config_.minRTTAggregateRequestCount()) {
+  const auto agg_count = config_.minRTTAggregateRequestCount();
+  if (inMinRTTSamplingWindow() && sample_count >= agg_count && min_rtt_update_mtx_.TryLock()) {
     // This sample has pushed the request count over the request count requirement for the minRTT
     // recalculation. It must now be finished.
     updateMinRTT();
+    min_rtt_update_mtx_.Unlock();
   }
 }
 

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -216,7 +216,7 @@ void GradientController::recordLatencySample(MonotonicTime rq_send_time) {
   }
 
   const auto agg_count = config_.minRTTAggregateRequestCount();
-  if (inMinRTTSamplingWindow() && sample_count >= agg_count && min_rtt_update_mtx_.TryLock()) {
+  if (min_rtt_update_mtx_.TryLock() && inMinRTTSamplingWindow() && sample_count >= agg_count) {
     // This sample has pushed the request count over the request count requirement for the minRTT
     // recalculation. It must now be finished.
     updateMinRTT();

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -219,6 +219,9 @@ void GradientController::recordLatencySample(MonotonicTime rq_send_time) {
   // enforce this with the 'min_rtt_update_mtx_'.
   if (min_rtt_update_mtx_.TryLock()) {
     if (inMinRTTSamplingWindow() && sample_count >= config_.minRTTAggregateRequestCount()) {
+      // Testing hook.
+      synchronizer_.syncPoint("pre_minrtt_update");
+
       // This sample has pushed the request count over the request count requirement for the minRTT
       // recalculation. It must now be finished.
       updateMinRTT();


### PR DESCRIPTION
It was possible that 2 concurrent requests on different worker threads
could succeed at the condition necessary to update the minRTT before one
of them was able to update and pull us out of the minRTT window. The
implications of this are not just calculating the percentile on an empty
histogram, but scheduling multiple sampleRTT update timers and creating
noise in the measurements as the race condition is hit over time.

This patch introduces a mutex used in a non-blocking manner to ensure 
that only a single worker thread updates the minRTT value and schedules 
the sampleRTT timer.

Risk Level:
Low (very minor change)

Testing:
Existing adaptive concurrency unit test.

Docs Changes:
n/a

Release Notes:
Done.

Fixes #14997