### PR TITLE
docs: mention approximate RAM requirements to build envoy

### DIFF
--- a/docs/root/start/building.rst
+++ b/docs/root/start/building.rst
@@ -22,6 +22,7 @@ recent Linux including Ubuntu 18.04 LTS.
 Building Envoy has the following requirements:
 
 * GCC 7+ or Clang/LLVM 7+ (for C++14 support). Clang/LLVM 9+ preferred where Clang is used (see below).
+* About 2GB of RAM per core (so 32GB of RAM for 8 cores with hyperthreading)
 * These :repo:`Bazel native <bazel/repository_locations.bzl>` dependencies.
 
 Please see the linked :repo:`CI <ci/README.md>` and :repo:`Bazel <bazel/README.md>` documentation


### PR DESCRIPTION
See https://github.com/envoyproxy/envoy/issues/4373

Requirements a bit lower if not using docker or not building tests, but this is close enough.

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: docs: mention approximate RAM requirements to build envoy
Additional Description: one-liner
Risk Level: Low
Testing: based on testing on one machine
Docs Changes: add a single line recommending 2GB RAM per core when building
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue] 
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
