### PR TITLE
dubbo: support wildcard match for dubbo interface

### DIFF
--- a/api/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
@@ -26,7 +26,15 @@ message RouteConfiguration {
   // The name of the route configuration. Reserved for future use in asynchronous route discovery.
   string name = 1;
 
-  // The interface name of the service.
+  // The interface name of the service. Wildcard interface are supported in the suffix or prefix form.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add``, ``com.prod.methods.add``, etc.
+  // ``com.dev.methods.*`` will match ``com.dev.methods.add``, ``com.dev.methods.update``, etc.
+  // Special wildcard ``*`` matching any interface.
+  //
+  // .. note::
+  //
+  // The wildcard will not match the empty string.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
@@ -33,8 +33,8 @@ message RouteConfiguration {
   //
   // .. note::
   //
-  // The wildcard will not match the empty string.
-  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
+  //  The wildcard will not match the empty string.
+  //  e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
@@ -26,7 +26,15 @@ message RouteConfiguration {
   // The name of the route configuration. Reserved for future use in asynchronous route discovery.
   string name = 1;
 
-  // The interface name of the service.
+  // The interface name of the service. Wildcard interface are supported in the suffix or prefix form.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add``, ``com.prod.methods.add``, etc.
+  // ``com.dev.methods.*`` will match ``com.dev.methods.add``, ``com.dev.methods.update``, etc.
+  // Special wildcard ``*`` matching any interface.
+  //
+  // .. note::
+  //
+  // The wildcard will not match the empty string.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
+++ b/api/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
@@ -33,8 +33,8 @@ message RouteConfiguration {
   //
   // .. note::
   //
-  // The wildcard will not match the empty string.
-  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
+  //  The wildcard will not match the empty string.
+  //  e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
@@ -26,7 +26,15 @@ message RouteConfiguration {
   // The name of the route configuration. Reserved for future use in asynchronous route discovery.
   string name = 1;
 
-  // The interface name of the service.
+  // The interface name of the service. Wildcard interface are supported in the suffix or prefix form.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add``, ``com.prod.methods.add``, etc.
+  // ``com.dev.methods.*`` will match ``com.dev.methods.add``, ``com.dev.methods.update``, etc.
+  // Special wildcard ``*`` matching any interface.
+  //
+  // .. note::
+  //
+  // The wildcard will not match the empty string.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v3/route.proto
@@ -33,8 +33,8 @@ message RouteConfiguration {
   //
   // .. note::
   //
-  // The wildcard will not match the empty string.
-  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
+  //  The wildcard will not match the empty string.
+  //  e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
@@ -26,7 +26,15 @@ message RouteConfiguration {
   // The name of the route configuration. Reserved for future use in asynchronous route discovery.
   string name = 1;
 
-  // The interface name of the service.
+  // The interface name of the service. Wildcard interface are supported in the suffix or prefix form.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add``, ``com.prod.methods.add``, etc.
+  // ``com.dev.methods.*`` will match ``com.dev.methods.add``, ``com.dev.methods.update``, etc.
+  // Special wildcard ``*`` matching any interface.
+  //
+  // .. note::
+  //
+  // The wildcard will not match the empty string.
+  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/dubbo_proxy/v4alpha/route.proto
@@ -33,8 +33,8 @@ message RouteConfiguration {
   //
   // .. note::
   //
-  // The wildcard will not match the empty string.
-  // e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
+  //  The wildcard will not match the empty string.
+  //  e.g. ``*.methods.add`` will match ``com.dev.methods.add`` but not ``.methods.add``.
   string interface = 2;
 
   // Which group does the interface belong to.

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.cc
@@ -170,7 +170,7 @@ RouteConstSharedPtr MethodRouteEntryImpl::matches(const MessageMetadata& metadat
 
 SingleRouteMatcherImpl::SingleRouteMatcherImpl(const RouteConfig& config,
                                                Server::Configuration::FactoryContext&)
-    : service_name_(config.interface()), group_(config.group()), version_(config.version()) {
+    : interface_matcher_(config.interface()), group_(config.group()), version_(config.version()) {
   using envoy::extensions::filters::network::dubbo_proxy::v3::RouteMatch;
 
   for (const auto& route : config.routes()) {
@@ -184,7 +184,7 @@ RouteConstSharedPtr SingleRouteMatcherImpl::route(const MessageMetadata& metadat
   ASSERT(metadata.hasInvocationInfo());
   const auto& invocation = metadata.invocationInfo();
 
-  if (service_name_ == invocation.serviceName() &&
+  if (interface_matcher_.match(invocation.serviceName()) &&
       (group_.value().empty() ||
        (invocation.serviceGroup().has_value() && invocation.serviceGroup().value() == group_)) &&
       (version_.value().empty() || (invocation.serviceVersion().has_value() &&

--- a/source/extensions/filters/network/dubbo_proxy/router/route_matcher.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/route_matcher.h
@@ -134,26 +134,23 @@ public:
     using MatcherImpl = std::function<bool(const absl::string_view)>;
     InterfaceMatcher(const std::string& interface_name) {
       if (interface_name == "*") {
-        impl_ = [](const absl::string_view) { return true; };
+        impl_ = [](const absl::string_view interface) { return !interface.empty(); };
         return;
       }
-
       if (absl::StartsWith(interface_name, "*")) {
         const std::string suffix = interface_name.substr(1);
         impl_ = [suffix](const absl::string_view interface) {
-          return absl::EndsWith(interface, suffix);
+          return interface.size() > suffix.size() && absl::EndsWith(interface, suffix);
         };
         return;
       }
-
       if (absl::EndsWith(interface_name, "*")) {
         const std::string prefix = interface_name.substr(0, interface_name.size() - 1);
         impl_ = [prefix](const absl::string_view interface) {
-          return absl::StartsWith(interface, prefix);
+          return interface.size() > prefix.size() && absl::StartsWith(interface, prefix);
         };
         return;
       }
-
       impl_ = [interface_name](const absl::string_view interface) {
         return interface == interface_name;
       };

--- a/test/extensions/filters/network/dubbo_proxy/route_matcher_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/route_matcher_test.cc
@@ -60,8 +60,7 @@ routes:
     MessageMetadata metadata;
     metadata.setInvocationInfo(invo);
     invo->setMethodName("add");
-
-    EXPECT_EQ("user_service_dubbo_server", matcher.route(metadata, 0)->routeEntry()->clusterName());
+    EXPECT_EQ(nullptr, matcher.route(metadata, 0));
 
     invo->setServiceName("unknown");
 
@@ -98,6 +97,9 @@ routes:
     invo->setMethodName("add");
     EXPECT_EQ(nullptr, matcher.route(metadata, 0));
 
+    invo->setServiceName(".test.com");
+    EXPECT_EQ(nullptr, matcher.route(metadata, 0));
+
     invo->setServiceName("code.test.com");
 
     EXPECT_EQ("user_service_dubbo_server", matcher.route(metadata, 0)->routeEntry()->clusterName());
@@ -131,6 +133,9 @@ routes:
     MessageMetadata metadata;
     metadata.setInvocationInfo(invo);
     invo->setMethodName("add");
+    EXPECT_EQ(nullptr, matcher.route(metadata, 0));
+
+    invo->setServiceName("com.test.");
     EXPECT_EQ(nullptr, matcher.route(metadata, 0));
 
     invo->setServiceName("com.test.code");


### PR DESCRIPTION
Signed-off-by: wbpcode <comems@msn.com>

Commit Message: support wildcard match for dubbo interface
Additional Description: 
Support wildcard match、suffix match and prefix match for dubbo interface name. Check #14765 get more information.

Risk Level: Low
Testing: Unit Test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]

