### PR TITLE
[json] enable new JSON in fuzzer

### DIFF
--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -17,6 +17,7 @@ envoy_cc_fuzz_test(
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
         "//test/fuzz:utility_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/common/json/json_fuzz_test.cc
+++ b/test/common/json/json_fuzz_test.cc
@@ -3,16 +3,20 @@
 
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Fuzz {
 
-// We have multiple third party JSON parsers in Envoy, both RapidJSON and Protobuf.
-// We only fuzz protobuf today, since RapidJSON is deprecated and has known
-// limitations when we have deeply nested structures. Do not use RapidJSON for
-// anything new in Envoy! See https://github.com/envoyproxy/envoy/issues/4705.
+// We have multiple third party JSON parsers in Envoy, nlohmann/JSON, RapidJSON and Protobuf.
+// We fuzz nlohmann/JSON and protobuf and compare their results, since RapidJSON is deprecated and
+// has known limitations. See https://github.com/envoyproxy/envoy/issues/4705.
 DEFINE_FUZZER(const uint8_t* buf, size_t len) {
+  TestScopedRuntime runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.remove_legacy_json", "true"}});
+
   std::string json_string{reinterpret_cast<const char*>(buf), len};
 
   // Load via Protobuf JSON parsing, if we can.


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Enables new json (nlohmann/json) in fuzzer.
Risk Level: Low, not enabled by default
Testing: Ran fuzzer locally for 10-ish minute, no crashes so far.
Progress on https://github.com/envoyproxy/envoy/issues/4705
