### PR TITLE
ci: disable wasm for osx

### DIFF
--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -26,6 +26,8 @@ BAZEL_BUILD_OPTIONS=(
     "--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
     "--test_output=all"
     "--flaky_test_attempts=integration@2"
+    #TODO: re-enable wasm when it doesn't cause build/test timeouts.
+    "--define" "wasm=disabled"
     "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
     "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 


### PR DESCRIPTION
As discussed on #envoy-maintainers it's believed this is part of the reason osx CI is timing out.

