### PR TITLE
coverage: adjust threshold on source/server to fix flaky failure

### DIFF
--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -65,7 +65,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/wasm_runtime/wavm:0.0" # Noe enabled in coverage build
 "source/extensions/watchdog:85.7" # Death tests within extensions
 "source/extensions/watchdog/profile_action:85.7"
-"source/server:94.5" # flaky: be careful adjusting
+"source/server:94.4" # flaky: be careful adjusting
 "source/server/admin:95.1"
 "source/server/config_validation:75.6"
 )

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -65,7 +65,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/extensions/wasm_runtime/wavm:0.0" # Noe enabled in coverage build
 "source/extensions/watchdog:85.7" # Death tests within extensions
 "source/extensions/watchdog/profile_action:85.7"
-"source/server:94.4" # flaky: be careful adjusting
+"source/server:94.4" # flaky: be careful adjusting. See https://github.com/envoyproxy/envoy/issues/15239
 "source/server/admin:95.1"
 "source/server/config_validation:75.6"
 )


### PR DESCRIPTION
The coverage on source/server recently has been flaky between 94.4 and 95.1. What's worse is
this is somehow deterministic, i.e. on some commits, retesting would not work to go green.

I have encountered this several times in a last few weeks, for example, https://github.com/envoyproxy/envoy/pull/15210 this is clearly unrelated to this coverage issue. You can see the same flake is happening to other PRs.

I see that the root cause sits in `source/server/connection_handler_impl.cc`, but I would like to introduce this change as a temporary workaround.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
