### PR TITLE
docs: Fix link to build image on install page

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -219,7 +219,7 @@ The following table shows the available Docker images
      -
      - latest
      - latest
-   * - `envoyproxy/envoy-build-ubuntu <https://hub.docker.com/r/envoyproxy/envoy-debug-dev/tags/>`_
+   * - `envoyproxy/envoy-build-ubuntu <https://hub.docker.com/r/envoyproxy/envoy-build-ubuntu/tags/>`_
      - Build image which includes tools for building multi-arch Envoy and containers.
      -
      -


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Fix link to build image on install page
Additional Description:

fixes a small link typo in the docker image table

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
