### PR TITLE
Remove dispatcher dependency from filesystem

### DIFF
--- a/include/envoy/filesystem/BUILD
+++ b/include/envoy/filesystem/BUILD
@@ -14,7 +14,6 @@ envoy_cc_library(
     deps = [
         "//include/envoy/api:io_error_interface",
         "//include/envoy/api:os_sys_calls_interface",
-        "//include/envoy/event:dispatcher_interface",
     ],
 )
 

--- a/test/mocks/filesystem/BUILD
+++ b/test/mocks/filesystem/BUILD
@@ -14,6 +14,7 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//include/envoy/filesystem:filesystem_interface",
+        "//include/envoy/filesystem:watcher_interface",
         "//source/common/common:thread_lib",
     ],
 )

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -6,7 +6,6 @@
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/filesystem/watcher.h"
 
-
 #include "common/common/thread.h"
 
 #include "gmock/gmock.h"
@@ -58,7 +57,6 @@ public:
 };
 
 class MockWatcher : public Watcher {
-using OnChangedCb = std::function<void(uint32_t events)>;
 public:
   MockWatcher();
   ~MockWatcher() override;

--- a/test/mocks/filesystem/mocks.h
+++ b/test/mocks/filesystem/mocks.h
@@ -6,6 +6,7 @@
 #include "envoy/filesystem/filesystem.h"
 #include "envoy/filesystem/watcher.h"
 
+
 #include "common/common/thread.h"
 
 #include "gmock/gmock.h"
@@ -57,6 +58,7 @@ public:
 };
 
 class MockWatcher : public Watcher {
+using OnChangedCb = std::function<void(uint32_t events)>;
 public:
   MockWatcher();
   ~MockWatcher() override;


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
Commit Message:
Remove unused dependency from filesystem

Risk Level: Low
Testing:
Running the tests on CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
