### PR TITLE
assert: mark slow asserts for ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -300,6 +300,11 @@ config_setting(
 )
 
 config_setting(
+    name = "enable_log_fast_debug_assert_in_release",
+    values = {"define": "log_fast_debug_assert_in_release=enabled"},
+)
+
+config_setting(
     name = "disable_known_issue_asserts",
     values = {"define": "disable_known_issue_asserts=true"},
 )

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -641,7 +641,7 @@ The following optional features can be enabled on the Bazel build command-line:
 * BoringSSL can be built in a FIPS-compliant mode with `--define boringssl=fips`
   (see [FIPS 140-2](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#fips-140-2) for details).
 * ASSERT() can be configured to log failures and increment a stat counter in a release build with
-  `--define log_debug_assert_in_release=enabled`. The default behavior is to compile debug assertions out of
+  `--define log_fast_debug_assert_in_release=enabled`. SLOW_ASSERT()s can be included with `--define log_debug_assert_in_release=enabled`. The default behavior is to compile all debug assertions out of
   release builds so that the condition is not evaluated. This option has no effect in debug builds.
 * memory-debugging (scribbling over memory after allocation and before freeing) with
   `--define tcmalloc=debug`. Note this option cannot be used with FIPS-compliant mode BoringSSL and

--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -104,6 +104,9 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:enable_log_debug_assert_in_release": ["-DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE"],
                "//conditions:default": [],
            }) + select({
+               repository + "//bazel:enable_log_fast_debug_assert_in_release": ["-DENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE"],
+               "//conditions:default": [],
+           }) + select({
                repository + "//bazel:disable_known_issue_asserts": ["-DENVOY_DISABLE_KNOWN_ISSUE_ASSERTS"],
                "//conditions:default": [],
            }) + select({

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -329,6 +329,9 @@ elif [[ "$CI_TARGET" == "bazel.compile_time_options" ]]; then
   # these tests under "-c opt" to save time in CI.
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" --define wasm=wavm "${COMPILE_TIME_OPTIONS[@]}" -c opt @envoy//test/common/common:assert_test @envoy//test/server:server_test
 
+  # "--define log_fast_debug_assert_in_release=enabled" must be tested with a release build, so run only these tests under "-c opt" to save time in CI. This option will test only ASSERT()s without SLOW_ASSERT()s, so additionally disable "--define log_debug_assert_in_release" which compiles in both.
+    bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" --define wasm=wavm "${COMPILE_TIME_OPTIONS[@]}" -c opt @envoy//test/common/common:assert_test --define log_fast_debug_assert_in_release=enabled --define log_debug_assert_in_release=disabled
+
   echo "Building binary with wasm=wavm..."
   bazel build "${BAZEL_BUILD_OPTIONS[@]}" --define wasm=wavm "${COMPILE_TIME_OPTIONS[@]}" -c dbg @envoy//source/exe:envoy-static --build_tag_filters=-nofips
   collect_build_profile build

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -126,6 +126,7 @@ void resetEnvoyBugCountersForTest();
 
 #if !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE) ||                              \
     defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE)
+// This if condition represents any case where ASSERT()s are compiled in.
 
 #if !defined(NDEBUG) // If this is a debug build.
 #define ASSERT_ACTION abort()
@@ -169,13 +170,14 @@ void resetEnvoyBugCountersForTest();
 #else
 // Non-implementation of SLOW_ASSERTs when building only ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE.
 #define SLOW_ASSERT _NULL_ASSERT_IMPL
-#endif
+#endif // !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
 
 #else
 #define ASSERT _NULL_ASSERT_IMPL
 #define KNOWN_ISSUE_ASSERT _NULL_ASSERT_IMPL
 #define SLOW_ASSERT _NULL_ASSERT_IMPL
-#endif // !defined(NDEBUG) || defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE)
+#endif // !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE) ||
+       // defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE)
 
 /**
  * Indicate a panic situation and exit.

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -156,9 +156,19 @@ void resetEnvoyBugCountersForTest();
 // _ASSERT_VERBOSE, and this will call _ASSERT_VERBOSE,(__VA_ARGS__)
 #define ASSERT(...)                                                                                \
   EXPAND(_ASSERT_SELECTOR(__VA_ARGS__, _ASSERT_VERBOSE, _ASSERT_ORIGINAL)(__VA_ARGS__))
+
+// SLOW_ASSERTs should mimic ASSERTs in debug mode.
+#if !defined(NDEBUG) // debug build
+#define SLOW_ASSERT(...) ASSERT(__VA_ARGS__)
+#else // ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE is defined
+// SLOW_ASSERTs in release mode should resolve to a non-implementation.
+#define ASSERT _NULL_ASSERT_IMPL
+#endif
+
 #else
 #define ASSERT _NULL_ASSERT_IMPL
 #define KNOWN_ISSUE_ASSERT _NULL_ASSERT_IMPL
+#define SLOW_ASSERT _NULL_ASSERT_IMPL
 #endif // !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
 
 /**

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -162,7 +162,7 @@ void resetEnvoyBugCountersForTest();
 #define SLOW_ASSERT(...) ASSERT(__VA_ARGS__)
 #else // ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE is defined
 // SLOW_ASSERTs in release mode should resolve to a non-implementation.
-#define ASSERT _NULL_ASSERT_IMPL
+#define SLOW_ASSERT _NULL_ASSERT_IMPL
 #endif
 
 #else

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -119,11 +119,17 @@ void resetEnvoyBugCountersForTest();
  */
 #define SECURITY_ASSERT(X, DETAILS) _ASSERT_IMPL(X, #X, abort(), DETAILS)
 
-#if !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
+// ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE compiles all ASSERTs in release mode.
+#ifdef ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE
+#define ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE
+#endif
+
+#if !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE) ||                              \
+    defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE)
 
 #if !defined(NDEBUG) // If this is a debug build.
 #define ASSERT_ACTION abort()
-#else // If this is not a debug build, but ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE is defined.
+#else // If this is not a debug build, but ENVOY_LOG_(FAST)_DEBUG_ASSERT_IN_RELEASE is defined.
 #define ASSERT_ACTION Envoy::Assert::invokeDebugAssertionFailureRecordActionForAssertMacroUseOnly()
 #endif // !defined(NDEBUG)
 
@@ -157,11 +163,11 @@ void resetEnvoyBugCountersForTest();
 #define ASSERT(...)                                                                                \
   EXPAND(_ASSERT_SELECTOR(__VA_ARGS__, _ASSERT_VERBOSE, _ASSERT_ORIGINAL)(__VA_ARGS__))
 
-// SLOW_ASSERTs should mimic ASSERTs in debug mode.
-#if !defined(NDEBUG) // debug build
+#if !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
+// debug build or all ASSERTs compiled in release.
 #define SLOW_ASSERT(...) ASSERT(__VA_ARGS__)
-#else // ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE is defined
-// SLOW_ASSERTs in release mode should resolve to a non-implementation.
+#else
+// Non-implementation of SLOW_ASSERTs when building only ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE.
 #define SLOW_ASSERT _NULL_ASSERT_IMPL
 #endif
 
@@ -169,7 +175,7 @@ void resetEnvoyBugCountersForTest();
 #define ASSERT _NULL_ASSERT_IMPL
 #define KNOWN_ISSUE_ASSERT _NULL_ASSERT_IMPL
 #define SLOW_ASSERT _NULL_ASSERT_IMPL
-#endif // !defined(NDEBUG) || defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
+#endif // !defined(NDEBUG) || defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE)
 
 /**
  * Indicate a panic situation and exit.

--- a/test/common/common/assert_test.cc
+++ b/test/common/common/assert_test.cc
@@ -32,6 +32,13 @@ TEST(AssertDeathTest, VariousLogs) {
   EXPECT_LOG_CONTAINS("critical", "assert failure: 0. Details: With some logs",
                       ASSERT(0, "With some logs"));
   expected_counted_failures = 3;
+#elif defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE)
+  // ASSERTs always run when ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE is compiled in.
+  EXPECT_LOG_CONTAINS("critical", "assert failure: 0", ASSERT(0));
+  EXPECT_LOG_CONTAINS("critical", "assert failure: 0", ASSERT(0, ""));
+  EXPECT_LOG_CONTAINS("critical", "assert failure: 0. Details: With some logs",
+                      ASSERT(0, "With some logs"));
+  expected_counted_failures = 3;
 #else
   EXPECT_NO_LOGS(ASSERT(0));
   EXPECT_NO_LOGS(ASSERT(0, ""));
@@ -81,26 +88,41 @@ TEST(EnvoyBugDeathTest, TestResetCounters) {
   }
 }
 
-TEST(SlowAssertTest, TestSlowAssert) {
+TEST(SlowAssertTest, TestSlowAssertInFastAssertInReleaseMode) {
+  int expected_counted_failures;
   int slow_assert_fail_count = 0;
   auto debug_assert_action_registration =
       Assert::setDebugAssertionFailureRecordAction([&]() { slow_assert_fail_count++; });
+
 #ifndef NDEBUG
   EXPECT_DEATH({ SLOW_ASSERT(0); }, ".*assert failure: 0.*");
   EXPECT_DEATH({ SLOW_ASSERT(0, ""); }, ".*assert failure: 0.*");
   EXPECT_DEATH({ SLOW_ASSERT(0, "With some logs"); },
                ".*assert failure: 0. Details: With some logs.*");
+  expected_counted_failures = 0;
 #elif defined(ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE)
-  // Non-implementation for slow debug asserts in release.
+  // SLOW_ASSERTs are included in ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE
+  EXPECT_LOG_CONTAINS("critical", "assert failure: 0", SLOW_ASSERT(0));
+  EXPECT_LOG_CONTAINS("critical", "assert failure: 0", SLOW_ASSERT(0, ""));
+  EXPECT_LOG_CONTAINS("critical", "assert failure: 0. Details: With some logs",
+                      SLOW_ASSERT(0, "With some logs"));
+  expected_counted_failures = 3;
+#elif defined(ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE) &&                                           \
+    !defined(ENVOY_LOG_SLOW_DEBUG_ASSERT_IN_RELEASE)
+  // Non-implementation for slow debug asserts when only ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE is
+  // compiled in.
   EXPECT_NO_LOGS(SLOW_ASSERT(0));
   EXPECT_NO_LOGS(SLOW_ASSERT(0, ""));
   EXPECT_NO_LOGS(SLOW_ASSERT(0, "With some logs"));
+  expected_counted_failures = 0;
 #else
   EXPECT_NO_LOGS(SLOW_ASSERT(0));
   EXPECT_NO_LOGS(SLOW_ASSERT(0, ""));
   EXPECT_NO_LOGS(SLOW_ASSERT(0, "With some logs"));
+  expected_counted_failures = 0;
 #endif
-  EXPECT_EQ(0, slow_assert_fail_count);
+
+  EXPECT_EQ(expected_counted_failures, slow_assert_fail_count);
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Adds a macro `SLOW_ASSERT` that can be used to mark slow ASSERTs. When `ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE` is compiled in, both ASSERT()s and SLOW_ASSERT()s are compiled in. When only `ENVOY_LOG_FAST_DEBUG_ASSERT_IN_RELEASE` is compiled in, only ASSERT()s are compiled in.
Risk Level: Low
Testing: Added test to show that SLOW_ASSERTs are no-ops in ENVOY_LOG_DEBUG_ASSERT_IN_RELEASE and otherwise ASSERTs. ENVOY_LOG_(FAST)_DEBUG_ASSERT_IN_RELEASE is tested in `compile_time_options`
Docs: Added documentation to bazel/README.md

Motivation:
We would like to enable staging jobs with ASSERTs enabled, but want to be able to no-op some ASSERTs to avoid performance degradation.
