### PR TITLE
backport to 1.17: cluster: destroy on main thread (#14954)

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -21,12 +21,7 @@ Removed Config or Runtime
 
 New Features
 ------------
-* access log: added the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point for custom formatters (command operators).
-* access log: support command operator: %REQUEST_HEADERS_BYTES%, %RESPONSE_HEADERS_BYTES% and %RESPONSE_TRAILERS_BYTES%.
 * dispatcher: supports a stack of `Envoy::ScopeTrackedObject` instead of a single tracked object. This will allow Envoy to dump more debug information on crash.
-* http: added support for :ref:`:ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
-* http: change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to false.
-* tcp_proxy: add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation <tunneling-tcp-over-http>` for details.
 
 Deprecated
 ----------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -21,6 +21,12 @@ Removed Config or Runtime
 
 New Features
 ------------
+* access log: added the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point for custom formatters (command operators).
+* access log: support command operator: %REQUEST_HEADERS_BYTES%, %RESPONSE_HEADERS_BYTES% and %RESPONSE_TRAILERS_BYTES%.
+* dispatcher: supports a stack of `Envoy::ScopeTrackedObject` instead of a single tracked object. This will allow Envoy to dump more debug information on crash.
+* http: added support for :ref:`:ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
+* http: change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to false.
+* tcp_proxy: add support for converting raw TCP streams into HTTP/1.1 CONNECT requests. See :ref:`upgrade documentation <tunneling-tcp-over-http>` for details.
 
 Deprecated
 ----------

--- a/include/envoy/event/BUILD
+++ b/include/envoy/event/BUILD
@@ -14,10 +14,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "dispatcher_thread_deletable",
+    hdrs = ["dispatcher_thread_deletable.h"],
+)
+
+envoy_cc_library(
     name = "dispatcher_interface",
     hdrs = ["dispatcher.h"],
     deps = [
         ":deferred_deletable",
+        ":dispatcher_thread_deletable",
         ":file_event_interface",
         ":schedulable_cb_interface",
         ":signal_interface",

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -8,6 +8,7 @@
 
 #include "envoy/common/scope_tracker.h"
 #include "envoy/common/time.h"
+#include "envoy/event/dispatcher_thread_deletable.h"
 #include "envoy/event/file_event.h"
 #include "envoy/event/schedulable_cb.h"
 #include "envoy/event/signal.h"
@@ -246,6 +247,12 @@ public:
   virtual void post(PostCb callback) PURE;
 
   /**
+   * Post the deletable to this dispatcher. The deletable objects are guaranteed to be destroyed on
+   * the dispatcher's thread before dispatcher destroy. This is safe cross thread.
+   */
+  virtual void deleteInDispatcherThread(DispatcherThreadDeletableConstPtr deletable) PURE;
+
+  /**
    * Runs the event loop. This will not return until exit() is called either from within a callback
    * or from a different thread.
    * @param type specifies whether to run in blocking mode (run() will not return until exit() is
@@ -272,6 +279,11 @@ public:
    * Updates approximate monotonic time to current value.
    */
   virtual void updateApproximateMonotonicTime() PURE;
+
+  /**
+   * Shutdown the dispatcher by clear dispatcher thread deletable.
+   */
+  virtual void shutdown() PURE;
 };
 
 using DispatcherPtr = std::unique_ptr<Dispatcher>;

--- a/include/envoy/event/dispatcher.h
+++ b/include/envoy/event/dispatcher.h
@@ -86,15 +86,18 @@ public:
   virtual Event::SchedulableCallbackPtr createSchedulableCallback(std::function<void()> cb) PURE;
 
   /**
-   * Sets a tracked object, which is currently operating in this Dispatcher.
-   * This should be cleared with another call to setTrackedObject() when the object is done doing
-   * work. Calling setTrackedObject(nullptr) results in no object being tracked.
+   * Appends a tracked object to the current stack of tracked objects operating
+   * in the dispatcher.
    *
-   * This is optimized for performance, to avoid allocation where we do scoped object tracking.
-   *
-   * @return The previously tracked object or nullptr if there was none.
+   * It's recommended to use ScopeTrackerScopeState to manage the object's tracking. If directly
+   * invoking, there needs to be a subsequent call to popTrackedObject().
    */
-  virtual const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) PURE;
+  virtual void pushTrackedObject(const ScopeTrackedObject* object) PURE;
+
+  /**
+   * Removes the top of the stack of tracked object and asserts that it was expected.
+   */
+  virtual void popTrackedObject(const ScopeTrackedObject* expected_object) PURE;
 
   /**
    * Validates that an operation is thread-safe with respect to this dispatcher; i.e. that the

--- a/include/envoy/event/dispatcher_thread_deletable.h
+++ b/include/envoy/event/dispatcher_thread_deletable.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+namespace Envoy {
+namespace Event {
+
+/**
+ * If an object derives from this class, it can be passed to the destination dispatcher who
+ * guarantees to delete it in that dispatcher thread. The common use case is to ensure config
+ * related objects are deleted in the main thread.
+ */
+class DispatcherThreadDeletable {
+public:
+  virtual ~DispatcherThreadDeletable() = default;
+};
+
+using DispatcherThreadDeletableConstPtr = std::unique_ptr<const DispatcherThreadDeletable>;
+
+} // namespace Event
+} // namespace Envoy

--- a/include/envoy/server/fatal_action_config.h
+++ b/include/envoy/server/fatal_action_config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "envoy/common/pure.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
@@ -17,11 +18,10 @@ class FatalAction {
 public:
   virtual ~FatalAction() = default;
   /**
-   * Callback function to run when we are crashing.
-   * @param current_object the object we were working on when we started
-   * crashing.
+   * Callback function to run when Envoy is crashing.
+   * @param tracked_objects a span of objects Envoy was working on when Envoy started crashing.
    */
-  virtual void run(const ScopeTrackedObject* current_object) PURE;
+  virtual void run(absl::Span<const ScopeTrackedObject* const> tracked_objects) PURE;
 
   /**
    * @return whether the action is async-signal-safe.

--- a/source/common/common/scope_tracker.h
+++ b/source/common/common/scope_tracker.h
@@ -3,24 +3,35 @@
 #include "envoy/common/scope_tracker.h"
 #include "envoy/event/dispatcher.h"
 
+#include "common/common/assert.h"
+
 namespace Envoy {
 
-// A small class for tracking the scope of the object which is currently having
+// A small class for managing the scope of a tracked object which is currently having
 // work done in this thread.
 //
-// When created, it sets the tracked object in the dispatcher, and when destroyed it points the
-// dispatcher at the previously tracked object.
+// When created, it appends the tracked object to the dispatcher's stack of tracked objects, and
+// when destroyed it pops the dispatcher's stack of tracked object, which should be the object it
+// registered.
 class ScopeTrackerScopeState {
 public:
   ScopeTrackerScopeState(const ScopeTrackedObject* object, Event::Dispatcher& dispatcher)
-      : dispatcher_(dispatcher) {
-    latched_object_ = dispatcher_.setTrackedObject(object);
+      : registered_object_(object), dispatcher_(dispatcher) {
+    dispatcher_.pushTrackedObject(registered_object_);
   }
 
-  ~ScopeTrackerScopeState() { dispatcher_.setTrackedObject(latched_object_); }
+  ~ScopeTrackerScopeState() {
+    // If ScopeTrackerScopeState is always used for managing tracked objects,
+    // then the object popped off should be the object we registered.
+    dispatcher_.popTrackedObject(registered_object_);
+  }
+
+  // Make this object stack-only, it doesn't make sense for it
+  // to be on the heap since it's tracking a stack of active operations.
+  void* operator new(std::size_t) = delete;
 
 private:
-  const ScopeTrackedObject* latched_object_;
+  const ScopeTrackedObject* registered_object_;
   Event::Dispatcher& dispatcher_;
 };
 

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -112,6 +112,9 @@ envoy_cc_library(
         "file_event_impl.h",
         "schedulable_cb_impl.h",
     ],
+    external_deps = [
+        "abseil_inlined_vector",
+    ],
     deps = [
         ":libevent_lib",
         ":libevent_scheduler_lib",

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -46,6 +46,8 @@ DispatcherImpl::DispatcherImpl(const std::string& name, Api::Api& api,
       buffer_factory_(factory != nullptr ? factory
                                          : std::make_shared<Buffer::WatermarkBufferFactory>()),
       scheduler_(time_system.createScheduler(base_scheduler_, base_scheduler_)),
+      thread_local_delete_cb_(
+          base_scheduler_.createSchedulableCallback([this]() -> void { runThreadLocalDelete(); })),
       deferred_delete_cb_(base_scheduler_.createSchedulableCallback(
           [this]() -> void { clearDeferredDeleteList(); })),
       post_cb_(base_scheduler_.createSchedulableCallback([this]() -> void { runPostCallbacks(); })),
@@ -57,7 +59,12 @@ DispatcherImpl::DispatcherImpl(const std::string& name, Api::Api& api,
       std::bind(&DispatcherImpl::updateApproximateMonotonicTime, this));
 }
 
-DispatcherImpl::~DispatcherImpl() { FatalErrorHandler::removeFatalErrorHandler(*this); }
+DispatcherImpl::~DispatcherImpl() {
+  ENVOY_LOG(debug, "destroying dispatcher {}", name_);
+  FatalErrorHandler::removeFatalErrorHandler(*this);
+  // TODO(lambdai): Resolve https://github.com/envoyproxy/envoy/issues/15072 and enable
+  // ASSERT(deletable_in_dispatcher_thread_.empty())
+}
 
 void DispatcherImpl::registerWatchdog(const Server::WatchDogSharedPtr& watchdog,
                                       std::chrono::milliseconds min_touch_interval) {
@@ -238,9 +245,23 @@ void DispatcherImpl::post(std::function<void()> callback) {
   }
 }
 
+void DispatcherImpl::deleteInDispatcherThread(DispatcherThreadDeletableConstPtr deletable) {
+  bool need_schedule;
+  {
+    Thread::LockGuard lock(thread_local_deletable_lock_);
+    need_schedule = deletables_in_dispatcher_thread_.empty();
+    deletables_in_dispatcher_thread_.emplace_back(std::move(deletable));
+    // TODO(lambdai): Enable below after https://github.com/envoyproxy/envoy/issues/15072
+    // ASSERT(!shutdown_called_, "inserted after shutdown");
+  }
+
+  if (need_schedule) {
+    thread_local_delete_cb_->scheduleCallbackCurrentIteration();
+  }
+}
+
 void DispatcherImpl::run(RunType type) {
   run_tid_ = api_.threadFactory().currentThreadId();
-
   // Flush all post callbacks before we run the event loop. We do this because there are post
   // callbacks that have to get run before the initial event loop starts running. libevent does
   // not guarantee that events are run in any particular order. So even if we post() and call
@@ -253,12 +274,56 @@ MonotonicTime DispatcherImpl::approximateMonotonicTime() const {
   return approximate_monotonic_time_;
 }
 
+void DispatcherImpl::shutdown() {
+  // TODO(lambdai): Resolve https://github.com/envoyproxy/envoy/issues/15072 and loop delete below
+  // below 3 lists until all lists are empty. The 3 lists are list of deferred delete objects, post
+  // callbacks and dispatcher thread deletable objects.
+  ASSERT(isThreadSafe());
+  auto deferred_deletables_size = current_to_delete_->size();
+  std::list<std::function<void()>>::size_type post_callbacks_size;
+  {
+    Thread::LockGuard lock(post_lock_);
+    post_callbacks_size = post_callbacks_.size();
+  }
+
+  std::list<DispatcherThreadDeletableConstPtr> local_deletables;
+  {
+    Thread::LockGuard lock(thread_local_deletable_lock_);
+    local_deletables = std::move(deletables_in_dispatcher_thread_);
+  }
+  auto thread_local_deletables_size = local_deletables.size();
+  while (!local_deletables.empty()) {
+    local_deletables.pop_front();
+  }
+  ASSERT(!shutdown_called_);
+  shutdown_called_ = true;
+  ENVOY_LOG(
+      trace,
+      "{} destroyed {} thread local objects. Peek {} deferred deletables, {} post callbacks. ",
+      __FUNCTION__, deferred_deletables_size, post_callbacks_size, thread_local_deletables_size);
+}
+
 void DispatcherImpl::updateApproximateMonotonicTime() { updateApproximateMonotonicTimeInternal(); }
 
 void DispatcherImpl::updateApproximateMonotonicTimeInternal() {
   approximate_monotonic_time_ = api_.timeSource().monotonicTime();
 }
 
+void DispatcherImpl::runThreadLocalDelete() {
+  std::list<DispatcherThreadDeletableConstPtr> to_be_delete;
+  {
+    Thread::LockGuard lock(thread_local_deletable_lock_);
+    to_be_delete = std::move(deletables_in_dispatcher_thread_);
+    ASSERT(deletables_in_dispatcher_thread_.empty());
+  }
+  while (!to_be_delete.empty()) {
+    // Touch the watchdog before deleting the objects to avoid spurious watchdog miss events when
+    // executing complicated destruction.
+    touchWatchdog();
+    // Delete in FIFO order.
+    to_be_delete.pop_front();
+  }
+}
 void DispatcherImpl::runPostCallbacks() {
   // Clear the deferred delete list before running post callbacks to reduce non-determinism in
   // callback processing, and more easily detect if a scheduled post callback refers to one of the

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -79,12 +79,14 @@ public:
   void exit() override;
   SignalEventPtr listenForSignal(signal_t signal_num, SignalCb cb) override;
   void post(std::function<void()> callback) override;
+  void deleteInDispatcherThread(DispatcherThreadDeletableConstPtr deletable) override;
   void run(RunType type) override;
   Buffer::WatermarkFactory& getWatermarkFactory() override { return *buffer_factory_; }
   void pushTrackedObject(const ScopeTrackedObject* object) override;
   void popTrackedObject(const ScopeTrackedObject* expected_object) override;
   MonotonicTime approximateMonotonicTime() const override;
   void updateApproximateMonotonicTime() override;
+  void shutdown() override;
 
   // FatalErrorInterface
   void onFatalError(std::ostream& os) const override;
@@ -120,6 +122,8 @@ private:
   TimerPtr createTimerInternal(TimerCb cb);
   void updateApproximateMonotonicTimeInternal();
   void runPostCallbacks();
+  void runThreadLocalDelete();
+
   // Helper used to touch the watchdog after most schedulable, fd, and timer callbacks.
   void touchWatchdog();
 
@@ -138,13 +142,24 @@ private:
   Buffer::WatermarkFactorySharedPtr buffer_factory_;
   LibeventScheduler base_scheduler_;
   SchedulerPtr scheduler_;
+
+  SchedulableCallbackPtr thread_local_delete_cb_;
+  Thread::MutexBasicLockable thread_local_deletable_lock_;
+  // `deletables_in_dispatcher_thread` must be destroyed last to allow other callbacks populate.
+  std::list<DispatcherThreadDeletableConstPtr>
+      deletables_in_dispatcher_thread_ ABSL_GUARDED_BY(thread_local_deletable_lock_);
+  bool shutdown_called_{false};
+
   SchedulableCallbackPtr deferred_delete_cb_;
+
   SchedulableCallbackPtr post_cb_;
+  Thread::MutexBasicLockable post_lock_;
+  std::list<std::function<void()>> post_callbacks_ ABSL_GUARDED_BY(post_lock_);
+
   std::vector<DeferredDeletablePtr> to_delete_1_;
   std::vector<DeferredDeletablePtr> to_delete_2_;
   std::vector<DeferredDeletablePtr>* current_to_delete_;
-  Thread::MutexBasicLockable post_lock_;
-  std::list<std::function<void()>> post_callbacks_ ABSL_GUARDED_BY(post_lock_);
+
   absl::InlinedVector<const ScopeTrackedObject*, ExpectedMaxTrackedObjectStackDepth>
       tracked_object_stack_;
   bool deferred_deleting_{};

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -20,8 +20,15 @@
 #include "common/event/libevent_scheduler.h"
 #include "common/signal/fatal_error_handler.h"
 
+#include "absl/container/inlined_vector.h"
+
 namespace Envoy {
 namespace Event {
+
+// The tracked object stack likely won't grow larger than this initial
+// reservation; this should make appends constant time since the stack
+// shouldn't have to grow larger.
+inline constexpr size_t ExpectedMaxTrackedObjectStackDepth = 10;
 
 /**
  * libevent implementation of Event::Dispatcher.
@@ -74,25 +81,13 @@ public:
   void post(std::function<void()> callback) override;
   void run(RunType type) override;
   Buffer::WatermarkFactory& getWatermarkFactory() override { return *buffer_factory_; }
-  const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) override {
-    const ScopeTrackedObject* return_object = current_object_;
-    current_object_ = object;
-    return return_object;
-  }
+  void pushTrackedObject(const ScopeTrackedObject* object) override;
+  void popTrackedObject(const ScopeTrackedObject* expected_object) override;
   MonotonicTime approximateMonotonicTime() const override;
   void updateApproximateMonotonicTime() override;
 
   // FatalErrorInterface
-  void onFatalError(std::ostream& os) const override {
-    // Dump the state of the tracked object if it is in the current thread. This generally results
-    // in dumping the active state only for the thread which caused the fatal error.
-    if (isThreadSafe()) {
-      if (current_object_) {
-        current_object_->dumpState(os);
-      }
-    }
-  }
-
+  void onFatalError(std::ostream& os) const override;
   void
   runFatalActionsOnTrackedObject(const FatalAction::FatalActionPtrList& actions) const override;
 
@@ -150,7 +145,8 @@ private:
   std::vector<DeferredDeletablePtr>* current_to_delete_;
   Thread::MutexBasicLockable post_lock_;
   std::list<std::function<void()>> post_callbacks_ ABSL_GUARDED_BY(post_lock_);
-  const ScopeTrackedObject* current_object_{};
+  absl::InlinedVector<const ScopeTrackedObject*, ExpectedMaxTrackedObjectStackDepth>
+      tracked_object_stack_;
   bool deferred_deleting_{};
   MonotonicTime approximate_monotonic_time_;
   WatchdogRegistrationPtr watchdog_registration_;

--- a/source/common/grpc/async_client_impl.cc
+++ b/source/common/grpc/async_client_impl.cc
@@ -210,6 +210,7 @@ void AsyncStreamImpl::cleanup() {
   // This will destroy us, but only do so if we are actually in a list. This does not happen in
   // the immediate failure case.
   if (LinkedObject<AsyncStreamImpl>::inserted()) {
+    ASSERT(dispatcher_->isThreadSafe());
     dispatcher_->deferredDelete(
         LinkedObject<AsyncStreamImpl>::removeFromList(parent_.active_streams_));
   }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -149,6 +149,7 @@ void AsyncStreamImpl::sendHeaders(RequestHeaderMap& headers, bool end_stream) {
 }
 
 void AsyncStreamImpl::sendData(Buffer::Instance& data, bool end_stream) {
+  ASSERT(dispatcher().isThreadSafe());
   // Map send calls after local closure to no-ops. The send call could have been queued prior to
   // remote reset or closure, and/or closure could have occurred synchronously in response to a
   // previous send. In these cases the router will have already cleaned up stream state. This
@@ -169,6 +170,7 @@ void AsyncStreamImpl::sendData(Buffer::Instance& data, bool end_stream) {
 }
 
 void AsyncStreamImpl::sendTrailers(RequestTrailerMap& trailers) {
+  ASSERT(dispatcher().isThreadSafe());
   // See explanation in sendData.
   if (local_closed_) {
     return;
@@ -226,6 +228,7 @@ void AsyncStreamImpl::reset() {
 }
 
 void AsyncStreamImpl::cleanup() {
+  ASSERT(dispatcher().isThreadSafe());
   local_closed_ = remote_closed_ = true;
   // This will destroy us, but only do so if we are actually in a list. This does not happen in
   // the immediate failure case.

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -210,6 +210,7 @@ Connection::State ConnectionImpl::state() const {
 void ConnectionImpl::closeConnectionImmediately() { closeSocket(ConnectionEvent::LocalClose); }
 
 void ConnectionImpl::setTransportSocketIsReadable() {
+  ASSERT(dispatcher_.isThreadSafe());
   // Remember that the transport requested read resumption, in case the resumption event is not
   // scheduled immediately or is "lost" because read was disabled.
   transport_wants_read_ = true;
@@ -300,6 +301,7 @@ void ConnectionImpl::noDelay(bool enable) {
 }
 
 void ConnectionImpl::onRead(uint64_t read_buffer_size) {
+  ASSERT(dispatcher_.isThreadSafe());
   if (inDelayedClose() || !filterChainWantsData()) {
     return;
   }
@@ -419,6 +421,7 @@ void ConnectionImpl::raiseEvent(ConnectionEvent event) {
 bool ConnectionImpl::readEnabled() const {
   // Calls to readEnabled on a closed socket are considered to be an error.
   ASSERT(state() == State::Open);
+  ASSERT(dispatcher_.isThreadSafe());
   return read_disable_count_ == 0;
 }
 
@@ -436,6 +439,7 @@ void ConnectionImpl::write(Buffer::Instance& data, bool end_stream) {
 
 void ConnectionImpl::write(Buffer::Instance& data, bool end_stream, bool through_filter_chain) {
   ASSERT(!end_stream || enable_half_close_);
+  ASSERT(dispatcher_.isThreadSafe());
 
   if (write_end_stream_) {
     // It is an API violation to write more data after writing end_stream, but a duplicate

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -919,9 +919,16 @@ ClusterImplBase::ClusterImplBase(
 
   auto socket_matcher = std::make_unique<TransportSocketMatcherImpl>(
       cluster.transport_socket_matches(), factory_context, socket_factory, *stats_scope);
-  info_ = std::make_unique<ClusterInfoImpl>(cluster, factory_context.clusterManager().bindConfig(),
-                                            runtime, std::move(socket_matcher),
-                                            std::move(stats_scope), added_via_api, factory_context);
+  auto& dispatcher = factory_context.dispatcher();
+  info_ = std::shared_ptr<const ClusterInfoImpl>(
+      new ClusterInfoImpl(cluster, factory_context.clusterManager().bindConfig(), runtime,
+                          std::move(socket_matcher), std::move(stats_scope), added_via_api,
+                          factory_context),
+      [&dispatcher](const ClusterInfoImpl* self) {
+        ENVOY_LOG(trace, "Schedule destroy cluster info {}", self->name());
+        dispatcher.deleteInDispatcherThread(
+            std::unique_ptr<const Event::DispatcherThreadDeletable>(self));
+      });
 
   if ((info_->features() & ClusterInfoImpl::Features::USE_ALPN) &&
       !raw_factory_pointer->supportsAlpn()) {
@@ -1098,7 +1105,7 @@ void ClusterImplBase::reloadHealthyHostsHelper(const HostSharedPtr&) {
   for (size_t priority = 0; priority < host_sets.size(); ++priority) {
     const auto& host_set = host_sets[priority];
     // TODO(htuch): Can we skip these copies by exporting out const shared_ptr from HostSet?
-    HostVectorConstSharedPtr hosts_copy(new HostVector(host_set->hosts()));
+    HostVectorConstSharedPtr hosts_copy = std::make_shared<HostVector>(host_set->hosts());
 
     HostsPerLocalityConstSharedPtr hosts_per_locality_copy = host_set->hostsPerLocality().clone();
     prioritySet().updateHosts(priority,
@@ -1289,10 +1296,10 @@ void PriorityStateManager::registerHostForPriority(
   auto metadata = lb_endpoint.has_metadata()
                       ? parent_.constMetadataSharedPool()->getObject(lb_endpoint.metadata())
                       : nullptr;
-  const HostSharedPtr host(new HostImpl(
+  const auto host = std::make_shared<HostImpl>(
       parent_.info(), hostname, address, metadata, lb_endpoint.load_balancing_weight().value(),
       locality_lb_endpoint.locality(), lb_endpoint.endpoint().health_check_config(),
-      locality_lb_endpoint.priority(), lb_endpoint.health_status(), time_source));
+      locality_lb_endpoint.priority(), lb_endpoint.health_status(), time_source);
   registerHostForPriority(host, locality_lb_endpoint);
 }
 

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -517,7 +517,9 @@ private:
 /**
  * Implementation of ClusterInfo that reads from JSON.
  */
-class ClusterInfoImpl : public ClusterInfo, protected Logger::Loggable<Logger::Id::upstream> {
+class ClusterInfoImpl : public ClusterInfo,
+                        public Event::DispatcherThreadDeletable,
+                        protected Logger::Loggable<Logger::Id::upstream> {
 public:
   using HttpProtocolOptionsConfigImpl =
       Envoy::Extensions::Upstreams::Http::ProtocolOptionsConfigImpl;

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -116,6 +116,7 @@ void ValidationInstance::shutdown() {
     config_.clusterManager()->shutdown();
   }
   thread_local_.shutdownThread();
+  dispatcher_->shutdown();
 }
 
 } // namespace Server

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -139,6 +139,7 @@ InstanceImpl::~InstanceImpl() {
   ENVOY_LOG(debug, "destroying listener manager");
   listener_manager_.reset();
   ENVOY_LOG(debug, "destroyed listener manager");
+  dispatcher_->shutdown();
 }
 
 Upstream::ClusterManager& InstanceImpl::clusterManager() { return *config_.clusterManager(); }

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -134,6 +134,7 @@ void WorkerImpl::threadRoutine(GuardDog& guard_dog) {
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   ENVOY_LOG(debug, "worker exited dispatch loop");
   guard_dog.stopWatching(watch_dog_);
+  dispatcher_->shutdown();
 
   // We must close all active connections before we actually exit the thread. This prevents any
   // destructors from running on the main thread which might reference thread locals. Destroying

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -361,3 +361,15 @@ envoy_cc_test(
     srcs = ["interval_value_test.cc"],
     deps = ["//source/common/common:interval_value"],
 )
+
+envoy_cc_test(
+    name = "scope_tracker_test",
+    srcs = ["scope_tracker_test.cc"],
+    deps = [
+        "//source/common/api:api_lib",
+        "//source/common/common:scope_tracker",
+        "//source/common/event:dispatcher_lib",
+        "//test/mocks:common_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/common/common/scope_tracker_test.cc
+++ b/test/common/common/scope_tracker_test.cc
@@ -1,0 +1,37 @@
+#include <iostream>
+
+#include "common/api/api_impl.h"
+#include "common/common/scope_tracker.h"
+#include "common/event/dispatcher_impl.h"
+
+#include "test/mocks/common.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace {
+
+using testing::_;
+
+TEST(ScopeTrackerScopeStateTest, ShouldManageTrackedObjectOnDispatcherStack) {
+  Api::ApiPtr api(Api::createApiForTest());
+  Event::DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
+  MockScopedTrackedObject tracked_object;
+  {
+    ScopeTrackerScopeState scope(&tracked_object, *dispatcher);
+    // Check that the tracked_object is on the tracked object stack
+    dispatcher->popTrackedObject(&tracked_object);
+
+    // Restore it to the top, it should be removed in the dtor of scope.
+    dispatcher->pushTrackedObject(&tracked_object);
+  }
+
+  // Check nothing is tracked now.
+  EXPECT_CALL(tracked_object, dumpState(_, _)).Times(0);
+  static_cast<Event::DispatcherImpl*>(dispatcher.get())->onFatalError(std::cerr);
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1,10 +1,13 @@
 #include <functional>
 
+#include "envoy/common/scope_tracker.h"
 #include "envoy/thread/thread.h"
 
 #include "common/api/api_impl.h"
 #include "common/api/os_sys_calls_impl.h"
 #include "common/common/lock_guard.h"
+#include "common/common/scope_tracker.h"
+#include "common/common/utility.h"
 #include "common/event/deferred_task.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/event/timer_impl.h"
@@ -533,9 +536,71 @@ TEST_F(DispatcherImplTest, IsThreadSafe) {
   EXPECT_FALSE(dispatcher_->isThreadSafe());
 }
 
+TEST_F(DispatcherImplTest, ShouldDumpNothingIfNoTrackedObjects) {
+  std::array<char, 1024> buffer;
+  OutputBufferStream ostream{buffer.data(), buffer.size()};
+
+  // Call on FatalError to trigger dumps of tracked objects.
+  dispatcher_->post([this, &ostream]() {
+    Thread::LockGuard lock(mu_);
+    static_cast<DispatcherImpl*>(dispatcher_.get())->onFatalError(ostream);
+    work_finished_ = true;
+    cv_.notifyOne();
+  });
+
+  Thread::LockGuard lock(mu_);
+  while (!work_finished_) {
+    cv_.wait(mu_);
+  }
+
+  // Check ostream still empty.
+  EXPECT_EQ(ostream.contents(), "");
+}
+
+class MessageTrackedObject : public ScopeTrackedObject {
+public:
+  MessageTrackedObject(absl::string_view sv) : sv_(sv) {}
+  void dumpState(std::ostream& os, int /*indent_level*/) const override { os << sv_; }
+
+private:
+  absl::string_view sv_;
+};
+
+TEST_F(DispatcherImplTest, ShouldDumpTrackedObjectsInFILO) {
+  std::array<char, 1024> buffer;
+  OutputBufferStream ostream{buffer.data(), buffer.size()};
+
+  // Call on FatalError to trigger dumps of tracked objects.
+  dispatcher_->post([this, &ostream]() {
+    Thread::LockGuard lock(mu_);
+
+    // Add several tracked objects to the dispatcher
+    MessageTrackedObject first{"first"};
+    ScopeTrackerScopeState first_state{&first, *dispatcher_};
+    MessageTrackedObject second{"second"};
+    ScopeTrackerScopeState second_state{&second, *dispatcher_};
+    MessageTrackedObject third{"third"};
+    ScopeTrackerScopeState third_state{&third, *dispatcher_};
+
+    static_cast<DispatcherImpl*>(dispatcher_.get())->onFatalError(ostream);
+    work_finished_ = true;
+    cv_.notifyOne();
+  });
+
+  Thread::LockGuard lock(mu_);
+  while (!work_finished_) {
+    cv_.wait(mu_);
+  }
+
+  // Check the dump includes and registered objects in a FILO order.
+  EXPECT_EQ(ostream.contents(), "thirdsecondfirst");
+}
+
 class TestFatalAction : public Server::Configuration::FatalAction {
 public:
-  void run(const ScopeTrackedObject* /*current_object*/) override { ++times_ran_; }
+  void run(absl::Span<const ScopeTrackedObject* const> /*tracked_objects*/) override {
+    ++times_ran_;
+  }
   bool isAsyncSignalSafe() const override { return true; }
   int getNumTimesRan() { return times_ran_; }
 

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -237,6 +237,15 @@ private:
   std::function<void()> on_destroy_;
 };
 
+class TestDispatcherThreadDeletable : public DispatcherThreadDeletable {
+public:
+  TestDispatcherThreadDeletable(std::function<void()> on_destroy) : on_destroy_(on_destroy) {}
+  ~TestDispatcherThreadDeletable() override { on_destroy_(); }
+
+private:
+  std::function<void()> on_destroy_;
+};
+
 TEST(DeferredDeleteTest, DeferredDelete) {
   InSequence s;
   Api::ApiPtr api = Api::createApiForTest();
@@ -476,6 +485,100 @@ TEST_F(DispatcherImplTest, RunPostCallbacksLocking) {
   Thread::LockGuard lock(mu_);
   while (!work_finished_) {
     cv_.wait(mu_);
+  }
+}
+
+TEST_F(DispatcherImplTest, DispatcherThreadDeleted) {
+  dispatcher_->deleteInDispatcherThread(std::make_unique<TestDispatcherThreadDeletable>(
+      [this, id = api_->threadFactory().currentThreadId()]() {
+        ASSERT(id != api_->threadFactory().currentThreadId());
+        {
+          Thread::LockGuard lock(mu_);
+          ASSERT(!work_finished_);
+          work_finished_ = true;
+        }
+        cv_.notifyOne();
+      }));
+
+  Thread::LockGuard lock(mu_);
+  while (!work_finished_) {
+    cv_.wait(mu_);
+  }
+}
+
+TEST(DispatcherThreadDeletedImplTest, DispatcherThreadDeletedAtNextCycle) {
+  Api::ApiPtr api_(Api::createApiForTest());
+  DispatcherPtr dispatcher(api_->allocateDispatcher("test_thread"));
+  std::vector<std::unique_ptr<ReadyWatcher>> watchers;
+  watchers.reserve(3);
+  for (int i = 0; i < 3; ++i) {
+    watchers.push_back(std::make_unique<ReadyWatcher>());
+  }
+  dispatcher->deleteInDispatcherThread(
+      std::make_unique<TestDispatcherThreadDeletable>([&watchers]() { watchers[0]->ready(); }));
+  EXPECT_CALL(*watchers[0], ready());
+  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+  dispatcher->deleteInDispatcherThread(
+      std::make_unique<TestDispatcherThreadDeletable>([&watchers]() { watchers[1]->ready(); }));
+  dispatcher->deleteInDispatcherThread(
+      std::make_unique<TestDispatcherThreadDeletable>([&watchers]() { watchers[2]->ready(); }));
+  EXPECT_CALL(*watchers[1], ready());
+  EXPECT_CALL(*watchers[2], ready());
+  dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+}
+
+class DispatcherShutdownTest : public testing::Test {
+protected:
+  DispatcherShutdownTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
+
+  Api::ApiPtr api_;
+  DispatcherPtr dispatcher_;
+};
+
+TEST_F(DispatcherShutdownTest, ShutdownClearThreadLocalDeletables) {
+  ReadyWatcher watcher;
+
+  dispatcher_->deleteInDispatcherThread(
+      std::make_unique<TestDispatcherThreadDeletable>([&watcher]() { watcher.ready(); }));
+  EXPECT_CALL(watcher, ready());
+  dispatcher_->shutdown();
+}
+
+TEST_F(DispatcherShutdownTest, ShutdownDoesnotClearDeferredListOrPostCallback) {
+  ReadyWatcher watcher;
+  ReadyWatcher deferred_watcher;
+  ReadyWatcher post_watcher;
+
+  {
+    InSequence s;
+
+    dispatcher_->deferredDelete(std::make_unique<TestDeferredDeletable>(
+        [&deferred_watcher]() { deferred_watcher.ready(); }));
+    dispatcher_->post([&post_watcher]() { post_watcher.ready(); });
+    dispatcher_->deleteInDispatcherThread(
+        std::make_unique<TestDispatcherThreadDeletable>([&watcher]() { watcher.ready(); }));
+    EXPECT_CALL(watcher, ready());
+    dispatcher_->shutdown();
+
+    ::testing::Mock::VerifyAndClearExpectations(&watcher);
+    EXPECT_CALL(deferred_watcher, ready());
+    dispatcher_.reset();
+  }
+}
+
+TEST_F(DispatcherShutdownTest, DestroyClearAllList) {
+  ReadyWatcher watcher;
+  ReadyWatcher deferred_watcher;
+  dispatcher_->deferredDelete(
+      std::make_unique<TestDeferredDeletable>([&deferred_watcher]() { deferred_watcher.ready(); }));
+  dispatcher_->deleteInDispatcherThread(
+      std::make_unique<TestDispatcherThreadDeletable>([&watcher]() { watcher.ready(); }));
+  {
+    InSequence s;
+    EXPECT_CALL(deferred_watcher, ready());
+    EXPECT_CALL(watcher, ready());
+    dispatcher_.reset();
   }
 }
 

--- a/test/common/event/scaled_range_timer_manager_impl_test.cc
+++ b/test/common/event/scaled_range_timer_manager_impl_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 
+#include "envoy/common/scope_tracker.h"
 #include "envoy/event/timer.h"
 
 #include "common/event/dispatcher_impl.h"
@@ -24,9 +25,14 @@ public:
   ScopeTrackingDispatcher(DispatcherPtr dispatcher)
       : WrappedDispatcher(*dispatcher), dispatcher_(std::move(dispatcher)) {}
 
-  const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) override {
+  void pushTrackedObject(const ScopeTrackedObject* object) override {
     scope_ = object;
-    return impl_.setTrackedObject(object);
+    return impl_.pushTrackedObject(object);
+  }
+
+  void popTrackedObject(const ScopeTrackedObject* expected_object) override {
+    scope_ = nullptr;
+    return impl_.popTrackedObject(expected_object);
   }
 
   const ScopeTrackedObject* scope_{nullptr};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2656,7 +2656,8 @@ TEST_F(HttpConnectionManagerImplTest, RequestTimeoutCallbackDisarmsAndReturns408
     EXPECT_CALL(response_encoder_, encodeData(_, true)).WillOnce(AddBufferToString(&response_body));
 
     conn_manager_->newStream(response_encoder_);
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, setTrackedObject(_)).Times(2);
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, pushTrackedObject(_));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, popTrackedObject(_));
     request_timer->invokeCallback();
     return Http::okStatus();
   }));
@@ -2886,7 +2887,8 @@ TEST_F(HttpConnectionManagerImplTest, RequestHeaderTimeoutCallbackDisarmsAndRetu
     EXPECT_CALL(*request_header_timer, enableTimer(request_headers_timeout_, _));
 
     conn_manager_->newStream(response_encoder_);
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, setTrackedObject(_)).Times(2);
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, pushTrackedObject(_));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, popTrackedObject(_));
     return Http::okStatus();
   }));
 

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -2348,9 +2348,10 @@ TEST_F(HttpConnectionManagerImplTest, TestSessionTrace) {
   {
     RequestHeaderMapPtr headers{
         new TestRequestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "POST"}}};
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, setTrackedObject(_))
-        .Times(2)
-        .WillOnce(Invoke([](const ScopeTrackedObject* object) -> const ScopeTrackedObject* {
+
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, pushTrackedObject(_))
+        .Times(1)
+        .WillOnce(Invoke([](const ScopeTrackedObject* object) -> void {
           ASSERT(object != nullptr); // On the first call, this should be the active stream.
           std::stringstream out;
           object->dumpState(out);
@@ -2358,9 +2359,8 @@ TEST_F(HttpConnectionManagerImplTest, TestSessionTrace) {
           EXPECT_THAT(state,
                       testing::HasSubstr("filter_manager_callbacks_.requestHeaders():   null"));
           EXPECT_THAT(state, testing::HasSubstr("protocol_: 1"));
-          return nullptr;
-        }))
-        .WillRepeatedly(Return(nullptr));
+        }));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, popTrackedObject(_));
     EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, false))
         .WillOnce(Invoke([](HeaderMap&, bool) -> FilterHeadersStatus {
           return FilterHeadersStatus::StopIteration;
@@ -2371,9 +2371,9 @@ TEST_F(HttpConnectionManagerImplTest, TestSessionTrace) {
   // Send trailers to that stream, and verify by this point headers are in logged state.
   {
     RequestTrailerMapPtr trailers{new TestRequestTrailerMapImpl{{"foo", "bar"}}};
-    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, setTrackedObject(_))
-        .Times(2)
-        .WillOnce(Invoke([](const ScopeTrackedObject* object) -> const ScopeTrackedObject* {
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, pushTrackedObject(_))
+        .Times(1)
+        .WillOnce(Invoke([](const ScopeTrackedObject* object) -> void {
           ASSERT(object != nullptr); // On the first call, this should be the active stream.
           std::stringstream out;
           object->dumpState(out);
@@ -2381,9 +2381,8 @@ TEST_F(HttpConnectionManagerImplTest, TestSessionTrace) {
           EXPECT_THAT(state, testing::HasSubstr("filter_manager_callbacks_.requestHeaders(): \n"));
           EXPECT_THAT(state, testing::HasSubstr("':authority', 'host'\n"));
           EXPECT_THAT(state, testing::HasSubstr("protocol_: 1"));
-          return nullptr;
-        }))
-        .WillRepeatedly(Return(nullptr));
+        }));
+    EXPECT_CALL(filter_callbacks_.connection_.dispatcher_, popTrackedObject(_));
     EXPECT_CALL(*decoder_filters_[0], decodeComplete());
     EXPECT_CALL(*decoder_filters_[0], decodeTrailers(_))
         .WillOnce(Return(FilterTrailersStatus::StopIteration));

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -198,7 +198,8 @@ TEST_F(FilterManagerTest, MatchTreeSkipActionDecodingHeaders) {
 TEST_F(FilterManagerTest, MatchTreeSkipActionRequestAndResponseHeaders) {
   initialize();
 
-  EXPECT_CALL(dispatcher_, setTrackedObject(_)).Times(2);
+  EXPECT_CALL(dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(dispatcher_, popTrackedObject(_));
 
   // This stream filter will skip further callbacks once it sees both the request and response
   // header. As such, it should see the decoding callbacks but none of the encoding callbacks.

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1978,7 +1978,8 @@ public:
         TransportSocketPtr(transport_socket_), stream_info_, true);
     connection_->addConnectionCallbacks(callbacks_);
     // File events will trigger setTrackedObject on the dispatcher.
-    EXPECT_CALL(dispatcher_, setTrackedObject(_)).WillRepeatedly(Return(nullptr));
+    EXPECT_CALL(dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
+    EXPECT_CALL(dispatcher_, popTrackedObject(_)).Times(AnyNumber());
   }
 
   ~MockTransportConnectionImplTest() override { connection_->close(ConnectionCloseType::NoFlush); }

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -1958,6 +1958,7 @@ private:
 class MockTransportConnectionImplTest : public testing::Test {
 public:
   MockTransportConnectionImplTest() : stream_info_(dispatcher_.timeSource(), nullptr) {
+    EXPECT_CALL(dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
     EXPECT_CALL(dispatcher_.buffer_factory_, create_(_, _, _))
         .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                   std::function<void()> above_overflow) -> Buffer::Instance* {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -99,7 +99,8 @@ public:
                                              ShadowWriterPtr(new MockShadowWriter()), router_proto);
     router_ = std::make_shared<TestFilter>(*config_);
     router_->setDecoderFilterCallbacks(callbacks_);
-    EXPECT_CALL(callbacks_.dispatcher_, setTrackedObject(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(callbacks_.dispatcher_, pushTrackedObject(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(callbacks_.dispatcher_, popTrackedObject(_)).Times(testing::AnyNumber());
 
     upstream_locality_.set_zone("to_az");
     context_.cluster_manager_.initializeThreadLocalClusters({"fake_cluster"});

--- a/test/common/signal/fatal_action_test.cc
+++ b/test/common/signal/fatal_action_test.cc
@@ -1,3 +1,6 @@
+#include <vector>
+
+#include "envoy/common/scope_tracker.h"
 #include "envoy/server/fatal_action_config.h"
 
 #include "common/signal/fatal_action.h"
@@ -23,9 +26,10 @@ class TestFatalErrorHandler : public FatalErrorHandlerInterface {
   void onFatalError(std::ostream& /*os*/) const override {}
   void
   runFatalActionsOnTrackedObject(const FatalAction::FatalActionPtrList& actions) const override {
-    // Call the Fatal Actions with nullptr
+    // Call the Fatal Actions with a non-empty vector so it runs the action.
+    std::vector<const ScopeTrackedObject*> tracked_objects{nullptr};
     for (const Server::Configuration::FatalActionPtr& action : actions) {
-      action->run(nullptr);
+      action->run(tracked_objects);
     }
   }
 };
@@ -33,7 +37,9 @@ class TestFatalErrorHandler : public FatalErrorHandlerInterface {
 class TestFatalAction : public Server::Configuration::FatalAction {
 public:
   TestFatalAction(bool is_safe, int* const counter) : is_safe_(is_safe), counter_(counter) {}
-  void run(const ScopeTrackedObject* /*current_object*/) override { ++(*counter_); }
+  void run(absl::Span<const ScopeTrackedObject* const> /*tracked_objects*/) override {
+    ++(*counter_);
+  }
   bool isAsyncSignalSafe() const override { return is_safe_; }
 
 private:

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -869,8 +869,10 @@ TEST_F(ClusterManagerImplTest, HttpHealthChecker) {
               createClientConnection_(
                   PointeesEq(Network::Utility::resolveUrl("tcp://127.0.0.1:11001")), _, _, _))
       .WillOnce(Return(connection));
+  EXPECT_CALL(factory_.dispatcher_, deleteInDispatcherThread(_));
   create(parseBootstrapFromV3Yaml(yaml));
   factory_.tls_.shutdownThread();
+  factory_.dispatcher_.to_delete_.clear();
 }
 
 TEST_F(ClusterManagerImplTest, UnknownCluster) {

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -202,11 +202,11 @@ protected:
   Network::DnsResolver::ResolveCb dns_callback_;
   NiceMock<ThreadLocal::MockInstance> tls_;
   Event::MockTimer* resolve_timer_;
-  std::shared_ptr<LogicalDnsCluster> cluster_;
   ReadyWatcher membership_updated_;
   ReadyWatcher initialized_;
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Event::MockDispatcher> dispatcher_;
+  std::shared_ptr<LogicalDnsCluster> cluster_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Server::MockAdmin> admin_;
   Singleton::ManagerImpl singleton_manager_{Thread::threadFactoryForTest()};

--- a/test/common/upstream/original_dst_cluster_test.cc
+++ b/test/common/upstream/original_dst_cluster_test.cc
@@ -94,11 +94,11 @@ public:
 
   Stats::TestUtil::TestStore stats_store_;
   Ssl::MockContextManager ssl_context_manager_;
+  NiceMock<Event::MockDispatcher> dispatcher_;
   OriginalDstClusterSharedPtr cluster_;
   ReadyWatcher membership_updated_;
   ReadyWatcher initialized_;
   NiceMock<Runtime::MockLoader> runtime_;
-  NiceMock<Event::MockDispatcher> dispatcher_;
   Event::MockTimer* cleanup_timer_;
   NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -122,15 +122,16 @@ public:
 
   const std::string v2_empty_fault_config_yaml = "{}";
 
-  void SetUpTest(const envoy::extensions::filters::http::fault::v3::HTTPFault fault) {
+  void setUpTest(const envoy::extensions::filters::http::fault::v3::HTTPFault fault) {
     config_ = std::make_shared<FaultFilterConfig>(fault, runtime_, "prefix.", stats_, time_system_);
     filter_ = std::make_unique<FaultFilter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_filter_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_filter_callbacks_);
-    EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(AnyNumber());
+    EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
+    EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, popTrackedObject(_)).Times(AnyNumber());
   }
 
-  void SetUpTest(const std::string& yaml) { SetUpTest(convertYamlStrToProtoConfig(yaml)); }
+  void setUpTest(const std::string& yaml) { setUpTest(convertYamlStrToProtoConfig(yaml)); }
 
   void expectDelayTimer(uint64_t duration_ms) {
     timer_ = new Event::MockTimer(&decoder_filter_callbacks_.dispatcher_);
@@ -228,7 +229,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   fault.mutable_abort()->mutable_percentage()->set_denominator(
       envoy::type::v3::FractionalPercent::HUNDRED);
   fault.mutable_abort()->set_http_status(429);
-  SetUpTest(fault);
+  setUpTest(fault);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -274,7 +275,7 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
 }
 
 TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
-  SetUpTest(header_abort_only_yaml);
+  setUpTest(header_abort_only_yaml);
 
   request_headers_.addCopy("x-envoy-fault-abort-request", "429");
 
@@ -329,7 +330,7 @@ TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
   fault.mutable_abort()->mutable_percentage()->set_denominator(
       envoy::type::v3::FractionalPercent::HUNDRED);
   fault.mutable_abort()->set_grpc_status(5);
-  SetUpTest(fault);
+  setUpTest(fault);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -377,7 +378,7 @@ TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
 
 TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
   decoder_filter_callbacks_.is_grpc_request_ = true;
-  SetUpTest(header_abort_only_yaml);
+  setUpTest(header_abort_only_yaml);
 
   request_headers_.addCopy("x-envoy-fault-abort-grpc-request", "5");
 
@@ -427,7 +428,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
 }
 
 TEST_F(FaultFilterTest, HeaderAbortWithHttpAndGrpcStatus) {
-  SetUpTest(header_abort_only_yaml);
+  setUpTest(header_abort_only_yaml);
 
   request_headers_.addCopy("x-envoy-fault-abort-request", "429");
   request_headers_.addCopy("x-envoy-fault-abort-grpc-request", "5");
@@ -478,7 +479,7 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpAndGrpcStatus) {
 }
 
 TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
-  SetUpTest(fixed_delay_only_yaml);
+  setUpTest(fixed_delay_only_yaml);
 
   // Delay related calls
   EXPECT_CALL(
@@ -506,7 +507,7 @@ TEST_F(FaultFilterTest, FixedDelayZeroDuration) {
 }
 
 TEST_F(FaultFilterTest, Overflow) {
-  SetUpTest(fixed_delay_only_yaml);
+  setUpTest(fixed_delay_only_yaml);
 
   // Delay related calls
   EXPECT_CALL(
@@ -532,7 +533,7 @@ TEST_F(FaultFilterTest, Overflow) {
 // Verifies that we don't increment the active_faults gauge when not applying a fault.
 TEST_F(FaultFilterTest, Passthrough) {
   envoy::extensions::filters::http::fault::v3::HTTPFault fault;
-  SetUpTest(fault);
+  setUpTest(fault);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
 
@@ -545,7 +546,7 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
   fault.mutable_delay()->mutable_percentage()->set_denominator(
       envoy::type::v3::FractionalPercent::HUNDRED);
   fault.mutable_delay()->mutable_fixed_delay()->set_seconds(5);
-  SetUpTest(fault);
+  setUpTest(fault);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -588,7 +589,7 @@ TEST_F(FaultFilterTest, FixedDelayDeprecatedPercentAndNonZeroDuration) {
 }
 
 TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
-  SetUpTest(fixed_delay_only_yaml);
+  setUpTest(fixed_delay_only_yaml);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -624,7 +625,8 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
   EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
 
-  EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(2);
+  EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, popTrackedObject(_));
   timer_->invokeCallback();
 
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
@@ -636,7 +638,7 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
 }
 
 TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
-  SetUpTest(fixed_delay_and_abort_yaml);
+  setUpTest(fixed_delay_and_abort_yaml);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -702,7 +704,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
 }
 
 TEST_F(FaultFilterTest, FixedDelayAndAbort) {
-  SetUpTest(fixed_delay_and_abort_yaml);
+  setUpTest(fixed_delay_and_abort_yaml);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -758,7 +760,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbort) {
 }
 
 TEST_F(FaultFilterTest, FixedDelayAndAbortDownstreamNodes) {
-  SetUpTest(fixed_delay_and_abort_nodes_yaml);
+  setUpTest(fixed_delay_and_abort_nodes_yaml);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -812,13 +814,13 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstreamNodes) {
 }
 
 TEST_F(FaultFilterTest, NoDownstreamMatch) {
-  SetUpTest(fixed_delay_and_abort_nodes_yaml);
+  setUpTest(fixed_delay_and_abort_nodes_yaml);
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, true));
 }
 
 TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
-  SetUpTest(fixed_delay_and_abort_match_headers_yaml);
+  setUpTest(fixed_delay_and_abort_match_headers_yaml);
   request_headers_.addCopy("x-foo1", "Bar");
   request_headers_.addCopy("x-foo2", "RandomValue");
 
@@ -875,7 +877,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
 }
 
 TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchFail) {
-  SetUpTest(fixed_delay_and_abort_match_headers_yaml);
+  setUpTest(fixed_delay_and_abort_match_headers_yaml);
   request_headers_.addCopy("x-foo1", "Bar");
   request_headers_.addCopy("x-foo3", "Baz");
 
@@ -903,7 +905,7 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchFail) {
 }
 
 TEST_F(FaultFilterTest, TimerResetAfterStreamReset) {
-  SetUpTest(fixed_delay_only_yaml);
+  setUpTest(fixed_delay_only_yaml);
 
   EXPECT_CALL(runtime_.snapshot_,
               getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
@@ -954,7 +956,7 @@ TEST_F(FaultFilterTest, TimerResetAfterStreamReset) {
 }
 
 TEST_F(FaultFilterTest, FaultWithTargetClusterMatchSuccess) {
-  SetUpTest(delay_with_upstream_cluster_yaml);
+  setUpTest(delay_with_upstream_cluster_yaml);
   const std::string upstream_cluster("www1");
 
   EXPECT_CALL(decoder_filter_callbacks_.route_->route_entry_, clusterName())
@@ -999,7 +1001,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchSuccess) {
 }
 
 TEST_F(FaultFilterTest, FaultWithTargetClusterMatchFail) {
-  SetUpTest(delay_with_upstream_cluster_yaml);
+  setUpTest(delay_with_upstream_cluster_yaml);
   const std::string upstream_cluster("mismatch");
 
   EXPECT_CALL(decoder_filter_callbacks_.route_->route_entry_, clusterName())
@@ -1027,7 +1029,7 @@ TEST_F(FaultFilterTest, FaultWithTargetClusterMatchFail) {
 }
 
 TEST_F(FaultFilterTest, FaultWithTargetClusterNullRoute) {
-  SetUpTest(delay_with_upstream_cluster_yaml);
+  setUpTest(delay_with_upstream_cluster_yaml);
   const std::string upstream_cluster("www1");
 
   EXPECT_CALL(*decoder_filter_callbacks_.route_, routeEntry()).WillRepeatedly(Return(nullptr));
@@ -1108,7 +1110,7 @@ TEST_F(FaultFilterTest, RouteFaultOverridesListenerFault) {
 
   // route-level fault overrides listener-level fault
   {
-    SetUpTest(v2_empty_fault_config_yaml); // This is a valid listener level fault
+    setUpTest(v2_empty_fault_config_yaml); // This is a valid listener level fault
     TestPerFilterConfigFault(&delay_fault, nullptr);
   }
 
@@ -1116,7 +1118,7 @@ TEST_F(FaultFilterTest, RouteFaultOverridesListenerFault) {
   {
     config_->stats().aborts_injected_.reset();
     config_->stats().delays_injected_.reset();
-    SetUpTest(v2_empty_fault_config_yaml);
+    setUpTest(v2_empty_fault_config_yaml);
     TestPerFilterConfigFault(nullptr, &delay_fault);
   }
 
@@ -1124,7 +1126,7 @@ TEST_F(FaultFilterTest, RouteFaultOverridesListenerFault) {
   {
     config_->stats().aborts_injected_.reset();
     config_->stats().delays_injected_.reset();
-    SetUpTest(v2_empty_fault_config_yaml);
+    setUpTest(v2_empty_fault_config_yaml);
     TestPerFilterConfigFault(&delay_fault, &abort_fault);
   }
 }
@@ -1135,7 +1137,7 @@ public:
     envoy::extensions::filters::http::fault::v3::HTTPFault fault;
     fault.mutable_response_rate_limit()->mutable_fixed_limit()->set_limit_kbps(1);
     fault.mutable_response_rate_limit()->mutable_percentage()->set_numerator(100);
-    SetUpTest(fault);
+    setUpTest(fault);
 
     EXPECT_CALL(
         runtime_.snapshot_,

--- a/test/extensions/filters/http/squash/squash_filter_test.cc
+++ b/test/extensions/filters/http/squash/squash_filter_test.cc
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/common/scope_tracker.h"
 #include "envoy/extensions/filters/http/squash/v3/squash.pb.h"
 
 #include "common/http/message_impl.h"
@@ -328,7 +329,8 @@ TEST_F(SquashFilterTest, Timeout) {
   EXPECT_CALL(request_, cancel());
   EXPECT_CALL(filter_callbacks_, continueDecoding());
 
-  EXPECT_CALL(filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(2);
+  EXPECT_CALL(filter_callbacks_.dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(filter_callbacks_.dispatcher_, popTrackedObject(_));
   attachmentTimeout_timer_->invokeCallback();
 
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
@@ -357,7 +359,9 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachment) {
 
   // Expect the second get attachment request
   expectAsyncClientSend();
-  EXPECT_CALL(filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(2);
+  EXPECT_CALL(filter_callbacks_.dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(filter_callbacks_.dispatcher_, popTrackedObject(_));
+
   retry_timer->invokeCallback();
   EXPECT_CALL(filter_callbacks_, continueDecoding());
   completeGetStatusRequest("attached");
@@ -377,7 +381,8 @@ TEST_F(SquashFilterTest, PollingAttachmentNoCluster) {
   // Expect the second get attachment request
   ON_CALL(factory_context_.cluster_manager_, getThreadLocalCluster("squash"))
       .WillByDefault(Return(nullptr));
-  EXPECT_CALL(filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(2);
+  EXPECT_CALL(filter_callbacks_.dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(filter_callbacks_.dispatcher_, popTrackedObject(_));
   EXPECT_CALL(*retry_timer, enableTimer(config_->attachmentPollPeriod(), _));
   retry_timer->invokeCallback();
 }
@@ -395,7 +400,8 @@ TEST_F(SquashFilterTest, CheckRetryPollingAttachmentOnFailure) {
   // Expect the second get attachment request
   expectAsyncClientSend();
 
-  EXPECT_CALL(filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(2);
+  EXPECT_CALL(filter_callbacks_.dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(filter_callbacks_.dispatcher_, popTrackedObject(_));
   retry_timer->invokeCallback();
 
   EXPECT_CALL(filter_callbacks_, continueDecoding());
@@ -466,7 +472,8 @@ TEST_F(SquashFilterTest, TimerExpiresInline) {
         attachmentTimeout_timer_->scope_ = scope;
         attachmentTimeout_timer_->enabled_ = true;
         // timer expires inline
-        EXPECT_CALL(filter_callbacks_.dispatcher_, setTrackedObject(_)).Times(2);
+        EXPECT_CALL(filter_callbacks_.dispatcher_, pushTrackedObject(_));
+        EXPECT_CALL(filter_callbacks_.dispatcher_, popTrackedObject(_));
         attachmentTimeout_timer_->invokeCallback();
       }));
 

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -673,5 +673,134 @@ TEST_P(SdsDynamicUpstreamIntegrationTest, WrongSecretFirst) {
   EXPECT_EQ(1, test_server_->counter("sds.client_cert.update_rejected")->value());
 }
 
+// Test CDS with SDS. A cluster provided by CDS raises new SDS request for upstream cert.
+class SdsCdsIntegrationTest : public SdsDynamicIntegrationBaseTest {
+public:
+  void initialize() override {
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // Create the dynamic cluster. This cluster will be using sds.
+      dynamic_cluster_ = bootstrap.mutable_static_resources()->clusters(0);
+      dynamic_cluster_.set_name("dynamic");
+      dynamic_cluster_.mutable_connect_timeout()->MergeFrom(
+          ProtobufUtil::TimeUtil::MillisecondsToDuration(500000));
+      auto* transport_socket = dynamic_cluster_.mutable_transport_socket();
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+      auto* secret_config =
+          tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
+      setUpSdsConfig(secret_config, "client_cert");
+
+      transport_socket->set_name("envoy.transport_sockets.tls");
+      transport_socket->mutable_typed_config()->PackFrom(tls_context);
+
+      // Add cds cluster first.
+      auto* cds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      cds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      cds_cluster->set_name("cds_cluster");
+      ConfigHelper::setHttp2(*cds_cluster);
+      // Then add sds cluster.
+      auto* sds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      sds_cluster->set_name("sds_cluster");
+      ConfigHelper::setHttp2(*sds_cluster);
+
+      const std::string cds_yaml = R"EOF(
+    resource_api_version: V3
+    api_config_source:
+      api_type: GRPC
+      transport_api_version: V3
+      grpc_services:
+        envoy_grpc:
+          cluster_name: cds_cluster
+      set_node_on_first_message_only: true
+)EOF";
+      auto* cds = bootstrap.mutable_dynamic_resources()->mutable_cds_config();
+      TestUtility::loadFromYaml(cds_yaml, *cds);
+    });
+
+    HttpIntegrationTest::initialize();
+  }
+
+  void TearDown() override {
+    {
+      AssertionResult result = sds_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = sds_connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      sds_connection_.reset();
+    }
+    cleanUpXdsConnection();
+    cleanupUpstreamAndDownstream();
+    codec_client_.reset();
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
+  void createUpstreams() override {
+    // Static cluster.
+    addFakeUpstream(FakeHttpConnection::Type::HTTP1);
+    // Cds Cluster.
+    addFakeUpstream(FakeHttpConnection::Type::HTTP2);
+    // Sds Cluster.
+    addFakeUpstream(FakeHttpConnection::Type::HTTP2);
+  }
+
+  void sendCdsResponse() {
+    EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Cluster, "", {}, {}, {}, true));
+    sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
+        Config::TypeUrl::get().Cluster, {dynamic_cluster_}, {dynamic_cluster_}, {}, "55");
+  }
+
+  void sendSdsResponse2(const envoy::extensions::transport_sockets::tls::v3::Secret& secret,
+                        FakeStream& sds_stream) {
+    API_NO_BOOST(envoy::api::v2::DiscoveryResponse) discovery_response;
+    discovery_response.set_version_info("1");
+    discovery_response.set_type_url(Config::TypeUrl::get().Secret);
+    discovery_response.add_resources()->PackFrom(secret);
+    sds_stream.sendGrpcMessage(discovery_response);
+  }
+  envoy::config::cluster::v3::Cluster dynamic_cluster_;
+  FakeHttpConnectionPtr sds_connection_;
+  FakeStreamPtr sds_stream_;
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, SdsCdsIntegrationTest, GRPC_CLIENT_INTEGRATION_PARAMS);
+
+TEST_P(SdsCdsIntegrationTest, BasicSuccess) {
+  on_server_init_function_ = [this]() {
+    {
+      // CDS.
+      AssertionResult result =
+          fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, xds_connection_);
+      RELEASE_ASSERT(result, result.message());
+      result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+      RELEASE_ASSERT(result, result.message());
+      xds_stream_->startGrpcStream();
+      sendCdsResponse();
+    }
+    {
+      // SDS.
+      AssertionResult result =
+          fake_upstreams_[2]->waitForHttpConnection(*dispatcher_, sds_connection_);
+      RELEASE_ASSERT(result, result.message());
+
+      result = sds_connection_->waitForNewStream(*dispatcher_, sds_stream_);
+      RELEASE_ASSERT(result, result.message());
+      sds_stream_->startGrpcStream();
+      sendSdsResponse2(getClientSecret(), *sds_stream_);
+    }
+  };
+  initialize();
+
+  test_server_->waitForCounterGe(
+      "cluster.dynamic.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
+  // The 4 clusters are CDS,SDS,static and dynamic cluster.
+  test_server_->waitForGaugeGe("cluster_manager.active_clusters", 4);
+
+  sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster, {}, {},
+                                                             {}, "42");
+  // Successfully removed the dynamic cluster.
+  test_server_->waitForGaugeEq("cluster_manager.active_clusters", 3);
+}
+
 } // namespace Ssl
 } // namespace Envoy

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -31,6 +31,7 @@ MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
                                std::function<void()> above_overflow) -> Buffer::Instance* {
         return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
       }));
+  ON_CALL(*this, isThreadSafe()).WillByDefault(Return(true));
 }
 
 MockDispatcher::~MockDispatcher() = default;

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <list>
 
+#include "envoy/common/scope_tracker.h"
 #include "envoy/common/time.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/dispatcher.h"
@@ -130,7 +131,8 @@ public:
   MOCK_METHOD(SignalEvent*, listenForSignal_, (signal_t signal_num, SignalCb cb));
   MOCK_METHOD(void, post, (std::function<void()> callback));
   MOCK_METHOD(void, run, (RunType type));
-  MOCK_METHOD(const ScopeTrackedObject*, setTrackedObject, (const ScopeTrackedObject* object));
+  MOCK_METHOD(void, pushTrackedObject, (const ScopeTrackedObject* object));
+  MOCK_METHOD(void, popTrackedObject, (const ScopeTrackedObject* expected_object));
   MOCK_METHOD(bool, isThreadSafe, (), (const));
   Buffer::WatermarkFactory& getWatermarkFactory() override { return buffer_factory_; }
   MOCK_METHOD(Thread::ThreadId, getCurrentThreadId, ());

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -130,6 +130,7 @@ public:
   MOCK_METHOD(void, exit, ());
   MOCK_METHOD(SignalEvent*, listenForSignal_, (signal_t signal_num, SignalCb cb));
   MOCK_METHOD(void, post, (std::function<void()> callback));
+  MOCK_METHOD(void, deleteInDispatcherThread, (DispatcherThreadDeletableConstPtr deletable));
   MOCK_METHOD(void, run, (RunType type));
   MOCK_METHOD(void, pushTrackedObject, (const ScopeTrackedObject* object));
   MOCK_METHOD(void, popTrackedObject, (const ScopeTrackedObject* expected_object));
@@ -138,6 +139,7 @@ public:
   MOCK_METHOD(Thread::ThreadId, getCurrentThreadId, ());
   MOCK_METHOD(MonotonicTime, approximateMonotonicTime, (), (const));
   MOCK_METHOD(void, updateApproximateMonotonicTime, ());
+  MOCK_METHOD(void, shutdown, ());
 
   GlobalTimeSystem time_system_;
   std::list<DeferredDeletablePtr> to_delete_;

--- a/test/mocks/event/wrapped_dispatcher.h
+++ b/test/mocks/event/wrapped_dispatcher.h
@@ -97,8 +97,12 @@ public:
   void run(RunType type) override { impl_.run(type); }
 
   Buffer::WatermarkFactory& getWatermarkFactory() override { return impl_.getWatermarkFactory(); }
-  const ScopeTrackedObject* setTrackedObject(const ScopeTrackedObject* object) override {
-    return impl_.setTrackedObject(object);
+  void pushTrackedObject(const ScopeTrackedObject* object) override {
+    return impl_.pushTrackedObject(object);
+  }
+
+  void popTrackedObject(const ScopeTrackedObject* expected_object) override {
+    return impl_.popTrackedObject(expected_object);
   }
 
   MonotonicTime approximateMonotonicTime() const override {

--- a/test/mocks/event/wrapped_dispatcher.h
+++ b/test/mocks/event/wrapped_dispatcher.h
@@ -94,6 +94,10 @@ public:
 
   void post(std::function<void()> callback) override { impl_.post(std::move(callback)); }
 
+  void deleteInDispatcherThread(DispatcherThreadDeletableConstPtr deletable) override {
+    impl_.deleteInDispatcherThread(std::move(deletable));
+  }
+
   void run(RunType type) override { impl_.run(type); }
 
   Buffer::WatermarkFactory& getWatermarkFactory() override { return impl_.getWatermarkFactory(); }
@@ -112,6 +116,8 @@ public:
   void updateApproximateMonotonicTime() override { impl_.updateApproximateMonotonicTime(); }
 
   bool isThreadSafe() const override { return impl_.isThreadSafe(); }
+
+  void shutdown() override { impl_.shutdown(); }
 
 protected:
   Dispatcher& impl_;

--- a/test/mocks/router/router_filter_interface.cc
+++ b/test/mocks/router/router_filter_interface.cc
@@ -18,7 +18,8 @@ MockRouterFilterInterface::MockRouterFilterInterface()
   ON_CALL(*this, config()).WillByDefault(ReturnRef(config_));
   ON_CALL(*this, cluster()).WillByDefault(Return(cluster_info_));
   ON_CALL(*this, upstreamRequests()).WillByDefault(ReturnRef(requests_));
-  EXPECT_CALL(callbacks_.dispatcher_, setTrackedObject(_)).Times(AnyNumber());
+  EXPECT_CALL(callbacks_.dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
+  EXPECT_CALL(callbacks_.dispatcher_, popTrackedObject(_)).Times(AnyNumber());
   ON_CALL(*this, routeEntry()).WillByDefault(Return(&route_entry_));
   ON_CALL(callbacks_, connection()).WillByDefault(Return(&client_connection_));
   route_entry_.connect_config_.emplace(RouteEntry::ConnectConfig());

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1363,7 +1363,7 @@ TEST_P(ServerInstanceImplTest, WithUnknownBootstrapExtensions) {
 #ifndef WIN32
 class SafeFatalAction : public Configuration::FatalAction {
 public:
-  void run(const ScopeTrackedObject* /*current_object*/) override {
+  void run(absl::Span<const ScopeTrackedObject* const> /*tracked_objects*/) override {
     std::cerr << "Called SafeFatalAction" << std::endl;
   }
 
@@ -1372,7 +1372,7 @@ public:
 
 class UnsafeFatalAction : public Configuration::FatalAction {
 public:
-  void run(const ScopeTrackedObject* /*current_object*/) override {
+  void run(absl::Span<const ScopeTrackedObject* const> /*tracked_objects*/) override {
     std::cerr << "Called UnsafeFatalAction" << std::endl;
   }
 


### PR DESCRIPTION
Commit Message:
Always destroy cluster info object on the master thread.
Fixed SDS churn and a rare crash case.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes:
#13209
istio/istio#30199
istio/istio#28315
[Optional Deprecated:]
[Optional API Considerations:]