### PR TITLE
[fuzz] remove tcp proxy from network fuzzers

### DIFF
--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -25,16 +25,13 @@ std::vector<absl::string_view> UberFilterFuzzer::filterNames() {
     const auto factories = Registry::FactoryRegistry<
         Server::Configuration::NamedNetworkFilterConfigFactory>::factories();
     const std::vector<absl::string_view> supported_filter_names = {
-        NetworkFilterNames::get().ClientSslAuth,
-        NetworkFilterNames::get().ExtAuthorization,
+        NetworkFilterNames::get().ClientSslAuth, NetworkFilterNames::get().ExtAuthorization,
         // A dedicated http_connection_manager fuzzer can be found in
         // test/common/http/conn_manager_impl_fuzz_test.cc
-        NetworkFilterNames::get().HttpConnectionManager,
-        NetworkFilterNames::get().LocalRateLimit,
-        NetworkFilterNames::get().RateLimit,
-        NetworkFilterNames::get().Rbac,
-        NetworkFilterNames::get().TcpProxy,
-
+        NetworkFilterNames::get().HttpConnectionManager, NetworkFilterNames::get().LocalRateLimit,
+        NetworkFilterNames::get().RateLimit, NetworkFilterNames::get().Rbac,
+        // TODO(asraa): Remove when fuzzer sets up connections for TcpProxy properly.
+        // NetworkFilterNames::get().TcpProxy,
     };
     // Check whether each filter is loaded into Envoy.
     // Some customers build Envoy without some filters. When they run fuzzing, the use of a filter


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Remove tcp-proxy from network fuzzer because the upstream connection isn't set up and we fail on this ASSERT:
https://github.com/envoyproxy/envoy/blob/280654be74c4760a7f61f3658b035e4800f2deca/source/common/tcp_proxy/tcp_proxy.cc#L558
Risk Level: Low
