### PR TITLE
listener: dropping api v2 header include

### DIFF
--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -282,7 +282,6 @@ envoy_cc_library(
         "//source/common/init:target_lib",
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
-        "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
@@ -344,8 +343,6 @@ envoy_cc_library(
         "//source/extensions/transport_sockets:well_known_names",
         "//source/extensions/upstreams/http/generic:config",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
-        "@envoy_api//envoy/api/v2:pkg_cc_proto",
-        "@envoy_api//envoy/api/v2/listener:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/listener/proxy_protocol/v3:pkg_cc_proto",
@@ -530,7 +527,7 @@ envoy_cc_library(
         ":well_known_names_lib",
         "//include/envoy/registry",
         "//include/envoy/server:active_udp_listener_config_interface",
-        "@envoy_api//envoy/api/v2/listener:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
     ],
 )
 
@@ -539,6 +536,6 @@ envoy_cc_library(
     hdrs = ["filter_chain_factory_context_callback.h"],
     deps = [
         "//include/envoy/server:filter_config_interface",
-        "@envoy_api//envoy/api/v2/listener:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
     ],
 )

--- a/source/server/active_raw_udp_listener_config.cc
+++ b/source/server/active_raw_udp_listener_config.cc
@@ -3,7 +3,7 @@
 #include <memory>
 #include <string>
 
-#include "envoy/api/v2/listener/listener.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
 
 #include "server/connection_handler_impl.h"
 #include "server/well_known_names.h"

--- a/source/server/api_listener_impl.cc
+++ b/source/server/api_listener_impl.cc
@@ -1,7 +1,6 @@
 #include "server/api_listener_impl.h"
 
-#include "envoy/api/v2/lds.pb.h"
-#include "envoy/api/v2/listener/listener.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/stats/scope.h"
 
 #include "common/http/conn_manager_impl.h"

--- a/source/server/filter_chain_factory_context_callback.h
+++ b/source/server/filter_chain_factory_context_callback.h
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include "envoy/api/v2/listener/listener.pb.h"
 #include "envoy/common/pure.h"
+#include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/server/filter_config.h"
 
 namespace Envoy {

--- a/source/server/lds_api.cc
+++ b/source/server/lds_api.cc
@@ -1,8 +1,8 @@
 #include "server/lds_api.h"
 
 #include "envoy/admin/v3/config_dump.pb.h"
-#include "envoy/api/v2/listener.pb.h"
 #include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/config/route/v3/route.pb.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 #include "envoy/stats/scope.h"

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -18,8 +18,8 @@ WorkerPtr ProdWorkerFactory::createWorker(uint32_t index, OverloadManager& overl
                                           const std::string& worker_name) {
   Event::DispatcherPtr dispatcher(
       api_.allocateDispatcher(worker_name, overload_manager.scaledTimerFactory()));
-  return std::make_unique<WorkerImpl>(tls_, hooks_, std::move(dispatcher),
-                                      std::make_unique<ConnectionHandlerImpl>(*dispatcher, index),
+  auto conn_handler = std::make_unique<ConnectionHandlerImpl>(*dispatcher, index);
+  return std::make_unique<WorkerImpl>(tls_, hooks_, std::move(dispatcher), std::move(conn_handler),
                                       overload_manager, api_);
 }
 


### PR DESCRIPTION
Commit Message:
dropping api v2 header include
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
The only left over `@envoy_api//envoy/api/v2/listener:pkg_cc_proto` dependency is in api/test/validate:pgv_test`

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
