### PR TITLE
dns cache: add host info to `onLoadDnsCacheComplete` callback

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -86,8 +86,10 @@ public:
 
     /**
      * Called when the DNS cache load is complete (or failed).
+     *
+     * @param host_info the DnsHostInfo for the resolved host.
      */
-    virtual void onLoadDnsCacheComplete() PURE;
+    virtual void onLoadDnsCacheComplete(const DnsHostInfoSharedPtr& host_info) PURE;
   };
 
   /**

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -139,7 +139,7 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
-void ProxyFilter::onLoadDnsCacheComplete() {
+void ProxyFilter::onLoadDnsCacheComplete(const Common::DynamicForwardProxy::DnsHostInfoSharedPtr&) {
   ENVOY_STREAM_LOG(debug, "load DNS cache complete, continuing", *decoder_callbacks_);
   ASSERT(circuit_breaker_ != nullptr);
   circuit_breaker_.reset();

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
@@ -55,7 +55,8 @@ public:
   void onDestroy() override;
 
   // Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks
-  void onLoadDnsCacheComplete() override;
+  void onLoadDnsCacheComplete(
+      const Extensions::Common::DynamicForwardProxy::DnsHostInfoSharedPtr&) override;
 
 private:
   const ProxyFilterConfigSharedPtr config_;

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -73,7 +73,7 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
-void ProxyFilter::onLoadDnsCacheComplete() {
+void ProxyFilter::onLoadDnsCacheComplete(const Common::DynamicForwardProxy::DnsHostInfoSharedPtr&) {
   ENVOY_CONN_LOG(debug, "load DNS cache complete, continuing", read_callbacks_->connection());
   ASSERT(circuit_breaker_ != nullptr);
   circuit_breaker_.reset();

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
@@ -51,7 +51,8 @@ public:
   }
 
   // Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks
-  void onLoadDnsCacheComplete() override;
+  void onLoadDnsCacheComplete(
+      const Extensions::Common::DynamicForwardProxy::DnsHostInfoSharedPtr&) override;
 
 private:
   const ProxyFilterConfigSharedPtr config_;

--- a/test/extensions/common/dynamic_forward_proxy/mocks.h
+++ b/test/extensions/common/dynamic_forward_proxy/mocks.h
@@ -108,7 +108,7 @@ public:
   MockLoadDnsCacheEntryCallbacks();
   ~MockLoadDnsCacheEntryCallbacks() override;
 
-  MOCK_METHOD(void, onLoadDnsCacheComplete, ());
+  MOCK_METHOD(void, onLoadDnsCacheComplete, (const DnsHostInfoSharedPtr&));
 };
 
 } // namespace DynamicForwardProxy

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -82,7 +82,8 @@ TEST_F(SniDynamicProxyFilterTest, LoadDnsCache) {
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 
   EXPECT_CALL(callbacks_, continueReading());
-  filter_->onLoadDnsCacheComplete();
+  filter_->onLoadDnsCacheComplete(
+      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>());
 
   EXPECT_CALL(*handle, onDestroy());
 }


### PR DESCRIPTION
Commit Message: Provide the host info in the `onLoadDnsCacheComplete` callback so that the worker threads do not have to do an additional lookup to get the resolved IP.
Additional Description:
Risk Level: Low - no change to functionality and code modifications are minimal
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
