### PR TITLE
benchmark: exposed google benchmark's intrinsic command-line options

### DIFF
--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -21,6 +21,19 @@ static bool skip_expensive_benchmarks = false;
 // separated by --.
 // TODO(pgenera): convert this to abseil/flags/ when benchmark also adopts abseil.
 int main(int argc, char** argv) {
+
+  bool is_help_flag = false;
+
+  for (int i = 1; i < argc; ++i) {
+    if (strcmp(argv[i], "--help") == 0) {
+      is_help_flag = true;
+    }
+  }
+
+  if (!is_help_flag) {
+    ::benchmark::Initialize(&argc, argv);
+  }
+
   TestEnvironment::initializeTestMain(argv[0]);
 
   // Suppressing non-error messages in benchmark tests. This hides warning
@@ -76,8 +89,6 @@ int main(int argc, char** argv) {
     const auto feature_val = runtime_feature_split[1];
     Runtime::LoaderSingleton::getExisting()->mergeValues({{feature_name, feature_val}});
   }
-
-  ::benchmark::Initialize(&argc, argv);
 
   if (skip_expensive_benchmarks) {
     ENVOY_LOG_MISC(

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -22,6 +22,9 @@ static bool skip_expensive_benchmarks = false;
 // TODO(pgenera): convert this to abseil/flags/ when benchmark also adopts abseil.
 int main(int argc, char** argv) {
 
+  // if the `--help` flag isn't considered separately, it runs "benchmark --help"
+  // and the help output doesn't contains details about custom defined flags
+  // like `--skip_expensive_benchmarks`, `--runtime_feature`, etc
   bool contains_help_flag = false;
 
   for (int i = 1; i < argc; ++i) {

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -22,11 +22,9 @@ static bool skip_expensive_benchmarks = false;
 // TODO(pgenera): convert this to abseil/flags/ when benchmark also adopts abseil.
 int main(int argc, char** argv) {
 
-  // if the `--help` flag isn't considered separately, it runs "benchmark --help"
-  // and the help output doesn't contains details about custom defined flags
-  // like `--skip_expensive_benchmarks`, `--runtime_feature`, etc
   bool contains_help_flag = false;
 
+  // Checking if any of the command-line arguments contains `--help`
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--help") == 0) {
       contains_help_flag = true;
@@ -34,7 +32,13 @@ int main(int argc, char** argv) {
     }
   }
 
+  // if the `--help` flag isn't considered separately, it runs "benchmark --help"
+  // (Google Benchmark Help) and the help output doesn't contains details about
+  // custom defined flags like `--skip_expensive_benchmarks`, `--runtime_feature`, etc
   if (!contains_help_flag) {
+    // Passing the arguments of the program to Google Benchmark.
+    // That way Google benchmark options would also be supported, along with the
+    // custom defined custom flags
     ::benchmark::Initialize(&argc, argv);
   }
 

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -22,15 +22,16 @@ static bool skip_expensive_benchmarks = false;
 // TODO(pgenera): convert this to abseil/flags/ when benchmark also adopts abseil.
 int main(int argc, char** argv) {
 
-  bool is_help_flag = false;
+  bool contains_help_flag = false;
 
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--help") == 0) {
-      is_help_flag = true;
+      contains_help_flag = true;
+      break;
     }
   }
 
-  if (!is_help_flag) {
+  if (!contains_help_flag) {
     ::benchmark::Initialize(&argc, argv);
   }
 


### PR DESCRIPTION
**Commit Message:** benchmark: exposed google benchmark's intrinsic command-line options

**Additional Description:**  If an argument containing the word "help" is passed, then it not
passed to the `::benchmark:Initialize()` method, and handled separately.
This PR addresses Issue #15076.

**Risk Level:** Low
**Testing:** No
**Docs Changes:** No


Signed-off-by: Rajdeep Roy Chowdhury <rrajdeeproychowdhury@gmail.com>
