### PR TITLE
[fuzz] fix h1 end to end fuzz test issue

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -160,6 +160,14 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
       absl::StartsWith(canonical_path.rc_, "/proc")) {
     return true;
   }
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  // Allow temporary files in OSS-Fuzz to prevent failures running (h1/h2)_capture_fuzz_test.
+  // Ideally this would be TestEnvironment::temporaryPath() but this avoids depending on test
+  // libraries.
+  if (absl::StartsWith(canonical_path.rc_, "/mnt")) {
+    return true;
+  }
+#endif
   return false;
 }
 

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -160,14 +160,6 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
       absl::StartsWith(canonical_path.rc_, "/proc")) {
     return true;
   }
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-  // Allow temporary files in OSS-Fuzz to prevent failures running (h1/h2)_capture_fuzz_test.
-  // Ideally this would be TestEnvironment::temporaryPath() but this avoids depending on test
-  // libraries.
-  if (absl::StartsWith(canonical_path.rc_, "/mnt")) {
-    return true;
-  }
-#endif
   return false;
 }
 

--- a/test/integration/h1_capture_direct_response_fuzz_test.cc
+++ b/test/integration/h1_capture_direct_response_fuzz_test.cc
@@ -9,7 +9,7 @@ void H1FuzzIntegrationTest::initialize() {
   const std::string prefix("/");
   const Http::Code status(Http::Code::OK);
   config_helper_.addConfigModifier(
-      [&file_path, &prefix](
+      [&body, &prefix](
           envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void {
         auto* route_config = hcm.mutable_route_config();

--- a/test/integration/h1_capture_direct_response_fuzz_test.cc
+++ b/test/integration/h1_capture_direct_response_fuzz_test.cc
@@ -6,7 +6,6 @@ namespace Envoy {
 
 void H1FuzzIntegrationTest::initialize() {
   const std::string body = "Response body";
-  const std::string file_path = TestEnvironment::writeStringToFileForTest("test_envoy", body);
   const std::string prefix("/");
   const Http::Code status(Http::Code::OK);
   config_helper_.addConfigModifier(
@@ -19,7 +18,9 @@ void H1FuzzIntegrationTest::initialize() {
             hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
         default_route->mutable_match()->set_prefix(prefix);
         default_route->mutable_direct_response()->set_status(static_cast<uint32_t>(status));
-        default_route->mutable_direct_response()->mutable_body()->set_filename(file_path);
+        // Use inline bytes rather than a filename to avoid using a path that may look illegal to
+        // Envoy.
+        default_route->mutable_direct_response()->mutable_body()->set_inline_bytes(body);
         // adding headers to the default route
         auto* header_value_option = route_config->mutable_response_headers_to_add()->Add();
         header_value_option->mutable_header()->set_value("direct-response-enabled");

--- a/test/integration/h1_corpus/clusterfuzz-testcase-h1_capture_direct_response_fuzz_test-5145199254831104
+++ b/test/integration/h1_corpus/clusterfuzz-testcase-h1_capture_direct_response_fuzz_test-5145199254831104
@@ -1,0 +1,3 @@
+events {
+  downstream_send_bytes: "POST /test/long/url HTTP/1.1\r\nhost: host\r\nx-lyft-user-id: 123\r\nx-fkrwarded-for: 10.0.0.1\r\ntransfer-encoding:event\r\nx-lyft-user-id: 123\r\nx-fkrwarded-for: 10.0.0.1\r\ntransfer-encoding:events er-id: 123\r\nx-fkrwarded-for: 10.0.0.1\r\ntransfer-encoding:events {\n   downnstrc"
+}

--- a/test/integration/h2_capture_direct_response_fuzz_test.cc
+++ b/test/integration/h2_capture_direct_response_fuzz_test.cc
@@ -6,7 +6,6 @@ namespace Envoy {
 
 void H2FuzzIntegrationTest::initialize() {
   const std::string body = "Response body";
-  const std::string file_path = TestEnvironment::writeStringToFileForTest("test_envoy", body);
   const std::string prefix("/");
   const Http::Code status(Http::Code::OK);
 
@@ -14,7 +13,7 @@ void H2FuzzIntegrationTest::initialize() {
   setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
 
   config_helper_.addConfigModifier(
-      [&file_path, &prefix](
+      [&body, &prefix](
           envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void {
         auto* route_config = hcm.mutable_route_config();
@@ -23,7 +22,9 @@ void H2FuzzIntegrationTest::initialize() {
             hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
         default_route->mutable_match()->set_prefix(prefix);
         default_route->mutable_direct_response()->set_status(static_cast<uint32_t>(status));
-        default_route->mutable_direct_response()->mutable_body()->set_filename(file_path);
+        // Use inline bytes rather than a filename to avoid using a path that may look illegal to
+        // Envoy.
+        default_route->mutable_direct_response()->mutable_body()->set_inline_bytes(body);
         // adding headers to the default route
         auto* header_value_option = route_config->mutable_response_headers_to_add()->Add();
         header_value_option->mutable_header()->set_value("direct-response-enabled");

--- a/test/integration/h2_corpus/clusterfuzz-testcase-h2_capture_fuzz_test-5096668204761088
+++ b/test/integration/h2_corpus/clusterfuzz-testcase-h2_capture_fuzz_test-5096668204761088
@@ -1,0 +1,28 @@
+events {
+  downstream_send_event {
+    h2_frames {
+      settings {
+      }
+    }
+    h2_frames {
+    }
+    h2_frames {
+      request {
+        stream_index: 1
+        host: "host"
+        path: "/path/to/long/url"
+      }
+    }
+  }
+}
+events {
+}
+events {
+  downstream_send_event {
+    h2_frames {
+      generic {
+        frame_bytes: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Removes temporary files used for direct responses in h1 and h2 end to end fuzz test.

Additional Description: This was causing a flakey issue where OSS-Fuzz's temporary path used for direct responses looked illegal to Envoy. It seems unlikely that it was one of the deny listed paths in `illegalPath` because the path is always `/mnt`. It may be flakey on a `realpath` failure when getting the canonical path. Replace with inline bytes since it's better not to mess around with the filesystem anyway.

```
[2021-02-17 14:24:17.258][49492][critical][assert] [test/integration/base_integration_test.cc:322] assert failure: rejected_counter == nullptr \|\| rejected_counter->value() == 0. Details: Lds update failed. Details
failed_configuration:
[...]
details: "Invalid path: /mnt/scratch0/clusterfuzz/bot/tmp/test_envoy"
```

and bootstrap path:
```
[2021-02-17 20:55:28.894][82532][critical][main] [source/server/server.cc:109] error initializing configuration '/mnt/scratch0/clusterfuzz/bot/tmp/bootstrap.pb': Invalid path: /mnt/scratch0/clusterfuzz/bot/tmp/bootstrap.pb'
```


Risk Level: Low
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31617