### PR TITLE
Fixes #15320: refactoring of handling of state on failed VHDS updates

### DIFF
--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -40,29 +40,26 @@ bool RouteConfigUpdateReceiverImpl::onVhdsUpdate(
     const Protobuf::RepeatedPtrField<std::string>& removed_resources,
     const std::string& version_info) {
 
-  auto vhosts_before_this_update =
+  auto vhosts_after_this_update =
       std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>(
           *vhds_virtual_hosts_);
-  const bool removed = removeVhosts(*vhds_virtual_hosts_, removed_resources);
-  const bool updated = updateVhosts(*vhds_virtual_hosts_, added_vhosts);
+  const bool removed = removeVhosts(*vhosts_after_this_update, removed_resources);
+  const bool updated = updateVhosts(*vhosts_after_this_update, added_vhosts);
 
-  auto route_config_before_this_update =
+  auto route_config_after_this_update =
       std::make_unique<envoy::config::route::v3::RouteConfiguration>();
-  route_config_before_this_update->CopyFrom(*route_config_proto_);
-  rebuildRouteConfig(rds_virtual_hosts_, *vhds_virtual_hosts_, *route_config_proto_);
+  route_config_after_this_update->CopyFrom(*route_config_proto_);
+  rebuildRouteConfig(rds_virtual_hosts_, *vhosts_after_this_update,
+                     *route_config_after_this_update);
   ConfigConstSharedPtr new_config;
 
-  try {
-    new_config = std::make_shared<ConfigImpl>(
-        *route_config_proto_, factory_context_,
-        factory_context_.messageValidationContext().dynamicValidationVisitor(), false);
-  } catch (const Envoy::EnvoyException& e) {
-    // revert the changes that failed validation
-    vhds_virtual_hosts_ = std::move(vhosts_before_this_update);
-    route_config_proto_ = std::move(route_config_before_this_update);
-    throw;
-  }
+  new_config = std::make_shared<ConfigImpl>(
+      *route_config_after_this_update, factory_context_,
+      factory_context_.messageValidationContext().dynamicValidationVisitor(), false);
 
+  // No exception, route_config_after_this_update is valid, can update the state.
+  vhds_virtual_hosts_ = std::move(vhosts_after_this_update);
+  route_config_proto_ = std::move(route_config_after_this_update);
   config_ = new_config;
   resource_ids_in_last_update_ = added_resource_ids;
   onUpdateCommon(version_info);


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/15320. Instead of reverting of state change on exception, the change is made permanent after a successful validation.

Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

Risk Level: low, refactoring of existing code
Testing: existing tests

ping @antoniovicente, @adisuissa. 