### PR TITLE
docs: fix reference to upstream_internal_redirect_succeeded_total metric

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -84,7 +84,7 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_flow_control_backed_up_total, Counter, Total number of times the upstream connection backed up and paused reads from downstream
   upstream_flow_control_drained_total, Counter, Total number of times the upstream connection drained and resumed reads from downstream
   upstream_internal_redirect_failed_total, Counter, Total number of times failed internal redirects resulted in redirects being passed downstream.
-  upstream_internal_redirect_succeed_total, Counter, Total number of times internal redirects resulted in a second upstream request.
+  upstream_internal_redirect_succeeded_total, Counter, Total number of times internal redirects resulted in a second upstream request.
   membership_change, Counter, Total cluster membership changes
   membership_healthy, Gauge, Current cluster healthy total (inclusive of both health checking and outlier detection)
   membership_degraded, Gauge, Current cluster :ref:`degraded <arch_overview_load_balancing_degraded>` total


### PR DESCRIPTION
Reference to this metric: https://github.com/envoyproxy/envoy/blob/ca60583f1c4dfc3547b4efac9ecac7e0bcc20eee/include/envoy/upstream/upstream.h#L559