### PR TITLE
stop using testing::property to match statusor::tostring

### DIFF
--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -262,9 +262,9 @@ TEST_F(ProtobufUtilityTest, JsonConvertAnyUnknownMessageType) {
   ProtobufWkt::Any source_any;
   source_any.set_type_url("type.googleapis.com/bad.type.url");
   source_any.set_value("asdf");
-  EXPECT_THAT(MessageUtil::getJsonStringFromMessage(source_any, true).status(),
-              AllOf(Property(&ProtobufUtil::Status::ok, false),
-                    Property(&ProtobufUtil::Status::ToString, testing::HasSubstr("bad.type.url"))));
+  auto status = MessageUtil::getJsonStringFromMessage(source_any, true).status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(status.ToString(), testing::HasSubstr("bad.type.url"));
 }
 
 TEST_F(ProtobufUtilityTest, JsonConvertKnownGoodMessage) {


### PR DESCRIPTION
Commit Message: Stop using testing::Property to match absl::StatusOr::ToString
Additional Description:
The official googletest docs recommend against matching on properties of
classes you don't own since that is brittle.
Risk Level: low
Testing: ran affected test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

See googletest recommendation against using Property [here](https://github.com/google/googletest/blob/d9c309fdab807b716c2cf4d4a42989b8c34f712a/docs/gmock_cheat_sheet.md#member-matchers).

@yanavlasov 