### PR TITLE
Fix GCC builds by declaring unused variables

### DIFF
--- a/source/common/upstream/cds_api_impl.cc
+++ b/source/common/upstream/cds_api_impl.cc
@@ -46,9 +46,11 @@ void CdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& r
   }
   Protobuf::RepeatedPtrField<std::string> to_remove_repeated;
   for (const auto& [cluster_name, _] : all_existing_clusters.active_clusters_) {
+    UNREFERENCED_PARAMETER(_);
     *to_remove_repeated.Add() = cluster_name;
   }
   for (const auto& [cluster_name, _] : all_existing_clusters.warming_clusters_) {
+    UNREFERENCED_PARAMETER(_);
     // Do not add the cluster twice when the cluster is both active and warming.
     if (all_existing_clusters.active_clusters_.count(cluster_name) == 0) {
       *to_remove_repeated.Add() = cluster_name;

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -136,6 +136,7 @@ void SubsetLoadBalancer::rebuildSingle() {
         if (fields_it != fields.end()) {
           auto [iterator, did_insert] =
               single_host_per_subset_map_.try_emplace(fields_it->second, host);
+          UNREFERENCED_PARAMETER(iterator);
           if (!did_insert) {
             // Two hosts with the same metadata value were found. Ignore all but one of them, and
             // set a metric for how many times this happened.

--- a/source/server/admin/clusters_handler.cc
+++ b/source/server/admin/clusters_handler.cc
@@ -111,6 +111,7 @@ void ClustersHandler::writeClustersAsJson(Buffer::Instance& response) {
   // TODO(mattklein123): Add ability to see warming clusters in admin output.
   auto all_clusters = server_.clusterManager().clusters();
   for (const auto& [name, cluster_ref] : all_clusters.active_clusters_) {
+    UNREFERENCED_PARAMETER(name);
     const Upstream::Cluster& cluster = cluster_ref.get();
     Upstream::ClusterInfoConstSharedPtr cluster_info = cluster.info();
 
@@ -197,6 +198,7 @@ void ClustersHandler::writeClustersAsText(Buffer::Instance& response) {
   // TODO(mattklein123): Add ability to see warming clusters in admin output.
   auto all_clusters = server_.clusterManager().clusters();
   for (const auto& [name, cluster_ref] : all_clusters.active_clusters_) {
+    UNREFERENCED_PARAMETER(name);
     const Upstream::Cluster& cluster = cluster_ref.get();
     const std::string& cluster_name = cluster.info()->name();
     addOutlierInfo(cluster_name, cluster.outlierDetector(), response);

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -156,6 +156,7 @@ parseTimerMinimums(const ProtobufWkt::Any& typed_config,
                   Event::ScaledMinimum(UnitFloat(scale_timer.min_scale().value() / 100.0)));
 
     auto [_, inserted] = timer_map.insert(std::make_pair(timer_type, minimum));
+    UNREFERENCED_PARAMETER(_);
     if (!inserted) {
       throw EnvoyException(fmt::format("Found duplicate entry for timer type {}",
                                        Config::TimerType_Name(scale_timer.timer())));


### PR DESCRIPTION
Commit Message: Fix GCC builds by declaring unused variables.
Risk Level: low
Testing: Local build with GCC succeeds

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>

