### PR TITLE
upstream: SNI support for OriginalDstCluster

### DIFF
--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -292,6 +292,7 @@ envoy_cc_library(
         "//include/envoy/upstream:cluster_factory_interface",
         "//source/common/common:empty_string",
         "//source/common/network:address_lib",
+        "//source/common/network:transport_socket_options_lib",
         "//source/common/network:utility_lib",
         "//source/extensions/clusters:well_known_names",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -19,31 +19,60 @@
 
 namespace Envoy {
 namespace Upstream {
-
-using HostMapSharedPtr = std::shared_ptr<HostMap>;
-using HostMapConstSharedPtr = std::shared_ptr<const HostMap>;
+namespace OriginalDst {
 
 /**
- * The OriginalDstCluster is a dynamic cluster that automatically adds hosts as needed based on the
+ * The OriginalDst Cluster is a dynamic cluster that automatically adds hosts as needed based on the
  * original destination address of the downstream connection. These hosts are also automatically
  * cleaned up after they have not seen traffic for a configurable cleanup interval time
  * ("cleanup_interval_ms").
  */
-class OriginalDstCluster : public ClusterImplBase {
+class Cluster : public ClusterImplBase {
 public:
-  OriginalDstCluster(const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
-                     Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
-                     Stats::ScopePtr&& stats_scope, bool added_via_api);
+  Cluster(const envoy::config::cluster::v3::Cluster& config, Runtime::Loader& runtime,
+          Server::Configuration::TransportSocketFactoryContextImpl& factory_context,
+          Stats::ScopePtr&& stats_scope, bool added_via_api);
 
   // Upstream::Cluster
   InitializePhase initializePhase() const override { return InitializePhase::Primary; }
+
+  /**
+   * A host implementation that supports default transport socket options.
+   */
+  class Host : public HostImpl {
+  public:
+    Host(const ClusterInfoConstSharedPtr& cluster, const std::string& hostname,
+         const Network::Address::InstanceConstSharedPtr& address, MetadataConstSharedPtr metadata,
+         uint32_t initial_weight, const envoy::config::core::v3::Locality& locality,
+         const envoy::config::endpoint::v3::Endpoint::HealthCheckConfig& health_check_config,
+         uint32_t priority, const envoy::config::core::v3::HealthStatus health_status,
+	 TimeSource& time_source,
+         const Network::TransportSocketOptionsSharedPtr& default_transport_socket_options)
+        : HostImpl(cluster, hostname, address, metadata, initial_weight, locality,
+                   health_check_config, priority, health_status, time_source),
+          default_transport_socket_options_(default_transport_socket_options) {}
+
+    // Upstream::Host
+    CreateConnectionData createConnection(
+        Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
+        Network::TransportSocketOptionsSharedPtr transport_socket_options) const override;
+
+  private:
+    const Network::TransportSocketOptionsSharedPtr default_transport_socket_options_;
+
+    friend class ClusterTest;
+  };
+  using HostSharedPtr = std::shared_ptr<Host>;
+  using HostMap = std::unordered_map<std::string, HostSharedPtr>;
+  using HostMapSharedPtr = std::shared_ptr<HostMap>;
+  using HostMapConstSharedPtr = std::shared_ptr<const HostMap>;
 
   /**
    * Special Load Balancer for Original Dst Cluster.
    *
    * Load balancer gets called with the downstream context which can be used to make sure the
    * Original Dst cluster has a Host for the original destination. Normally load balancers can't
-   * modify clusters, but in this case we access a singleton OriginalDstCluster that we can ask to
+   * modify clusters, but in this case we access a singleton OriginalDst Cluster that we can ask to
    * add hosts on demand. Additions are synced with all other threads so that the host set in the
    * cluster remains (eventually) consistent. If multiple threads add a host to the same upstream
    * address then two distinct HostSharedPtr's (with the same upstream IP address) will be added,
@@ -51,7 +80,7 @@ public:
    */
   class LoadBalancer : public Upstream::LoadBalancer {
   public:
-    LoadBalancer(const std::shared_ptr<OriginalDstCluster>& parent)
+    LoadBalancer(const std::shared_ptr<Cluster>& parent)
         : parent_(parent), host_map_(parent->getCurrentHostMap()) {}
 
     // Upstream::LoadBalancer
@@ -62,23 +91,22 @@ public:
   private:
     Network::Address::InstanceConstSharedPtr requestOverrideHost(LoadBalancerContext* context);
 
-    const std::shared_ptr<OriginalDstCluster> parent_;
+    const std::shared_ptr<Cluster> parent_;
     HostMapConstSharedPtr host_map_;
   };
 
 private:
   struct LoadBalancerFactory : public Upstream::LoadBalancerFactory {
-    LoadBalancerFactory(const std::shared_ptr<OriginalDstCluster>& cluster) : cluster_(cluster) {}
+    LoadBalancerFactory(const std::shared_ptr<Cluster>& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancerFactory
     Upstream::LoadBalancerPtr create() override { return std::make_unique<LoadBalancer>(cluster_); }
 
-    const std::shared_ptr<OriginalDstCluster> cluster_;
+    const std::shared_ptr<Cluster> cluster_;
   };
 
   struct ThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBalancer {
-    ThreadAwareLoadBalancer(const std::shared_ptr<OriginalDstCluster>& cluster)
-        : cluster_(cluster) {}
+    ThreadAwareLoadBalancer(const std::shared_ptr<Cluster>& cluster) : cluster_(cluster) {}
 
     // Upstream::ThreadAwareLoadBalancer
     Upstream::LoadBalancerFactorySharedPtr factory() override {
@@ -86,7 +114,7 @@ private:
     }
     void initialize() override {}
 
-    const std::shared_ptr<OriginalDstCluster> cluster_;
+    const std::shared_ptr<Cluster> cluster_;
   };
 
   HostMapConstSharedPtr getCurrentHostMap() {
@@ -109,18 +137,20 @@ private:
   const std::chrono::milliseconds cleanup_interval_ms_;
   Event::TimerPtr cleanup_timer_;
   const bool use_http_header_;
+  const bool implements_secure_transport_;
 
   absl::Mutex host_map_lock_;
   HostMapConstSharedPtr host_map_ ABSL_GUARDED_BY(host_map_lock_);
 
-  friend class OriginalDstClusterFactory;
+  friend class ClusterFactory;
+  friend class ClusterTest;
 };
 
-using OriginalDstClusterSharedPtr = std::shared_ptr<OriginalDstCluster>;
+using ClusterSharedPtr = std::shared_ptr<Cluster>;
 
-class OriginalDstClusterFactory : public ClusterFactoryImplBase {
+class ClusterFactory : public ClusterFactoryImplBase {
 public:
-  OriginalDstClusterFactory()
+  ClusterFactory()
       : ClusterFactoryImplBase(Extensions::Clusters::ClusterTypes::get().OriginalDst) {}
 
 private:
@@ -130,5 +160,6 @@ private:
       Stats::ScopePtr&& stats_scope) override;
 };
 
+} // namespace OriginalDst
 } // namespace Upstream
 } // namespace Envoy

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -395,6 +395,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "original_dst_cluster_test",
     srcs = ["original_dst_cluster_test.cc"],
+    data = ["//test/extensions/transport_sockets/tls/test_data:certs"],
     deps = [
         ":utility_lib",
         "//source/common/event:dispatcher_lib",
@@ -402,6 +403,7 @@ envoy_cc_test(
         "//source/common/upstream:original_dst_cluster_lib",
         "//source/common/upstream:upstream_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/tls:config",
         "//test/mocks:common_lib",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",
@@ -412,6 +414,7 @@ envoy_cc_test(
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/test_common:test_runtime_lib",
+        "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],


### PR DESCRIPTION
Commit Message:

Add SNI support for OriginalDstCluster for upstream TLS connections by detecting SNI from the downstream connection or a host name from the Host header. A HostImpl wrapper is used to override createConnection() using TransportSocketOptions derived from the downstream info.

Move OriginalDstCluster into a new OriginalDst namespace instead of using an anonymous namespace in the implementation to facilitate testing. Rename identifiers to not replicate the new namespace name, so instead of "OriginalDst::OriginalDstCluster" use "OriginalDst::Cluster". Unfortunately most changes in the PR are due to this renaming.

Risk Level: low
Testing: New unit tests pass on local build
Release Notes: ORIGINAL_DST clusters now pass SNI from downstream TLS connections to upstream TLS connections.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
