### PR TITLE
Avoid recomputing hash of the cluster config proto in the ClusterManagerImpl::addOrUpdateCluster()

### DIFF
--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -309,7 +309,7 @@ ClusterManagerImpl::ClusterManagerImpl(
   // Load all the primary clusters.
   for (const auto& cluster : bootstrap.static_resources().clusters()) {
     if (is_primary_cluster(cluster)) {
-      loadCluster(cluster, "", false, active_clusters_);
+      loadCluster(cluster, MessageUtil::hash(cluster), "", false, active_clusters_);
     }
   }
 
@@ -365,7 +365,7 @@ ClusterManagerImpl::ClusterManagerImpl(
     if (cluster.type() == envoy::config::cluster::v3::Cluster::EDS &&
         cluster.eds_cluster_config().eds_config().config_source_specifier_case() !=
             envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kPath) {
-      loadCluster(cluster, "", false, active_clusters_);
+      loadCluster(cluster, MessageUtil::hash(cluster), "", false, active_clusters_);
     }
   }
 
@@ -650,7 +650,8 @@ bool ClusterManagerImpl::addOrUpdateCluster(const envoy::config::cluster::v3::Cl
       init_helper_.state() == ClusterManagerInitHelper::State::AllClustersInitialized;
   // Preserve the previous cluster data to avoid early destroy. The same cluster should be added
   // before destroy to avoid early initialization complete.
-  const auto previous_cluster = loadCluster(cluster, version_info, true, warming_clusters_);
+  const auto previous_cluster =
+      loadCluster(cluster, new_hash, version_info, true, warming_clusters_);
   auto& cluster_entry = warming_clusters_.at(cluster_name);
   if (!all_clusters_initialized) {
     ENVOY_LOG(debug, "add/update cluster {} during init", cluster_name);
@@ -720,8 +721,8 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name) {
 
 ClusterManagerImpl::ClusterDataPtr
 ClusterManagerImpl::loadCluster(const envoy::config::cluster::v3::Cluster& cluster,
-                                const std::string& version_info, bool added_via_api,
-                                ClusterMap& cluster_map) {
+                                uint64_t cluster_hash, const std::string& version_info,
+                                bool added_via_api, ClusterMap& cluster_map) {
   std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr> new_cluster_pair =
       factory_.clusterFromProto(cluster, *this, outlier_event_logger_, added_via_api);
   auto& new_cluster = new_cluster_pair.first;
@@ -770,14 +771,15 @@ ClusterManagerImpl::loadCluster(const envoy::config::cluster::v3::Cluster& clust
   auto cluster_entry_it = cluster_map.find(cluster_reference.info()->name());
   if (cluster_entry_it != cluster_map.end()) {
     result = std::exchange(cluster_entry_it->second,
-                           std::make_unique<ClusterData>(cluster, version_info, added_via_api,
-                                                         std::move(new_cluster), time_source_));
+                           std::make_unique<ClusterData>(cluster, cluster_hash, version_info,
+                                                         added_via_api, std::move(new_cluster),
+                                                         time_source_));
   } else {
     bool inserted = false;
-    std::tie(cluster_entry_it, inserted) =
-        cluster_map.emplace(cluster_reference.info()->name(),
-                            std::make_unique<ClusterData>(cluster, version_info, added_via_api,
-                                                          std::move(new_cluster), time_source_));
+    std::tie(cluster_entry_it, inserted) = cluster_map.emplace(
+        cluster_reference.info()->name(),
+        std::make_unique<ClusterData>(cluster, cluster_hash, version_info, added_via_api,
+                                      std::move(new_cluster), time_source_));
     ASSERT(inserted);
   }
   // If an LB is thread aware, create it here. The LB is not initialized until cluster pre-init

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -467,11 +467,11 @@ private:
   };
 
   struct ClusterData : public ClusterManagerCluster {
-    ClusterData(const envoy::config::cluster::v3::Cluster& cluster_config,
+    ClusterData(const envoy::config::cluster::v3::Cluster& cluster_config, uint64_t cluster_hash,
                 const std::string& version_info, bool added_via_api, ClusterSharedPtr&& cluster,
                 TimeSource& time_source)
-        : cluster_config_(cluster_config), config_hash_(MessageUtil::hash(cluster_config)),
-          version_info_(version_info), added_via_api_(added_via_api), cluster_(std::move(cluster)),
+        : cluster_config_(cluster_config), config_hash_(cluster_hash), version_info_(version_info),
+          added_via_api_(added_via_api), cluster_(std::move(cluster)),
           last_updated_(time_source.systemTime()) {}
 
     bool blockUpdate(uint64_t hash) { return !added_via_api_ || config_hash_ == hash; }
@@ -563,8 +563,9 @@ private:
    * nullptr if cluster_map did not contain the same cluster.
    */
   ClusterDataPtr loadCluster(const envoy::config::cluster::v3::Cluster& cluster,
-                             const std::string& version_info, bool added_via_api,
-                             ClusterMap& cluster_map);
+                             uint64_t cluster_hash, const std::string& version_info,
+                             bool added_via_api, ClusterMap& cluster_map);
+
   void onClusterInit(ClusterManagerCluster& cluster);
   void postThreadLocalHealthFailure(const HostSharedPtr& host);
   void updateClusterCounts();


### PR DESCRIPTION
Commit Message:
Refactoring of ClusterData constructor to avoid recomputing hash of the cluster config proto when cluster are updated through xDS. Hash computation is a significant CPU burner (~7%) for configs with large number of clusters. Existing unit tests should be sufficient.

Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
