### PR TITLE
Lint: Lint for std::for_each_n 

### DIFF
--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1409,8 +1409,12 @@ void ConnectionImpl::dumpState(std::ostream& os, int indent_level) const {
   DUMP_DETAILS(&protocol_constraints_);
 
   os << spaces << "Number of active streams: " << active_streams_.size() << " Active Streams:\n";
-  std::for_each_n(active_streams_.begin(), std::min<size_t>(active_streams_.size(), 100),
-                  [&](auto& stream) { DUMP_DETAILS(stream); });
+  const size_t num_iterations = std::min<size_t>(active_streams_.size(), 100);
+  auto stream = active_streams_.begin();
+  for (size_t i = 0; i < num_iterations; ++i) {
+    DUMP_DETAILS(*stream);
+    ++stream;
+  }
 
   // Dump the active slice
   if (current_slice_ == nullptr) {

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1409,11 +1409,12 @@ void ConnectionImpl::dumpState(std::ostream& os, int indent_level) const {
   DUMP_DETAILS(&protocol_constraints_);
 
   os << spaces << "Number of active streams: " << active_streams_.size() << " Active Streams:\n";
-  const size_t num_iterations = std::min<size_t>(active_streams_.size(), 100);
-  auto stream = active_streams_.begin();
-  for (size_t i = 0; i < num_iterations; ++i) {
-    DUMP_DETAILS(*stream);
-    ++stream;
+  size_t count = 0;
+  for (auto& stream : active_streams_) {
+    DUMP_DETAILS(stream);
+    if (++count >= 100) {
+      break;
+    }
   }
 
   // Dump the active slice

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1033,7 +1033,7 @@ TEST_P(Http2CodecImplTest, ShouldDumpActiveStreamsWithoutAllocatingMemory) {
 
     // Check contents for active stream, trailers to encode and header map.
     EXPECT_THAT(ostream.contents(), HasSubstr("  Number of active streams: 1 Active Streams:\n"
-                                              "  stream: \n"
+                                              "  *stream: \n"
                                               "    ConnectionImpl::StreamImpl"));
     EXPECT_THAT(ostream.contents(),
                 HasSubstr("pending_trailers_to_encode_:     null\n"
@@ -1056,7 +1056,7 @@ TEST_P(Http2CodecImplTest, ShouldDumpActiveStreamsWithoutAllocatingMemory) {
 
     // Check contents for active stream, trailers to encode and header map.
     EXPECT_THAT(ostream.contents(), HasSubstr("  Number of active streams: 1 Active Streams:\n"
-                                              "  stream: \n"
+                                              "  *stream: \n"
                                               "    ConnectionImpl::StreamImpl"));
     EXPECT_THAT(ostream.contents(),
                 HasSubstr("pending_trailers_to_encode_:     null\n"

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1033,7 +1033,7 @@ TEST_P(Http2CodecImplTest, ShouldDumpActiveStreamsWithoutAllocatingMemory) {
 
     // Check contents for active stream, trailers to encode and header map.
     EXPECT_THAT(ostream.contents(), HasSubstr("  Number of active streams: 1 Active Streams:\n"
-                                              "  *stream: \n"
+                                              "  stream: \n"
                                               "    ConnectionImpl::StreamImpl"));
     EXPECT_THAT(ostream.contents(),
                 HasSubstr("pending_trailers_to_encode_:     null\n"
@@ -1056,7 +1056,7 @@ TEST_P(Http2CodecImplTest, ShouldDumpActiveStreamsWithoutAllocatingMemory) {
 
     // Check contents for active stream, trailers to encode and header map.
     EXPECT_THAT(ostream.contents(), HasSubstr("  Number of active streams: 1 Active Streams:\n"
-                                              "  *stream: \n"
+                                              "  stream: \n"
                                               "    ConnectionImpl::StreamImpl"));
     EXPECT_THAT(ostream.contents(),
                 HasSubstr("pending_trailers_to_encode_:     null\n"

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -155,6 +155,8 @@ VERSION_HISTORY_SECTION_NAME = re.compile("^[A-Z][A-Za-z ]*$")
 RELOADABLE_FLAG_REGEX = re.compile(".*(..)(envoy.reloadable_features.[^ ]*)\s.*")
 INVALID_REFLINK = re.compile(".* ref:.*")
 OLD_MOCK_METHOD_REGEX = re.compile("MOCK_METHOD\d")
+# C++17 feature, lacks sufficient support across various libraries / compilers.
+FOR_EACH_N_REGEX = re.compile("for_each_n\(")
 # Check for punctuation in a terminal ref clause, e.g.
 # :ref:`panic mode. <arch_overview_load_balancing_panic_threshold>`
 REF_WITH_PUNCTUATION_REGEX = re.compile(".*\. <[^<]*>`\s*")
@@ -779,6 +781,8 @@ class FormatChecker:
       reportError("Test names should be CamelCase, starting with a capital letter")
     if OLD_MOCK_METHOD_REGEX.search(line):
       reportError("The MOCK_METHODn() macros should not be used, use MOCK_METHOD() instead")
+    if FOR_EACH_N_REGEX.search(line):
+      reportError("std::for_each_n should not be used, use an alternative for loop instead")
 
     if not self.allowlistedForSerializeAsString(file_path) and "SerializeAsString" in line:
       # The MessageLite::SerializeAsString doesn't generate deterministic serialization,

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -231,6 +231,7 @@ def runChecks():
   errors += checkUnfixableError("test_naming.cc",
                                 "Test names should be CamelCase, starting with a capital letter")
   errors += checkUnfixableError("mock_method_n.cc", "use MOCK_METHOD() instead")
+  errors += checkUnfixableError("for_each_n.cc", "use an alternative for loop instead")
   errors += checkUnfixableError(
       "test/register_factory.cc",
       "Don't use Registry::RegisterFactory or REGISTER_FACTORY in tests, use "

--- a/tools/testdata/check_format/for_each_n.cc
+++ b/tools/testdata/check_format/for_each_n.cc
@@ -1,0 +1,10 @@
+#include <algorithm>
+#include <vector>
+namespace Envoy {
+
+void foo() {
+  std::vector<int> vec;
+  std::for_each_n(vec.begin(), 10, (int){});
+}
+
+} // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: Lint: Lint for std::for_each_n 
Additional Description: It's insufficiently supported in C++17. See #14923
Risk Level: low
Testing: unit test
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA

