### PR TITLE
eds: add overhead measurement

### DIFF
--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1285,7 +1285,8 @@ void CdsHelper::setCds(const std::vector<envoy::config::cluster::v3::Cluster>& c
   TestEnvironment::renameFile(path, cds_path_);
 }
 
-EdsHelper::EdsHelper() : eds_path_(TestEnvironment::writeStringToFileForTest("eds.pb_text", "")) {
+EdsHelper::EdsHelper(const std::string& path)
+    : eds_path_(TestEnvironment::writeStringToFileForTest(path, "")) {
   // cluster.cluster_0.update_success will be incremented on the initial
   // load when Envoy comes up.
   ++update_successes_;

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -366,7 +366,7 @@ private:
 // Common code for tests that deliver EDS update via the filesystem.
 class EdsHelper {
 public:
-  EdsHelper();
+  explicit EdsHelper(const std::string& path = "eds.pb_text");
 
   // Set EDS contents on filesystem and wait for Envoy to pick this up.
   void setEds(const std::vector<envoy::config::endpoint::v3::ClusterLoadAssignment>&

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -229,6 +229,7 @@ private:
 
   size_t edsClusterMemoryHelper(int num_clusters, int num_hosts, int concurrency,
                                 bool allow_stats) {
+    concurrency_ = concurrency;
     CdsHelper cds_helper;
     Stats::TestUtil::MemoryTest memory_test;
     config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {


### PR DESCRIPTION
Commit Message:

base: concurrency = 1
EDS cluster with 1 host: 44k bytes
EDS cluster with 1 host no stats:  24k bytes
Extra host per cluster: 250 bytes
Extra concurrency per cluster: 2200 bytes

Protobuf message
Cluster: 1108 bytes on heap or 205 bytes on the wire
1 endpoint CLA: 852 bytes on heap or 32 bytes on the wire
101 endpoint CLA: 38650 bytes on heap or 1933 bytes on the wire


Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
Risk Level: LOW
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
