### PR TITLE
[network] handle onWriteReady socket failure

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -656,8 +656,6 @@ void ConnectionImpl::onWriteReady() {
     socklen_t error_size = sizeof(error);
     Api::SysCallIntResult result =
         socket_->getSocketOption(SOL_SOCKET, SO_ERROR, &error, &error_size);
-    RELEASE_ASSERT(result.rc_ == 0,
-                   fmt::format("Failed to connect: {}", errorDetails(result.errno_)));
 
     if (error == 0) {
       ENVOY_CONN_LOG(debug, "connected", *this);
@@ -669,7 +667,8 @@ void ConnectionImpl::onWriteReady() {
         return;
       }
     } else {
-      ENVOY_CONN_LOG(debug, "delayed connection error: {}", *this, error);
+      ENVOY_BUG(result.rc_ == 0, fmt::format("failed to connect: {}", errorDetails(result.errno_)));
+      ENVOY_CONN_LOG(debug, "delayed connection error: {}", *this, errorDetails(result.errno_));
       closeSocket(ConnectionEvent::RemoteClose);
       return;
     }

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -654,8 +654,10 @@ void ConnectionImpl::onWriteReady() {
   if (connecting_) {
     int error;
     socklen_t error_size = sizeof(error);
-    RELEASE_ASSERT(socket_->getSocketOption(SOL_SOCKET, SO_ERROR, &error, &error_size).rc_ == 0,
-                   fmt::format("Failed to connect: {}", error));
+    Api::SysCallIntResult result =
+        socket_->getSocketOption(SOL_SOCKET, SO_ERROR, &error, &error_size);
+    RELEASE_ASSERT(result.rc_ == 0,
+                   fmt::format("Failed to connect: {}", errorDetails(result.errno_)));
 
     if (error == 0) {
       ENVOY_CONN_LOG(debug, "connected", *this);

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -655,7 +655,7 @@ void ConnectionImpl::onWriteReady() {
     int error;
     socklen_t error_size = sizeof(error);
     RELEASE_ASSERT(socket_->getSocketOption(SOL_SOCKET, SO_ERROR, &error, &error_size).rc_ == 0,
-                   "");
+                   fmt::format("Failed to connect: {}", error));
 
     if (error == 0) {
       ENVOY_CONN_LOG(debug, "connected", *this);


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Remove `RELEASE_ASSERT` and handle socket connection failure
Additional Description: https://github.com/envoyproxy/envoy/blob/70fbf11109b2503bedc4fc6f84324c897f19a978/source/common/network/connection_impl.cc#L657 was changed from ASSERT to RELEASE_ASSERT in https://github.com/envoyproxy/envoy/pull/10107/ and so the else branch following never executes: . Improve log message to understand crash (maybe an OOM condition)
Risk Level: Arguably negative risk. Removes risk of crash in favor of error handling (that was already existing)

