### PR TITLE
Update the bazel_rules dependency to a stable release

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,7 +4,7 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-load("@rules_fuzzing//fuzzing:repositories.bzl", "oss_fuzz_dependencies", "rules_fuzzing_dependencies")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")
@@ -31,8 +31,10 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     upb_deps()
     antlr_dependencies(472)
     proxy_wasm_rust_sdk_dependencies()
-    rules_fuzzing_dependencies()
-    oss_fuzz_dependencies()
+    rules_fuzzing_dependencies(
+        oss_fuzz = True,
+        honggfuzz = False,
+    )
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -2,7 +2,7 @@
 # Envoy test targets. This includes both test library and test binary targets.
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("@rules_fuzzing//fuzzing:cc_deps.bzl", "fuzzing_decoration")
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "fuzzing_decoration")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
 load(
@@ -133,21 +133,6 @@ def envoy_cc_fuzz_test(
         corpus = [corpus_name],
         dicts = dictionaries,
         define_regression_test = False,
-    )
-
-    # This target exists only for
-    # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield
-    # anything useful on its own, as it expects to be run in an environment where the linker options
-    # provide a path to FuzzingEngine.
-    cc_binary(
-        name = name + "_driverless",
-        copts = ["-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"] +
-                envoy_copts("@envoy", test = True),
-        linkopts = ["-lFuzzingEngine"] + _envoy_test_linkopts(),
-        linkstatic = 1,
-        testonly = 1,
-        deps = [":" + test_lib_name],
-        tags = ["manual"] + tags,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -49,11 +49,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Fuzzing Rules for Bazel",
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
-        version = "f6062a88d83463e2900e47bc218547ba046dad44",
-        sha256 = "9397f26694e0bf8efb1a67a0a88e1770eddeebbb95d0a2cd9d2043b366dc0480",
+        version = "0.1.1",
+        sha256 = "bc286c36bf40c5447d8e4ee047f471c934fe99d4acba0de7a866f38d2ea83a21",
         strip_prefix = "rules_fuzzing-{version}",
-        urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
-        release_date = "2021-01-29",
+        urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v{version}.tar.gz"],
+        release_date = "2021-02-24",
         use_category = ["test_only"],
         implied_untracked_deps = [
             # This is a repository rule generated to define an OSS-Fuzz fuzzing

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -6,7 +6,7 @@ load(
     "envoy_proto_library",
 )
 load(
-    "@rules_fuzzing//fuzzing:cc_deps.bzl",
+    "@rules_fuzzing//fuzzing:cc_defs.bzl",
     "cc_fuzzing_engine",
 )
 


### PR DESCRIPTION
Commit Message: Update the bazel_rules dependency to a stable release. 
Additional Description: This also incorporates bug fixes (including bazelbuild/rules_fuzzing#124) and removes old, no longer used code.
Risk Level: Low.
Testing: Ran `$ bazel run --config=remote-clang-libc++ --config=asan-fuzzer //test/common/common:base64_fuzz_test_run -- --clean` to exercise the rules_fuzzing code.
Docs Changes: None.
Release Notes: N/A.
Platform Specific Features: None (fuzzing is Linux-only).