### PR TITLE
log: Add "%j" to print message as JSON escaped string

### DIFF
--- a/docs/root/operations/cli.rst
+++ b/docs/root/operations/cli.rst
@@ -124,6 +124,7 @@ following are the command line options that Envoy supports.
 
    :%v:	The actual message to log ("some user text")
    :%_:	The actual message to log, but with escaped newlines (from (if using ``%v``) "some user text\nbelow", to "some user text\\nbelow")
+   :%j:	The actual message to log as JSON escaped string (https://tools.ietf.org/html/rfc7159#page-8).
    :%t:	Thread id ("1232")
    :%P:	Process id ("3456")
    :%n:	Logger's name ("filter")

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -98,6 +98,7 @@ New Features
 * http: added support for :ref:`preconnecting <envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic, especially if using HTTP/1.1.
 * http: change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to false.
 * json: introduced new JSON parser (https://github.com/nlohmann/json) to replace RapidJSON. The new parser is disabled by default. To test the new RapidJSON parser, enable the runtime feature `envoy.reloadable_features.remove_legacy_json`.
+* log: added a new custom flag ``%j`` to the log pattern to print the actual message to log as JSON escaped string.
 * original_dst: added support for :ref:`Original Destination <config_listener_filters_original_dst>` on Windows. This enables the use of Envoy as a sidecar proxy on Windows.
 * overload: add support for scaling :ref:`transport connection timeouts<envoy_v3_api_enum_value_config.overload.v3.ScaleTimersOverloadActionConfig.TimerType.TRANSPORT_SOCKET_CONNECT>`. This can be used to reduce the TLS handshake timeout in response to overload.
 * postgres: added ability to :ref:`terminate SSL<envoy_v3_api_field_extensions.filters.network.postgres_proxy.v3alpha.PostgresProxy.terminate_ssl>`.

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -148,6 +148,7 @@ envoy_cc_library(
     ],
     hdrs = [
         "fancy_logger.h",
+        "json_escape_string.h",
         "logger.h",
     ],
     external_deps = ["abseil_synchronization"],

--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -32,43 +32,36 @@ public:
         result[position + 1] = '"';
         position += 2;
         break;
-
       case '\\':
         // Reverse solidus (0x5c).
         // Nothing to change.
         position += 2;
         break;
-
       case '\b':
         // Backspace (0x08).
         result[position + 1] = 'b';
         position += 2;
         break;
-
       case '\f':
         // Form feed (0x0c).
         result[position + 1] = 'f';
         position += 2;
         break;
-
       case '\n':
         // Newline (0x0a).
         result[position + 1] = 'n';
         position += 2;
         break;
-
       case '\r':
         // Carriage return (0x0d).
         result[position + 1] = 'r';
         position += 2;
         break;
-
       case '\t':
         // Horizontal tab (0x09).
         result[position + 1] = 't';
         position += 2;
         break;
-
       default:
         if (character >= 0x00 and character <= 0x1f) {
           // Print character as unicode hex.

--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -11,8 +11,9 @@ namespace Envoy {
 
 // The JSON string escape implementation is taken from:
 // https://github.com/nlohmann/json/blob/ec7a1d834773f9fee90d8ae908a0c9933c5646fc/src/json.hpp#L4604-L4697.
-// Assumption: the input string will be ASCII only. This is here to reduce dependencies that
-// minimal_logger_lib maintains.
+// Note: UTF-8 encoded strings are passed through without modification.
+//
+// This is here to reduce dependencies that minimal_logger_lib maintains.
 class JsonEscaper {
 public:
   // Escape a string by replacing certain special characters by a sequence of an escape character

--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -28,18 +28,16 @@ public:
     for (const auto& character : input) {
       switch (character) {
       // Quotation mark (0x22).
-      case '"': {
+      case '"':
         result[position + 1] = '"';
         position += 2;
         break;
-      }
 
       // Reverse solidus (0x5c).
-      case '\\': {
+      case '\\':
         // Nothing to change.
         position += 2;
         break;
-      }
 
       // Backspace (0x08).
       case '\b': {
@@ -49,34 +47,30 @@ public:
       }
 
       // Form feed (0x0c).
-      case '\f': {
+      case '\f':
         result[position + 1] = 'f';
         position += 2;
         break;
-      }
 
       // Newline (0x0a).
-      case '\n': {
+      case '\n':
         result[position + 1] = 'n';
         position += 2;
         break;
-      }
 
       // Carriage return (0x0d).
-      case '\r': {
+      case '\r':
         result[position + 1] = 'r';
         position += 2;
         break;
-      }
 
       // Horizontal tab (0x09).
-      case '\t': {
+      case '\t':
         result[position + 1] = 't';
         position += 2;
         break;
-      }
 
-      default: {
+      default:
         if (character >= 0x00 and character <= 0x1f) {
           // Print character as unicode hex.
           sprintf(&result[position + 1], "u%04x", int(character));
@@ -88,7 +82,6 @@ public:
           result[position++] = character;
         }
         break;
-      }
       }
     }
 
@@ -131,6 +124,6 @@ public:
     }
     return result;
   }
-};
+}; // namespace Envoy
 
 } // namespace Envoy

--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -27,45 +27,44 @@ public:
 
     for (const auto& character : input) {
       switch (character) {
-      // Quotation mark (0x22).
       case '"':
+        // Quotation mark (0x22).
         result[position + 1] = '"';
         position += 2;
         break;
 
-      // Reverse solidus (0x5c).
       case '\\':
+        // Reverse solidus (0x5c).
         // Nothing to change.
         position += 2;
         break;
 
-      // Backspace (0x08).
-      case '\b': {
+      case '\b':
+        // Backspace (0x08).
         result[position + 1] = 'b';
         position += 2;
         break;
-      }
 
-      // Form feed (0x0c).
       case '\f':
+        // Form feed (0x0c).
         result[position + 1] = 'f';
         position += 2;
         break;
 
-      // Newline (0x0a).
       case '\n':
+        // Newline (0x0a).
         result[position + 1] = 'n';
         position += 2;
         break;
 
-      // Carriage return (0x0d).
       case '\r':
+        // Carriage return (0x0d).
         result[position + 1] = 'r';
         position += 2;
         break;
 
-      // Horizontal tab (0x09).
       case '\t':
+        // Horizontal tab (0x09).
         result[position + 1] = 't';
         position += 2;
         break;

--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "common/common/macros.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+
+// The JSON string escape implementation is taken from:
+// https://github.com/nlohmann/json/blob/ec7a1d834773f9fee90d8ae908a0c9933c5646fc/src/json.hpp#L4604-L4697.
+// Assumption: the input string will be ASCII only. This is here to reduce dependencies that
+// minimal_logger_lib maintains.
+class JsonEscaper {
+public:
+  // Escape a string by replacing certain special characters by a sequence of an escape character
+  // (backslash) and another character and other control characters by a sequence of "\u" followed
+  // by a four-digit hex representation (https://tools.ietf.org/html/rfc7159#page-8).
+  // @param input input string.
+  // @return std::string JSON escaped string.
+  static std::string escapeString(absl::string_view input, uint64_t required_size) {
+    // Create a result string of necessary size.
+    std::string result(input.size() + required_size, '\\');
+    uint64_t position = 0;
+
+    for (const auto& character : input) {
+      switch (character) {
+      // Quotation mark (0x22).
+      case '"': {
+        result[position + 1] = '"';
+        position += 2;
+        break;
+      }
+
+      // Reverse solidus (0x5c).
+      case '\\': {
+        // Nothing to change.
+        position += 2;
+        break;
+      }
+
+      // Backspace (0x08).
+      case '\b': {
+        result[position + 1] = 'b';
+        position += 2;
+        break;
+      }
+
+      // Form feed (0x0c).
+      case '\f': {
+        result[position + 1] = 'f';
+        position += 2;
+        break;
+      }
+
+      // Newline (0x0a).
+      case '\n': {
+        result[position + 1] = 'n';
+        position += 2;
+        break;
+      }
+
+      // Carriage return (0x0d).
+      case '\r': {
+        result[position + 1] = 'r';
+        position += 2;
+        break;
+      }
+
+      // Horizontal tab (0x09).
+      case '\t': {
+        result[position + 1] = 't';
+        position += 2;
+        break;
+      }
+
+      default: {
+        if (character >= 0x00 and character <= 0x1f) {
+          // Print character as unicode hex.
+          sprintf(&result[position + 1], "u%04x", int(character));
+          position += 6;
+          // Overwrite trailing null character.
+          result[position] = '\\';
+        } else {
+          // All other characters are added as-is.
+          result[position++] = character;
+        }
+        break;
+      }
+      }
+    }
+
+    return result;
+  }
+
+  // Calculates the extra space to build a JSON escaped string.
+  // @param input input string.
+  // @return uint64_t the number of extra characters required to to build a JSON escaped string.
+  static uint64_t extraSpace(absl::string_view input) {
+    uint64_t result = 0;
+    for (const auto& character : input) {
+      switch (character) {
+      case '"':
+        FALLTHRU;
+      case '\\':
+        FALLTHRU;
+      case '\b':
+        FALLTHRU;
+      case '\f':
+        FALLTHRU;
+      case '\n':
+        FALLTHRU;
+      case '\r':
+        FALLTHRU;
+      case '\t': {
+        // From character (1 byte) to hex (2 bytes).
+        result += 1;
+        break;
+      }
+
+      default: {
+        if (character >= 0x00 and character <= 0x1f) {
+          // From character (1 byte) to unicode hex (6 bytes).
+          result += 5;
+        }
+        break;
+      }
+      }
+    }
+    return result;
+  }
+};
+
+} // namespace Envoy

--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -63,9 +63,9 @@ public:
         position += 2;
         break;
       default:
-        if (character >= 0x00 and character <= 0x1f) {
+        if (character >= 0x00 && character <= 0x1f) {
           // Print character as unicode hex.
-          sprintf(&result[position + 1], "u%04x", int(character));
+          sprintf(&result[position + 1], "u%04x", static_cast<int>(character));
           position += 6;
           // Overwrite trailing null character.
           result[position] = '\\';
@@ -80,7 +80,7 @@ public:
     return result;
   }
 
-  // Calculates the extra space to build a JSON escaped string.
+  // Calculate the extra space to build a JSON escaped string.
   // @param input input string.
   // @return uint64_t the number of extra characters required to to build a JSON escaped string.
   static uint64_t extraSpace(absl::string_view input) {
@@ -106,7 +106,7 @@ public:
       }
 
       default: {
-        if (character >= 0x00 and character <= 0x1f) {
+        if (character >= 0x00 && character <= 0x1f) {
           // From character (1 byte) to unicode hex (6 bytes).
           result += 5;
         }
@@ -116,6 +116,5 @@ public:
     }
     return result;
   }
-}; // namespace Envoy
-
+};
 } // namespace Envoy

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "common/common/json_escape_string.h"
 #include "common/common/lock_guard.h"
 
 #include "absl/strings/ascii.h"
@@ -207,6 +208,12 @@ void Registry::setLogFormat(const std::string& log_format) {
         ->add_flag<CustomFlagFormatter::EscapeMessageNewLine>(
             CustomFlagFormatter::EscapeMessageNewLine::Placeholder)
         .set_pattern(log_format);
+
+    // Escape log payload as JSON string when it sees "%j".
+    formatter
+        ->add_flag<CustomFlagFormatter::EscapeMessageJsonString>(
+            CustomFlagFormatter::EscapeMessageJsonString::Placeholder)
+        .set_pattern(log_format);
     logger.logger_->set_formatter(std::move(formatter));
   }
 }
@@ -226,8 +233,21 @@ namespace CustomFlagFormatter {
 
 void EscapeMessageNewLine::format(const spdlog::details::log_msg& msg, const std::tm&,
                                   spdlog::memory_buf_t& dest) {
-  auto escaped = absl::StrReplaceAll(absl::string_view(msg.payload.data(), msg.payload.size()),
-                                     replacements());
+  const std::string escaped = absl::StrReplaceAll(
+      absl::string_view(msg.payload.data(), msg.payload.size()), replacements());
+  dest.append(escaped.data(), escaped.data() + escaped.size());
+}
+
+void EscapeMessageJsonString::format(const spdlog::details::log_msg& msg, const std::tm&,
+                                     spdlog::memory_buf_t& dest) {
+
+  absl::string_view payload = absl::string_view(msg.payload.data(), msg.payload.size());
+  const uint64_t required_space = JsonEscaper::extraSpace(payload);
+  if (required_space == 0) {
+    dest.append(payload.data(), payload.data() + payload.size());
+    return;
+  }
+  const std::string escaped = JsonEscaper::escapeString(payload, required_space);
   dest.append(escaped.data(), escaped.data() + escaped.size());
 }
 

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -356,6 +356,22 @@ private:
   }
 };
 
+/**
+ * When added to a formatter, this adds 'j' as a user defined flag in the log pattern that makes a
+ * log payload message a valid JSON escaped string.
+ */
+class EscapeMessageJsonString : public spdlog::custom_flag_formatter {
+public:
+  void format(const spdlog::details::log_msg& msg, const std::tm& tm,
+              spdlog::memory_buf_t& dest) override;
+
+  std::unique_ptr<custom_flag_formatter> clone() const override {
+    return spdlog::details::make_unique<EscapeMessageJsonString>();
+  }
+
+  constexpr static char Placeholder = 'j';
+};
+
 } // namespace CustomFlagFormatter
 } // namespace Logger
 

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -1,6 +1,7 @@
 #include <memory>
 #include <string>
 
+#include "common/common/json_escape_string.h"
 #include "common/common/logger.h"
 
 #include "gmock/gmock.h"
@@ -44,6 +45,52 @@ TEST(LoggerEscapeTest, WhitespaceOnly) {
 
 TEST(LoggerEscapeTest, Empty) { EXPECT_EQ("", DelegatingLogSink::escapeLogLine("")); }
 
+TEST(JsonEscapeTest, Escape) {
+  const auto expect_json_escape = [](absl::string_view to_be_escaped, absl::string_view escaped) {
+    EXPECT_EQ(escaped,
+              JsonEscaper::escapeString(to_be_escaped, JsonEscaper::extraSpace(to_be_escaped)));
+  };
+
+  expect_json_escape("\"", "\\\"");
+  expect_json_escape("\\", "\\\\");
+  expect_json_escape("\b", "\\b");
+  expect_json_escape("\f", "\\f");
+  expect_json_escape("\n", "\\n");
+  expect_json_escape("\r", "\\r");
+  expect_json_escape("\t", "\\t");
+  expect_json_escape("\x01", "\\u0001");
+  expect_json_escape("\x02", "\\u0002");
+  expect_json_escape("\x03", "\\u0003");
+  expect_json_escape("\x04", "\\u0004");
+  expect_json_escape("\x05", "\\u0005");
+  expect_json_escape("\x06", "\\u0006");
+  expect_json_escape("\x07", "\\u0007");
+  expect_json_escape("\x08", "\\b");
+  expect_json_escape("\x09", "\\t");
+  expect_json_escape("\x0a", "\\n");
+  expect_json_escape("\x0b", "\\u000b");
+  expect_json_escape("\x0c", "\\f");
+  expect_json_escape("\x0d", "\\r");
+  expect_json_escape("\x0e", "\\u000e");
+  expect_json_escape("\x0f", "\\u000f");
+  expect_json_escape("\x10", "\\u0010");
+  expect_json_escape("\x11", "\\u0011");
+  expect_json_escape("\x12", "\\u0012");
+  expect_json_escape("\x13", "\\u0013");
+  expect_json_escape("\x14", "\\u0014");
+  expect_json_escape("\x15", "\\u0015");
+  expect_json_escape("\x16", "\\u0016");
+  expect_json_escape("\x17", "\\u0017");
+  expect_json_escape("\x18", "\\u0018");
+  expect_json_escape("\x19", "\\u0019");
+  expect_json_escape("\x1a", "\\u001a");
+  expect_json_escape("\x1b", "\\u001b");
+  expect_json_escape("\x1c", "\\u001c");
+  expect_json_escape("\x1d", "\\u001d");
+  expect_json_escape("\x1e", "\\u001e");
+  expect_json_escape("\x1f", "\\u001f");
+}
+
 class LoggerCustomFlagsTest : public testing::Test {
 public:
   LoggerCustomFlagsTest() : logger_(Registry::getSink()) {}
@@ -54,6 +101,10 @@ public:
     formatter
         ->add_flag<CustomFlagFormatter::EscapeMessageNewLine>(
             CustomFlagFormatter::EscapeMessageNewLine::Placeholder)
+        .set_pattern(pattern);
+    formatter
+        ->add_flag<CustomFlagFormatter::EscapeMessageJsonString>(
+            CustomFlagFormatter::EscapeMessageJsonString::Placeholder)
         .set_pattern(pattern);
     logger_->set_formatter(std::move(formatter));
 
@@ -79,6 +130,26 @@ TEST_F(LoggerCustomFlagsTest, LogMessageAsIs) {
 TEST_F(LoggerCustomFlagsTest, LogMessageAsEscaped) {
   // This uses "%_", the added custom flag that escapes newlines from the actual text to log.
   expectLogMessage("%_", "\n\nmessage\n\n", "\\n\\nmessage\\n\\n");
+}
+
+TEST_F(LoggerCustomFlagsTest, LogMessageAsJsonStringEscaped) {
+  // This uses "%j", the added custom flag that JSON escape the characters inside the log message
+  // payload.
+  expectLogMessage("%j", "message", "message");
+  expectLogMessage("%j", "\n\nmessage\n\n", "\\n\\nmessage\\n\\n");
+  expectLogMessage("%j", "\bok\b", "\\bok\\b");
+  expectLogMessage("%j", "\fok\f", "\\fok\\f");
+  expectLogMessage("%j", "\rok\r", "\\rok\\r");
+  expectLogMessage("%j", "\tok\t", "\\tok\\t");
+  expectLogMessage("%j", "\\ok\\", "\\\\ok\\\\");
+  expectLogMessage("%j", "\"ok\"", "\\\"ok\\\"");
+  expectLogMessage("%j", "\x01ok\x0e", "\\u0001ok\\u000e");
+  expectLogMessage(
+      "%j",
+      "StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "
+      "\"transport: Error while dialing dial tcp [::1]:15012: connect: connection refused\"",
+      "StreamAggregatedResources gRPC config stream closed: 14, connection error: desc = "
+      "\\\"transport: Error while dialing dial tcp [::1]:15012: connect: connection refused\\\"");
 }
 
 } // namespace Logger


### PR DESCRIPTION
Commit Message: This patch adds a new custom flag `%j` to the log pattern to print the actual message to log as JSON escaped string.

Additional description: This produces JSON escaped string for the `msg.payload` part only, not the whole logline. Further description of the use case: https://github.com/envoyproxy/envoy/issues/13636.
Risk Level: Low
Testing: Unit
Docs Changes: Updated
Release Notes: Added
Fixes https://github.com/envoyproxy/envoy/issues/15020

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>