### PR TITLE
Drop spammy "Unable to use runtime singleton" logs

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -16,7 +16,7 @@ bool runtimeFeatureEnabled(absl::string_view feature) {
     return Runtime::LoaderSingleton::getExisting()->threadsafeSnapshot()->runtimeFeatureEnabled(
         feature);
   }
-  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::runtime), warn,
+  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::runtime), debug,
                       "Unable to use runtime singleton for feature {}", feature);
   return RuntimeFeaturesDefaults::get().enabledByDefault(feature);
 }
@@ -27,7 +27,7 @@ uint64_t getInteger(absl::string_view feature, uint64_t default_value) {
     return Runtime::LoaderSingleton::getExisting()->threadsafeSnapshot()->getInteger(
         std::string(feature), default_value);
   }
-  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::runtime), warn,
+  ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::runtime), debug,
                       "Unable to use runtime singleton for feature {}", feature);
   return default_value;
 }


### PR DESCRIPTION
For https://github.com/envoyproxy/envoy/issues/13504

These logs have been spamming all(?) envoy deployments for a long time,
confusing users. I don't know how to "fix" them, so instead dropping the
level so it doesn't bother everyone until they are fixed properly.

Signed-off-by: John Howard <howardjohn@google.com>

Commit Message: Drop spammy "Unable to use runtime singleton" logs
Additional Description:
Risk Level: None
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None
