### PR TITLE
Add RouteEntry::currentUrlPathAfterRewrite method.

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -49,6 +49,7 @@ Minor Behavior Changes
 * oauth filter: added the optional parameter :ref:`auth_scopes <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.auth_scopes>` with default value of 'user' if not provided. Enables this value to be overridden in the Authorization request to the OAuth provider.
 * perf: allow reading more bytes per operation from raw sockets to improve performance.
 * router: extended custom date formatting to DOWNSTREAM_PEER_CERT_V_START and DOWNSTREAM_PEER_CERT_V_END when using :ref:`custom request/response header formats <config_http_conn_man_headers_custom_request_headers>`.
+* router: made the path rewrite available without finalizing headers, so the filter could calculate the current value of the final url.
 * tracing: added `upstream_cluster.name` tag that resolves to resolve to :ref:`alt_stat_name <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` if provided (and otherwise the cluster name).
 * upstream: host weight changes now cause a full load balancer rebuild as opposed to happening
   atomically inline. This change has been made to support load balancer pre-computation of data

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -728,6 +728,14 @@ public:
   virtual const CorsPolicy* corsPolicy() const PURE;
 
   /**
+   * Returns the URL path as it will be calculated by finalizeRequestHeaders
+   * using current values of headers. Note that final path may be different if
+   * headers change before finalization.
+   */
+  virtual absl::optional<std::string>
+  currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const PURE;
+
+  /**
    * Do potentially destructive header transforms on request headers prior to forwarding. For
    * example URL prefix rewriting, adding headers, etc. This should only be called ONCE
    * immediately prior to forwarding. It is done this way vs. copying for performance reasons.

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -731,6 +731,9 @@ public:
    * Returns the URL path as it will be calculated by finalizeRequestHeaders
    * using current values of headers. Note that final path may be different if
    * headers change before finalization.
+   * @param headers supplies the request headers.
+   * @return absl::optional<std::string> the value of the URL path after rewrite or an empty
+   *         value if rewrite is not configured.
    */
   virtual absl::optional<std::string>
   currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const PURE;

--- a/include/envoy/router/router.h
+++ b/include/envoy/router/router.h
@@ -732,8 +732,8 @@ public:
    * using current values of headers. Note that final path may be different if
    * headers change before finalization.
    * @param headers supplies the request headers.
-   * @return absl::optional<std::string> the value of the URL path after rewrite or an empty
-   *         value if rewrite is not configured.
+   * @return absl::optional<std::string> the value of the URL path after rewrite or absl::nullopt
+   *         if rewrite is not configured.
    */
   virtual absl::optional<std::string>
   currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const PURE;

--- a/source/common/http/async_client_impl.h
+++ b/source/common/http/async_client_impl.h
@@ -229,6 +229,10 @@ private:
       return Http::Code::InternalServerError;
     }
     const Router::CorsPolicy* corsPolicy() const override { return nullptr; }
+    absl::optional<std::string>
+    currentUrlPathAfterRewrite(const Http::RequestHeaderMap&) const override {
+      return absl::optional<std::string>();
+    }
     void finalizeRequestHeaders(Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                                 bool) const override {}
     void finalizeResponseHeaders(Http::ResponseHeaderMap&,

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -638,43 +638,57 @@ RouteEntryImplBase::getPathRewrite(const Http::RequestHeaderMap& headers,
   return prefix_rewrite_redirect_;
 }
 
-// finalizePathHeaders does the "standard" path rewriting, meaning that it
+void RouteEntryImplBase::finalizePathHeader(Http::RequestHeaderMap& headers,
+                                            absl::string_view matched_path,
+                                            bool insert_envoy_original_path) const {
+  absl::optional<std::string> new_path =
+      currentUrlPathAfterRewriteWithMatchedPath(headers, matched_path);
+  if (!new_path.has_value()) {
+    // There are no rewrites configured. Just return.
+    return;
+  }
+
+  if (insert_envoy_original_path) {
+    headers.setEnvoyOriginalPath(headers.getPathValue());
+  }
+
+  headers.setPath(new_path.value());
+}
+
+// currentUrlPathAfterRewriteWithMatchedPath does the "standard" path rewriting, meaning that it
 // handles the "prefix_rewrite" and "regex_rewrite" route actions, only one of
 // which can be specified. The "matched_path" argument applies only to the
 // prefix rewriting, and describes the portion of the path (excluding query
 // parameters) that should be replaced by the rewrite. A "regex_rewrite"
 // applies to the entire path (excluding query parameters), regardless of what
 // portion was matched.
-void RouteEntryImplBase::finalizePathHeader(Http::RequestHeaderMap& headers,
-                                            absl::string_view matched_path,
-                                            bool insert_envoy_original_path) const {
+absl::optional<std::string> RouteEntryImplBase::currentUrlPathAfterRewriteWithMatchedPath(
+    const Http::RequestHeaderMap& headers, absl::string_view matched_path) const {
   absl::optional<std::string> container;
   const auto& rewrite = getPathRewrite(headers, container);
   if (rewrite.empty() && regex_rewrite_ == nullptr) {
-    // There are no rewrites configured. Just return.
-    return;
+    // There are no rewrites configured.
+    return absl::optional<std::string>();
   }
 
   // TODO(perf): can we avoid the string copy for the common case?
   std::string path(headers.getPathValue());
-  if (insert_envoy_original_path) {
-    headers.setEnvoyOriginalPath(path);
-  }
 
   if (!rewrite.empty()) {
     ASSERT(case_sensitive_ ? absl::StartsWith(path, matched_path)
                            : absl::StartsWithIgnoreCase(path, matched_path));
-    headers.setPath(path.replace(0, matched_path.size(), rewrite));
-    return;
+    return path.replace(0, matched_path.size(), rewrite);
   }
 
   if (regex_rewrite_ != nullptr) {
     // Replace the entire path, but preserve the query parameters
     auto just_path(Http::PathUtil::removeQueryAndFragment(path));
-    headers.setPath(path.replace(
-        0, just_path.size(), regex_rewrite_->replaceAll(just_path, regex_rewrite_substitution_)));
-    return;
+    return path.replace(0, just_path.size(),
+                        regex_rewrite_->replaceAll(just_path, regex_rewrite_substitution_));
   }
+
+  // This shouldn't happen.
+  return absl::optional<std::string>();
 }
 
 absl::string_view RouteEntryImplBase::processRequestHost(const Http::RequestHeaderMap& headers,
@@ -1018,6 +1032,11 @@ void PrefixRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
   finalizePathHeader(headers, prefix_, insert_envoy_original_path);
 }
 
+absl::optional<std::string>
+PrefixRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const {
+  return currentUrlPathAfterRewriteWithMatchedPath(headers, prefix_);
+}
+
 RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
                                                   const StreamInfo::StreamInfo& stream_info,
                                                   uint64_t random_value) const {
@@ -1038,6 +1057,11 @@ PathRouteEntryImpl::PathRouteEntryImpl(const VirtualHostImpl& vhost,
 void PathRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                            bool insert_envoy_original_path) const {
   finalizePathHeader(headers, path_, insert_envoy_original_path);
+}
+
+absl::optional<std::string>
+PathRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const {
+  return currentUrlPathAfterRewriteWithMatchedPath(headers, path_);
 }
 
 RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
@@ -1079,6 +1103,12 @@ void RegexRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
   finalizePathHeader(headers, path, insert_envoy_original_path);
 }
 
+absl::optional<std::string>
+RegexRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const {
+  const absl::string_view path = Http::PathUtil::removeQueryAndFragment(headers.getPathValue());
+  return currentUrlPathAfterRewriteWithMatchedPath(headers, path);
+}
+
 RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
                                                  const StreamInfo::StreamInfo& stream_info,
                                                  uint64_t random_value) const {
@@ -1101,6 +1131,12 @@ void ConnectRouteEntryImpl::rewritePathHeader(Http::RequestHeaderMap& headers,
                                               bool insert_envoy_original_path) const {
   const absl::string_view path = Http::PathUtil::removeQueryAndFragment(headers.getPathValue());
   finalizePathHeader(headers, path, insert_envoy_original_path);
+}
+
+absl::optional<std::string>
+ConnectRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const {
+  const absl::string_view path = Http::PathUtil::removeQueryAndFragment(headers.getPathValue());
+  return currentUrlPathAfterRewriteWithMatchedPath(headers, path);
 }
 
 RouteConstSharedPtr ConnectRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -582,6 +582,10 @@ protected:
   void finalizePathHeader(Http::RequestHeaderMap& headers, absl::string_view matched_path,
                           bool insert_envoy_original_path) const;
 
+  absl::optional<std::string>
+  currentUrlPathAfterRewriteWithMatchedPath(const Http::RequestHeaderMap& headers,
+                                            absl::string_view matched_path) const;
+
 private:
   struct RuntimeData {
     std::string fractional_runtime_key_{};
@@ -600,6 +604,10 @@ private:
       return parent_->clusterNotFoundResponseCode();
     }
 
+    absl::optional<std::string>
+    currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const override {
+      return parent_->currentUrlPathAfterRewrite(headers);
+    }
     void finalizeRequestHeaders(Http::RequestHeaderMap& headers,
                                 const StreamInfo::StreamInfo& stream_info,
                                 bool insert_envoy_original_path) const override {
@@ -862,6 +870,10 @@ public:
   void rewritePathHeader(Http::RequestHeaderMap& headers,
                          bool insert_envoy_original_path) const override;
 
+  // Router::RouteEntry
+  absl::optional<std::string>
+  currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const override;
+
 private:
   const std::string prefix_;
   const Matchers::PathMatcherConstSharedPtr path_matcher_;
@@ -888,6 +900,10 @@ public:
   // Router::DirectResponseEntry
   void rewritePathHeader(Http::RequestHeaderMap& headers,
                          bool insert_envoy_original_path) const override;
+
+  // Router::RouteEntry
+  absl::optional<std::string>
+  currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const override;
 
 private:
   const std::string path_;
@@ -916,6 +932,10 @@ public:
   void rewritePathHeader(Http::RequestHeaderMap& headers,
                          bool insert_envoy_original_path) const override;
 
+  // Router::RouteEntry
+  absl::optional<std::string>
+  currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const override;
+
 private:
   Regex::CompiledMatcherPtr regex_;
   std::string regex_str_;
@@ -941,6 +961,10 @@ public:
 
   // Router::DirectResponseEntry
   void rewritePathHeader(Http::RequestHeaderMap&, bool) const override;
+
+  // Router::RouteEntry
+  absl::optional<std::string>
+  currentUrlPathAfterRewrite(const Http::RequestHeaderMap& headers) const override;
 
   bool supportsPathlessHeaders() const override { return true; }
 };

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -577,6 +577,7 @@ virtual_hosts:
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("bat3.com", "/api/locations?works=true", "CONNECT");
     const RouteEntry* route = config.route(headers, 0)->routeEntry();
+    EXPECT_EQ("/rewrote?works=true", route->currentUrlPathAfterRewrite(headers));
     route->finalizeRequestHeaders(headers, stream_info, true);
     EXPECT_EQ("/rewrote?works=true", headers.get_(Http::Headers::get().Path));
   }

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -382,6 +382,8 @@ public:
   MOCK_METHOD((const std::multimap<std::string, std::string>&), opaqueConfig, (), (const));
   MOCK_METHOD(bool, includeVirtualHostRateLimits, (), (const));
   MOCK_METHOD(const CorsPolicy*, corsPolicy, (), (const));
+  MOCK_METHOD(absl::optional<std::string>, currentUrlPathAfterRewrite,
+              (const Http::RequestHeaderMap&), (const));
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, metadata, (), (const));
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
   MOCK_METHOD(const PathMatchCriterion&, pathMatchCriterion, (), (const));


### PR DESCRIPTION
It returns the URL path as it will be calculated by finalizeRequestHeaders
using current values of headers. Note that final path may be different if
headers change before finalization.

Signed-off-by: Misha Efimov <mef@google.com>

Commit Message: Add RouteEntry::currentUrlPathAfterRewrite method.
Additional Description:
Risk Level: Low
Testing: Updated RouteMatcherTest::TestRoutes
Docs Changes: none
Release Notes: none
Platform Specific Features:
Fixes #15246 
