### PR TITLE
Fix flaky test script environment variable warning

### DIFF
--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
   if os.getenv('TEST_TMPDIR') and os.getenv('REPO_URI') and os.getenv("BUILD_URI"):
     os.environ["TMP_OUTPUT_PROCESS_XML"] = os.getenv("TEST_TMPDIR") + "/tmp_output_process_xml.txt"
   else:
-    print("Set the env variables TEST_TMPDIR and REPO_URI first.")
+    print("Set the env variables TEST_TMPDIR, REPO_URI, and BUILD_URI first.")
     sys.exit(0)
 
   find_dir = "{}/**/**/**/**/bazel-testlogs/".format(os.environ['TEST_TMPDIR']).replace('\\', '/')


### PR DESCRIPTION
Commit Message:
A warning in the flaky test script asks the user to set two particular environment variables, failing to mention the third required variable.  This PR fixes that.

Risk Level: None.
Testing: Ran the script to trigger the message.