### PR TITLE
docker: Remove unused package install

### DIFF
--- a/ci/Dockerfile-envoy
+++ b/ci/Dockerfile-envoy
@@ -1,15 +1,8 @@
 ARG BUILD_OS=ubuntu
 ARG BUILD_TAG=18.04
 
-# Final stage
 FROM $BUILD_OS:$BUILD_TAG
 ARG TARGETPLATFORM
-
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install --no-install-recommends -y ca-certificates \
-    && apt-get autoremove -y && apt-get clean \
-    && rm -rf /tmp/* /var/tmp/* \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/envoy
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docker: Remove unused package install
Additional Description:

the `ca-certs` package was added to allow curling the `su-exec` binary from github https

see https://github.com/envoyproxy/envoy/commit/e8a2d1e24dc9a0da5273442204ec3cdfad1e7ca8

now that su-exec is handled outside of the image build, we dont need the ca-certs package

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Possible fix for #14971
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
