### PR TITLE
Adding the ability to build a minimal docker container using bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,3 +19,34 @@ envoy_dependencies_extra()
 load("//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()
+# Getting Docker rules
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
+    strip_prefix = "rules_docker-0.15.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
+
+container_repositories()
+
+load(
+    "@io_bazel_rules_docker//cc:image.bzl",
+    _cc_image_repos = "repositories",
+)
+
+_cc_image_repos()
+
+container_pull(
+    name = "distroless_base",
+    registry = "gcr.io",
+    repository = "distroless/base-debian10",
+    tag = "latest",
+)

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -9,10 +9,30 @@ load(
 )
 load("//source/extensions:all_extensions.bzl", "envoy_all_core_extensions", "envoy_all_extensions")
 load("//bazel:repositories.bzl", "PPC_SKIP_TARGETS", "WINDOWS_SKIP_TARGETS")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
+
+container_image(
+    name = "envoy-docker",
+    base = "@distroless_base//image",
+    user = "nonroot",
+    cmd = [
+        "-c",
+        "/envoy-demo.yaml",
+    ],
+    entrypoint = ["/envoy-static"],
+    files = [
+        ":envoy-static",
+        "//configs:envoy-demo.yaml",
+    ],
+    symlinks = {
+        "/usr/local/bin/envoy": "/envoy-static",
+        "/etc/envoy.yaml": "/envoy-demo.yaml",
+    },
+)
 
 alias(
     name = "envoy",


### PR DESCRIPTION
Commit Message: Adding the ability to build a minimal docker container using bazel
Additional Description:
This is an initial example of using [rules_docker](https://github.com/bazelbuild/rules_docker) to build envoy container image. This has certain benefits over the current do_ci.sh:

1. Declarative build instead of scripts
2. Reproducible docker containers
3. Leveraging bazel build flags
4. Minimal and secure container with nonroot user based on [distroless](https://github.com/GoogleContainerTools/distroless)

It is also possible to add container_push rule to add pushing the container as part of the bazel targets

Risk Level: Low
Testing: Container built and run
Docs Changes: Pending
Release Notes:
Platform Specific Features: