### PR TITLE
build: Bump build image hash to e33c93e6d7

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -246,7 +246,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:d9b1f1cbb24b2cecca768feaa9fa3c6e6660a948
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/envoy-ci/envoy-build:d9b1f1cbb24b2cecca768feaa9fa3c6e6660a948
+FROM gcr.io/envoy-ci/envoy-build:e33c93e6d79804bf95ff80426d10bdcc9096c785
 
 ARG USERNAME=vscode
 ARG USER_UID=501

--- a/examples/wasm-cc/docker-compose-wasm.yaml
+++ b/examples/wasm-cc/docker-compose-wasm.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   wasm_compile_update:
-    image: envoyproxy/envoy-build-ubuntu:d9b1f1cbb24b2cecca768feaa9fa3c6e6660a948
+    image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
     command: |
       bash -c "bazel build //examples/wasm-cc:envoy_filter_http_wasm_updated_example.wasm \
                 && cp -a bazel-bin/examples/wasm-cc/* /build"
@@ -12,7 +12,7 @@ services:
       - ./lib:/build
 
   wasm_compile:
-    image: envoyproxy/envoy-build-ubuntu:d9b1f1cbb24b2cecca768feaa9fa3c6e6660a948
+    image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
     command: |
       bash -c "bazel build //examples/wasm-cc:envoy_filter_http_wasm_example.wasm \
                 && cp -a bazel-bin/examples/wasm-cc/* /build"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: build: Bump build image hash to e33c93e6d7
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
