### PR TITLE
wasm: fix getHeaderMapValue() in case of early client disconnect.

### DIFF
--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -452,6 +452,7 @@ protected:
   Http::RequestHeaderMapPtr grpc_initial_metadata_;
 
   // Access log state.
+  bool access_log_phase_ = false;
   const StreamInfo::StreamInfo* access_log_stream_info_{};
   const Http::RequestHeaderMap* access_log_request_headers_{};
   const Http::ResponseHeaderMap* access_log_response_headers_{};

--- a/test/extensions/filters/http/wasm/test_data/headers_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/headers_rust.rs
@@ -46,9 +46,13 @@ impl HttpContext for TestStream {
     }
 
     fn on_log(&mut self) {
-        if let Some(path) = self.get_http_request_header(":path") {
-            warn!("onLog {} {}", self.context_id, path);
-        }
+        let path = self
+            .get_http_request_header(":path")
+            .unwrap_or(String::from(""));
+        let status = self
+            .get_http_response_header(":status")
+            .unwrap_or(String::from(""));
+        warn!("onLog {} {} {}", self.context_id, path, status);
     }
 }
 

--- a/test/extensions/filters/http/wasm/test_data/test_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_cpp.cc
@@ -329,7 +329,9 @@ void TestContext::onLog() {
   auto test = root()->test_;
   if (test == "headers") {
     auto path = getRequestHeader(":path");
-    logWarn("onLog " + std::to_string(id()) + " " + std::string(path->view()));
+    auto status = getResponseHeader(":status");
+    logWarn("onLog " + std::to_string(id()) + " " + std::string(path->view()) + " " +
+            std::string(status->view()));
     auto response_header = getResponseHeader("bogus-header");
     if (response_header && response_header->view() != "") {
       logWarn("response bogus-header found");

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -548,11 +548,11 @@ TEST_P(WasmHttpFilterTest, AccessLog) {
   EXPECT_CALL(filter(),
               log_(spdlog::level::debug, Eq(absl::string_view("onRequestHeaders 2 headers"))));
   EXPECT_CALL(filter(), log_(spdlog::level::info, Eq(absl::string_view("header path /"))));
-  EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onLog 2 /"))));
+  EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onLog 2 / 200"))));
   EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onDone 2"))));
 
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
-  Http::TestResponseHeaderMapImpl response_headers{};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   Http::TestResponseTrailerMapImpl response_trailers{};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   filter().continueStream(proxy_wasm::WasmStreamType::Response);
@@ -562,15 +562,31 @@ TEST_P(WasmHttpFilterTest, AccessLog) {
   filter().onDestroy();
 }
 
+TEST_P(WasmHttpFilterTest, AccessLogClientDisconnected) {
+  setupTest("", "headers");
+  setupFilter();
+  EXPECT_CALL(filter(),
+              log_(spdlog::level::debug, Eq(absl::string_view("onRequestHeaders 2 headers"))));
+  EXPECT_CALL(filter(), log_(spdlog::level::info, Eq(absl::string_view("header path /"))));
+  EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onLog 2 / "))));
+  EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onDone 2"))));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
+  StreamInfo::MockStreamInfo log_stream_info;
+  filter().log(&request_headers, nullptr, nullptr, log_stream_info);
+  filter().onDestroy();
+}
+
 TEST_P(WasmHttpFilterTest, AccessLogCreate) {
   setupTest("", "headers");
   setupFilter();
-  EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onLog 2 /"))));
+  EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onLog 2 / 200"))));
   EXPECT_CALL(filter(), log_(spdlog::level::warn, Eq(absl::string_view("onDone 2"))));
 
   StreamInfo::MockStreamInfo log_stream_info;
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
-  Http::TestResponseHeaderMapImpl response_headers{};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   Http::TestResponseTrailerMapImpl response_trailers{};
   filter().log(&request_headers, &response_headers, &response_trailers, log_stream_info);
   filter().onDestroy();


### PR DESCRIPTION
Previously, getHeaderMapValuei() would incorrectly return BadArgument
when called in the access log phase after an early client disconnect,
because the code assumed that a HeaderMap can point to a nullptr only
when called from a callback in which given map is not available.

Fixes proxy-wasm/proxy-wasm-rust-sdk#82.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>