### PR TITLE
lua http filter: Expose requestedServerName on streamInfo

### DIFF
--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -692,6 +692,17 @@ Returns a downstream :ref:`SSL connection info object <config_http_filters_lua_s
 
 .. _config_http_filters_lua_stream_info_dynamic_metadata_wrapper:
 
+requestedServerName()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: lua
+
+  streamInfo:requestedServerName()
+
+// TODO: fix this below
+Returns the string representation of :repo:`requested server name <include/envoy/stream_info/stream_info.h>`
+(e.g. SNI in TLS) for the current request if present.
+
 Dynamic metadata object API
 ---------------------------
 

--- a/docs/root/configuration/http/http_filters/lua_filter.rst
+++ b/docs/root/configuration/http/http_filters/lua_filter.rst
@@ -699,7 +699,6 @@ requestedServerName()
 
   streamInfo:requestedServerName()
 
-// TODO: fix this below
 Returns the string representation of :repo:`requested server name <include/envoy/stream_info/stream_info.h>`
 (e.g. SNI in TLS) for the current request if present.
 

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -141,6 +141,11 @@ int StreamInfoWrapper::luaDownstreamDirectRemoteAddress(lua_State* state) {
   return 1;
 }
 
+int StreamInfoWrapper::luaRequestedServerName(lua_State* state) {
+  lua_pushstring(state, stream_info_.requestedServerName().c_str());
+  return 1;
+}
+
 DynamicMetadataMapIterator::DynamicMetadataMapIterator(DynamicMetadataMapWrapper& parent)
     : parent_{parent}, current_{parent_.streamInfo().dynamicMetadata().filter_metadata().begin()} {}
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -186,7 +186,8 @@ public:
             {"dynamicMetadata", static_luaDynamicMetadata},
             {"downstreamLocalAddress", static_luaDownstreamLocalAddress},
             {"downstreamDirectRemoteAddress", static_luaDownstreamDirectRemoteAddress},
-            {"downstreamSslConnection", static_luaDownstreamSslConnection}};
+            {"downstreamSslConnection", static_luaDownstreamSslConnection},
+            {"requestedServerName", static_luaRequestedServerName}};
   }
 
 private:
@@ -220,6 +221,12 @@ private:
    * This is equivalent to the address of the physical connection.
    */
   DECLARE_LUA_FUNCTION(StreamInfoWrapper, luaDownstreamDirectRemoteAddress);
+
+  /**
+   * Get requested server name
+   * @return requested server name (e.g. SNI in TLS), if any.
+   */
+  DECLARE_LUA_FUNCTION(StreamInfoWrapper, luaRequestedServerName);
 
   // Envoy::Lua::BaseLuaObject
   void onMarkDead() override {

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -291,6 +291,8 @@ typed_config:
         request_handle:streamInfo():downstreamLocalAddress())
       request_handle:headers():add("request_downstream_directremote_address_value", 
         request_handle:streamInfo():downstreamDirectRemoteAddress())
+      request_handle:headers():add("request_requested_server_name",
+        request_handle:streamInfo():requestedServerName())
     end
 
     function envoy_on_response(response_handle)
@@ -363,6 +365,11 @@ typed_config:
           ->value()
           .getStringView(),
       GetParam() == Network::Address::IpVersion::v4 ? "127.0.0.1:" : "[::1]:"));
+
+  EXPECT_EQ("", upstream_request_->headers()
+                    .get(Http::LowerCaseString("request_requested_server_name"))[0]
+                    ->value()
+                    .getStringView());
 
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
   upstream_request_->encodeHeaders(response_headers, false);

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -300,6 +300,25 @@ TEST_F(LuaStreamInfoWrapperTest, ReturnCurrentDownstreamAddresses) {
   wrapper.reset();
 }
 
+TEST_F(LuaStreamInfoWrapperTest, ReturnRequestedServerName) {
+  const std::string SCRIPT{R"EOF(
+      function callMe(object)
+        testPrint(object:requestedServerName())
+      end
+    )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  stream_info.requested_server_name_ = "some.sni.io";
+  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
+      StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
+  EXPECT_CALL(printer_, testPrint("some.sni.io"));
+  start("callMe");
+  wrapper.reset();
+}
+
 // Set, get and iterate stream info dynamic metadata.
 TEST_F(LuaStreamInfoWrapperTest, SetGetAndIterateDynamicMetadata) {
   const std::string SCRIPT{R"EOF(


### PR DESCRIPTION
Commit Message: lua http filter: Expose requestedServerName on streamInfo
Additional Description: N/A
Risk Level: Low
Testing: Adds integration and unit tests
Docs Changes: Added note to Lua documentation.
Release Notes: Expose requested server name (e.g. SNI in TLS) on stream info in Lua filter.
Platform Specific Features: N/A
Fixes: https://github.com/envoyproxy/envoy/issues/15142
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
