### PR TITLE
[coverage] make ENVOY_BUGs non-fatal in coverage mode

### DIFF
--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -171,7 +171,9 @@ void resetEnvoyBugCountersForTest();
     abort();                                                                                       \
   } while (false)
 
-#if !defined(NDEBUG)
+// We do not want to crash on failure in tests exercises ENVOY_BUGs while running coverage in debug
+// mode. Crashing causes flakes when forking to expect a debug death and reduces lines of coverage.
+#if !defined(NDEBUG) && !defined(ENVOY_CONFIG_COVERAGE)
 #define ENVOY_BUG_ACTION abort()
 #else
 #define ENVOY_BUG_ACTION Envoy::Assert::invokeEnvoyBugFailureRecordActionForEnvoyBugMacroUseOnly()
@@ -209,6 +211,8 @@ void resetEnvoyBugCountersForTest();
  * mode, it is logged and a stat is incremented with exponential back-off per ENVOY_BUG. In debug
  * mode, it will crash if the condition is not met. ENVOY_BUG must be called with two arguments for
  * verbose logging.
+ * Note: ENVOY_BUGs in coverage mode will never crash. They will log and increment a stat like in
+ * release mode. This prevents flakiness and increases code coverage.
  */
 #define ENVOY_BUG(...) PASS_ON(PASS_ON(_ENVOY_BUG_VERBOSE)(__VA_ARGS__))
 

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -171,7 +171,7 @@ void resetEnvoyBugCountersForTest();
     abort();                                                                                       \
   } while (false)
 
-// We do not want to crash on failure in tests exercises ENVOY_BUGs while running coverage in debug
+// We do not want to crash on failure in tests exercising ENVOY_BUGs while running coverage in debug
 // mode. Crashing causes flakes when forking to expect a debug death and reduces lines of coverage.
 #if !defined(NDEBUG) && !defined(ENVOY_CONFIG_COVERAGE)
 #define ENVOY_BUG_ACTION abort()

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -82,11 +82,11 @@ namespace Envoy {
                              ::testing::Not(::testing::ContainsRegex(regex_str)))
 
 // Expect that the statement hits an ENVOY_BUG containing the specified message.
-#ifdef NDEBUG
-// ENVOY_BUGs in release mode log error.
+#if defined(NDEBUG) || defined(ENVOY_CONFIG_COVERAGE)
+// ENVOY_BUGs in release mode or in a coverage test log error.
 #define EXPECT_ENVOY_BUG(statement, message) EXPECT_LOG_CONTAINS("error", message, statement)
 #else
-// ENVOY_BUGs in debug mode is fatal.
+// ENVOY_BUGs in (non-coverage) debug mode is fatal.
 #define EXPECT_ENVOY_BUG(statement, message)                                                       \
   EXPECT_DEBUG_DEATH(statement, ::testing::HasSubstr(message))
 #endif


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Make ENVOY_BUGs non-fatal in coverage mode to reduce flakiness from EXPECT_DEBUG_DEATH forks.
Risk Level: Low, coverage only.
Testing: Tested unit tests in dbg/opt/coverage
Fixes https://github.com/envoyproxy/envoy/issues/15092
