### PR TITLE
hcm: Handle stream destroy during encodeData due to sendLocalReply

### DIFF
--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -183,11 +183,15 @@ bool ActiveStreamFilterBase::commonHandleAfterDataCallback(FilterDataStatus stat
       buffer_was_streaming = status == FilterDataStatus::StopIterationAndWatermark;
       commonHandleBufferData(provided_data);
     } else if (complete() && !hasTrailers() && !bufferedData()) {
-      // If this filter is doing StopIterationNoBuffer and this stream is terminated with a zero
-      // byte data frame, we need to create an empty buffer to make sure that when commonContinue
-      // is called, the pipeline resumes with an empty data frame with end_stream = true
-      ASSERT(end_stream_);
-      bufferedData() = createBuffer();
+      if (end_stream_) {
+        // If this filter is doing StopIterationNoBuffer and this stream is terminated with a zero
+        // byte data frame, we need to create an empty buffer to make sure that when commonContinue
+        // is called, the pipeline resumes with an empty data frame with end_stream = true
+        bufferedData() = createBuffer();
+      } else {
+        // Otherwise the entire connection was closed.
+        ASSERT(parent_.state_.local_complete_ || parent_.state_.remote_complete_);
+      }
     }
 
     return false;

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -1108,16 +1108,19 @@ private:
 
   struct State {
     State()
-        : remote_complete_(false), local_complete_(false), has_continue_headers_(false),
-          created_filter_chain_(false), is_head_request_(false), is_grpc_request_(false),
-          non_100_response_headers_encoded_(false) {}
+        : remote_complete_(false), local_complete_(false), end_stream_encoded_(false),
+          has_continue_headers_(false), created_filter_chain_(false), is_head_request_(false),
+          is_grpc_request_(false), non_100_response_headers_encoded_(false) {}
 
     uint32_t filter_call_state_{0};
 
     bool remote_complete_ : 1;
-    bool local_complete_ : 1; // This indicates that local is complete prior to filter processing.
-                              // A filter can still stop the stream from being complete as seen
-                              // by the codec.
+    // This indicates that local is complete prior to filter processing.
+    // A filter can still stop the stream from being complete as seen
+    // by the codec.
+    bool local_complete_ : 1;
+    // Indicates whether envoy has sent a complete response for the current stream.
+    bool end_stream_encoded_ : 1;
     // By default, we will assume there are no 100-Continue headers. If encode100ContinueHeaders
     // is ever called, this is set to true so commonContinue resumes processing the 100-Continue.
     bool has_continue_headers_ : 1;

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -444,6 +444,7 @@ envoy_cc_test_library(
         "//test/integration/filters:continue_headers_only_inject_body",
         "//test/integration/filters:encoder_decoder_buffer_filter_lib",
         "//test/integration/filters:invalid_header_filter_lib",
+        "//test/integration/filters:local_reply_during_encoding_data_filter_lib",
         "//test/integration/filters:local_reply_during_encoding_filter_lib",
         "//test/integration/filters:random_pause_filter_lib",
         "//test/test_common:logging_lib",

--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -40,6 +40,21 @@ envoy_cc_test_library(
 )
 
 envoy_cc_test_library(
+    name = "local_reply_during_encoding_data_filter_lib",
+    srcs = [
+        "local_reply_during_encoding_data_filter.cc",
+    ],
+    deps = [
+        ":common_lib",
+        "//include/envoy/http:filter_interface",
+        "//include/envoy/registry",
+        "//include/envoy/server:filter_config_interface",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+    ],
+)
+
+envoy_cc_test_library(
     name = "continue_after_local_reply_filter_lib",
     srcs = [
         "continue_after_local_reply_filter.cc",

--- a/test/integration/filters/local_reply_during_encoding_data_filter.cc
+++ b/test/integration/filters/local_reply_during_encoding_data_filter.cc
@@ -1,0 +1,30 @@
+#include <string>
+
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "extensions/filters/http/common/pass_through_filter.h"
+
+#include "test/extensions/filters/http/common/empty_http_filter_config.h"
+#include "test/integration/filters/common.h"
+
+namespace Envoy {
+
+class LocalReplyDuringEncodeData : public Http::PassThroughFilter {
+public:
+  constexpr static char name[] = "local-reply-during-encode-data";
+
+  Http::FilterDataStatus encodeData(Buffer::Instance&, bool) override {
+    encoder_callbacks_->sendLocalReply(Http::Code::InternalServerError, "", nullptr, absl::nullopt,
+                                       "");
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+};
+
+constexpr char LocalReplyDuringEncodeData::name[];
+static Registry::RegisterFactory<SimpleFilterConfig<LocalReplyDuringEncodeData>,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_;
+
+} // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1458,7 +1458,7 @@ name: local-reply-during-encode-data
   upstream_request_->encodeTrailers(response_trailers);
 
   // Response was aborted after headers were sent to the client.
-  // The entire connection is reset. Client does not receive body or trailers.
+  // The stream was reset. Client does not receive body or trailers.
   response->waitForReset();
   EXPECT_FALSE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());


### PR DESCRIPTION
Commit Message:
hcm: Handle stream destroy during encodeData due to sendLocalReply

Additional Description:
Fixes an issue that surfaced when adding buffer limits to the grpc_json_transcoder filter in #14906.

When `sendLocalReply` occurs during `encodeData`, the stream is reset because headers were already sent.
Short-circuit the logic as the data buffer does not need to be handled - the `sendLocalReply` should be shipped back right away.

Risk Level:
Medium. Changes existing logic in HCM, but has integration tests.

Testing:
Integration test here and in grpc_json_transcoder filter (#14906).

Docs Changes:
None

Release Notes:
None

Platform Specific Features:
None

Signed-off-by: Teju Nareddy <nareddyt@google.com>