### PR TITLE
Docs: add SDS file secret name

### DIFF
--- a/docs/root/configuration/security/secret.rst
+++ b/docs/root/configuration/security/secret.rst
@@ -267,6 +267,7 @@ Paths to client certificate, including client's certificate chain and private ke
 
     resources:
       - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: tls_sds
         tls_certificate:
           certificate_chain:
             filename: /certs/sds_cert.pem
@@ -279,6 +280,7 @@ Path to CA certificate bundle for validating the xDS server certificate is given
 
     resources:
       - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: validation_context_sds
         validation_context:
           trusted_ca:
             filename: /certs/cacert.pem
@@ -293,6 +295,7 @@ supports this scheme via the use of *watched_directory*. Continuing the above ex
 
     resources:
       - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: tls_sds
         tls_certificate:
           certificate_chain:
             filename: /certs/current/sds_cert.pem
@@ -305,6 +308,7 @@ supports this scheme via the use of *watched_directory*. Continuing the above ex
 
     resources:
       - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: validation_context_sds
         validation_context:
           trusted_ca:
             filename: /certs/current/cacert.pem


### PR DESCRIPTION
I tried to run [Example three: certificate rotation for xDS gRPC connection](https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#example-three-certificate-rotation-for-xds-grpc-connection) and got the following error:

```
[2021-02-24 03:37:06.883][1][warning][config] [source/common/config/filesystem_subscription_impl.cc:43] Filesystem config update rejected: Unexpected SDS secret (expecting tls_sds): 
```

Additionally, Envoy did not serve a TLS Certificate on my Listener Transport Socket

Upon further inspection, it appears that Envoy is looking for a matching secret name in the SDS response.  When I added `name: tls_sds` to the SDS Response in the file, the error went away and the proper TLS Certificate was served on my Listener Transport Socket

Version Information:

```
envoy  version: f155eaac66fc23cd3e1a7bf5c4ec2309d308dbb1/1.18.0-dev/Clean/RELEASE/BoringSSL
```