### PR TITLE
test: laying the groundwork for http3 protocol test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -428,14 +428,12 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
-    name = "protocol_integration_test",
+envoy_cc_test_library(
+    name = "protocol_integration_test_lib",
     srcs = [
         "protocol_integration_test.cc",
+        "protocol_integration_test.h",
     ],
-    # As this test has many H1/H2/v4/v6 tests it takes a while to run.
-    # Shard it enough to bring the run time in line with other integration tests.
-    shard_count = 5,
     deps = [
         ":http_protocol_integration_lib",
         "//source/common/http:header_map_lib",
@@ -453,6 +451,19 @@ envoy_cc_test(
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "protocol_integration_test",
+    srcs = [
+        "instantiate_protocol_integration_test.cc",
+    ],
+    # As this test has many H1/H2/v4/v6 tests it takes a while to run.
+    # Shard it enough to bring the run time in line with other integration tests.
+    shard_count = 5,
+    deps = [
+        ":protocol_integration_test_lib",
     ],
 )
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -247,7 +247,8 @@ HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type downstream_prot
           downstream_protocol,
           [version](int) {
             return Network::Utility::parseInternetAddress(
-                Network::Test::getAnyAddressString(version), 0);
+                // FIXME maybe only for UDP?
+                Network::Test::getLoopbackAddressString(version), 0);
           },
           version, config) {}
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -247,8 +247,7 @@ HttpIntegrationTest::HttpIntegrationTest(Http::CodecClient::Type downstream_prot
           downstream_protocol,
           [version](int) {
             return Network::Utility::parseInternetAddress(
-                // FIXME maybe only for UDP?
-                Network::Test::getLoopbackAddressString(version), 0);
+                Network::Test::getAnyAddressString(version), 0);
           },
           version, config) {}
 

--- a/test/integration/instantiate_protocol_integration_test.cc
+++ b/test/integration/instantiate_protocol_integration_test.cc
@@ -1,0 +1,17 @@
+#include "test/integration/protocol_integration_test.h"
+
+namespace Envoy {
+
+// For tests which focus on downstream-to-Envoy behavior, and don't need to be
+// run with both HTTP/1 and HTTP/2 upstreams.
+INSTANTIATE_TEST_SUITE_P(Protocols, DownstreamProtocolIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
+                             {Http::CodecClient::Type::HTTP1, Http::CodecClient::Type::HTTP2},
+                             {FakeHttpConnection::Type::HTTP1})),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+INSTANTIATE_TEST_SUITE_P(Protocols, ProtocolIntegrationTest,
+                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
+                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+
+} // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -54,11 +54,6 @@ void setDoNotValidateRouteConfig(
 };
 
 TEST_P(ProtocolIntegrationTest, TrailerSupportHttp1) {
-  if (upstreamProtocol() == FakeHttpConnection::Type::HTTP3 &&
-      version_ == Network::Address::IpVersion::v6) {
-    return;
-  }
-
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1,3 +1,5 @@
+#include "test/integration/protocol_integration_test.h"
+
 #include <functional>
 #include <list>
 #include <memory>
@@ -28,7 +30,6 @@
 #include "test/common/upstream/utility.h"
 #include "test/integration/autonomous_upstream.h"
 #include "test/integration/http_integration.h"
-#include "test/integration/http_protocol_integration.h"
 #include "test/integration/test_host_predicate_config.h"
 #include "test/integration/utility.h"
 #include "test/mocks/upstream/retry_priority.h"
@@ -52,45 +53,12 @@ void setDoNotValidateRouteConfig(
   route_config->mutable_validate_clusters()->set_value(false);
 };
 
-// Tests for DownstreamProtocolIntegrationTest will be run with all protocols
-// (H1/H2 downstream) but only H1 upstreams.
-//
-// This is useful for things which will likely not differ based on upstream
-// behavior, for example "how does Envoy handle duplicate content lengths from
-// downstream"?
-class DownstreamProtocolIntegrationTest : public HttpProtocolIntegrationTest {
-protected:
-  template <class T> void changeHeadersForStopAllTests(T& headers, bool set_buffer_limit) {
-    headers.addCopy("content_size", std::to_string(count_ * size_));
-    headers.addCopy("added_size", std::to_string(added_decoded_data_size_));
-    headers.addCopy("is_first_trigger", "value");
-    if (set_buffer_limit) {
-      headers.addCopy("buffer_limit", std::to_string(buffer_limit_));
-    }
-  }
-
-  void verifyUpStreamRequestAfterStopAllFilter() {
-    if (downstreamProtocol() == Http::CodecClient::Type::HTTP2) {
-      // decode-headers-return-stop-all-filter calls addDecodedData in decodeData and
-      // decodeTrailers. 2 decoded data were added.
-      EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 2, upstream_request_->bodyLength());
-    } else {
-      EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 1, upstream_request_->bodyLength());
-    }
-    EXPECT_EQ(true, upstream_request_->complete());
-  }
-
-  const int count_ = 70;
-  const int size_ = 1000;
-  const int added_decoded_data_size_ = 1;
-  const int buffer_limit_ = 100;
-};
-
-// Tests for ProtocolIntegrationTest will be run with the full mesh of H1/H2
-// downstream and H1/H2 upstreams.
-using ProtocolIntegrationTest = HttpProtocolIntegrationTest;
-
 TEST_P(ProtocolIntegrationTest, TrailerSupportHttp1) {
+  if (upstreamProtocol() == FakeHttpConnection::Type::HTTP3 &&
+      version_ == Network::Address::IpVersion::v6) {
+    return;
+  }
+
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
 
@@ -2182,17 +2150,5 @@ TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnectLegacy) {
     EXPECT_FALSE(response->complete());
   }
 }
-
-// For tests which focus on downstream-to-Envoy behavior, and don't need to be
-// run with both HTTP/1 and HTTP/2 upstreams.
-INSTANTIATE_TEST_SUITE_P(Protocols, DownstreamProtocolIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
-                             {Http::CodecClient::Type::HTTP1, Http::CodecClient::Type::HTTP2},
-                             {FakeHttpConnection::Type::HTTP1})),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
-
-INSTANTIATE_TEST_SUITE_P(Protocols, ProtocolIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams()),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 } // namespace Envoy

--- a/test/integration/protocol_integration_test.h
+++ b/test/integration/protocol_integration_test.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "test/integration/http_protocol_integration.h"
+
+namespace Envoy {
+
+// Tests for DownstreamProtocolIntegrationTest will be run with all protocols
+// (H1/H2 downstream) but only H1 upstreams.
+//
+// This is useful for things which will likely not differ based on upstream
+// behavior, for example "how does Envoy handle duplicate content lengths from
+// downstream"?
+class DownstreamProtocolIntegrationTest : public HttpProtocolIntegrationTest {
+protected:
+  template <class T> void changeHeadersForStopAllTests(T& headers, bool set_buffer_limit) {
+    headers.addCopy("content_size", std::to_string(count_ * size_));
+    headers.addCopy("added_size", std::to_string(added_decoded_data_size_));
+    headers.addCopy("is_first_trigger", "value");
+    if (set_buffer_limit) {
+      headers.addCopy("buffer_limit", std::to_string(buffer_limit_));
+    }
+  }
+
+  void verifyUpStreamRequestAfterStopAllFilter() {
+    if (downstreamProtocol() == Http::CodecClient::Type::HTTP2) {
+      // decode-headers-return-stop-all-filter calls addDecodedData in decodeData and
+      // decodeTrailers. 2 decoded data were added.
+      EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 2, upstream_request_->bodyLength());
+    } else {
+      EXPECT_EQ(count_ * size_ + added_decoded_data_size_ * 1, upstream_request_->bodyLength());
+    }
+    EXPECT_EQ(true, upstream_request_->complete());
+  }
+
+  const int count_ = 70;
+  const int size_ = 1000;
+  const int added_decoded_data_size_ = 1;
+  const int buffer_limit_ = 100;
+};
+
+// Tests for ProtocolIntegrationTest will be run with the full mesh of H1/H2
+// downstream and H1/H2 upstreams.
+using ProtocolIntegrationTest = HttpProtocolIntegrationTest;
+
+} // namespace Envoy


### PR DESCRIPTION
Additional Description: 
splitting the protocol integration test into multiple files, so that the quic-specific version can run 
See 
https://github.com/envoyproxy/envoy/compare/main...alyssawilk:upstream_quic?expand=1
for example usage

The alternate choice is we can simply run the HTTP/3 test in protocol integration test, but 
1) we'd need some bazel magic to not cause fips problems or problems for folks who compile QUIC out
2) it breaks the extension model somewhat.

Risk Level: n/a (test only)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a