### PR TITLE
Replace htuch with asraa and avd on ALTS codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,7 +38,7 @@ extensions/filters/common/original_src @snowp @klarose
 # header_to_metadata extension
 /*/extensions/filters/http/header_to_metadata @rgs1 @zuercher
 # alts transport socket extension
-/*/extensions/transport_sockets/alts @htuch @yangminzhu
+/*/extensions/transport_sockets/alts @asraa @yangminzhu
 # tls transport socket extension
 /*/extensions/transport_sockets/tls @lizan @asraa @ggreenway
 # tls SPIFFE certificate validator extension

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,7 +38,7 @@ extensions/filters/common/original_src @snowp @klarose
 # header_to_metadata extension
 /*/extensions/filters/http/header_to_metadata @rgs1 @zuercher
 # alts transport socket extension
-/*/extensions/transport_sockets/alts @asraa @yangminzhu
+/*/extensions/transport_sockets/alts @antoniovicente @asraa @yangminzhu
 # tls transport socket extension
 /*/extensions/transport_sockets/tls @lizan @asraa @ggreenway
 # tls SPIFFE certificate validator extension


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Moving ownership: replace htuch with asraa on ALTS codeowners
Risk Level: Low