### PR TITLE
upstream: avoid double hashing of protos in CDS init

### DIFF
--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -468,9 +468,9 @@ private:
 
   struct ClusterData : public ClusterManagerCluster {
     ClusterData(const envoy::config::cluster::v3::Cluster& cluster_config,
-                const std::string& version_info, bool added_via_api, ClusterSharedPtr&& cluster,
-                TimeSource& time_source)
-        : cluster_config_(cluster_config), config_hash_(MessageUtil::hash(cluster_config)),
+                const uint64_t cluster_config_hash, const std::string& version_info,
+                bool added_via_api, ClusterSharedPtr&& cluster, TimeSource& time_source)
+        : cluster_config_(cluster_config), config_hash_(cluster_config_hash),
           version_info_(version_info), added_via_api_(added_via_api), cluster_(std::move(cluster)),
           last_updated_(time_source.systemTime()) {}
 
@@ -563,8 +563,8 @@ private:
    * nullptr if cluster_map did not contain the same cluster.
    */
   ClusterDataPtr loadCluster(const envoy::config::cluster::v3::Cluster& cluster,
-                             const std::string& version_info, bool added_via_api,
-                             ClusterMap& cluster_map);
+                             const uint64_t cluster_hash, const std::string& version_info,
+                             bool added_via_api, ClusterMap& cluster_map);
   void onClusterInit(ClusterManagerCluster& cluster);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
   void updateClusterCounts();


### PR DESCRIPTION
Commit Message: upstream: avoid double hashing of protos in CDS init
Additional Description:
Currently Cluster messages are hashed unconditionally upon instantiation of `ClusterManagerImpl::ClusterData` even if their hashes are known already.
Calculate the hashes outside of `ClusterManagerImpl::ClusterData` ctor to make use of already calculated ones.
Risk Level: Low
Testing: unit tests, manual tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Contributes to #12138 
