### PR TITLE
docs: Move docs/build.sh to bazel

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -10,6 +10,7 @@ exports_files([
     "v2_mapping.json",
     "empty_extensions.json",
     "redirects.txt",
+    "VERSION",
 ])
 
 envoy_package()
@@ -189,5 +190,27 @@ genrule(
         ":examples_rst",
         ":extensions_security_rst",
         ":external_deps_rst",
+    ],
+)
+
+genrule(
+    name = "html",
+    outs = ["html.tar"],
+    cmd = """
+    $(location //tools/docs:sphinx_runner) \\
+         --build_sha="$${BUILD_SHA:-}" \\
+         --docs_tag="$${DOCS_TAG:-}" \\
+         --version_file=$(location //:VERSION) \\
+         --validator_path=$(location //tools/config_validation:validate_fragment) \\
+         --descriptor_path=$(location //tools/type_whisperer:all_protos_with_ext_pb_text.pb_text) \\
+         $(location rst) \\
+         $@
+    """,
+    exec_tools = [
+        "//tools/docs:sphinx_runner",
+        ":rst",
+        "//tools/config_validation:validate_fragment",
+        "//tools/type_whisperer:all_protos_with_ext_pb_text.pb_text",
+        "//:VERSION",
     ],
 )

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -3,8 +3,6 @@
 # set SPHINX_SKIP_CONFIG_VALIDATION environment variable to true to skip
 # validation of configuration examples
 
-. tools/shell_utils.sh
-
 set -e
 
 if [[ ! $(command -v bazel) ]]; then
@@ -21,83 +19,26 @@ fi
 RELEASE_TAG_REGEX="^refs/tags/v.*"
 
 if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then
-  DOCS_TAG="${AZP_BRANCH/refs\/tags\//}"
-fi
-
-# We need to set ENVOY_DOCS_VERSION_STRING and ENVOY_DOCS_RELEASE_LEVEL for Sphinx.
-# We also validate that the tag and version match at this point if needed.
-VERSION_NUMBER=$(cat VERSION)
-export DOCKER_IMAGE_TAG_NAME
-DOCKER_IMAGE_TAG_NAME=$(echo "$VERSION_NUMBER" | sed -E 's/([0-9]+\.[0-9]+)\.[0-9]+.*/v\1-latest/')
-if [[ -n "${DOCS_TAG}" ]]; then
-  # Check the git tag matches the version number in the VERSION file.
-  if [[ "v${VERSION_NUMBER}" != "${DOCS_TAG}" ]]; then
-    echo "Given git tag does not match the VERSION file content:"
-    echo "${DOCS_TAG} vs $(cat VERSION)"
-    exit 1
-  fi
-  # Check the version_history.rst contains current release version.
-  grep --fixed-strings "$VERSION_NUMBER" docs/root/version_history/current.rst \
-    || (echo "Git tag not found in version_history/current.rst" && exit 1)
-
-  # Now that we know there is a match, we can use the tag.
-  export ENVOY_DOCS_VERSION_STRING="tag-${DOCS_TAG}"
-  export ENVOY_DOCS_RELEASE_LEVEL=tagged
-  export ENVOY_BLOB_SHA="${DOCS_TAG}"
+    DOCS_TAG="${AZP_BRANCH/refs\/tags\//}"
+    export DOCS_TAG
 else
-  BUILD_SHA=$(git rev-parse HEAD)
-  export ENVOY_DOCS_VERSION_STRING="${VERSION_NUMBER}"-"${BUILD_SHA:0:6}"
-  export ENVOY_DOCS_RELEASE_LEVEL=pre-release
-  export ENVOY_BLOB_SHA="$BUILD_SHA"
+    BUILD_SHA=$(git rev-parse HEAD)
+    export BUILD_SHA
 fi
-
-SCRIPT_DIR="$(dirname "$0")"
-BUILD_DIR=build_docs
-[[ -z "${DOCS_OUTPUT_DIR}" ]] && DOCS_OUTPUT_DIR=generated/docs
-[[ -z "${GENERATED_RST_DIR}" ]] && GENERATED_RST_DIR=generated/rst
-
-rm -rf "${DOCS_OUTPUT_DIR}"
-mkdir -p "${DOCS_OUTPUT_DIR}"
-
-rm -rf "${GENERATED_RST_DIR}"
-mkdir -p "${GENERATED_RST_DIR}"
-
-source_venv "$BUILD_DIR"
-pip3 install --require-hashes -r "${SCRIPT_DIR}"/../tools/docs/requirements.txt
-
-# Clean up any stale files in the API tree output. Bazel remembers valid cached
-# files still.
-rm -rf bazel-bin/external/envoy_api_canonical
-
-GENERATED_RST_DIR="$(realpath "${GENERATED_RST_DIR}")"
-export GENERATED_RST_DIR
 
 # This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
 IFS=" " read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
 BAZEL_BUILD_OPTIONS+=(
+    "--color=yes"
     "--remote_download_outputs=all"
     "--strategy=protodoc=sandboxed,local"
-    "--action_env=ENVOY_BLOB_SHA")
+    "--action_env=DOCS_TAG"
+    "--action_env=BUILD_SHA"
+    "--action_env=SPHINX_SKIP_CONFIG_VALIDATION")
 
-bazel build "${BAZEL_BUILD_OPTIONS[@]}" //docs:rst
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" //docs:html
 
-# TODO(phlax): once all of above jobs are moved to bazel build genrules these can be done as part of the sphinx build
-tar -xf bazel-bin/docs/rst.tar -C "${GENERATED_RST_DIR}"
-
-# TODO(phlax): these will move to python
-ENVOY_DOCS_BUILD_CONFIG="${GENERATED_RST_DIR}/build.yaml"
-{
-    echo "blob_sha: ${ENVOY_BLOB_SHA}"
-    echo "release_level: ${ENVOY_DOCS_RELEASE_LEVEL}"
-    echo "version_string: ${ENVOY_DOCS_VERSION_STRING}"
-    echo "docker_image_tag_name: ${DOCKER_IMAGE_TAG_NAME}"
-} > "$ENVOY_DOCS_BUILD_CONFIG"
-if [[ -n "$SPHINX_SKIP_CONFIG_VALIDATION" ]]; then
-    echo "skip_validation: true" >> "$ENVOY_DOCS_BUILD_CONFIG"
-fi
-export ENVOY_DOCS_BUILD_CONFIG
-
-# To speed up validate_fragment invocations in validating_code_block
-bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/config_validation:validate_fragment
-
-sphinx-build -W --keep-going -b html "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"
+[[ -z "${DOCS_OUTPUT_DIR}" ]] && DOCS_OUTPUT_DIR=generated/docs
+rm -rf "${DOCS_OUTPUT_DIR}"
+mkdir -p "${DOCS_OUTPUT_DIR}"
+tar -xf bazel-bin/docs/html.tar -C "$DOCS_OUTPUT_DIR"

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -1,6 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("@docs_pip3//:requirements.bzl", "requirement")
+load("//tools/base:envoy_python.bzl", "envoy_py_binary")
 
 licenses(["notice"])  # Apache 2
 
@@ -30,5 +31,47 @@ py_binary(
     name = "generate_api_rst",
     srcs = [
         "generate_api_rst.py",
+    ],
+)
+
+envoy_py_binary(
+    name = "tools.docs.sphinx_runner",
+    deps = [
+        "//tools/base:runner",
+        requirement("alabaster"),
+        requirement("Babel"),
+        requirement("certifi"),
+        requirement("chardet"),
+        requirement("colorama"),
+        requirement("docutils"),
+        requirement("gitdb"),
+        requirement("GitPython"),
+        requirement("idna"),
+        requirement("imagesize"),
+        requirement("Jinja2"),
+        requirement("MarkupSafe"),
+        requirement("packaging"),
+        requirement("Pygments"),
+        requirement("pyparsing"),
+        requirement("pytz"),
+        requirement("pyyaml"),
+        requirement("requests"),
+        requirement("setuptools"),
+        requirement("six"),
+        requirement("smmap"),
+        requirement("snowballstemmer"),
+        requirement("Sphinx"),
+        requirement("sphinx-copybutton"),
+        requirement("sphinx-rtd-theme"),
+        requirement("sphinx-tabs"),
+        requirement("sphinxcontrib-applehelp"),
+        requirement("sphinxcontrib-devhelp"),
+        requirement("sphinxcontrib-htmlhelp"),
+        requirement("sphinxcontrib-httpdomain"),
+        requirement("sphinxcontrib-jsmath"),
+        requirement("sphinxcontrib-qthelp"),
+        requirement("sphinxext-rediraffe"),
+        requirement("sphinxcontrib-serializinghtml"),
+        requirement("urllib3"),
     ],
 )

--- a/tools/docs/sphinx_runner.py
+++ b/tools/docs/sphinx_runner.py
@@ -1,0 +1,228 @@
+import argparse
+import os
+import platform
+import re
+import sys
+import tarfile
+import tempfile
+from functools import cached_property
+
+import yaml
+
+from colorama import Fore, Style
+
+from sphinx.cmd.build import main as sphinx_build
+
+from tools.base import runner
+
+
+class SphinxBuildError(Exception):
+    pass
+
+
+class SphinxEnvError(Exception):
+    pass
+
+
+class SphinxRunner(runner.Runner):
+    _build_dir = "."
+    _build_sha = "UNKNOWN"
+
+    @property
+    def blob_sha(self) -> str:
+        """Returns either the version tag or the current build sha"""
+        return self.docs_tag or self.build_sha
+
+    @property
+    def build_dir(self) -> str:
+        """Returns current build_dir - most likely a temp directory"""
+        return self._build_dir
+
+    @property
+    def build_sha(self) -> str:
+        """Returns either a provided build_sha or a default"""
+        return self.args.build_sha or self._build_sha
+
+    @cached_property
+    def colors(self) -> dict:
+        """Color scheme for build summary"""
+        return dict(chrome=Fore.LIGHTYELLOW_EX, key=Fore.LIGHTCYAN_EX, value=Fore.LIGHTMAGENTA_EX)
+
+    @cached_property
+    def config_file(self) -> str:
+        """Populates a config file with self.configs and returns the file path"""
+        with open(self.config_file_path, "w") as f:
+            f.write(yaml.dump(self.configs))
+        return self.config_file_path
+
+    @property
+    def config_file_path(self) -> str:
+        """Path to a (temporary) build config"""
+        return os.path.join(self.build_dir, "build.yaml")
+
+    @cached_property
+    def configs(self) -> str:
+        """Build configs derived from provided args"""
+        _configs = dict(
+            version_string=self.version_string,
+            release_level=self.release_level,
+            blob_sha=self.blob_sha,
+            version_number=self.version_number,
+            docker_image_tag_name=self.docker_image_tag_name)
+        if self.validator_path:
+            _configs["validator_path"] = self.validator_path
+        if self.descriptor_path:
+            _configs["descriptor_path"] = self.descriptor_path
+        return _configs
+
+    @property
+    def descriptor_path(self) -> str:
+        """Path to a descriptor file for config validation"""
+        return os.path.abspath(self.args.descriptor_path)
+
+    @property
+    def docker_image_tag_name(self) -> str:
+        """Tag name of current docker image"""
+        return re.sub(r"([0-9]+\.[0-9]+)\.[0-9]+.*", r"v\1-latest", self.version_number)
+
+    @property
+    def docs_tag(self) -> str:
+        """Tag name - ie named version for this docs build"""
+        return self.args.docs_tag
+
+    @cached_property
+    def html_dir(self) -> str:
+        """Path to (temporary) directory for outputting html"""
+        return os.path.join(self.build_dir, "generated/html")
+
+    @property
+    def output_filename(self) -> str:
+        """Path to tar file for saving generated html docs"""
+        return self.args.output_filename
+
+    @property
+    def py_compatible(self) -> bool:
+        """Current python version is compatible"""
+        return bool(sys.version_info.major == 3 and sys.version_info.minor >= 8)
+
+    @property
+    def release_level(self) -> str:
+        """Current python version is compatible"""
+        return "tagged" if self.docs_tag else "pre-release"
+
+    @cached_property
+    def rst_dir(self) -> str:
+        """Populates an rst directory with contents of given rst tar,
+        and returns the path to the directory
+        """
+        rst_dir = os.path.join(self.build_dir, "generated/rst")
+        if self.rst_tar:
+            with tarfile.open(self.rst_tar) as tarfiles:
+                tarfiles.extractall(path=rst_dir)
+        return rst_dir
+
+    @property
+    def rst_tar(self) -> str:
+        """Path to the rst tarball"""
+        return self.args.rst_tar
+
+    @property
+    def sphinx_args(self) -> list:
+        """Command args for sphinx"""
+        return ["-W", "--keep-going", "--color", "-b", "html", self.rst_dir, self.html_dir]
+
+    @property
+    def validator_path(self) -> str:
+        """Path to validator utility for validating snippets"""
+        return os.path.abspath(self.args.validator_path)
+
+    @property
+    def version_file(self) -> str:
+        """Path to version files for deriving docs version"""
+        return self.args.version_file
+
+    @cached_property
+    def version_number(self) -> str:
+        """Semantic version"""
+        with open(self.version_file) as f:
+            return f.read().strip()
+
+    @property
+    def version_string(self) -> str:
+        """Version string derived from either docs_tag or build_sha"""
+        return (
+            f"tag-{self.docs_tag}"
+            if self.docs_tag else f"{self.version_number}-{self.build_sha[:6]}")
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--build_sha")
+        parser.add_argument("--docs_tag")
+        parser.add_argument("--version_file")
+        parser.add_argument("--validator_path")
+        parser.add_argument("--descriptor_path")
+        parser.add_argument("rst_tar")
+        parser.add_argument("output_filename")
+
+    def build_html(self) -> None:
+        if sphinx_build(self.sphinx_args):
+            raise SphinxBuildError("BUILD FAILED")
+
+    def build_summary(self) -> None:
+        print()
+        print(self._color("#### Sphinx build configs #####################"))
+        print(self._color("###"))
+        for k, v in self.configs.items():
+            print(f"{self._color('###')} {self._color(k, 'key')}: {self._color(v, 'value')}")
+        print(self._color("###"))
+        print(self._color("###############################################"))
+        print()
+
+    def check_env(self) -> None:
+        if not self.py_compatible:
+            raise SphinxEnvError(
+                f"ERROR: python version must be >= 3.8, you have {platform.python_version()}")
+        if not self.configs["release_level"] == "tagged":
+            return
+        if f"v{self.version_number}" != self.docs_tag:
+            raise SphinxEnvError(
+                "Given git tag does not match the VERSION file content:"
+                f"{self.docs_tag} vs v{self.version_number}")
+        with open(os.path.join(self.rst_dir, "version_history/current.rst")) as f:
+            if not self.version_number in f.read():
+                raise SphinxEnvError(
+                    f"Git tag ({self.version_number}) not found in version_history/current.rst")
+
+    def create_tarball(self) -> None:
+        with tarfile.open(self.output_filename, "w") as tar:
+            tar.add(self.html_dir, arcname=".")
+
+    def run(self) -> int:
+        with tempfile.TemporaryDirectory() as build_dir:
+            return self._run(build_dir)
+
+    def _color(self, msg, name=None):
+        return f"{self.colors[name or 'chrome']}{msg}{Style.RESET_ALL}"
+
+    def _run(self, build_dir):
+        self._build_dir = build_dir
+        os.environ["ENVOY_DOCS_BUILD_CONFIG"] = self.config_file
+        try:
+            self.check_env()
+        except SphinxEnvError as e:
+            print(e)
+            return 1
+        self.build_summary()
+        try:
+            self.build_html()
+        except SphinxBuildError as e:
+            print(e)
+            return 1
+        self.create_tarball()
+
+
+def main(*args) -> int:
+    return SphinxRunner(*args).run()
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/tools/docs/tests/test_sphinx_runner.py
+++ b/tools/docs/tests/test_sphinx_runner.py
@@ -1,0 +1,659 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from tools.docs import sphinx_runner
+
+
+def test_sphinx_runner_constructor():
+    runner = sphinx_runner.SphinxRunner()
+    assert runner.build_dir == "."
+    runner._build_dir = "foo"
+    assert runner.build_dir == "foo"
+    assert runner._build_sha == "UNKNOWN"
+    assert "blob_dir" not in runner.__dict__
+
+
+@pytest.mark.parametrize("docs_tag", [None, "", "SOME_DOCS_TAG"])
+def test_sphinx_runner_blob_sha(patches, docs_tag):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.build_sha", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.docs_tag", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_sha, m_tag):
+        m_tag.return_value = docs_tag
+        if docs_tag:
+            assert runner.blob_sha == docs_tag
+        else:
+            assert runner.blob_sha == m_sha.return_value
+    assert "blob_sha" not in runner.__dict__
+
+
+@pytest.mark.parametrize("build_sha", [None, "", "SOME_BUILD_SHA"])
+def test_sphinx_runner_build_sha(patches, build_sha):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_args, ):
+        m_args.return_value.build_sha = build_sha
+        if build_sha:
+            assert runner.build_sha == build_sha
+        else:
+            assert runner.build_sha == "UNKNOWN"
+
+    assert "build_sha" not in runner.__dict__
+
+
+def test_sphinx_runner_colors(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "Fore",
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_colors, ):
+        assert (
+            runner.colors
+            == dict(
+                chrome=m_colors.LIGHTYELLOW_EX,
+                key=m_colors.LIGHTCYAN_EX,
+                value=m_colors.LIGHTMAGENTA_EX))
+
+    assert "colors" in runner.__dict__
+
+
+def test_sphinx_runner_config_file(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "open",
+        "yaml",
+        ("SphinxRunner.config_file_path", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.configs", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_open, m_yaml, m_fpath,  m_configs):
+        assert (
+            runner.config_file
+            == m_fpath.return_value)
+
+    assert (
+        list(m_open.call_args)
+        == [(m_fpath.return_value, 'w'), {}])
+    assert (
+        list(m_yaml.dump.call_args)
+        == [(m_configs.return_value,), {}])
+    assert (
+        m_open.return_value.__enter__.return_value.write.call_args
+        == [(m_yaml.dump.return_value,), {}])
+
+    assert "config_file" in runner.__dict__
+
+
+def test_sphinx_runner_config_file_path(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "os.path",
+        ("SphinxRunner.build_dir", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_path, m_build):
+        assert runner.config_file_path == m_path.join.return_value
+
+    assert (
+        list(m_path.join.call_args)
+        == [(m_build.return_value, 'build.yaml',), {}])
+    assert "config_file_path" not in runner.__dict__
+
+
+def test_sphinx_runner_configs(patches):
+    runner = sphinx_runner.SphinxRunner()
+    mapping = dict(
+        version_string="version_string",
+        release_level="release_level",
+        blob_sha="blob_sha",
+        version_number="version_number",
+        docker_image_tag_name="docker_image_tag_name",
+        validator_path="validator_path",
+        descriptor_path="descriptor_path")
+
+    patched = patches(
+        *[f"SphinxRunner.{v}" for v in mapping.values()],
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as _mocks:
+        result = runner.configs
+
+    _configs = {}
+    for k, v in mapping.items():
+        _configs[k] = _mocks[list(mapping.values()).index(v)]
+    assert result == _configs
+    assert "configs" in runner.__dict__
+
+
+def test_sphinx_runner_descriptor_path(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "os.path",
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_path, m_args):
+        assert (
+            runner.descriptor_path
+            == m_path.abspath.return_value)
+
+    assert (
+        list(m_path.abspath.call_args)
+        == [(m_args.return_value.descriptor_path,), {}])
+    assert "descriptor_path" not in runner.__dict__
+
+
+def test_sphinx_runner_docker_image_tag_name(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "re",
+        ("SphinxRunner.version_number", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_re, m_version):
+        assert (
+            runner.docker_image_tag_name
+            == m_re.sub.return_value)
+
+    assert (
+        list(m_re.sub.call_args)
+        == [('([0-9]+\\.[0-9]+)\\.[0-9]+.*', 'v\\1-latest',
+             m_version.return_value), {}])
+    assert "docker_image_tag_name" not in runner.__dict__
+
+
+def test_sphinx_runner_docs_tag(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_args, ):
+        assert runner.docs_tag == m_args.return_value.docs_tag
+
+    assert "docs_tag" not in runner.__dict__
+
+
+def test_sphinx_runner_html_dir(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "os.path",
+        ("SphinxRunner.build_dir", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_path, m_build, m_args):
+        assert runner.html_dir == m_path.join.return_value
+
+    assert (
+        list(m_path.join.call_args)
+        == [(m_build.return_value, 'generated/html'), {}])
+
+    assert "html_dir" in runner.__dict__
+
+
+def test_sphinx_runner_output_filename(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_args, ):
+        assert runner.output_filename == m_args.return_value.output_filename
+    assert "output_filename" not in runner.__dict__
+
+
+@pytest.mark.parametrize("major", [2, 3, 4])
+@pytest.mark.parametrize("minor", [5, 6, 7, 8, 9])
+def test_sphinx_runner_py_compatible(patches, major, minor):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "bool",
+        "sys",
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_bool, m_sys):
+        m_sys.version_info.major = major
+        m_sys.version_info.minor = minor
+        assert runner.py_compatible == m_bool.return_value
+    expected = (
+        True
+        if major == 3 and minor >= 8
+        else False)
+    assert (
+        list(m_bool.call_args)
+        == [(expected,), {}])
+    assert "py_compatible" not in runner.__dict__
+
+
+@pytest.mark.parametrize("docs_tag", [None, "", "SOME_DOCS_TAG"])
+def test_sphinx_runner_release_level(patches, docs_tag):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.docs_tag", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_tag, ):
+        m_tag.return_value = docs_tag
+        if docs_tag:
+            assert runner.release_level == "tagged"
+        else:
+            assert runner.release_level == "pre-release"
+    assert "release_level" not in runner.__dict__
+
+
+@pytest.mark.parametrize("rst_tar", [None, "", "SOME_DOCS_TAG"])
+def test_sphinx_runner_rst_dir(patches, rst_tar):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "os.path",
+        "tarfile",
+        ("SphinxRunner.build_dir", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.rst_tar", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_path, m_tar, m_dir, m_rst):
+        m_rst.return_value = rst_tar
+        assert runner.rst_dir == m_path.join.return_value
+
+    assert (
+        list(m_path.join.call_args)
+        == [(m_dir.return_value, 'generated/rst'), {}])
+
+    if rst_tar:
+        assert (
+            list(m_tar.open.call_args)
+            == [(rst_tar,), {}])
+        assert (
+            list(m_tar.open.return_value.__enter__.return_value.extractall.call_args)
+            == [(), {'path': m_path.join.return_value}])
+    else:
+        assert not m_tar.open.called
+    assert "rst_dir" in runner.__dict__
+
+
+def test_sphinx_runner_rst_tar(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_args, ):
+        assert runner.rst_tar == m_args.return_value.rst_tar
+
+    assert "rst_tar" not in runner.__dict__
+
+
+def test_sphinx_runner_sphinx_args(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.html_dir", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.rst_dir", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_html, m_rst):
+        assert (
+            runner.sphinx_args
+            == ['-W', '--keep-going', '--color', '-b', 'html',
+                m_rst.return_value,
+                m_html.return_value])
+
+    assert "sphinx_args" not in runner.__dict__
+
+
+def test_sphinx_runner_validator_path(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "os.path",
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_path, m_args):
+        assert (
+            runner.validator_path
+            == m_path.abspath.return_value)
+
+    assert (
+        list(m_path.abspath.call_args)
+        == [(m_args.return_value.validator_path,), {}])
+    assert "validator_path" not in runner.__dict__
+
+
+def test_sphinx_runner_version_file(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_args, ):
+        assert runner.version_file == m_args.return_value.version_file
+
+    assert "version_file" not in runner.__dict__
+
+
+def test_sphinx_runner_version_number(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "open",
+        ("SphinxRunner.version_file", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_open, m_file):
+        assert (
+            runner.version_number
+            == m_open.return_value.__enter__.return_value.read.return_value.strip.return_value)
+
+    assert (
+        list(m_open.call_args)
+        == [(m_file.return_value,), {}])
+    assert (
+        list(m_open.return_value.__enter__.return_value.read.call_args)
+        == [(), {}])
+    assert (
+        list(m_open.return_value.__enter__.return_value.read.return_value.strip.call_args)
+        == [(), {}])
+
+    assert "version_number" in runner.__dict__
+
+
+@pytest.mark.parametrize("docs_tag", [None, "", "SOME_DOCS_TAG"])
+def test_sphinx_runner_version_string(patches, docs_tag):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        ("SphinxRunner.docs_tag", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.build_sha", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.version_number", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_tag, m_sha, m_version):
+        m_tag.return_value = docs_tag
+        if docs_tag:
+            assert runner.version_string == f"tag-{docs_tag}"
+        else:
+            assert runner.version_string == f"{m_version.return_value}-{m_sha.return_value.__getitem__.return_value}"
+            assert (
+                list(m_sha.return_value.__getitem__.call_args)
+                == [(slice(None, 6, None),), {}])
+
+    assert "version_string" not in runner.__dict__
+
+
+def test_sphinx_runner_add_arguments():
+    runner = sphinx_runner.SphinxRunner()
+    parser = MagicMock()
+    runner.add_arguments(parser)
+    assert (
+        list(list(c) for c in parser.add_argument.call_args_list)
+        == [[('--build_sha',), {}],
+            [('--docs_tag',), {}],
+            [('--version_file',), {}],
+            [('--validator_path',), {}],
+            [('--descriptor_path',), {}],
+            [('rst_tar',), {}],
+            [('output_filename',), {}]])
+
+
+@pytest.mark.parametrize("fails", [True, False])
+def test_sphinx_runner_build_html(patches, fails):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "sphinx_build",
+        ("SphinxRunner.sphinx_args", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_sphinx, m_args):
+        m_sphinx.side_effect = lambda s: fails
+        e = None
+        if fails:
+            with pytest.raises(sphinx_runner.SphinxBuildError) as e:
+                runner.build_html()
+        else:
+            runner.build_html()
+
+    assert (
+        list(m_sphinx.call_args)
+        == [(m_args.return_value,), {}])
+
+    if fails:
+        assert e.value.args == ('BUILD FAILED',)
+    else:
+        assert not e
+
+
+def test_sphinx_runner_build_summary(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "print",
+        "SphinxRunner._color",
+        ("SphinxRunner.configs", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_print, m_color, m_configs):
+        m_configs.return_value.items.return_value = (("a", "A"), ("b", "B"))
+        runner.build_summary()
+
+    assert (
+        list(list(c) for c in m_print.call_args_list)
+        == [[(), {}],
+            [(m_color.return_value,), {}],
+            [(m_color.return_value,), {}],
+            [(f"{m_color.return_value} {m_color.return_value}: {m_color.return_value}",), {}],
+            [(f"{m_color.return_value} {m_color.return_value}: {m_color.return_value}",), {}],
+            [(m_color.return_value,), {}],
+            [(m_color.return_value,), {}],
+            [(), {}]])
+    assert (
+        list(list(c) for c in m_color.call_args_list)
+        == [[('#### Sphinx build configs #####################',), {}],
+            [('###',), {}],
+            [('###',), {}],
+            [('a', 'key'), {}],
+            [('A', 'value'), {}],
+            [('###',), {}],
+            [('b', 'key'), {}],
+            [('B', 'value'), {}],
+            [('###',), {}],
+            [('###############################################',), {}]])
+
+
+@pytest.mark.parametrize("py_compat", [True, False])
+@pytest.mark.parametrize("release_level", ["pre-release", "tagged"])
+@pytest.mark.parametrize("version_number", ["1.17", "1.23", "1.43"])
+@pytest.mark.parametrize("docs_tag", ["v1.17", "v1.23", "v1.73"])
+@pytest.mark.parametrize("current", ["XXX v1.17 ZZZ", "AAA v1.23 VVV", "BBB v1.73 EEE"])
+def test_sphinx_runner_check_env(patches, py_compat, release_level, version_number, docs_tag, current):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "open",
+        "os.path",
+        "platform",
+        ("SphinxRunner.configs", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.version_number", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.docs_tag", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.py_compatible", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.rst_dir", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    fails = (
+        not py_compat
+        or (release_level == "tagged"
+            and (f"v{version_number}" != docs_tag
+                 or version_number not in current)))
+
+    with patched as (m_open, m_path, m_platform, m_configs, m_version, m_tag, m_py, m_rst):
+        m_py.return_value = py_compat
+        m_configs.return_value.__getitem__.return_value = release_level
+        m_version.return_value = version_number
+        m_tag.return_value = docs_tag
+        m_open.return_value.__enter__.return_value.read.return_value = current
+
+        if fails:
+            with pytest.raises(sphinx_runner.SphinxEnvError) as e:
+                runner.check_env()
+        else:
+            runner.check_env()
+
+    if not py_compat:
+        assert (
+            e.value.args
+            == ("ERROR: python version must be >= 3.8, "
+                f"you have {m_platform.python_version.return_value}", ))
+        assert not m_open.called
+        return
+
+    if release_level != "tagged":
+        assert not m_open.called
+        return
+
+    if f"v{version_number}" != docs_tag:
+        assert not m_open.called
+        assert (
+            e.value.args
+            == ("Given git tag does not match the VERSION file content:"
+                f"{docs_tag} vs v{version_number}", ))
+        return
+
+    assert (
+        list(m_open.call_args)
+        == [(m_path.join.return_value,), {}])
+    assert (
+        list(m_path.join.call_args)
+        == [(m_rst.return_value, "version_history/current.rst"), {}])
+    assert (
+        list(m_open.return_value.__enter__.return_value.read.call_args)
+        == [(), {}])
+
+    if version_number not in current:
+        assert (
+            e.value.args
+            == (f"Git tag ({version_number}) not found in version_history/current.rst", ))
+
+
+def test_sphinx_runner_create_tarball(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "tarfile",
+        ("SphinxRunner.output_filename", dict(new_callable=PropertyMock)),
+        ("SphinxRunner.html_dir", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_tar, m_out, m_html):
+        runner.create_tarball()
+
+    assert (
+        list(m_tar.open.call_args)
+        == [(m_out.return_value, 'w'), {}])
+    assert (
+        list(m_tar.open.return_value.__enter__.return_value.add.call_args)
+        == [(m_html.return_value,), {'arcname': '.'}])
+
+
+def test_sphinx_runner_run(patches):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "tempfile",
+        "SphinxRunner._run",
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_tmp, m_run):
+        assert runner.run() == m_run.return_value
+
+    assert (
+        list(m_run.call_args)
+        == [(m_tmp.TemporaryDirectory.return_value.__enter__.return_value,), {}])
+
+
+@pytest.mark.parametrize("color", [None, "COLOR"])
+def test_sphinx_runner__color(patches, color):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "Style",
+        ("SphinxRunner.colors", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    with patched as (m_style, m_colors):
+        assert (
+            runner._color("MSG", color)
+            == f"{m_colors.return_value.__getitem__.return_value}MSG{m_style.RESET_ALL}")
+    assert (
+        list(m_colors.return_value.__getitem__.call_args)
+        == [(color or "chrome",), {}])
+
+
+@pytest.mark.parametrize("check_fails", [True, False])
+@pytest.mark.parametrize("build_fails", [True, False])
+def test_sphinx_runner__run(patches, check_fails, build_fails):
+    runner = sphinx_runner.SphinxRunner()
+    patched = patches(
+        "print",
+        "os",
+        "SphinxRunner.build_summary",
+        "SphinxRunner.check_env",
+        "SphinxRunner.build_html",
+        "SphinxRunner.create_tarball",
+        ("SphinxRunner.config_file", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.sphinx_runner")
+
+    def _raise(error):
+        raise error
+
+    with patched as (m_print, m_os, m_summary, m_check, m_build, m_create, m_config):
+        if check_fails:
+            _check_error = sphinx_runner.SphinxEnvError("CHECK FAILED")
+            m_check.side_effect = lambda: _raise(_check_error)
+        if build_fails:
+            _build_error = sphinx_runner.SphinxBuildError("BUILD FAILED")
+            m_build.side_effect = lambda: _raise(_build_error)
+        assert runner._run("BUILD_DIR") == (1 if (check_fails or build_fails) else None)
+
+    assert (
+        runner._build_dir
+        == "BUILD_DIR")
+    assert (
+        list(m_check.call_args)
+        == [(), {}])
+    assert (
+        list(m_os.environ.__setitem__.call_args)
+        == [('ENVOY_DOCS_BUILD_CONFIG', m_config.return_value), {}])
+
+    if check_fails:
+        assert (
+            list(m_print.call_args)
+            == [(_check_error,), {}])
+        assert not m_summary.called
+        assert not m_build.called
+        assert not m_create.called
+        return
+
+    assert (
+        list(m_summary.call_args)
+        == [(), {}])
+    assert (
+        list(m_build.call_args)
+        == [(), {}])
+
+    if build_fails:
+        assert (
+            list(m_print.call_args)
+            == [(_build_error,), {}])
+        assert not m_create.called
+        return
+
+    assert not m_print.called
+    assert (
+        list(m_create.call_args)
+        == [(), {}])
+
+
+def test_sphinx_runner_main(command_main):
+    command_main(
+        sphinx_runner.main,
+        "tools.docs.sphinx_runner.SphinxRunner")


### PR DESCRIPTION
Commit Message: docs: Move docs/build.sh to bazel
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #13229
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
