### PR TITLE
protos/docs: Cleanups for extensions/categories

### DIFF
--- a/api/envoy/config/listener/v3/listener_components.proto
+++ b/api/envoy/config/listener/v3/listener_components.proto
@@ -35,10 +35,10 @@ message Filter {
   // :ref:`supported filter <config_network_filters>`.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // [#extension-category: envoy.filters.network]
   oneof config_type {
     // Filter specific configuration which depends on the filter being
     // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.network]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery
@@ -240,6 +240,7 @@ message FilterChain {
   // :ref:`DownstreamTlsContext <envoy_api_msg_extensions.transport_sockets.tls.v3.DownstreamTlsContext>` in the `typed_config`.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
+  // [#extension-category: envoy.transport_sockets.downstream]
   core.v3.TransportSocket transport_socket = 6;
 
   // If present and nonzero, the amount of time to allow incoming connections to complete any
@@ -332,13 +333,12 @@ message ListenerFilter {
 
   // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_listener_filters>`.
-  // [#extension-category: envoy.transport_sockets.downstream]
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // Filter specific configuration which depends on the filter being instantiated.
-  // See the supported filters for further documentation.
-  // [#extension-category: envoy.filters.listener]
   oneof config_type {
+    // Filter specific configuration which depends on the filter being
+    // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.listener]
     google.protobuf.Any typed_config = 3;
   }
 

--- a/api/envoy/config/listener/v4alpha/listener_components.proto
+++ b/api/envoy/config/listener/v4alpha/listener_components.proto
@@ -35,10 +35,10 @@ message Filter {
   // :ref:`supported filter <config_network_filters>`.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // [#extension-category: envoy.filters.network]
   oneof config_type {
     // Filter specific configuration which depends on the filter being
     // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.network]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery
@@ -232,6 +232,7 @@ message FilterChain {
   // :ref:`DownstreamTlsContext <envoy_api_msg_extensions.transport_sockets.tls.v4alpha.DownstreamTlsContext>` in the `typed_config`.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
+  // [#extension-category: envoy.transport_sockets.downstream]
   core.v4alpha.TransportSocket transport_socket = 6;
 
   // If present and nonzero, the amount of time to allow incoming connections to complete any
@@ -324,13 +325,12 @@ message ListenerFilter {
 
   // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_listener_filters>`.
-  // [#extension-category: envoy.transport_sockets.downstream]
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // Filter specific configuration which depends on the filter being instantiated.
-  // See the supported filters for further documentation.
-  // [#extension-category: envoy.filters.listener]
   oneof config_type {
+    // Filter specific configuration which depends on the filter being
+    // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.listener]
     google.protobuf.Any typed_config = 3;
   }
 

--- a/api/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
+++ b/api/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
@@ -16,7 +16,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // redirect and b) safe cross scheme redirect, which means if the downstream
 // scheme is HTTPS, both HTTPS and HTTP redirect targets are allowed, but if the
 // downstream scheme is HTTP, only HTTP redirect targets are allowed.
-// [#extension:
-// envoy.internal_redirect_predicates.safe_cross_scheme]
+// [#extension: envoy.internal_redirect_predicates.safe_cross_scheme]
 message SafeCrossSchemeConfig {
 }

--- a/generated_api_shadow/envoy/config/listener/v3/listener_components.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/listener_components.proto
@@ -35,10 +35,10 @@ message Filter {
   // :ref:`supported filter <config_network_filters>`.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // [#extension-category: envoy.filters.network]
   oneof config_type {
     // Filter specific configuration which depends on the filter being
     // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.network]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery
@@ -238,6 +238,7 @@ message FilterChain {
   // :ref:`DownstreamTlsContext <envoy_api_msg_extensions.transport_sockets.tls.v3.DownstreamTlsContext>` in the `typed_config`.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
+  // [#extension-category: envoy.transport_sockets.downstream]
   core.v3.TransportSocket transport_socket = 6;
 
   // If present and nonzero, the amount of time to allow incoming connections to complete any
@@ -329,13 +330,12 @@ message ListenerFilter {
 
   // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_listener_filters>`.
-  // [#extension-category: envoy.transport_sockets.downstream]
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // Filter specific configuration which depends on the filter being instantiated.
-  // See the supported filters for further documentation.
-  // [#extension-category: envoy.filters.listener]
   oneof config_type {
+    // Filter specific configuration which depends on the filter being
+    // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.listener]
     google.protobuf.Any typed_config = 3;
 
     google.protobuf.Struct hidden_envoy_deprecated_config = 2 [deprecated = true];

--- a/generated_api_shadow/envoy/config/listener/v4alpha/listener_components.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/listener_components.proto
@@ -35,10 +35,10 @@ message Filter {
   // :ref:`supported filter <config_network_filters>`.
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // [#extension-category: envoy.filters.network]
   oneof config_type {
     // Filter specific configuration which depends on the filter being
     // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.network]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery
@@ -244,6 +244,7 @@ message FilterChain {
   // :ref:`DownstreamTlsContext <envoy_api_msg_extensions.transport_sockets.tls.v4alpha.DownstreamTlsContext>` in the `typed_config`.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
+  // [#extension-category: envoy.transport_sockets.downstream]
   core.v4alpha.TransportSocket transport_socket = 6;
 
   // If present and nonzero, the amount of time to allow incoming connections to complete any
@@ -336,13 +337,12 @@ message ListenerFilter {
 
   // The name of the filter to instantiate. The name must match a
   // :ref:`supported filter <config_listener_filters>`.
-  // [#extension-category: envoy.transport_sockets.downstream]
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  // Filter specific configuration which depends on the filter being instantiated.
-  // See the supported filters for further documentation.
-  // [#extension-category: envoy.filters.listener]
   oneof config_type {
+    // Filter specific configuration which depends on the filter being
+    // instantiated. See the supported filters for further documentation.
+    // [#extension-category: envoy.filters.listener]
     google.protobuf.Any typed_config = 3;
   }
 

--- a/generated_api_shadow/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
+++ b/generated_api_shadow/envoy/extensions/internal_redirect/safe_cross_scheme/v3/safe_cross_scheme_config.proto
@@ -16,7 +16,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // redirect and b) safe cross scheme redirect, which means if the downstream
 // scheme is HTTPS, both HTTPS and HTTP redirect targets are allowed, but if the
 // downstream scheme is HTTP, only HTTP redirect targets are allowed.
-// [#extension:
-// envoy.internal_redirect_predicates.safe_cross_scheme]
+// [#extension: envoy.internal_redirect_predicates.safe_cross_scheme]
 message SafeCrossSchemeConfig {
 }


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: protos/docs: Cleanups for extensions/categories
Additional Description:

Some of the categories etc added in #14721 were not exactly correct and/or consistent

Also there is now some duplication from where links/info have been added manually previously

This PR should address these issues

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Ref #13167
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
