### PR TITLE
build: Fix git describe bug in flaky test script

### DIFF
--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -200,7 +200,7 @@ def getGitInfo(CI_TARGET):
     output = subprocess.check_output(['git', 'remote', 'get-url', 'upstream'], encoding='utf-8')
     ret += "Upstream:\t{}".format(output.replace('.git', ''))
 
-  output = subprocess.check_output(['git', 'describe', '--all'], encoding='utf-8')
+  output = subprocess.check_output(['git', 'describe', '--all', '--always'], encoding='utf-8')
   ret += "Latest ref:\t{}".format(output)
 
   ret += "\n"


### PR DESCRIPTION
Commit Message:
In the flaky test script, "git describe --all" is invoked, but there may not be any tags to show.  This results in a fatal error that fails the CI, eg like [this](https://dev.azure.com/cncf/envoy/_build/results?buildId=65615&view=logs&jobId=d1f76054-8f79-554b-6f4a-11d6a63b8e00&j=d1f76054-8f79-554b-6f4a-11d6a63b8e00&t=266e17e3-d213-54b5-deef-0dcee01da137).  This PR fixes that by appending the "--always" parameter.

Signed-off-by: Randy Miller <rmiller14@gmail.com>

Risk Level: Low
Testing: Ran the script a few times.