### PR TITLE
DO_NOT_SUBMIT quic: Revert "quiche: update QUICHE and boringSSL dependency (#15181)"

### DIFF
--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -57,7 +57,6 @@ quiche_common_copts = [
     "-Wno-unused-function",
     # quic_inlined_frame.h uses offsetof() to optimize memory usage in frames.
     "-Wno-invalid-offsetof",
-    "-Wno-parentheses",
 ]
 
 quiche_copts = select({
@@ -200,7 +199,6 @@ envoy_cc_library(
         ":http2_decoder_payload_decoders_headers_payload_decoder_lib",
         ":http2_decoder_payload_decoders_ping_payload_decoder_lib",
         ":http2_decoder_payload_decoders_priority_payload_decoder_lib",
-        ":http2_decoder_payload_decoders_priority_update_payload_decoder_lib",
         ":http2_decoder_payload_decoders_push_promise_payload_decoder_lib",
         ":http2_decoder_payload_decoders_rst_stream_payload_decoder_lib",
         ":http2_decoder_payload_decoders_settings_payload_decoder_lib",
@@ -409,28 +407,6 @@ envoy_cc_library(
         ":http2_decoder_frame_decoder_state_lib",
         ":http2_platform",
         ":http2_structures_lib",
-    ],
-)
-
-envoy_cc_library(
-    name = "http2_decoder_payload_decoders_priority_update_payload_decoder_lib",
-    srcs = [
-        "quiche/http2/decoder/payload_decoders/priority_update_payload_decoder.cc",
-    ],
-    hdrs = [
-        "quiche/http2/decoder/payload_decoders/priority_update_payload_decoder.h",
-    ],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_constants_lib",
-        ":http2_decoder_decode_buffer_lib",
-        ":http2_decoder_decode_status_lib",
-        ":http2_decoder_frame_decoder_listener_lib",
-        ":http2_decoder_frame_decoder_state_lib",
-        ":http2_platform",
-        ":http2_structures_lib",
-        ":quiche_common_platform_export",
     ],
 )
 
@@ -758,9 +734,9 @@ envoy_cc_library(
         "quiche/spdy/platform/api/spdy_bug_tracker.h",
         "quiche/spdy/platform/api/spdy_containers.h",
         "quiche/spdy/platform/api/spdy_estimate_memory_usage.h",
-        "quiche/spdy/platform/api/spdy_flag_utils.h",
         "quiche/spdy/platform/api/spdy_flags.h",
         "quiche/spdy/platform/api/spdy_logging.h",
+        "quiche/spdy/platform/api/spdy_macros.h",
         "quiche/spdy/platform/api/spdy_mem_slice.h",
         "quiche/spdy/platform/api/spdy_string_utils.h",
     ],
@@ -938,6 +914,7 @@ envoy_cc_library(
         "quiche/spdy/core/hpack/hpack_encoder.cc",
         "quiche/spdy/core/hpack/hpack_entry.cc",
         "quiche/spdy/core/hpack/hpack_header_table.cc",
+        "quiche/spdy/core/hpack/hpack_huffman_table.cc",
         "quiche/spdy/core/hpack/hpack_output_stream.cc",
         "quiche/spdy/core/hpack/hpack_static_table.cc",
     ],
@@ -946,6 +923,7 @@ envoy_cc_library(
         "quiche/spdy/core/hpack/hpack_encoder.h",
         "quiche/spdy/core/hpack/hpack_entry.h",
         "quiche/spdy/core/hpack/hpack_header_table.h",
+        "quiche/spdy/core/hpack/hpack_huffman_table.h",
         "quiche/spdy/core/hpack/hpack_output_stream.h",
         "quiche/spdy/core/hpack/hpack_static_table.h",
     ],
@@ -1048,6 +1026,7 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_mutex.cc",
     ],
     hdrs = [
+        "quiche/quic/platform/api/quic_cert_utils.h",
         "quiche/quic/platform/api/quic_file_utils.h",
         "quiche/quic/platform/api/quic_hostname_utils.h",
         "quiche/quic/platform/api/quic_mutex.h",
@@ -1084,6 +1063,7 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_server_stats.h",
         "quiche/quic/platform/api/quic_stack_trace.h",
         "quiche/quic/platform/api/quic_stream_buffer_allocator.h",
+        "quiche/quic/platform/api/quic_string_utils.h",
         "quiche/quic/platform/api/quic_uint128.h",
         "quiche/quic/platform/api/quic_testvalue.h",
         # TODO: uncomment the following files as implementations are added.
@@ -1106,9 +1086,7 @@ envoy_cc_library(
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
-    deps = [
-        ":quiche_common_platform_default_quiche_platform_impl_export_lib",
-    ],
+    deps = ["@envoy//source/extensions/quic_listeners/quiche/platform:quic_platform_export_impl_lib"],
 )
 
 envoy_cc_test_library(
@@ -1243,46 +1221,13 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "quiche_common_platform_default_quiche_platform_impl_lib",
-    srcs = [
-        "quiche/common/platform/default/quiche_platform_impl/quic_mutex_impl.cc",
-        "quiche/common/platform/default/quiche_platform_impl/quiche_time_utils_impl.cc",
-    ],
-    hdrs = [
-        "quiche/common/platform/default/quiche_platform_impl/quic_mutex_impl.h",
-        "quiche/common/platform/default/quiche_platform_impl/quic_testvalue_impl.h",
-        "quiche/common/platform/default/quiche_platform_impl/quiche_containers_impl.h",
-        "quiche/common/platform/default/quiche_platform_impl/quiche_estimate_memory_usage_impl.h",
-        "quiche/common/platform/default/quiche_platform_impl/quiche_time_utils_impl.h",
-    ],
-    repository = "@envoy",
-    tags = ["nofips"],
-    deps = [
-        ":quic_platform_export",
-        ":quiche_common_platform_export",
-    ],
-)
-
-envoy_cc_library(
-    name = "quiche_common_platform_default_quiche_platform_impl_export_lib",
-    hdrs = [
-        "quiche/common/platform/default/quiche_platform_impl/quiche_export_impl.h",
-    ],
-    repository = "@envoy",
-    tags = ["nofips"],
-)
-
-envoy_cc_library(
     name = "quiche_common_platform_export",
-    hdrs = [
-        "quiche/common/platform/api/quiche_export.h",
-    ],
+    hdrs = ["quiche/common/platform/api/quiche_export.h"],
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
-    deps = [
-        ":quiche_common_platform_default_quiche_platform_impl_export_lib",
-    ],
+    deps =
+        ["@envoy//source/extensions/quic_listeners/quiche/platform:quiche_common_platform_export_impl_lib"],
 )
 
 envoy_cc_test_library(
@@ -1879,7 +1824,6 @@ envoy_cc_library(
         ":quic_core_packet_creator_lib",
         ":quic_core_packet_writer_interface_lib",
         ":quic_core_packets_lib",
-        ":quic_core_path_validator_lib",
         ":quic_core_proto_cached_network_parameters_proto_header",
         ":quic_core_sent_packet_manager_lib",
         ":quic_core_time_lib",
@@ -2327,7 +2271,6 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "quic_core_http_http_constants_lib",
-    srcs = ["quiche/quic/core/http/http_constants.cc"],
     hdrs = ["quiche/quic/core/http/http_constants.h"],
     copts = quiche_copts,
     repository = "@envoy",
@@ -3270,8 +3213,6 @@ envoy_cc_library(
         ":quic_core_crypto_random_lib",
         ":quic_core_crypto_tls_handshake_lib",
         ":quic_core_frames_frames_lib",
-        ":quic_core_http_http_decoder_lib",
-        ":quic_core_http_http_encoder_lib",
         ":quic_core_packet_creator_lib",
         ":quic_core_packets_lib",
         ":quic_core_server_id_lib",
@@ -3963,18 +3904,17 @@ envoy_cc_test_library(
 envoy_cc_library(
     name = "quiche_common_platform",
     hdrs = [
-        "quiche/common/platform/api/quiche_flag_utils.h",
-        "quiche/common/platform/api/quiche_flags.h",
         "quiche/common/platform/api/quiche_logging.h",
+        "quiche/common/platform/api/quiche_str_cat.h",
         "quiche/common/platform/api/quiche_string_piece.h",
         "quiche/common/platform/api/quiche_text_utils.h",
         "quiche/common/platform/api/quiche_time_utils.h",
+        "quiche/common/platform/api/quiche_unordered_containers.h",
     ],
     repository = "@envoy",
     tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
-        ":quiche_common_platform_default_quiche_platform_impl_lib",
         ":quiche_common_platform_export",
         "@envoy//source/extensions/quic_listeners/quiche/platform:quiche_common_platform_impl_lib",
     ],
@@ -3983,6 +3923,7 @@ envoy_cc_library(
 envoy_cc_test_library(
     name = "quiche_common_platform_test",
     srcs = [
+        "quiche/common/platform/api/quiche_str_cat_test.cc",
         "quiche/common/platform/api/quiche_text_utils_test.cc",
         "quiche/common/platform/api/quiche_time_utils_test.cc",
     ],
@@ -4115,6 +4056,7 @@ envoy_cc_test(
         # "quiche/quic/platform/api/quic_mem_slice_storage_test.cc",
         "quiche/quic/platform/api/quic_mem_slice_test.cc",
         "quiche/quic/platform/api/quic_reference_counted_test.cc",
+        "quiche/quic/platform/api/quic_string_utils_test.cc",
     ],
     copts = quiche_copts,
     repository = "@envoy",

--- a/bazel/external/quiche.genrule_cmd
+++ b/bazel/external/quiche.genrule_cmd
@@ -39,16 +39,8 @@ cat <<EOF >sed_commands
 # Rewrite include directives for epoll_server platform impl files.
 /^#include/ s!net/tools/epoll_server/platform/impl!test/extensions/quic_listeners/quiche/platform/!
 
-# Append "quiche/" to include directives to other QUICHE files.
-/^#include/ s!"quic/!"quiche/quic/!
-/^#include/ s!"spdy/!"quiche/spdy/!
-/^#include/ s!"http2/!"quiche/http2/!
-/^#include/ s!"common/!"quiche/common/!
-/^#include/ s!"epoll_server/!"quiche/epoll_server/!
-
-# Use envoy specific implementations for below platform APIs.
-/^#include/ s!"quiche_platform_impl/quiche_logging_impl.h!"extensions/quic_listeners/quiche/platform/quiche_logging_impl.h!
-/^#include/ s!"quiche_platform_impl/!"quiche/common/platform/default/quiche_platform_impl/!
+# Strip "net/third_party" from include directives to other QUICHE files.
+/^#include/ s!net/third_party/quiche/src/!quiche/!
 
 # Rewrite gmock & gtest includes.
 /^#include/ s!testing/gmock/include/gmock/!gmock/!
@@ -58,7 +50,7 @@ cat <<EOF >sed_commands
 /^#include/ s!third_party/boringssl/src/include/!!
 /^#include/ s!third_party/zlib/zlib!zlib!
 
-/^import/ s!quic/core/proto/cached_network_parameters!quiche/quic/core/proto/cached_network_parameters!
+/^import/ s!cached_network_parameters!quiche/quic/core/proto/cached_network_parameters!
 
 # Rewrite #pragma clang
 /^#pragma/ s!clang!GCC!

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -81,13 +81,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         # 2. Open https://chromium.googlesource.com/chromium/src/+/refs/tags/<current_version>/DEPS and note <boringssl_revision>.
         # 3. Find a commit in BoringSSL's "master-with-bazel" branch that merges <boringssl_revision>.
         #
-        # chromium-90.0.4395.0(linux/dev)
-        version = "b049eae83d25977661556dcd913b35fbafb3a93a",
-        sha256 = "d78f7b11b8665feea1b6def8e6f235ad8671db8de950f5429f1bf2b3503b3894",
+        # chromium-88.0.4324.96
+        version = "fbbf8781456c38a90f674d4771126ed39132855b",
+        sha256 = "76a571c1c3f6f6618d538384319ccc2b7ba9f7ae3f60087ba67894faba11a6b6",
         strip_prefix = "boringssl-{version}",
         urls = ["https://github.com/google/boringssl/archive/{version}.tar.gz"],
         use_category = ["controlplane", "dataplane_core"],
-        release_date = "2021-01-25",
+        release_date = "2020-11-04",
         cpe = "cpe:2.3:a:google:boringssl:*",
     ),
     boringssl_fips = dict(
@@ -752,13 +752,13 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "QUICHE",
         project_desc = "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols",
         project_url = "https://quiche.googlesource.com/quiche",
-        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/2475cc8246d3e77e391347ae319f0ab9db132fb4.tar.gz
-        version = "6fec8e97a1ab1a945b86bd6b7252666294448ddb",
-        sha256 = "3045254cbf03c29ee7166fb01b1072a463c58df405669b8573677d4638869290",
+        # Static snapshot of https://quiche.googlesource.com/quiche/+archive/ecc28c0d7428f3323ea26eb1ddb98a5e06b23dea.tar.gz
+        version = "ecc28c0d7428f3323ea26eb1ddb98a5e06b23dea",
+        sha256 = "52680dea984dbe899c27176155578b97276e1f1516b7c3a63fb16ba593061859",
         urls = ["https://storage.googleapis.com/quiche-envoy-integration/{version}.tar.gz"],
         use_category = ["dataplane_ext"],
         extensions = ["envoy.transport_sockets.quic", "envoy.listener.quic"],
-        release_date = "2021-02-24",
+        release_date = "2020-11-10",
         cpe = "N/A",
     ),
     com_googlesource_googleurl = dict(

--- a/source/extensions/quic_listeners/quiche/codec_impl.h
+++ b/source/extensions/quic_listeners/quiche/codec_impl.h
@@ -33,6 +33,10 @@ public:
   // stream send buffer.
   bool wantsToWrite() override;
 
+  void runWatermarkCallbacksForEachStream(
+      quic::QuicSmallMap<quic::QuicStreamId, std::unique_ptr<quic::QuicStream>, 10>& stream_map,
+      bool high_watermark);
+
 protected:
   QuicFilterManagerConnectionImpl& quic_session_;
 };

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_session.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_session.cc
@@ -13,15 +13,16 @@ EnvoyQuicClientSession::EnvoyQuicClientSession(
     uint32_t send_buffer_limit)
     : QuicFilterManagerConnectionImpl(*connection, dispatcher, send_buffer_limit),
       quic::QuicSpdyClientSession(config, supported_versions, connection.release(), server_id,
-                                  crypto_config, push_promise_index),
-      host_name_(server_id.host()) {}
+                                  crypto_config, push_promise_index) {}
 
 EnvoyQuicClientSession::~EnvoyQuicClientSession() {
   ASSERT(!connection()->connected());
   quic_connection_ = nullptr;
 }
 
-absl::string_view EnvoyQuicClientSession::requestedServerName() const { return host_name_; }
+absl::string_view EnvoyQuicClientSession::requestedServerName() const {
+  return {GetCryptoStream()->crypto_negotiated_params().sni};
+}
 
 void EnvoyQuicClientSession::connect() {
   dynamic_cast<EnvoyQuicClientConnection*>(quic_connection_)->setUpConnectionSocket();

--- a/source/extensions/quic_listeners/quiche/envoy_quic_client_session.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_client_session.h
@@ -62,7 +62,7 @@ public:
   // quic::QuicSpdyClientSessionBase
   void SetDefaultEncryptionLevel(quic::EncryptionLevel level) override;
 
-  using quic::QuicSpdyClientSession::PerformActionOnActiveStreams;
+  using quic::QuicSpdyClientSession::stream_map;
 
 protected:
   // quic::QuicSpdyClientSession
@@ -78,7 +78,6 @@ private:
   // These callbacks are owned by network filters and quic session should outlive
   // them.
   Http::ConnectionCallbacks* http_connection_callbacks_{nullptr};
-  const absl::string_view host_name_;
 };
 
 } // namespace Quic

--- a/source/extensions/quic_listeners/quiche/envoy_quic_connection.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_connection.h
@@ -52,6 +52,11 @@ public:
 protected:
   Network::Connection::ConnectionStats& connectionStats() const { return *connection_stats_; }
 
+  Network::Connection& envoyConnection() const {
+    ASSERT(envoy_connection_ != nullptr);
+    return *envoy_connection_;
+  }
+
   void setConnectionSocket(Network::ConnectionSocketPtr&& connection_socket) {
     connection_socket_ = std::move(connection_socket);
   }

--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier.cc
@@ -12,7 +12,7 @@ quic::QuicAsyncStatus EnvoyQuicProofVerifier::VerifyCertChain(
     const std::string& hostname, const uint16_t /*port*/, const std::vector<std::string>& certs,
     const std::string& /*ocsp_response*/, const std::string& /*cert_sct*/,
     const quic::ProofVerifyContext* /*context*/, std::string* error_details,
-    std::unique_ptr<quic::ProofVerifyDetails>* /*details*/, uint8_t* /*out_alert*/,
+    std::unique_ptr<quic::ProofVerifyDetails>* /*details*/,
     std::unique_ptr<quic::ProofVerifierCallback> /*callback*/) {
   ASSERT(!certs.empty());
   bssl::UniquePtr<STACK_OF(X509)> intermediates(sk_X509_new_null());

--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier.h
@@ -20,7 +20,6 @@ public:
                   const std::vector<std::string>& certs, const std::string& ocsp_response,
                   const std::string& cert_sct, const quic::ProofVerifyContext* context,
                   std::string* error_details, std::unique_ptr<quic::ProofVerifyDetails>* details,
-                  uint8_t* out_alert,
                   std::unique_ptr<quic::ProofVerifierCallback> callback) override;
 
 private:

--- a/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_base.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_base.cc
@@ -26,7 +26,7 @@ quic::QuicAsyncStatus EnvoyQuicProofVerifierBase::VerifyProof(
   }
 
   return VerifyCertChain(hostname, port, certs, "", cert_sct, context, error_details, details,
-                         nullptr, std::move(callback));
+                         std::move(callback));
 }
 
 bool EnvoyQuicProofVerifierBase::verifySignature(const std::string& server_config,

--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_session.h
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_session.h
@@ -59,7 +59,7 @@ public:
   // quic::QuicSpdySession
   void SetDefaultEncryptionLevel(quic::EncryptionLevel level) override;
 
-  using quic::QuicSession::PerformActionOnActiveStreams;
+  using quic::QuicSession::stream_map;
 
 protected:
   // quic::QuicServerSessionBase

--- a/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.cc
+++ b/source/extensions/quic_listeners/quiche/envoy_quic_server_stream.cc
@@ -130,7 +130,6 @@ void EnvoyQuicServerStream::resetStream(Http::StreamResetReason reason) {
     // of propagating original reset reason. In QUICHE if a stream stops reading
     // before FIN or RESET received, it resets the steam with QUIC_STREAM_NO_ERROR.
     StopReading();
-    runResetCallbacks(Http::StreamResetReason::LocalReset);
   } else {
     Reset(envoyResetReasonToQuicRstError(reason));
   }

--- a/source/extensions/quic_listeners/quiche/platform/BUILD
+++ b/source/extensions/quic_listeners/quiche/platform/BUILD
@@ -34,9 +34,9 @@ envoy_extension_package()
 # TODO: add build target for quic_platform_impl_lib
 
 envoy_cc_library(
-    name = "quiche_flags_impl_lib",
-    srcs = ["quiche_flags_impl.cc"],
-    hdrs = ["quiche_flags_impl.h"],
+    name = "flags_impl_lib",
+    srcs = ["flags_impl.cc"],
+    hdrs = ["flags_impl.h"],
     external_deps = [
         "abseil_base",
         "abseil_synchronization",
@@ -66,6 +66,8 @@ envoy_cc_library(
         "http2_bug_tracker_impl.h",
         "http2_containers_impl.h",
         "http2_estimate_memory_usage_impl.h",
+        "http2_flag_utils_impl.h",
+        "http2_flags_impl.h",
         "http2_logging_impl.h",
         "http2_macros_impl.h",
         "http2_string_utils_impl.h",
@@ -76,8 +78,8 @@ envoy_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":flags_impl_lib",
         ":quic_platform_logging_impl_lib",
-        ":quiche_flags_impl_lib",
         ":string_utils_lib",
     ],
 )
@@ -115,6 +117,7 @@ envoy_cc_library(
         "quic_containers_impl.h",
         "quic_error_code_wrappers_impl.h",
         "quic_estimate_memory_usage_impl.h",
+        "quic_flag_utils_impl.h",
         "quic_flags_impl.h",
         "quic_iovec_impl.h",
         "quic_map_util_impl.h",
@@ -139,13 +142,12 @@ envoy_cc_library(
     tags = ["nofips"],
     visibility = ["//visibility:public"],
     deps = [
-        ":quiche_flags_impl_lib",
+        ":flags_impl_lib",
         ":string_utils_lib",
         "//include/envoy/api:io_error_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:assert_lib",
         "//source/server:backtrace_lib",
-        "@com_google_absl//absl/container:btree",
         "@com_googlesource_quiche//:quic_core_buffer_allocator_lib",
         "@com_googlesource_quiche//:quic_platform_export",
         "@com_googlesource_quiche//:quic_platform_ip_address_family",
@@ -156,14 +158,17 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_platform_impl_lib",
     srcs = [
+        "quic_cert_utils_impl.cc",
         "quic_file_utils_impl.cc",
         "quic_hostname_utils_impl.cc",
     ],
     hdrs = [
+        "quic_cert_utils_impl.h",
         "quic_file_utils_impl.h",
         "quic_hostname_utils_impl.h",
         "quic_mutex_impl.h",
         "quic_pcc_sender_impl.h",
+        "quic_string_utils_impl.h",
     ],
     external_deps = [
         "quiche_quic_platform_base",
@@ -244,12 +249,15 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "quiche_common_platform_impl_lib",
+    srcs = ["quiche_time_utils_impl.cc"],
     hdrs = [
-        "quiche_flag_utils_impl.h",
         "quiche_logging_impl.h",
         "quiche_map_util_impl.h",
+        "quiche_str_cat_impl.h",
         "quiche_string_piece_impl.h",
         "quiche_text_utils_impl.h",
+        "quiche_time_utils_impl.h",
+        "quiche_unordered_containers_impl.h",
     ],
     external_deps = [
         "abseil_hash",
@@ -258,7 +266,6 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_logging_impl_lib",
-        ":quiche_flags_impl_lib",
         ":string_utils_lib",
     ],
 )
@@ -269,7 +276,9 @@ envoy_cc_library(
         "spdy_bug_tracker_impl.h",
         "spdy_containers_impl.h",
         "spdy_estimate_memory_usage_impl.h",
+        "spdy_flags_impl.h",
         "spdy_logging_impl.h",
+        "spdy_macros_impl.h",
         "spdy_mem_slice_impl.h",
         "spdy_string_utils_impl.h",
         "spdy_test_helpers_impl.h",
@@ -284,8 +293,8 @@ envoy_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":flags_impl_lib",
         ":quic_platform_logging_impl_lib",
-        ":quiche_flags_impl_lib",
         ":string_utils_lib",
         "//source/common/common:assert_lib",
         "@com_googlesource_quiche//:quiche_common_lib",

--- a/source/extensions/quic_listeners/quiche/platform/flags_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/flags_impl.cc
@@ -4,7 +4,7 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
-#include "extensions/quic_listeners/quiche/platform/quiche_flags_impl.h"
+#include "extensions/quic_listeners/quiche/platform/flags_impl.h"
 
 #include <set>
 

--- a/source/extensions/quic_listeners/quiche/platform/flags_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/flags_impl.h
@@ -121,20 +121,4 @@ QUIC_FLAG(FLAGS_quic_restart_flag_http2_testonly_default_true, true)
 #include "quiche/quic/core/quic_protocol_flags_list.h"
 #undef QUIC_PROTOCOL_FLAG
 
-// |flag| is the global flag variable, which is a pointer to TypedFlag<type>.
-#define GetQuicheFlagImpl(flag) (quiche::flag)->value()
-
-// |flag| is the global flag variable, which is a pointer to TypedFlag<type>.
-#define SetQuicheFlagImpl(flag, value) (quiche::flag)->setValue(value)
-
-#define GetQuicheReloadableFlagImpl(module, flag) quiche::FLAGS_quic_reloadable_flag_##flag->value()
-
-#define SetQuicheReloadableFlagImpl(module, flag, value)                                           \
-  quiche::FLAGS_quic_reloadable_flag_##flag->setValue(value)
-
-#define GetQuicheRestartFlagImpl(module, flag) quiche::FLAGS_quic_restart_flag_##flag->value()
-
-#define SetQuicheRestartFlagImpl(module, flag, value)                                              \
-  quiche::FLAGS_quic_restart_flag_##flag->setValue(value)
-
 } // namespace quiche

--- a/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/http2_macros_impl.h
@@ -14,12 +14,12 @@
 
 #define HTTP2_FALLTHROUGH_IMPL ABSL_FALLTHROUGH_INTENDED
 #define HTTP2_DIE_IF_NULL_IMPL(ptr) dieIfNull(ptr)
-#define HTTP2_UNREACHABLE_IMPL() QUICHE_DCHECK(false)
+#define HTTP2_UNREACHABLE_IMPL() DCHECK(false)
 
 namespace http2 {
 
 template <typename T> inline T dieIfNull(T&& ptr) {
-  QUICHE_CHECK((ptr) != nullptr);
+  CHECK((ptr) != nullptr);
   return std::forward<T>(ptr);
 }
 

--- a/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.cc
@@ -1,0 +1,68 @@
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h"
+
+#include "openssl/bytestring.h"
+
+namespace quic {
+
+bool seekToSubject(absl::string_view cert, CBS* tbs_certificate) {
+  CBS der;
+  CBS_init(&der, reinterpret_cast<const uint8_t*>(cert.data()), cert.size());
+  CBS certificate;
+  // From RFC 5280, section 4.1
+  //    Certificate  ::=  SEQUENCE  {
+  //      tbsCertificate       TBSCertificate,
+  //      signatureAlgorithm   AlgorithmIdentifier,
+  //      signatureValue       BIT STRING  }
+
+  // TBSCertificate  ::=  SEQUENCE  {
+  //      version         [0]  EXPLICIT Version DEFAULT v1,
+  //      serialNumber         CertificateSerialNumber,
+  //      signature            AlgorithmIdentifier,
+  //      issuer               Name,
+  //      validity             Validity,
+  //      subject              Name,
+  //      subjectPublicKeyInfo SubjectPublicKeyInfo,
+  if (!CBS_get_asn1(&der, &certificate, CBS_ASN1_SEQUENCE) ||
+      CBS_len(&der) != 0 || // We don't allow junk after the certificate.
+      !CBS_get_asn1(&certificate, tbs_certificate, CBS_ASN1_SEQUENCE) ||
+      // version.
+      !CBS_get_optional_asn1(tbs_certificate, nullptr, nullptr,
+                             CBS_ASN1_CONSTRUCTED | CBS_ASN1_CONTEXT_SPECIFIC | 0) ||
+      // Serial number.
+      !CBS_get_asn1(tbs_certificate, nullptr, CBS_ASN1_INTEGER) ||
+      // Signature.
+      !CBS_get_asn1(tbs_certificate, nullptr, CBS_ASN1_SEQUENCE) ||
+      // Issuer.
+      !CBS_get_asn1(tbs_certificate, nullptr, CBS_ASN1_SEQUENCE) ||
+      // Validity.
+      !CBS_get_asn1(tbs_certificate, nullptr, CBS_ASN1_SEQUENCE)) {
+    return false;
+  }
+  return true;
+}
+
+// static
+// NOLINTNEXTLINE(readability-identifier-naming)
+bool QuicCertUtilsImpl::ExtractSubjectNameFromDERCert(absl::string_view cert,
+                                                      absl::string_view* subject_out) {
+  CBS tbs_certificate;
+  if (!seekToSubject(cert, &tbs_certificate)) {
+    return false;
+  }
+
+  CBS subject;
+  if (!CBS_get_asn1_element(&tbs_certificate, &subject, CBS_ASN1_SEQUENCE)) {
+    return false;
+  }
+  *subject_out =
+      absl::string_view(reinterpret_cast<const char*>(CBS_data(&subject)), CBS_len(&subject));
+  return true;
+}
+
+} // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_cert_utils_impl.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#include "absl/strings/string_view.h"
+#include "openssl/base.h"
+
+namespace quic {
+
+class QuicCertUtilsImpl {
+public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static bool ExtractSubjectNameFromDERCert(absl::string_view cert, absl::string_view* subject_out);
+};
+
+} // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_containers_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_containers_impl.h
@@ -6,7 +6,6 @@
 #include <queue>
 #include <sstream>
 
-#include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
@@ -63,8 +62,5 @@ inline std::ostream& operator<<(std::ostream& os,
   debug_string << "}";
   return os << debug_string.str();
 }
-
-template <typename Key, typename Compare, typename Rep>
-using QuicOrderedSetImpl = absl::btree_set<Key, Compare>;
 
 } // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_flag_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_flag_utils_impl.h
@@ -6,26 +6,26 @@
 // consumed or referenced directly by other Envoy code. It serves purely as a
 // porting layer for QUICHE.
 
-#define QUICHE_RELOADABLE_FLAG_COUNT_IMPL(flag)                                                    \
+#define QUIC_RELOADABLE_FLAG_COUNT_IMPL(flag)                                                      \
   do {                                                                                             \
   } while (0)
 
-#define QUICHE_RELOADABLE_FLAG_COUNT_N_IMPL(flag, instance, total)                                 \
+#define QUIC_RELOADABLE_FLAG_COUNT_N_IMPL(flag, instance, total)                                   \
   do {                                                                                             \
   } while (0)
 
-#define QUICHE_RESTART_FLAG_COUNT_IMPL(flag)                                                       \
+#define QUIC_RESTART_FLAG_COUNT_IMPL(flag)                                                         \
   do {                                                                                             \
   } while (0)
 
-#define QUICHE_RESTART_FLAG_COUNT_N_IMPL(flag, instance, total)                                    \
+#define QUIC_RESTART_FLAG_COUNT_N_IMPL(flag, instance, total)                                      \
   do {                                                                                             \
   } while (0)
 
-#define QUICHE_CODE_COUNT_IMPL(name)                                                               \
+#define QUIC_CODE_COUNT_IMPL(name)                                                                 \
   do {                                                                                             \
   } while (0)
 
-#define QUICHE_CODE_COUNT_N_IMPL(name, instance, total)                                            \
+#define QUIC_CODE_COUNT_N_IMPL(name, instance, total)                                              \
   do {                                                                                             \
   } while (0)

--- a/source/extensions/quic_listeners/quiche/platform/quic_flags_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_flags_impl.h
@@ -9,7 +9,22 @@
 #include <string>
 #include <vector>
 
-#include "extensions/quic_listeners/quiche/platform/quiche_flags_impl.h"
+#include "extensions/quic_listeners/quiche/platform/flags_impl.h"
+
+// |flag| is the global flag variable, which is a pointer to TypedFlag<type>.
+#define GetQuicFlagImpl(flag) (quiche::flag)->value()
+
+// |flag| is the global flag variable, which is a pointer to TypedFlag<type>.
+#define SetQuicFlagImpl(flag, value) (quiche::flag)->setValue(value)
+
+#define GetQuicReloadableFlagImpl(flag) quiche::FLAGS_quic_reloadable_flag_##flag->value()
+
+#define SetQuicReloadableFlagImpl(flag, value)                                                     \
+  quiche::FLAGS_quic_reloadable_flag_##flag->setValue(value)
+
+#define GetQuicRestartFlagImpl(flag) quiche::FLAGS_quic_restart_flag_##flag->value()
+
+#define SetQuicRestartFlagImpl(flag, value) quiche::FLAGS_quic_restart_flag_##flag->setValue(value)
 
 // Not wired into command-line parsing.
 #define DEFINE_QUIC_COMMAND_LINE_FLAG_IMPL(type, flag, value, help)                                \

--- a/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_logging_impl.h
@@ -65,19 +65,19 @@
 #define QUICHE_LOG_WARNING_IS_ON_IMPL() quic::IsLogLevelEnabled(quic::WARNING)
 #define QUICHE_LOG_ERROR_IS_ON_IMPL() quic::IsLogLevelEnabled(quic::ERROR)
 
-#define QUICHE_CHECK_IMPL(condition)                                                               \
+#define CHECK(condition)                                                                           \
   QUICHE_LOG_IF_IMPL(FATAL, ABSL_PREDICT_FALSE(!(condition))) << "CHECK failed: " #condition "."
 
-#define QUICHE_CHECK_GT_IMPL(a, b) QUICHE_CHECK_IMPL((a) > (b))
-#define QUICHE_CHECK_GE_IMPL(a, b) QUICHE_CHECK_IMPL((a) >= (b))
-#define QUICHE_CHECK_LT_IMPL(a, b) QUICHE_CHECK_IMPL((a) < (b))
-#define QUICHE_CHECK_LE_IMPL(a, b) QUICHE_CHECK_IMPL((a) <= (b))
-#define QUICHE_CHECK_NE_IMPL(a, b) QUICHE_CHECK_IMPL((a) != (b))
-#define QUICHE_CHECK_EQ_IMPL(a, b) QUICHE_CHECK_IMPL((a) == (b))
+#define CHECK_GT(a, b) CHECK((a) > (b))
+#define CHECK_GE(a, b) CHECK((a) >= (b))
+#define CHECK_LT(a, b) CHECK((a) < (b))
+#define CHECK_LE(a, b) CHECK((a) <= (b))
+#define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_EQ(a, b) CHECK((a) == (b))
 
 #ifdef NDEBUG
 // Release build
-#define QUICHE_DCHECK_IMPL(condition) QUICHE_COMPILED_OUT_LOG(condition)
+#define DCHECK(condition) QUICHE_COMPILED_OUT_LOG(condition)
 #define QUICHE_COMPILED_OUT_LOG(condition)                                                         \
   QUICHE_LOG_IMPL_INTERNAL(false && (condition), quic::NullLogStream().stream())
 #define QUICHE_DVLOG_IMPL(verbosity) QUICHE_COMPILED_OUT_LOG(false)
@@ -89,7 +89,7 @@
 #define QUICHE_NOTREACHED_IMPL()
 #else
 // Debug build
-#define QUICHE_DCHECK_IMPL(condition) QUICHE_CHECK_IMPL(condition)
+#define DCHECK(condition) CHECK(condition)
 #define QUICHE_DVLOG_IMPL(verbosity) QUICHE_VLOG_IMPL(verbosity)
 #define QUICHE_DVLOG_IF_IMPL(verbosity, condition) QUICHE_VLOG_IF_IMPL(verbosity, condition)
 #define QUICHE_DLOG_IMPL(severity) QUICHE_LOG_IMPL(severity)
@@ -99,12 +99,12 @@
 #define QUICHE_NOTREACHED_IMPL() NOT_REACHED_GCOVR_EXCL_LINE
 #endif
 
-#define QUICHE_DCHECK_GE_IMPL(a, b) QUICHE_DCHECK_IMPL((a) >= (b))
-#define QUICHE_DCHECK_GT_IMPL(a, b) QUICHE_DCHECK_IMPL((a) > (b))
-#define QUICHE_DCHECK_LT_IMPL(a, b) QUICHE_DCHECK_IMPL((a) < (b))
-#define QUICHE_DCHECK_LE_IMPL(a, b) QUICHE_DCHECK_IMPL((a) <= (b))
-#define QUICHE_DCHECK_NE_IMPL(a, b) QUICHE_DCHECK_IMPL((a) != (b))
-#define QUICHE_DCHECK_EQ_IMPL(a, b) QUICHE_DCHECK_IMPL((a) == (b))
+#define DCHECK_GE(a, b) DCHECK((a) >= (b))
+#define DCHECK_GT(a, b) DCHECK((a) > (b))
+#define DCHECK_LT(a, b) DCHECK((a) < (b))
+#define DCHECK_LE(a, b) DCHECK((a) <= (b))
+#define DCHECK_NE(a, b) DCHECK((a) != (b))
+#define DCHECK_EQ(a, b) DCHECK((a) == (b))
 
 #define QUICHE_PREDICT_FALSE_IMPL(x) ABSL_PREDICT_FALSE(x)
 

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.cc
@@ -14,16 +14,10 @@ namespace quic {
 
 QuicMemSliceImpl::QuicMemSliceImpl(QuicUniqueBufferPtr buffer, size_t length)
     : fragment_(std::make_unique<Envoy::Buffer::BufferFragmentImpl>(
-          buffer.get(), length,
-          // TODO(danzh) change the buffer fragment constructor to take the lambda by move instead
-          // of copy, so that the ownership of |buffer| can be transferred to lambda via capture
-          // here and below to unify and simplify the constructor implementations.
-          [allocator = buffer.get_deleter().allocator()](const void* p, size_t,
-                                                         const Envoy::Buffer::BufferFragmentImpl*) {
-            quic::QuicBufferDeleter deleter(allocator);
-            deleter(const_cast<char*>(static_cast<const char*>(p)));
+          buffer.release(), length,
+          [](const void* p, size_t, const Envoy::Buffer::BufferFragmentImpl*) {
+            delete[] static_cast<const char*>(p);
           })) {
-  buffer.release();
   single_slice_buffer_.addBufferFragment(*fragment_);
   ASSERT(this->length() == length);
 }
@@ -32,16 +26,6 @@ QuicMemSliceImpl::QuicMemSliceImpl(Envoy::Buffer::Instance& buffer, size_t lengt
   ASSERT(firstSliceLength(buffer) == length);
   single_slice_buffer_.move(buffer, length);
   ASSERT(single_slice_buffer_.getRawSlices().size() == 1);
-}
-
-QuicMemSliceImpl::QuicMemSliceImpl(std::unique_ptr<char[]> buffer, size_t length)
-    : fragment_(std::make_unique<Envoy::Buffer::BufferFragmentImpl>(
-          buffer.release(), length,
-          [](const void* p, size_t, const Envoy::Buffer::BufferFragmentImpl*) {
-            delete[] static_cast<const char*>(p);
-          })) {
-  single_slice_buffer_.addBufferFragment(*fragment_);
-  ASSERT(this->length() == length);
 }
 
 const char* QuicMemSliceImpl::data() const {

--- a/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_mem_slice_impl.h
@@ -25,7 +25,6 @@ public:
 
   // Constructs a QuicMemSliceImpl by taking ownership of the memory in |buffer|.
   QuicMemSliceImpl(QuicUniqueBufferPtr buffer, size_t length);
-  QuicMemSliceImpl(std::unique_ptr<char[]> buffer, size_t length);
 
   // Constructs a QuicMemSliceImpl from a Buffer::Instance with first |length| bytes in it.
   // Data will be moved from |buffer| to this mem slice.

--- a/source/extensions/quic_listeners/quiche/platform/quic_string_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_string_utils_impl.h
@@ -10,9 +10,10 @@
 
 namespace quic {
 
+// clang-format off
 template <typename... Args>
 inline void QuicStrAppendImpl(std::string* output, const Args&... args) {
   absl::StrAppend(output, args...);
 }
-
+// clang-format on
 } // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/quic_string_utils_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/quic_string_utils_impl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "absl/strings/str_cat.h"
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+namespace quic {
+
+template <typename... Args>
+inline void QuicStrAppendImpl(std::string* output, const Args&... args) {
+  absl::StrAppend(output, args...);
+}
+
+} // namespace quic

--- a/source/extensions/quic_listeners/quiche/platform/spdy_macros_impl.h
+++ b/source/extensions/quic_listeners/quiche/platform/spdy_macros_impl.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "absl/base/attributes.h"
+
+// NOLINT(namespace-envoy)
+
+// This file is part of the QUICHE platform implementation, and is not to be
+// consumed or referenced directly by other Envoy code. It serves purely as a
+// porting layer for QUICHE.
+
+#define SPDY_MUST_USE_RESULT_IMPL ABSL_MUST_USE_RESULT
+#define SPDY_UNUSED_IMPL ABSL_ATTRIBUTE_UNUSED

--- a/source/extensions/quic_listeners/quiche/quic_transport_socket_factory.h
+++ b/source/extensions/quic_listeners/quiche/quic_transport_socket_factory.h
@@ -74,6 +74,9 @@ public:
 
   // Server::Configuration::TransportSocketConfigFactory
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+  // Prevent double registration for the config proto
+  std::string configType() override { return ""; }
 };
 
 DECLARE_FACTORY(QuicServerTransportSocketConfigFactory);
@@ -89,6 +92,9 @@ public:
 
   // Server::Configuration::TransportSocketConfigFactory
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+  // Prevent double registration for the config proto
+  std::string configType() override { return ""; }
 };
 
 DECLARE_FACTORY(QuicClientTransportSocketConfigFactory);

--- a/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
+++ b/test/extensions/quic_listeners/quiche/active_quic_listener_test.cc
@@ -87,6 +87,7 @@ protected:
           }
           bool use_http3 = GetParam().second == QuicVersionType::Iquic;
           SetQuicReloadableFlag(quic_disable_version_draft_29, !use_http3);
+          SetQuicReloadableFlag(quic_disable_version_draft_27, !use_http3);
           return quic::CurrentSupportedVersions();
         }()[0]) {}
 
@@ -330,7 +331,7 @@ TEST_P(ActiveQuicListenerTest, ReceiveCHLO) {
   sendCHLO(quic::test::TestConnectionId(1));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   EXPECT_FALSE(buffered_packets->HasChlosBuffered());
-  EXPECT_NE(0u, quic_dispatcher_->NumSessions());
+  EXPECT_FALSE(quic_dispatcher_->session_map().empty());
   readFromClientSockets();
 }
 
@@ -355,7 +356,7 @@ TEST_P(ActiveQuicListenerTest, ProcessBufferedChlos) {
     EXPECT_FALSE(buffered_packets->HasBufferedPackets(quic::test::TestConnectionId(i)));
   }
   EXPECT_FALSE(buffered_packets->HasChlosBuffered());
-  EXPECT_NE(0u, quic_dispatcher_->NumSessions());
+  EXPECT_FALSE(quic_dispatcher_->session_map().empty());
   readFromClientSockets();
 }
 
@@ -364,19 +365,19 @@ TEST_P(ActiveQuicListenerTest, QuicProcessingDisabledAndEnabled) {
   EXPECT_TRUE(ActiveQuicListenerPeer::enabled(*quic_listener_));
   sendCHLO(quic::test::TestConnectionId(1));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(quic_dispatcher_->NumSessions(), 1);
+  EXPECT_EQ(quic_dispatcher_->session_map().size(), 1);
 
   Runtime::LoaderSingleton::getExisting()->mergeValues({{"quic.enabled", " false"}});
   sendCHLO(quic::test::TestConnectionId(2));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   // If listener was enabled, there should have been session created for active connection.
-  EXPECT_EQ(quic_dispatcher_->NumSessions(), 1);
+  EXPECT_EQ(quic_dispatcher_->session_map().size(), 1);
   EXPECT_FALSE(ActiveQuicListenerPeer::enabled(*quic_listener_));
 
   Runtime::LoaderSingleton::getExisting()->mergeValues({{"quic.enabled", " true"}});
   sendCHLO(quic::test::TestConnectionId(2));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
-  EXPECT_EQ(quic_dispatcher_->NumSessions(), 2);
+  EXPECT_EQ(quic_dispatcher_->session_map().size(), 2);
   EXPECT_TRUE(ActiveQuicListenerPeer::enabled(*quic_listener_));
 }
 
@@ -401,7 +402,7 @@ TEST_P(ActiveQuicListenerEmptyFlagConfigTest, ReceiveFullQuicCHLO) {
   sendCHLO(quic::test::TestConnectionId(1));
   dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   EXPECT_FALSE(buffered_packets->HasChlosBuffered());
-  EXPECT_NE(0u, quic_dispatcher_->NumSessions());
+  EXPECT_FALSE(quic_dispatcher_->session_map().empty());
   EXPECT_TRUE(ActiveQuicListenerPeer::enabled(*quic_listener_));
   readFromClientSockets();
 }

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_session_test.cc
@@ -54,9 +54,7 @@ public:
     SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
   }
 
-  MOCK_METHOD(void, SendConnectionClosePacket,
-              (quic::QuicErrorCode, quic::QuicIetfTransportErrorCodes ietf_error,
-               const std::string&));
+  MOCK_METHOD(void, SendConnectionClosePacket, (quic::QuicErrorCode, const std::string&));
   MOCK_METHOD(bool, SendControlFrame, (const quic::QuicFrame& frame));
 
   using EnvoyQuicClientConnection::connectionStats;
@@ -100,6 +98,7 @@ public:
         dispatcher_(api_->allocateDispatcher("test_thread")), connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_disable_version_draft_29, !GetParam());
+          SetQuicReloadableFlag(quic_disable_version_draft_27, !GetParam());
           return quic::ParsedVersionOfIndex(quic::CurrentSupportedVersions(), 0);
         }()),
         peer_addr_(Network::Utility::getAddressWithPort(*Network::Utility::getIpv6LoopbackAddress(),
@@ -138,7 +137,7 @@ public:
   void TearDown() override {
     if (quic_connection_->connected()) {
       EXPECT_CALL(*quic_connection_,
-                  SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+                  SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
       EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
       envoy_quic_session_.close(Network::ConnectionCloseType::NoFlush);
     }
@@ -230,8 +229,7 @@ TEST_P(EnvoyQuicClientSessionTest, OnGoAwayFrame) {
 TEST_P(EnvoyQuicClientSessionTest, ConnectionClose) {
   std::string error_details("dummy details");
   quic::QuicErrorCode error(quic::QUIC_INVALID_FRAME_DATA);
-  quic::QuicConnectionCloseFrame frame(quic_version_[0].transport_version, error,
-                                       quic::NO_IETF_QUIC_ERROR, error_details,
+  quic::QuicConnectionCloseFrame frame(quic_version_[0].transport_version, error, error_details,
                                        /* transport_close_frame_type = */ 0);
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::RemoteClose));
   quic_connection_->OnConnectionCloseFrame(frame);
@@ -245,7 +243,7 @@ TEST_P(EnvoyQuicClientSessionTest, ConnectionCloseWithActiveStream) {
   Http::MockStreamCallbacks stream_callbacks;
   EnvoyQuicClientStream& stream = sendGetRequest(response_decoder, stream_callbacks);
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   envoy_quic_session_.close(Network::ConnectionCloseType::NoFlush);

--- a/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_client_stream_test.cc
@@ -26,6 +26,7 @@ public:
         connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_disable_version_draft_29, !GetParam());
+          SetQuicReloadableFlag(quic_disable_version_draft_27, !GetParam());
           return quic::CurrentSupportedVersions()[0];
         }()),
         peer_addr_(Network::Utility::getAddressWithPort(*Network::Utility::getIpv6LoopbackAddress(),

--- a/test/extensions/quic_listeners/quiche/envoy_quic_dispatcher_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_dispatcher_test.cc
@@ -68,6 +68,7 @@ public:
           }
           bool use_http3 = GetParam().second == QuicVersionType::Iquic;
           SetQuicReloadableFlag(quic_disable_version_draft_29, !use_http3);
+          SetQuicReloadableFlag(quic_disable_version_draft_27, !use_http3);
           return quic::CurrentSupportedVersions();
         }()),
         quic_version_(version_manager_.GetSupportedVersions()[0]),
@@ -157,13 +158,13 @@ public:
     EXPECT_FALSE(buffered_packets->HasBufferedPackets(connection_id_));
 
     // A new QUIC connection is created and its filter installed based on self and peer address.
-    EXPECT_EQ(1u, envoy_quic_dispatcher_.NumSessions());
-    const quic::QuicSession* session =
-        quic::test::QuicDispatcherPeer::FindSession(&envoy_quic_dispatcher_, connection_id_);
+    EXPECT_EQ(1u, envoy_quic_dispatcher_.session_map().size());
+    quic::QuicSession* session =
+        envoy_quic_dispatcher_.session_map().find(connection_id_)->second.get();
     ASSERT(session != nullptr);
     EXPECT_TRUE(session->IsEncryptionEstablished());
     EXPECT_EQ(1u, connection_handler_.numConnections());
-    auto envoy_connection = static_cast<const EnvoyQuicServerSession*>(session);
+    auto envoy_connection = static_cast<EnvoyQuicServerSession*>(session);
     EXPECT_EQ("test.example.org", envoy_connection->requestedServerName());
     EXPECT_EQ(peer_addr, envoyIpAddressToQuicSocketAddress(
                              envoy_connection->addressProvider().remoteAddress()->ip()));

--- a/test/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_proof_verifier_test.cc
@@ -100,7 +100,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainSuccess) {
   EXPECT_EQ(quic::QUIC_SUCCESS,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
                                        {leaf_cert_}, ocsp_response, cert_sct, nullptr,
-                                       &error_details, nullptr, nullptr, nullptr))
+                                       &error_details, nullptr, nullptr))
       << error_details;
 }
 
@@ -114,7 +114,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureFromSsl) {
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
                                        {leaf_cert_}, ocsp_response, cert_sct, nullptr,
-                                       &error_details, nullptr, nullptr, nullptr))
+                                       &error_details, nullptr, nullptr))
       << error_details;
   EXPECT_EQ("X509_verify_cert: certificate verification error at depth 1: certificate has expired",
             error_details);
@@ -128,7 +128,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureInvalidLeafCert) {
   const std::vector<std::string> certs{"invalid leaf cert"};
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain("www.google.com", 54321, certs, ocsp_response, cert_sct,
-                                       nullptr, &error_details, nullptr, nullptr, nullptr));
+                                       nullptr, &error_details, nullptr, nullptr));
   EXPECT_EQ("d2i_X509: fail to parse DER", error_details);
 }
 
@@ -143,7 +143,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureLeafCertWithGarbage) {
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
                                        {cert_with_trailing_garbage}, ocsp_response, cert_sct,
-                                       nullptr, &error_details, nullptr, nullptr, nullptr))
+                                       nullptr, &error_details, nullptr, nullptr))
       << error_details;
   EXPECT_EQ("There is trailing garbage in DER.", error_details);
 }
@@ -157,7 +157,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureInvalidHost) {
   std::string error_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain("unknown.org", 54321, {leaf_cert_}, ocsp_response, cert_sct,
-                                       nullptr, &error_details, nullptr, nullptr, nullptr))
+                                       nullptr, &error_details, nullptr, nullptr))
       << error_details;
   EXPECT_EQ("Leaf certificate doesn't match hostname: unknown.org", error_details);
 }

--- a/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
+++ b/test/extensions/quic_listeners/quiche/envoy_quic_server_session_test.cc
@@ -70,8 +70,7 @@ public:
     return EnvoyQuicConnection::connectionStats();
   }
 
-  MOCK_METHOD(void, SendConnectionClosePacket,
-              (quic::QuicErrorCode, quic::QuicIetfTransportErrorCodes, const std::string&));
+  MOCK_METHOD(void, SendConnectionClosePacket, (quic::QuicErrorCode, const std::string&));
   MOCK_METHOD(bool, SendControlFrame, (const quic::QuicFrame& frame));
 };
 
@@ -124,7 +123,7 @@ public:
 
   TestEnvoyQuicTlsServerHandshaker(quic::QuicSession* session,
                                    const quic::QuicCryptoServerConfig& crypto_config)
-      : quic::TlsServerHandshaker(session, &crypto_config),
+      : quic::TlsServerHandshaker(session, crypto_config),
         params_(new quic::QuicCryptoNegotiatedParameters) {
     params_->cipher_suite = 1;
   }
@@ -150,6 +149,7 @@ public:
         dispatcher_(api_->allocateDispatcher("test_thread")), connection_helper_(*dispatcher_),
         alarm_factory_(*dispatcher_, *connection_helper_.GetClock()), quic_version_([]() {
           SetQuicReloadableFlag(quic_disable_version_draft_29, !GetParam());
+          SetQuicReloadableFlag(quic_disable_version_draft_27, !GetParam());
           return quic::ParsedVersionOfIndex(quic::CurrentSupportedVersions(), 0);
         }()),
         quic_connection_(new TestEnvoyQuicServerConnection(
@@ -246,7 +246,7 @@ public:
   void TearDown() override {
     if (quic_connection_->connected()) {
       EXPECT_CALL(*quic_connection_,
-                  SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+                  SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
       EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
       EXPECT_CALL(*quic_connection_, SendControlFrame(_))
           .Times(testing::AtMost(1))
@@ -317,6 +317,7 @@ TEST_P(EnvoyQuicServerSessionTest, NewStream) {
 }
 
 TEST_P(EnvoyQuicServerSessionTest, InvalidIncomingStreamId) {
+  quic::SetVerbosityLogThreshold(1);
   installReadFilter();
   Http::MockRequestDecoder request_decoder;
   Http::MockStreamCallbacks stream_callbacks;
@@ -330,7 +331,7 @@ TEST_P(EnvoyQuicServerSessionTest, InvalidIncomingStreamId) {
               SendConnectionClosePacket((quic::VersionUsesHttp3(quic_version_[0].transport_version)
                                              ? quic::QUIC_HTTP_STREAM_WRONG_DIRECTION
                                              : quic::QUIC_INVALID_STREAM_ID),
-                                        _, "Data for nonexistent stream"));
+                                        "Data for nonexistent stream"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
 
   envoy_quic_session_.OnStreamFrame(stream_frame);
@@ -348,7 +349,7 @@ TEST_P(EnvoyQuicServerSessionTest, NoNewStreamForInvalidIncomingStream) {
               SendConnectionClosePacket(quic::VersionUsesHttp3(quic_version_[0].transport_version)
                                             ? quic::QUIC_HTTP_STREAM_WRONG_DIRECTION
                                             : quic::QUIC_INVALID_STREAM_ID,
-                                        _, "Data for nonexistent stream"));
+                                        "Data for nonexistent stream"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
 
   // Stream creation on closed connection should fail.
@@ -393,8 +394,7 @@ TEST_P(EnvoyQuicServerSessionTest, ConnectionClose) {
 
   std::string error_details("dummy details");
   quic::QuicErrorCode error(quic::QUIC_INVALID_FRAME_DATA);
-  quic::QuicConnectionCloseFrame frame(quic_version_[0].transport_version, error,
-                                       quic::NO_IETF_QUIC_ERROR, error_details,
+  quic::QuicConnectionCloseFrame frame(quic_version_[0].transport_version, error, error_details,
                                        /* transport_close_frame_type = */ 0);
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::RemoteClose));
   quic_connection_->OnConnectionCloseFrame(frame);
@@ -410,7 +410,7 @@ TEST_P(EnvoyQuicServerSessionTest, ConnectionCloseWithActiveStream) {
   Http::MockStreamCallbacks stream_callbacks;
   quic::QuicStream* stream = createNewStream(request_decoder, stream_callbacks);
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   envoy_quic_session_.close(Network::ConnectionCloseType::NoFlush);
@@ -426,7 +426,7 @@ TEST_P(EnvoyQuicServerSessionTest, NoFlushWithDataToWrite) {
   quic::QuicStream* stream = createNewStream(request_decoder, stream_callbacks);
   envoy_quic_session_.MarkConnectionLevelWriteBlocked(stream->id());
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Even though the stream is write blocked, connection should be closed
@@ -448,7 +448,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlushCloseWithDataToWrite) {
   envoy_quic_session_.close(Network::ConnectionCloseType::FlushWrite);
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Unblock that stream to trigger actual connection close.
@@ -532,7 +532,7 @@ TEST_P(EnvoyQuicServerSessionTest, WriteUpdatesDelayCloseTimer) {
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Advance the time to fire connection close timer.
@@ -623,7 +623,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlushCloseNoTimeout) {
 
   // Force close connection.
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   EXPECT_CALL(*quic_connection_, SendControlFrame(_))
@@ -653,7 +653,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlushCloseWithTimeout) {
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Advance the time to fire connection close timer.
@@ -686,7 +686,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlushAndWaitForCloseWithTimeout) {
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Advance the time to fire connection close timer.
@@ -723,7 +723,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlusWriteTransitToFlushWriteWithDelay) {
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::ConnectionTermination, _));
   // Advance the time to fire connection close timer.
@@ -748,7 +748,7 @@ TEST_P(EnvoyQuicServerSessionTest, FlushAndWaitForCloseWithNoPendingData) {
   EXPECT_EQ(Network::Connection::State::Open, envoy_quic_session_.state());
 
   EXPECT_CALL(*quic_connection_,
-              SendConnectionClosePacket(quic::QUIC_NO_ERROR, _, "Closed by application"));
+              SendConnectionClosePacket(quic::QUIC_NO_ERROR, "Closed by application"));
   EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   // Advance the time to fire connection close timer.
   time_system_.advanceTimeAndRun(std::chrono::milliseconds(90), *dispatcher_,

--- a/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
+++ b/test/extensions/quic_listeners/quiche/integration/quic_http_integration_test.cc
@@ -65,11 +65,9 @@ createQuicClientTransportSocketFactory(const Ssl::ClientSslTransportOptions& opt
       trusted_ca:
         filename: "{{ test_rundir }}/test/config/integration/certs/cacert.pem"
 )EOF";
-  envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport
-      quic_transport_socket_config;
-  auto* tls_context = quic_transport_socket_config.mutable_upstream_tls_context();
-  TestUtility::loadFromYaml(TestEnvironment::substitute(yaml_plain), *tls_context);
-  auto* common_context = tls_context->mutable_common_tls_context();
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(yaml_plain), tls_context);
+  auto* common_context = tls_context.mutable_common_tls_context();
 
   if (options.alpn_) {
     common_context->add_alpn_protocols("h3");
@@ -82,23 +80,17 @@ createQuicClientTransportSocketFactory(const Ssl::ClientSslTransportOptions& opt
     common_context->mutable_tls_params()->add_cipher_suites(cipher_suite);
   }
   if (!options.sni_.empty()) {
-    tls_context->set_sni(options.sni_);
+    tls_context.set_sni(options.sni_);
   }
 
   common_context->mutable_tls_params()->set_tls_minimum_protocol_version(options.tls_version_);
   common_context->mutable_tls_params()->set_tls_maximum_protocol_version(options.tls_version_);
 
-  envoy::config::core::v3::TransportSocket message;
-  message.mutable_typed_config()->PackFrom(quic_transport_socket_config);
-  auto& config_factory = Config::Utility::getAndCheckFactory<
-      Server::Configuration::UpstreamTransportSocketConfigFactory>(message);
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> mock_factory_ctx;
   ON_CALL(mock_factory_ctx, api()).WillByDefault(testing::ReturnRef(api));
-  return std::unique_ptr<QuicClientTransportSocketFactory>(
-      static_cast<QuicClientTransportSocketFactory*>(
-          config_factory
-              .createTransportSocketFactory(quic_transport_socket_config, mock_factory_ctx)
-              .release()));
+  auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ClientContextConfigImpl>(
+      tls_context, options.sigalgs_, mock_factory_ctx);
+  return std::make_unique<QuicClientTransportSocketFactory>(std::move(cfg));
 }
 
 class QuicHttpIntegrationTest : public HttpIntegrationTest, public QuicMultiVersionTest {
@@ -112,6 +104,7 @@ public:
           }
           bool use_http3 = GetParam().second == QuicVersionType::Iquic;
           SetQuicReloadableFlag(quic_disable_version_draft_29, !use_http3);
+          SetQuicReloadableFlag(quic_disable_version_draft_27, !use_http3);
           return quic::CurrentSupportedVersions();
         }()),
         conn_helper_(*dispatcher_), alarm_factory_(*dispatcher_, *conn_helper_.GetClock()),
@@ -120,12 +113,7 @@ public:
         file_updater_1_(injected_resource_filename_1_),
         file_updater_2_(injected_resource_filename_2_) {}
 
-  ~QuicHttpIntegrationTest() override {
-    cleanupUpstreamAndDownstream();
-    // Release the client before destroying |conn_helper_|. No such need once |conn_helper_| is
-    // moved into a client connection factory in the base test class.
-    codec_client_.reset();
-  }
+  ~QuicHttpIntegrationTest() override { cleanupUpstreamAndDownstream(); }
 
   Network::ClientConnectionPtr makeClientConnectionWithOptions(
       uint32_t port, const Network::ConnectionSocket::OptionsSharedPtr& options) override {
@@ -167,7 +155,6 @@ public:
     } else {
       codec->setCodecClientCallbacks(client_codec_callback_);
     }
-    EXPECT_EQ(server_id_.host(), codec->connection()->requestedServerName());
     return codec;
   }
 
@@ -539,8 +526,7 @@ TEST_P(QuicHttpIntegrationTest, CertVerificationFailure) {
       GetParam().second == QuicVersionType::GquicQuicCrypto
           ? "QUIC_PROOF_INVALID with details: Proof invalid: X509_verify_cert: certificate "
             "verification error at depth 0: ok"
-          : "QUIC_TLS_CERTIFICATE_UNKNOWN with details: TLS handshake failure "
-            "(ENCRYPTION_HANDSHAKE) 46: "
+          : "QUIC_HANDSHAKE_FAILED with details: TLS handshake failure (ENCRYPTION_HANDSHAKE) 46: "
             "certificate unknown";
   EXPECT_EQ(failure_reason, codec_client_->connection()->transportFailureReason());
 }

--- a/test/extensions/quic_listeners/quiche/platform/BUILD
+++ b/test/extensions/quic_listeners/quiche/platform/BUILD
@@ -14,7 +14,7 @@ envoy_cc_test(
     srcs = ["http2_platform_test.cc"],
     external_deps = ["quiche_http2_platform"],
     deps = [
-        "//source/extensions/quic_listeners/quiche/platform:quiche_flags_impl_lib",
+        "//source/extensions/quic_listeners/quiche/platform:flags_impl_lib",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
         "@com_googlesource_quiche//:http2_test_tools_random",
@@ -37,7 +37,7 @@ envoy_cc_test(
     deps = [
         ":quic_platform_epoll_clock_lib",
         "//source/common/memory:stats_lib",
-        "//source/extensions/quic_listeners/quiche/platform:quiche_flags_impl_lib",
+        "//source/extensions/quic_listeners/quiche/platform:flags_impl_lib",
         "//test/common/buffer:utility_lib",
         "//test/common/stats:stat_test_utility_lib",
         "//test/extensions/transport_sockets/tls:ssl_test_utils",
@@ -66,7 +66,7 @@ envoy_cc_test(
     srcs = ["spdy_platform_test.cc"],
     external_deps = ["quiche_spdy_platform"],
     deps = [
-        "//source/extensions/quic_listeners/quiche/platform:quiche_flags_impl_lib",
+        "//source/extensions/quic_listeners/quiche/platform:flags_impl_lib",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
         "@com_googlesource_quiche//:spdy_platform",

--- a/test/extensions/quic_listeners/quiche/platform/epoll_logging_impl.h
+++ b/test/extensions/quic_listeners/quiche/platform/epoll_logging_impl.h
@@ -10,15 +10,6 @@
 
 namespace epoll_server {
 
-#define CHECK(expression) QUICHE_CHECK_IMPL(expression)
-#define CHECK_EQ(a, b) QUICHE_CHECK_EQ_IMPL(a, b)
-#define CHECK_NE(a, b) QUICHE_CHECK_NE_IMPL(a, b)
-#define DCHECK(expression) QUICHE_DCHECK_IMPL(expression)
-#define DCHECK_GE(a, b) QUICHE_DCHECK_GE_IMPL(a, b)
-#define DCHECK_GT(a, b) QUICHE_DCHECK_GT_IMPL(a, b)
-#define DCHECK_NE(a, b) QUICHE_DCHECK_NE_IMPL(a, b)
-#define DCHECK_EQ(a, b) QUICHE_DCHECK_EQ_IMPL(a, b)
-
 #define EPOLL_LOG_IMPL(severity) QUICHE_LOG_IMPL(severity)
 #define EPOLL_VLOG_IMPL(verbosity) QUICHE_VLOG_IMPL(verbosity)
 

--- a/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/http2_platform_test.cc
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string>
 
-#include "extensions/quic_listeners/quiche/platform/quiche_flags_impl.h"
+#include "extensions/quic_listeners/quiche/platform/flags_impl.h"
 
 #include "test/test_common/logging.h"
 
@@ -68,6 +68,8 @@ TEST(Http2PlatformTest, Http2Log) {
 
   HTTP2_DVLOG_IF(3, true) << "DVLOG_IF(3, true)";
   HTTP2_DVLOG_IF(4, false) << "DVLOG_IF(4, false)";
+
+  HTTP2_DLOG_EVERY_N(ERROR, 2) << "DLOG_EVERY_N(ERROR, 2)";
 }
 
 TEST(Http2PlatformTest, Http2Macro) {

--- a/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/quic_platform_test.cc
@@ -12,7 +12,7 @@
 #include "common/network/socket_impl.h"
 #include "common/network/utility.h"
 
-#include "extensions/quic_listeners/quiche/platform/quiche_flags_impl.h"
+#include "extensions/quic_listeners/quiche/platform/flags_impl.h"
 
 #include "test/common/buffer/utility.h"
 #include "test/common/stats/stat_test_utility.h"
@@ -31,6 +31,7 @@
 #include "quiche/common/platform/api/quiche_string_piece.h"
 #include "quiche/epoll_server/fake_simple_epoll_server.h"
 #include "quiche/quic/platform/api/quic_bug_tracker.h"
+#include "quiche/quic/platform/api/quic_cert_utils.h"
 #include "quiche/quic/platform/api/quic_client_stats.h"
 #include "quiche/quic/platform/api/quic_containers.h"
 #include "quiche/quic/platform/api/quic_estimate_memory_usage.h"
@@ -452,6 +453,27 @@ TEST_F(QuicPlatformTest, QuicNotification) {
   notification.Notify();
   notification.WaitForNotification();
   EXPECT_TRUE(notification.HasBeenNotified());
+}
+
+TEST_F(QuicPlatformTest, QuicCertUtils) {
+  bssl::UniquePtr<X509> x509_cert =
+      Envoy::Extensions::TransportSockets::Tls::readCertFromFile(Envoy::TestEnvironment::substitute(
+          "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/san_dns_cert.pem"));
+  // Encode X509 cert with DER encoding.
+  unsigned char* der = nullptr;
+  int len = i2d_X509(x509_cert.get(), &der);
+  ASSERT_GT(len, 0);
+  absl::string_view out;
+  QuicCertUtils::ExtractSubjectNameFromDERCert(
+      absl::string_view(reinterpret_cast<const char*>(der), len), &out);
+  EXPECT_EQ("0z1\v0\t\x6\x3U\x4\x6\x13\x2US1\x13"
+            "0\x11\x6\x3U\x4\b\f\nCalifornia1\x16"
+            "0\x14\x6\x3U\x4\a\f\rSan Francisco1\r"
+            "0\v\x6\x3U\x4\n\f\x4Lyft1\x19"
+            "0\x17\x6\x3U\x4\v\f\x10Lyft Engineering1\x14"
+            "0\x12\x6\x3U\x4\x3\f\vTest Server",
+            out);
+  OPENSSL_free(static_cast<void*>(der));
 }
 
 TEST_F(QuicPlatformTest, QuicTestOutput) {

--- a/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
+++ b/test/extensions/quic_listeners/quiche/platform/spdy_platform_test.cc
@@ -1,7 +1,7 @@
 #include <functional>
 #include <string>
 
-#include "extensions/quic_listeners/quiche/platform/quiche_flags_impl.h"
+#include "extensions/quic_listeners/quiche/platform/flags_impl.h"
 
 #include "test/test_common/logging.h"
 

--- a/test/extensions/quic_listeners/quiche/test_proof_verifier.h
+++ b/test/extensions/quic_listeners/quiche/test_proof_verifier.h
@@ -14,7 +14,7 @@ public:
                   const std::vector<std::string>& /*certs*/, const std::string& /*ocsp_response*/,
                   const std::string& /*cert_sct*/, const quic::ProofVerifyContext* /*context*/,
                   std::string* /*error_details*/,
-                  std::unique_ptr<quic::ProofVerifyDetails>* /*details*/, uint8_t* /*out_alert*/,
+                  std::unique_ptr<quic::ProofVerifyDetails>* /*details*/,
                   std::unique_ptr<quic::ProofVerifierCallback> /*callback*/) override {
     return quic::QUIC_SUCCESS;
   }

--- a/test/extensions/quic_listeners/quiche/test_utils.h
+++ b/test/extensions/quic_listeners/quiche/test_utils.h
@@ -52,11 +52,6 @@ public:
                quic::StreamSendingState state, quic::TransmissionType type,
                absl::optional<quic::EncryptionLevel> level));
   MOCK_METHOD(bool, ShouldYield, (quic::QuicStreamId id));
-  MOCK_METHOD(void, MaybeSendRstStreamFrame,
-              (quic::QuicStreamId id, quic::QuicRstStreamErrorCode error,
-               quic::QuicStreamOffset bytes_written));
-  MOCK_METHOD(void, MaybeSendStopSendingFrame,
-              (quic::QuicStreamId id, quic::QuicRstStreamErrorCode error));
 
   absl::string_view requestedServerName() const override {
     return {GetCryptoStream()->crypto_negotiated_params().sni};


### PR DESCRIPTION
Rolling back due to multiple test breakage (picked up during race-merge)

Kicking this off in case https://github.com/envoyproxy/envoy/pull/15294 fails CI at which point we can remove the DO_NOT_SUBMIT and check this in.