### PR TITLE
wasm: fix root_context_id that was incorrectly cached across threads.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -907,10 +907,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "WebAssembly for Proxies (C++ host implementation)",
         project_desc = "WebAssembly for Proxies (C++ host implementation)",
         project_url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host",
-        version = "5a53cf4b231599e1d2a1f2f4598fdfbb727ff948",
-        sha256 = "600dbc651a2837e6f1db964eb7e1078e5e338049a34c9ab47415dfa7f3de5478",
+        version = "a64096d7911c3d83a025c879401190d949c138bc",
+        sha256 = "e9db068367627a9b6b8b678499e0cf5dbaf0ad25552b32f42b45626fcde12fa0",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
+        urls = ["https://github.com/PiotrSikora/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = [
             "envoy.access_loggers.wasm",
@@ -923,7 +923,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.wasm.runtime.wavm",
             "envoy.wasm.runtime.wasmtime",
         ],
-        release_date = "2021-01-12",
+        release_date = "2021-02-10",
         cpe = "N/A",
     ),
     proxy_wasm_rust_sdk = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -907,10 +907,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "WebAssembly for Proxies (C++ host implementation)",
         project_desc = "WebAssembly for Proxies (C++ host implementation)",
         project_url = "https://github.com/proxy-wasm/proxy-wasm-cpp-host",
-        version = "a64096d7911c3d83a025c879401190d949c138bc",
-        sha256 = "e9db068367627a9b6b8b678499e0cf5dbaf0ad25552b32f42b45626fcde12fa0",
+        version = "c51fbca35e9e7968fc5319258ed7a38b1bc1ec7a",
+        sha256 = "533944a9084c2f75c36bda627152b9f31047ff3554b6361a88a542f16dee9483",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
-        urls = ["https://github.com/PiotrSikora/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = [
             "envoy.access_loggers.wasm",
@@ -923,7 +923,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "envoy.wasm.runtime.wavm",
             "envoy.wasm.runtime.wasmtime",
         ],
-        release_date = "2021-02-10",
+        release_date = "2021-02-11",
         cpe = "N/A",
     ),
     proxy_wasm_rust_sdk = dict(

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -48,6 +48,7 @@ using GrpcService = envoy::config::core::v3::GrpcService;
 
 class Wasm;
 
+using PluginBaseSharedPtr = std::shared_ptr<PluginBase>;
 using PluginHandleBaseSharedPtr = std::shared_ptr<PluginHandleBase>;
 using WasmHandleBaseSharedPtr = std::shared_ptr<WasmHandleBase>;
 

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -282,10 +282,12 @@ getCloneFactory(WasmExtension* wasm_extension, Event::Dispatcher& dispatcher,
 
 static proxy_wasm::PluginHandleFactory getPluginFactory(WasmExtension* wasm_extension) {
   auto wasm_plugin_factory = wasm_extension->pluginFactory();
-  return [wasm_plugin_factory](WasmHandleBaseSharedPtr base_wasm,
-                               absl::string_view plugin_key) -> std::shared_ptr<PluginHandleBase> {
-    return wasm_plugin_factory(std::static_pointer_cast<WasmHandle>(base_wasm), plugin_key);
-  };
+  return
+      [wasm_plugin_factory](WasmHandleBaseSharedPtr base_wasm,
+                            PluginBaseSharedPtr base_plugin) -> std::shared_ptr<PluginHandleBase> {
+        return wasm_plugin_factory(std::static_pointer_cast<WasmHandle>(base_wasm),
+                                   std::static_pointer_cast<Plugin>(base_plugin));
+      };
 }
 
 WasmEvent toWasmEvent(const std::shared_ptr<WasmHandleBase>& wasm) {

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -150,7 +150,7 @@ public:
 
   WasmSharedPtr& wasm() { return wasm_handle_->wasm(); }
   WasmHandleSharedPtr& wasmHandleForTest() { return wasm_handle_; }
-  uint32_t config_id() { return config_id_; }
+  uint32_t configId() { return config_id_; }
 
 private:
   WasmHandleSharedPtr wasm_handle_;

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -146,8 +146,7 @@ public:
       : PluginHandleBase(std::static_pointer_cast<WasmHandleBase>(wasm_handle),
                          std::static_pointer_cast<PluginBase>(plugin)),
         wasm_handle_(wasm_handle),
-        config_id_(wasm_handle->wasm()->getRootContext(plugin, false)->id()) {
-  }
+        config_id_(wasm_handle->wasm()->getRootContext(plugin, false)->id()) {}
 
   WasmSharedPtr& wasm() { return wasm_handle_->wasm(); }
   WasmHandleSharedPtr& wasmHandleForTest() { return wasm_handle_; }

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -146,15 +146,15 @@ public:
       : PluginHandleBase(std::static_pointer_cast<WasmHandleBase>(wasm_handle),
                          std::static_pointer_cast<PluginBase>(plugin)),
         wasm_handle_(wasm_handle),
-        config_id_(wasm_handle->wasm()->getRootContext(plugin, false)->id()) {}
+        root_context_id_(wasm_handle->wasm()->getRootContext(plugin, false)->id()) {}
 
   WasmSharedPtr& wasm() { return wasm_handle_->wasm(); }
   WasmHandleSharedPtr& wasmHandleForTest() { return wasm_handle_; }
-  uint32_t configId() { return config_id_; }
+  uint32_t rootContextId() { return root_context_id_; }
 
 private:
   WasmHandleSharedPtr wasm_handle_;
-  const uint32_t config_id_;
+  const uint32_t root_context_id_;
 };
 
 using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -142,15 +142,20 @@ using WasmHandleSharedPtr = std::shared_ptr<WasmHandle>;
 
 class PluginHandle : public PluginHandleBase, public ThreadLocal::ThreadLocalObject {
 public:
-  explicit PluginHandle(const WasmHandleSharedPtr& wasm_handle, absl::string_view plugin_key)
-      : PluginHandleBase(std::static_pointer_cast<WasmHandleBase>(wasm_handle), plugin_key),
-        wasm_handle_(wasm_handle) {}
+  explicit PluginHandle(const WasmHandleSharedPtr& wasm_handle, const PluginSharedPtr& plugin)
+      : PluginHandleBase(std::static_pointer_cast<WasmHandleBase>(wasm_handle),
+                         std::static_pointer_cast<PluginBase>(plugin)),
+        wasm_handle_(wasm_handle),
+        config_id_(wasm_handle->wasm()->getRootContext(plugin, false)->id()) {
+  }
 
   WasmSharedPtr& wasm() { return wasm_handle_->wasm(); }
   WasmHandleSharedPtr& wasmHandleForTest() { return wasm_handle_; }
+  uint32_t config_id() { return config_id_; }
 
 private:
   WasmHandleSharedPtr wasm_handle_;
+  const uint32_t config_id_;
 };
 
 using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;

--- a/source/extensions/common/wasm/wasm_extension.cc
+++ b/source/extensions/common/wasm/wasm_extension.cc
@@ -40,10 +40,10 @@ RegisterWasmExtension::RegisterWasmExtension(WasmExtension* extension) {
 }
 
 PluginHandleExtensionFactory EnvoyWasm::pluginFactory() {
-  return [](const WasmHandleSharedPtr& base_wasm,
-            absl::string_view plugin_key) -> PluginHandleBaseSharedPtr {
+  return [](const WasmHandleSharedPtr& wasm_handle,
+            const PluginSharedPtr& plugin) -> PluginHandleBaseSharedPtr {
     return std::static_pointer_cast<PluginHandleBase>(
-        std::make_shared<PluginHandle>(base_wasm, plugin_key));
+        std::make_shared<PluginHandle>(wasm_handle, plugin));
   };
 }
 

--- a/source/extensions/common/wasm/wasm_extension.h
+++ b/source/extensions/common/wasm/wasm_extension.h
@@ -32,7 +32,7 @@ using WasmHandleSharedPtr = std::shared_ptr<WasmHandle>;
 using CreateContextFn =
     std::function<ContextBase*(Wasm* wasm, const std::shared_ptr<Plugin>& plugin)>;
 using PluginHandleExtensionFactory = std::function<PluginHandleBaseSharedPtr(
-    const WasmHandleSharedPtr& base_wasm, absl::string_view plugin_key)>;
+    const WasmHandleSharedPtr& wasm_handle, const PluginSharedPtr& plugin)>;
 using WasmHandleExtensionFactory = std::function<WasmHandleBaseSharedPtr(
     const VmConfig& vm_config, const CapabilityRestrictionConfig& capability_restriction_config,
     const Stats::ScopeSharedPtr& scope, Upstream::ClusterManager& cluster_manager,

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -34,14 +34,10 @@ public:
     if (plugin_->fail_open_ && (!wasm || wasm->isFailed())) {
       return nullptr;
     }
-    if (wasm && !root_context_id_) {
-      root_context_id_ = wasm->getRootContext(plugin_, false)->id();
-    }
-    return std::make_shared<Context>(wasm, root_context_id_, plugin_);
+    return std::make_shared<Context>(wasm, handle->config_id(), plugin_);
   }
 
 private:
-  uint32_t root_context_id_{0};
   PluginSharedPtr plugin_;
   ThreadLocal::TypedSlotPtr<PluginHandle> tls_slot_;
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -40,7 +40,7 @@ public:
         return std::make_shared<Context>(nullptr, 0, plugin_);
       }
     }
-    return std::make_shared<Context>(wasm, handle->configId(), plugin_);
+    return std::make_shared<Context>(wasm, handle->rootContextId(), plugin_);
   }
 
 private:

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -40,7 +40,7 @@ public:
         return std::make_shared<Context>(nullptr, 0, plugin_);
       }
     }
-    return std::make_shared<Context>(wasm, handle->config_id(), plugin_);
+    return std::make_shared<Context>(wasm, handle->configId(), plugin_);
   }
 
 private:

--- a/source/extensions/filters/http/wasm/wasm_filter.h
+++ b/source/extensions/filters/http/wasm/wasm_filter.h
@@ -31,8 +31,14 @@ public:
     if (handle.has_value()) {
       wasm = handle->wasm().get();
     }
-    if (plugin_->fail_open_ && (!wasm || wasm->isFailed())) {
-      return nullptr;
+    if (!wasm || wasm->isFailed()) {
+      if (plugin_->fail_open_) {
+        // Fail open skips adding this filter to callbacks.
+        return nullptr;
+      } else {
+        // Fail closed is handled by an empty Context.
+        return std::make_shared<Context>(nullptr, 0, plugin_);
+      }
     }
     return std::make_shared<Context>(wasm, handle->config_id(), plugin_);
   }

--- a/source/extensions/filters/network/wasm/wasm_filter.h
+++ b/source/extensions/filters/network/wasm/wasm_filter.h
@@ -40,7 +40,7 @@ public:
         return std::make_shared<Context>(nullptr, 0, plugin_);
       }
     }
-    return std::make_shared<Context>(wasm, handle->config_id(), plugin_);
+    return std::make_shared<Context>(wasm, handle->configId(), plugin_);
   }
 
   Wasm* wasmForTest() { return tls_slot_->get()->wasm().get(); }

--- a/source/extensions/filters/network/wasm/wasm_filter.h
+++ b/source/extensions/filters/network/wasm/wasm_filter.h
@@ -34,16 +34,12 @@ public:
     if (plugin_->fail_open_ && (!wasm || wasm->isFailed())) {
       return nullptr;
     }
-    if (wasm && !root_context_id_) {
-      root_context_id_ = wasm->getRootContext(plugin_, false)->id();
-    }
-    return std::make_shared<Context>(wasm, root_context_id_, plugin_);
+    return std::make_shared<Context>(wasm, handle->config_id(), plugin_);
   }
 
   Wasm* wasmForTest() { return tls_slot_->get()->wasm().get(); }
 
 private:
-  uint32_t root_context_id_{0};
   PluginSharedPtr plugin_;
   ThreadLocal::TypedSlotPtr<PluginHandle> tls_slot_;
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;

--- a/source/extensions/filters/network/wasm/wasm_filter.h
+++ b/source/extensions/filters/network/wasm/wasm_filter.h
@@ -31,8 +31,14 @@ public:
     if (handle.has_value()) {
       wasm = handle->wasm().get();
     }
-    if (plugin_->fail_open_ && (!wasm || wasm->isFailed())) {
-      return nullptr;
+    if (!wasm || wasm->isFailed()) {
+      if (plugin_->fail_open_) {
+        // Fail open skips adding this filter to callbacks.
+        return nullptr;
+      } else {
+        // Fail closed is handled by an empty Context.
+        return std::make_shared<Context>(nullptr, 0, plugin_);
+      }
     }
     return std::make_shared<Context>(wasm, handle->config_id(), plugin_);
   }

--- a/source/extensions/filters/network/wasm/wasm_filter.h
+++ b/source/extensions/filters/network/wasm/wasm_filter.h
@@ -40,7 +40,7 @@ public:
         return std::make_shared<Context>(nullptr, 0, plugin_);
       }
     }
-    return std::make_shared<Context>(wasm, handle->configId(), plugin_);
+    return std::make_shared<Context>(wasm, handle->rootContextId(), plugin_);
   }
 
   Wasm* wasmForTest() { return tls_slot_->get()->wasm().get(); }

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -711,10 +711,10 @@ TEST_P(WasmCommonTest, VmCache) {
             });
         return std::make_shared<WasmHandle>(wasm);
       },
-      [](const WasmHandleBaseSharedPtr& base_wasm,
-         absl::string_view plugin_key) -> PluginHandleBaseSharedPtr {
-        return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(base_wasm),
-                                              plugin_key);
+      [](const WasmHandleBaseSharedPtr& wasm_handle,
+         const PluginBaseSharedPtr& plugin) -> PluginHandleBaseSharedPtr {
+        return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(wasm_handle),
+                                              std::static_pointer_cast<Plugin>(plugin));
       });
   wasm_handle.reset();
   wasm_handle2.reset();
@@ -818,10 +818,10 @@ TEST_P(WasmCommonTest, RemoteCode) {
             });
         return std::make_shared<WasmHandle>(wasm);
       },
-      [](const WasmHandleBaseSharedPtr& base_wasm,
-         absl::string_view plugin_key) -> PluginHandleBaseSharedPtr {
-        return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(base_wasm),
-                                              plugin_key);
+      [](const WasmHandleBaseSharedPtr& wasm_handle,
+         const PluginBaseSharedPtr& plugin) -> PluginHandleBaseSharedPtr {
+        return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(wasm_handle),
+                                              std::static_pointer_cast<Plugin>(plugin));
       });
   wasm_handle.reset();
 
@@ -936,10 +936,10 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
             });
         return std::make_shared<WasmHandle>(wasm);
       },
-      [](const WasmHandleBaseSharedPtr& base_wasm,
-         absl::string_view plugin_key) -> PluginHandleBaseSharedPtr {
-        return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(base_wasm),
-                                              plugin_key);
+      [](const WasmHandleBaseSharedPtr& wasm_handle,
+         const PluginBaseSharedPtr& plugin) -> PluginHandleBaseSharedPtr {
+        return std::make_shared<PluginHandle>(std::static_pointer_cast<WasmHandle>(wasm_handle),
+                                              std::static_pointer_cast<Plugin>(plugin));
       });
   wasm_handle.reset();
 


### PR DESCRIPTION
Fixes proxy-wasm/proxy-wasm-cpp-host#125.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>