### PR TITLE
Revert "grpc_http1_bridge: correctly set downstream status for traile…

### DIFF
--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.cc
@@ -44,28 +44,16 @@ Http::FilterHeadersStatus Http1BridgeFilter::encodeHeaders(Http::ResponseHeaderM
     chargeStat(headers);
   }
 
-  if (!do_bridging_) {
-    return Http::FilterHeadersStatus::Continue;
-  }
-
-  response_headers_ = &headers;
-  if (end_stream) {
-    // We may still need to set an http status and content length based on gRPC trailers
-    // present in the response headers. This is known as a gRPC trailers-only response.
-    // If the grpc status is non-zero, this will change the response code.
-    updateHttpStatusAndContentLength(headers);
+  if (!do_bridging_ || end_stream) {
     return Http::FilterHeadersStatus::Continue;
   } else {
+    response_headers_ = &headers;
     return Http::FilterHeadersStatus::StopIteration;
   }
 }
 
 Http::FilterDataStatus Http1BridgeFilter::encodeData(Buffer::Instance&, bool end_stream) {
-  if (!do_bridging_) {
-    return Http::FilterDataStatus::Continue;
-  }
-
-  if (end_stream) {
+  if (!do_bridging_ || end_stream) {
     return Http::FilterDataStatus::Continue;
   } else {
     // Buffer until the complete request has been processed.
@@ -79,60 +67,33 @@ Http::FilterTrailersStatus Http1BridgeFilter::encodeTrailers(Http::ResponseTrail
   }
 
   if (do_bridging_) {
-    // We're bridging, so we need to process trailers and set the http status, content length,
-    // grpc status, and grpc message from those trailers.
-    doResponseTrailers(trailers);
+    // Here we check for grpc-status. If it's not zero, we change the response code. We assume
+    // that if a reset comes in and we disconnect the HTTP/1.1 client it will raise some type
+    // of exception/error that the response was not complete.
+    const Http::HeaderEntry* grpc_status_header = trailers.GrpcStatus();
+    if (grpc_status_header) {
+      uint64_t grpc_status_code;
+      if (!absl::SimpleAtoi(grpc_status_header->value().getStringView(), &grpc_status_code) ||
+          grpc_status_code != 0) {
+        response_headers_->setStatus(enumToInt(Http::Code::ServiceUnavailable));
+      }
+      response_headers_->setGrpcStatus(grpc_status_header->value().getStringView());
+    }
+
+    const Http::HeaderEntry* grpc_message_header = trailers.GrpcMessage();
+    if (grpc_message_header) {
+      response_headers_->setGrpcMessage(grpc_message_header->value().getStringView());
+    }
+
+    // Since we are buffering, set content-length so that HTTP/1.1 callers can better determine
+    // if this is a complete response.
+    response_headers_->setContentLength(
+        encoder_callbacks_->encodingBuffer() ? encoder_callbacks_->encodingBuffer()->length() : 0);
   }
 
   // NOTE: We will still write the trailers, but the HTTP/1.1 codec will just eat them and end
   //       the chunk encoded response which is what we want.
   return Http::FilterTrailersStatus::Continue;
-}
-
-void Http1BridgeFilter::updateHttpStatusAndContentLength(
-    const Http::ResponseHeaderOrTrailerMap& trailers) {
-  // Here we check for grpc-status. If it's not zero, we change the response code. We assume
-  // that if a reset comes in and we disconnect the HTTP/1.1 client it will raise some type
-  // of exception/error that the response was not complete.
-  const Http::HeaderEntry* grpc_status_header = trailers.GrpcStatus();
-  if (grpc_status_header) {
-    uint64_t grpc_status_code;
-    if (!absl::SimpleAtoi(grpc_status_header->value().getStringView(), &grpc_status_code) ||
-        grpc_status_code != 0) {
-      response_headers_->setStatus(enumToInt(Http::Code::ServiceUnavailable));
-    }
-  }
-
-  // Since we are buffering, set content-length so that HTTP/1.1 callers can better determine
-  // if this is a complete response.
-  response_headers_->setContentLength(
-      encoder_callbacks_->encodingBuffer() ? encoder_callbacks_->encodingBuffer()->length() : 0);
-}
-
-// Set grpc response headers based on incoming trailers. Sometimes, the incoming
-// trailers are in fact upstream headers, in the case of a gRPC trailers-only response.
-void Http1BridgeFilter::updateGrpcStatusAndMessage(
-    const Http::ResponseHeaderOrTrailerMap& trailers) {
-  const Http::HeaderEntry* grpc_status_header = trailers.GrpcStatus();
-  if (grpc_status_header) {
-    response_headers_->setGrpcStatus(grpc_status_header->value().getStringView());
-  }
-
-  const Http::HeaderEntry* grpc_message_header = trailers.GrpcMessage();
-  if (grpc_message_header) {
-    response_headers_->setGrpcMessage(grpc_message_header->value().getStringView());
-  }
-}
-
-// Process response trailers. This involves setting an appropriate http status and content length,
-// as well as gRPC status and message headers.
-void Http1BridgeFilter::doResponseTrailers(const Http::ResponseHeaderOrTrailerMap& trailers) {
-  // First we need to set an HTTP status based on the gRPC status in `trailers`.
-  // We also set content length based on whether there exists an encoding buffer.
-  updateHttpStatusAndContentLength(trailers);
-
-  // Finally we set the grpc status and message headers based on `trailers`.
-  updateGrpcStatusAndMessage(trailers);
 }
 
 void Http1BridgeFilter::setupStatTracking(const Http::RequestHeaderMap& headers) {

--- a/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter.h
@@ -52,9 +52,6 @@ public:
 private:
   void chargeStat(const Http::ResponseHeaderOrTrailerMap& headers);
   void setupStatTracking(const Http::RequestHeaderMap& headers);
-  void doResponseTrailers(const Http::ResponseHeaderOrTrailerMap& trailers);
-  void updateGrpcStatusAndMessage(const Http::ResponseHeaderOrTrailerMap& trailers);
-  void updateHttpStatusAndContentLength(const Http::ResponseHeaderOrTrailerMap& trailers);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};

--- a/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/http1_bridge_filter_test.cc
@@ -224,29 +224,6 @@ TEST_F(GrpcHttp1BridgeFilterTest, HandlingBadGrpcStatus) {
   EXPECT_EQ("foo", response_headers.get_("grpc-message"));
 }
 
-// Regression test for https://github.com/envoyproxy/envoy/issues/14872 testing trailers-only
-// responses
-TEST_F(GrpcHttp1BridgeFilterTest, HandlingBadGrpcStatusTrailersOnlyResponse) {
-  Http::TestRequestHeaderMapImpl request_headers{
-      {"content-type", "application/grpc"},
-      {":path", "/lyft.users.BadCompanions/GetBadCompanions"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
-  Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(data, false));
-  Http::TestRequestTrailerMapImpl request_trailers{{"hello", "world"}};
-  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.decodeTrailers(request_trailers));
-
-  // gRPC responses may optimize and put would-be-trailers in the headers frame if there are no data
-  // frames. The gRPC spec refers to this a a "Trailers-Only" response.
-  Http::TestResponseHeaderMapImpl response_headers{
-      {":status", "200"}, {"grpc-status", "1"}, {"grpc-message", "foo"}};
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.encodeHeaders(response_headers, true));
-  EXPECT_EQ("503", response_headers.get_(":status"));
-  EXPECT_EQ("0", response_headers.get_("content-length"));
-  EXPECT_EQ("1", response_headers.get_("grpc-status"));
-  EXPECT_EQ("foo", response_headers.get_("grpc-message"));
-}
-
 } // namespace
 } // namespace GrpcHttp1Bridge
 } // namespace HttpFilters


### PR DESCRIPTION
…rs-only gRPC responses (#14903)"

This reverts commit 5e7eb111f4ac4af6bd8ec1be7169d6f1e982475c.

This change appears to cause issues with existing deployments that were handling
the existing behavior by treating 200 + bad grpc-status as a failure. Reverting for now
to allow these deployments to continue using main.

@esmet Do you think you could prepare a new version of this where we additionally
1) use the canonical error mapping from grpc-status -> HTTP status instead of unconditionally converting to 503. 
    There should be some helpers in the repo already for this afaik.
2) provide a configuration option to enable this new error handling, allowing deployments that prefer the old behavior to opt out.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
