### PR TITLE
container: Only drop privs if user is root

### DIFF
--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 set -e
 
 loglevel="${loglevel:-}"
+USERID=$(id -u)
+
 
 # if the first argument look like a parameter (i.e. start with '-'), run Envoy
 if [ "${1#-}" != "$1" ]; then
@@ -15,7 +17,7 @@ if [ "$1" = 'envoy' ]; then
 	fi
 fi
 
-if [ "$ENVOY_UID" != "0" ]; then
+if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
     if [ -n "$ENVOY_UID" ]; then
 	usermod -u "$ENVOY_UID" envoy
     fi


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: container: Only drop privs if user is root
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Partial fix for #14141
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
