### PR TITLE
[access log] handle empty string in formatter

### DIFF
--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -504,7 +504,9 @@ SubstitutionFormatParser::parse(const std::string& format,
     pos = command_end_position;
   }
 
-  if (!current_token.empty()) {
+  if (!current_token.empty() || format.empty()) {
+    // Create a PlainStringFormatter with the final string literal. If the format string was empty,
+    // this creates a PlainStringFormatter with an empty string.
     formatters.emplace_back(FormatterProviderPtr{new PlainStringFormatter(current_token)});
   }
 

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1848,6 +1848,32 @@ TEST(SubstitutionFormatterTest, StructFormatterSingleOperatorTest) {
       expected_json_map);
 }
 
+TEST(SubstitutionFormatterTest, EmptyStructFormatterTest) {
+  StreamInfo::MockStreamInfo stream_info;
+  Http::TestRequestHeaderMapImpl request_header;
+  Http::TestResponseHeaderMapImpl response_header;
+  Http::TestResponseTrailerMapImpl response_trailer;
+  std::string body;
+
+  envoy::config::core::v3::Metadata metadata;
+  populateMetadataTestData(metadata);
+  absl::optional<Http::Protocol> protocol = Http::Protocol::Http11;
+  EXPECT_CALL(stream_info, protocol()).WillRepeatedly(Return(protocol));
+
+  absl::node_hash_map<std::string, std::string> expected_json_map = {{"protocol", ""}};
+
+  ProtobufWkt::Struct key_mapping;
+  TestUtility::loadFromYaml(R"EOF(
+    protocol: ''
+  )EOF",
+                            key_mapping);
+  StructFormatter formatter(key_mapping, false, false);
+
+  verifyStructOutput(
+      formatter.format(request_header, response_header, response_trailer, stream_info, body),
+      expected_json_map);
+}
+
 TEST(SubstitutionFormatterTest, StructFormatterNonExistentHeaderTest) {
   StreamInfo::MockStreamInfo stream_info;
   Http::TestRequestHeaderMapImpl request_header{{"some_request_header", "SOME_REQUEST_HEADER"}};
@@ -2716,6 +2742,20 @@ TEST(SubstitutionFormatterTest, ParserSuccesses) {
   for (const std::string& test_case : test_cases) {
     EXPECT_NO_THROW(parser.parse(test_case));
   }
+}
+
+TEST(SubstitutionFormatterTest, EmptyFormatParse) {
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
+  Http::TestResponseHeaderMapImpl response_headers;
+  Http::TestResponseTrailerMapImpl response_trailers;
+  StreamInfo::MockStreamInfo stream_info;
+  std::string body;
+
+  auto providers = SubstitutionFormatParser::parse("");
+
+  EXPECT_EQ(providers.size(), 1);
+  EXPECT_EQ("", providers[0]->format(request_headers, response_headers, response_trailers,
+                                     stream_info, body));
 }
 
 TEST(SubstitutionFormatterTest, FormatterExtension) {

--- a/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/empty_providers
+++ b/test/extensions/filters/network/common/fuzz/network_readfilter_corpus/empty_providers
@@ -1,0 +1,12 @@
+config {
+  name: "envoy.filters.network.http_connection_manager"
+  typed_config {
+    type_url: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    value: "\022\001.\"\002P\001\262\001\010/dev/fd/\210\002\001\262\002\014\022\n\022\010\n\006\n\000\022\002\032\000"
+  }
+}
+actions {
+  on_data {
+    data: "set"
+  }
+}

--- a/test/integration/local_reply_integration_test.cc
+++ b/test/integration/local_reply_integration_test.cc
@@ -85,6 +85,63 @@ body_format:
   EXPECT_TRUE(TestUtility::jsonStringEqual(response->body(), expected_body));
 }
 
+TEST_P(LocalReplyIntegrationTest, EmptyStructFormatter) {
+  const std::string yaml = R"EOF(
+mappers:
+  - filter:
+      header_filter:
+        header:
+          name: test-header
+          exact_match: exact-match-value
+    status_code: 550
+body_format:
+  json_format:
+    level: TRACE
+    user_agent: ""
+  )EOF";
+  setLocalReplyConfig(yaml);
+  initialize();
+
+  const std::string expected_body = R"({
+      "level": "TRACE",
+      "user_agent": "",
+})";
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"test-header", "exact-match-value"}});
+  auto response = std::move(encoder_decoder.second);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  ASSERT_TRUE(fake_upstream_connection_->close());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  response->waitForEndStream();
+
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+  } else {
+    codec_client_->close();
+  }
+
+  EXPECT_FALSE(upstream_request_->complete());
+  EXPECT_EQ(0U, upstream_request_->bodyLength());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("application/json", response->headers().ContentType()->value().getStringView());
+  EXPECT_EQ("34", response->headers().ContentLength()->value().getStringView());
+  EXPECT_EQ("550", response->headers().Status()->value().getStringView());
+  // Check if returned json is same as expected
+  EXPECT_TRUE(TestUtility::jsonStringEqual(response->body(), expected_body));
+}
+
 // For grpc, the error message is in grpc-message header.
 // If it is json, the header value is in json format.
 TEST_P(LocalReplyIntegrationTest, MapStatusCodeAndFormatToJson4Grpc) {


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: If a struct formatter is configured with an empty string, then we crash on this ASSERT that has an assumption that [parse](https://github.com/envoyproxy/envoy/blob/3f740bc90d32ac442e70da46ebf4d03a1bdb479d/source/common/formatter/substitution_formatter.cc#L453) always adds a formatter. Parsing does not add any formatters on an empty string, so handle that case. https://github.com/envoyproxy/envoy/blob/3f740bc90d32ac442e70da46ebf4d03a1bdb479d/source/common/formatter/substitution_formatter.cc#L215
Risk Level: Low, configuration issue only.
Testing: Added unit tests for struct formatter, parse, and local_reply_integration_test, as well as fuzzer regression testcase
Fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29752&sort=-opened&can=1&q=proj%3Aenvoy%20status%3DNew

Alternatively I could have removed that ASSERT and returned `ValueUtil::stringValue("")` from the callback if there were no providers, but that is what this does too at a lower level. It also doesn't seem right to treat the value as `DefaultUnspecifiedValueString`, since it's not looking for a value.