### PR TITLE
Add variable binding support

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/api/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -233,3 +233,7 @@ message GrpcJsonTranscoder {
   // This incorrect error message may conflict with other Envoy components, such as retry policies.
   RequestValidationOptions request_validation_options = 11;
 }
+
+message UnknownVariableBindings {
+  map<string, string> bindings = 1;
+}

--- a/generated_api_shadow/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.proto
@@ -233,3 +233,7 @@ message GrpcJsonTranscoder {
   // This incorrect error message may conflict with other Envoy components, such as retry policies.
   RequestValidationOptions request_validation_options = 11;
 }
+
+message UnknownVariableBindings {
+  map<string, string> bindings = 1;
+}

--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -46,6 +46,7 @@ envoy_cc_library(
     deps = [
         "//source/common/grpc:codec_lib",
         "//source/common/protobuf",
+        "@envoy_api//envoy/extensions/filters/http/grpc_json_transcoder/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -1,4 +1,5 @@
 #include "extensions/filters/http/grpc_json_transcoder/http_body_utils.h"
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
 
 #include "google/api/httpbody.pb.h"
 
@@ -6,6 +7,7 @@ using Envoy::Protobuf::io::CodedInputStream;
 using Envoy::Protobuf::io::CodedOutputStream;
 using Envoy::Protobuf::io::StringOutputStream;
 using Envoy::Protobuf::io::ZeroCopyInputStream;
+using envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings;
 
 namespace Envoy {
 namespace Extensions {
@@ -62,7 +64,7 @@ bool HttpBodyUtils::parseMessageByFieldPath(ZeroCopyInputStream* stream,
 
 void HttpBodyUtils::appendHttpBodyEnvelope(
     Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
-    std::string content_type, uint64_t content_length) {
+    std::string content_type, uint64_t content_length, const UnknownVariableBindings& unknown_bindings) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded for wire format.
 
@@ -76,6 +78,7 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
 
     ::google::api::HttpBody body;
     body.set_content_type(std::move(content_type));
+    body.add_extensions()->PackFrom(unknown_bindings);
 
     uint64_t envelope_size = body.ByteSizeLong() +
                              CodedOutputStream::VarintSize32(http_body_field_number) +

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h
@@ -5,6 +5,7 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/grpc/codec.h"
 #include "common/protobuf/protobuf.h"
+#include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -19,7 +20,8 @@ public:
   static void
   appendHttpBodyEnvelope(Buffer::Instance& output,
                          const std::vector<const Protobuf::Field*>& request_body_field_path,
-                         std::string content_type, uint64_t content_length);
+                         std::string content_type, uint64_t content_length,
+                         const envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings& unknown_bindings);
 };
 
 } // namespace GrpcJsonTranscoder

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -86,7 +86,8 @@ public:
                    Protobuf::io::ZeroCopyInputStream& request_input,
                    google::grpc::transcoding::TranscoderInputStream& response_input,
                    std::unique_ptr<google::grpc::transcoding::Transcoder>& transcoder,
-                   MethodInfoSharedPtr& method_info) const;
+                   MethodInfoSharedPtr& method_info,
+                   envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings& unknown_bindings) const;
 
   /**
    * Converts an arbitrary protobuf message to JSON.
@@ -198,6 +199,7 @@ private:
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   MethodInfoSharedPtr method_;
   Http::ResponseHeaderMap* response_headers_{};
+  envoy::extensions::filters::http::grpc_json_transcoder::v3::UnknownVariableBindings unknown_bindings_;
   Grpc::Decoder decoder_;
 
   // Data of the initial request message, initialized from query arguments, path, etc.


### PR DESCRIPTION
Commit Message: Add unknown variable binding support to grpc transcoder
Additional Description: In some cases the names of the variable bindings may not be known ahead of time and downstream needs to receive an arbitrary mapping. This implements support for such a mapping.
Risk Level: Low
Testing: As this is mostly for demonstration purposes testing deferred until after further discussion.
Docs Changes:
Release Notes:
When allowing missing variable bindings, missing bindings are added to a HttpBody extension as a map of strings.
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] https://github.com/envoyproxy/envoy/issues/14710
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
