### PR TITLE
Add unit test of MessageUtil::anyToBytes

### DIFF
--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -331,7 +331,7 @@ public:
 
   /**
    * Convert from google.protobuf.Any to bytes as std::string
-   * @param message source google.protobuf.Any message.
+   * @param any source google.protobuf.Any message.
    *
    * @return std::string consists of bytes in the input message.
    */

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1249,7 +1249,6 @@ TEST_F(ProtobufUtilityTest, HashedValueStdHash) {
   EXPECT_NE(set.find(hv3), set.end());
 }
 
-// Validated exception thrown when anyConvertAndValidate observes a PGV failures.
 TEST_F(ProtobufUtilityTest, AnyBytes) {
   {
     ProtobufWkt::StringValue source;

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1249,6 +1249,30 @@ TEST_F(ProtobufUtilityTest, HashedValueStdHash) {
   EXPECT_NE(set.find(hv3), set.end());
 }
 
+// Validated exception thrown when anyConvertAndValidate observes a PGV failures.
+TEST_F(ProtobufUtilityTest, AnyBytes) {
+  {
+    ProtobufWkt::StringValue source;
+    source.set_value("abc");
+    ProtobufWkt::Any source_any;
+    source_any.PackFrom(source);
+    EXPECT_EQ(MessageUtil::anyToBytes(source_any), "abc");
+  }
+  {
+    ProtobufWkt::BytesValue source;
+    source.set_value({0x01, 0x02, 0x03});
+    ProtobufWkt::Any source_any;
+    source_any.PackFrom(source);
+    EXPECT_EQ(MessageUtil::anyToBytes(source_any), "\x01\x02\x03");
+  }
+  {
+    envoy::config::cluster::v3::Filter filter;
+    ProtobufWkt::Any source_any;
+    source_any.PackFrom(filter);
+    EXPECT_EQ(MessageUtil::anyToBytes(source_any), source_any.value());
+  }
+}
+
 // MessageUtility::anyConvert() with the wrong type throws.
 TEST_F(ProtobufUtilityTest, AnyConvertWrongType) {
   ProtobufWkt::Duration source_duration;


### PR DESCRIPTION
Added a missing unittest in https://github.com/envoyproxy/envoy/pull/15210 

resolves https://github.com/envoyproxy/envoy/pull/15210#discussion_r587878705

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
