### PR TITLE
wrong api type (v2-alpha) included under api-v3/ docs

### DIFF
--- a/docs/root/api-v3/config/filter/thrift/thrift.rst
+++ b/docs/root/api-v3/config/filter/thrift/thrift.rst
@@ -5,5 +5,4 @@ Thrift filters
   :glob:
   :maxdepth: 2
 
-  router/v2alpha1/*
   ../../../extensions/filters/network/thrift_proxy/**/v3/*


### PR DESCRIPTION

Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>


Commit Message: Wrong inclusion of api type.
Additional Description: in doc https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/filter/thrift/thrift 
wrong Router is included in api-v3/ as https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/filter/thrift/router/v2alpha1/router.proto#config-filter-thrift-router-v2alpha1-router
Risk Level: LOW
Testing: 
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
part of #11027