### PR TITLE
rds: use optional to store provider in subscription

### DIFF
--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -141,7 +141,7 @@ void RdsRouteConfigSubscription::onConfigUpdate(
               config_update_info_->configHash());
 
     if (route_config_provider_opt_.has_value()) {
-      route_config_provider_opt_.value()->validateConfig(route_config);
+      route_config_provider_opt_.value()->onConfigUpdate();
     }
     // RDS update removed VHDS configuration
     if (!config_update_info_->routeConfiguration().has_vhds()) {
@@ -243,6 +243,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
 }
 
 RdsRouteConfigProviderImpl::~RdsRouteConfigProviderImpl() {
+  ASSERT(subscription_->routeConfigProvider().has_value());
   subscription_->routeConfigProvider().reset();
 }
 
@@ -370,7 +371,7 @@ RouteConfigProviderManagerImpl::dumpRouteConfigs() const {
     // in the RdsRouteConfigSubscription destructor, and the single threaded nature
     // of this code, locking the weak_ptr will not fail.
     ASSERT(subscription);
-    ASSERT(!subscription->route_config_provider_opt_.has_value());
+    ASSERT(subscription->route_config_provider_opt_.has_value());
 
     if (subscription->routeConfigUpdate()->configInfo()) {
       auto* dynamic_config = config_dump->mutable_dynamic_route_configs()->Add();

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -116,10 +116,8 @@ void RdsRouteConfigSubscription::onConfigUpdate(
     throw EnvoyException(fmt::format("Unexpected RDS configuration (expecting {}): {}",
                                      route_config_name_, route_config.name()));
   }
-  for (auto* provider : route_config_providers_) {
-    // This seems inefficient, though it is necessary to validate config in each context,
-    // especially when it comes with per_filter_config,
-    provider->validateConfig(route_config);
+  if (route_config_provider_opt_.has_value()) {
+    route_config_provider_opt_.value()->validateConfig(route_config);
   }
   std::unique_ptr<Init::ManagerImpl> noop_init_manager;
   std::unique_ptr<Cleanup> resume_rds;
@@ -133,7 +131,7 @@ void RdsRouteConfigSubscription::onConfigUpdate(
           route_config_name_, config_update_info_->configHash());
       maybeCreateInitManager(version_info, noop_init_manager, resume_rds);
       vhds_subscription_ = std::make_unique<VhdsSubscription>(
-          config_update_info_, factory_context_, stat_prefix_, route_config_providers_,
+          config_update_info_, factory_context_, stat_prefix_, route_config_provider_opt_,
           config_update_info_->routeConfiguration().vhds().config_source().resource_api_version());
       vhds_subscription_->registerInitTargetWithInitManager(
           noop_init_manager == nullptr ? local_init_manager_ : *noop_init_manager);
@@ -142,8 +140,8 @@ void RdsRouteConfigSubscription::onConfigUpdate(
     ENVOY_LOG(debug, "rds: loading new configuration: config_name={} hash={}", route_config_name_,
               config_update_info_->configHash());
 
-    for (auto* provider : route_config_providers_) {
-      provider->onConfigUpdate();
+    if (route_config_provider_opt_.has_value()) {
+      route_config_provider_opt_.value()->validateConfig(route_config);
     }
     // RDS update removed VHDS configuration
     if (!config_update_info_->routeConfiguration().has_vhds()) {
@@ -240,14 +238,12 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
     return std::make_shared<ThreadLocalConfig>(initial_config);
   });
   // It should be 1:1 mapping due to shared rds config.
-  ASSERT(subscription_->routeConfigProviders().empty());
-  subscription_->routeConfigProviders().insert(this);
+  ASSERT(!subscription_->routeConfigProvider().has_value());
+  subscription_->routeConfigProvider().emplace(this);
 }
 
 RdsRouteConfigProviderImpl::~RdsRouteConfigProviderImpl() {
-  subscription_->routeConfigProviders().erase(this);
-  // It should be 1:1 mapping due to shared rds config.
-  ASSERT(subscription_->routeConfigProviders().empty());
+  subscription_->routeConfigProvider().reset();
 }
 
 Router::ConfigConstSharedPtr RdsRouteConfigProviderImpl::config() { return tls_->config_; }
@@ -374,7 +370,7 @@ RouteConfigProviderManagerImpl::dumpRouteConfigs() const {
     // in the RdsRouteConfigSubscription destructor, and the single threaded nature
     // of this code, locking the weak_ptr will not fail.
     ASSERT(subscription);
-    ASSERT(!subscription->route_config_providers_.empty());
+    ASSERT(!subscription->route_config_provider_opt_.has_value());
 
     if (subscription->routeConfigUpdate()->configInfo()) {
       auto* dynamic_config = config_dump->mutable_dynamic_route_configs()->Add();

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -119,10 +119,7 @@ class RdsRouteConfigSubscription
 public:
   ~RdsRouteConfigSubscription() override;
 
-  absl::node_hash_set<RouteConfigProvider*>& routeConfigProviders() {
-    ASSERT(route_config_providers_.size() == 1 || route_config_providers_.empty());
-    return route_config_providers_;
-  }
+  absl::optional<RouteConfigProvider*>& routeConfigProvider() { return route_config_provider_opt_; }
   RouteConfigUpdatePtr& routeConfigUpdate() { return config_update_info_; }
   void updateOnDemand(const std::string& aliases);
   void maybeCreateInitManager(const std::string& version_info,
@@ -169,8 +166,7 @@ private:
   RdsStats stats_;
   RouteConfigProviderManagerImpl& route_config_provider_manager_;
   const uint64_t manager_identifier_;
-  // TODO(lambdai): Prove that a subscription has exactly one provider and remove the container.
-  absl::node_hash_set<RouteConfigProvider*> route_config_providers_;
+  absl::optional<RouteConfigProvider*> route_config_provider_opt_;
   VhdsSubscriptionPtr vhds_subscription_;
   RouteConfigUpdatePtr config_update_info_;
   Common::CallbackManager<> update_callback_manager_;

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -20,11 +20,11 @@ namespace Envoy {
 namespace Router {
 
 // Implements callbacks to handle DeltaDiscovery protocol for VirtualHostDiscoveryService
-VhdsSubscription::VhdsSubscription(
-    RouteConfigUpdatePtr& config_update_info,
-    Server::Configuration::ServerFactoryContext& factory_context, const std::string& stat_prefix,
-    absl::node_hash_set<RouteConfigProvider*>& route_config_providers,
-    envoy::config::core::v3::ApiVersion resource_api_version)
+VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
+                                   Server::Configuration::ServerFactoryContext& factory_context,
+                                   const std::string& stat_prefix,
+                                   absl::optional<RouteConfigProvider*>& route_config_provider_opt,
+                                   envoy::config::core::v3::ApiVersion resource_api_version)
     : Envoy::Config::SubscriptionBase<envoy::config::route::v3::VirtualHost>(
           resource_api_version,
           factory_context.messageValidationContext().dynamicValidationVisitor(), "name"),
@@ -34,7 +34,7 @@ VhdsSubscription::VhdsSubscription(
       stats_({ALL_VHDS_STATS(POOL_COUNTER(*scope_))}),
       init_target_(fmt::format("VhdsConfigSubscription {}", config_update_info_->routeConfigName()),
                    [this]() { subscription_->start({config_update_info_->routeConfigName()}); }),
-      route_config_providers_(route_config_providers) {
+      route_config_provider_opt_(route_config_provider_opt) {
   const auto& config_source = config_update_info_->routeConfiguration()
                                   .vhds()
                                   .config_source()
@@ -85,8 +85,8 @@ void VhdsSubscription::onConfigUpdate(
     stats_.config_reload_.inc();
     ENVOY_LOG(debug, "vhds: loading new configuration: config_name={} hash={}",
               config_update_info_->routeConfigName(), config_update_info_->configHash());
-    for (auto* provider : route_config_providers_) {
-      provider->onConfigUpdate();
+    if (route_config_provider_opt_.has_value()) {
+      route_config_provider_opt_.value()->onConfigUpdate();
     }
   }
 

--- a/source/common/router/vhds.h
+++ b/source/common/router/vhds.h
@@ -42,7 +42,7 @@ public:
   VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
                    Server::Configuration::ServerFactoryContext& factory_context,
                    const std::string& stat_prefix,
-                   absl::node_hash_set<RouteConfigProvider*>& route_config_providers,
+                   absl::optional<RouteConfigProvider*>& route_config_providers,
                    const envoy::config::core::v3::ApiVersion resource_api_version =
                        envoy::config::core::v3::ApiVersion::AUTO);
   ~VhdsSubscription() override { init_target_.ready(); }
@@ -74,7 +74,7 @@ private:
   VhdsStats stats_;
   Envoy::Config::SubscriptionPtr subscription_;
   Init::TargetImpl init_target_;
-  absl::node_hash_set<RouteConfigProvider*>& route_config_providers_;
+  absl::optional<RouteConfigProvider*>& route_config_provider_opt_;
 };
 
 using VhdsSubscriptionPtr = std::unique_ptr<VhdsSubscription>;

--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -85,7 +85,7 @@ vhds:
   Init::ExpectableWatcherImpl init_watcher_;
   Init::TargetHandlePtr init_target_handle_;
   const std::string context_ = "vhds_test";
-  absl::node_hash_set<Envoy::Router::RouteConfigProvider*> providers_;
+  absl::optional<Envoy::Router::RouteConfigProvider*> provider_;
   Protobuf::util::MessageDifferencer messageDifferencer_;
   std::string default_vhds_config_;
   NiceMock<Envoy::Config::MockSubscriptionFactory> subscription_factory_;
@@ -97,7 +97,7 @@ TEST_F(VhdsTest, VhdsInstantiationShouldSucceedWithDELTA_GRPC) {
       TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(default_vhds_config_);
   RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
 
-  EXPECT_NO_THROW(VhdsSubscription(config_update_info, factory_context_, context_, providers_));
+  EXPECT_NO_THROW(VhdsSubscription(config_update_info, factory_context_, context_, provider_));
 }
 
 // verify that api_type: GRPC fails validation
@@ -115,7 +115,7 @@ vhds:
   )EOF");
   RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
 
-  EXPECT_THROW(VhdsSubscription(config_update_info, factory_context_, context_, providers_),
+  EXPECT_THROW(VhdsSubscription(config_update_info, factory_context_, context_, provider_),
                EnvoyException);
 }
 
@@ -125,7 +125,7 @@ TEST_F(VhdsTest, VhdsAddsVirtualHosts) {
       TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(default_vhds_config_);
   RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
 
-  VhdsSubscription subscription(config_update_info, factory_context_, context_, providers_);
+  VhdsSubscription subscription(config_update_info, factory_context_, context_, provider_);
   EXPECT_EQ(0UL, config_update_info->routeConfiguration().virtual_hosts_size());
 
   auto vhost = buildVirtualHost("vhost1", "vhost.first");
@@ -184,7 +184,7 @@ vhds:
   )EOF");
   RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
 
-  VhdsSubscription subscription(config_update_info, factory_context_, context_, providers_);
+  VhdsSubscription subscription(config_update_info, factory_context_, context_, provider_);
   EXPECT_EQ(1UL, config_update_info->routeConfiguration().virtual_hosts_size());
   EXPECT_EQ("vhost_rds1", config_update_info->routeConfiguration().virtual_hosts(0).name());
 


### PR DESCRIPTION
Commit Message:
Optimize RdsSubscription under the fact that a RdsSubscription object has at most 1 provider.

Additional Description:
Risk Level: Low. The ASSERT has been running for 1+ year.
Testing: Fixed test
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
