### PR TITLE
jwt_authn: use timeSource for jwt_authn time validation

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -262,6 +262,12 @@ uint64_t DateUtil::nowToMilliseconds(TimeSource& time_source) {
   return std::chrono::time_point_cast<UnsignedMilliseconds>(now).time_since_epoch().count();
 }
 
+uint64_t DateUtil::nowToSeconds(TimeSource& time_source) {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             time_source.systemTime().time_since_epoch())
+      .count();
+}
+
 const char StringUtil::WhitespaceChars[] = " \t\f\v\n\r";
 
 const char* StringUtil::strtoull(const char* str, uint64_t& out, int base) {

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -177,6 +177,12 @@ public:
    * @return uint64_t the number of milliseconds since the epoch.
    */
   static uint64_t nowToMilliseconds(TimeSource& time_source);
+
+  /**
+   * @param time_source time keeping source.
+   * @return uint64_t the number os seconds since the epoch.
+   */
+  static uint64_t nowToSeconds(TimeSource& time_source);
 };
 
 /**

--- a/source/common/router/reset_header_parser.cc
+++ b/source/common/router/reset_header_parser.cc
@@ -46,8 +46,7 @@ ResetHeaderParserImpl::parseInterval(TimeSource& time_source,
 
   case ResetHeaderFormat::UnixTimestamp:
     if (absl::SimpleAtoi(header_value, &num_seconds)) {
-      const auto time_now = time_source.systemTime().time_since_epoch();
-      const uint64_t timestamp = std::chrono::duration_cast<std::chrono::seconds>(time_now).count();
+      const uint64_t timestamp = DateUtil::nowToSeconds(time_source);
 
       if (num_seconds < timestamp) {
         return absl::nullopt;

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -175,7 +175,10 @@ void AuthenticatorImpl::startVerify() {
   if (jwks_data_->getJwtProvider().clock_skew_seconds() > 0) {
     clock_skew_seconds = jwks_data_->getJwtProvider().clock_skew_seconds();
   }
-  status = jwt_->verifyTimeConstraint(absl::ToUnixSeconds(absl::Now()), clock_skew_seconds);
+  const uint64_t unix_timestamp =
+      std::chrono::duration_cast<std::chrono::seconds>(timeSource().systemTime().time_since_epoch())
+          .count();
+  status = jwt_->verifyTimeConstraint(unix_timestamp, clock_skew_seconds);
   if (status != Status::Ok) {
     doneWithStatus(status);
     return;

--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -175,9 +175,7 @@ void AuthenticatorImpl::startVerify() {
   if (jwks_data_->getJwtProvider().clock_skew_seconds() > 0) {
     clock_skew_seconds = jwks_data_->getJwtProvider().clock_skew_seconds();
   }
-  const uint64_t unix_timestamp =
-      std::chrono::duration_cast<std::chrono::seconds>(timeSource().systemTime().time_since_epoch())
-          .count();
+  const uint64_t unix_timestamp = DateUtil::nowToSeconds(timeSource());
   status = jwt_->verifyTimeConstraint(unix_timestamp, clock_skew_seconds);
   if (status != Status::Ok) {
     doneWithStatus(status);

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.cc
@@ -14,9 +14,7 @@ void DnsFilterResolver::resolveExternalQuery(DnsQueryContextPtr context,
   ctx.query_rec = domain_query;
   ctx.query_context = std::move(context);
   ctx.query_context->in_callback_ = false;
-  ctx.expiry = std::chrono::duration_cast<std::chrono::seconds>(
-                   dispatcher_.timeSource().systemTime().time_since_epoch())
-                   .count() +
+  ctx.expiry = DateUtil::nowToSeconds(dispatcher_.timeSource()) +
                std::chrono::duration_cast<std::chrono::seconds>(timeout_).count();
   ctx.resolver_status = DnsFilterResolverStatus::Pending;
 
@@ -104,9 +102,7 @@ void DnsFilterResolver::resolveExternalQuery(DnsQueryContextPtr context,
 }
 
 void DnsFilterResolver::onResolveTimeout() {
-  const uint64_t now = std::chrono::duration_cast<std::chrono::seconds>(
-                           dispatcher_.timeSource().systemTime().time_since_epoch())
-                           .count();
+  const uint64_t now = DateUtil::nowToSeconds(dispatcher_.timeSource());
   ENVOY_LOG(trace, "Pending queries: {}", lookups_.size());
 
   // Find an outstanding pending query and purge it

--- a/source/extensions/watchdog/profile_action/profile_action.cc
+++ b/source/extensions/watchdog/profile_action/profile_action.cc
@@ -17,8 +17,8 @@ namespace ProfileAction {
 namespace {
 static constexpr uint64_t DefaultMaxProfiles = 10;
 
-std::string generateProfileFilePath(const std::string& directory, const SystemTime& now) {
-  auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+std::string generateProfileFilePath(const std::string& directory, TimeSource& time_source) {
+  const uint64_t timestamp = DateUtil::nowToSeconds(time_source);
   if (absl::EndsWith(directory, "/")) {
     return absl::StrFormat("%s%s.%d", directory, "ProfileAction", timestamp);
   }
@@ -89,7 +89,7 @@ void ProfileAction::run(
   }
 
   // Generate file path for output and try to profile
-  profile_filename_ = generateProfileFilePath(path_, context_.api_.timeSource().systemTime());
+  profile_filename_ = generateProfileFilePath(path_, context_.api_.timeSource());
 
   if (!Profiler::Cpu::profilerEnabled()) {
     if (Profiler::Cpu::startProfiler(profile_filename_)) {

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -415,10 +415,7 @@ TEST_F(OAuth2Test, CookieValidator) {
   // Set SystemTime to a fixed point so we get consistent HMAC encodings between test runs.
   test_time_.setSystemTime(SystemTime(std::chrono::seconds(0)));
 
-  const auto expires_at_s =
-      std::chrono::duration_cast<std::chrono::seconds>(
-          test_time_.timeSystem().systemTime().time_since_epoch() + std::chrono::seconds(10))
-          .count();
+  const auto expires_at_s = DateUtil::nowToSeconds(test_time_.timeSystem()) + 10;
 
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Host.get(), "traffic.example.com"},

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -129,10 +129,7 @@ TEST_F(OauthIntegrationTest, AuthenticationFlow) {
 
   envoy::extensions::http_filters::oauth2::OAuthResponse oauth_response;
   oauth_response.mutable_access_token()->set_value("bar");
-  oauth_response.mutable_expires_in()->set_value(
-      std::chrono::duration_cast<std::chrono::seconds>(
-          api_->timeSource().systemTime().time_since_epoch() + std::chrono::seconds(10))
-          .count());
+  oauth_response.mutable_expires_in()->set_value(DateUtil::nowToSeconds(api_->timeSource()) + 10);
 
   Buffer::OwnedImpl buffer(MessageUtil::getJsonStringFromMessageOrDie(oauth_response));
   upstream_request_->encodeData(buffer, true);


### PR DESCRIPTION
Commit Message: use timeSource for jwt_authn time validation
Additional Description:
Risk Level: low
Testing: I expect existing tests to cover this change.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
