### PR TITLE
wasm: remove non-representative and redundant benchmarks.

### DIFF
--- a/test/extensions/bootstrap/wasm/wasm_speed_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_speed_test.cc
@@ -113,11 +113,8 @@ B(grpc_service1000)
 B(modify_metadata)
 B(modify_metadata1000)
 B(json_serialize)
-B(json_serialize_arena)
 B(json_deserialize)
-B(json_deserialize_arena)
 B(json_deserialize_empty)
-B(json_serialize_deserialize)
 B(convert_to_filter_state)
 
 } // namespace Wasm


### PR DESCRIPTION
The "json_serialize_arena" test was non-representative, and it was running
out of memory in WasmVM during benchmarks, leading to invalid results.

The "json_deserialize_arena" test was measuring exactly the same process as
the "json_deserialize" test, so it was redundant.

The "json_serialize_deserialize" test was a combinantion of "json_serialize"
and "json_deserialize" tests, so it was redundant.

While there, make sure that inputs are not used as outputs, and vice-versa.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>