### PR TITLE
AsyncClientFactory: use getThreadLocalCluster for thread safety

### DIFF
--- a/include/envoy/grpc/async_client_manager.h
+++ b/include/envoy/grpc/async_client_manager.h
@@ -22,6 +22,8 @@ public:
 
 using AsyncClientFactoryPtr = std::unique_ptr<AsyncClientFactory>;
 
+enum class AsyncClientFactoryClusterChecks { Skip, ValidateStatic, ValidateStaticDuringBootstrap };
+
 // Singleton gRPC client manager. Grpc::AsyncClientManager can be used to create per-service
 // Grpc::AsyncClientFactory instances. All manufactured Grpc::AsyncClients must
 // be destroyed before the AsyncClientManager can be safely destructed.
@@ -34,14 +36,16 @@ public:
    * will raise an exception on failure.
    * @param grpc_service envoy::config::core::v3::GrpcService configuration.
    * @param scope stats scope.
-   * @param skip_cluster_check if set to true skips checks for cluster presence and being statically
-   * configured.
+   * @param checks Skip will skip checking cluster validity, ValidateStatic checks for
+   * cluster presence and being statically configured, ValidateStaticDuringBootstrap checks for
+   * cluster presence and being statically configured with methods that are not threadsafe but can
+   * be used during bootstrap.
    * @return AsyncClientFactoryPtr factory for grpc_service.
    * @throws EnvoyException when grpc_service validation fails.
    */
   virtual AsyncClientFactoryPtr
   factoryForGrpcService(const envoy::config::core::v3::GrpcService& grpc_service,
-                        Stats::Scope& scope, bool skip_cluster_check) PURE;
+                        Stats::Scope& scope, AsyncClientFactoryClusterChecks checks) PURE;
 };
 
 using AsyncClientManagerPtr = std::unique_ptr<AsyncClientManager>;

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -251,7 +251,10 @@ Grpc::AsyncClientFactoryPtr Utility::factoryForGrpcApiConfigSource(
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.MergeFrom(api_config_source.grpc_services(0));
 
-  return async_client_manager.factoryForGrpcService(grpc_service, scope, skip_cluster_check);
+  return async_client_manager.factoryForGrpcService(
+      grpc_service, scope,
+      skip_cluster_check ? Grpc::AsyncClientFactoryClusterChecks::Skip
+                         : Grpc::AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap);
 }
 
 envoy::config::endpoint::v3::ClusterLoadAssignment Utility::translateClusterHosts(

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -33,8 +33,8 @@ AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
   if (skip_cluster_check) {
     return;
   }
-  ENVOY_BUG(Thread::MainThread::isMainThread(),
-            "async client factory cluster checks should only be performed on the main thread");
+  ASSERT(Thread::MainThread::isMainThread(),
+         "async client factory cluster checks should only be performed on the main thread");
 
   const std::string& cluster_name = config.envoy_grpc().cluster_name();
   auto all_clusters = cm_.clusters();

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -28,19 +28,35 @@ bool validateGrpcHeaderChars(absl::string_view key) {
 
 AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
                                                const envoy::config::core::v3::GrpcService& config,
-                                               bool skip_cluster_check, TimeSource& time_source)
+                                               AsyncClientFactoryClusterChecks checks,
+                                               TimeSource& time_source)
     : cm_(cm), config_(config), time_source_(time_source) {
-  if (skip_cluster_check) {
+  const std::string& cluster_name = config.envoy_grpc().cluster_name();
+  switch (checks) {
+  case AsyncClientFactoryClusterChecks::Skip:
+    return;
+  case AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap: {
+    ASSERT(Thread::MainThread::isMainThread());
+    auto all_clusters = cm_.clusters();
+    const auto& it = all_clusters.active_clusters_.find(cluster_name);
+    if (it == all_clusters.active_clusters_.end()) {
+      throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
+    }
+    if (it->second.get().info()->addedViaApi()) {
+      throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
+    }
     return;
   }
-
-  const std::string& cluster_name = config.envoy_grpc().cluster_name();
-  const auto cluster = cm_.getThreadLocalCluster(cluster_name);
-  if (!cluster) {
-    throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
+  case AsyncClientFactoryClusterChecks::ValidateStatic: {
+    const auto cluster = cm_.getThreadLocalCluster(cluster_name);
+    if (!cluster) {
+      throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
+    }
+    if (cluster->info()->addedViaApi()) {
+      throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
+    }
+    return;
   }
-  if (cluster->info()->addedViaApi()) {
-    throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
   }
 }
 
@@ -102,10 +118,11 @@ RawAsyncClientPtr GoogleAsyncClientFactoryImpl::create() {
 
 AsyncClientFactoryPtr
 AsyncClientManagerImpl::factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
-                                              Stats::Scope& scope, bool skip_cluster_check) {
+                                              Stats::Scope& scope,
+                                              AsyncClientFactoryClusterChecks checks) {
   switch (config.target_specifier_case()) {
   case envoy::config::core::v3::GrpcService::TargetSpecifierCase::kEnvoyGrpc:
-    return std::make_unique<AsyncClientFactoryImpl>(cm_, config, skip_cluster_check, time_source_);
+    return std::make_unique<AsyncClientFactoryImpl>(cm_, config, checks, time_source_);
   case envoy::config::core::v3::GrpcService::TargetSpecifierCase::kGoogleGrpc:
     return std::make_unique<GoogleAsyncClientFactoryImpl>(tls_, google_tls_slot_.get(), scope,
                                                           config, api_, stat_names_);

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -33,6 +33,8 @@ AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
   if (skip_cluster_check) {
     return;
   }
+  ENVOY_BUG(Thread::MainThread::isMainThread(),
+            "async client factory cluster checks should only be performed on the main thread");
 
   const std::string& cluster_name = config.envoy_grpc().cluster_name();
   auto all_clusters = cm_.clusters();

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -17,7 +17,7 @@ class AsyncClientFactoryImpl : public AsyncClientFactory {
 public:
   AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
                          const envoy::config::core::v3::GrpcService& config,
-                         bool skip_cluster_check, TimeSource& time_source);
+                         AsyncClientFactoryClusterChecks check, TimeSource& time_source);
 
   RawAsyncClientPtr create() override;
 
@@ -53,7 +53,7 @@ public:
   // Grpc::AsyncClientManager
   AsyncClientFactoryPtr factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
                                               Stats::Scope& scope,
-                                              bool skip_cluster_check) override;
+                                              AsyncClientFactoryClusterChecks checks) override;
 
 private:
   Upstream::ClusterManager& cm_;

--- a/source/common/grpc/google_async_client_cache.h
+++ b/source/common/grpc/google_async_client_cache.h
@@ -27,8 +27,8 @@ private:
   struct ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
     ThreadLocalCache(AsyncClientManager& async_client_manager, Stats::Scope& scope,
                      const ::envoy::config::core::v3::GrpcService& grpc_proto_config) {
-      const AsyncClientFactoryPtr factory =
-          async_client_manager.factoryForGrpcService(grpc_proto_config, scope, true);
+      const AsyncClientFactoryPtr factory = async_client_manager.factoryForGrpcService(
+          grpc_proto_config, scope, AsyncClientFactoryClusterChecks::Skip);
       async_client_ = factory->create();
     }
     RawAsyncClientSharedPtr async_client_;

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -287,8 +287,8 @@ public:
     if (it != cache.access_loggers_.end()) {
       return it->second;
     }
-    const Grpc::AsyncClientFactoryPtr factory =
-        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, false);
+    const Grpc::AsyncClientFactoryPtr factory = async_client_manager_.factoryForGrpcService(
+        config.grpc_service(), scope_, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic);
     const auto logger = createLogger(
         config, factory->create(),
         std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -288,7 +288,7 @@ public:
       return it->second;
     }
     const Grpc::AsyncClientFactoryPtr factory =
-        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, false);
+        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, true);
     const auto logger = createLogger(
         config, factory->create(),
         std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -288,7 +288,7 @@ public:
       return it->second;
     }
     const Grpc::AsyncClientFactoryPtr factory =
-        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, true);
+        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, false);
     const auto logger = createLogger(
         config, factory->create(),
         std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -986,11 +986,11 @@ WasmResult Context::grpcCall(absl::string_view grpc_service, absl::string_view s
   auto& handler = grpc_call_request_[token];
   handler.context_ = this;
   handler.token_ = token;
-  auto grpc_client =
-      clusterManager()
-          .grpcAsyncClientManager()
-          .factoryForGrpcService(service_proto, *wasm()->scope_, true /* skip_cluster_check */)
-          ->create();
+  auto grpc_client = clusterManager()
+                         .grpcAsyncClientManager()
+                         .factoryForGrpcService(service_proto, *wasm()->scope_,
+                                                AsyncClientFactoryClusterChecks::Skip)
+                         ->create();
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
   // set default hash policy to be based on :authority to enable consistent hash
@@ -1044,11 +1044,11 @@ WasmResult Context::grpcStream(absl::string_view grpc_service, absl::string_view
   auto& handler = grpc_stream_[token];
   handler.context_ = this;
   handler.token_ = token;
-  auto grpc_client =
-      clusterManager()
-          .grpcAsyncClientManager()
-          .factoryForGrpcService(service_proto, *wasm()->scope_, true /* skip_cluster_check */)
-          ->create();
+  auto grpc_client = clusterManager()
+                         .grpcAsyncClientManager()
+                         .factoryForGrpcService(service_proto, *wasm()->scope_,
+                                                AsyncClientFactoryClusterChecks::Skip)
+                         ->create();
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
   // set default hash policy to be based on :authority to enable consistent hash

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -989,7 +989,7 @@ WasmResult Context::grpcCall(absl::string_view grpc_service, absl::string_view s
   auto grpc_client = clusterManager()
                          .grpcAsyncClientManager()
                          .factoryForGrpcService(service_proto, *wasm()->scope_,
-                                                AsyncClientFactoryClusterChecks::Skip)
+                                                Grpc::AsyncClientFactoryClusterChecks::Skip)
                          ->create();
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
@@ -1047,7 +1047,7 @@ WasmResult Context::grpcStream(absl::string_view grpc_service, absl::string_view
   auto grpc_client = clusterManager()
                          .grpcAsyncClientManager()
                          .factoryForGrpcService(service_proto, *wasm()->scope_,
-                                                AsyncClientFactoryClusterChecks::Skip)
+                                                Grpc::AsyncClientFactoryClusterChecks::Skip)
                          ->create();
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -130,7 +130,7 @@ ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
   // requests.
   const auto async_client_factory =
       context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-          grpc_service, context.scope(), AsyncClientFactoryClusterChecks::Skip);
+          grpc_service, context.scope(), Grpc::AsyncClientFactoryClusterChecks::Skip);
   return std::make_unique<Filters::Common::RateLimit::GrpcClientImpl>(
       async_client_factory->create(), timeout, transport_api_version);
 }

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -130,7 +130,7 @@ ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
   // requests.
   const auto async_client_factory =
       context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-          grpc_service, context.scope(), true);
+          grpc_service, context.scope(), AsyncClientFactoryClusterChecks::Skip);
   return std::make_unique<Filters::Common::RateLimit::GrpcClientImpl>(
       async_client_factory->create(), timeout, transport_api_version);
 }

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -82,7 +82,7 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
                    Http::FilterChainFactoryCallbacks& callbacks) {
       const auto async_client_factory =
           context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, context.scope(), true);
+              grpc_service, context.scope(), AsyncClientFactoryClusterChecks::Skip);
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
           async_client_factory->create(), std::chrono::milliseconds(timeout_ms),
           transport_api_version);

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -82,7 +82,7 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
                    Http::FilterChainFactoryCallbacks& callbacks) {
       const auto async_client_factory =
           context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, context.scope(), AsyncClientFactoryClusterChecks::Skip);
+              grpc_service, context.scope(), Grpc::AsyncClientFactoryClusterChecks::Skip);
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
           async_client_factory->create(), std::chrono::milliseconds(timeout_ms),
           transport_api_version);

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -11,7 +11,8 @@ static constexpr char kExternalMethod[] =
 ExternalProcessorClientImpl::ExternalProcessorClientImpl(
     Grpc::AsyncClientManager& client_manager,
     const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope) {
-  factory_ = client_manager.factoryForGrpcService(grpc_service, scope, true);
+  factory_ = client_manager.factoryForGrpcService(grpc_service, scope,
+                                                  AsyncClientFactoryClusterChecks::Skip);
 }
 
 ExternalProcessorStreamPtr

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -12,7 +12,7 @@ ExternalProcessorClientImpl::ExternalProcessorClientImpl(
     Grpc::AsyncClientManager& client_manager,
     const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope) {
   factory_ = client_manager.factoryForGrpcService(grpc_service, scope,
-                                                  AsyncClientFactoryClusterChecks::Skip);
+                                                  Grpc::AsyncClientFactoryClusterChecks::Skip);
 }
 
 ExternalProcessorStreamPtr

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -32,7 +32,7 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
           timeout_ms](Network::FilterManager& filter_manager) -> void {
     auto async_client_factory =
         context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-            grpc_service, context.scope(), AsyncClientFactoryClusterChecks::Skip);
+            grpc_service, context.scope(), Grpc::AsyncClientFactoryClusterChecks::Skip);
 
     auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
         async_client_factory->create(), std::chrono::milliseconds(timeout_ms),

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -32,7 +32,7 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
           timeout_ms](Network::FilterManager& filter_manager) -> void {
     auto async_client_factory =
         context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-            grpc_service, context.scope(), true);
+            grpc_service, context.scope(), AsyncClientFactoryClusterChecks::Skip);
 
     auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
         async_client_factory->create(), std::chrono::milliseconds(timeout_ms),

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -34,7 +34,7 @@ MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
                                       envoy::service::metrics::v3::StreamMetricsResponse>>
       grpc_metrics_streamer = std::make_shared<GrpcMetricsStreamerImpl>(
           server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, server.scope(), AsyncClientFactoryClusterChecks::ValidateStatic),
+              grpc_service, server.scope(), Grpc::AsyncClientFactoryClusterChecks::ValidateStatic),
           server.localInfo(), transport_api_version);
 
   return std::make_unique<MetricsServiceSink<envoy::service::metrics::v3::StreamMetricsMessage,

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -34,7 +34,7 @@ MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
                                       envoy::service::metrics::v3::StreamMetricsResponse>>
       grpc_metrics_streamer = std::make_shared<GrpcMetricsStreamerImpl>(
           server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, server.scope(), false),
+              grpc_service, server.scope(), AsyncClientFactoryClusterChecks::ValidateStatic),
           server.localInfo(), transport_api_version);
 
   return std::make_unique<MetricsServiceSink<envoy::service::metrics::v3::StreamMetricsMessage,

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -38,7 +38,7 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
     TracerPtr tracer = std::make_unique<Tracer>(std::make_unique<TraceSegmentReporter>(
         factory_context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
             proto_config.grpc_service(), factory_context.scope(),
-            AsyncClientFactoryClusterChecks::ValidateStatic),
+            Grpc::AsyncClientFactoryClusterChecks::ValidateStatic),
         dispatcher, factory_context.api().randomGenerator(), tracing_stats_,
         config_.delayed_buffer_size(), config_.token()));
     return std::make_shared<TlsTracer>(std::move(tracer));

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -38,7 +38,7 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
     TracerPtr tracer = std::make_unique<Tracer>(std::make_unique<TraceSegmentReporter>(
         factory_context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
             proto_config.grpc_service(), factory_context.scope(),
-            Grpc::AsyncClientFactoryClusterChecks::ValidateStatic),
+            Grpc::AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap),
         dispatcher, factory_context.api().randomGenerator(), tracing_stats_,
         config_.delayed_buffer_size(), config_.token()));
     return std::make_shared<TlsTracer>(std::move(tracer));

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -37,7 +37,8 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
   tls_slot_ptr_->set([proto_config, &factory_context, this](Event::Dispatcher& dispatcher) {
     TracerPtr tracer = std::make_unique<Tracer>(std::make_unique<TraceSegmentReporter>(
         factory_context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-            proto_config.grpc_service(), factory_context.scope(), false),
+            proto_config.grpc_service(), factory_context.scope(),
+            AsyncClientFactoryClusterChecks::ValidateStatic),
         dispatcher, factory_context.api().randomGenerator(), tracing_stats_,
         config_.delayed_buffer_size(), config_.token()));
     return std::make_shared<TlsTracer>(std::move(tracer));

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -138,7 +138,8 @@ TEST_F(SubscriptionFactoryTest, GrpcClusterSingleton) {
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
   EXPECT_CALL(cm_.async_client_manager_,
               factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          Grpc::AsyncClientFactoryClusterChecks) {
         auto async_client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
         EXPECT_CALL(*async_client_factory, create()).WillOnce(Invoke([] {
           return std::make_unique<Grpc::MockAsyncClient>();
@@ -317,7 +318,8 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
   EXPECT_CALL(cm_.async_client_manager_,
               factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          Grpc::AsyncClientFactoryClusterChecks) {
         auto async_client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
         EXPECT_CALL(*async_client_factory, create()).WillOnce(Invoke([] {
           return std::make_unique<NiceMock<Grpc::MockAsyncClient>>();

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -231,7 +231,9 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     envoy::config::core::v3::GrpcService expected_grpc_service;
     expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
     EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), false));
+                factoryForGrpcService(
+                    ProtoEq(expected_grpc_service), Ref(scope),
+                    Grpc::AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap));
     Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope, false);
   }
 
@@ -239,9 +241,9 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     envoy::config::core::v3::ApiConfigSource api_config_source;
     api_config_source.set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
     api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
-    EXPECT_CALL(
-        async_client_manager,
-        factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope), true));
+    EXPECT_CALL(async_client_manager,
+                factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope),
+                                      Grpc::AsyncClientFactoryClusterChecks::Skip));
     Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope, true);
   }
 }

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -45,7 +45,8 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcOk) {
   EXPECT_CALL(*cluster, info());
   EXPECT_CALL(*cluster->cluster_.info_, addedViaApi());
 
-  async_client_manager_.factoryForGrpcService(grpc_service, scope_, false);
+  async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                              AsyncClientFactoryClusterChecks::ValidateStatic);
 }
 
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknown) {
@@ -54,8 +55,9 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknown) {
 
   EXPECT_CALL(cm_, getThreadLocalCluster("foo"));
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "Unknown gRPC client cluster 'foo'");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
+      EnvoyException, "Unknown gRPC client cluster 'foo'");
 }
 
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcDynamicCluster) {
@@ -68,8 +70,9 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcDynamicCluster) {
   EXPECT_CALL(*cluster, info());
   EXPECT_CALL(*cluster->cluster_.info_, addedViaApi()).WillOnce(Return(true));
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "gRPC client cluster 'foo' is not static");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
+      EnvoyException, "gRPC client cluster 'foo' is not static");
 }
 
 TEST_F(AsyncClientManagerImplTest, GoogleGrpc) {
@@ -78,11 +81,13 @@ TEST_F(AsyncClientManagerImplTest, GoogleGrpc) {
   grpc_service.mutable_google_grpc()->set_stat_prefix("foo");
 
 #ifdef ENVOY_GOOGLE_GRPC
-  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(grpc_service, scope_, false));
+  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(
+                         grpc_service, scope_, AsyncClientFactoryClusterChecks::ValidateStatic));
 #else
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "Google C++ gRPC client is not linked");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
+      EnvoyException, "Google C++ gRPC client is not linked");
 #endif
 }
 
@@ -97,12 +102,14 @@ TEST_F(AsyncClientManagerImplTest, GoogleGrpcIllegalChars) {
 
 #ifdef ENVOY_GOOGLE_GRPC
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "Illegal characters in gRPC initial metadata.");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
+      EnvoyException, "Illegal characters in gRPC initial metadata.");
 #else
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "Google C++ gRPC client is not linked");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
+      EnvoyException, "Google C++ gRPC client is not linked");
 #endif
 }
 
@@ -116,11 +123,13 @@ TEST_F(AsyncClientManagerImplTest, LegalGoogleGrpcChar) {
   metadata.set_value("value");
 
 #ifdef ENVOY_GOOGLE_GRPC
-  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(grpc_service, scope_, false));
+  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(
+                         grpc_service, scope_, AsyncClientFactoryClusterChecks::ValidateStatic));
 #else
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
-      "Google C++ gRPC client is not linked");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
+                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
+      EnvoyException, "Google C++ gRPC client is not linked");
 #endif
 }
 
@@ -129,7 +138,8 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknownOk) {
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
   EXPECT_CALL(cm_, getThreadLocalCluster(Eq("foo"))).Times(0);
-  ASSERT_NO_THROW(async_client_manager_.factoryForGrpcService(grpc_service, scope_, true));
+  ASSERT_NO_THROW(async_client_manager_.factoryForGrpcService(
+      grpc_service, scope_, AsyncClientFactoryClusterChecks::Skip));
 }
 
 } // namespace

--- a/test/common/grpc/google_async_client_cache_test.cc
+++ b/test/common/grpc/google_async_client_cache_test.cc
@@ -18,8 +18,10 @@ public:
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
     async_client_ = new Grpc::MockAsyncClient;
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+    EXPECT_CALL(async_client_manager_,
+                factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                                AsyncClientFactoryClusterChecks) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -343,8 +343,10 @@ public:
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
     async_client_ = new Grpc::MockAsyncClient;
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+    EXPECT_CALL(async_client_manager_,
+                factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                                Grpc::AsyncClientFactoryClusterChecks) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -343,7 +343,7 @@ public:
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
     async_client_ = new Grpc::MockAsyncClient;
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -343,7 +343,7 @@ public:
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
     async_client_ = new Grpc::MockAsyncClient;
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -129,7 +129,7 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -129,7 +129,7 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -129,8 +129,10 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+    EXPECT_CALL(async_client_manager_,
+                factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                                Grpc::AsyncClientFactoryClusterChecks) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/grpc/http_config_test.cc
+++ b/test/extensions/access_loggers/grpc/http_config_test.cc
@@ -33,7 +33,8 @@ public:
     ASSERT_NE(nullptr, message_);
 
     EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+        .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                            Grpc::AsyncClientFactoryClusterChecks) {
           return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
         }));
 

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -152,7 +152,7 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -152,7 +152,7 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -152,8 +152,10 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+    EXPECT_CALL(async_client_manager_,
+                factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::ValidateStatic))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                                AsyncClientFactoryClusterChecks) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -153,9 +153,9 @@ public:
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
     EXPECT_CALL(async_client_manager_,
-                factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::ValidateStatic))
+                factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic))
         .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                                AsyncClientFactoryClusterChecks) {
+                                Grpc::AsyncClientFactoryClusterChecks) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -53,7 +53,8 @@ void expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion api_version) {
   EXPECT_CALL(context, runtime());
   EXPECT_CALL(context, scope()).Times(2);
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -54,7 +54,7 @@ void expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion api_version) {
   EXPECT_CALL(context, scope()).Times(2);
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
       .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          AsyncClientFactoryClusterChecks) {
+                          Grpc::AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -45,7 +45,7 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
       .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          AsyncClientFactoryClusterChecks) {
+                          Grpc::AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -44,7 +44,8 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -809,8 +809,9 @@ TEST_P(WasmHttpFilterTest, GrpcCall) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+  EXPECT_CALL(client_manager,
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
                            -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   EXPECT_CALL(rootContext(), log_(spdlog::level::debug, Eq("response")));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
@@ -851,8 +852,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallBadCall) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+  EXPECT_CALL(client_manager,
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
                            -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
@@ -891,8 +893,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallFailure) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+  EXPECT_CALL(client_manager,
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
                            -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   EXPECT_CALL(rootContext(), log_(spdlog::level::debug, Eq("failure bad")));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
@@ -952,8 +955,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallCancel) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+  EXPECT_CALL(client_manager,
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
                            -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -995,8 +999,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallClose) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+  EXPECT_CALL(client_manager,
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
                            -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -1038,8 +1043,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallAfterDestroyed) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+  EXPECT_CALL(client_manager,
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
                            -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
@@ -1071,29 +1077,30 @@ void WasmHttpFilterTest::setupGrpcStreamTest(Grpc::RawAsyncStreamCallbacks*& cal
   setupFilter();
 
   EXPECT_CALL(async_client_manager_,
-              factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-      .WillRepeatedly(Invoke([&](const GrpcService&, Stats::Scope&,
-                                 AsyncClientFactoryClusterChecks) -> Grpc::AsyncClientFactoryPtr {
-        auto client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
-        EXPECT_CALL(*client_factory, create)
-            .WillRepeatedly(Invoke([&]() -> Grpc::RawAsyncClientPtr {
-              auto async_client = std::make_unique<Grpc::MockAsyncClient>();
-              EXPECT_CALL(*async_client, startRaw(_, _, _, _))
-                  .WillRepeatedly(
-                      Invoke([&](absl::string_view service_full_name, absl::string_view method_name,
-                                 Grpc::RawAsyncStreamCallbacks& cb,
-                                 const Http::AsyncClient::StreamOptions&) -> Grpc::RawAsyncStream* {
-                        EXPECT_EQ(service_full_name, "service");
-                        if (method_name != "method") {
-                          return nullptr;
-                        }
-                        callbacks = &cb;
-                        return &async_stream_;
-                      }));
-              return async_client;
-            }));
-        return client_factory;
-      }));
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+      .WillRepeatedly(
+          Invoke([&](const GrpcService&, Stats::Scope&,
+                     Grpc::AsyncClientFactoryClusterChecks) -> Grpc::AsyncClientFactoryPtr {
+            auto client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
+            EXPECT_CALL(*client_factory, create)
+                .WillRepeatedly(Invoke([&]() -> Grpc::RawAsyncClientPtr {
+                  auto async_client = std::make_unique<Grpc::MockAsyncClient>();
+                  EXPECT_CALL(*async_client, startRaw(_, _, _, _))
+                      .WillRepeatedly(Invoke(
+                          [&](absl::string_view service_full_name, absl::string_view method_name,
+                              Grpc::RawAsyncStreamCallbacks& cb,
+                              const Http::AsyncClient::StreamOptions&) -> Grpc::RawAsyncStream* {
+                            EXPECT_EQ(service_full_name, "service");
+                            if (method_name != "method") {
+                              return nullptr;
+                            }
+                            callbacks = &cb;
+                            return &async_stream_;
+                          }));
+                  return async_client;
+                }));
+            return client_factory;
+          }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillRepeatedly(Invoke([&]() -> Grpc::AsyncClientManager& { return async_client_manager_; }));
 }

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -809,10 +809,9 @@ TEST_P(WasmHttpFilterTest, GrpcCall) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-        return std::move(client_factory);
-      }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   EXPECT_CALL(rootContext(), log_(spdlog::level::debug, Eq("response")));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -852,10 +851,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallBadCall) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-        return std::move(client_factory);
-      }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
 }
@@ -893,10 +891,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallFailure) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-        return std::move(client_factory);
-      }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   EXPECT_CALL(rootContext(), log_(spdlog::level::debug, Eq("failure bad")));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -955,10 +952,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallCancel) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-        return std::move(client_factory);
-      }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter().decodeHeaders(request_headers, false));
@@ -999,10 +995,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallClose) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-        return std::move(client_factory);
-      }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter().decodeHeaders(request_headers, false));
@@ -1043,10 +1038,9 @@ TEST_P(WasmHttpFilterTest, GrpcCallAfterDestroyed) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-        return std::move(client_factory);
-      }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, AsyncClientFactoryClusterChecks)
+                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -1076,29 +1070,30 @@ void WasmHttpFilterTest::setupGrpcStreamTest(Grpc::RawAsyncStreamCallbacks*& cal
   setupTest("grpc_stream");
   setupFilter();
 
-  EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillRepeatedly(
-          Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
-            auto client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
-            EXPECT_CALL(*client_factory, create)
-                .WillRepeatedly(Invoke([&]() -> Grpc::RawAsyncClientPtr {
-                  auto async_client = std::make_unique<Grpc::MockAsyncClient>();
-                  EXPECT_CALL(*async_client, startRaw(_, _, _, _))
-                      .WillRepeatedly(Invoke(
-                          [&](absl::string_view service_full_name, absl::string_view method_name,
-                              Grpc::RawAsyncStreamCallbacks& cb,
-                              const Http::AsyncClient::StreamOptions&) -> Grpc::RawAsyncStream* {
-                            EXPECT_EQ(service_full_name, "service");
-                            if (method_name != "method") {
-                              return nullptr;
-                            }
-                            callbacks = &cb;
-                            return &async_stream_;
-                          }));
-                  return async_client;
-                }));
-            return client_factory;
-          }));
+  EXPECT_CALL(async_client_manager_,
+              factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillRepeatedly(Invoke([&](const GrpcService&, Stats::Scope&,
+                                 AsyncClientFactoryClusterChecks) -> Grpc::AsyncClientFactoryPtr {
+        auto client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
+        EXPECT_CALL(*client_factory, create)
+            .WillRepeatedly(Invoke([&]() -> Grpc::RawAsyncClientPtr {
+              auto async_client = std::make_unique<Grpc::MockAsyncClient>();
+              EXPECT_CALL(*async_client, startRaw(_, _, _, _))
+                  .WillRepeatedly(
+                      Invoke([&](absl::string_view service_full_name, absl::string_view method_name,
+                                 Grpc::RawAsyncStreamCallbacks& cb,
+                                 const Http::AsyncClient::StreamOptions&) -> Grpc::RawAsyncStream* {
+                        EXPECT_EQ(service_full_name, "service");
+                        if (method_name != "method") {
+                          return nullptr;
+                        }
+                        callbacks = &cb;
+                        return &async_stream_;
+                      }));
+              return async_client;
+            }));
+        return client_factory;
+      }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillRepeatedly(Invoke([&]() -> Grpc::AsyncClientManager& { return async_client_manager_; }));
 }

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -77,9 +77,9 @@ void UberFilterFuzzer::perFilterSetup(const std::string& filter_name) {
 
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_manager_,
                 factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
-          return std::move(async_client_factory_);
-        }));
+        .WillOnce(Invoke(
+            [&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                AsyncClientFactoryClusterChecks) { return std::move(async_client_factory_); }));
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setLocalAddress(
         pipe_addr_);
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setRemoteAddress(
@@ -110,9 +110,9 @@ void UberFilterFuzzer::perFilterSetup(const std::string& filter_name) {
 
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_manager_,
                 factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
-          return std::move(async_client_factory_);
-        }));
+        .WillOnce(Invoke(
+            [&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                AsyncClientFactoryClusterChecks) { return std::move(async_client_factory_); }));
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setLocalAddress(
         pipe_addr_);
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setRemoteAddress(

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -77,9 +77,10 @@ void UberFilterFuzzer::perFilterSetup(const std::string& filter_name) {
 
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_manager_,
                 factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke(
-            [&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                AsyncClientFactoryClusterChecks) { return std::move(async_client_factory_); }));
+        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                             Grpc::AsyncClientFactoryClusterChecks) {
+          return std::move(async_client_factory_);
+        }));
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setLocalAddress(
         pipe_addr_);
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setRemoteAddress(
@@ -110,9 +111,10 @@ void UberFilterFuzzer::perFilterSetup(const std::string& filter_name) {
 
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_manager_,
                 factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke(
-            [&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                AsyncClientFactoryClusterChecks) { return std::move(async_client_factory_); }));
+        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                             Grpc::AsyncClientFactoryClusterChecks) {
+          return std::move(async_client_factory_);
+        }));
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setLocalAddress(
         pipe_addr_);
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setRemoteAddress(

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -43,8 +43,10 @@ void expectCorrectProto(envoy::config::core::v3::ApiVersion api_version) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+  EXPECT_CALL(context.cluster_manager_.async_client_manager_,
+              factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, context);

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -44,9 +44,9 @@ void expectCorrectProto(envoy::config::core::v3::ApiVersion api_version) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_,
-              factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
+              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
       .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          AsyncClientFactoryClusterChecks) {
+                          Grpc::AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, context);

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -49,7 +49,8 @@ TEST(RateLimitFilterConfigTest, CorrectProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -50,7 +50,7 @@ TEST(RateLimitFilterConfigTest, CorrectProto) {
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
       .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          AsyncClientFactoryClusterChecks) {
+                          Grpc::AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
@@ -52,7 +52,8 @@ rate_limit_service:
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                          AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
@@ -53,7 +53,7 @@ rate_limit_service:
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
       .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          AsyncClientFactoryClusterChecks) {
+                          Grpc::AsyncClientFactoryClusterChecks) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/mocks/grpc/mocks.cc
+++ b/test/mocks/grpc/mocks.cc
@@ -26,7 +26,8 @@ MockAsyncClientFactory::~MockAsyncClientFactory() = default;
 
 MockAsyncClientManager::MockAsyncClientManager() {
   ON_CALL(*this, factoryForGrpcService(_, _, _))
-      .WillByDefault(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
+      .WillByDefault(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
+                               AsyncClientFactoryClusterChecks) {
         return std::make_unique<testing::NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 }

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -107,7 +107,7 @@ public:
 
   MOCK_METHOD(AsyncClientFactoryPtr, factoryForGrpcService,
               (const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope,
-               bool skip_cluster_check));
+               AsyncClientFactoryClusterChecks checks));
 };
 
 MATCHER_P(ProtoBufferEq, expected, "") {


### PR DESCRIPTION
Commit Message: AsyncClientFactory: use getThreadLocalCluster for thread safety
Additional Description: due to https://github.com/envoyproxy/envoy/pull/14204, AsyncClientFactory should use `ClusterManager::getThreadLocalCluster` to ensure that checking the cluster status can be performed on main or worker threads.
Risk Level: low
Testing: existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
