### PR TITLE
style: remove useless definition in cc file

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -30,11 +30,6 @@
 namespace Envoy {
 namespace Network {
 
-// TODO(lambdai): Remove below re-declare in C++17.
-constexpr absl::string_view Utility::TCP_SCHEME;
-constexpr absl::string_view Utility::UDP_SCHEME;
-constexpr absl::string_view Utility::UNIX_SCHEME;
-
 Address::InstanceConstSharedPtr Utility::resolveUrl(const std::string& url) {
   if (urlIsTcpScheme(url)) {
     return parseInternetAddressAndPort(url.substr(TCP_SCHEME.size()));

--- a/test/test_common/utility.cc
+++ b/test/test_common/utility.cc
@@ -353,8 +353,6 @@ void ConditionalInitializer::wait() {
   EXPECT_TRUE(ready_);
 }
 
-constexpr std::chrono::milliseconds TestUtility::DefaultTimeout;
-
 namespace Api {
 
 class TestImplProvider {


### PR DESCRIPTION
Commit Message:
since C++ 17, `static constexpr` in header file implies `inline` so in variables doesn't need to be defined.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
