### PR TITLE
ext_authz: match on route entry metadata not filter dynamic metadata 

### DIFF
--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -86,11 +86,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     return Http::FilterHeadersStatus::Continue;
   }
 
-  if (route == nullptr || route->routeEntry() == nullptr) {
-    return Http::FilterHeadersStatus::Continue;
-  }
-
-  if (!config_->filterEnabled(route->routeEntry()->metadata())) {
+  if (!config_->filterEnabled(route->routeEntry())) {
     stats_.disabled_.inc();
     if (config_->denyAtDisable()) {
       ENVOY_STREAM_LOG(trace, "ext_authz filter is disabled. Deny the request.",

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -86,7 +86,11 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     return Http::FilterHeadersStatus::Continue;
   }
 
-  if (!config_->filterEnabled(decoder_callbacks_->streamInfo().dynamicMetadata())) {
+  if (route == nullptr || route->routeEntry() == nullptr) {
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  if (!config_->filterEnabled(route->routeEntry()->metadata())) {
     stats_.disabled_.inc();
     if (config_->denyAtDisable()) {
       ENVOY_STREAM_LOG(trace, "ext_authz filter is disabled. Deny the request.",

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -103,9 +103,9 @@ public:
     const bool enabled = filter_enabled_.has_value() ? filter_enabled_->enabled() : true;
     const bool enabled_metadata =
         route_entry == nullptr ? !filter_enabled_metadata_.has_value()
-                              : filter_enabled_metadata_.has_value()
-                                    ? filter_enabled_metadata_->match(route_entry->metadata())
-                                    : true;
+                               : filter_enabled_metadata_.has_value()
+                                     ? filter_enabled_metadata_->match(route_entry->metadata())
+                                     : true;
 
     return enabled && enabled_metadata;
   }

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -101,7 +101,7 @@ public:
 
   bool filterEnabled(const Router::RouteEntry* routeEntry) {
     const bool enabled = filter_enabled_.has_value() ? filter_enabled_->enabled() : true;
-    const bool enabled_metadata = routeEntry == nullptr ? true :
+    const bool enabled_metadata = routeEntry == nullptr ? !filter_enabled_metadata_.has_value() :
       filter_enabled_metadata_.has_value() ? 
         filter_enabled_metadata_->match(routeEntry->metadata()) : true;
 

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -99,12 +99,12 @@ public:
 
   Http::Code statusOnError() const { return status_on_error_; }
 
-  bool filterEnabled(const Router::RouteEntry* routeEntry) {
+  bool filterEnabled(const Router::RouteEntry* route_entry) {
     const bool enabled = filter_enabled_.has_value() ? filter_enabled_->enabled() : true;
     const bool enabled_metadata =
-        routeEntry == nullptr ? !filter_enabled_metadata_.has_value()
+        route_entry == nullptr ? !filter_enabled_metadata_.has_value()
                               : filter_enabled_metadata_.has_value()
-                                    ? filter_enabled_metadata_->match(routeEntry->metadata())
+                                    ? filter_enabled_metadata_->match(route_entry->metadata())
                                     : true;
 
     return enabled && enabled_metadata;

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -99,10 +99,12 @@ public:
 
   Http::Code statusOnError() const { return status_on_error_; }
 
-  bool filterEnabled(const envoy::config::core::v3::Metadata& metadata) {
+  bool filterEnabled(const Router::RouteEntry* routeEntry) {
     const bool enabled = filter_enabled_.has_value() ? filter_enabled_->enabled() : true;
-    const bool enabled_metadata =
-        filter_enabled_metadata_.has_value() ? filter_enabled_metadata_->match(metadata) : true;
+    const bool enabled_metadata = routeEntry == nullptr ? true :
+      filter_enabled_metadata_.has_value() ? 
+        filter_enabled_metadata_->match(routeEntry->metadata()) : true;
+
     return enabled && enabled_metadata;
   }
 

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -101,9 +101,11 @@ public:
 
   bool filterEnabled(const Router::RouteEntry* routeEntry) {
     const bool enabled = filter_enabled_.has_value() ? filter_enabled_->enabled() : true;
-    const bool enabled_metadata = routeEntry == nullptr ? !filter_enabled_metadata_.has_value() :
-      filter_enabled_metadata_.has_value() ? 
-        filter_enabled_metadata_->match(routeEntry->metadata()) : true;
+    const bool enabled_metadata =
+        routeEntry == nullptr ? !filter_enabled_metadata_.has_value()
+                              : filter_enabled_metadata_.has_value()
+                                    ? filter_enabled_metadata_->match(routeEntry->metadata())
+                                    : true;
 
     return enabled && enabled_metadata;
   }

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1265,8 +1265,8 @@ TEST_F(HttpFilterTest, MetadataEnabled) {
             filter_->decodeHeaders(request_headers_, false));
 }
 
-// Test that the filter is disabled if the filter_enabled and filter_enabled_metadata fields are enabled
-// but the route entry is not present.
+// Test that the filter is disabled if the filter_enabled and filter_enabled_metadata fields are
+// enabled but the route entry is not present.
 TEST_F(HttpFilterTest, FilterEnabledButRouteEntryIsNotPresent) {
   initialize(R"EOF(
   transport_api_version: V3
@@ -1293,7 +1293,7 @@ TEST_F(HttpFilterTest, FilterEnabledButRouteEntryIsNotPresent) {
                          testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
       .WillByDefault(Return(true));
 
-  // No route has matched 
+  // No route has matched
   ON_CALL(*filter_callbacks_.route_, routeEntry()).WillByDefault(Return(nullptr));
 
   // Make sure check is not called.
@@ -1301,7 +1301,6 @@ TEST_F(HttpFilterTest, FilterEnabledButRouteEntryIsNotPresent) {
   // Engage the filter.
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
 }
-
 
 // Test that the filter is disabled if one of the filter_enabled and filter_enabled_metadata field
 // is disabled.

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1222,7 +1222,7 @@ TEST_F(HttpFilterTest, MetadataDisabled) {
   )EOF";
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(yaml, metadata);
-  ON_CALL(filter_callbacks_.stream_info_, dynamicMetadata()).WillByDefault(ReturnRef(metadata));
+  ON_CALL(filter_callbacks_.route_->route_entry_, metadata()).WillByDefault(ReturnRef(metadata));
 
   // Make sure check is not called.
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
@@ -1254,7 +1254,7 @@ TEST_F(HttpFilterTest, MetadataEnabled) {
   )EOF";
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(yaml, metadata);
-  ON_CALL(filter_callbacks_.stream_info_, dynamicMetadata()).WillByDefault(ReturnRef(metadata));
+  ON_CALL(filter_callbacks_.route_->route_entry_, metadata()).WillByDefault(ReturnRef(metadata));
 
   prepareCheck();
 
@@ -1301,7 +1301,7 @@ TEST_F(HttpFilterTest, FilterEnabledButMetadataDisabled) {
   )EOF";
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(yaml, metadata);
-  ON_CALL(filter_callbacks_.stream_info_, dynamicMetadata()).WillByDefault(ReturnRef(metadata));
+  ON_CALL(filter_callbacks_.route_->route_entry_, metadata()).WillByDefault(ReturnRef(metadata));
 
   // Make sure check is not called.
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
@@ -1345,7 +1345,7 @@ TEST_F(HttpFilterTest, FilterDisabledButMetadataEnabled) {
   )EOF";
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(yaml, metadata);
-  ON_CALL(filter_callbacks_.stream_info_, dynamicMetadata()).WillByDefault(ReturnRef(metadata));
+  ON_CALL(filter_callbacks_.route_->route_entry_, metadata()).WillByDefault(ReturnRef(metadata));
 
   // Make sure check is not called.
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);
@@ -1389,7 +1389,7 @@ TEST_F(HttpFilterTest, FilterEnabledAndMetadataEnabled) {
   )EOF";
   envoy::config::core::v3::Metadata metadata;
   TestUtility::loadFromYaml(yaml, metadata);
-  ON_CALL(filter_callbacks_.stream_info_, dynamicMetadata()).WillByDefault(ReturnRef(metadata));
+  ON_CALL(filter_callbacks_.route_->route_entry_, metadata()).WillByDefault(ReturnRef(metadata));
 
   prepareCheck();
 

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1293,6 +1293,7 @@ TEST_F(HttpFilterTest, FilterEnabledButRouteEntryIsNotPresent) {
                          testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
       .WillByDefault(Return(true));
 
+  // No route has matched 
   ON_CALL(*filter_callbacks_.route_, routeEntry()).WillByDefault(Return(nullptr));
 
   // Make sure check is not called.

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1266,8 +1266,8 @@ TEST_F(HttpFilterTest, MetadataEnabled) {
 }
 
 // Test that the filter is disabled if the filter_enabled and filter_enabled_metadata fields are enabled
-// but the route metadata is not present.
-TEST_F(HttpFilterTest, FilterEnabledButMetadataIsNotPresent) {
+// but the route entry is not present.
+TEST_F(HttpFilterTest, FilterEnabledButRouteEntryIsNotPresent) {
   initialize(R"EOF(
   transport_api_version: V3
   grpc_service:
@@ -1293,7 +1293,7 @@ TEST_F(HttpFilterTest, FilterEnabledButMetadataIsNotPresent) {
                          testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
       .WillByDefault(Return(true));
 
-  ON_CALL(filter_callbacks_.route_->route_entry_, metadata()).WillByDefault(ReturnRef(envoy::config::core::v3::Metadata::default_instance()));
+  ON_CALL(*filter_callbacks_.route_, routeEntry()).WillByDefault(Return(nullptr));
 
   // Make sure check is not called.
   EXPECT_CALL(*client_, check(_, _, _, _)).Times(0);


### PR DESCRIPTION
The current implementation does not match the documentation: 
https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/matcher/v3/metadata.proto#metadata-matcher

`filter_metadata:` can be retrieved from the `Router::RouteEntry` , but not from the dynamic metadata. 

Commit Message: ext_authz: this fixes a tiny bug in the http filter, as it should match on the route metadata, not the filter dynamic metadata 
Additional Description: Small correction from https://github.com/envoyproxy/envoy/pull/13404
Risk Level: Low
Testing: Added a new unit test 
Docs Changes: No need, docs are already present 
Release Notes: N/A
Platform Specific Features: N/A

Currently, it is possible to workaround the issue with something like this in a lua filter: 

` 
local filter_metadata = request_handle:metadata():get("k1");
request_handle:streamInfo():dynamicMetadata():set("abc.xyz", "k1",  filter_metadata);
`
