### PR TITLE
upstream: fix subset_lb crash when host configured with no metadata

### DIFF
--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -128,21 +128,22 @@ void SubsetLoadBalancer::rebuildSingle() {
   for (const auto& host_set : original_priority_set_.hostSetsPerPriority()) {
     for (const auto& host : host_set->hosts()) {
       MetadataConstSharedPtr metadata = host->metadata();
-      if (metadata != nullptr) {
-        const auto& filter_metadata = metadata->filter_metadata();
-        auto filter_it = filter_metadata.find(Config::MetadataFilters::get().ENVOY_LB);
-        if (filter_it != filter_metadata.end()) {
-          const auto& fields = filter_it->second.fields();
-          auto fields_it = fields.find(single_key_);
-          if (fields_it != fields.end()) {
-            auto [iterator, did_insert] =
-                single_host_per_subset_map_.try_emplace(fields_it->second, host);
-            UNREFERENCED_PARAMETER(iterator);
-            if (!did_insert) {
-              // Two hosts with the same metadata value were found. Ignore all but one of them, and
-              // set a metric for how many times this happened.
-              collision_count++;
-            }
+      if (metadata == nullptr) {
+        continue;
+      }
+      const auto& filter_metadata = metadata->filter_metadata();
+      auto filter_it = filter_metadata.find(Config::MetadataFilters::get().ENVOY_LB);
+      if (filter_it != filter_metadata.end()) {
+        const auto& fields = filter_it->second.fields();
+        auto fields_it = fields.find(single_key_);
+        if (fields_it != fields.end()) {
+          auto [iterator, did_insert] =
+              single_host_per_subset_map_.try_emplace(fields_it->second, host);
+          UNREFERENCED_PARAMETER(iterator);
+          if (!did_insert) {
+            // Two hosts with the same metadata value were found. Ignore all but one of them, and
+            // set a metric for how many times this happened.
+            collision_count++;
           }
         }
       }

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -128,19 +128,21 @@ void SubsetLoadBalancer::rebuildSingle() {
   for (const auto& host_set : original_priority_set_.hostSetsPerPriority()) {
     for (const auto& host : host_set->hosts()) {
       MetadataConstSharedPtr metadata = host->metadata();
-      const auto& filter_metadata = metadata->filter_metadata();
-      auto filter_it = filter_metadata.find(Config::MetadataFilters::get().ENVOY_LB);
-      if (filter_it != filter_metadata.end()) {
-        const auto& fields = filter_it->second.fields();
-        auto fields_it = fields.find(single_key_);
-        if (fields_it != fields.end()) {
-          auto [iterator, did_insert] =
-              single_host_per_subset_map_.try_emplace(fields_it->second, host);
-          UNREFERENCED_PARAMETER(iterator);
-          if (!did_insert) {
-            // Two hosts with the same metadata value were found. Ignore all but one of them, and
-            // set a metric for how many times this happened.
-            collision_count++;
+      if (metadata != nullptr) {
+        const auto& filter_metadata = metadata->filter_metadata();
+        auto filter_it = filter_metadata.find(Config::MetadataFilters::get().ENVOY_LB);
+        if (filter_it != filter_metadata.end()) {
+          const auto& fields = filter_it->second.fields();
+          auto fields_it = fields.find(single_key_);
+          if (fields_it != fields.end()) {
+            auto [iterator, did_insert] =
+                single_host_per_subset_map_.try_emplace(fields_it->second, host);
+            UNREFERENCED_PARAMETER(iterator);
+            if (!did_insert) {
+              // Two hosts with the same metadata value were found. Ignore all but one of them, and
+              // set a metric for how many times this happened.
+              collision_count++;
+            }
           }
         }
       }

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -216,13 +216,15 @@ TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancer) {
   runTest(type_b_request_headers_, "b");
 }
 
-// Tests subset-compatible load balancer policy without metadata does not crash on initialization.
-TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancerNoMetadata) {
+// Tests subset-compatible load balancer policy without metadata does not crash on initialization
+// with single_host_per_subset set to be true.
+TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancerSingleHostPerSubsetNoMetadata) {
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     auto* static_resources = bootstrap.mutable_static_resources();
     auto* cluster = static_resources->mutable_clusters(0);
 
-    // Set single_host_per_subset to be true
+    // Set single_host_per_subset to be true. This will avoid function
+    // SubsetLoadBalancer::rebuildSingle() bailout early. Thus exercise the no metadata logic.
     auto* subset_selector = cluster->mutable_lb_subset_config()->mutable_subset_selectors(0);
     subset_selector->set_single_host_per_subset(true);
 

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -216,4 +216,26 @@ TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancer) {
   runTest(type_b_request_headers_, "b");
 }
 
+// Tests subset-compatible load balancer policy with empty metadata
+TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancer_null_metadata) {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* static_resources = bootstrap.mutable_static_resources();
+    auto* cluster = static_resources->mutable_clusters(0);
+
+    // Set single_host_per_subset to be true
+    auto* subset_selector = cluster->mutable_lb_subset_config()->mutable_subset_selectors(0);
+    subset_selector->set_single_host_per_subset(true);
+
+    // Clear the metadata for each host
+    auto* load_assignment = cluster->mutable_load_assignment();
+    auto* endpoints = load_assignment->mutable_endpoints(0);
+    for (uint32_t i = 0; i < num_hosts_; i++) {
+      auto* lb_endpoint = endpoints->mutable_lb_endpoints(i);
+      lb_endpoint->clear_metadata();
+    }
+  });
+
+  initialize();
+}
+
 } // namespace Envoy

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -241,12 +241,14 @@ TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancerSingleHostPerSubsetNoMetad
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(
       Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                     {":path", "/test/long/url"},
+                                     {":path", "/test"},
                                      {":scheme", "http"},
-                                     {":authority", "host"}});
+                                     {":authority", "host"},
+                                     {"x-type", "a"},
+                                     {"x-hash", "hash-a"}});
   response->waitForEndStream();
   EXPECT_TRUE(response->complete());
-  EXPECT_THAT(response->headers(), Http::HttpStatusIs("404"));
+  EXPECT_THAT(response->headers(), Http::HttpStatusIs("503"));
 }
 
 } // namespace Envoy

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -239,13 +239,13 @@ TEST_P(HttpSubsetLbIntegrationTest, SubsetLoadBalancerSingleHostPerSubsetNoMetad
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestRequestHeaderMapImpl{{":method", "GET"},
-                                     {":path", "/test"},
-                                     {":scheme", "http"},
-                                     {":authority", "host"},
-                                     {"x-type", "a"},
-                                     {"x-hash", "hash-a"}});
+  auto response =
+      codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                          {":path", "/test"},
+                                                                          {":scheme", "http"},
+                                                                          {":authority", "host"},
+                                                                          {"x-type", "a"},
+                                                                          {"x-hash", "hash-a"}});
   response->waitForEndStream();
   EXPECT_TRUE(response->complete());
   EXPECT_THAT(response->headers(), Http::HttpStatusIs("503"));

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5135200453525504
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5135200453525504
@@ -1,0 +1,32 @@
+static_resources {
+  clusters {
+    name: "0"
+    connect_timeout {
+      nanos: 813
+    }
+    lb_policy: RING_HASH
+    lb_subset_config {
+      fallback_policy: ANY_ENDPOINT
+      subset_selectors {
+        keys: "\010,"
+        single_host_per_subset: true
+      }
+    }
+    load_assignment {
+      cluster_name: "."
+      endpoints {
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "y"
+              }
+            }
+            hostname: "y"
+          }
+          health_status: UNHEALTHY
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Problem Description:
The problem is that when executing a fuzz test case with empty hostmetadata, envoy crashed at subset_lb.cc:rebuildSingle(): line 131.

Root cause:
The root cause is that current envoy code is assuming host->medata is valid, and directly using it without NULL check. In the case if metadata is actually NULL, which is a valid configuration, it crashes.

Fix:
1)The fix is to add a if (metadat != nullptr) in subset_lb.cc:rebuildSingle() before accessing metadata.
2)GTEST code is added to reproduce the issue, also verifies the fix.
3)The oss-fuzz test file which exposed the issue is pushed with the change.

Testing:
1)The fix is tested by running the oss-fuzz test with the special test file which has host configured without metadata.
2)The fix is also tested by the newly added GTEST code.

Release Notes:
N/A 

Issues:

Fix #30705 : https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30705

Signed-off-by: Yanjun Xiang <yanjunxiang@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
