### PR TITLE
refactor: active listener and connection handler

### DIFF
--- a/include/envoy/network/BUILD
+++ b/include/envoy/network/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
     name = "connection_handler_interface",
     hdrs = ["connection_handler.h"],
     deps = [
+        ":connection_balancer_interface",
         ":listen_socket_interface",
         ":listener_interface",
         "//include/envoy/ssl:context_interface",

--- a/include/envoy/network/connection_balancer.h
+++ b/include/envoy/network/connection_balancer.h
@@ -32,6 +32,9 @@ public:
    * transfer during the balancing process.
    */
   virtual void post(Network::ConnectionSocketPtr&& socket) PURE;
+
+  virtual void onAcceptWorker(Network::ConnectionSocketPtr&& socket,
+                              bool hand_off_restored_destination_connections, bool rebalanced) PURE;
 };
 
 /**
@@ -66,6 +69,8 @@ public:
 };
 
 using ConnectionBalancerSharedPtr = std::shared_ptr<ConnectionBalancer>;
+using BalancedConnectionHandlerOptRef =
+    absl::optional<std::reference_wrapper<BalancedConnectionHandler>>;
 
 } // namespace Network
 } // namespace Envoy

--- a/include/envoy/network/connection_balancer.h
+++ b/include/envoy/network/connection_balancer.h
@@ -33,6 +33,12 @@ public:
    */
   virtual void post(Network::ConnectionSocketPtr&& socket) PURE;
 
+  /**
+   * Take the ownership of the accepted socket.
+   * @param socket the accepted tcp socket.
+   * @param hand_off_restored_destination_connections true if redirection is allowed.
+   * @param rebalanced true if no more balance is allowed.
+   */
   virtual void onAcceptWorker(Network::ConnectionSocketPtr&& socket,
                               bool hand_off_restored_destination_connections, bool rebalanced) PURE;
 };

--- a/include/envoy/network/connection_handler.h
+++ b/include/envoy/network/connection_handler.h
@@ -155,14 +155,34 @@ public:
 
 using ConnectionHandlerPtr = std::unique_ptr<ConnectionHandler>;
 
+/**
+ * The connection handler from the view of a tcp listener.
+ */
 class TcpConnectionHandler : public virtual ConnectionHandler {
 public:
   virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
+   * Obtain the rebalancer of the tcp listener.
+   * @param listener_tag supplies the tag of the tcp listener that was passed to addListener().
+   * @return BalancedConnectionHandlerOptRef the balancer attached to the listener. `nullopt` if
+   * listener doesn't exist or rebalancer doesn't exist.
+   */
   virtual BalancedConnectionHandlerOptRef getBalancedHandlerByTag(uint64_t listener_tag) PURE;
+
+  /**
+   * Obtain the rebalancer of the tcp listener.
+   * @param address supplies the address of the tcp listener.
+   * @return BalancedConnectionHandlerOptRef the balancer attached to the listener. ``nullopt`` if
+   * listener doesn't exist or rebalancer doesn't exist.
+   */
   virtual BalancedConnectionHandlerOptRef
   getBalancedHandlerByAddress(const Network::Address::Instance& address) PURE;
 };
 
+/**
+ * The connection handler from the view of a udp listener.
+ */
 class UdpConnectionHandler : public virtual ConnectionHandler {
 public:
   /**

--- a/source/extensions/quic_listeners/quiche/active_quic_listener.cc
+++ b/source/extensions/quic_listeners/quiche/active_quic_listener.cc
@@ -2,6 +2,8 @@
 
 #include "envoy/network/exception.h"
 
+#include "server/active_udp_listener.h"
+
 #if defined(__linux__)
 #include <linux/filter.h>
 #endif
@@ -21,7 +23,7 @@ namespace Quic {
 
 ActiveQuicListener::ActiveQuicListener(
     uint32_t worker_index, uint32_t concurrency, Event::Dispatcher& dispatcher,
-    Network::ConnectionHandler& parent, Network::ListenerConfig& listener_config,
+    Network::UdpConnectionHandler& parent, Network::ListenerConfig& listener_config,
     const quic::QuicConfig& quic_config, Network::Socket::OptionsSharedPtr options,
     bool kernel_worker_routing, const envoy::config::core::v3::RuntimeFeatureFlag& enabled)
     : ActiveQuicListener(worker_index, concurrency, dispatcher, parent,
@@ -30,7 +32,7 @@ ActiveQuicListener::ActiveQuicListener(
 
 ActiveQuicListener::ActiveQuicListener(
     uint32_t worker_index, uint32_t concurrency, Event::Dispatcher& dispatcher,
-    Network::ConnectionHandler& parent, Network::SocketSharedPtr listen_socket,
+    Network::UdpConnectionHandler& parent, Network::SocketSharedPtr listen_socket,
     Network::ListenerConfig& listener_config, const quic::QuicConfig& quic_config,
     Network::Socket::OptionsSharedPtr options, bool kernel_worker_routing,
     const envoy::config::core::v3::RuntimeFeatureFlag& enabled)
@@ -221,7 +223,7 @@ ActiveQuicListenerFactory::ActiveQuicListenerFactory(
 }
 
 Network::ConnectionHandler::ActiveUdpListenerPtr ActiveQuicListenerFactory::createActiveUdpListener(
-    uint32_t worker_index, Network::ConnectionHandler& parent, Event::Dispatcher& disptacher,
+    uint32_t worker_index, Network::UdpConnectionHandler& parent, Event::Dispatcher& disptacher,
     Network::ListenerConfig& config) {
   bool kernel_worker_routing = false;
   std::unique_ptr<Network::Socket::Options> options = std::make_unique<Network::Socket::Options>();

--- a/source/extensions/quic_listeners/quiche/active_quic_listener.h
+++ b/source/extensions/quic_listeners/quiche/active_quic_listener.h
@@ -9,6 +9,7 @@
 #include "common/protobuf/utility.h"
 #include "common/runtime/runtime_protos.h"
 
+#include "server/active_udp_listener.h"
 #include "server/connection_handler_impl.h"
 
 #include "extensions/quic_listeners/quiche/envoy_quic_dispatcher.h"
@@ -25,13 +26,13 @@ public:
   static const size_t kNumSessionsToCreatePerLoop = 16;
 
   ActiveQuicListener(uint32_t worker_index, uint32_t concurrency, Event::Dispatcher& dispatcher,
-                     Network::ConnectionHandler& parent, Network::ListenerConfig& listener_config,
-                     const quic::QuicConfig& quic_config, Network::Socket::OptionsSharedPtr options,
-                     bool kernel_worker_routing,
+                     Network::UdpConnectionHandler& parent,
+                     Network::ListenerConfig& listener_config, const quic::QuicConfig& quic_config,
+                     Network::Socket::OptionsSharedPtr options, bool kernel_worker_routing,
                      const envoy::config::core::v3::RuntimeFeatureFlag& enabled);
 
   ActiveQuicListener(uint32_t worker_index, uint32_t concurrency, Event::Dispatcher& dispatcher,
-                     Network::ConnectionHandler& parent, Network::SocketSharedPtr listen_socket,
+                     Network::UdpConnectionHandler& parent, Network::SocketSharedPtr listen_socket,
                      Network::ListenerConfig& listener_config, const quic::QuicConfig& quic_config,
                      Network::Socket::OptionsSharedPtr options, bool kernel_worker_routing,
                      const envoy::config::core::v3::RuntimeFeatureFlag& enabled);
@@ -86,7 +87,7 @@ public:
 
   // Network::ActiveUdpListenerFactory.
   Network::ConnectionHandler::ActiveUdpListenerPtr
-  createActiveUdpListener(uint32_t worker_index, Network::ConnectionHandler& parent,
+  createActiveUdpListener(uint32_t worker_index, Network::UdpConnectionHandler& parent,
                           Event::Dispatcher& disptacher, Network::ListenerConfig& config) override;
   bool isTransportConnectionless() const override { return false; }
 

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -60,8 +60,21 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "connection_handler_lib",
+    deps = [
+        ":active_stream_listener",
+        ":active_udp_listener",
+        ":connection_handler_impl",
+    ],
+)
+
+envoy_cc_library(
+    name = "connection_handler_impl",
     srcs = ["connection_handler_impl.cc"],
-    hdrs = ["connection_handler_impl.h"],
+    hdrs = [
+        "active_stream_listener.h",
+        "active_udp_listener.h",
+        "connection_handler_impl.h",
+    ],
     deps = [
         "//include/envoy/common:time_interface",
         "//include/envoy/event:deferred_deletable",
@@ -80,8 +93,28 @@ envoy_cc_library(
         "//source/common/common:non_copyable",
         "//source/common/event:deferred_task",
         "//source/common/network:connection_lib",
-        "//source/common/stats:timespan_lib",
         "//source/common/stream_info:stream_info_lib",
+        "//source/extensions/transport_sockets:well_known_names",
+    ],
+)
+
+envoy_cc_library(
+    name = "active_udp_listener",
+    srcs = ["active_udp_listener.cc"],
+    hdrs = ["active_udp_listener.h"],
+    deps = [
+        ":connection_handler_impl",
+    ],
+)
+
+envoy_cc_library(
+    name = "active_stream_listener",
+    srcs = ["active_stream_listener.cc"],
+    hdrs = ["active_stream_listener.h"],
+    deps = [
+        ":connection_handler_impl",
+        "//include/envoy/event:timer_interface",
+        "//source/common/stats:timespan_lib",
         "//source/extensions/transport_sockets:well_known_names",
     ],
 )

--- a/source/server/active_raw_udp_listener_config.cc
+++ b/source/server/active_raw_udp_listener_config.cc
@@ -5,6 +5,7 @@
 
 #include "envoy/api/v2/listener/listener.pb.h"
 
+#include "server/active_udp_listener.h"
 #include "server/connection_handler_impl.h"
 #include "server/well_known_names.h"
 
@@ -16,7 +17,7 @@ ActiveRawUdpListenerFactory::ActiveRawUdpListenerFactory(uint32_t concurrency)
 
 Network::ConnectionHandler::ActiveUdpListenerPtr
 ActiveRawUdpListenerFactory::createActiveUdpListener(uint32_t worker_index,
-                                                     Network::ConnectionHandler& parent,
+                                                     Network::UdpConnectionHandler& parent,
                                                      Event::Dispatcher& dispatcher,
                                                      Network::ListenerConfig& config) {
   return std::make_unique<ActiveRawUdpListener>(worker_index, concurrency_, parent, dispatcher,

--- a/source/server/active_raw_udp_listener_config.h
+++ b/source/server/active_raw_udp_listener_config.h
@@ -12,7 +12,7 @@ public:
   ActiveRawUdpListenerFactory(uint32_t concurrency);
 
   Network::ConnectionHandler::ActiveUdpListenerPtr
-  createActiveUdpListener(uint32_t worker_index, Network::ConnectionHandler& parent,
+  createActiveUdpListener(uint32_t worker_index, Network::UdpConnectionHandler& parent,
                           Event::Dispatcher& disptacher, Network::ListenerConfig& config) override;
 
   bool isTransportConnectionless() const override { return true; }

--- a/source/server/active_stream_listener.cc
+++ b/source/server/active_stream_listener.cc
@@ -1,0 +1,425 @@
+#include "server/active_stream_listener.h"
+
+#include "envoy/common/time.h"
+
+#include "common/stats/timespan_impl.h"
+
+#include "extensions/transport_sockets/well_known_names.h"
+
+namespace Envoy {
+namespace Server {
+
+namespace {
+void emitLogs(Network::ListenerConfig& config, StreamInfo::StreamInfo& stream_info) {
+  stream_info.onRequestComplete();
+  for (const auto& access_log : config.accessLogs()) {
+    access_log->log(nullptr, nullptr, nullptr, stream_info);
+  }
+}
+} // namespace
+
+void ActiveTcpListener::removeConnection(ActiveTcpConnection& connection) {
+  ENVOY_CONN_LOG(debug, "adding to cleanup list", *connection.connection_);
+  ActiveConnections& active_connections = connection.active_connections_;
+  ActiveTcpConnectionPtr removed = connection.removeFromList(active_connections.connections_);
+  parent_.dispatcher().deferredDelete(std::move(removed));
+  // Delete map entry only iff connections becomes empty.
+  if (active_connections.connections_.empty()) {
+    auto iter = connections_by_context_.find(&active_connections.filter_chain_);
+    ASSERT(iter != connections_by_context_.end());
+    // To cover the lifetime of every single connection, Connections need to be deferred deleted
+    // because the previously contained connection is deferred deleted.
+    parent_.dispatcher().deferredDelete(std::move(iter->second));
+    // The erase will break the iteration over the connections_by_context_ during the deletion.
+    if (!is_deleting_) {
+      connections_by_context_.erase(iter);
+    }
+  }
+}
+
+ActiveTcpListener::ActiveTcpListener(Network::TcpConnectionHandler& parent,
+                                     Network::ListenerConfig& config)
+    : ActiveTcpListener(
+          parent,
+          parent.dispatcher().createListener(config.listenSocketFactory().getListenSocket(), *this,
+                                             config.bindToPort(), config.tcpBacklogSize()),
+          config) {}
+
+ActiveTcpListener::ActiveTcpListener(Network::TcpConnectionHandler& parent,
+                                     Network::ListenerPtr&& listener,
+                                     Network::ListenerConfig& config)
+    : ActiveListenerImplBase(parent, &config), parent_(parent), listener_(std::move(listener)),
+      listener_filters_timeout_(config.listenerFiltersTimeout()),
+      continue_on_listener_filters_timeout_(config.continueOnListenerFiltersTimeout()) {
+  config.connectionBalancer().registerHandler(*this);
+}
+
+void ActiveTcpListener::updateListenerConfig(Network::ListenerConfig& config) {
+  ENVOY_LOG(trace, "replacing listener ", config_->listenerTag(), " by ", config.listenerTag());
+  ASSERT(&config_->connectionBalancer() == &config.connectionBalancer());
+  config_ = &config;
+}
+
+ActiveTcpListener::~ActiveTcpListener() {
+  is_deleting_ = true;
+  config_->connectionBalancer().unregisterHandler(*this);
+
+  // Purge sockets that have not progressed to connections. This should only happen when
+  // a listener filter stops iteration and never resumes.
+  while (!sockets_.empty()) {
+    ActiveTcpSocketPtr removed = sockets_.front()->removeFromList(sockets_);
+    parent_.dispatcher().deferredDelete(std::move(removed));
+  }
+
+  for (auto& chain_and_connections : connections_by_context_) {
+    ASSERT(chain_and_connections.second != nullptr);
+    auto& connections = chain_and_connections.second->connections_;
+    while (!connections.empty()) {
+      connections.front()->connection_->close(Network::ConnectionCloseType::NoFlush);
+    }
+  }
+  parent_.dispatcher().clearDeferredDeleteList();
+
+  // By the time a listener is destroyed, in the common case, there should be no connections.
+  // However, this is not always true if there is an in flight rebalanced connection that is
+  // being posted. This assert is extremely useful for debugging the common path so we will leave it
+  // for now. If it becomes a problem (developers hitting this assert when using debug builds) we
+  // can revisit. This case, if it happens, should be benign on production builds. This case is
+  // covered in ConnectionHandlerTest::RemoveListenerDuringRebalance.
+  ASSERT(num_listener_connections_ == 0);
+}
+
+void ActiveTcpSocket::onTimeout() {
+  listener_.stats_.downstream_pre_cx_timeout_.inc();
+  ASSERT(inserted());
+  ENVOY_LOG(debug, "listener filter times out after {} ms",
+            listener_.listener_filters_timeout_.count());
+
+  if (listener_.continue_on_listener_filters_timeout_) {
+    ENVOY_LOG(debug, "fallback to default listener filter");
+    newConnection();
+  }
+  unlink();
+}
+
+void ActiveTcpSocket::startTimer() {
+  if (listener_.listener_filters_timeout_.count() > 0) {
+    timer_ = listener_.parent_.dispatcher().createTimer([this]() -> void { onTimeout(); });
+    timer_->enableTimer(listener_.listener_filters_timeout_);
+  }
+}
+
+void ActiveTcpSocket::unlink() {
+  ActiveTcpSocketPtr removed = removeFromList(listener_.sockets_);
+  if (removed->timer_ != nullptr) {
+    removed->timer_->disableTimer();
+  }
+  // Emit logs if a connection is not established.
+  if (!connected_) {
+    emitLogs(*listener_.config_, *stream_info_);
+  }
+  listener_.parent_.dispatcher().deferredDelete(std::move(removed));
+}
+
+void ActiveTcpSocket::continueFilterChain(bool success) {
+  if (success) {
+    bool no_error = true;
+    if (iter_ == accept_filters_.end()) {
+      iter_ = accept_filters_.begin();
+    } else {
+      iter_ = std::next(iter_);
+    }
+
+    for (; iter_ != accept_filters_.end(); iter_++) {
+      Network::FilterStatus status = (*iter_)->onAccept(*this);
+      if (status == Network::FilterStatus::StopIteration) {
+        // The filter is responsible for calling us again at a later time to continue the filter
+        // chain from the next filter.
+        if (!socket().ioHandle().isOpen()) {
+          // break the loop but should not create new connection
+          no_error = false;
+          break;
+        } else {
+          // Blocking at the filter but no error
+          return;
+        }
+      }
+    }
+    // Successfully ran all the accept filters.
+    if (no_error) {
+      newConnection();
+    } else {
+      // Signal the caller that no extra filter chain iteration is needed.
+      iter_ = accept_filters_.end();
+    }
+  }
+
+  // Filter execution concluded, unlink and delete this ActiveTcpSocket if it was linked.
+  if (inserted()) {
+    unlink();
+  }
+}
+
+void ActiveTcpSocket::setDynamicMetadata(const std::string& name,
+                                         const ProtobufWkt::Struct& value) {
+  stream_info_->setDynamicMetadata(name, value);
+}
+
+void ActiveTcpSocket::newConnection() {
+  connected_ = true;
+
+  // Check if the socket may need to be redirected to another listener.
+  Network::BalancedConnectionHandlerOptRef new_listener;
+
+  if (hand_off_restored_destination_connections_ &&
+      socket_->addressProvider().localAddressRestored()) {
+    // Find a listener associated with the original destination address.
+    new_listener =
+        listener_.parent_.getBalancedHandlerByAddress(*socket_->addressProvider().localAddress());
+  }
+  if (new_listener.has_value()) {
+    // Hands off connections redirected by iptables to the listener associated with the
+    // original destination address. Pass 'hand_off_restored_destination_connections' as false to
+    // prevent further redirection as well as 'rebalanced' as true since the connection has
+    // already been balanced if applicable inside onAcceptWorker() when the connection was
+    // initially accepted. Note also that we must account for the number of connections properly
+    // across both listeners.
+    // TODO(mattklein123): See note in ~ActiveTcpSocket() related to making this accounting better.
+    listener_.decNumConnections();
+    new_listener.value().get().incNumConnections();
+    new_listener.value().get().onAcceptWorker(std::move(socket_), false, true);
+  } else {
+    // Set default transport protocol if none of the listener filters did it.
+    if (socket_->detectedTransportProtocol().empty()) {
+      socket_->setDetectedTransportProtocol(
+          Extensions::TransportSockets::TransportProtocolNames::get().RawBuffer);
+    }
+    // TODO(lambdai): add integration test
+    // TODO: Address issues in wider scope. See https://github.com/envoyproxy/envoy/issues/8925
+    // Erase accept filter states because accept filters may not get the opportunity to clean up.
+    // Particularly the assigned events need to reset before assigning new events in the follow up.
+    accept_filters_.clear();
+    // Create a new connection on this listener.
+    listener_.newConnection(std::move(socket_), std::move(stream_info_));
+  }
+}
+
+void ActiveTcpListener::onAccept(Network::ConnectionSocketPtr&& socket) {
+  if (listenerConnectionLimitReached()) {
+    ENVOY_LOG(trace, "closing connection: listener connection limit reached for {}",
+              config_->name());
+    socket->close();
+    stats_.downstream_cx_overflow_.inc();
+    return;
+  }
+
+  onAcceptWorker(std::move(socket), config_->handOffRestoredDestinationConnections(), false);
+}
+
+void ActiveTcpListener::onReject(RejectCause cause) {
+  switch (cause) {
+  case RejectCause::GlobalCxLimit:
+    stats_.downstream_global_cx_overflow_.inc();
+    break;
+  case RejectCause::OverloadAction:
+    stats_.downstream_cx_overload_reject_.inc();
+    break;
+  }
+}
+
+void ActiveTcpListener::onAcceptWorker(Network::ConnectionSocketPtr&& socket,
+                                       bool hand_off_restored_destination_connections,
+                                       bool rebalanced) {
+  if (!rebalanced) {
+    Network::BalancedConnectionHandler& target_handler =
+        config_->connectionBalancer().pickTargetHandler(*this);
+    if (&target_handler != this) {
+      target_handler.post(std::move(socket));
+      return;
+    }
+  }
+
+  auto active_socket = std::make_unique<ActiveTcpSocket>(*this, std::move(socket),
+                                                         hand_off_restored_destination_connections);
+
+  // Create and run the filters
+  config_->filterChainFactory().createListenerFilterChain(*active_socket);
+  active_socket->continueFilterChain(true);
+
+  // Move active_socket to the sockets_ list if filter iteration needs to continue later.
+  // Otherwise we let active_socket be destructed when it goes out of scope.
+  if (active_socket->iter_ != active_socket->accept_filters_.end()) {
+    active_socket->startTimer();
+    LinkedList::moveIntoListBack(std::move(active_socket), sockets_);
+  } else {
+    // If active_socket is about to be destructed, emit logs if a connection is not created.
+    if (!active_socket->connected_) {
+      emitLogs(*config_, *active_socket->stream_info_);
+    }
+  }
+}
+
+void ActiveTcpListener::pauseListening() {
+  if (listener_ != nullptr) {
+    listener_->disable();
+  }
+}
+
+void ActiveTcpListener::resumeListening() {
+  if (listener_ != nullptr) {
+    listener_->enable();
+  }
+}
+
+void ActiveTcpListener::newConnection(Network::ConnectionSocketPtr&& socket,
+                                      std::unique_ptr<StreamInfo::StreamInfo> stream_info) {
+
+  // Find matching filter chain.
+  const auto filter_chain = config_->filterChainManager().findFilterChain(*socket);
+  if (filter_chain == nullptr) {
+    ENVOY_LOG(debug, "closing connection: no matching filter chain found");
+    stats_.no_filter_chain_match_.inc();
+    stream_info->setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
+    stream_info->setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().FilterChainNotFound);
+    emitLogs(*config_, *stream_info);
+    socket->close();
+    return;
+  }
+
+  stream_info->setFilterChainName(filter_chain->name());
+  auto transport_socket = filter_chain->transportSocketFactory().createTransportSocket(nullptr);
+  stream_info->setDownstreamSslConnection(transport_socket->ssl());
+  auto& active_connections = getOrCreateActiveConnections(*filter_chain);
+  auto server_conn_ptr = parent_.dispatcher().createServerConnection(
+      std::move(socket), std::move(transport_socket), *stream_info);
+  if (const auto timeout = filter_chain->transportSocketConnectTimeout();
+      timeout != std::chrono::milliseconds::zero()) {
+    server_conn_ptr->setTransportSocketConnectTimeout(timeout);
+  }
+  ActiveTcpConnectionPtr active_connection(
+      new ActiveTcpConnection(active_connections, std::move(server_conn_ptr),
+                              parent_.dispatcher().timeSource(), std::move(stream_info)));
+  active_connection->connection_->setBufferLimits(config_->perConnectionBufferLimitBytes());
+
+  const bool empty_filter_chain = !config_->filterChainFactory().createNetworkFilterChain(
+      *active_connection->connection_, filter_chain->networkFilterFactories());
+  if (empty_filter_chain) {
+    ENVOY_CONN_LOG(debug, "closing connection: no filters", *active_connection->connection_);
+    active_connection->connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+
+  // If the connection is already closed, we can just let this connection immediately die.
+  if (active_connection->connection_->state() != Network::Connection::State::Closed) {
+    ENVOY_CONN_LOG(debug, "new connection", *active_connection->connection_);
+    active_connection->connection_->addConnectionCallbacks(*active_connection);
+    LinkedList::moveIntoList(std::move(active_connection), active_connections.connections_);
+  }
+}
+
+ActiveConnections&
+ActiveTcpListener::getOrCreateActiveConnections(const Network::FilterChain& filter_chain) {
+  ActiveConnectionsPtr& connections = connections_by_context_[&filter_chain];
+  if (connections == nullptr) {
+    connections = std::make_unique<ActiveConnections>(*this, filter_chain);
+  }
+  return *connections;
+}
+
+void ActiveTcpListener::deferredRemoveFilterChains(
+    const std::list<const Network::FilterChain*>& draining_filter_chains) {
+  // Need to recover the original deleting state.
+  const bool was_deleting = is_deleting_;
+  is_deleting_ = true;
+  for (const auto* filter_chain : draining_filter_chains) {
+    auto iter = connections_by_context_.find(filter_chain);
+    if (iter == connections_by_context_.end()) {
+      // It is possible when listener is stopping.
+    } else {
+      auto& connections = iter->second->connections_;
+      while (!connections.empty()) {
+        connections.front()->connection_->close(Network::ConnectionCloseType::NoFlush);
+      }
+      // Since is_deleting_ is on, we need to manually remove the map value and drive the iterator.
+      // Defer delete connection container to avoid race condition in destroying connection.
+      parent_.dispatcher().deferredDelete(std::move(iter->second));
+      connections_by_context_.erase(iter);
+    }
+  }
+  is_deleting_ = was_deleting;
+}
+
+namespace {
+// Structure used to allow a unique_ptr to be captured in a posted lambda. See below.
+struct RebalancedSocket {
+  Network::ConnectionSocketPtr socket;
+};
+using RebalancedSocketSharedPtr = std::shared_ptr<RebalancedSocket>;
+} // namespace
+
+void ActiveTcpListener::post(Network::ConnectionSocketPtr&& socket) {
+  // It is not possible to capture a unique_ptr because the post() API copies the lambda, so we must
+  // bundle the socket inside a shared_ptr that can be captured.
+  // TODO(mattklein123): It may be possible to change the post() API such that the lambda is only
+  // moved, but this is non-trivial and needs investigation.
+  RebalancedSocketSharedPtr socket_to_rebalance = std::make_shared<RebalancedSocket>();
+  socket_to_rebalance->socket = std::move(socket);
+
+  parent_.dispatcher().post([socket_to_rebalance, tag = config_->listenerTag(), &parent = parent_,
+                             handoff = config_->handOffRestoredDestinationConnections()]() {
+    auto balanced_handler = parent.getBalancedHandlerByTag(tag);
+    if (balanced_handler.has_value()) {
+      balanced_handler->get().onAcceptWorker(std::move(socket_to_rebalance->socket), handoff, true);
+      return;
+    }
+  });
+}
+
+ActiveConnections::ActiveConnections(ActiveTcpListener& listener,
+                                     const Network::FilterChain& filter_chain)
+    : listener_(listener), filter_chain_(filter_chain) {}
+
+ActiveConnections::~ActiveConnections() {
+  // connections should be defer deleted already.
+  ASSERT(connections_.empty());
+}
+
+ActiveTcpConnection::ActiveTcpConnection(ActiveConnections& active_connections,
+                                         Network::ConnectionPtr&& new_connection,
+                                         TimeSource& time_source,
+                                         std::unique_ptr<StreamInfo::StreamInfo>&& stream_info)
+    : stream_info_(std::move(stream_info)), active_connections_(active_connections),
+      connection_(std::move(new_connection)),
+      conn_length_(new Stats::HistogramCompletableTimespanImpl(
+          active_connections_.listener_.stats_.downstream_cx_length_ms_, time_source)) {
+  // We just universally set no delay on connections. Theoretically we might at some point want
+  // to make this configurable.
+  connection_->noDelay(true);
+  auto& listener = active_connections_.listener_;
+  listener.stats_.downstream_cx_total_.inc();
+  listener.stats_.downstream_cx_active_.inc();
+  listener.per_worker_stats_.downstream_cx_total_.inc();
+  listener.per_worker_stats_.downstream_cx_active_.inc();
+  stream_info_->setConnectionID(connection_->id());
+
+  // Active connections on the handler (not listener). The per listener connections have already
+  // been incremented at this point either via the connection balancer or in the socket accept
+  // path if there is no configured balancer.
+  listener.parent_.incNumConnections();
+}
+
+ActiveTcpConnection::~ActiveTcpConnection() {
+  emitLogs(*active_connections_.listener_.config_, *stream_info_);
+  auto& listener = active_connections_.listener_;
+  listener.stats_.downstream_cx_active_.dec();
+  listener.stats_.downstream_cx_destroy_.inc();
+  listener.per_worker_stats_.downstream_cx_active_.dec();
+  conn_length_->complete();
+
+  // Active listener connections (not handler).
+  listener.decNumConnections();
+
+  // Active handler connections (not listener).
+  listener.parent_.decNumConnections();
+}
+} // namespace Server
+} // namespace Envoy

--- a/source/server/active_stream_listener.h
+++ b/source/server/active_stream_listener.h
@@ -229,6 +229,7 @@ struct ActiveTcpSocket : public Network::ListenerFilterManager,
   const envoy::config::core::v3::Metadata& dynamicMetadata() const override {
     return stream_info_->dynamicMetadata();
   };
+  StreamInfo::FilterState& filterState() override { return *stream_info_->filterState().get(); }
 
   ActiveTcpListener& listener_;
   Network::ConnectionSocketPtr socket_;

--- a/source/server/active_stream_listener.h
+++ b/source/server/active_stream_listener.h
@@ -1,0 +1,244 @@
+#pragma once
+#include "envoy/stats/timespan.h"
+
+#include "server/connection_handler_impl.h"
+
+namespace Envoy {
+namespace Server {
+
+struct ActiveTcpConnection;
+using ActiveTcpConnectionPtr = std::unique_ptr<ActiveTcpConnection>;
+struct ActiveTcpSocket;
+using ActiveTcpSocketPtr = std::unique_ptr<ActiveTcpSocket>;
+class ActiveConnections;
+using ActiveConnectionsPtr = std::unique_ptr<ActiveConnections>;
+
+/**
+ * Wrapper for an active tcp listener owned by this handler.
+ */
+class ActiveTcpListener : public Network::TcpListenerCallbacks,
+                          public ActiveListenerImplBase,
+                          public Network::BalancedConnectionHandler,
+                          Logger::Loggable<Logger::Id::conn_handler> {
+public:
+  ActiveTcpListener(Network::TcpConnectionHandler& parent, Network::ListenerConfig& config);
+  ActiveTcpListener(Network::TcpConnectionHandler& parent, Network::ListenerPtr&& listener,
+                    Network::ListenerConfig& config);
+  ~ActiveTcpListener() override;
+  bool listenerConnectionLimitReached() const {
+    // TODO(tonya11en): Delegate enforcement of per-listener connection limits to overload
+    // manager.
+    return !config_->openConnections().canCreate();
+  }
+
+  void decNumConnections() {
+    ASSERT(num_listener_connections_ > 0);
+    --num_listener_connections_;
+    config_->openConnections().dec();
+  }
+
+  // Network::TcpListenerCallbacks
+  void onAccept(Network::ConnectionSocketPtr&& socket) override;
+  void onReject(RejectCause) override;
+
+  // ActiveListenerImplBase
+  Network::Listener* listener() override { return listener_.get(); }
+  void pauseListening() override;
+  void resumeListening() override;
+  void shutdownListener() override { listener_.reset(); }
+
+  // Network::BalancedConnectionHandler
+  uint64_t numConnections() const override { return num_listener_connections_; }
+  void incNumConnections() override {
+    ++num_listener_connections_;
+    config_->openConnections().inc();
+  }
+  void post(Network::ConnectionSocketPtr&& socket) override;
+  void onAcceptWorker(Network::ConnectionSocketPtr&& socket,
+                      bool hand_off_restored_destination_connections, bool rebalanced) override;
+
+  /**
+   * Remove and destroy an active connection.
+   * @param connection supplies the connection to remove.
+   */
+  void removeConnection(ActiveTcpConnection& connection);
+
+  /**
+   * Create a new connection from a socket accepted by the listener.
+   */
+  void newConnection(Network::ConnectionSocketPtr&& socket,
+                     std::unique_ptr<StreamInfo::StreamInfo> stream_info);
+
+  /**
+   * Return the active connections container attached with the given filter chain.
+   */
+  ActiveConnections& getOrCreateActiveConnections(const Network::FilterChain& filter_chain);
+
+  /**
+   * Schedule to remove and destroy the active connections which are not tracked by listener
+   * config. Caution: The connection are not destroyed yet when function returns.
+   */
+  void
+  deferredRemoveFilterChains(const std::list<const Network::FilterChain*>& draining_filter_chains);
+
+  /**
+   * Update the listener config. The follow up connections will see the new config. The existing
+   * connections are not impacted.
+   */
+  void updateListenerConfig(Network::ListenerConfig& config);
+
+  Network::TcpConnectionHandler& parent_;
+  Network::ListenerPtr listener_;
+  const std::chrono::milliseconds listener_filters_timeout_;
+  const bool continue_on_listener_filters_timeout_;
+  std::list<ActiveTcpSocketPtr> sockets_;
+  absl::node_hash_map<const Network::FilterChain*, ActiveConnectionsPtr> connections_by_context_;
+
+  // The number of connections currently active on this listener. This is typically used for
+  // connection balancing across per-handler listeners.
+  std::atomic<uint64_t> num_listener_connections_{};
+  bool is_deleting_{false};
+};
+
+/**
+ * Wrapper for a group of active connections which are attached to the same filter chain context.
+ */
+class ActiveConnections : public Event::DeferredDeletable {
+public:
+  ActiveConnections(ActiveTcpListener& listener, const Network::FilterChain& filter_chain);
+  ~ActiveConnections() override;
+
+  // listener filter chain pair is the owner of the connections
+  ActiveTcpListener& listener_;
+  const Network::FilterChain& filter_chain_;
+  // Owned connections
+  std::list<ActiveTcpConnectionPtr> connections_;
+};
+
+/**
+ * Wrapper for an active TCP connection owned by this handler.
+ */
+struct ActiveTcpConnection : LinkedObject<ActiveTcpConnection>,
+                             public Event::DeferredDeletable,
+                             public Network::ConnectionCallbacks {
+  ActiveTcpConnection(ActiveConnections& active_connections,
+                      Network::ConnectionPtr&& new_connection, TimeSource& time_system,
+                      std::unique_ptr<StreamInfo::StreamInfo>&& stream_info);
+  ~ActiveTcpConnection() override;
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override {
+    // Any event leads to destruction of the connection.
+    if (event == Network::ConnectionEvent::LocalClose ||
+        event == Network::ConnectionEvent::RemoteClose) {
+      active_connections_.listener_.removeConnection(*this);
+    }
+  }
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+  std::unique_ptr<StreamInfo::StreamInfo> stream_info_;
+  ActiveConnections& active_connections_;
+  Network::ConnectionPtr connection_;
+  Stats::TimespanPtr conn_length_;
+};
+
+/**
+ * Wrapper for an active accepted TCP socket owned by this handler.
+ */
+struct ActiveTcpSocket : public Network::ListenerFilterManager,
+                         public Network::ListenerFilterCallbacks,
+                         LinkedObject<ActiveTcpSocket>,
+                         public Event::DeferredDeletable,
+                         Logger::Loggable<Logger::Id::conn_handler> {
+  ActiveTcpSocket(ActiveTcpListener& listener, Network::ConnectionSocketPtr&& socket,
+                  bool hand_off_restored_destination_connections)
+      : listener_(listener), socket_(std::move(socket)),
+        hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
+        iter_(accept_filters_.end()),
+        stream_info_(std::make_unique<StreamInfo::StreamInfoImpl>(
+            listener_.parent_.dispatcher().timeSource(), socket_->addressProviderSharedPtr(),
+            StreamInfo::FilterState::LifeSpan::Connection)) {
+    listener_.stats_.downstream_pre_cx_active_.inc();
+  }
+  ~ActiveTcpSocket() override {
+    accept_filters_.clear();
+    listener_.stats_.downstream_pre_cx_active_.dec();
+
+    // If the underlying socket is no longer attached, it means that it has been transferred to
+    // an active connection. In this case, the active connection will decrement the number
+    // of listener connections.
+    // TODO(mattklein123): In general the way we account for the number of listener connections
+    // is incredibly fragile. Revisit this by potentially merging ActiveTcpSocket and
+    // ActiveTcpConnection, having a shared object which does accounting (but would require
+    // another allocation, etc.).
+    if (socket_ != nullptr) {
+      listener_.decNumConnections();
+    }
+  }
+
+  void onTimeout();
+  void startTimer();
+  void unlink();
+  void newConnection();
+
+  class GenericListenerFilter : public Network::ListenerFilter {
+  public:
+    GenericListenerFilter(const Network::ListenerFilterMatcherSharedPtr& matcher,
+                          Network::ListenerFilterPtr listener_filter)
+        : listener_filter_(std::move(listener_filter)), matcher_(std::move(matcher)) {}
+    Network::FilterStatus onAccept(ListenerFilterCallbacks& cb) override {
+      if (isDisabled(cb)) {
+        return Network::FilterStatus::Continue;
+      }
+      return listener_filter_->onAccept(cb);
+    }
+    /**
+     * Check if this filter filter should be disabled on the incoming socket.
+     * @param cb the callbacks the filter instance can use to communicate with the filter chain.
+     **/
+    bool isDisabled(ListenerFilterCallbacks& cb) {
+      if (matcher_ == nullptr) {
+        return false;
+      } else {
+        return matcher_->matches(cb);
+      }
+    }
+
+  private:
+    const Network::ListenerFilterPtr listener_filter_;
+    const Network::ListenerFilterMatcherSharedPtr matcher_;
+  };
+  using ListenerFilterWrapperPtr = std::unique_ptr<GenericListenerFilter>;
+
+  // Network::ListenerFilterManager
+  void addAcceptFilter(const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,
+                       Network::ListenerFilterPtr&& filter) override {
+    accept_filters_.emplace_back(
+        std::make_unique<GenericListenerFilter>(listener_filter_matcher, std::move(filter)));
+  }
+
+  // Network::ListenerFilterCallbacks
+  Network::ConnectionSocket& socket() override { return *socket_.get(); }
+  Event::Dispatcher& dispatcher() override { return listener_.parent_.dispatcher(); }
+  void continueFilterChain(bool success) override;
+  void setDynamicMetadata(const std::string& name, const ProtobufWkt::Struct& value) override;
+  envoy::config::core::v3::Metadata& dynamicMetadata() override {
+    return stream_info_->dynamicMetadata();
+  };
+  const envoy::config::core::v3::Metadata& dynamicMetadata() const override {
+    return stream_info_->dynamicMetadata();
+  };
+
+  ActiveTcpListener& listener_;
+  Network::ConnectionSocketPtr socket_;
+  const bool hand_off_restored_destination_connections_;
+  std::list<ListenerFilterWrapperPtr> accept_filters_;
+  std::list<ListenerFilterWrapperPtr>::iterator iter_;
+  Event::TimerPtr timer_;
+  std::unique_ptr<StreamInfo::StreamInfo> stream_info_;
+  bool connected_{false};
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/active_udp_listener.cc
+++ b/source/server/active_udp_listener.cc
@@ -1,0 +1,132 @@
+#include "server/active_udp_listener.h"
+
+#include "envoy/network/exception.h"
+
+#include "server/connection_handler_impl.h"
+
+namespace Envoy {
+namespace Server {
+ActiveUdpListenerBase::ActiveUdpListenerBase(uint32_t worker_index, uint32_t concurrency,
+                                             Network::UdpConnectionHandler& parent,
+                                             Network::Socket& listen_socket,
+                                             Network::UdpListenerPtr&& listener,
+                                             Network::ListenerConfig* config)
+    : ActiveListenerImplBase(parent, config), worker_index_(worker_index),
+      concurrency_(concurrency), parent_(parent), listen_socket_(listen_socket),
+      udp_listener_(std::move(listener)) {
+  ASSERT(worker_index_ < concurrency_);
+  config_->udpListenerWorkerRouter()->get().registerWorkerForListener(*this);
+}
+
+ActiveUdpListenerBase::~ActiveUdpListenerBase() {
+  config_->udpListenerWorkerRouter()->get().unregisterWorkerForListener(*this);
+}
+
+void ActiveUdpListenerBase::post(Network::UdpRecvData&& data) {
+  ASSERT(!udp_listener_->dispatcher().isThreadSafe(),
+         "Shouldn't be posting if thread safe; use onWorkerData() instead.");
+
+  // It is not possible to capture a unique_ptr because the post() API copies the lambda, so we must
+  // bundle the socket inside a shared_ptr that can be captured.
+  // TODO(mattklein123): It may be possible to change the post() API such that the lambda is only
+  // moved, but this is non-trivial and needs investigation.
+  auto data_to_post = std::make_shared<Network::UdpRecvData>();
+  *data_to_post = std::move(data);
+
+  udp_listener_->dispatcher().post(
+      [data_to_post, tag = config_->listenerTag(), &parent = parent_]() {
+        Network::UdpListenerCallbacksOptRef listener = parent.getUdpListenerCallbacks(tag);
+        if (listener.has_value()) {
+          listener->get().onDataWorker(std::move(*data_to_post));
+        }
+      });
+}
+
+void ActiveUdpListenerBase::onData(Network::UdpRecvData&& data) {
+  uint32_t dest = worker_index_;
+
+  // For concurrency == 1, the packet will always go to the current worker.
+  if (concurrency_ > 1) {
+    dest = destination(data);
+    ASSERT(dest < concurrency_);
+  }
+
+  if (dest == worker_index_) {
+    onDataWorker(std::move(data));
+  } else {
+    config_->udpListenerWorkerRouter()->get().deliver(dest, std::move(data));
+  }
+}
+
+ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                                           Network::UdpConnectionHandler& parent,
+                                           Event::Dispatcher& dispatcher,
+                                           Network::ListenerConfig& config)
+    : ActiveRawUdpListener(worker_index, concurrency, parent,
+                           config.listenSocketFactory().getListenSocket(), dispatcher, config) {}
+
+ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                                           Network::UdpConnectionHandler& parent,
+                                           Network::SocketSharedPtr listen_socket_ptr,
+                                           Event::Dispatcher& dispatcher,
+                                           Network::ListenerConfig& config)
+    : ActiveRawUdpListener(worker_index, concurrency, parent, *listen_socket_ptr, listen_socket_ptr,
+                           dispatcher, config) {}
+
+ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                                           Network::UdpConnectionHandler& parent,
+                                           Network::Socket& listen_socket,
+                                           Network::SocketSharedPtr listen_socket_ptr,
+                                           Event::Dispatcher& dispatcher,
+                                           Network::ListenerConfig& config)
+    : ActiveRawUdpListener(worker_index, concurrency, parent, listen_socket,
+                           dispatcher.createUdpListener(listen_socket_ptr, *this), config) {}
+
+ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                                           Network::UdpConnectionHandler& parent,
+                                           Network::Socket& listen_socket,
+                                           Network::UdpListenerPtr&& listener,
+                                           Network::ListenerConfig& config)
+    : ActiveUdpListenerBase(worker_index, concurrency, parent, listen_socket, std::move(listener),
+                            &config),
+      read_filter_(nullptr) {
+  // Create the filter chain on creating a new udp listener
+  config_->filterChainFactory().createUdpListenerFilterChain(*this, *this);
+
+  // If filter is nullptr, fail the creation of the listener
+  if (read_filter_ == nullptr) {
+    throw Network::CreateListenerException(
+        fmt::format("Cannot create listener as no read filter registered for the udp listener: {} ",
+                    config_->name()));
+  }
+
+  // Create udp_packet_writer
+  udp_packet_writer_ = config.udpPacketWriterFactory()->get().createUdpPacketWriter(
+      listen_socket_.ioHandle(), config.listenerScope());
+}
+
+void ActiveRawUdpListener::onDataWorker(Network::UdpRecvData&& data) { read_filter_->onData(data); }
+
+void ActiveRawUdpListener::onReadReady() {}
+
+void ActiveRawUdpListener::onWriteReady(const Network::Socket&) {
+  // TODO(sumukhs): This is not used now. When write filters are implemented, this is a
+  // trigger to invoke the on write ready API on the filters which is when they can write
+  // data.
+
+  // Clear write_blocked_ status for udpPacketWriter.
+  udp_packet_writer_->setWritable();
+}
+
+void ActiveRawUdpListener::onReceiveError(Api::IoError::IoErrorCode error_code) {
+  read_filter_->onReceiveError(error_code);
+}
+
+void ActiveRawUdpListener::addReadFilter(Network::UdpListenerReadFilterPtr&& filter) {
+  ASSERT(read_filter_ == nullptr, "Cannot add a 2nd UDP read filter");
+  read_filter_ = std::move(filter);
+}
+
+Network::UdpListener& ActiveRawUdpListener::udpListener() { return *udp_listener_; }
+} // namespace Server
+} // namespace Envoy

--- a/source/server/active_udp_listener.h
+++ b/source/server/active_udp_listener.h
@@ -1,0 +1,91 @@
+#pragma once
+#include "server/connection_handler_impl.h"
+
+namespace Envoy {
+namespace Server {
+
+class ActiveUdpListenerBase : public ActiveListenerImplBase,
+                              public Network::ConnectionHandler::ActiveUdpListener {
+public:
+  ActiveUdpListenerBase(uint32_t worker_index, uint32_t concurrency,
+                        Network::UdpConnectionHandler& parent, Network::Socket& listen_socket,
+                        Network::UdpListenerPtr&& listener, Network::ListenerConfig* config);
+  ~ActiveUdpListenerBase() override;
+
+  // Network::UdpListenerCallbacks
+  void onData(Network::UdpRecvData&& data) final;
+  uint32_t workerIndex() const final { return worker_index_; }
+  void post(Network::UdpRecvData&& data) final;
+
+  // ActiveListenerImplBase
+  Network::Listener* listener() override { return udp_listener_.get(); }
+
+protected:
+  uint32_t destination(const Network::UdpRecvData& /*data*/) const override {
+    // By default, route to the current worker.
+    return worker_index_;
+  }
+
+  const uint32_t worker_index_;
+  const uint32_t concurrency_;
+  Network::UdpConnectionHandler& parent_;
+  Network::Socket& listen_socket_;
+  Network::UdpListenerPtr udp_listener_;
+};
+
+/**
+ * Wrapper for an active udp listener owned by this handler.
+ */
+class ActiveRawUdpListener : public ActiveUdpListenerBase,
+                             public Network::UdpListenerFilterManager,
+                             public Network::UdpReadFilterCallbacks {
+public:
+  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                       Network::UdpConnectionHandler& parent, Event::Dispatcher& dispatcher,
+                       Network::ListenerConfig& config);
+  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                       Network::UdpConnectionHandler& parent,
+                       Network::SocketSharedPtr listen_socket_ptr, Event::Dispatcher& dispatcher,
+                       Network::ListenerConfig& config);
+  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                       Network::UdpConnectionHandler& parent, Network::Socket& listen_socket,
+                       Network::SocketSharedPtr listen_socket_ptr, Event::Dispatcher& dispatcher,
+                       Network::ListenerConfig& config);
+  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
+                       Network::UdpConnectionHandler& parent, Network::Socket& listen_socket,
+                       Network::UdpListenerPtr&& listener, Network::ListenerConfig& config);
+
+  // Network::UdpListenerCallbacks
+  void onReadReady() override;
+  void onWriteReady(const Network::Socket& socket) override;
+  void onReceiveError(Api::IoError::IoErrorCode error_code) override;
+  Network::UdpPacketWriter& udpPacketWriter() override { return *udp_packet_writer_; }
+
+  // Network::UdpWorker
+  void onDataWorker(Network::UdpRecvData&& data) override;
+
+  // ActiveListenerImplBase
+  void pauseListening() override { udp_listener_->disable(); }
+  void resumeListening() override { udp_listener_->enable(); }
+  void shutdownListener() override {
+    // The read filter should be deleted before the UDP listener is deleted.
+    // The read filter refers to the UDP listener to send packets to downstream.
+    // If the UDP listener is deleted before the read filter, the read filter may try to use it
+    // after deletion.
+    read_filter_.reset();
+    udp_listener_.reset();
+  }
+
+  // Network::UdpListenerFilterManager
+  void addReadFilter(Network::UdpListenerReadFilterPtr&& filter) override;
+
+  // Network::UdpReadFilterCallbacks
+  Network::UdpListener& udpListener() override;
+
+private:
+  Network::UdpListenerReadFilterPtr read_filter_;
+  Network::UdpPacketWriterPtr udp_packet_writer_;
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/source/server/connection_handler_impl.cc
+++ b/source/server/connection_handler_impl.cc
@@ -7,26 +7,18 @@
 #include "envoy/network/exception.h"
 #include "envoy/network/filter.h"
 #include "envoy/stats/scope.h"
-#include "envoy/stats/timespan.h"
 
 #include "common/event/deferred_task.h"
 #include "common/network/connection_impl.h"
 #include "common/network/utility.h"
-#include "common/stats/timespan_impl.h"
+
+#include "server/active_stream_listener.h"
+#include "server/active_udp_listener.h"
 
 #include "extensions/transport_sockets/well_known_names.h"
 
 namespace Envoy {
 namespace Server {
-
-namespace {
-void emitLogs(Network::ListenerConfig& config, StreamInfo::StreamInfo& stream_info) {
-  stream_info.onRequestComplete();
-  for (const auto& access_log : config.accessLogs()) {
-    access_log->log(nullptr, nullptr, nullptr, stream_info);
-  }
-}
-} // namespace
 
 ConnectionHandlerImpl::ConnectionHandlerImpl(Event::Dispatcher& dispatcher,
                                              absl::optional<uint32_t> worker_index)
@@ -82,20 +74,6 @@ void ConnectionHandlerImpl::removeListeners(uint64_t listener_tag) {
       ++listener;
     }
   }
-}
-
-ConnectionHandlerImpl::ActiveListenerDetailsOptRef
-ConnectionHandlerImpl::findActiveListenerByTag(uint64_t listener_tag) {
-  // TODO(mattklein123): We should probably use a hash table here to lookup the tag
-  // instead of iterating through the listener list.
-  for (auto& listener : listeners_) {
-    if (listener.second.listener_->listener() != nullptr &&
-        listener.second.listener_->listenerTag() == listener_tag) {
-      return listener.second;
-    }
-  }
-
-  return absl::nullopt;
 }
 
 Network::UdpListenerCallbacksOptRef
@@ -160,465 +138,6 @@ void ConnectionHandlerImpl::setListenerRejectFraction(UnitFloat reject_fraction)
   }
 }
 
-void ConnectionHandlerImpl::ActiveTcpListener::removeConnection(ActiveTcpConnection& connection) {
-  ENVOY_CONN_LOG(debug, "adding to cleanup list", *connection.connection_);
-  ActiveConnections& active_connections = connection.active_connections_;
-  ActiveTcpConnectionPtr removed = connection.removeFromList(active_connections.connections_);
-  parent_.dispatcher_.deferredDelete(std::move(removed));
-  // Delete map entry only iff connections becomes empty.
-  if (active_connections.connections_.empty()) {
-    auto iter = connections_by_context_.find(&active_connections.filter_chain_);
-    ASSERT(iter != connections_by_context_.end());
-    // To cover the lifetime of every single connection, Connections need to be deferred deleted
-    // because the previously contained connection is deferred deleted.
-    parent_.dispatcher_.deferredDelete(std::move(iter->second));
-    // The erase will break the iteration over the connections_by_context_ during the deletion.
-    if (!is_deleting_) {
-      connections_by_context_.erase(iter);
-    }
-  }
-}
-
-ConnectionHandlerImpl::ActiveListenerImplBase::ActiveListenerImplBase(
-    Network::ConnectionHandler& parent, Network::ListenerConfig* config)
-    : stats_({ALL_LISTENER_STATS(POOL_COUNTER(config->listenerScope()),
-                                 POOL_GAUGE(config->listenerScope()),
-                                 POOL_HISTOGRAM(config->listenerScope()))}),
-      per_worker_stats_({ALL_PER_HANDLER_LISTENER_STATS(
-          POOL_COUNTER_PREFIX(config->listenerScope(), parent.statPrefix()),
-          POOL_GAUGE_PREFIX(config->listenerScope(), parent.statPrefix()))}),
-      config_(config) {}
-
-ConnectionHandlerImpl::ActiveTcpListener::ActiveTcpListener(ConnectionHandlerImpl& parent,
-                                                            Network::ListenerConfig& config)
-    : ActiveTcpListener(
-          parent,
-          parent.dispatcher_.createListener(config.listenSocketFactory().getListenSocket(), *this,
-                                            config.bindToPort(), config.tcpBacklogSize()),
-          config) {}
-
-ConnectionHandlerImpl::ActiveTcpListener::ActiveTcpListener(ConnectionHandlerImpl& parent,
-                                                            Network::ListenerPtr&& listener,
-                                                            Network::ListenerConfig& config)
-    : ConnectionHandlerImpl::ActiveListenerImplBase(parent, &config), parent_(parent),
-      listener_(std::move(listener)), listener_filters_timeout_(config.listenerFiltersTimeout()),
-      continue_on_listener_filters_timeout_(config.continueOnListenerFiltersTimeout()) {
-  config.connectionBalancer().registerHandler(*this);
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::updateListenerConfig(
-    Network::ListenerConfig& config) {
-  ENVOY_LOG(trace, "replacing listener ", config_->listenerTag(), " by ", config.listenerTag());
-  ASSERT(&config_->connectionBalancer() == &config.connectionBalancer());
-  config_ = &config;
-}
-
-ConnectionHandlerImpl::ActiveTcpListener::~ActiveTcpListener() {
-  is_deleting_ = true;
-  config_->connectionBalancer().unregisterHandler(*this);
-
-  // Purge sockets that have not progressed to connections. This should only happen when
-  // a listener filter stops iteration and never resumes.
-  while (!sockets_.empty()) {
-    ActiveTcpSocketPtr removed = sockets_.front()->removeFromList(sockets_);
-    parent_.dispatcher_.deferredDelete(std::move(removed));
-  }
-
-  for (auto& chain_and_connections : connections_by_context_) {
-    ASSERT(chain_and_connections.second != nullptr);
-    auto& connections = chain_and_connections.second->connections_;
-    while (!connections.empty()) {
-      connections.front()->connection_->close(Network::ConnectionCloseType::NoFlush);
-    }
-  }
-  parent_.dispatcher_.clearDeferredDeleteList();
-
-  // By the time a listener is destroyed, in the common case, there should be no connections.
-  // However, this is not always true if there is an in flight rebalanced connection that is
-  // being posted. This assert is extremely useful for debugging the common path so we will leave it
-  // for now. If it becomes a problem (developers hitting this assert when using debug builds) we
-  // can revisit. This case, if it happens, should be benign on production builds. This case is
-  // covered in ConnectionHandlerTest::RemoveListenerDuringRebalance.
-  ASSERT(num_listener_connections_ == 0);
-}
-
-ConnectionHandlerImpl::ActiveTcpListenerOptRef
-ConnectionHandlerImpl::findActiveTcpListenerByAddress(const Network::Address::Instance& address) {
-  // This is a linear operation, may need to add a map<address, listener> to improve performance.
-  // However, linear performance might be adequate since the number of listeners is small.
-  // We do not return stopped listeners.
-  auto listener_it = std::find_if(
-      listeners_.begin(), listeners_.end(),
-      [&address](std::pair<Network::Address::InstanceConstSharedPtr, ActiveListenerDetails>& p) {
-        return p.second.tcpListener().has_value() && p.second.listener_->listener() != nullptr &&
-               p.first->type() == Network::Address::Type::Ip && *(p.first) == address;
-      });
-
-  // If there is exact address match, return the corresponding listener.
-  if (listener_it != listeners_.end()) {
-    return listener_it->second.tcpListener();
-  }
-
-  // Otherwise, we need to look for the wild card match, i.e., 0.0.0.0:[address_port].
-  // We do not return stopped listeners.
-  // TODO(wattli): consolidate with previous search for more efficiency.
-  listener_it = std::find_if(
-      listeners_.begin(), listeners_.end(),
-      [&address](
-          const std::pair<Network::Address::InstanceConstSharedPtr, ActiveListenerDetails>& p) {
-        return absl::holds_alternative<std::reference_wrapper<ActiveTcpListener>>(
-                   p.second.typed_listener_) &&
-               p.second.listener_->listener() != nullptr &&
-               p.first->type() == Network::Address::Type::Ip &&
-               p.first->ip()->port() == address.ip()->port() && p.first->ip()->isAnyAddress();
-      });
-  return (listener_it != listeners_.end())
-             ? ActiveTcpListenerOptRef(absl::get<std::reference_wrapper<ActiveTcpListener>>(
-                   listener_it->second.typed_listener_))
-             : absl::nullopt;
-}
-
-void ConnectionHandlerImpl::ActiveTcpSocket::onTimeout() {
-  listener_.stats_.downstream_pre_cx_timeout_.inc();
-  ASSERT(inserted());
-  ENVOY_LOG(debug, "listener filter times out after {} ms",
-            listener_.listener_filters_timeout_.count());
-
-  if (listener_.continue_on_listener_filters_timeout_) {
-    ENVOY_LOG(debug, "fallback to default listener filter");
-    newConnection();
-  }
-  unlink();
-}
-
-void ConnectionHandlerImpl::ActiveTcpSocket::startTimer() {
-  if (listener_.listener_filters_timeout_.count() > 0) {
-    timer_ = listener_.parent_.dispatcher_.createTimer([this]() -> void { onTimeout(); });
-    timer_->enableTimer(listener_.listener_filters_timeout_);
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpSocket::unlink() {
-  ActiveTcpSocketPtr removed = removeFromList(listener_.sockets_);
-  if (removed->timer_ != nullptr) {
-    removed->timer_->disableTimer();
-  }
-  // Emit logs if a connection is not established.
-  if (!connected_) {
-    emitLogs(*listener_.config_, *stream_info_);
-  }
-  listener_.parent_.dispatcher_.deferredDelete(std::move(removed));
-}
-
-void ConnectionHandlerImpl::ActiveTcpSocket::continueFilterChain(bool success) {
-  if (success) {
-    bool no_error = true;
-    if (iter_ == accept_filters_.end()) {
-      iter_ = accept_filters_.begin();
-    } else {
-      iter_ = std::next(iter_);
-    }
-
-    for (; iter_ != accept_filters_.end(); iter_++) {
-      Network::FilterStatus status = (*iter_)->onAccept(*this);
-      if (status == Network::FilterStatus::StopIteration) {
-        // The filter is responsible for calling us again at a later time to continue the filter
-        // chain from the next filter.
-        if (!socket().ioHandle().isOpen()) {
-          // break the loop but should not create new connection
-          no_error = false;
-          break;
-        } else {
-          // Blocking at the filter but no error
-          return;
-        }
-      }
-    }
-    // Successfully ran all the accept filters.
-    if (no_error) {
-      newConnection();
-    } else {
-      // Signal the caller that no extra filter chain iteration is needed.
-      iter_ = accept_filters_.end();
-    }
-  }
-
-  // Filter execution concluded, unlink and delete this ActiveTcpSocket if it was linked.
-  if (inserted()) {
-    unlink();
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpSocket::setDynamicMetadata(const std::string& name,
-                                                                const ProtobufWkt::Struct& value) {
-  stream_info_->setDynamicMetadata(name, value);
-}
-
-void ConnectionHandlerImpl::ActiveTcpSocket::newConnection() {
-  connected_ = true;
-
-  // Check if the socket may need to be redirected to another listener.
-  ActiveTcpListenerOptRef new_listener;
-
-  if (hand_off_restored_destination_connections_ &&
-      socket_->addressProvider().localAddressRestored()) {
-    // Find a listener associated with the original destination address.
-    new_listener = listener_.parent_.findActiveTcpListenerByAddress(
-        *socket_->addressProvider().localAddress());
-  }
-  if (new_listener.has_value()) {
-    // Hands off connections redirected by iptables to the listener associated with the
-    // original destination address. Pass 'hand_off_restored_destination_connections' as false to
-    // prevent further redirection as well as 'rebalanced' as true since the connection has
-    // already been balanced if applicable inside onAcceptWorker() when the connection was
-    // initially accepted. Note also that we must account for the number of connections properly
-    // across both listeners.
-    // TODO(mattklein123): See note in ~ActiveTcpSocket() related to making this accounting better.
-    listener_.decNumConnections();
-    new_listener.value().get().incNumConnections();
-    new_listener.value().get().onAcceptWorker(std::move(socket_), false, true);
-  } else {
-    // Set default transport protocol if none of the listener filters did it.
-    if (socket_->detectedTransportProtocol().empty()) {
-      socket_->setDetectedTransportProtocol(
-          Extensions::TransportSockets::TransportProtocolNames::get().RawBuffer);
-    }
-    // TODO(lambdai): add integration test
-    // TODO: Address issues in wider scope. See https://github.com/envoyproxy/envoy/issues/8925
-    // Erase accept filter states because accept filters may not get the opportunity to clean up.
-    // Particularly the assigned events need to reset before assigning new events in the follow up.
-    accept_filters_.clear();
-    // Create a new connection on this listener.
-    listener_.newConnection(std::move(socket_), std::move(stream_info_));
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::onAccept(Network::ConnectionSocketPtr&& socket) {
-  if (listenerConnectionLimitReached()) {
-    ENVOY_LOG(trace, "closing connection: listener connection limit reached for {}",
-              config_->name());
-    socket->close();
-    stats_.downstream_cx_overflow_.inc();
-    return;
-  }
-
-  onAcceptWorker(std::move(socket), config_->handOffRestoredDestinationConnections(), false);
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::onReject(RejectCause cause) {
-  switch (cause) {
-  case RejectCause::GlobalCxLimit:
-    stats_.downstream_global_cx_overflow_.inc();
-    break;
-  case RejectCause::OverloadAction:
-    stats_.downstream_cx_overload_reject_.inc();
-    break;
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::onAcceptWorker(
-    Network::ConnectionSocketPtr&& socket, bool hand_off_restored_destination_connections,
-    bool rebalanced) {
-  if (!rebalanced) {
-    Network::BalancedConnectionHandler& target_handler =
-        config_->connectionBalancer().pickTargetHandler(*this);
-    if (&target_handler != this) {
-      target_handler.post(std::move(socket));
-      return;
-    }
-  }
-
-  auto active_socket = std::make_unique<ActiveTcpSocket>(*this, std::move(socket),
-                                                         hand_off_restored_destination_connections);
-
-  // Create and run the filters
-  config_->filterChainFactory().createListenerFilterChain(*active_socket);
-  active_socket->continueFilterChain(true);
-
-  // Move active_socket to the sockets_ list if filter iteration needs to continue later.
-  // Otherwise we let active_socket be destructed when it goes out of scope.
-  if (active_socket->iter_ != active_socket->accept_filters_.end()) {
-    active_socket->startTimer();
-    LinkedList::moveIntoListBack(std::move(active_socket), sockets_);
-  } else {
-    // If active_socket is about to be destructed, emit logs if a connection is not created.
-    if (!active_socket->connected_) {
-      emitLogs(*config_, *active_socket->stream_info_);
-    }
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::pauseListening() {
-  if (listener_ != nullptr) {
-    listener_->disable();
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::resumeListening() {
-  if (listener_ != nullptr) {
-    listener_->enable();
-  }
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::newConnection(
-    Network::ConnectionSocketPtr&& socket, std::unique_ptr<StreamInfo::StreamInfo> stream_info) {
-
-  // Find matching filter chain.
-  const auto filter_chain = config_->filterChainManager().findFilterChain(*socket);
-  if (filter_chain == nullptr) {
-    ENVOY_LOG(debug, "closing connection: no matching filter chain found");
-    stats_.no_filter_chain_match_.inc();
-    stream_info->setResponseFlag(StreamInfo::ResponseFlag::NoRouteFound);
-    stream_info->setResponseCodeDetails(StreamInfo::ResponseCodeDetails::get().FilterChainNotFound);
-    emitLogs(*config_, *stream_info);
-    socket->close();
-    return;
-  }
-
-  stream_info->setFilterChainName(filter_chain->name());
-  auto transport_socket = filter_chain->transportSocketFactory().createTransportSocket(nullptr);
-  stream_info->setDownstreamSslConnection(transport_socket->ssl());
-  auto& active_connections = getOrCreateActiveConnections(*filter_chain);
-  auto server_conn_ptr = parent_.dispatcher_.createServerConnection(
-      std::move(socket), std::move(transport_socket), *stream_info);
-  if (const auto timeout = filter_chain->transportSocketConnectTimeout();
-      timeout != std::chrono::milliseconds::zero()) {
-    server_conn_ptr->setTransportSocketConnectTimeout(timeout);
-  }
-  ActiveTcpConnectionPtr active_connection(
-      new ActiveTcpConnection(active_connections, std::move(server_conn_ptr),
-                              parent_.dispatcher_.timeSource(), std::move(stream_info)));
-  active_connection->connection_->setBufferLimits(config_->perConnectionBufferLimitBytes());
-
-  const bool empty_filter_chain = !config_->filterChainFactory().createNetworkFilterChain(
-      *active_connection->connection_, filter_chain->networkFilterFactories());
-  if (empty_filter_chain) {
-    ENVOY_CONN_LOG(debug, "closing connection: no filters", *active_connection->connection_);
-    active_connection->connection_->close(Network::ConnectionCloseType::NoFlush);
-  }
-
-  // If the connection is already closed, we can just let this connection immediately die.
-  if (active_connection->connection_->state() != Network::Connection::State::Closed) {
-    ENVOY_CONN_LOG(debug, "new connection", *active_connection->connection_);
-    active_connection->connection_->addConnectionCallbacks(*active_connection);
-    LinkedList::moveIntoList(std::move(active_connection), active_connections.connections_);
-  }
-}
-
-ConnectionHandlerImpl::ActiveConnections&
-ConnectionHandlerImpl::ActiveTcpListener::getOrCreateActiveConnections(
-    const Network::FilterChain& filter_chain) {
-  ActiveConnectionsPtr& connections = connections_by_context_[&filter_chain];
-  if (connections == nullptr) {
-    connections = std::make_unique<ConnectionHandlerImpl::ActiveConnections>(*this, filter_chain);
-  }
-  return *connections;
-}
-
-void ConnectionHandlerImpl::ActiveTcpListener::deferredRemoveFilterChains(
-    const std::list<const Network::FilterChain*>& draining_filter_chains) {
-  // Need to recover the original deleting state.
-  const bool was_deleting = is_deleting_;
-  is_deleting_ = true;
-  for (const auto* filter_chain : draining_filter_chains) {
-    auto iter = connections_by_context_.find(filter_chain);
-    if (iter == connections_by_context_.end()) {
-      // It is possible when listener is stopping.
-    } else {
-      auto& connections = iter->second->connections_;
-      while (!connections.empty()) {
-        connections.front()->connection_->close(Network::ConnectionCloseType::NoFlush);
-      }
-      // Since is_deleting_ is on, we need to manually remove the map value and drive the iterator.
-      // Defer delete connection container to avoid race condition in destroying connection.
-      parent_.dispatcher_.deferredDelete(std::move(iter->second));
-      connections_by_context_.erase(iter);
-    }
-  }
-  is_deleting_ = was_deleting;
-}
-
-namespace {
-// Structure used to allow a unique_ptr to be captured in a posted lambda. See below.
-struct RebalancedSocket {
-  Network::ConnectionSocketPtr socket;
-};
-using RebalancedSocketSharedPtr = std::shared_ptr<RebalancedSocket>;
-} // namespace
-
-void ConnectionHandlerImpl::ActiveTcpListener::post(Network::ConnectionSocketPtr&& socket) {
-  // It is not possible to capture a unique_ptr because the post() API copies the lambda, so we must
-  // bundle the socket inside a shared_ptr that can be captured.
-  // TODO(mattklein123): It may be possible to change the post() API such that the lambda is only
-  // moved, but this is non-trivial and needs investigation.
-  RebalancedSocketSharedPtr socket_to_rebalance = std::make_shared<RebalancedSocket>();
-  socket_to_rebalance->socket = std::move(socket);
-
-  parent_.dispatcher_.post(
-      [socket_to_rebalance, tag = config_->listenerTag(), &parent = parent_]() {
-        auto listener = parent.findActiveListenerByTag(tag);
-        if (listener.has_value()) {
-          // If the tag matches this must be a TCP listener.
-          ASSERT(absl::holds_alternative<std::reference_wrapper<ActiveTcpListener>>(
-              listener->get().typed_listener_));
-          auto& tcp_listener =
-              absl::get<std::reference_wrapper<ActiveTcpListener>>(listener->get().typed_listener_)
-                  .get();
-          tcp_listener.onAcceptWorker(std::move(socket_to_rebalance->socket),
-                                      tcp_listener.config_->handOffRestoredDestinationConnections(),
-                                      true);
-          return;
-        }
-      });
-}
-
-ConnectionHandlerImpl::ActiveConnections::ActiveConnections(
-    ConnectionHandlerImpl::ActiveTcpListener& listener, const Network::FilterChain& filter_chain)
-    : listener_(listener), filter_chain_(filter_chain) {}
-
-ConnectionHandlerImpl::ActiveConnections::~ActiveConnections() {
-  // connections should be defer deleted already.
-  ASSERT(connections_.empty());
-}
-
-ConnectionHandlerImpl::ActiveTcpConnection::ActiveTcpConnection(
-    ActiveConnections& active_connections, Network::ConnectionPtr&& new_connection,
-    TimeSource& time_source, std::unique_ptr<StreamInfo::StreamInfo>&& stream_info)
-    : stream_info_(std::move(stream_info)), active_connections_(active_connections),
-      connection_(std::move(new_connection)),
-      conn_length_(new Stats::HistogramCompletableTimespanImpl(
-          active_connections_.listener_.stats_.downstream_cx_length_ms_, time_source)) {
-  // We just universally set no delay on connections. Theoretically we might at some point want
-  // to make this configurable.
-  connection_->noDelay(true);
-  auto& listener = active_connections_.listener_;
-  listener.stats_.downstream_cx_total_.inc();
-  listener.stats_.downstream_cx_active_.inc();
-  listener.per_worker_stats_.downstream_cx_total_.inc();
-  listener.per_worker_stats_.downstream_cx_active_.inc();
-  stream_info_->setConnectionID(connection_->id());
-
-  // Active connections on the handler (not listener). The per listener connections have already
-  // been incremented at this point either via the connection balancer or in the socket accept
-  // path if there is no configured balancer.
-  ++listener.parent_.num_handler_connections_;
-}
-
-ConnectionHandlerImpl::ActiveTcpConnection::~ActiveTcpConnection() {
-  emitLogs(*active_connections_.listener_.config_, *stream_info_);
-  auto& listener = active_connections_.listener_;
-  listener.stats_.downstream_cx_active_.dec();
-  listener.stats_.downstream_cx_destroy_.inc();
-  listener.per_worker_stats_.downstream_cx_active_.dec();
-  conn_length_->complete();
-
-  // Active listener connections (not handler).
-  listener.decNumConnections();
-
-  // Active handler connections (not listener).
-  listener.parent_.decNumConnections();
-}
-
 ConnectionHandlerImpl::ActiveTcpListenerOptRef
 ConnectionHandlerImpl::ActiveListenerDetails::tcpListener() {
   auto* val = absl::get_if<std::reference_wrapper<ActiveTcpListener>>(&typed_listener_);
@@ -631,128 +150,85 @@ ConnectionHandlerImpl::ActiveListenerDetails::udpListener() {
   return (val != nullptr) ? absl::make_optional(*val) : absl::nullopt;
 }
 
-ActiveUdpListenerBase::ActiveUdpListenerBase(uint32_t worker_index, uint32_t concurrency,
-                                             Network::ConnectionHandler& parent,
-                                             Network::Socket& listen_socket,
-                                             Network::UdpListenerPtr&& listener,
-                                             Network::ListenerConfig* config)
-    : ConnectionHandlerImpl::ActiveListenerImplBase(parent, config), worker_index_(worker_index),
-      concurrency_(concurrency), parent_(parent), listen_socket_(listen_socket),
-      udp_listener_(std::move(listener)) {
-  ASSERT(worker_index_ < concurrency_);
-  config_->udpListenerWorkerRouter()->get().registerWorkerForListener(*this);
-}
-
-ActiveUdpListenerBase::~ActiveUdpListenerBase() {
-  config_->udpListenerWorkerRouter()->get().unregisterWorkerForListener(*this);
-}
-
-void ActiveUdpListenerBase::post(Network::UdpRecvData&& data) {
-  ASSERT(!udp_listener_->dispatcher().isThreadSafe(),
-         "Shouldn't be post'ing if thread safe; use onWorkerData() instead.");
-
-  // It is not possible to capture a unique_ptr because the post() API copies the lambda, so we must
-  // bundle the socket inside a shared_ptr that can be captured.
-  // TODO(mattklein123): It may be possible to change the post() API such that the lambda is only
-  // moved, but this is non-trivial and needs investigation.
-  auto data_to_post = std::make_shared<Network::UdpRecvData>();
-  *data_to_post = std::move(data);
-
-  udp_listener_->dispatcher().post(
-      [data_to_post, tag = config_->listenerTag(), &parent = parent_]() {
-        Network::UdpListenerCallbacksOptRef listener = parent.getUdpListenerCallbacks(tag);
-        if (listener.has_value()) {
-          listener->get().onDataWorker(std::move(*data_to_post));
-        }
-      });
-}
-
-void ActiveUdpListenerBase::onData(Network::UdpRecvData&& data) {
-  uint32_t dest = worker_index_;
-
-  // For concurrency == 1, the packet will always go to the current worker.
-  if (concurrency_ > 1) {
-    dest = destination(data);
-    ASSERT(dest < concurrency_);
+ConnectionHandlerImpl::ActiveListenerDetailsOptRef
+ConnectionHandlerImpl::findActiveListenerByTag(uint64_t listener_tag) {
+  // TODO(mattklein123): We should probably use a hash table here to lookup the tag
+  // instead of iterating through the listener list.
+  for (auto& listener : listeners_) {
+    if (listener.second.listener_->listener() != nullptr &&
+        listener.second.listener_->listenerTag() == listener_tag) {
+      return listener.second;
+    }
   }
 
-  if (dest == worker_index_) {
-    onDataWorker(std::move(data));
-  } else {
-    config_->udpListenerWorkerRouter()->get().deliver(dest, std::move(data));
-  }
+  return absl::nullopt;
 }
 
-ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                                           Network::ConnectionHandler& parent,
-                                           Event::Dispatcher& dispatcher,
-                                           Network::ListenerConfig& config)
-    : ActiveRawUdpListener(worker_index, concurrency, parent,
-                           config.listenSocketFactory().getListenSocket(), dispatcher, config) {}
+Network::BalancedConnectionHandlerOptRef
+ConnectionHandlerImpl::getBalancedHandlerByTag(uint64_t listener_tag) {
+  auto active_listener = findActiveListenerByTag(listener_tag);
+  if (active_listener.has_value()) {
+    ASSERT(absl::holds_alternative<std::reference_wrapper<ActiveTcpListener>>(
+        active_listener->get().typed_listener_));
+    return Network::BalancedConnectionHandlerOptRef(
+        active_listener->get().tcpListener().value().get());
+  }
+  return absl::nullopt;
+}
 
-ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                                           Network::ConnectionHandler& parent,
-                                           Network::SocketSharedPtr listen_socket_ptr,
-                                           Event::Dispatcher& dispatcher,
-                                           Network::ListenerConfig& config)
-    : ActiveRawUdpListener(worker_index, concurrency, parent, *listen_socket_ptr, listen_socket_ptr,
-                           dispatcher, config) {}
+Network::BalancedConnectionHandlerOptRef
+ConnectionHandlerImpl::getBalancedHandlerByAddress(const Network::Address::Instance& address) {
+  // This is a linear operation, may need to add a map<address, listener> to improve performance.
+  // However, linear performance might be adequate since the number of listeners is small.
+  // We do not return stopped listeners.
+  auto listener_it =
+      std::find_if(listeners_.begin(), listeners_.end(),
+                   [&address](std::pair<Network::Address::InstanceConstSharedPtr,
+                                        ConnectionHandlerImpl::ActiveListenerDetails>& p) {
+                     return p.second.tcpListener().has_value() &&
+                            p.second.listener_->listener() != nullptr &&
+                            p.first->type() == Network::Address::Type::Ip && *(p.first) == address;
+                   });
 
-ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                                           Network::ConnectionHandler& parent,
-                                           Network::Socket& listen_socket,
-                                           Network::SocketSharedPtr listen_socket_ptr,
-                                           Event::Dispatcher& dispatcher,
-                                           Network::ListenerConfig& config)
-    : ActiveRawUdpListener(worker_index, concurrency, parent, listen_socket,
-                           dispatcher.createUdpListener(listen_socket_ptr, *this), config) {}
-
-ActiveRawUdpListener::ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                                           Network::ConnectionHandler& parent,
-                                           Network::Socket& listen_socket,
-                                           Network::UdpListenerPtr&& listener,
-                                           Network::ListenerConfig& config)
-    : ActiveUdpListenerBase(worker_index, concurrency, parent, listen_socket, std::move(listener),
-                            &config),
-      read_filter_(nullptr) {
-  // Create the filter chain on creating a new udp listener
-  config_->filterChainFactory().createUdpListenerFilterChain(*this, *this);
-
-  // If filter is nullptr, fail the creation of the listener
-  if (read_filter_ == nullptr) {
-    throw Network::CreateListenerException(
-        fmt::format("Cannot create listener as no read filter registered for the udp listener: {} ",
-                    config_->name()));
+  // If there is exact address match, return the corresponding listener.
+  if (listener_it != listeners_.end()) {
+    return Network::BalancedConnectionHandlerOptRef(
+        listener_it->second.tcpListener().value().get());
   }
 
-  // Create udp_packet_writer
-  udp_packet_writer_ = config.udpPacketWriterFactory()->get().createUdpPacketWriter(
-      listen_socket_.ioHandle(), config.listenerScope());
+  // Otherwise, we need to look for the wild card match, i.e., 0.0.0.0:[address_port].
+  // We do not return stopped listeners.
+  // TODO(wattli): consolidate with previous search for more efficiency.
+  listener_it =
+      std::find_if(listeners_.begin(), listeners_.end(),
+                   [&address](const std::pair<Network::Address::InstanceConstSharedPtr,
+                                              ConnectionHandlerImpl::ActiveListenerDetails>& p) {
+                     return absl::holds_alternative<std::reference_wrapper<ActiveTcpListener>>(
+                                p.second.typed_listener_) &&
+                            p.second.listener_->listener() != nullptr &&
+                            p.first->type() == Network::Address::Type::Ip &&
+                            p.first->ip()->port() == address.ip()->port() &&
+                            p.first->ip()->isAnyAddress();
+                   });
+  return (listener_it != listeners_.end())
+             ? Network::BalancedConnectionHandlerOptRef(
+                   ConnectionHandlerImpl::ActiveTcpListenerOptRef(
+                       absl::get<std::reference_wrapper<ActiveTcpListener>>(
+                           listener_it->second.typed_listener_))
+                       .value()
+                       .get())
+             : absl::nullopt;
 }
 
-void ActiveRawUdpListener::onDataWorker(Network::UdpRecvData&& data) { read_filter_->onData(data); }
-
-void ActiveRawUdpListener::onReadReady() {}
-
-void ActiveRawUdpListener::onWriteReady(const Network::Socket&) {
-  // TODO(sumukhs): This is not used now. When write filters are implemented, this is a
-  // trigger to invoke the on write ready API on the filters which is when they can write
-  // data
-
-  // Clear write_blocked_ status for udpPacketWriter
-  udp_packet_writer_->setWritable();
-}
-
-void ActiveRawUdpListener::onReceiveError(Api::IoError::IoErrorCode error_code) {
-  read_filter_->onReceiveError(error_code);
-}
-
-void ActiveRawUdpListener::addReadFilter(Network::UdpListenerReadFilterPtr&& filter) {
-  ASSERT(read_filter_ == nullptr, "Cannot add a 2nd UDP read filter");
-  read_filter_ = std::move(filter);
-}
-
-Network::UdpListener& ActiveRawUdpListener::udpListener() { return *udp_listener_; }
+ActiveListenerImplBase::ActiveListenerImplBase(Network::ConnectionHandler& parent,
+                                               Network::ListenerConfig* config)
+    : stats_({ALL_LISTENER_STATS(POOL_COUNTER(config->listenerScope()),
+                                 POOL_GAUGE(config->listenerScope()),
+                                 POOL_HISTOGRAM(config->listenerScope()))}),
+      per_worker_stats_({ALL_PER_HANDLER_LISTENER_STATS(
+          POOL_COUNTER_PREFIX(config->listenerScope(), parent.statPrefix()),
+          POOL_GAUGE_PREFIX(config->listenerScope(), parent.statPrefix()))}),
+      config_(config) {}
 
 } // namespace Server
 } // namespace Envoy

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -15,7 +15,6 @@
 #include "envoy/server/active_udp_listener_config.h"
 #include "envoy/server/listener_manager.h"
 #include "envoy/stats/scope.h"
-#include "envoy/stats/timespan.h"
 
 #include "common/common/linked_object.h"
 #include "common/common/non_copyable.h"
@@ -57,15 +56,20 @@ struct PerHandlerListenerStats {
 };
 
 class ActiveUdpListenerBase;
+class ActiveTcpListener;
 
 /**
  * Server side connection handler. This is used both by workers as well as the
  * main thread for non-threaded listeners.
  */
-class ConnectionHandlerImpl : public Network::ConnectionHandler,
+class ConnectionHandlerImpl : public Network::TcpConnectionHandler,
+                              public Network::UdpConnectionHandler,
                               NonCopyable,
                               Logger::Loggable<Logger::Id::conn_handler> {
 public:
+  using ActiveTcpListenerOptRef = absl::optional<std::reference_wrapper<ActiveTcpListener>>;
+  using UdpListenerCallbacksOptRef =
+      absl::optional<std::reference_wrapper<Network::UdpListenerCallbacks>>;
   ConnectionHandlerImpl(Event::Dispatcher& dispatcher, absl::optional<uint32_t> worker_index);
 
   // Network::ConnectionHandler
@@ -75,7 +79,6 @@ public:
   void addListener(absl::optional<uint64_t> overridden_listener,
                    Network::ListenerConfig& config) override;
   void removeListeners(uint64_t listener_tag) override;
-  Network::UdpListenerCallbacksOptRef getUdpListenerCallbacks(uint64_t listener_tag) override;
   void removeFilterChains(uint64_t listener_tag,
                           const std::list<const Network::FilterChain*>& filter_chains,
                           std::function<void()> completion) override;
@@ -86,258 +89,28 @@ public:
   void setListenerRejectFraction(UnitFloat reject_fraction) override;
   const std::string& statPrefix() const override { return per_handler_stat_prefix_; }
 
-  /**
-   * Wrapper for an active listener owned by this handler.
-   */
-  class ActiveListenerImplBase : public virtual Network::ConnectionHandler::ActiveListener {
-  public:
-    ActiveListenerImplBase(Network::ConnectionHandler& parent, Network::ListenerConfig* config);
+  // Network::TcpConnectionHandler
+  Event::Dispatcher& dispatcher() override { return dispatcher_; }
+  Network::BalancedConnectionHandlerOptRef getBalancedHandlerByTag(uint64_t listener_tag) override;
+  Network::BalancedConnectionHandlerOptRef
+  getBalancedHandlerByAddress(const Network::Address::Instance& address) override;
 
-    // Network::ConnectionHandler::ActiveListener.
-    uint64_t listenerTag() override { return config_->listenerTag(); }
-
-    ListenerStats stats_;
-    PerHandlerListenerStats per_worker_stats_;
-    Network::ListenerConfig* config_{};
-  };
+  // Network::UdpConnectionHandler
+  Network::UdpListenerCallbacksOptRef getUdpListenerCallbacks(uint64_t listener_tag) override;
 
 private:
-  struct ActiveTcpConnection;
-  using ActiveTcpConnectionPtr = std::unique_ptr<ActiveTcpConnection>;
-  struct ActiveTcpSocket;
-  using ActiveTcpSocketPtr = std::unique_ptr<ActiveTcpSocket>;
-  class ActiveConnections;
-  using ActiveConnectionsPtr = std::unique_ptr<ActiveConnections>;
-
-  /**
-   * Wrapper for an active tcp listener owned by this handler.
-   */
-  class ActiveTcpListener : public Network::TcpListenerCallbacks,
-                            public ActiveListenerImplBase,
-                            public Network::BalancedConnectionHandler {
+  friend struct ActiveTcpSocket;
+  struct ActiveTcpListenerDetail {
   public:
-    ActiveTcpListener(ConnectionHandlerImpl& parent, Network::ListenerConfig& config);
-    ActiveTcpListener(ConnectionHandlerImpl& parent, Network::ListenerPtr&& listener,
-                      Network::ListenerConfig& config);
-    ~ActiveTcpListener() override;
-    bool listenerConnectionLimitReached() const {
-      // TODO(tonya11en): Delegate enforcement of per-listener connection limits to overload
-      // manager.
-      return !config_->openConnections().canCreate();
-    }
-    void onAcceptWorker(Network::ConnectionSocketPtr&& socket,
-                        bool hand_off_restored_destination_connections, bool rebalanced);
-    void decNumConnections() {
-      ASSERT(num_listener_connections_ > 0);
-      --num_listener_connections_;
-      config_->openConnections().dec();
-    }
-
-    // Network::TcpListenerCallbacks
-    void onAccept(Network::ConnectionSocketPtr&& socket) override;
-    void onReject(RejectCause) override;
-
-    // ActiveListenerImplBase
-    Network::Listener* listener() override { return listener_.get(); }
-    void pauseListening() override;
-    void resumeListening() override;
-    void shutdownListener() override { listener_.reset(); }
-
-    // Network::BalancedConnectionHandler
-    uint64_t numConnections() const override { return num_listener_connections_; }
-    void incNumConnections() override {
-      ++num_listener_connections_;
-      config_->openConnections().inc();
-    }
-    void post(Network::ConnectionSocketPtr&& socket) override;
-
-    /**
-     * Remove and destroy an active connection.
-     * @param connection supplies the connection to remove.
-     */
-    void removeConnection(ActiveTcpConnection& connection);
-
-    /**
-     * Create a new connection from a socket accepted by the listener.
-     */
-    void newConnection(Network::ConnectionSocketPtr&& socket,
-                       std::unique_ptr<StreamInfo::StreamInfo> stream_info);
-
-    /**
-     * Return the active connections container attached with the given filter chain.
-     */
-    ActiveConnections& getOrCreateActiveConnections(const Network::FilterChain& filter_chain);
-
-    /**
-     * Schedule to remove and destroy the active connections which are not tracked by listener
-     * config. Caution: The connection are not destroyed yet when function returns.
-     */
-    void deferredRemoveFilterChains(
-        const std::list<const Network::FilterChain*>& draining_filter_chains);
-
-    /**
-     * Update the listener config. The follow up connections will see the new config. The existing
-     * connections are not impacted.
-     */
-    void updateListenerConfig(Network::ListenerConfig& config);
-
-    ConnectionHandlerImpl& parent_;
-    Network::ListenerPtr listener_;
-    const std::chrono::milliseconds listener_filters_timeout_;
-    const bool continue_on_listener_filters_timeout_;
-    std::list<ActiveTcpSocketPtr> sockets_;
-    absl::node_hash_map<const Network::FilterChain*, ActiveConnectionsPtr> connections_by_context_;
-
-    // The number of connections currently active on this listener. This is typically used for
-    // connection balancing across per-handler listeners.
-    std::atomic<uint64_t> num_listener_connections_{};
-    bool is_deleting_{false};
+    virtual ~ActiveTcpListenerDetail() = default;
+    virtual ActiveTcpListenerOptRef tcpListener() PURE;
   };
-
-  /**
-   * Wrapper for a group of active connections which are attached to the same filter chain context.
-   */
-  class ActiveConnections : public Event::DeferredDeletable {
+  struct ActiveUdpListenerDetail {
   public:
-    ActiveConnections(ActiveTcpListener& listener, const Network::FilterChain& filter_chain);
-    ~ActiveConnections() override;
-
-    // listener filter chain pair is the owner of the connections
-    ActiveTcpListener& listener_;
-    const Network::FilterChain& filter_chain_;
-    // Owned connections
-    std::list<ActiveTcpConnectionPtr> connections_;
+    virtual ~ActiveUdpListenerDetail() = default;
+    virtual UdpListenerCallbacksOptRef udpListener() PURE;
   };
-
-  /**
-   * Wrapper for an active TCP connection owned by this handler.
-   */
-  struct ActiveTcpConnection : LinkedObject<ActiveTcpConnection>,
-                               public Event::DeferredDeletable,
-                               public Network::ConnectionCallbacks {
-    ActiveTcpConnection(ActiveConnections& active_connections,
-                        Network::ConnectionPtr&& new_connection, TimeSource& time_system,
-                        std::unique_ptr<StreamInfo::StreamInfo>&& stream_info);
-    ~ActiveTcpConnection() override;
-
-    // Network::ConnectionCallbacks
-    void onEvent(Network::ConnectionEvent event) override {
-      // Any event leads to destruction of the connection.
-      if (event == Network::ConnectionEvent::LocalClose ||
-          event == Network::ConnectionEvent::RemoteClose) {
-        active_connections_.listener_.removeConnection(*this);
-      }
-    }
-    void onAboveWriteBufferHighWatermark() override {}
-    void onBelowWriteBufferLowWatermark() override {}
-
-    std::unique_ptr<StreamInfo::StreamInfo> stream_info_;
-    ActiveConnections& active_connections_;
-    Network::ConnectionPtr connection_;
-    Stats::TimespanPtr conn_length_;
-  };
-
-  /**
-   * Wrapper for an active accepted TCP socket owned by this handler.
-   */
-  struct ActiveTcpSocket : public Network::ListenerFilterManager,
-                           public Network::ListenerFilterCallbacks,
-                           LinkedObject<ActiveTcpSocket>,
-                           public Event::DeferredDeletable {
-    ActiveTcpSocket(ActiveTcpListener& listener, Network::ConnectionSocketPtr&& socket,
-                    bool hand_off_restored_destination_connections)
-        : listener_(listener), socket_(std::move(socket)),
-          hand_off_restored_destination_connections_(hand_off_restored_destination_connections),
-          iter_(accept_filters_.end()),
-          stream_info_(std::make_unique<StreamInfo::StreamInfoImpl>(
-              listener_.parent_.dispatcher_.timeSource(), socket_->addressProviderSharedPtr(),
-              StreamInfo::FilterState::LifeSpan::Connection)) {
-      listener_.stats_.downstream_pre_cx_active_.inc();
-    }
-    ~ActiveTcpSocket() override {
-      accept_filters_.clear();
-      listener_.stats_.downstream_pre_cx_active_.dec();
-
-      // If the underlying socket is no longer attached, it means that it has been transferred to
-      // an active connection. In this case, the active connection will decrement the number
-      // of listener connections.
-      // TODO(mattklein123): In general the way we account for the number of listener connections
-      // is incredibly fragile. Revisit this by potentially merging ActiveTcpSocket and
-      // ActiveTcpConnection, having a shared object which does accounting (but would require
-      // another allocation, etc.).
-      if (socket_ != nullptr) {
-        listener_.decNumConnections();
-      }
-    }
-
-    void onTimeout();
-    void startTimer();
-    void unlink();
-    void newConnection();
-
-    class GenericListenerFilter : public Network::ListenerFilter {
-    public:
-      GenericListenerFilter(const Network::ListenerFilterMatcherSharedPtr& matcher,
-                            Network::ListenerFilterPtr listener_filter)
-          : listener_filter_(std::move(listener_filter)), matcher_(std::move(matcher)) {}
-      Network::FilterStatus onAccept(ListenerFilterCallbacks& cb) override {
-        if (isDisabled(cb)) {
-          return Network::FilterStatus::Continue;
-        }
-        return listener_filter_->onAccept(cb);
-      }
-      /**
-       * Check if this filter filter should be disabled on the incoming socket.
-       * @param cb the callbacks the filter instance can use to communicate with the filter chain.
-       **/
-      bool isDisabled(ListenerFilterCallbacks& cb) {
-        if (matcher_ == nullptr) {
-          return false;
-        } else {
-          return matcher_->matches(cb);
-        }
-      }
-
-    private:
-      const Network::ListenerFilterPtr listener_filter_;
-      const Network::ListenerFilterMatcherSharedPtr matcher_;
-    };
-    using ListenerFilterWrapperPtr = std::unique_ptr<GenericListenerFilter>;
-
-    // Network::ListenerFilterManager
-    void addAcceptFilter(const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,
-                         Network::ListenerFilterPtr&& filter) override {
-      accept_filters_.emplace_back(
-          std::make_unique<GenericListenerFilter>(listener_filter_matcher, std::move(filter)));
-    }
-
-    // Network::ListenerFilterCallbacks
-    Network::ConnectionSocket& socket() override { return *socket_.get(); }
-    Event::Dispatcher& dispatcher() override { return listener_.parent_.dispatcher_; }
-    void continueFilterChain(bool success) override;
-    void setDynamicMetadata(const std::string& name, const ProtobufWkt::Struct& value) override;
-    envoy::config::core::v3::Metadata& dynamicMetadata() override {
-      return stream_info_->dynamicMetadata();
-    };
-    const envoy::config::core::v3::Metadata& dynamicMetadata() const override {
-      return stream_info_->dynamicMetadata();
-    };
-
-    ActiveTcpListener& listener_;
-    Network::ConnectionSocketPtr socket_;
-    const bool hand_off_restored_destination_connections_;
-    std::list<ListenerFilterWrapperPtr> accept_filters_;
-    std::list<ListenerFilterWrapperPtr>::iterator iter_;
-    Event::TimerPtr timer_;
-    std::unique_ptr<StreamInfo::StreamInfo> stream_info_;
-    bool connected_{false};
-  };
-
-  using ActiveTcpListenerOptRef = absl::optional<std::reference_wrapper<ActiveTcpListener>>;
-  using UdpListenerCallbacksOptRef =
-      absl::optional<std::reference_wrapper<Network::UdpListenerCallbacks>>;
-
-  struct ActiveListenerDetails {
+  struct ActiveListenerDetails : public ActiveTcpListenerDetail, public ActiveUdpListenerDetail {
     // Strong pointer to the listener, whether TCP, UDP, QUIC, etc.
     Network::ConnectionHandler::ActiveListenerPtr listener_;
 
@@ -346,12 +119,10 @@ private:
         typed_listener_;
 
     // Helpers for accessing the data in the variant for cleaner code.
-    ActiveTcpListenerOptRef tcpListener();
-    UdpListenerCallbacksOptRef udpListener();
+    ActiveTcpListenerOptRef tcpListener() override;
+    UdpListenerCallbacksOptRef udpListener() override;
   };
   using ActiveListenerDetailsOptRef = absl::optional<std::reference_wrapper<ActiveListenerDetails>>;
-
-  ActiveTcpListenerOptRef findActiveTcpListenerByAddress(const Network::Address::Instance& address);
   ActiveListenerDetailsOptRef findActiveListenerByTag(uint64_t listener_tag);
 
   // This has a value on worker threads, and no value on the main thread.
@@ -364,87 +135,19 @@ private:
   UnitFloat listener_reject_fraction_{UnitFloat::min()};
 };
 
-class ActiveUdpListenerBase : public ConnectionHandlerImpl::ActiveListenerImplBase,
-                              public Network::ConnectionHandler::ActiveUdpListener {
-public:
-  ActiveUdpListenerBase(uint32_t worker_index, uint32_t concurrency,
-                        Network::ConnectionHandler& parent, Network::Socket& listen_socket,
-                        Network::UdpListenerPtr&& listener, Network::ListenerConfig* config);
-  ~ActiveUdpListenerBase() override;
-
-  // Network::UdpListenerCallbacks
-  void onData(Network::UdpRecvData&& data) final;
-  uint32_t workerIndex() const final { return worker_index_; }
-  void post(Network::UdpRecvData&& data) final;
-
-  // ActiveListenerImplBase
-  Network::Listener* listener() override { return udp_listener_.get(); }
-
-protected:
-  uint32_t destination(const Network::UdpRecvData& /*data*/) const override {
-    // By default, route to the current worker.
-    return worker_index_;
-  }
-
-  const uint32_t worker_index_;
-  const uint32_t concurrency_;
-  Network::ConnectionHandler& parent_;
-  Network::Socket& listen_socket_;
-  Network::UdpListenerPtr udp_listener_;
-};
-
 /**
- * Wrapper for an active udp listener owned by this handler.
+ * Wrapper for an active listener owned by this handler.
  */
-class ActiveRawUdpListener : public ActiveUdpListenerBase,
-                             public Network::UdpListenerFilterManager,
-                             public Network::UdpReadFilterCallbacks {
+class ActiveListenerImplBase : public virtual Network::ConnectionHandler::ActiveListener {
 public:
-  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                       Network::ConnectionHandler& parent, Event::Dispatcher& dispatcher,
-                       Network::ListenerConfig& config);
-  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                       Network::ConnectionHandler& parent,
-                       Network::SocketSharedPtr listen_socket_ptr, Event::Dispatcher& dispatcher,
-                       Network::ListenerConfig& config);
-  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                       Network::ConnectionHandler& parent, Network::Socket& listen_socket,
-                       Network::SocketSharedPtr listen_socket_ptr, Event::Dispatcher& dispatcher,
-                       Network::ListenerConfig& config);
-  ActiveRawUdpListener(uint32_t worker_index, uint32_t concurrency,
-                       Network::ConnectionHandler& parent, Network::Socket& listen_socket,
-                       Network::UdpListenerPtr&& listener, Network::ListenerConfig& config);
+  ActiveListenerImplBase(Network::ConnectionHandler& parent, Network::ListenerConfig* config);
 
-  // Network::UdpListenerCallbacks
-  void onReadReady() override;
-  void onWriteReady(const Network::Socket& socket) override;
-  void onReceiveError(Api::IoError::IoErrorCode error_code) override;
-  Network::UdpPacketWriter& udpPacketWriter() override { return *udp_packet_writer_; }
+  // Network::ConnectionHandler::ActiveListener.
+  uint64_t listenerTag() override { return config_->listenerTag(); }
 
-  // Network::UdpWorker
-  void onDataWorker(Network::UdpRecvData&& data) override;
-
-  // ActiveListenerImplBase
-  void pauseListening() override { udp_listener_->disable(); }
-  void resumeListening() override { udp_listener_->enable(); }
-  void shutdownListener() override {
-    // The read filter should be deleted before the UDP listener is deleted.
-    // The read filter refers to the UDP listener to send packets to downstream.
-    // If the UDP listener is deleted before the read filter, the read filter may try to use it
-    // after deletion.
-    read_filter_.reset();
-    udp_listener_.reset();
-  }
-
-  // Network::UdpListenerFilterManager
-  void addReadFilter(Network::UdpListenerReadFilterPtr&& filter) override;
-
-  // Network::UdpReadFilterCallbacks
-  Network::UdpListener& udpListener() override;
-
-private:
-  Network::UdpListenerReadFilterPtr read_filter_;
-  Network::UdpPacketWriterPtr udp_packet_writer_;
+  ListenerStats stats_;
+  PerHandlerListenerStats per_worker_stats_;
+  Network::ListenerConfig* config_{};
 };
 
 } // namespace Server

--- a/source/server/connection_handler_impl.h
+++ b/source/server/connection_handler_impl.h
@@ -323,8 +323,6 @@ private:
       return stream_info_->dynamicMetadata();
     };
 
-    StreamInfo::FilterState& filterState() override { return *stream_info_->filterState().get(); }
-
     ActiveTcpListener& listener_;
     Network::ConnectionSocketPtr socket_;
     const bool hand_off_restored_destination_connections_;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -365,7 +365,6 @@ protected:
   Event::DispatcherPtr dispatcher_;
   Network::ListenerPtr upstream_listener_;
   Network::MockTcpListenerCallbacks listener_callbacks_;
-  Network::MockConnectionHandler connection_handler_;
   Network::Address::InstanceConstSharedPtr source_address_;
   Http::MockClientConnection* codec_;
   std::unique_ptr<CodecClientForTest> client_;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -259,7 +259,6 @@ protected:
   Event::DispatcherPtr dispatcher_;
   std::shared_ptr<Network::TcpListenSocket> socket_{nullptr};
   Network::MockTcpListenerCallbacks listener_callbacks_;
-  Network::MockConnectionHandler connection_handler_;
   Network::ListenerPtr listener_;
   Network::ClientConnectionPtr client_connection_;
   StrictMock<MockConnectionCallbacks> client_callbacks_;

--- a/test/common/network/dns_impl_test.cc
+++ b/test/common/network/dns_impl_test.cc
@@ -551,7 +551,6 @@ protected:
   virtual bool setResolverInConstructor() const { return false; }
   std::unique_ptr<TestDnsServer> server_;
   std::unique_ptr<DnsResolverImplPeer> peer_;
-  Network::MockConnectionHandler connection_handler_;
   std::shared_ptr<Network::TcpListenSocket> socket_;
   std::unique_ptr<Network::Listener> listener_;
   Api::ApiPtr api_;

--- a/test/common/network/listener_impl_test.cc
+++ b/test/common/network/listener_impl_test.cc
@@ -35,7 +35,6 @@ static void errorCallbackTest(Address::IpVersion version) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(version), nullptr, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher->createListener(socket, listener_callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -84,7 +83,6 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, TcpListenerImplTest,
 // Test that socket options are set after the listener is setup.
 TEST_P(TcpListenerImplTest, SetListeningSocketOptionsSuccess) {
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Random::MockRandomGenerator random_generator;
 
   auto socket = std::make_shared<TcpListenSocket>(
@@ -100,7 +98,6 @@ TEST_P(TcpListenerImplTest, SetListeningSocketOptionsSuccess) {
 // Test that an exception is thrown if there is an error setting socket options.
 TEST_P(TcpListenerImplTest, SetListeningSocketOptionsError) {
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Random::MockRandomGenerator random_generator;
 
   auto socket = std::make_shared<TcpListenSocket>(
@@ -121,7 +118,6 @@ TEST_P(TcpListenerImplTest, UseActualDst) {
       Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   auto socketDst = std::make_shared<TcpListenSocket>(alt_address_, nullptr, false);
   Network::MockTcpListenerCallbacks listener_callbacks1;
-  Network::MockConnectionHandler connection_handler;
   Random::MockRandomGenerator random_generator;
   // Do not redirect since use_original_dst is false.
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
@@ -162,7 +158,6 @@ TEST_P(TcpListenerImplTest, GlobalConnectionLimitEnforcement) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, listener_callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -226,7 +221,6 @@ TEST_P(TcpListenerImplTest, WildcardListenerUseActualDst) {
   auto socket = std::make_shared<TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(version_), nullptr, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Random::MockRandomGenerator random_generator;
   // Do not redirect since use_original_dst is false.
   Network::TestTcpListenerImpl listener(dispatcherImpl(), random_generator, socket,
@@ -268,7 +262,6 @@ TEST_P(TcpListenerImplTest, WildcardListenerIpv4Compat) {
   auto socket = std::make_shared<TcpListenSocket>(Network::Test::getAnyAddress(version_, true),
                                                   options, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Random::MockRandomGenerator random_generator;
 
   ASSERT_TRUE(socket->addressProvider().localAddress()->ip()->isAnyAddress());

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -316,7 +316,6 @@ void testUtil(const TestUtilOptions& options) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(options.version()), nullptr, true);
   Network::MockTcpListenerCallbacks callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher->createListener(socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -629,7 +628,6 @@ const std::string testUtilV2(const TestUtilOptionsV2& options) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(options.version()), nullptr, true);
   NiceMock<Network::MockTcpListenerCallbacks> callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher->createListener(socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -2436,7 +2434,6 @@ TEST_P(SslSocketTest, FlushCloseDuringHandshake) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -2493,7 +2490,6 @@ TEST_P(SslSocketTest, HalfClose) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, listener_callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
   std::shared_ptr<Network::MockReadFilter> server_read_filter(new Network::MockReadFilter());
@@ -2576,7 +2572,6 @@ TEST_P(SslSocketTest, ShutdownWithCloseNotify) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, listener_callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
   std::shared_ptr<Network::MockReadFilter> server_read_filter(new Network::MockReadFilter());
@@ -2665,7 +2660,6 @@ TEST_P(SslSocketTest, ShutdownWithoutCloseNotify) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks listener_callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, listener_callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
   std::shared_ptr<Network::MockReadFilter> server_read_filter(new Network::MockReadFilter());
@@ -2770,7 +2764,6 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -2868,7 +2861,6 @@ void testTicketSessionResumption(const std::string& server_ctx_yaml1,
   auto socket2 = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr, true);
   NiceMock<Network::MockTcpListenerCallbacks> callbacks;
-  Network::MockConnectionHandler connection_handler;
   Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   Network::ListenerPtr listener1 =
       dispatcher->createListener(socket1, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
@@ -3008,7 +3000,6 @@ void testSupportForStatelessSessionResumption(const std::string& server_ctx_yaml
   auto tcp_socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(ip_version), nullptr, true);
   NiceMock<Network::MockTcpListenerCallbacks> callbacks;
-  Network::MockConnectionHandler connection_handler;
   Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   Network::ListenerPtr listener =
       dispatcher->createListener(tcp_socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
@@ -3452,7 +3443,6 @@ TEST_P(SslSocketTest, ClientAuthCrossListenerSessionResumption) {
   auto socket2 = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
   Network::ListenerPtr listener2 =
@@ -3569,7 +3559,6 @@ void SslSocketTest::testClientSessionResumption(const std::string& server_ctx_ya
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(version), nullptr, true);
   NiceMock<Network::MockTcpListenerCallbacks> callbacks;
-  Network::MockConnectionHandler connection_handler;
   Api::ApiPtr api = Api::createApiForTest(server_stats_store, time_system_);
   Event::DispatcherPtr dispatcher(server_api->allocateDispatcher("test_thread"));
   Network::ListenerPtr listener =
@@ -3832,7 +3821,6 @@ TEST_P(SslSocketTest, SslError) {
   auto socket = std::make_shared<Network::TcpListenSocket>(
       Network::Test::getCanonicalLoopbackAddress(GetParam()), nullptr, true);
   Network::MockTcpListenerCallbacks callbacks;
-  Network::MockConnectionHandler connection_handler;
   Network::ListenerPtr listener =
       dispatcher_->createListener(socket, callbacks, true, ENVOY_TCP_BACKLOG_SIZE);
 
@@ -4971,7 +4959,6 @@ protected:
   Stats::TestUtil::TestStore client_stats_store_;
   std::shared_ptr<Network::TcpListenSocket> socket_;
   Network::MockTcpListenerCallbacks listener_callbacks_;
-  Network::MockConnectionHandler connection_handler_;
   const std::string server_ctx_yaml_ = R"EOF(
   common_tls_context:
     tls_certificates:

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -417,7 +417,6 @@ public:
   MOCK_METHOD(void, addListener,
               (absl::optional<uint64_t> overridden_listener, ListenerConfig& config));
   MOCK_METHOD(void, removeListeners, (uint64_t listener_tag));
-  MOCK_METHOD(UdpListenerCallbacksOptRef, getUdpListenerCallbacks, (uint64_t listener_tag));
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -967,6 +967,7 @@ readonly
 readv
 realloc
 rebalanced
+rebalancer
 rebalancing
 rebuffer
 rebuilder


### PR DESCRIPTION
Commit Message:
Refactor ConnectionHandler: separate inferfaces for tcp listener and udp listener.


Additional Description:
Since an active listener doesn't depend on ConnectionImpl, the complexity of writing a functional test of an active tcp listener is greatly reduced. 

Also easier to add a new type of listener wrt my ongoing work to add the envoy internal address listener which has a quite different "accept()" flow and findListenerByAddress implementation.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #15126
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
