### PR TITLE
wasm: Add support for environment variables injection

### DIFF
--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -40,7 +40,7 @@ message SanitizationConfig {
 }
 
 // Configuration for a Wasm VM.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message VmConfig {
   // An ID which will be used along with a hash of the wasm code (or the name of the registered Null
   // VM plugin) to determine which VM will be used for the plugin. All plugins which use the same
@@ -92,6 +92,10 @@ message VmConfig {
   // update and do a background fetch to fill the cache, otherwise fetch the code asynchronously and enter
   // warming state.
   bool nack_on_code_cache_miss = 6;
+
+  // The keys of *Envoy's* environment variables exposed to this VM through WASI's environ_get function.
+  // Note that if a key does not exist, then it will be ignored.
+  repeated string env_keys = 7;
 }
 
 // Base Configuration for Wasm Plugins e.g. filters and services.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -923,7 +923,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.wasm.runtime.wavm",
             "envoy.wasm.runtime.wasmtime",
         ],
-        release_date = "2021-01-12",
+        release_date = "2021-02-09",
         cpe = "N/A",
     ),
     proxy_wasm_rust_sdk = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -907,10 +907,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "WebAssembly for Proxies (C++ host implementation)",
         project_desc = "WebAssembly for Proxies (C++ host implementation)",
         project_url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host",
-        version = "5a53cf4b231599e1d2a1f2f4598fdfbb727ff948",
-        sha256 = "600dbc651a2837e6f1db964eb7e1078e5e338049a34c9ab47415dfa7f3de5478",
+        version = "2065bd56a78a9cb7245dfd767111e8cfb58e3d81",
+        sha256 = "36daabb10f6c56913d809c6a5d3a97a022a5607b99067dcaec2b9c5afc6f143d",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
+        urls = ["https://github.com/mathetake/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = [
             "envoy.access_loggers.wasm",

--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -165,6 +165,8 @@ proto_library(
         "//envoy/extensions/common/matching/v3:pkg",
         "//envoy/extensions/common/ratelimit/v3:pkg",
         "//envoy/extensions/common/tap/v3:pkg",
+        "//envoy/extensions/compression/brotli/compressor/v3:pkg",
+        "//envoy/extensions/compression/brotli/decompressor/v3:pkg",
         "//envoy/extensions/compression/gzip/compressor/v3:pkg",
         "//envoy/extensions/compression/gzip/decompressor/v3:pkg",
         "//envoy/extensions/filters/common/dependency/v3:pkg",

--- a/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
@@ -40,7 +40,7 @@ message SanitizationConfig {
 }
 
 // Configuration for a Wasm VM.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message VmConfig {
   // An ID which will be used along with a hash of the wasm code (or the name of the registered Null
   // VM plugin) to determine which VM will be used for the plugin. All plugins which use the same
@@ -92,6 +92,10 @@ message VmConfig {
   // update and do a background fetch to fill the cache, otherwise fetch the code asynchronously and enter
   // warming state.
   bool nack_on_code_cache_miss = 6;
+
+  // The keys of *Envoy's* environment variables exposed to this VM through WASI's environ_get function.
+  // Note that if a key does not exist, then it will be ignored.
+  repeated string env_keys = 7;
 }
 
 // Base Configuration for Wasm Plugins e.g. filters and services.

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <unordered_map>
 
 #include "envoy/event/deferred_deletable.h"
 
@@ -99,11 +100,13 @@ void Wasm::initializeLifecycle(Server::ServerLifecycleNotifier& lifecycle_notifi
                                       });
 }
 
+// clang-format off
 Wasm::Wasm(absl::string_view runtime, absl::string_view vm_id, absl::string_view vm_configuration,
            absl::string_view vm_key, proxy_wasm::AllowedCapabilitiesMap allowed_capabilities,
            const Stats::ScopeSharedPtr& scope, Upstream::ClusterManager& cluster_manager,
-           Event::Dispatcher& dispatcher)
-    : WasmBase(createWasmVm(runtime), vm_id, vm_configuration, vm_key, allowed_capabilities),
+           Event::Dispatcher& dispatcher, std::unordered_map<std::string, std::string> envs)
+    // clang-format on
+    : WasmBase(createWasmVm(runtime), vm_id, vm_configuration, vm_key, envs, allowed_capabilities),
       scope_(scope), cluster_manager_(cluster_manager), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()),
       wasm_stats_(WasmStats{

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -46,10 +46,14 @@ struct WasmStats {
 // Wasm execution instance. Manages the Envoy side of the Wasm interface.
 class Wasm : public WasmBase, Logger::Loggable<Logger::Id::wasm> {
 public:
+  // clang-format off
   Wasm(absl::string_view runtime, absl::string_view vm_id, absl::string_view vm_configuration,
        absl::string_view vm_key, proxy_wasm::AllowedCapabilitiesMap allowed_capabilities,
        const Stats::ScopeSharedPtr& scope, Upstream::ClusterManager& cluster_manager,
-       Event::Dispatcher& dispatcher);
+       Event::Dispatcher& dispatcher,
+       std::unordered_map<std::string, std::string> envs);
+  // clang-format on
+
   Wasm(std::shared_ptr<WasmHandle> other, Event::Dispatcher& dispatcher);
   ~Wasm() override;
 

--- a/test/extensions/bootstrap/wasm/test_data/BUILD
+++ b/test/extensions/bootstrap/wasm/test_data/BUILD
@@ -12,6 +12,7 @@ envoy_package()
 wasm_rust_binary(
     name = "logging_rust.wasm",
     srcs = ["logging_rust.rs"],
+    wasi = True,
     deps = [
         "@proxy_wasm_rust_sdk//:proxy_wasm",
         "@proxy_wasm_rust_sdk//bazel/cargo:log",

--- a/test/extensions/bootstrap/wasm/test_data/http_cpp.cc
+++ b/test/extensions/bootstrap/wasm/test_data/http_cpp.cc
@@ -11,6 +11,7 @@ START_WASM_PLUGIN(WasmHttpCpp)
 WASM_EXPORT(void, proxy_abi_version_0_1_0, ()) {}
 
 WASM_EXPORT(uint32_t, proxy_on_configure, (uint32_t, uint32_t)) {
+  logTrace("KEY1: " + std::string(std::getenv("KEY1")));
   proxy_set_tick_period_milliseconds(100);
   return 1;
 }
@@ -31,6 +32,7 @@ WASM_EXPORT(void, proxy_on_tick, (uint32_t)) {
 }
 
 WASM_EXPORT(void, proxy_on_http_call_response, (uint32_t, uint32_t, uint32_t headers, uint32_t, uint32_t)) {
+  logTrace("KEY2: " + std::string(std::getenv("KEY2")));
   if (headers != 0) {
     auto status = getHeaderMapValue(WasmHeaderMapType::HttpCallResponseHeaders, "status");
     if ("200" == status->view()) {

--- a/test/extensions/bootstrap/wasm/test_data/logging_cpp.cc
+++ b/test/extensions/bootstrap/wasm/test_data/logging_cpp.cc
@@ -9,6 +9,7 @@
 extern "C" PROXY_WASM_KEEPALIVE void proxy_abi_version_0_1_0() {}
 
 extern "C" PROXY_WASM_KEEPALIVE uint32_t proxy_on_configure(uint32_t, uint32_t configuration_size) {
+  logTrace("ON_CONFIGURE: "+std::string(std::getenv("ON_CONFIGURE")));
   fprintf(stdout, "printf stdout test");
   fflush(stdout);
   fprintf(stderr, "printf stderr test");
@@ -29,6 +30,7 @@ extern "C" PROXY_WASM_KEEPALIVE void proxy_on_context_create(uint32_t, uint32_t)
 extern "C" PROXY_WASM_KEEPALIVE uint32_t proxy_on_vm_start(uint32_t, uint32_t) { return 1; }
 
 extern "C" PROXY_WASM_KEEPALIVE void proxy_on_tick(uint32_t) {
+  logTrace("ON_TICK: "+std::string(std::getenv("ON_TICK")));
   const char* root_id = nullptr;
   size_t size;
   proxy_get_property("plugin_root_id", sizeof("plugin_root_id") - 1, &root_id, &size);

--- a/test/extensions/bootstrap/wasm/test_data/logging_rust.rs
+++ b/test/extensions/bootstrap/wasm/test_data/logging_rust.rs
@@ -3,7 +3,15 @@ use proxy_wasm::traits::{Context, RootContext};
 use proxy_wasm::types::LogLevel;
 
 #[no_mangle]
+extern "C" {
+    fn __wasilibc_initialize_environ();
+}
+
+#[no_mangle]
 pub fn _start() {
+    unsafe {
+        __wasilibc_initialize_environ();
+    }
     proxy_wasm::set_log_level(LogLevel::Trace);
     proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(TestRoot) });
 }
@@ -16,6 +24,7 @@ impl RootContext for TestRoot {
     }
 
     fn on_configure(&mut self, _: usize) -> bool {
+        trace!("ON_CONFIGURE: {}", std::env::var("ON_CONFIGURE").unwrap());
         trace!("test trace logging");
         debug!("test debug logging");
         error!("test error logging");
@@ -26,6 +35,7 @@ impl RootContext for TestRoot {
     }
 
     fn on_tick(&mut self) {
+        trace!("ON_TICK: {}", std::env::var("ON_TICK").unwrap());
         if let Some(value) = self.get_property(vec!["plugin_root_id"]) {
             info!("test tick logging{}", String::from_utf8(value).unwrap());
         } else {

--- a/test/extensions/bootstrap/wasm/wasm_integration_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_integration_test.cc
@@ -48,6 +48,7 @@ typed_config:
       '@type': type.googleapis.com/google.protobuf.StringValue
       value: ""
     vm_config:
+      env_keys: ["KEY1", "KEY2"]
       vm_id: "my_vm_id"
       runtime: "envoy.wasm.runtime.{}"
       code:

--- a/test/extensions/bootstrap/wasm/wasm_speed_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_speed_test.cc
@@ -4,6 +4,9 @@
  * Run with:
  * `bazel run --config=libc++ -c opt //test/extensions/bootstrap/wasm:wasm_speed_test`
  */
+#include <string>
+#include <unordered_map>
+
 #include "common/event/dispatcher_impl.h"
 #include "common/stats/isolated_store_impl.h"
 
@@ -59,9 +62,13 @@ static void bmWasmSimpleCallSpeedTest(benchmark::State& state, std::string test,
       name, root_id, vm_id, runtime, plugin_configuration, false,
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", runtime), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   std::string code;
   if (runtime == "null") {
     code = "WasmSpeedCpp";

--- a/test/extensions/bootstrap/wasm/wasm_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_test.cc
@@ -48,7 +48,7 @@ public:
         envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info_, nullptr);
     wasm_ = std::make_shared<Extensions::Common::Wasm::Wasm>(
         absl::StrCat("envoy.wasm.runtime.", runtime), vm_id_, vm_configuration_, vm_key_,
-        allowed_capabilities, scope_, cluster_manager, *dispatcher_);
+        allowed_capabilities_, scope_, cluster_manager, *dispatcher_, envs_);
     EXPECT_NE(wasm_, nullptr);
     wasm_->setCreateContextForTesting(
         nullptr,
@@ -69,7 +69,10 @@ public:
   std::string vm_id_;
   std::string vm_configuration_;
   std::string vm_key_;
-  proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  proxy_wasm::AllowedCapabilitiesMap allowed_capabilities_;
+  // clang-format off
+  std::unordered_map<std::string, std::string> envs_;
+  // clang-format on
   std::string plugin_configuration_;
   std::shared_ptr<Extensions::Common::Wasm::Plugin> plugin_;
   std::shared_ptr<Extensions::Common::Wasm::Wasm> wasm_;
@@ -125,15 +128,15 @@ GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(WasmTestMatrix);
 
 TEST_P(WasmTestMatrix, Logging) {
   plugin_configuration_ = "configure-test";
+  envs_ = {{"ON_TICK", "TICK_VALUE"}, {"ON_CONFIGURE", "CONFIGURE_VALUE"}};
+
   createWasm();
   setWasmCode("logging");
 
   auto wasm_weak = std::weak_ptr<Extensions::Common::Wasm::Wasm>(wasm_);
   auto wasm_handler = std::make_unique<Extensions::Common::Wasm::WasmHandle>(std::move(wasm_));
-
   EXPECT_TRUE(wasm_weak.lock()->initialize(code_, false));
   auto context = static_cast<TestContext*>(wasm_weak.lock()->start(plugin_));
-
   if (std::get<1>(GetParam()) == "cpp") {
     EXPECT_CALL(*context, log_(spdlog::level::info, Eq("printf stdout test")));
     EXPECT_CALL(*context, log_(spdlog::level::err, Eq("printf stderr test")));
@@ -146,6 +149,8 @@ TEST_P(WasmTestMatrix, Logging) {
       .Times(testing::AtLeast(1));
   EXPECT_CALL(*context, log_(spdlog::level::info, Eq("onDone logging")));
   EXPECT_CALL(*context, log_(spdlog::level::info, Eq("onDelete logging")));
+  EXPECT_CALL(*context, log_(spdlog::level::trace, Eq("ON_TICK: TICK_VALUE")));
+  EXPECT_CALL(*context, log_(spdlog::level::trace, Eq("ON_CONFIGURE: CONFIGURE_VALUE")));
 
   EXPECT_TRUE(wasm_weak.lock()->configure(context, plugin_));
   wasm_handler.reset();

--- a/test/extensions/common/wasm/wasm_speed_test.cc
+++ b/test/extensions/common/wasm/wasm_speed_test.cc
@@ -31,9 +31,11 @@ void bmWasmSpeedTest(benchmark::State& state) {
   Envoy::Event::DispatcherPtr dispatcher(api->allocateDispatcher("wasm_test"));
   auto scope = Envoy::Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Envoy::Extensions::Common::Wasm::Wasm>(
       "envoy.wasm.runtime.null", "", "", "", allowed_capabilities, scope, cluster_manager,
-      *dispatcher);
+      *dispatcher, std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   auto context = std::make_shared<Envoy::Extensions::Common::Wasm::Context>(wasm.get());
   Envoy::Thread::ThreadFactory& thread_factory{Envoy::Thread::threadFactoryForTest()};

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -1,3 +1,5 @@
+#include <unordered_map>
+
 #include "envoy/server/lifecycle_notifier.h"
 
 #include "common/common/hex.h"
@@ -105,9 +107,13 @@ TEST_P(WasmCommonTest, EnvoyWasm) {
       "", "", "", GetParam(), "", false, envoy::config::core::v3::TrafficDirection::UNSPECIFIED,
       local_info, nullptr);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
-  auto wasm = std::make_shared<WasmHandle>(std::make_unique<Wasm>(
-      absl::StrCat("envoy.wasm.runtime.", GetParam()), "", "vm_configuration", "",
-      allowed_capabilities, scope, cluster_manager, *dispatcher));
+  // clang-format off
+  auto wasm = std::make_shared<WasmHandle>(
+      std::make_unique<Wasm>(absl::StrCat("envoy.wasm.runtime.", GetParam()), "",
+                             "vm_configuration", "", allowed_capabilities, scope, cluster_manager,
+                             *dispatcher, std::unordered_map<std::string, std::string>{}));
+  // clang-format on
+
   auto wasm_base = std::dynamic_pointer_cast<proxy_wasm::WasmHandleBase>(wasm);
   wasm->wasm()->setFailStateForTesting(proxy_wasm::FailState::UnableToCreateVM);
   EXPECT_EQ(toWasmEvent(wasm_base), EnvoyWasm::WasmEvent::UnableToCreateVM);
@@ -185,9 +191,13 @@ TEST_P(WasmCommonTest, Logging) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_NE(wasm, nullptr);
   EXPECT_NE(wasm->buildVersion(), "");
   EXPECT_NE(std::unique_ptr<ContextBase>(wasm->createContext(plugin)), nullptr);
@@ -257,9 +267,13 @@ TEST_P(WasmCommonTest, BadSignature) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_FALSE(wasm->initialize(code, false));
   EXPECT_TRUE(wasm->isFailed());
 }
@@ -287,9 +301,13 @@ TEST_P(WasmCommonTest, Segv) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_TRUE(wasm->initialize(code, false));
   TestContext* root_context = nullptr;
   wasm->setCreateContextForTesting(
@@ -331,9 +349,13 @@ TEST_P(WasmCommonTest, DivByZero) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_NE(wasm, nullptr);
   auto context = std::make_unique<TestContext>(wasm.get());
   EXPECT_TRUE(wasm->initialize(code, false));
@@ -372,9 +394,13 @@ TEST_P(WasmCommonTest, IntrinsicGlobals) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_NE(wasm, nullptr);
   EXPECT_TRUE(wasm->initialize(code, false));
   wasm->setCreateContextForTesting(
@@ -413,9 +439,13 @@ TEST_P(WasmCommonTest, Utilities) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_NE(wasm, nullptr);
   EXPECT_TRUE(wasm->initialize(code, false));
   wasm->setCreateContextForTesting(
@@ -482,9 +512,13 @@ TEST_P(WasmCommonTest, Stats) {
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_NE(wasm, nullptr);
   EXPECT_TRUE(wasm->initialize(code, false));
   wasm->setCreateContextForTesting(
@@ -519,9 +553,12 @@ TEST_P(WasmCommonTest, Foreign) {
       name, root_id, vm_id, GetParam(), plugin_configuration, false,
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
   EXPECT_NE(wasm, nullptr);
   std::string code;
   if (GetParam() != "null") {
@@ -565,9 +602,12 @@ TEST_P(WasmCommonTest, OnForeign) {
       name, root_id, vm_id, GetParam(), plugin_configuration, false,
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
   EXPECT_NE(wasm, nullptr);
   std::string code;
   if (GetParam() != "null") {
@@ -613,9 +653,13 @@ TEST_P(WasmCommonTest, WASI) {
       name, root_id, vm_id, GetParam(), plugin_configuration, false,
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities;
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
+
   EXPECT_NE(wasm, nullptr);
   std::string code;
   if (GetParam() != "null") {
@@ -980,9 +1024,12 @@ TEST_P(WasmCommonTest, RestrictCapabilities) {
   // restriction enforced if allowed_capabilities is non-empty
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities{
       {"foo", proxy_wasm::SanitizationConfig()}};
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   EXPECT_FALSE(wasm->capabilityAllowed("proxy_on_vm_start"));
   EXPECT_FALSE(wasm->capabilityAllowed("proxy_log"));
@@ -1030,9 +1077,12 @@ TEST_P(WasmCommonTest, AllowOnVmStart) {
   auto vm_key = proxy_wasm::makeVmKey(vm_id, vm_configuration, code);
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities{
       {"proxy_on_vm_start", proxy_wasm::SanitizationConfig()}};
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   EXPECT_TRUE(wasm->capabilityAllowed("proxy_on_vm_start"));
   EXPECT_FALSE(wasm->capabilityAllowed("proxy_log"));
@@ -1085,9 +1135,12 @@ TEST_P(WasmCommonTest, AllowLog) {
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities{
       {"proxy_on_vm_start", proxy_wasm::SanitizationConfig()},
       {"proxy_log", proxy_wasm::SanitizationConfig()}};
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   // Restrict capabilities, but allow proxy_log
   EXPECT_TRUE(wasm->capabilityAllowed("proxy_on_vm_start"));
@@ -1136,9 +1189,12 @@ TEST_P(WasmCommonTest, AllowWASI) {
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities{
       {"proxy_on_vm_start", proxy_wasm::SanitizationConfig()},
       {"fd_write", proxy_wasm::SanitizationConfig()}};
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   // Restrict capabilities, but allow fd_write
   EXPECT_TRUE(wasm->capabilityAllowed("proxy_on_vm_start"));
@@ -1188,9 +1244,12 @@ TEST_P(WasmCommonTest, AllowOnContextCreate) {
       {"proxy_on_vm_start", proxy_wasm::SanitizationConfig()},
       {"proxy_on_context_create", proxy_wasm::SanitizationConfig()},
       {"proxy_log", proxy_wasm::SanitizationConfig()}};
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   // Restrict capabilities, but allow proxy_log
   EXPECT_TRUE(wasm->capabilityAllowed("proxy_on_vm_start"));
@@ -1240,9 +1299,12 @@ TEST_P(WasmCommonTest, ThreadLocalCopyRetainsEnforcement) {
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities{
       {"proxy_on_vm_start", proxy_wasm::SanitizationConfig()},
       {"fd_write", proxy_wasm::SanitizationConfig()}};
+  // clang-format off
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.runtime.", GetParam()), vm_id, vm_configuration, vm_key,
-      allowed_capabilities, scope, cluster_manager, *dispatcher);
+      allowed_capabilities, scope, cluster_manager, *dispatcher,
+      std::unordered_map<std::string, std::string>{});
+  // clang-format on
 
   // Restrict capabilities
   EXPECT_TRUE(wasm->capabilityAllowed("proxy_on_vm_start"));
@@ -1283,12 +1345,12 @@ public:
   WasmCommonContextTest() = default;
 
   void setup(const std::string& code, std::string vm_configuration, std::string root_id = "") {
-    setupBase(
-        GetParam(), code,
-        [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
-          return new TestContext(wasm, plugin);
-        },
-        root_id, vm_configuration);
+    setRootId(root_id);
+    setVmConfiguration(vm_configuration);
+    setupBase(GetParam(), code,
+              [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
+                return new TestContext(wasm, plugin);
+              });
   }
   void setupContext() {
     context_ = std::make_unique<TestContext>(wasm_->wasm().get(), root_context_->id(), plugin_);

--- a/test/extensions/filters/http/wasm/test_data/BUILD
+++ b/test/extensions/filters/http/wasm/test_data/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
@@ -30,6 +32,7 @@ wasm_rust_binary(
 wasm_rust_binary(
     name = "headers_rust.wasm",
     srcs = ["headers_rust.rs"],
+    wasi = True,
     deps = [
         "@proxy_wasm_rust_sdk//:proxy_wasm",
         "@proxy_wasm_rust_sdk//bazel/cargo:log",

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -94,6 +94,9 @@ FilterHeadersStatus TestContext::onRequestHeaders(uint32_t, bool) {
   root()->stream_context_id_ = id();
   auto test = root()->test_;
   if (test == "headers") {
+    if (const char* value = std::getenv("ENVOY_HTTP_WASM_TEST_HEADERS")) {
+      logTrace("ENVOY_HTTP_WASM_TEST_HEADERS: " + std::string(value));
+    }
     logDebug(std::string("onRequestHeaders ") + std::to_string(id()) + std::string(" ") + test);
     auto path = getRequestHeader(":path");
     logInfo(std::string("header path ") + std::string(path->view()));

--- a/test/extensions/filters/network/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/network/wasm/wasm_filter_test.cc
@@ -53,13 +53,13 @@ public:
     } else {
       code_ = code;
     }
-    setupBase(
-        std::get<0>(GetParam()), code_,
-        [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
-          return new TestRoot(wasm, plugin);
-        },
-        "" /* root_id */, "" /* vm_configuration */, fail_open, "" /* plugin configuration*/,
-        allowed_capabilities);
+    setVmConfiguration(vm_configuration);
+    setFailOpen(fail_open);
+    setAllowedCapabilities(allowed_capabilities);
+    setupBase(std::get<0>(GetParam()), code_,
+              [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
+                return new TestRoot(wasm, plugin);
+              });
   }
 
   void setupFilter() { setupFilterBase<TestFilter>(); }

--- a/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
+++ b/test/extensions/stats_sinks/wasm/wasm_stat_sink_test.cc
@@ -37,12 +37,11 @@ public:
   WasmCommonContextTest() = default;
 
   void setup(const std::string& code, std::string root_id = "") {
-    setupBase(
-        GetParam(), code,
-        [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
-          return new TestContext(wasm, plugin);
-        },
-        root_id);
+    setRootId(root_id);
+    setupBase(GetParam(), code,
+              [](Wasm* wasm, const std::shared_ptr<Plugin>& plugin) -> ContextBase* {
+                return new TestContext(wasm, plugin);
+              });
   }
   void setupContext() {
     context_ = std::make_unique<TestContext>(wasm_->wasm().get(), root_context_->id(), plugin_);

--- a/test/test_common/wasm_base.h
+++ b/test/test_common/wasm_base.h
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <unordered_map>
 
 #include "envoy/extensions/wasm/v3/wasm.pb.validate.h"
 #include "envoy/server/lifecycle_notifier.h"
@@ -56,30 +57,28 @@ public:
   // NOLINTNEXTLINE(readability-identifier-naming)
   void SetUp() override { clearCodeCacheForTesting(); }
 
-  void setupBase(const std::string& runtime, const std::string& code, CreateContextFn create_root,
-                 std::string root_id = "", std::string vm_configuration = "",
-                 bool fail_open = false, std::string plugin_configuration = "",
-                 proxy_wasm::AllowedCapabilitiesMap allowed_capabilities = {}) {
+  void setupBase(const std::string& runtime, const std::string& code, CreateContextFn create_root) {
     envoy::extensions::wasm::v3::VmConfig vm_config;
     vm_config.set_vm_id("vm_id");
     vm_config.set_runtime(absl::StrCat("envoy.wasm.runtime.", runtime));
     ProtobufWkt::StringValue vm_configuration_string;
-    vm_configuration_string.set_value(vm_configuration);
+    vm_configuration_string.set_value(vm_configuration_);
     vm_config.mutable_configuration()->PackFrom(vm_configuration_string);
     vm_config.mutable_code()->mutable_local()->set_inline_bytes(code);
+    *vm_config.mutable_env_keys() = {env_keys_.begin(), env_keys_.end()};
     envoy::extensions::wasm::v3::CapabilityRestrictionConfig cr_config;
-    Protobuf::Map<std::string, SanitizationConfig> allowed_capabilities_;
-    for (auto& capability : allowed_capabilities) {
+    Protobuf::Map<std::string, SanitizationConfig> allowed_capabilities;
+    for (auto& capability : allowed_capabilities_) {
       // TODO(rapilado): Set the SanitizationConfig fields once sanitization is implemented.
-      allowed_capabilities_[capability.first] = SanitizationConfig();
+      allowed_capabilities[capability.first] = SanitizationConfig();
     }
-    *cr_config.mutable_allowed_capabilities() = allowed_capabilities_;
+    *cr_config.mutable_allowed_capabilities() = allowed_capabilities;
     Api::ApiPtr api = Api::createApiForTest(stats_store_);
     scope_ = Stats::ScopeSharedPtr(stats_store_.createScope("wasm."));
     auto name = "plugin_name";
     auto vm_id = "";
     plugin_ = std::make_shared<Extensions::Common::Wasm::Plugin>(
-        name, root_id, vm_id, runtime, plugin_configuration, fail_open,
+        name, root_id_, vm_id, runtime, plugin_configuration_, fail_open_,
         envoy::config::core::v3::TrafficDirection::INBOUND, local_info_, &listener_metadata_);
     // Passes ownership of root_context_.
     Extensions::Common::Wasm::createWasm(
@@ -119,6 +118,25 @@ public:
   envoy::config::core::v3::Metadata listener_metadata_;
   Context* root_context_ = nullptr; // Unowned.
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;
+
+  void setRootId(std::string root_id) { root_id_ = root_id; }
+  void setVmConfiguration(std::string vm_configuration) { vm_configuration_ = vm_configuration; }
+  void setPluginConfiguration(std::string plugin_configuration) {
+    plugin_configuration_ = plugin_configuration;
+  }
+  void setFailOpen(bool fail_open) { fail_open_ = fail_open; }
+  void setAllowedCapabilities(proxy_wasm::AllowedCapabilitiesMap allowed_capabilities) {
+    allowed_capabilities_ = allowed_capabilities;
+  }
+  void setEnvKeys(std::vector<std::string> env_keys) { env_keys_ = env_keys; }
+
+private:
+  std::string root_id_ = "";
+  std::string vm_configuration_ = "";
+  bool fail_open_ = false;
+  std::string plugin_configuration_ = "";
+  proxy_wasm::AllowedCapabilitiesMap allowed_capabilities_ = {};
+  std::vector<std::string> env_keys_ = {};
 };
 
 template <typename Base = testing::Test> class WasmHttpFilterTestBase : public WasmTestBase<Base> {


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

Commit Message: wasm: Add support for environment variables injection
Additional Description: wasm: Add support for environment variables injection to Wasm VMs. Envoy looks for specified env keys in the host, and if found, then inject the key-value(s) to the Wasm VMs. This is the counterpart of  https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/126, and resolves https://github.com/envoyproxy/envoy/issues/14958. 
Risk Level: low
Testing: unittest
Release Notes: 
[Optional Fixes #Issue] resolves https://github.com/envoyproxy/envoy/issues/14958
