### PR TITLE
build: Fix whitespace in flaky test script's output

### DIFF
--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -174,7 +174,7 @@ def getGitInfo(CI_TARGET):
 
   if os.getenv('SYSTEM_STAGEDISPLAYNAME') and os.getenv('SYSTEM_STAGEJOBNAME'):
     ret += "Stage:          {} {}\n".format(os.environ['SYSTEM_STAGEDISPLAYNAME'],
-                                      os.environ['SYSTEM_STAGEJOBNAME'])
+                                            os.environ['SYSTEM_STAGEJOBNAME'])
 
   if os.getenv('BUILD_REASON') == "PullRequest" and os.getenv(
       'SYSTEM_PULLREQUEST_PULLREQUESTNUMBER'):

--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -24,9 +24,9 @@ def didTestPass(file):
 # Returns a pretty-printed string of a test case failure.
 def printTestCaseFailure(testcase, testsuite, failure_msg, log_path):
   ret = "Test flake details:\n"
-  ret += "- Test suite:\t{}\n".format(testsuite)
-  ret += "- Test case:\t{}\n".format(testcase)
-  ret += "- Log path:\t{}\n".format(log_path)
+  ret += "- Test suite:   {}\n".format(testsuite)
+  ret += "- Test case:    {}\n".format(testcase)
+  ret += "- Log path:     {}\n".format(log_path)
   ret += "- Details:\n"
   for line in failure_msg.splitlines():
     ret += "\t" + line + "\n"
@@ -37,15 +37,15 @@ def printTestCaseFailure(testcase, testsuite, failure_msg, log_path):
 # Returns a pretty-printed string of a test suite error, such as an exception or a timeout.
 def printTestSuiteError(testsuite, testcase, log_path, duration, time, error_msg, output):
   ret = "Test flake details:\n"
-  ret += "- Test suite:\t{}\n".format(testsuite)
-  ret += "- Test case:\t{}\n".format(testcase)
-  ret += "- Log path:\t{}\n".format(log_path)
+  ret += "- Test suite:   {}\n".format(testsuite)
+  ret += "- Test case:    {}\n".format(testcase)
+  ret += "- Log path:     {}\n".format(log_path)
 
   errno_string = os.strerror(int(error_msg.split(' ')[-1]))
-  ret += "- Error:\t{} ({})\n".format(error_msg.capitalize(), errno_string)
+  ret += "- Error:        {} ({})\n".format(error_msg.capitalize(), errno_string)
 
   if duration == time and duration in well_known_timeouts:
-    ret += "- Note:\t\tThis error is likely a timeout (test duration == {}, a well known timeout value).\n".format(
+    ret += "- Note:         This error is likely a timeout (test duration == {}, a well known timeout value).\n".format(
         duration)
 
   # If there's a call stack, print it. Otherwise, attempt to print the most recent,
@@ -170,24 +170,24 @@ def getGitInfo(CI_TARGET):
   ret = ""
 
   if CI_TARGET != "":
-    ret += "Target:\t\t{}\n".format(CI_TARGET)
+    ret += "Target:         {}\n".format(CI_TARGET)
 
   if os.getenv('SYSTEM_STAGEDISPLAYNAME') and os.getenv('SYSTEM_STAGEJOBNAME'):
-    ret += "Stage:\t\t{} {}\n".format(os.environ['SYSTEM_STAGEDISPLAYNAME'],
+    ret += "Stage:          {} {}\n".format(os.environ['SYSTEM_STAGEDISPLAYNAME'],
                                       os.environ['SYSTEM_STAGEJOBNAME'])
 
   if os.getenv('BUILD_REASON') == "PullRequest" and os.getenv(
       'SYSTEM_PULLREQUEST_PULLREQUESTNUMBER'):
-    ret += "Pull request:\t{}/pull/{}\n".format(os.environ['REPO_URI'],
-                                                os.environ['SYSTEM_PULLREQUEST_PULLREQUESTNUMBER'])
+    ret += "Pull request:   {}/pull/{}\n".format(os.environ['REPO_URI'],
+                                                 os.environ['SYSTEM_PULLREQUEST_PULLREQUESTNUMBER'])
   elif os.getenv('BUILD_REASON'):
-    ret += "Build reason:\t{}\n".format(os.environ['BUILD_REASON'])
+    ret += "Build reason:   {}\n".format(os.environ['BUILD_REASON'])
 
   output = subprocess.check_output(['git', 'log', '--format=%H', '-n', '1'], encoding='utf-8')
-  ret += "Commmit:\t{}/commit/{}".format(os.environ['REPO_URI'], output)
+  ret += "Commmit:        {}/commit/{}".format(os.environ['REPO_URI'], output)
 
   build_id = os.environ['BUILD_URI'].split('/')[-1]
-  ret += "CI results:\thttps://dev.azure.com/cncf/envoy/_build/results?buildId=" + build_id + "\n"
+  ret += "CI results:     https://dev.azure.com/cncf/envoy/_build/results?buildId=" + build_id + "\n"
 
   ret += "\n"
 
@@ -195,14 +195,14 @@ def getGitInfo(CI_TARGET):
 
   if ("origin" in remotes):
     output = subprocess.check_output(['git', 'remote', 'get-url', 'origin'], encoding='utf-8')
-    ret += "Origin:\t\t{}".format(output.replace('.git', ''))
+    ret += "Origin:         {}".format(output.replace('.git', ''))
 
   if ("upstream" in remotes):
     output = subprocess.check_output(['git', 'remote', 'get-url', 'upstream'], encoding='utf-8')
-    ret += "Upstream:\t{}".format(output.replace('.git', ''))
+    ret += "Upstream:       {}".format(output.replace('.git', ''))
 
   output = subprocess.check_output(['git', 'describe', '--all', '--always'], encoding='utf-8')
-  ret += "Latest ref:\t{}".format(output)
+  ret += "Latest ref:     {}".format(output)
 
   ret += "\n"
 


### PR DESCRIPTION
Commit Message:
The flaky test script currently uses tabs to line up columns in its output.  In Slack, tabs are converted to 4 spaces, so the columns are not aligned.  This PR fixes that by replacing the tabs with spaces.

Signed-off-by: Randy Miller <rmiller14@gmail.com>

Risk Level: None
Testing: Ran the script a few times.