### PR TITLE
bazel: Bump rules_python version to 0.1.0

### DIFF
--- a/DEPENDENCY_POLICY.md
+++ b/DEPENDENCY_POLICY.md
@@ -58,7 +58,7 @@ Dependency declarations must:
   be used if no CPE for the project is available in the CPE database. CPEs should be _versionless_
   with a `:*` suffix, since the version can be computed from `version`.
 
-When build or test code references Python modules, they should be imported via `pip3_import` in
+When build or test code references Python modules, they should be specified via `pip_install` in
 [bazel/repositories_extra.bzl](bazel/repositories_extra.bzl). Python modules should not be listed in
 `repository_locations.bzl` entries. `requirements.txt` files for Python dependencies must pin to
 exact versions, e.g. `PyYAML==5.3.1` and ideally also include a [SHA256

--- a/bazel/EXTERNAL_DEPS.md
+++ b/bazel/EXTERNAL_DEPS.md
@@ -59,16 +59,13 @@ to binaries, libraries, headers, etc.
 
 # Adding external dependencies to Envoy (Python)
 
-Python dependencies should be added via `pip3` and `rules_python`. The process
+Python dependencies should be added via `pip` and `rules_python`. The process
 is:
 
-1. Define a `pip3_import()` pointing at your target `requirements.txt` in
+1. Define a `pip_install()` pointing at your target `requirements.txt` in
    [`bazel/repositories_extra.bzl`](repositories_extra.bzl)
 
-2. Add a `pip_install()` invocation in
-   [`bazel/dependency_imports.bzl`](dependency_imports.bzl).
-
-3. Add a `requirements("<package name")` in the `BUILD` file that depends on
+2. Add a `requirements("<package name")` in the `BUILD` file that depends on
    this package.
 
 You can use [`tools/config_validation/BUILD`](../tools/config_validation/BUILD) as an example

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -7,13 +7,6 @@ load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependenci
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
-load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")
-load("@configs_pip3//:requirements.bzl", configs_pip_install = "pip_install")
-load("@headersplit_pip3//:requirements.bzl", headersplit_pip_install = "pip_install")
-load("@kafka_pip3//:requirements.bzl", kafka_pip_install = "pip_install")
-load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
-load("@thrift_pip3//:requirements.bzl", thrift_pip_install = "pip_install")
-load("@fuzzing_pip3//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
 
@@ -81,11 +74,3 @@ def envoy_dependency_imports(go_version = GO_VERSION):
         sum = "h1:ux/56T2xqZO/3cP1I2F86qpeoYPCOzk+KF/UH/Ar+lk=",
         version = "v0.0.0-20180726023541-3605ed457bf7",
     )
-
-    config_validation_pip_install()
-    configs_pip_install()
-    headersplit_pip_install()
-    kafka_pip_install()
-    protodoc_pip_install()
-    thrift_pip_install()
-    fuzzing_pip_install()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -592,7 +592,12 @@ def _com_google_absl():
     )
 
 def _com_google_protobuf():
-    external_http_archive("rules_python")
+    external_http_archive(
+        name = "rules_python",
+        patches = ["@envoy//bazel:rules_python.patch"],
+        patch_args = ["-p1"],
+    )
+
     external_http_archive(
         "com_google_protobuf",
         patches = ["@envoy//bazel:protobuf.patch"],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -592,6 +592,9 @@ def _com_google_absl():
     )
 
 def _com_google_protobuf():
+    # patch is applied to update setuptools version (0.5.4), and can be removed once this
+    # has been updated in rules_python
+    # see https://github.com/envoyproxy/envoy/pull/15236#issuecomment-788650946 for discussion
     external_http_archive(
         name = "rules_python",
         patches = ["@envoy//bazel:rules_python.patch"],

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -592,9 +592,10 @@ def _com_google_absl():
     )
 
 def _com_google_protobuf():
-    # patch is applied to update setuptools version (0.5.4), and can be removed once this
-    # has been updated in rules_python
-    # see https://github.com/envoyproxy/envoy/pull/15236#issuecomment-788650946 for discussion
+    # TODO(phlax): remove patch
+    #    patch is applied to update setuptools to version (0.5.4),
+    #    and can be removed once this has been updated in rules_python
+    #    see https://github.com/envoyproxy/envoy/pull/15236#issuecomment-788650946 for discussion
     external_http_archive(
         name = "rules_python",
         patches = ["@envoy//bazel:rules_python.patch"],

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -1,5 +1,5 @@
 load("@rules_python//python:repositories.bzl", "py_repositories")
-load("@rules_python//python:pip.bzl", "pip3_import", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_install", "pip_repositories")
 load("@proxy_wasm_cpp_host//bazel/cargo:crates.bzl", "proxy_wasm_cpp_host_fetch_remote_crates")
 
 # Python dependencies.
@@ -7,7 +7,7 @@ def _python_deps():
     py_repositories()
     pip_repositories()
 
-    pip3_import(
+    pip_install(
         name = "config_validation_pip3",
         requirements = "@envoy//tools/config_validation:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -19,7 +19,7 @@ def _python_deps():
         # use_category = ["devtools"],
         # cpe = "cpe:2.3:a:pyyaml:pyyaml:*",
     )
-    pip3_import(
+    pip_install(
         name = "configs_pip3",
         requirements = "@envoy//configs:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -37,7 +37,7 @@ def _python_deps():
         # release_date = "2019-02-23"
         # use_category = ["test"],
     )
-    pip3_import(
+    pip_install(
         name = "kafka_pip3",
         requirements = "@envoy//source/extensions/filters/network/kafka:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -55,7 +55,7 @@ def _python_deps():
         # release_date = "2019-02-23"
         # use_category = ["test"],
     )
-    pip3_import(
+    pip_install(
         name = "headersplit_pip3",
         requirements = "@envoy//tools/envoy_headersplit:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -67,7 +67,7 @@ def _python_deps():
         # use_category = ["devtools"],
         # cpe = "cpe:2.3:a:llvm:clang:*",
     )
-    pip3_import(
+    pip_install(
         name = "protodoc_pip3",
         requirements = "@envoy//tools/protodoc:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -79,7 +79,7 @@ def _python_deps():
         # use_category = ["docs"],
         # cpe = "cpe:2.3:a:pyyaml:pyyaml:*",
     )
-    pip3_import(
+    pip_install(
         name = "thrift_pip3",
         requirements = "@envoy//test/extensions/filters/network/thrift_proxy:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -97,7 +97,7 @@ def _python_deps():
         # release_date = "2020-05-21"
         # use_category = ["test"],
     )
-    pip3_import(
+    pip_install(
         name = "fuzzing_pip3",
         requirements = "@rules_fuzzing//fuzzing:requirements.txt",
         extra_pip_args = ["--require-hashes"],

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -1,11 +1,10 @@
 load("@rules_python//python:repositories.bzl", "py_repositories")
-load("@rules_python//python:pip.bzl", "pip_install", "pip_repositories")
+load("@rules_python//python:pip.bzl", "pip_install")
 load("@proxy_wasm_cpp_host//bazel/cargo:crates.bzl", "proxy_wasm_cpp_host_fetch_remote_crates")
 
 # Python dependencies.
 def _python_deps():
     py_repositories()
-    pip_repositories()
 
     pip_install(
         name = "config_validation_pip3",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -635,7 +635,6 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         version = "0.1.0",
         sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
         release_date = "2020-10-15",
-        strip_prefix = "",
         urls = ["https://github.com/bazelbuild/rules_python/releases/download/{version}/rules_python-{version}.tar.gz"],
         use_category = ["build"],
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -632,12 +632,11 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Python rules for Bazel",
         project_desc = "Bazel rules for the Python language",
         project_url = "https://github.com/bazelbuild/rules_python",
-        # TODO(htuch): revert back to a point releases when pip3_import appears.
-        version = "a0fbf98d4e3a232144df4d0d80b577c7a693b570",
-        sha256 = "76a8fd4e7eca2a3590f816958faa0d83c9b2ce9c32634c5c375bcccf161d3bb5",
+        version = "0.1.0",
+        sha256 = "48f7e716f4098b85296ad93f5a133baf712968c13fbc2fdf3a6136158fe86eac",
         strip_prefix = "rules_python-{version}",
         urls = ["https://github.com/bazelbuild/rules_python/archive/{version}.tar.gz"],
-        release_date = "2020-04-09",
+        release_date = "2020-10-15",
         use_category = ["build"],
     ),
     six = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -633,10 +633,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_desc = "Bazel rules for the Python language",
         project_url = "https://github.com/bazelbuild/rules_python",
         version = "0.1.0",
-        sha256 = "48f7e716f4098b85296ad93f5a133baf712968c13fbc2fdf3a6136158fe86eac",
-        strip_prefix = "rules_python-{version}",
-        urls = ["https://github.com/bazelbuild/rules_python/archive/{version}.tar.gz"],
+        sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
         release_date = "2020-10-15",
+        strip_prefix = "",
+        urls = ["https://github.com/bazelbuild/rules_python/releases/download/{version}/rules_python-{version}.tar.gz"],
         use_category = ["build"],
     ),
     six = dict(

--- a/bazel/rules_python.patch
+++ b/bazel/rules_python.patch
@@ -8,8 +8,8 @@ index df63674..80824e4 100644
          "pypi__setuptools",
 -        "https://files.pythonhosted.org/packages/54/28/c45d8b54c1339f9644b87663945e54a8503cfef59cf0f65b3ff5dd17cf64/setuptools-42.0.2-py2.py3-none-any.whl",
 -        "c8abd0f3574bc23afd2f6fd2c415ba7d9e097c8a99b845473b0d957ba1e2dac6",
-+        "https://files.pythonhosted.org/packages/ab/b5/3679d7c98be5b65fa5522671ef437b792d909cf3908ba54fe9eca5d2a766/setuptools-44.1.0-py2.py3-none-any.whl",
-+        "992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30",
++        "https://files.pythonhosted.org/packages/70/06/849cc805ac6332210083f2114a95b22ee252ce81ed4e1be4f1d2b87c9108/setuptools-54.0.0-py3-none-any.whl",
++        "d85b57c41e88b69ab87065c964134ec85b7573cbab0fdaa7ef32330ed764600a",
      ),
      (
          "pypi__wheel",

--- a/bazel/rules_python.patch
+++ b/bazel/rules_python.patch
@@ -8,8 +8,8 @@ index df63674..80824e4 100644
          "pypi__setuptools",
 -        "https://files.pythonhosted.org/packages/54/28/c45d8b54c1339f9644b87663945e54a8503cfef59cf0f65b3ff5dd17cf64/setuptools-42.0.2-py2.py3-none-any.whl",
 -        "c8abd0f3574bc23afd2f6fd2c415ba7d9e097c8a99b845473b0d957ba1e2dac6",
-+        "https://files.pythonhosted.org/packages/3d/f2/1489d3b6c72d68bf79cd0fba6b6c7497df4ebf7d40970e2d7eceb8d0ea9c/setuptools-51.0.0-py3-none-any.whl",
-+        "8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529",
++        "https://files.pythonhosted.org/packages/ab/b5/3679d7c98be5b65fa5522671ef437b792d909cf3908ba54fe9eca5d2a766/setuptools-44.1.0-py2.py3-none-any.whl",
++        "992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30",
      ),
      (
          "pypi__wheel",

--- a/bazel/rules_python.patch
+++ b/bazel/rules_python.patch
@@ -1,0 +1,15 @@
+diff --git a/python/pip_install/repositories.bzl b/python/pip_install/repositories.bzl
+index df63674..80824e4 100644
+--- a/python/pip_install/repositories.bzl
++++ b/python/pip_install/repositories.bzl
+@@ -16,8 +16,8 @@ _RULE_DEPS = [
+     ),
+     (
+         "pypi__setuptools",
+-        "https://files.pythonhosted.org/packages/54/28/c45d8b54c1339f9644b87663945e54a8503cfef59cf0f65b3ff5dd17cf64/setuptools-42.0.2-py2.py3-none-any.whl",
+-        "c8abd0f3574bc23afd2f6fd2c415ba7d9e097c8a99b845473b0d957ba1e2dac6",
++        "https://files.pythonhosted.org/packages/3d/f2/1489d3b6c72d68bf79cd0fba6b6c7497df4ebf7d40970e2d7eceb8d0ea9c/setuptools-51.0.0-py3-none-any.whl",
++        "8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529",
+     ),
+     (
+         "pypi__wheel",

--- a/tools/dependency/validate.py
+++ b/tools/dependency/validate.py
@@ -60,7 +60,7 @@ def TestOnlyIgnore(dep):
   if dep.startswith('remotejdk'):
     return True
   # Python (pip3)
-  if '_pip3_' in dep:
+  if '_pip3' in dep:
     return True
   return False
 

--- a/tools/dependency/validate_test.py
+++ b/tools/dependency/validate_test.py
@@ -61,7 +61,7 @@ class ValidateTest(unittest.TestCase):
   def test_valid_test_only_deps(self):
     validator = self.BuildValidator({'a': FakeDep('dataplane_core')}, {'//source/...': ['a']})
     validator.ValidateTestOnlyDeps()
-    validator = self.BuildValidator({'a': FakeDep('test_only')}, {'//test/...': ['a', 'b__pip3_']})
+    validator = self.BuildValidator({'a': FakeDep('test_only')}, {'//test/...': ['a', 'b__pip3']})
     validator.ValidateTestOnlyDeps()
 
   def test_invalid_test_only_deps(self):


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: bazel: Bump rules_python version to 0.1.0
Additional Description:

afaict the current `rules_python` has quite a few things that dont work correctly - namespaced packages, entrypoints and wheels eg

version 0.1.0 at least seems to fix the issue of namespaced packages, and possibly other problems too

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
