### PR TITLE
docs: Added support for validation of example configs that are stored in yaml files

### DIFF
--- a/docs/_ext/validating_literal_include.py
+++ b/docs/_ext/validating_literal_include.py
@@ -1,0 +1,63 @@
+from typing import List
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst import directives
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+from sphinx.directives.code import LiteralInclude 
+from sphinx.errors import ExtensionError
+
+import os
+import subprocess
+
+
+class ValidatingLiteralInclude(LiteralInclude):
+  """Like ``.. literalinclude::``, but with protobuf validation.
+
+    'type-name' option is required and expected to conain full Envoy API type.
+    An ExtensionError is raised on validation failure.
+    Validation will be skipped if SPHINX_SKIP_CONFIG_VALIDATION environment variable is set.
+    """
+  has_content = False
+  required_arguments = LiteralInclude.required_arguments
+  optional_arguments = LiteralInclude.optional_arguments
+  final_argument_whitespace = LiteralInclude.final_argument_whitespace
+  option_spec = {
+      'type-name': directives.unchanged,
+  }
+  option_spec.update(LiteralInclude.option_spec)
+  skip_validation = (os.getenv('SPHINX_SKIP_CONFIG_VALIDATION') or 'false').lower() == 'true'
+
+  def run(self):
+    source, line = self.state_machine.get_source_and_line(self.lineno)
+    # built-in directives.unchanged_required option validator produces a confusing error message
+    if self.options.get('type-name') == None:
+      raise ExtensionError("Expected type name in: {0} line: {1}".format(source, line))
+
+    if not ValidatingLiteralInclude.skip_validation:
+      relative_filename, filename = self.env.relfn2path(self.arguments[0])
+      args = [
+          'bazel-bin/tools/config_validation/validate_fragment',
+          self.options.get('type-name'), filename
+      ]
+      completed = subprocess.run(args,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 encoding='utf-8')
+      if completed.returncode != 0:
+        raise ExtensionError(
+            "Failed config validation for type: '{0}' in: {1}:\n {2}".format(
+                self.options.get('type-name'), relative_filename, completed.stderr))
+
+    self.options.pop('type-name', None)
+    return list(LiteralInclude.run(self))
+
+
+def setup(app):
+  app.add_directive("validatingliteralinclude", ValidatingLiteralInclude)
+
+  return {
+      'version': '0.1',
+      'parallel_read_safe': True,
+      'parallel_write_safe': True,
+  }

--- a/docs/_ext/validating_literal_include.py
+++ b/docs/_ext/validating_literal_include.py
@@ -4,7 +4,7 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
-from sphinx.directives.code import LiteralInclude 
+from sphinx.directives.code import LiteralInclude
 from sphinx.errors import ExtensionError
 
 import os
@@ -45,9 +45,8 @@ class ValidatingLiteralInclude(LiteralInclude):
                                  stderr=subprocess.PIPE,
                                  encoding='utf-8')
       if completed.returncode != 0:
-        raise ExtensionError(
-            "Failed config validation for type: '{0}' in: {1}:\n {2}".format(
-                self.options.get('type-name'), relative_filename, completed.stderr))
+        raise ExtensionError("Failed config validation for type: '{0}' in: {1}:\n {2}".format(
+            self.options.get('type-name'), relative_filename, completed.stderr))
 
     self.options.pop('type-name', None)
     return list(LiteralInclude.run(self))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ sys.path.append(os.path.abspath("./_ext"))
 
 extensions = [
     'sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig', 'sphinx_tabs.tabs',
-    'sphinx_copybutton', 'validating_code_block', 'sphinxext.rediraffe'
+    'sphinx_copybutton', 'validating_code_block', 'sphinxext.rediraffe', 'validating_literal_include'
 ]
 extlinks = {
     'repo': ('https://github.com/envoyproxy/envoy/blob/{}/%s'.format(blob_sha), ''),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,8 @@ sys.path.append(os.path.abspath("./_ext"))
 
 extensions = [
     'sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig', 'sphinx_tabs.tabs',
-    'sphinx_copybutton', 'validating_code_block', 'sphinxext.rediraffe', 'validating_literal_include'
+    'sphinx_copybutton', 'validating_code_block', 'sphinxext.rediraffe',
+    'validating_literal_include'
 ]
 extlinks = {
     'repo': ('https://github.com/envoyproxy/envoy/blob/{}/%s'.format(blob_sha), ''),

--- a/docs/root/configuration/best_practices/_include/edge.yaml
+++ b/docs/root/configuration/best_practices/_include/edge.yaml
@@ -68,14 +68,14 @@ static_resources:
           route_config:
             virtual_hosts:
             - name: default
-              domains: "*"
+              domains: ["*"]
               routes:
               - match: { prefix: "/" }
                 route:
                   cluster: service_foo
                   idle_timeout: 15s # must be disabled for long-lived and streaming requests
   clusters:
-    name: service_foo
+  - name: service_foo
     connect_timeout: 15s
     per_connection_buffer_limit_bytes: 32768 # 32 KiB
     load_assignment:

--- a/docs/root/configuration/best_practices/edge.rst
+++ b/docs/root/configuration/best_practices/edge.rst
@@ -30,5 +30,6 @@ HTTP proxies should additionally configure:
 The following is a YAML example of the above recommendation (taken from the :ref:`Google VRP
 <arch_overview_google_vrp>` edge server configuration):
 
-.. literalinclude:: _include/edge.yaml
+.. validatingliteralinclude:: _include/edge.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap

--- a/docs/root/configuration/http/http_filters/_include/grpc-reverse-bridge-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/grpc-reverse-bridge-filter.yaml
@@ -70,8 +70,8 @@ static_resources:
                   port_value: 4630
   - name: grpc
     connect_timeout: 5.00s
-    type: strict_dns
-    lb_policy: round_robin
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN 
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/docs/root/configuration/http/http_filters/_include/grpc-transcoder-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/grpc-transcoder-filter.yaml
@@ -24,7 +24,7 @@ static_resources:
               # NOTE: by default, matching happens based on the gRPC route, and not on the incoming request path.
               # Reference: https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/grpc_json_transcoder_filter#route-configs-for-transcoded-requests
               - match: { prefix: "/helloworld.Greeter" }
-                route: { cluster: grpc, timeout: { seconds: 60 } }
+                route: { cluster: grpc, timeout: 60s }
           http_filters:
           - name: envoy.filters.http.grpc_json_transcoder
             typed_config:
@@ -41,8 +41,8 @@ static_resources:
   clusters:
   - name: grpc
     connect_timeout: 1.25s
-    type: logical_dns
-    lb_policy: round_robin
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
     dns_lookup_family: V4_ONLY
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/http/http_filters/dynamic_forward_proxy_filter.rst
@@ -33,8 +33,9 @@ host when forwarding. See the example below within the configured routes.
   Dynamic forward proxy uses circuit breakers built in to the DNS cache with the configuration
   of :ref:`DNS cache circuit breakers <envoy_v3_api_field_extensions.common.dynamic_forward_proxy.v3.DnsCacheConfig.dns_cache_circuit_breaker>`.
 
-.. literalinclude:: _include/dns-cache-circuit-breaker.yaml
+.. validatingliteralinclude:: _include/dns-cache-circuit-breaker.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 Statistics
 ----------

--- a/docs/root/configuration/http/http_filters/grpc_http1_reverse_bridge_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_http1_reverse_bridge_filter.rst
@@ -42,5 +42,6 @@ with the gRPC frame header and respond with gRPC formatted responses.
 How to disable HTTP/1.1 reverse bridge filter per route
 -------------------------------------------------------
 
-.. literalinclude:: _include/grpc-reverse-bridge-filter.yaml
+.. validatingliteralinclude:: _include/grpc-reverse-bridge-filter.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap

--- a/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
+++ b/docs/root/configuration/http/http_filters/grpc_json_transcoder_filter.rst
@@ -102,5 +102,6 @@ Here's a sample Envoy configuration that proxies to a gRPC server running on loc
 gRPC requests and uses the gRPC-JSON transcoder filter to provide the RESTful JSON mapping. I.e., you can make either
 gRPC or RESTful JSON requests to localhost:51051.
 
-.. literalinclude:: _include/grpc-transcoder-filter.yaml
+.. validatingliteralinclude:: _include/grpc-transcoder-filter.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap

--- a/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
@@ -25,5 +25,6 @@ SNI dynamic forward proxy.
   The following config doesn't terminate TLS in listener, so there is no need to configure TLS context
   in cluster. The TLS handshake is passed through by Envoy.
 
-.. literalinclude:: _include/sni-dynamic-forward-proxy-filter.yaml
+.. validatingliteralinclude:: _include/sni-dynamic-forward-proxy-filter.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap

--- a/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
+++ b/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
@@ -49,8 +49,9 @@ Example configuration
 The following example configuration will cause Envoy to listen on UDP port 1234 and proxy to a UDP
 server listening on port 1235.
 
-.. literalinclude:: _include/udp-proxy.yaml
+.. validatingliteralinclude:: _include/udp-proxy.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 
 Statistics

--- a/docs/root/intro/arch_overview/security/_include/ssl.yaml
+++ b/docs/root/intro/arch_overview/security/_include/ssl.yaml
@@ -11,7 +11,7 @@ static_resources:
           route_config:
             virtual_hosts:
             - name: default
-              domains: "*"
+              domains: ["*"]
               routes:
               - match: { prefix: "/" }
                 route:
@@ -47,11 +47,11 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         common_tls_context:
           tls_certificates:
-            certificate_chain: { "filename": "certs/servercert.pem" }
+          - certificate_chain: { "filename": "certs/servercert.pem" }
             private_key: { "filename": "certs/serverkey.pem" }
             ocsp_staple: { "filename": "certs/server_ocsp_resp.der" }
           validation_context:
             match_subject_alt_names:
-              exact: "foo"
+            - exact: "foo"
             trusted_ca:
               filename: /etc/ssl/certs/ca-certificates.crt

--- a/docs/root/intro/arch_overview/security/ssl.rst
+++ b/docs/root/intro/arch_overview/security/ssl.rst
@@ -71,8 +71,9 @@ validation context specifies one or more trusted authority certificates.
 Example configuration
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. literalinclude:: _include/ssl.yaml
+.. validatingliteralinclude:: _include/ssl.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 */etc/ssl/certs/ca-certificates.crt* is the default path for the system CA bundle on Debian systems.
 :ref:`trusted_ca <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>` along with

--- a/docs/root/intro/life_of_a_request.rst
+++ b/docs/root/intro/life_of_a_request.rst
@@ -118,8 +118,9 @@ It's helpful to focus on one at a time, so this example covers the following:
 
 We assume a static bootstrap configuration file for simplicity:
 
-.. literalinclude:: _include/life-of-a-request.yaml
+.. validatingliteralinclude:: _include/life-of-a-request.yaml
     :language: yaml
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 High level architecture
 -----------------------

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
@@ -37,7 +37,7 @@ static_resources:
               match_subject_alt_names:
               - exact: proxy-postgres-frontend.example.com
             tls_certificates:
-              certificate_chain:
+            - certificate_chain:
                 filename: certs/servercert.pem
               private_key:
                 filename: certs/serverkey.pem
@@ -63,7 +63,7 @@ static_resources:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         common_tls_context:
           tls_certificates:
-            certificate_chain:
+          - certificate_chain:
               filename: certs/clientcert.pem
             private_key:
               filename: certs/clientkey.pem

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
@@ -34,7 +34,7 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           common_tls_context:
             tls_certificates:
-              certificate_chain:
+            - certificate_chain:
                 filename: certs/servercert.pem
               private_key:
                 filename: certs/serverkey.pem

--- a/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
@@ -31,7 +31,7 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           common_tls_context:
             tls_certificates:
-              certificate_chain:
+            - certificate_chain:
                 filename: certs/servercert.pem
               private_key:
                 filename: certs/serverkey.pem

--- a/docs/root/start/quick-start/_include/envoy-dynamic-cds-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-cds-demo.yaml
@@ -2,7 +2,7 @@ resources:
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: example_proxy_cluster
   connect_timeout: 1s
-  type: strict_dns
+  type: STRICT_DNS
   typed_extension_protocol_options:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/docs/root/start/quick-start/_include/envoy-dynamic-control-plane-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-control-plane-demo.yaml
@@ -19,7 +19,7 @@ dynamic_resources:
 static_resources:
   clusters:
   - connect_timeout: 1s
-    type: strict_dns
+    type: STRICT_DNS
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/docs/root/start/quick-start/_include/envoy-dynamic-lds-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-lds-demo.yaml
@@ -7,7 +7,7 @@ resources:
       port_value: 10000
   filter_chains:
   - filters:
-      name: envoy.http_connection_manager
+    - name: envoy.http_connection_manager
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         stat_prefix: ingress_http

--- a/docs/root/start/quick-start/admin.rst
+++ b/docs/root/start/quick-start/admin.rst
@@ -70,11 +70,12 @@ In the :download:`envoy-demo.yaml <_include/envoy-demo.yaml>` the listener is co
 :ref:`stat_prefix <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.stat_prefix>`
 of ``ingress_http``.
 
-.. literalinclude:: _include/envoy-demo.yaml
+.. validatingliteralinclude:: _include/envoy-demo.yaml
     :language: yaml
     :linenos:
     :lines: 1-29
     :emphasize-lines: 13-14
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 .. _start_quick_start_admin_config_dump:
 

--- a/docs/root/start/quick-start/configuration-dynamic-control-plane.rst
+++ b/docs/root/start/quick-start/configuration-dynamic-control-plane.rst
@@ -32,11 +32,12 @@ The following sections walk through the dynamic configuration provided in the
 
 The :ref:`node <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.node>` should specify ``cluster`` and ``id``.
 
-.. literalinclude:: _include/envoy-dynamic-control-plane-demo.yaml
+.. validatingliteralinclude:: _include/envoy-dynamic-control-plane-demo.yaml
     :language: yaml
     :linenos:
     :lines: 1-5
     :emphasize-lines: 1-3
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 .. _start_quick_start_dynamic_dynamic_resources:
 

--- a/docs/root/start/quick-start/configuration-dynamic-filesystem.rst
+++ b/docs/root/start/quick-start/configuration-dynamic-filesystem.rst
@@ -32,11 +32,12 @@ The following sections walk through the dynamic configuration provided in the
 
 The :ref:`node <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.node>` should specify ``cluster`` and ``id``.
 
-.. literalinclude:: _include/envoy-dynamic-filesystem-demo.yaml
+.. validatingliteralinclude:: _include/envoy-dynamic-filesystem-demo.yaml
     :language: yaml
     :linenos:
     :lines: 1-5
     :emphasize-lines: 1-3
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 .. _start_quick_start_dynamic_fs_dynamic_resources:
 
@@ -70,10 +71,11 @@ All domains and paths are matched and routed to the ``service_envoyproxy_io`` cl
 
 The ``host`` headers are rewritten to ``www.envoyproxy.io``
 
-.. literalinclude:: _include/envoy-dynamic-lds-demo.yaml
+.. validatingliteralinclude:: _include/envoy-dynamic-lds-demo.yaml
     :language: yaml
     :linenos:
     :emphasize-lines: 6-7, 20-21, 24, 26-27
+    :type-name: envoy.service.discovery.v3.DiscoveryResponse
 
 .. _start_quick_start_dynamic_fs_dynamic_cds:
 
@@ -86,7 +88,8 @@ In the following example of a :download:`dynamic CDS file <_include/envoy-dynami
 the ``example_proxy_cluster`` :ref:`cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`
 proxies over ``TLS`` to https://www.envoyproxy.io.
 
-.. literalinclude:: _include/envoy-dynamic-cds-demo.yaml
+.. validatingliteralinclude:: _include/envoy-dynamic-cds-demo.yaml
     :language: yaml
     :linenos:
     :emphasize-lines: 8, 14-15, 19-20
+    :type-name: envoy.service.discovery.v3.DiscoveryResponse

--- a/docs/root/start/quick-start/configuration-static.rst
+++ b/docs/root/start/quick-start/configuration-static.rst
@@ -21,11 +21,12 @@ The following sections walk through the static configuration provided in the
 The :ref:`static_resources <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.static_resources>` contain
 everything that is configured statically when Envoy starts, as opposed to dynamically at runtime.
 
-.. literalinclude:: _include/envoy-demo.yaml
+.. validatingliteralinclude:: _include/envoy-demo.yaml
     :language: yaml
     :linenos:
     :lines: 1-3
     :emphasize-lines: 1
+    :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 .. _start_quick_start_static_listeners:
 

--- a/docs/root/start/quick-start/securing.rst
+++ b/docs/root/start/quick-start/securing.rst
@@ -43,12 +43,13 @@ in the :ref:`transport_socket <extension_envoy.transport_sockets.tls>` of a
 
 You will also need to provide valid certificates.
 
-.. literalinclude:: _include/envoy-demo-tls.yaml
+.. validatingliteralinclude:: _include/envoy-demo-tls.yaml
    :language: yaml
    :linenos:
    :lines: 1-37
    :emphasize-lines: 28-37
    :caption: :download:`envoy-demo-tls.yaml <_include/envoy-demo-tls.yaml>`
+   :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 Connecting to an "upstream" ``TLS`` service is conversely done by adding an
 :ref:`UpstreamTLSContext <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.UpstreamTlsContext>`
@@ -76,13 +77,14 @@ to specify how Envoy should validate these certificates.
 
 Firstly, you can ensure that the certificates are from a mutually trusted certificate authority:
 
-.. literalinclude:: _include/envoy-demo-tls-validation.yaml
+.. validatingliteralinclude:: _include/envoy-demo-tls-validation.yaml
    :language: yaml
    :linenos:
    :lineno-start: 43
    :lines: 43-53
    :emphasize-lines: 6-9
    :caption: :download:`envoy-demo-tls-validation.yaml <_include/envoy-demo-tls-validation.yaml>`
+   :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 You can also ensure that the "Subject Alternative Names" for the cerficate match.
 
@@ -118,13 +120,14 @@ At a minimum you will need to set
 :ref:`require_client_certificate <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.require_client_certificate>`
 and specify a mutually trusted certificate authority:
 
-.. literalinclude:: _include/envoy-demo-tls-client-auth.yaml
+.. validatingliteralinclude:: _include/envoy-demo-tls-client-auth.yaml
    :language: yaml
    :linenos:
    :lineno-start: 27
    :lines: 27-39
    :emphasize-lines: 6, 8-10
    :caption: :download:`envoy-demo-tls-client-auth.yaml <_include/envoy-demo-tls-client-auth.yaml>`
+   :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 You can further restrict the authentication of connecting clients by specifying the allowed
 "Subject Alternative Names" in
@@ -171,13 +174,14 @@ To secure specific domains on a listening connection with ``SNI``, you should se
 :ref:`filter_chain_match <envoy_v3_api_msg_config.listener.v3.FilterChainMatch>` of the
 :ref:`listener <envoy_v3_api_msg_config.listener.v3.Listener>`:
 
-.. literalinclude:: _include/envoy-demo-tls-sni.yaml
+.. validatingliteralinclude:: _include/envoy-demo-tls-sni.yaml
    :language: yaml
    :linenos:
    :lineno-start: 27
    :lines: 27-35
    :emphasize-lines: 2-4
    :caption: :download:`envoy-demo-tls-sni.yaml <_include/envoy-demo-tls-sni.yaml>`
+   :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 See here for :ref:`more info about creating multiple endpoints with SNI <faq_how_to_setup_sni>`
 

--- a/docs/root/start/sandboxes/dynamic-configuration-filesystem.rst
+++ b/docs/root/start/sandboxes/dynamic-configuration-filesystem.rst
@@ -87,12 +87,13 @@ The example setup provides Envoy with two dynamic configuration files:
 Edit ``cds.yaml`` inside the container and change the cluster address
 from ``service1`` to ``service2``:
 
-.. literalinclude:: _include/dynamic-config-fs/configs/cds.yaml
+.. validatingliteralinclude:: _include/dynamic-config-fs/configs/cds.yaml
    :language: yaml
    :linenos:
    :lines: 7-15
    :lineno-start: 7
    :emphasize-lines: 8
+   :type-name: envoy.service.discovery.v3.DiscoveryResponse
 
 You can do this using ``sed`` inside the container:
 

--- a/docs/root/start/sandboxes/websocket.rst
+++ b/docs/root/start/sandboxes/websocket.rst
@@ -81,11 +81,12 @@ In order for Envoy to terminate the WebSocket connection, the
 in :ref:`HttpConnectionManager <envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager>`
 must be set, as can be seen in the provided :download:`ws -> ws configuration <_include/websocket/envoy-ws.yaml>`:
 
-.. literalinclude:: _include/websocket/envoy-ws.yaml
+.. validatingliteralinclude:: _include/websocket/envoy-ws.yaml
    :language: yaml
    :lines: 1-29
    :linenos:
    :emphasize-lines: 13-14
+   :type-name: envoy.config.bootstrap.v3.Bootstrap
 
 You can start an interactive session with the socket as follows:
 

--- a/examples/dynamic-config-fs/configs/cds.yaml
+++ b/examples/dynamic-config-fs/configs/cds.yaml
@@ -2,7 +2,7 @@ resources:
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: example_proxy_cluster
   connect_timeout: 1s
-  type: strict_dns
+  type: STRICT_DNS
   http2_protocol_options: {}
   load_assignment:
     cluster_name: example_proxy_cluster

--- a/examples/websocket/envoy-ws.yaml
+++ b/examples/websocket/envoy-ws.yaml
@@ -29,8 +29,8 @@ static_resources:
   clusters:
   - name: service_ws
     connect_timeout: 0.25s
-    type: strict_dns
-    lb_policy: round_robin
+    type: STRICT_DNS 
+    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: service_ws
       endpoints:


### PR DESCRIPTION
Also fixed configs that failed validation.

Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

Commit Message: Added support for validation of example configs that are stored in dedicated files (not snippets in rds files).
Additional Description:
Risk Level: low, docs only
Testing:
Docs Changes: fixed errors in example configurations
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/master/api/review_checklist.md):]
