### PR TITLE
extensions: Separate generation of extension db from docs in CI

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,7 @@ package_group(
         "//test/extensions/...",
         "//test/server",
         "//test/server/config_validation",
+        "//tools/extensions/...",
     ],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -19,7 +19,6 @@ package_group(
         "//test/extensions/...",
         "//test/server",
         "//test/server/config_validation",
-        "//tools/extensions/...",
     ],
 )
 
@@ -28,5 +27,6 @@ package_group(
     packages = [
         "//source/extensions/...",
         "//test/extensions/...",
+        "//tools/extensions:generate_extension_db",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,6 @@ package_group(
     packages = [
         "//source/extensions/...",
         "//test/extensions/...",
-        "//tools/extensions",
+        "//tools/extensions/...",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,6 @@ package_group(
     packages = [
         "//source/extensions/...",
         "//test/extensions/...",
-        "//tools/extensions:generate_extension_db",
+        "//tools/extensions",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -19,7 +19,7 @@ package_group(
         "//test/extensions/...",
         "//test/server",
         "//test/server/config_validation",
-        "//tools/extensions:generate_extension_db",
+        "//tools/extensions/...",
     ],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,7 @@ package_group(
         "//test/extensions/...",
         "//test/server",
         "//test/server/config_validation",
+        "//tools/extensions:generate_extension_db",
     ],
 )
 
@@ -27,6 +28,5 @@ package_group(
     packages = [
         "//source/extensions/...",
         "//test/extensions/...",
-        "//tools/extensions/...",
     ],
 )

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -23,6 +23,9 @@ def api_dependencies():
         name = "com_google_googleapis",
     )
     external_http_archive(
+        name = "com_github_bazelbuild_buildtools",
+    )
+    external_http_archive(
         name = "com_github_cncf_udpa",
     )
 

--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -28,6 +28,17 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "org_golang_x_text",
         ],
     ),
+    com_github_bazelbuild_buildtools = dict(
+        project_name = "Bazel build tools",
+        project_desc = "Developer tools for working with Google's bazel buildtool.",
+        project_url = "https://github.com/bazelbuild/buildtools",
+        version = "4.0.0",
+        sha256 = "0d3ca4ed434958dda241fb129f77bd5ef0ce246250feed2d5a5470c6f29a77fa",
+        strip_prefix = "buildtools-4.0.0",
+        urls = ["https://github.com/bazelbuild/buildtools/archive/4.0.0.tar.gz"],
+        release_date = "2021-02-03",
+        use_category = ["api"],
+    ),
     com_github_cncf_udpa = dict(
         project_name = "xDS API",
         project_desc = "xDS API Working Group (xDS-WG)",

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -73,7 +73,8 @@ BAZEL_BUILD_OPTIONS+=(
 
 # Generate extension database. This maps from extension name to extension
 # metadata, based on the envoy_cc_extension() Bazel target attributes.
-./docs/generate_extension_db.py "${EXTENSION_DB_PATH}"
+bazel build //tools/extensions:generate_extension_db
+bazel run //tools/extensions:generate_extension_db
 
 # Generate RST for the lists of trusted/untrusted extensions in
 # intro/arch_overview/security docs.

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -73,7 +73,6 @@ BAZEL_BUILD_OPTIONS+=(
 
 # Generate extension database. This maps from extension name to extension
 # metadata, based on the envoy_cc_extension() Bazel target attributes.
-# bazel build //tools/extensions:generate_extension_db
 bazel run //tools/extensions:generate_extension_db
 
 # Generate RST for the lists of trusted/untrusted extensions in

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -73,7 +73,7 @@ BAZEL_BUILD_OPTIONS+=(
 
 # Generate extension database. This maps from extension name to extension
 # metadata, based on the envoy_cc_extension() Bazel target attributes.
-bazel build //tools/extensions:generate_extension_db
+# bazel build //tools/extensions:generate_extension_db
 bazel run //tools/extensions:generate_extension_db
 
 # Generate RST for the lists of trusted/untrusted extensions in

--- a/generated_api_shadow/bazel/repositories.bzl
+++ b/generated_api_shadow/bazel/repositories.bzl
@@ -23,6 +23,9 @@ def api_dependencies():
         name = "com_google_googleapis",
     )
     external_http_archive(
+        name = "com_github_bazelbuild_buildtools",
+    )
+    external_http_archive(
         name = "com_github_cncf_udpa",
     )
 

--- a/generated_api_shadow/bazel/repository_locations.bzl
+++ b/generated_api_shadow/bazel/repository_locations.bzl
@@ -28,6 +28,17 @@ REPOSITORY_LOCATIONS_SPEC = dict(
             "org_golang_x_text",
         ],
     ),
+    com_github_bazelbuild_buildtools = dict(
+        project_name = "Bazel build tools",
+        project_desc = "Developer tools for working with Google's bazel buildtool.",
+        project_url = "https://github.com/bazelbuild/buildtools",
+        version = "4.0.0",
+        sha256 = "0d3ca4ed434958dda241fb129f77bd5ef0ce246250feed2d5a5470c6f29a77fa",
+        strip_prefix = "buildtools-4.0.0",
+        urls = ["https://github.com/bazelbuild/buildtools/archive/4.0.0.tar.gz"],
+        release_date = "2021-02-03",
+        use_category = ["api"],
+    ),
     com_github_cncf_udpa = dict(
         project_name = "xDS API",
         project_desc = "xDS API Working Group (xDS-WG)",

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -251,5 +251,7 @@ EXTENSIONS = {
     "envoy.io_socket.user_space":                       "//source/extensions/io_socket/user_space:config",
 }
 
-EXTENSION_CONFIG_VISIBILITY = ["//visibility:public"]
-EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]
+# These can be changed to ["//visibility:public"], for  downstream builds which
+# need to directly reference Envoy extensions.
+EXTENSION_CONFIG_VISIBILITY = ["//:extension_config"]
+EXTENSION_PACKAGE_VISIBILITY = ["//:extension_library"]

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -243,7 +243,7 @@ EXTENSIONS = {
     #
 
     "envoy.rate_limit_descriptors.expr":                "//source/extensions/rate_limit_descriptors/expr:config",
-    
+
     #
     # IO socket
     #
@@ -251,7 +251,5 @@ EXTENSIONS = {
     "envoy.io_socket.user_space":                       "//source/extensions/io_socket/user_space:config",
 }
 
-# These can be changed to ["//visibility:public"], for  downstream builds which
-# need to directly reference Envoy extensions.
-EXTENSION_CONFIG_VISIBILITY = ["//:extension_config"]
-EXTENSION_PACKAGE_VISIBILITY = ["//:extension_library"]
+EXTENSION_CONFIG_VISIBILITY = ["//visibility:public"]
+EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]

--- a/tools/extensions/BUILD
+++ b/tools/extensions/BUILD
@@ -1,0 +1,18 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+load("//source/extensions:all_extensions.bzl", "envoy_all_extensions")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+py_binary(
+    name = "generate_extension_db",
+    srcs = ["generate_extension_db.py"],
+    data = [
+        "@com_github_bazelbuild_buildtools//buildozer:buildozer",
+    ] + envoy_all_extensions(),
+    python_version = "PY3",
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+)

--- a/tools/extensions/generate_extension_db.py
+++ b/tools/extensions/generate_extension_db.py
@@ -22,7 +22,7 @@ ENVOY_SOURCE = os.getenv('ENVOY_SOURCE', '/source')
 
 if not os.path.exists(ENVOY_SOURCE):
   raise SystemExit(
-    "Envoy source must either be located at /source, or ENVOY_SOURCE env var must be set")
+      "Envoy source must either be located at /source, or ENVOY_SOURCE env var must be set")
 
 # source/extensions/extensions_build_config.bzl must have a .bzl suffix for Starlark
 # import, so we are forced to do this workaround.
@@ -44,7 +44,9 @@ def IsMissing(value):
 
 def NumReadFiltersFuzzed():
   data = pathlib.Path(
-    os.path.join(ENVOY_SOURCE, 'test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc')).read_text()
+      os.path.join(
+          ENVOY_SOURCE,
+          'test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc')).read_text()
   # Hack-ish! We only search the first 50 lines to capture the filters in filterNames().
   return len(re.findall('NetworkFilterNames::get()', ''.join(data.splitlines()[:50])))
 
@@ -89,9 +91,11 @@ def GetExtensionMetadata(target):
 
 if __name__ == '__main__':
   try:
-    output_path = (os.environ["EXTENSION_DB_PATH"] if os.getenv("EXTENSION_DB_PATH") else sys.argv[1])
+    output_path = (os.environ["EXTENSION_DB_PATH"]
+                   if os.getenv("EXTENSION_DB_PATH") else sys.argv[1])
   except IndexError:
-    raise SystemExit("Output path must be either specified as arg or with EXTENSION_DB_PATH env var")
+    raise SystemExit(
+        "Output path must be either specified as arg or with EXTENSION_DB_PATH env var")
 
   extension_db = {}
   # Include all extensions from source/extensions/extensions_build_config.bzl

--- a/tools/extensions/generate_extension_db.py
+++ b/tools/extensions/generate_extension_db.py
@@ -98,8 +98,7 @@ def GetExtensionMetadata(target):
 
 if __name__ == '__main__':
   try:
-    output_path = (os.environ["EXTENSION_DB_PATH"]
-                   if os.getenv("EXTENSION_DB_PATH") else sys.argv[1])
+    output_path = os.getenv("EXTENSION_DB_PATH") or sys.argv[1]
   except IndexError:
     raise SystemExit(
         "Output path must be either specified as arg or with EXTENSION_DB_PATH env var")


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message:  extensions: Separate generation of extension db from docs in CI
Additional Description:

As we will require the extension DB to be generated for docs *and* schema, it makes sense to separate this task so that those jobs can run in parallel

Im wondering if this job should be moved to a bazel build somewhere - but initially im just gonna  get it working by splitting the script/job

### UPDATE

rather than separating the ci job, i have moved the db generation into a bazel job - which will allow other tasks that also require this data to make use of it more easily/bazely

this also adds buildozer into the bazel env, so we might want to make use of that elsewhere and potentially remove buildozer from the build-image env


Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Touch #13229
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
