### PR TITLE
callbacks: use RAII for handle tracking

### DIFF
--- a/include/envoy/common/callback.h
+++ b/include/envoy/common/callback.h
@@ -1,23 +1,22 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/common/pure.h"
 
 namespace Envoy {
 namespace Common {
 
 /**
- * Handle for a callback that can be removed. Destruction of the handle does NOT remove the
+ * Handle for a callback that can be removed. Destruction of the handle removes the
  * callback.
  */
 class CallbackHandle {
 public:
   virtual ~CallbackHandle() = default;
-
-  /**
-   * Remove the callback. After this routine returns the callback will no longer be called.
-   */
-  virtual void remove() PURE;
 };
+
+using CallbackHandlePtr = std::unique_ptr<CallbackHandle>;
 
 } // namespace Common
 } // namespace Envoy

--- a/include/envoy/config/context_provider.h
+++ b/include/envoy/config/context_provider.h
@@ -59,9 +59,9 @@ public:
   /**
    * Register a callback for notification when the dynamic context changes.
    * @param callback notification callback.
-   * @return Common::CallbackHandle* callback handle for removal.
+   * @return Common::CallbackHandlePtr callback handle for removal.
    */
-  virtual Common::CallbackHandle*
+  ABSL_MUST_USE_RESULT virtual Common::CallbackHandlePtr
   addDynamicContextUpdateCallback(UpdateNotificationCb callback) const PURE;
 };
 

--- a/include/envoy/secret/secret_provider.h
+++ b/include/envoy/secret/secret_provider.h
@@ -31,7 +31,7 @@ public:
    * @param callback callback that is executed by secret provider.
    * @return CallbackHandle the handle which can remove that validation callback.
    */
-  virtual Common::CallbackHandle*
+  ABSL_MUST_USE_RESULT virtual Common::CallbackHandlePtr
   addValidationCallback(std::function<void(const SecretType&)> callback) PURE;
 
   /**
@@ -41,7 +41,8 @@ public:
    * @param callback callback that is executed by secret provider.
    * @return CallbackHandle the handle which can remove that update callback.
    */
-  virtual Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) PURE;
+  ABSL_MUST_USE_RESULT virtual Common::CallbackHandlePtr
+  addUpdateCallback(std::function<void()> callback) PURE;
 
   /**
    * @return const Init::Target* A shared init target that can be used by multiple init managers.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -404,9 +404,10 @@ public:
    * This includes when a new HostSet is created.
    *
    * @param callback supplies the callback to invoke.
-   * @return Common::CallbackHandle* a handle which can be used to unregister the callback.
+   * @return Common::CallbackHandlePtr a handle which can be used to unregister the callback.
    */
-  virtual Common::CallbackHandle* addMemberUpdateCb(MemberUpdateCb callback) const PURE;
+  ABSL_MUST_USE_RESULT virtual Common::CallbackHandlePtr
+  addMemberUpdateCb(MemberUpdateCb callback) const PURE;
 
   /**
    * Install a callback that will be invoked when a host set changes. Triggers when any change
@@ -414,9 +415,10 @@ public:
    * added/removed hosts will be passed to the callback.
    *
    * @param callback supplies the callback to invoke.
-   * @return Common::CallbackHandle* a handle which can be used to unregister the callback.
+   * @return Common::CallbackHandlePtr a handle which can be used to unregister the callback.
    */
-  virtual Common::CallbackHandle* addPriorityUpdateCb(PriorityUpdateCb callback) const PURE;
+  ABSL_MUST_USE_RESULT virtual Common::CallbackHandlePtr
+  addPriorityUpdateCb(PriorityUpdateCb callback) const PURE;
 
   /**
    * @return const std::vector<HostSetPtr>& the host sets, ordered by priority.

--- a/source/common/config/context_provider_impl.h
+++ b/source/common/config/context_provider_impl.h
@@ -38,7 +38,7 @@ public:
     dynamic_context_[resource_type_url].mutable_params()->erase(key);
     update_cb_helper_.runCallbacks(resource_type_url);
   }
-  Common::CallbackHandle*
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addDynamicContextUpdateCallback(UpdateNotificationCb callback) const override {
     ASSERT(Thread::MainThread::isMainThread());
     return update_cb_helper_.add(callback);

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -39,7 +39,6 @@ public:
               envoy::config::core::v3::ApiVersion transport_api_version,
               Random::RandomGenerator& random, Stats::Scope& scope,
               const RateLimitSettings& rate_limit_settings, bool skip_subsequent_node);
-  ~GrpcMuxImpl() override { dynamic_update_callback_handle_->remove(); }
 
   void start() override;
 
@@ -176,7 +175,7 @@ private:
 
   Event::Dispatcher& dispatcher_;
   bool enable_type_url_downgrade_and_upgrade_;
-  Common::CallbackHandle* dynamic_update_callback_handle_;
+  Common::CallbackHandlePtr dynamic_update_callback_handle_;
 };
 
 using GrpcMuxImplPtr = std::unique_ptr<GrpcMuxImpl>;

--- a/source/common/config/new_grpc_mux_impl.h
+++ b/source/common/config/new_grpc_mux_impl.h
@@ -37,7 +37,6 @@ public:
                  Random::RandomGenerator& random, Stats::Scope& scope,
                  const RateLimitSettings& rate_limit_settings,
                  const LocalInfo::LocalInfo& local_info);
-  ~NewGrpcMuxImpl() override { dynamic_update_callback_handle_->remove(); }
 
   GrpcMuxWatchPtr addWatch(const std::string& type_url,
                            const absl::flat_hash_set<std::string>& resources,
@@ -158,7 +157,7 @@ private:
       grpc_stream_;
 
   const LocalInfo::LocalInfo& local_info_;
-  Common::CallbackHandle* dynamic_update_callback_handle_;
+  Common::CallbackHandlePtr dynamic_update_callback_handle_;
   const envoy::config::core::v3::ApiVersion transport_api_version_;
   Event::Dispatcher& dispatcher_;
 

--- a/source/common/local_info/local_info_impl.h
+++ b/source/common/local_info/local_info_impl.h
@@ -58,7 +58,6 @@ public:
               (*node_.mutable_dynamic_parameters())[resource_type_url].CopyFrom(
                   context_provider_.dynamicContext(resource_type_url));
             })) {}
-  ~LocalInfoImpl() override { dynamic_update_callback_handle_->remove(); }
 
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
   const std::string& zoneName() const override { return node_.locality().zone(); }
@@ -75,7 +74,7 @@ private:
   Config::ContextProviderImpl context_provider_;
   const Stats::StatNameManagedStorage zone_stat_name_storage_;
   const Stats::StatName zone_stat_name_;
-  Common::CallbackHandle* dynamic_update_callback_handle_;
+  Common::CallbackHandlePtr dynamic_update_callback_handle_;
 };
 
 } // namespace LocalInfo

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -136,7 +136,7 @@ private:
   void onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reason,
                             const EnvoyException* e) override;
 
-  Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addUpdateCallback(std::function<void()> callback) {
     return update_callback_manager_.add(callback);
   }
 

--- a/source/common/router/scoped_rds.h
+++ b/source/common/router/scoped_rds.h
@@ -144,7 +144,6 @@ private:
     ~RdsRouteConfigProviderHelper() {
       // Only remove the rds update when the rds provider has been initialized.
       if (route_provider_) {
-        rds_update_callback_handle_->remove();
         parent_.stats_.active_scopes_.dec();
       }
       if (on_demand_) {
@@ -172,7 +171,7 @@ private:
     RdsRouteConfigProviderImplSharedPtr route_provider_;
     // This handle_ is owned by the route config provider's RDS subscription, when the helper
     // destructs, the handle is deleted as well.
-    Common::CallbackHandle* rds_update_callback_handle_;
+    Common::CallbackHandlePtr rds_update_callback_handle_;
     std::vector<std::function<void()>> on_demand_update_callbacks_;
   };
 

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -158,12 +158,13 @@ public:
   const envoy::extensions::transport_sockets::tls::v3::TlsCertificate* secret() const override {
     return resolved_tls_certificate_secrets_.get();
   }
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<void(const envoy::extensions::transport_sockets::tls::v3::TlsCertificate&)>)
       override {
     return nullptr;
   }
-  Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addUpdateCallback(std::function<void()> callback) override {
     if (secret()) {
       callback();
     }
@@ -242,13 +243,14 @@ public:
   secret() const override {
     return resolved_certificate_validation_context_secrets_.get();
   }
-  Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addUpdateCallback(std::function<void()> callback) override {
     if (secret()) {
       callback();
     }
     return update_callback_manager_.add(callback);
   }
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<
           void(const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&)>
           callback) override {
@@ -337,14 +339,15 @@ public:
     return tls_session_ticket_keys_.get();
   }
 
-  Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addUpdateCallback(std::function<void()> callback) override {
     if (secret()) {
       callback();
     }
     return update_callback_manager_.add(callback);
   }
 
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<
           void(const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys&)>
           callback) override {
@@ -405,10 +408,11 @@ public:
   const envoy::extensions::transport_sockets::tls::v3::GenericSecret* secret() const override {
     return generic_secret_.get();
   }
-  Common::CallbackHandle* addUpdateCallback(std::function<void()> callback) override {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addUpdateCallback(std::function<void()> callback) override {
     return update_callback_manager_.add(callback);
   }
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<void(const envoy::extensions::transport_sockets::tls::v3::GenericSecret&)>
           callback) override {
     return validation_callback_manager_.add(callback);

--- a/source/common/secret/secret_provider_impl.h
+++ b/source/common/secret/secret_provider_impl.h
@@ -19,13 +19,15 @@ public:
     return tls_certificate_.get();
   }
 
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<void(const envoy::extensions::transport_sockets::tls::v3::TlsCertificate&)>)
       override {
     return nullptr;
   }
 
-  Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addUpdateCallback(std::function<void()>) override {
+    return nullptr;
+  }
 
 private:
   Secret::TlsCertificatePtr tls_certificate_;
@@ -43,14 +45,16 @@ public:
     return certificate_validation_context_.get();
   }
 
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<
           void(const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&)>)
       override {
     return nullptr;
   }
 
-  Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addUpdateCallback(std::function<void()>) override {
+    return nullptr;
+  }
 
 private:
   Secret::CertificateValidationContextPtr certificate_validation_context_;
@@ -67,13 +71,15 @@ public:
     return tls_session_ticket_keys_.get();
   }
 
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<void(
           const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys&)>) override {
     return nullptr;
   }
 
-  Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addUpdateCallback(std::function<void()>) override {
+    return nullptr;
+  }
 
 private:
   Secret::TlsSessionTicketKeysPtr tls_session_ticket_keys_;
@@ -88,13 +94,15 @@ public:
     return generic_secret_.get();
   }
 
-  Common::CallbackHandle* addValidationCallback(
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addValidationCallback(
       std::function<void(const envoy::extensions::transport_sockets::tls::v3::GenericSecret&)>)
       override {
     return nullptr;
   }
 
-  Common::CallbackHandle* addUpdateCallback(std::function<void()>) override { return nullptr; }
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr addUpdateCallback(std::function<void()>) override {
+    return nullptr;
+  }
 
 private:
   Secret::GenericSecretPtr generic_secret_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -457,7 +457,7 @@ void ClusterManagerImpl::onClusterInit(ClusterManagerCluster& cm_cluster) {
   }
 
   // Now setup for cross-thread updates.
-  cluster.prioritySet().addMemberUpdateCb(
+  cluster_data->second->member_update_cb_ = cluster.prioritySet().addMemberUpdateCb(
       [&cluster, this](const HostVector&, const HostVector& hosts_removed) -> void {
         if (cluster.info()->lbConfig().close_connections_on_host_set_change()) {
           for (const auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
@@ -477,43 +477,43 @@ void ClusterManagerImpl::onClusterInit(ClusterManagerCluster& cm_cluster) {
         }
       });
 
-  cluster.prioritySet().addPriorityUpdateCb([&cm_cluster, this](uint32_t priority,
-                                                                const HostVector& hosts_added,
-                                                                const HostVector& hosts_removed) {
-    // This fires when a cluster is about to have an updated member set. We need to send this
-    // out to all of the thread local configurations.
+  cluster_data->second->priority_update_cb_ = cluster.prioritySet().addPriorityUpdateCb(
+      [&cm_cluster, this](uint32_t priority, const HostVector& hosts_added,
+                          const HostVector& hosts_removed) {
+        // This fires when a cluster is about to have an updated member set. We need to send this
+        // out to all of the thread local configurations.
 
-    // Should we save this update and merge it with other updates?
-    //
-    // Note that we can only _safely_ merge updates that have no added/removed hosts. That is,
-    // only those updates that signal a change in host healthcheck state, weight or metadata.
-    //
-    // We've discussed merging updates related to hosts being added/removed, but it's really
-    // tricky to merge those given that downstream consumers of these updates expect to see the
-    // full list of updates, not a condensed one. This is because they use the broadcasted
-    // HostSharedPtrs within internal maps to track hosts. If we fail to broadcast the entire list
-    // of removals, these maps will leak those HostSharedPtrs.
-    //
-    // See https://github.com/envoyproxy/envoy/pull/3941 for more context.
-    bool scheduled = false;
-    const auto merge_timeout = PROTOBUF_GET_MS_OR_DEFAULT(cm_cluster.cluster().info()->lbConfig(),
-                                                          update_merge_window, 1000);
-    // Remember: we only merge updates with no adds/removes — just hc/weight/metadata changes.
-    const bool is_mergeable = hosts_added.empty() && hosts_removed.empty();
+        // Should we save this update and merge it with other updates?
+        //
+        // Note that we can only _safely_ merge updates that have no added/removed hosts. That is,
+        // only those updates that signal a change in host healthcheck state, weight or metadata.
+        //
+        // We've discussed merging updates related to hosts being added/removed, but it's really
+        // tricky to merge those given that downstream consumers of these updates expect to see the
+        // full list of updates, not a condensed one. This is because they use the broadcasted
+        // HostSharedPtrs within internal maps to track hosts. If we fail to broadcast the entire
+        // list of removals, these maps will leak those HostSharedPtrs.
+        //
+        // See https://github.com/envoyproxy/envoy/pull/3941 for more context.
+        bool scheduled = false;
+        const auto merge_timeout = PROTOBUF_GET_MS_OR_DEFAULT(
+            cm_cluster.cluster().info()->lbConfig(), update_merge_window, 1000);
+        // Remember: we only merge updates with no adds/removes — just hc/weight/metadata changes.
+        const bool is_mergeable = hosts_added.empty() && hosts_removed.empty();
 
-    if (merge_timeout > 0) {
-      // If this is not mergeable, we should cancel any scheduled updates since
-      // we'll deliver it immediately.
-      scheduled = scheduleUpdate(cm_cluster, priority, is_mergeable, merge_timeout);
-    }
+        if (merge_timeout > 0) {
+          // If this is not mergeable, we should cancel any scheduled updates since
+          // we'll deliver it immediately.
+          scheduled = scheduleUpdate(cm_cluster, priority, is_mergeable, merge_timeout);
+        }
 
-    // If an update was not scheduled for later, deliver it immediately.
-    if (!scheduled) {
-      cm_stats_.cluster_updated_.inc();
-      postThreadLocalClusterUpdate(
-          cm_cluster, ThreadLocalClusterUpdateParams(priority, hosts_added, hosts_removed));
-    }
-  });
+        // If an update was not scheduled for later, deliver it immediately.
+        if (!scheduled) {
+          cm_stats_.cluster_updated_.inc();
+          postThreadLocalClusterUpdate(
+              cm_cluster, ThreadLocalClusterUpdateParams(priority, hosts_added, hosts_removed));
+        }
+      });
 
   // Finally, post updates cross-thread so the per-thread load balancers are ready. First we
   // populate any update information that may be available after cluster init.

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "envoy/api/api.h"
+#include "envoy/common/callback.h"
 #include "envoy/common/random_generator.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
@@ -499,6 +500,8 @@ private:
     ThreadAwareLoadBalancerPtr thread_aware_lb_;
     SystemTime last_updated_;
     bool added_or_updated_{};
+    Common::CallbackHandlePtr member_update_cb_;
+    Common::CallbackHandlePtr priority_update_cb_;
   };
 
   struct ClusterUpdateCallbacksHandleImpl : public ClusterUpdateCallbacksHandle,

--- a/source/common/upstream/health_checker_base_impl.cc
+++ b/source/common/upstream/health_checker_base_impl.cc
@@ -38,12 +38,11 @@ HealthCheckerImplBase::HealthCheckerImplBase(const Cluster& cluster,
       healthy_edge_interval_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, healthy_edge_interval, interval_.count())),
       transport_socket_options_(initTransportSocketOptions(config)),
-      transport_socket_match_metadata_(initTransportSocketMatchMetadata(config)) {
-  cluster_.prioritySet().addMemberUpdateCb(
-      [this](const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
-        onClusterMemberUpdate(hosts_added, hosts_removed);
-      });
-}
+      transport_socket_match_metadata_(initTransportSocketMatchMetadata(config)),
+      member_update_cb_{cluster_.prioritySet().addMemberUpdateCb(
+          [this](const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
+            onClusterMemberUpdate(hosts_added, hosts_removed);
+          })} {}
 
 std::shared_ptr<const Network::TransportSocketOptionsImpl>
 HealthCheckerImplBase::initTransportSocketOptions(

--- a/source/common/upstream/health_checker_base_impl.h
+++ b/source/common/upstream/health_checker_base_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/access_log/access_log.h"
+#include "envoy/common/callback.h"
 #include "envoy/common/random_generator.h"
 #include "envoy/config/core/v3/health_check.pb.h"
 #include "envoy/data/core/v3/health_check_event.pb.h"
@@ -176,6 +177,7 @@ private:
   absl::node_hash_map<HostSharedPtr, ActiveHealthCheckSessionPtr> active_sessions_;
   const std::shared_ptr<const Network::TransportSocketOptionsImpl> transport_socket_options_;
   const MetadataConstSharedPtr transport_socket_match_metadata_;
+  const Common::CallbackHandlePtr member_update_cb_;
 };
 
 class HealthCheckEventLoggerImpl : public HealthCheckEventLogger {

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <vector>
 
+#include "envoy/common/callback.h"
 #include "envoy/common/random_generator.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/runtime/runtime.h"
@@ -157,6 +158,9 @@ protected:
   std::vector<bool> per_priority_panic_;
   // The total count of healthy hosts across all priority levels.
   uint32_t total_healthy_hosts_;
+
+private:
+  Common::CallbackHandlePtr priority_update_cb_;
 };
 
 class LoadBalancerContextBase : public LoadBalancerContext {
@@ -196,7 +200,6 @@ protected:
       const PrioritySet& priority_set, const PrioritySet* local_priority_set, ClusterStats& stats,
       Runtime::Loader& runtime, Random::RandomGenerator& random,
       const envoy::config::cluster::v3::Cluster::CommonLbConfig& common_config);
-  ~ZoneAwareLoadBalancerBase() override;
 
   // When deciding which hosts to use on an LB decision, we need to know how to index into the
   // priority_set. This priority_set cursor is used by ZoneAwareLoadBalancerBase subclasses, e.g.
@@ -350,7 +353,8 @@ private:
   using PerPriorityStatePtr = std::unique_ptr<PerPriorityState>;
   // Routing state broken out for each priority level in priority_set_.
   std::vector<PerPriorityStatePtr> per_priority_state_;
-  Common::CallbackHandle* local_priority_set_member_update_cb_handle_{};
+  Common::CallbackHandlePtr priority_update_cb_;
+  Common::CallbackHandlePtr local_priority_set_member_update_cb_handle_;
 };
 
 /**
@@ -410,6 +414,7 @@ private:
 
   // Scheduler for each valid HostsSource.
   absl::node_hash_map<HostsSource, Scheduler, HostsSourceHash> scheduler_;
+  Common::CallbackHandlePtr priority_update_cb_;
 };
 
 /**

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -302,7 +302,7 @@ void DetectorImpl::initialize(const Cluster& cluster) {
       addHostMonitor(host);
     }
   }
-  cluster.prioritySet().addMemberUpdateCb(
+  member_update_cb_ = cluster.prioritySet().addMemberUpdateCb(
       [this](const HostVector& hosts_added, const HostVector& hosts_removed) -> void {
         for (const HostSharedPtr& host : hosts_added) {
           addHostMonitor(host);

--- a/source/common/upstream/outlier_detection_impl.h
+++ b/source/common/upstream/outlier_detection_impl.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "envoy/access_log/access_log.h"
+#include "envoy/common/callback.h"
 #include "envoy/common/time.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/cluster/v3/outlier_detection.pb.h"
@@ -460,6 +461,7 @@ private:
   std::list<ChangeStateCb> callbacks_;
   absl::node_hash_map<HostSharedPtr, DetectorHostMonitorImpl*> host_monitors_;
   EventLoggerSharedPtr event_logger_;
+  Common::CallbackHandlePtr member_update_cb_;
 
   // EjectionPair for external and local origin events.
   // When external/local origin events are not split, external_origin_sr_num_ are used for

--- a/source/common/upstream/subset_lb.cc
+++ b/source/common/upstream/subset_lb.cc
@@ -102,8 +102,6 @@ SubsetLoadBalancer::SubsetLoadBalancer(
 }
 
 SubsetLoadBalancer::~SubsetLoadBalancer() {
-  original_priority_set_callback_handle_->remove();
-
   // Ensure gauges reflect correct values.
   forEachSubset(subsets_, [&](LbSubsetEntryPtr entry) {
     if (entry->active()) {

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -250,7 +250,7 @@ private:
 
   const PrioritySet& original_priority_set_;
   const PrioritySet* original_local_priority_set_;
-  Common::CallbackHandle* original_priority_set_callback_handle_;
+  Common::CallbackHandlePtr original_priority_set_callback_handle_;
 
   LbSubsetEntryPtr subset_any_;
   LbSubsetEntryPtr fallback_subset_;

--- a/source/common/upstream/thread_aware_lb_impl.cc
+++ b/source/common/upstream/thread_aware_lb_impl.cc
@@ -94,7 +94,7 @@ void ThreadAwareLoadBalancerBase::initialize() {
   // I will look into doing this in a follow up. Doing everything using a background thread heavily
   // complicated initialization as the load balancer would need its own initialized callback. I
   // think the synchronous/asynchronous split is probably the best option.
-  priority_set_.addPriorityUpdateCb(
+  priority_update_cb_ = priority_set_.addPriorityUpdateCb(
       [this](uint32_t, const HostVector&, const HostVector&) -> void { refresh(); });
 
   refresh();

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/callback.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
 #include "common/upstream/load_balancer_impl.h"
@@ -129,6 +130,7 @@ private:
   void refresh();
 
   std::shared_ptr<LoadBalancerFactoryImpl> factory_;
+  Common::CallbackHandlePtr priority_update_cb_;
 };
 
 } // namespace Upstream

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "envoy/common/callback.h"
 #include "envoy/common/time.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/address.pb.h"
@@ -296,9 +297,10 @@ public:
   /**
    * Install a callback that will be invoked when the host set membership changes.
    * @param callback supplies the callback to invoke.
-   * @return Common::CallbackHandle* the callback handle.
+   * @return Common::CallbackHandlePtr the callback handle.
    */
-  Common::CallbackHandle* addPriorityUpdateCb(PrioritySet::PriorityUpdateCb callback) const {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addPriorityUpdateCb(PrioritySet::PriorityUpdateCb callback) const {
     return member_update_cb_helper_.add(callback);
   }
 
@@ -433,10 +435,12 @@ class PrioritySetImpl : public PrioritySet {
 public:
   PrioritySetImpl() : batch_update_(false) {}
   // From PrioritySet
-  Common::CallbackHandle* addMemberUpdateCb(MemberUpdateCb callback) const override {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addMemberUpdateCb(MemberUpdateCb callback) const override {
     return member_update_cb_helper_.add(callback);
   }
-  Common::CallbackHandle* addPriorityUpdateCb(PriorityUpdateCb callback) const override {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addPriorityUpdateCb(PriorityUpdateCb callback) const override {
     return priority_update_cb_helper_.add(callback);
   }
   const std::vector<std::unique_ptr<HostSet>>& hostSetsPerPriority() const override {
@@ -475,6 +479,9 @@ protected:
   std::vector<std::unique_ptr<HostSet>> host_sets_;
 
 private:
+  // This is a matching vector to store the callback handles for host_sets_. It is kept separately
+  // because host_sets_ is directly returned so we avoid translation.
+  std::vector<Common::CallbackHandlePtr> host_sets_priority_update_cbs_;
   // TODO(mattklein123): Remove mutable.
   mutable Common::CallbackManager<const HostVector&, const HostVector&> member_update_cb_helper_;
   mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
@@ -837,6 +844,7 @@ private:
   uint64_t pending_initialize_health_checks_{};
   const bool local_cluster_;
   Config::ConstMetadataSharedPoolSharedPtr const_metadata_shared_pool_;
+  Common::CallbackHandlePtr priority_update_cb_;
 };
 
 using ClusterImplBaseSharedPtr = std::shared_ptr<ClusterImplBase>;

--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -46,13 +46,14 @@ AggregateClusterLoadBalancer::AggregateClusterLoadBalancer(
 
 void AggregateClusterLoadBalancer::addMemberUpdateCallbackForCluster(
     Upstream::ThreadLocalCluster& thread_local_cluster) {
-  thread_local_cluster.prioritySet().addMemberUpdateCb(
-      [this, target_cluster_info = thread_local_cluster.info()](const Upstream::HostVector&,
-                                                                const Upstream::HostVector&) {
-        ENVOY_LOG(debug, "member update for cluster '{}' in aggregate cluster '{}'",
-                  target_cluster_info->name(), parent_info_->name());
-        refresh();
-      });
+  member_update_cbs_[thread_local_cluster.info()->name()] =
+      thread_local_cluster.prioritySet().addMemberUpdateCb(
+          [this, target_cluster_info = thread_local_cluster.info()](const Upstream::HostVector&,
+                                                                    const Upstream::HostVector&) {
+            ENVOY_LOG(debug, "member update for cluster '{}' in aggregate cluster '{}'",
+                      target_cluster_info->name(), parent_info_->name());
+            refresh();
+          });
 }
 
 PriorityContextPtr

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/callback.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/aggregate/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/aggregate/v3/cluster.pb.validate.h"
@@ -127,6 +128,7 @@ private:
   PriorityContextPtr priority_context_;
   const ClusterSetConstSharedPtr clusters_;
   Upstream::ClusterUpdateCallbacksHandlePtr handle_;
+  absl::flat_hash_map<std::string, Envoy::Common::CallbackHandlePtr> member_update_cbs_;
 };
 
 // Load balancer factory created by the main thread and will be called in each worker thread to

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/callback.h"
 #include "envoy/common/matchers.h"
 #include "envoy/config/core/v3/http_uri.pb.h"
 #include "envoy/extensions/filters/http/oauth2/v3alpha/oauth.pb.h"
@@ -66,7 +67,7 @@ private:
       value = Config::DataSource::read(secret->secret(), true, api_);
     }
 
-    secret_provider.addUpdateCallback([&secret_provider, this, &value]() {
+    update_callback_ = secret_provider.addUpdateCallback([&secret_provider, this, &value]() {
       const auto* secret = secret_provider.secret();
       if (secret != nullptr) {
         value = Config::DataSource::read(secret->secret(), true, api_);
@@ -76,6 +77,7 @@ private:
   std::string client_secret_;
   std::string token_secret_;
   Api::Api& api_;
+  Envoy::Common::CallbackHandlePtr update_callback_;
 
   Secret::GenericSecretConfigProviderSharedPtr client_secret_provider_;
   Secret::GenericSecretConfigProviderSharedPtr token_secret_provider_;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -101,9 +101,6 @@ InstanceImpl::ThreadLocalPool::ThreadLocalPool(std::shared_ptr<InstanceImpl> par
 }
 
 InstanceImpl::ThreadLocalPool::~ThreadLocalPool() {
-  if (host_set_member_update_cb_handle_ != nullptr) {
-    host_set_member_update_cb_handle_->remove();
-  }
   while (!pending_requests_.empty()) {
     pending_requests_.pop_front();
   }
@@ -166,10 +163,7 @@ void InstanceImpl::ThreadLocalPool::onClusterRemoval(const std::string& cluster_
 
   // Treat cluster removal as a removal of all hosts. Close all connections and fail all pending
   // requests.
-  if (host_set_member_update_cb_handle_ != nullptr) {
-    host_set_member_update_cb_handle_->remove();
-    host_set_member_update_cb_handle_ = nullptr;
-  }
+  host_set_member_update_cb_handle_ = nullptr;
   while (!client_map_.empty()) {
     client_map_.begin()->second->redis_client_->close();
   }

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -157,7 +157,7 @@ private:
     Upstream::ClusterUpdateCallbacksHandlePtr cluster_update_handle_;
     Upstream::ThreadLocalCluster* cluster_{};
     absl::node_hash_map<Upstream::HostConstSharedPtr, ThreadLocalActiveClientPtr> client_map_;
-    Envoy::Common::CallbackHandle* host_set_member_update_cb_handle_{};
+    Envoy::Common::CallbackHandlePtr host_set_member_update_cb_handle_;
     absl::node_hash_map<std::string, Upstream::HostConstSharedPtr> host_address_map_;
     std::string auth_username_;
     std::string auth_password_;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -75,7 +75,6 @@ UdpProxyFilter::ClusterInfo::ClusterInfo(UdpProxyFilter& filter,
           })) {}
 
 UdpProxyFilter::ClusterInfo::~ClusterInfo() {
-  member_update_cb_handle_->remove();
   // Sanity check the session accounting. This is not as fast as a straight teardown, but this is
   // not a performance critical path.
   while (!sessions_.empty()) {

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -249,7 +249,7 @@ private:
       return {ALL_UDP_PROXY_UPSTREAM_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
     }
 
-    Envoy::Common::CallbackHandle* member_update_cb_handle_;
+    Envoy::Common::CallbackHandlePtr member_update_cb_handle_;
     absl::flat_hash_set<ActiveSessionPtr, HeterogeneousActiveSessionHash,
                         HeterogeneousActiveSessionEqual>
         sessions_;

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -247,9 +247,6 @@ Ssl::CertificateValidationContextConfigPtr ContextConfigImpl::getCombinedValidat
 
 void ContextConfigImpl::setSecretUpdateCallback(std::function<void()> callback) {
   if (!tls_certificate_providers_.empty()) {
-    if (tc_update_callback_handle_) {
-      tc_update_callback_handle_->remove();
-    }
     // Once tls_certificate_config_ receives new secret, this callback updates
     // ContextConfigImpl::tls_certificate_config_ with new secret.
     tc_update_callback_handle_ =
@@ -263,9 +260,6 @@ void ContextConfigImpl::setSecretUpdateCallback(std::function<void()> callback) 
         });
   }
   if (certificate_validation_context_provider_) {
-    if (cvc_update_callback_handle_) {
-      cvc_update_callback_handle_->remove();
-    }
     if (default_cvc_) {
       // Once certificate_validation_context_provider_ receives new secret, this callback updates
       // ContextConfigImpl::validation_context_config_ with a combined certificate validation
@@ -293,18 +287,6 @@ void ContextConfigImpl::setSecretUpdateCallback(std::function<void()> callback) 
 
 Ssl::HandshakerFactoryCb ContextConfigImpl::createHandshaker() const {
   return handshaker_factory_cb_;
-}
-
-ContextConfigImpl::~ContextConfigImpl() {
-  if (tc_update_callback_handle_) {
-    tc_update_callback_handle_->remove();
-  }
-  if (cvc_update_callback_handle_) {
-    cvc_update_callback_handle_->remove();
-  }
-  if (cvc_validation_callback_handle_) {
-    cvc_validation_callback_handle_->remove();
-  }
 }
 
 unsigned ContextConfigImpl::tlsVersionFromProto(
@@ -434,21 +416,9 @@ ServerContextConfigImpl::ServerContextConfigImpl(
   }
 }
 
-ServerContextConfigImpl::~ServerContextConfigImpl() {
-  if (stk_update_callback_handle_ != nullptr) {
-    stk_update_callback_handle_->remove();
-  }
-  if (stk_validation_callback_handle_ != nullptr) {
-    stk_validation_callback_handle_->remove();
-  }
-}
-
 void ServerContextConfigImpl::setSecretUpdateCallback(std::function<void()> callback) {
   ContextConfigImpl::setSecretUpdateCallback(callback);
   if (session_ticket_keys_provider_) {
-    if (stk_update_callback_handle_) {
-      stk_update_callback_handle_->remove();
-    }
     // Once session_ticket_keys_ receives new secret, this callback updates
     // ContextConfigImpl::session_ticket_keys_ with new session ticket keys.
     stk_update_callback_handle_ =

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -22,8 +22,6 @@ static const std::string INLINE_STRING = "<inline>";
 
 class ContextConfigImpl : public virtual Ssl::ContextConfig {
 public:
-  ~ContextConfigImpl() override;
-
   // Ssl::ContextConfig
   const std::string& alpnProtocols() const override { return alpn_protocols_; }
   const std::string& cipherSuites() const override { return cipher_suites_; }
@@ -88,12 +86,12 @@ private:
       default_cvc_;
   std::vector<Secret::TlsCertificateConfigProviderSharedPtr> tls_certificate_providers_;
   // Handle for TLS certificate dynamic secret callback.
-  Envoy::Common::CallbackHandle* tc_update_callback_handle_{};
+  Envoy::Common::CallbackHandlePtr tc_update_callback_handle_;
   Secret::CertificateValidationContextConfigProviderSharedPtr
       certificate_validation_context_provider_;
   // Handle for certificate validation context dynamic secret callback.
-  Envoy::Common::CallbackHandle* cvc_update_callback_handle_{};
-  Envoy::Common::CallbackHandle* cvc_validation_callback_handle_{};
+  Envoy::Common::CallbackHandlePtr cvc_update_callback_handle_;
+  Envoy::Common::CallbackHandlePtr cvc_validation_callback_handle_;
   const unsigned min_protocol_version_;
   const unsigned max_protocol_version_;
 
@@ -136,7 +134,6 @@ public:
   ServerContextConfigImpl(
       const envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext& config,
       Server::Configuration::TransportSocketFactoryContext& secret_provider_context);
-  ~ServerContextConfigImpl() override;
 
   // Ssl::ServerContextConfig
   bool requireClientCertificate() const override { return require_client_certificate_; }
@@ -168,8 +165,8 @@ private:
   const OcspStaplePolicy ocsp_staple_policy_;
   std::vector<SessionTicketKey> session_ticket_keys_;
   const Secret::TlsSessionTicketKeysConfigProviderSharedPtr session_ticket_keys_provider_;
-  Envoy::Common::CallbackHandle* stk_update_callback_handle_{};
-  Envoy::Common::CallbackHandle* stk_validation_callback_handle_{};
+  Envoy::Common::CallbackHandlePtr stk_update_callback_handle_;
+  Envoy::Common::CallbackHandlePtr stk_validation_callback_handle_;
 
   std::vector<ServerContextConfig::SessionTicketKey> getSessionTicketKeys(
       const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys& keys);

--- a/test/common/common/callback_impl_test.cc
+++ b/test/common/common/callback_impl_test.cc
@@ -17,27 +17,40 @@ TEST_F(CallbackManagerTest, All) {
   InSequence s;
 
   CallbackManager<int> manager;
-  CallbackHandle* handle1 = manager.add([this](int arg) -> void { called(arg); });
-  manager.add([this](int arg) -> void { called(arg * 2); });
+  auto handle1 = manager.add([this](int arg) -> void { called(arg); });
+  auto handle2 = manager.add([this](int arg) -> void { called(arg * 2); });
 
   EXPECT_CALL(*this, called(5));
   EXPECT_CALL(*this, called(10));
   manager.runCallbacks(5);
 
-  handle1->remove();
+  handle1.reset();
   EXPECT_CALL(*this, called(10));
   manager.runCallbacks(5);
 
   EXPECT_CALL(*this, called(10));
   EXPECT_CALL(*this, called(20));
-  CallbackHandle* handle3 = manager.add([this, &handle3](int arg) -> void {
+  CallbackHandlePtr handle3 = manager.add([this, &handle3](int arg) -> void {
     called(arg * 4);
-    handle3->remove();
+    handle3.reset();
   });
   manager.runCallbacks(5);
 
   EXPECT_CALL(*this, called(10));
   manager.runCallbacks(5);
+}
+
+TEST_F(CallbackManagerTest, DestroyManagerBeforeHandle) {
+  CallbackHandlePtr handle;
+  {
+    CallbackManager<int> manager;
+    handle = manager.add([this](int arg) -> void { called(arg); });
+    EXPECT_CALL(*this, called(5));
+    manager.runCallbacks(5);
+  }
+  EXPECT_NE(nullptr, handle);
+  // It should be safe to destruct the handle after the manager.
+  handle.reset();
 }
 
 } // namespace Common

--- a/test/common/config/context_provider_impl_test.cc
+++ b/test/common/config/context_provider_impl_test.cc
@@ -43,7 +43,7 @@ TEST(ContextProviderTest, DynamicContextParameters) {
 
   uint32_t update_count = 0;
   std::string last_updated_resource;
-  auto* callback_handle = context_provider.addDynamicContextUpdateCallback(
+  auto callback_handle = context_provider.addDynamicContextUpdateCallback(
       [&update_count, &last_updated_resource](absl::string_view resource_type_url) {
         ++update_count;
         last_updated_resource = resource_type_url;
@@ -78,8 +78,6 @@ TEST(ContextProviderTest, DynamicContextParameters) {
   EXPECT_EQ(4, update_count);
   EXPECT_EQ("some_type", last_updated_resource);
   EXPECT_EQ(0, context_provider.dynamicContext("some_type").params().count("foo"));
-
-  callback_handle->remove();
 }
 
 } // namespace

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -185,8 +185,6 @@ TEST_F(SdsApiTest, DynamicTlsCertificateUpdateSuccess) {
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_key.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(key_pem)),
             tls_config.privateKey());
-
-  handle->remove();
 }
 
 class SdsRotationApiTest : public SdsApiTestBase {
@@ -201,7 +199,7 @@ protected:
   }
 
   Secret::MockSecretCallbacks secret_callback_;
-  Common::CallbackHandle* handle_{};
+  Common::CallbackHandlePtr handle_;
   std::vector<Filesystem::Watcher::OnChangedCb> watch_cbs_;
   Event::MockDispatcher mock_dispatcher_;
   Filesystem::MockInstance filesystem_;
@@ -221,8 +219,6 @@ protected:
     initialize();
     handle_ = sds_api_->addUpdateCallback([this]() { secret_callback_.onAddOrUpdateSecret(); });
   }
-
-  ~TlsCertificateSdsRotationApiTest() override { handle_->remove(); }
 
   void onConfigUpdate(const std::string& cert_value, const std::string& key_value) {
     const std::string yaml = fmt::format(
@@ -291,8 +287,6 @@ protected:
     initialize();
     handle_ = sds_api_->addUpdateCallback([this]() { secret_callback_.onAddOrUpdateSecret(); });
   }
-
-  ~CertificateValidationContextSdsRotationApiTest() override { handle_->remove(); }
 
   void onConfigUpdate(const std::string& trusted_ca_path, const std::string& trusted_ca_value,
                       const std::string& watch_path) {
@@ -587,8 +581,6 @@ TEST_F(SdsApiTest, DeltaUpdateSuccess) {
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/selfsigned_key.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(key_pem)),
             tls_config.privateKey());
-
-  handle->remove();
 }
 
 // Validate that CertificateValidationContextSdsApi updates secrets successfully if
@@ -625,8 +617,6 @@ TEST_F(SdsApiTest, DynamicCertificateValidationContextUpdateSuccess) {
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ca_cert.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(ca_cert)),
             cvc_config.caCert());
-
-  handle->remove();
 }
 
 class CvcValidationCallback {
@@ -713,9 +703,6 @@ TEST_F(SdsApiTest, DefaultCertificateValidationContextTest) {
   // secret contains SPKI list from dynamic CertificateValidationContext.
   EXPECT_EQ(1, cvc_config.verifyCertificateSpkiList().size());
   EXPECT_EQ(dynamic_verify_certificate_spki, cvc_config.verifyCertificateSpkiList()[0]);
-
-  handle->remove();
-  validation_handle->remove();
 }
 
 class GenericSecretValidationCallback {
@@ -774,9 +761,6 @@ generic_secret:
       "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/aes_128_key";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(secret_path)),
             Config::DataSource::read(generic_secret.secret(), true, *api_));
-
-  handle->remove();
-  validation_handle->remove();
 }
 
 // Validate that SdsApi throws exception if an empty secret is passed to onConfigUpdate().

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1198,7 +1198,7 @@ TEST_F(ClusterManagerImplTest, DynamicRemoveWithLocalCluster) {
 
   // Add another update callback on foo so we make sure callbacks keep working.
   ReadyWatcher membership_updated;
-  foo->prioritySet().addPriorityUpdateCb(
+  auto priority_update_cb = foo->prioritySet().addPriorityUpdateCb(
       [&membership_updated](uint32_t, const HostVector&, const HostVector&) -> void {
         membership_updated.ready();
       });

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -883,10 +883,11 @@ TEST_F(EdsTest, EndpointMovedToNewPriorityWithDrain) {
   add_endpoint(80, 1);
 
   // Verify that no hosts gets added or removed to/from the PrioritySet.
-  cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
-    EXPECT_TRUE(added.empty());
-    EXPECT_TRUE(removed.empty());
-  });
+  auto member_update_cb =
+      cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
+        EXPECT_TRUE(added.empty());
+        EXPECT_TRUE(removed.empty());
+      });
 
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 
@@ -996,10 +997,11 @@ TEST_F(EdsTest, EndpointMovedWithDrain) {
   add_endpoint(81, 0);
   add_endpoint(80, 1);
   // Verify that no hosts gets added or removed to/from the PrioritySet.
-  cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
-    EXPECT_TRUE(added.empty());
-    EXPECT_TRUE(removed.empty());
-  });
+  auto member_update_cb =
+      cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
+        EXPECT_TRUE(added.empty());
+        EXPECT_TRUE(removed.empty());
+      });
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 
   {
@@ -1077,10 +1079,11 @@ TEST_F(EdsTest, EndpointMovedToNewPriority) {
   add_endpoint(80, 1);
 
   // Verify that no hosts gets added or removed to/from the PrioritySet.
-  cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
-    EXPECT_TRUE(added.empty());
-    EXPECT_TRUE(removed.empty());
-  });
+  auto member_update_cb =
+      cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
+        EXPECT_TRUE(added.empty());
+        EXPECT_TRUE(removed.empty());
+      });
 
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 
@@ -1190,10 +1193,11 @@ TEST_F(EdsTest, EndpointMoved) {
   add_endpoint(81, 0);
   add_endpoint(80, 1);
   // Verify that no hosts gets added or removed to/from the PrioritySet.
-  cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
-    EXPECT_TRUE(added.empty());
-    EXPECT_TRUE(removed.empty());
-  });
+  auto member_update_cb =
+      cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
+        EXPECT_TRUE(added.empty());
+        EXPECT_TRUE(removed.empty());
+      });
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 
   {
@@ -1277,10 +1281,11 @@ TEST_F(EdsTest, EndpointMovedToNewPriorityWithHealthAddressChange) {
   add_endpoint(81, 0, 82);
 
   // Changing a health check endpoint at the same time as priority is an add and immediate remove
-  cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
-    EXPECT_EQ(added.size(), 1);
-    EXPECT_EQ(removed.size(), 1);
-  });
+  auto member_update_cb =
+      cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
+        EXPECT_EQ(added.size(), 1);
+        EXPECT_EQ(removed.size(), 1);
+      });
 
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 
@@ -1299,10 +1304,11 @@ TEST_F(EdsTest, EndpointMovedToNewPriorityWithHealthAddressChange) {
   add_endpoint(81, 1, 83);
 
   // Changing a health check endpoint at the same time as priority is an add and immediate remove
-  cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
-    EXPECT_EQ(added.size(), 1);
-    EXPECT_EQ(removed.size(), 1);
-  });
+  auto member_update_cb2 =
+      cluster_->prioritySet().addMemberUpdateCb([&](const auto& added, const auto& removed) {
+        EXPECT_EQ(added.size(), 1);
+        EXPECT_EQ(removed.size(), 1);
+      });
 
   doOnConfigUpdateVerifyNoThrow(cluster_load_assignment);
 

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -4,6 +4,7 @@
 #include <tuple>
 #include <vector>
 
+#include "envoy/common/callback.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/stats/scope.h"
@@ -57,7 +58,7 @@ protected:
         singleton_manager_, tls_, validation_visitor_, *api_, options_);
     cluster_ = std::make_shared<LogicalDnsCluster>(cluster_config, runtime_, dns_resolver_,
                                                    factory_context, std::move(scope), false);
-    cluster_->prioritySet().addPriorityUpdateCb(
+    priority_update_cb_ = cluster_->prioritySet().addPriorityUpdateCb(
         [&](uint32_t, const HostVector&, const HostVector&) -> void {
           membership_updated_.ready();
         });
@@ -215,6 +216,7 @@ protected:
   NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor_;
   Api::ApiPtr api_;
   Server::MockOptions options_;
+  Common::CallbackHandlePtr priority_update_cb_;
 };
 
 using LogicalDnsConfigTuple =

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -108,7 +108,9 @@ public:
                                   factory_context, std::move(scope), false);
 
     cm_.initializeThreadLocalClusters({"primary", "secondary"});
+    primary_.cluster_.info_->name_ = "primary";
     EXPECT_CALL(cm_, getThreadLocalCluster(Eq("primary"))).WillRepeatedly(Return(&primary_));
+    secondary_.cluster_.info_->name_ = "secondary";
     EXPECT_CALL(cm_, getThreadLocalCluster(Eq("secondary"))).WillRepeatedly(Return(&secondary_));
     ON_CALL(primary_, prioritySet()).WillByDefault(ReturnRef(primary_ps_));
     ON_CALL(secondary_, prioritySet()).WillByDefault(ReturnRef(secondary_ps_));

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -60,7 +60,7 @@ public:
 
     ON_CALL(lb_context_, downstreamHeaders()).WillByDefault(Return(&downstream_headers_));
 
-    cluster_->prioritySet().addMemberUpdateCb(
+    member_update_cb_ = cluster_->prioritySet().addMemberUpdateCb(
         [this](const Upstream::HostVector& hosts_added,
                const Upstream::HostVector& hosts_removed) -> void {
           onMemberUpdateCb(hosts_added, hosts_removed);
@@ -137,6 +137,7 @@ public:
   absl::flat_hash_map<std::string,
                       std::shared_ptr<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>>
       host_map_;
+  Envoy::Common::CallbackHandlePtr member_update_cb_;
 
   const std::string default_yaml_config_ = R"EOF(
 name: name

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -349,7 +349,7 @@ TEST_P(EdsIntegrationTest, BatchMemberUpdateCb) {
                            .prioritySet();
 
   // Keep track of how many times we're seeing a member update callback.
-  priority_set.addMemberUpdateCb([&](const auto& hosts_added, const auto&) {
+  auto member_update_cb = priority_set.addMemberUpdateCb([&](const auto& hosts_added, const auto&) {
     // We should see both hosts present in the member update callback.
     EXPECT_EQ(2, hosts_added.size());
     member_update_count++;

--- a/test/mocks/config/mocks.cc
+++ b/test/mocks/config/mocks.cc
@@ -49,7 +49,7 @@ MockTypedFactory::~MockTypedFactory() = default;
 
 MockContextProvider::MockContextProvider() {
   ON_CALL(*this, addDynamicContextUpdateCallback(_))
-      .WillByDefault(Invoke([this](UpdateNotificationCb update_cb) -> Common::CallbackHandle* {
+      .WillByDefault(Invoke([this](UpdateNotificationCb update_cb) -> Common::CallbackHandlePtr {
         return update_cb_handler_.add(update_cb);
       }));
   ON_CALL(*this, dynamicContext(_))

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -181,7 +181,7 @@ public:
                absl::string_view value));
   MOCK_METHOD(void, unsetDynamicContextParam,
               (absl::string_view resource_type_url, absl::string_view key));
-  MOCK_METHOD(Common::CallbackHandle*, addDynamicContextUpdateCallback,
+  MOCK_METHOD(Common::CallbackHandlePtr, addDynamicContextUpdateCallback,
               (UpdateNotificationCb callback), (const));
 
   Common::CallbackManager<absl::string_view> update_cb_handler_;

--- a/test/mocks/upstream/host_set.h
+++ b/test/mocks/upstream/host_set.h
@@ -20,7 +20,8 @@ public:
     member_update_cb_helper_.runCallbacks(priority(), added, removed);
   }
 
-  Common::CallbackHandle* addMemberUpdateCb(PrioritySet::PriorityUpdateCb callback) {
+  ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
+  addMemberUpdateCb(PrioritySet::PriorityUpdateCb callback) {
     return member_update_cb_helper_.add(callback);
   }
 

--- a/test/mocks/upstream/priority_set.cc
+++ b/test/mocks/upstream/priority_set.cc
@@ -18,11 +18,11 @@ MockPrioritySet::MockPrioritySet() {
   ON_CALL(*this, hostSetsPerPriority()).WillByDefault(ReturnRef(host_sets_));
   ON_CALL(testing::Const(*this), hostSetsPerPriority()).WillByDefault(ReturnRef(host_sets_));
   ON_CALL(*this, addMemberUpdateCb(_))
-      .WillByDefault(Invoke([this](PrioritySet::MemberUpdateCb cb) -> Common::CallbackHandle* {
+      .WillByDefault(Invoke([this](PrioritySet::MemberUpdateCb cb) -> Common::CallbackHandlePtr {
         return member_update_cb_helper_.add(cb);
       }));
   ON_CALL(*this, addPriorityUpdateCb(_))
-      .WillByDefault(Invoke([this](PrioritySet::PriorityUpdateCb cb) -> Common::CallbackHandle* {
+      .WillByDefault(Invoke([this](PrioritySet::PriorityUpdateCb cb) -> Common::CallbackHandlePtr {
         return priority_update_cb_helper_.add(cb);
       }));
 }
@@ -34,10 +34,11 @@ HostSet& MockPrioritySet::getHostSet(uint32_t priority) {
     for (size_t i = host_sets_.size(); i <= priority; ++i) {
       auto host_set = new ::testing::NiceMock<MockHostSet>(i);
       host_sets_.push_back(HostSetPtr{host_set});
-      host_set->addMemberUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
-                                         const HostVector& hosts_removed) {
-        runUpdateCallbacks(priority, hosts_added, hosts_removed);
-      });
+      member_update_cbs_.push_back(
+          host_set->addMemberUpdateCb([this](uint32_t priority, const HostVector& hosts_added,
+                                             const HostVector& hosts_removed) {
+            runUpdateCallbacks(priority, hosts_added, hosts_removed);
+          }));
     }
   }
   return *host_sets_[priority];

--- a/test/mocks/upstream/priority_set.h
+++ b/test/mocks/upstream/priority_set.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/common/callback.h"
 #include "envoy/upstream/upstream.h"
 
 #include "gmock/gmock.h"
@@ -17,8 +18,8 @@ public:
   void runUpdateCallbacks(uint32_t priority, const HostVector& hosts_added,
                           const HostVector& hosts_removed);
 
-  MOCK_METHOD(Common::CallbackHandle*, addMemberUpdateCb, (MemberUpdateCb callback), (const));
-  MOCK_METHOD(Common::CallbackHandle*, addPriorityUpdateCb, (PriorityUpdateCb callback), (const));
+  MOCK_METHOD(Common::CallbackHandlePtr, addMemberUpdateCb, (MemberUpdateCb callback), (const));
+  MOCK_METHOD(Common::CallbackHandlePtr, addPriorityUpdateCb, (PriorityUpdateCb callback), (const));
   MOCK_METHOD(const std::vector<HostSetPtr>&, hostSetsPerPriority, (), (const));
   MOCK_METHOD(std::vector<HostSetPtr>&, hostSetsPerPriority, ());
   MOCK_METHOD(void, updateHosts,
@@ -33,6 +34,7 @@ public:
   }
 
   std::vector<HostSetPtr> host_sets_;
+  std::vector<Common::CallbackHandlePtr> member_update_cbs_;
   Common::CallbackManager<const HostVector&, const HostVector&> member_update_cb_helper_;
   Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;


### PR DESCRIPTION
This changes the callback code to use RAII with weak
pointers. This allows both the callee and the callback
manager to be safely destructed in different orders which
does happen during normal operation, for example with cluster
and listener changes.

Fixes https://github.com/envoyproxy/envoy/issues/14866

Risk Level: Low
Testing: New and existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
