### PR TITLE
dns: honor endpoint hostname in strict and logical dns clusters

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -12,6 +12,13 @@ Minor Behavior Changes
 ----------------------
 *Changes that may cause incompatibilities for some users, but should not for most*
 
+* dns: both the :ref:`strict DNS <arch_overview_service_discovery_types_strict_dns>` and
+  :ref:`logical DNS <arch_overview_service_discovery_types_logical_dns>` cluster types now honor the
+  :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.hostname>` field if not empty.
+  Previously resolved hosts would have their hostname set to the configured DNS address for use with
+  logging, :ref:`auto_host_rewrite <envoy_api_field_route.RouteAction.auto_host_rewrite>`, etc.
+  Setting the hostname manually allows overriding the internal hostname used for such features while
+  still allowing the original DNS resolution name to be used.
 * hds: support custom health check port via :ref:`health_check_config <envoy_v3_api_msg_config.endpoint.v3.endpoint.healthcheckconfig>`.
 * healthcheck: the :ref:`health check filter <config_http_filters_health_check>` now sends the
   :ref:`x-envoy-immediate-health-check-fail <config_http_filters_router_x-envoy-immediate-health-check-fail>` header

--- a/source/common/upstream/logical_dns_cluster.cc
+++ b/source/common/upstream/logical_dns_cluster.cc
@@ -83,7 +83,11 @@ LogicalDnsCluster::LogicalDnsCluster(
   }
 
   dns_url_ = fmt::format("tcp://{}:{}", socket_address.address(), socket_address.port_value());
-  hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
+  if (lbEndpoint().endpoint().hostname().empty()) {
+    hostname_ = Network::Utility::hostFromTcpUrl(dns_url_);
+  } else {
+    hostname_ = lbEndpoint().endpoint().hostname();
+  }
   Network::Utility::portFromTcpUrl(dns_url_);
   dns_lookup_family_ = getDnsLookupFamilyFromCluster(cluster);
 }

--- a/source/common/upstream/strict_dns_cluster.h
+++ b/source/common/upstream/strict_dns_cluster.h
@@ -34,12 +34,13 @@ private:
 
     StrictDnsClusterImpl& parent_;
     Network::ActiveDnsQuery* active_query_{};
-    std::string dns_address_;
-    uint32_t port_;
-    Event::TimerPtr resolve_timer_;
+    const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoints_;
+    const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint_;
+    const std::string dns_address_;
+    const std::string hostname_;
+    const uint32_t port_;
+    const Event::TimerPtr resolve_timer_;
     HostVector hosts_;
-    const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint_;
-    const envoy::config::endpoint::v3::LbEndpoint lb_endpoint_;
     HostMap all_hosts_;
   };
 

--- a/test/common/upstream/logical_dns_cluster_test.cc
+++ b/test/common/upstream/logical_dns_cluster_test.cc
@@ -315,6 +315,7 @@ TEST_F(LogicalDnsParamTest, FailureRefreshRateBackoffResetsWhenSuccessHappens) {
         endpoints:
           - lb_endpoints:
             - endpoint:
+                hostname: foo
                 address:
                   socket_address:
                     address: foo.bar.com
@@ -335,6 +336,9 @@ TEST_F(LogicalDnsParamTest, FailureRefreshRateBackoffResetsWhenSuccessHappens) {
   EXPECT_CALL(*resolve_timer_, enableTimer(std::chrono::milliseconds(4000), _));
   dns_callback_(Network::DnsResolver::ResolutionStatus::Success,
                 TestUtility::makeDnsResponse({"127.0.0.1", "127.0.0.2"}));
+  EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+  EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
+  EXPECT_EQ("foo", cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->hostname());
 
   // Therefore, a subsequent failure should get a [0,base * 1] refresh.
   ON_CALL(random_, random()).WillByDefault(Return(8000));

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -320,6 +320,7 @@ TEST_F(StrictDnsClusterImplTest, Basic) {
                     address: localhost1
                     port_value: 11001
             - endpoint:
+                hostname: foo
                 address:
                   socket_address:
                     address: localhost2
@@ -416,6 +417,8 @@ TEST_F(StrictDnsClusterImplTest, Basic) {
   EXPECT_THAT(
       std::list<std::string>({"127.0.0.3:11001", "10.0.0.1:11002"}),
       ContainerEq(hostListToAddresses(cluster.prioritySet().hostSetsPerPriority()[0]->hosts())));
+  EXPECT_EQ("localhost1", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[0]->hostname());
+  EXPECT_EQ("foo", cluster.prioritySet().hostSetsPerPriority()[0]->hosts()[1]->hostname());
 
   EXPECT_EQ(2UL, cluster.prioritySet().hostSetsPerPriority()[0]->healthyHosts().size());
   EXPECT_EQ(1UL, cluster.prioritySet().hostSetsPerPriority()[0]->hostsPerLocality().get().size());


### PR DESCRIPTION
This allows the user to override the DNS name for use with logging,
auto host rewrite, etc.

Fixes https://github.com/envoyproxy/envoy/issues/14873

Risk Level: Low
Testing: New unit tests
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
