### PR TITLE
bazel: Sync toolchains to current Bazel version

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -25,14 +25,14 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "bazel-toolchains",
         project_desc = "Bazel toolchain configs for RBE",
         project_url = "https://github.com/bazelbuild/bazel-toolchains",
-        version = "3.7.1",
-        sha256 = "8c9728dc1bb3e8356b344088dfd10038984be74e1c8d6e92dbb05f21cabbb8e4",
+        version = "3.7.2",
+        sha256 = "1caf8584434d3e31be674067996be787cfa511fda2a0f05811131b588886477f",
         strip_prefix = "bazel-toolchains-{version}",
         urls = [
             "https://github.com/bazelbuild/bazel-toolchains/releases/download/{version}/bazel-toolchains-{version}.tar.gz",
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/{version}.tar.gz",
         ],
-        release_date = "2020-11-26",
+        release_date = "2021-01-07",
         use_category = ["build"],
     ),
     build_bazel_rules_apple = dict(


### PR DESCRIPTION
Commit Message: Sync toolchains to current Bazel version. This silences warnings on Bazel build.
Risk Level: low
Testing: Local build

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
