### PR TITLE
tls: fix flaky integration test of SPIFFE validator

### DIFF
--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -380,6 +380,7 @@ typed_config:
   EXPECT_EQ(0, counter->value());
   counter->reset();
 }
+
 // Server configured on SPIFFE certificate validation for mTLS
 // clientcert.pem's san is "spiffe://lyft.com/frontend-team" so it should be rejected.
 TEST_P(SslCertficateIntegrationTest, ServerRsaSPIFFEValidatorRejected1) {
@@ -402,9 +403,10 @@ typed_config:
     auto codec = makeRawHttpConnection(std::move(conn), absl::nullopt);
     EXPECT_FALSE(codec->connected());
   } else {
-    makeHttpConnection(std::move(conn))->close();
+    auto codec = makeHttpConnection(std::move(conn));
+    ASSERT_TRUE(codec->waitForDisconnect());
+    codec->close();
   }
-
   Stats::CounterSharedPtr counter =
       test_server_->counter(listenerStatPrefix("ssl.fail_verify_error"));
   EXPECT_EQ(1, counter->value());
@@ -437,7 +439,9 @@ typed_config:
     auto codec = makeRawHttpConnection(std::move(conn), absl::nullopt);
     EXPECT_FALSE(codec->connected());
   } else {
-    makeHttpConnection(std::move(conn))->close();
+    auto codec = makeHttpConnection(std::move(conn));
+    ASSERT_TRUE(codec->waitForDisconnect());
+    codec->close();
   }
   Stats::CounterSharedPtr counter =
       test_server_->counter(listenerStatPrefix("ssl.fail_verify_error"));


### PR DESCRIPTION
Previously these tests flake due to early counter check before the counter is actually incremented, and fail occasionally around 1~3%.

I tried this with `--runs_per_test=10000` and never failed.

cc @mattklein123 @lizan 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>