### PR TITLE
ecds: use last received filter config from a subscription

### DIFF
--- a/docs/root/configuration/overview/extension.rst
+++ b/docs/root/configuration/overview/extension.rst
@@ -89,3 +89,4 @@ to the common subscription statistics, it also provides the following:
 
   config_reload, Counter, Total number of successful configuration updates
   config_fail, Counter, Total number of failed configuration updates
+  config_conflict, Counter, Total number of conflicting applications of configuration updates; this may happen when a new listener cannot reuse a subscribed extension configuration due to an invalid type URL.

--- a/include/envoy/config/extension_config_provider.h
+++ b/include/envoy/config/extension_config_provider.h
@@ -35,14 +35,6 @@ public:
   virtual absl::optional<FactoryCallback> config() PURE;
 
   /**
-   * Validate that the configuration is applicable in the context of the provider. If an exception
-   * is thrown by any of the config providers for an update, the extension configuration update is
-   * rejected.
-   * @param type_url is the candidate configuration protobuf type URL.
-   */
-  virtual void validateConfig(const std::string& type_url) PURE;
-
-  /**
    * Update the provider with a new configuration.
    * @param config is an extension factory callback to replace the existing configuration.
    * @param version_info is the version of the new extension configuration.

--- a/include/envoy/config/extension_config_provider.h
+++ b/include/envoy/config/extension_config_provider.h
@@ -38,10 +38,9 @@ public:
    * Validate that the configuration is applicable in the context of the provider. If an exception
    * is thrown by any of the config providers for an update, the extension configuration update is
    * rejected.
-   * @param proto_config is the candidate configuration update.
-   * @param factory used to instantiate an extension config.
+   * @param type_url is the candidate configuration protobuf type URL.
    */
-  virtual void validateConfig(const ProtobufWkt::Any& proto_config, Factory& factory) PURE;
+  virtual void validateConfig(const std::string& type_url) PURE;
 
   /**
    * Update the provider with a new configuration.

--- a/include/envoy/filter/http/filter_config_provider.h
+++ b/include/envoy/filter/http/filter_config_provider.h
@@ -28,19 +28,15 @@ public:
   /**
    * Get an FilterConfigProviderPtr for a filter config. The config providers may share
    * the underlying subscriptions to the filter config discovery service.
-   * @param config_source supplies the configuration source for the filter configs.
+   * @param config_source supplies the extension configuration source for the filter configs.
    * @param filter_config_name the filter config resource name.
-   * @param require_type_urls enforces that the typed filter config must have a certain type URL.
    * @param factory_context is the context to use for the filter config provider.
    * @param stat_prefix supplies the stat_prefix to use for the provider stats.
-   * @param apply_without_warming initializes immediately with the default config and starts the
-   * subscription.
    */
   virtual FilterConfigProviderPtr createDynamicFilterConfigProvider(
-      const envoy::config::core::v3::ConfigSource& config_source,
-      const std::string& filter_config_name, const std::set<std::string>& require_type_urls,
-      Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
-      bool apply_without_warming) PURE;
+      const envoy::config::core::v3::ExtensionConfigSource& config_source,
+      const std::string& filter_config_name, Server::Configuration::FactoryContext& factory_context,
+      const std::string& stat_prefix) PURE;
 
   /**
    * Get an FilterConfigProviderPtr for a statically inlined filter config.

--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -224,6 +224,10 @@ FilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFilterConf
   }
 
   // If the subscription already received a config, attempt to apply it.
+  // It is possible that the received extension config fails to satisfy the listener
+  // type URL constraints. This may happen if ECDS and LDS updates are racing, and tne LDS
+  // update arrives first. In this case, use the default config, increment a metric,
+  // and the applied config eventually converges once ECDS update arrives.
   bool last_config_valid = false;
   if (subscription->lastConfig().has_value()) {
     try {

--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -14,10 +14,9 @@ namespace Filter {
 namespace Http {
 
 DynamicFilterConfigProviderImpl::DynamicFilterConfigProviderImpl(
-    FilterConfigSubscriptionSharedPtr&& subscription,
-    const std::set<std::string>& require_type_urls,
+    FilterConfigSubscriptionSharedPtr& subscription, const std::set<std::string>& require_type_urls,
     Server::Configuration::FactoryContext& factory_context)
-    : subscription_(std::move(subscription)), require_type_urls_(require_type_urls),
+    : subscription_(subscription), require_type_urls_(require_type_urls),
       tls_(factory_context.threadLocal()),
       init_target_("DynamicFilterConfigProviderImpl", [this]() {
         subscription_->start();
@@ -40,9 +39,7 @@ absl::optional<Envoy::Http::FilterFactoryCb> DynamicFilterConfigProviderImpl::co
   return tls_->config_;
 }
 
-void DynamicFilterConfigProviderImpl::validateConfig(
-    const ProtobufWkt::Any& proto_config, Server::Configuration::NamedHttpFilterConfigFactory&) {
-  auto type_url = Config::Utility::getFactoryType(proto_config);
+void DynamicFilterConfigProviderImpl::validateConfig(const std::string& type_url) {
   if (require_type_urls_.count(type_url) == 0) {
     throw EnvoyException(fmt::format("Error: filter config has type URL {} but expect {}.",
                                      type_url, absl::StrJoin(require_type_urls_, ", ")));
@@ -124,8 +121,9 @@ void FilterConfigSubscription::onConfigUpdate(
   // Ensure that the filter config is valid in the filter chain context once the proto is processed.
   // Validation happens before updating to prevent a partial update application. It might be
   // possible that the providers have distinct type URL constraints.
+  const auto type_url = Config::Utility::getFactoryType(filter_config.typed_config());
   for (auto* provider : filter_config_providers_) {
-    provider->validateConfig(filter_config.typed_config(), factory);
+    provider->validateConfig(type_url);
   }
   ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
       filter_config.typed_config(), validator_, factory);
@@ -142,6 +140,9 @@ void FilterConfigSubscription::onConfigUpdate(
     });
   }
   last_config_hash_ = new_hash;
+  last_config_ = factory_callback;
+  last_type_url_ = type_url;
+  last_version_info_ = version_info;
 }
 
 void FilterConfigSubscription::onConfigUpdate(
@@ -196,23 +197,61 @@ std::shared_ptr<FilterConfigSubscription> FilterConfigProviderManagerImpl::getSu
 }
 
 FilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFilterConfigProvider(
-    const envoy::config::core::v3::ConfigSource& config_source,
-    const std::string& filter_config_name, const std::set<std::string>& require_type_urls,
-    Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
-    bool apply_without_warming) {
-  auto subscription =
-      getSubscription(config_source, filter_config_name, factory_context, stat_prefix);
+    const envoy::config::core::v3::ExtensionConfigSource& config_source,
+    const std::string& filter_config_name, Server::Configuration::FactoryContext& factory_context,
+    const std::string& stat_prefix) {
+  auto subscription = getSubscription(config_source.config_source(), filter_config_name,
+                                      factory_context, stat_prefix);
   // For warming, wait until the subscription receives the first response to indicate readiness.
   // Otherwise, mark ready immediately and start the subscription on initialization. A default
   // config is expected in the latter case.
-  if (!apply_without_warming) {
+  if (!config_source.apply_default_config_without_warming()) {
     factory_context.initManager().add(subscription->initTarget());
   }
-  auto provider = std::make_unique<DynamicFilterConfigProviderImpl>(
-      std::move(subscription), require_type_urls, factory_context);
+  std::set<std::string> require_type_urls;
+  for (const auto& type_url : config_source.type_urls()) {
+    auto factory_type_url = TypeUtil::typeUrlToDescriptorFullName(type_url);
+    require_type_urls.emplace(factory_type_url);
+  }
+  auto provider = std::make_unique<DynamicFilterConfigProviderImpl>(subscription, require_type_urls,
+                                                                    factory_context);
   // Ensure the subscription starts if it has not already.
-  if (apply_without_warming) {
+  if (config_source.apply_default_config_without_warming()) {
     factory_context.initManager().add(provider->init_target_);
+  }
+
+  // If the subscription already received a config, attempt to apply it.
+  bool config_applied = false;
+  if (subscription->lastConfig().has_value()) {
+    try {
+      provider->validateConfig(subscription->lastTypeUrl());
+      provider->onConfigUpdate(subscription->lastConfig().value(), subscription->lastVersionInfo(),
+                               nullptr);
+      config_applied = true;
+    } catch (const EnvoyException& e) {
+      ENVOY_LOG(debug, "ECDS subscription {} is invalid in a listener context: {}.",
+                filter_config_name, e.what());
+    }
+  }
+
+  // Apply the default config if none has been applied.
+  if (config_source.has_default_config() && !config_applied) {
+    auto* default_factory =
+        Config::Utility::getFactoryByType<Server::Configuration::NamedHttpFilterConfigFactory>(
+            config_source.default_config());
+    if (default_factory == nullptr) {
+      throw EnvoyException(fmt::format("Error: cannot find filter factory {} for default filter "
+                                       "configuration with type URL {}.",
+                                       filter_config_name,
+                                       config_source.default_config().type_url()));
+    }
+    provider->validateConfig(Config::Utility::getFactoryType(config_source.default_config()));
+    ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
+        config_source.default_config(), factory_context.messageValidationVisitor(),
+        *default_factory);
+    Envoy::Http::FilterFactoryCb default_config =
+        default_factory->createFilterFactoryFromProto(*message, stat_prefix, factory_context);
+    provider->onConfigUpdate(default_config, "", nullptr);
   }
   return provider;
 }

--- a/source/common/filter/http/filter_config_discovery_impl.cc
+++ b/source/common/filter/http/filter_config_discovery_impl.cc
@@ -225,7 +225,7 @@ FilterConfigProviderPtr FilterConfigProviderManagerImpl::createDynamicFilterConf
 
   // If the subscription already received a config, attempt to apply it.
   // It is possible that the received extension config fails to satisfy the listener
-  // type URL constraints. This may happen if ECDS and LDS updates are racing, and tne LDS
+  // type URL constraints. This may happen if ECDS and LDS updates are racing, and the LDS
   // update arrives first. In this case, use the default config, increment a metric,
   // and the applied config eventually converges once ECDS update arrives.
   bool last_config_valid = false;

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -31,7 +31,7 @@ using FilterConfigSubscriptionSharedPtr = std::shared_ptr<FilterConfigSubscripti
  **/
 class DynamicFilterConfigProviderImpl : public FilterConfigProvider {
 public:
-  DynamicFilterConfigProviderImpl(FilterConfigSubscriptionSharedPtr&& subscription,
+  DynamicFilterConfigProviderImpl(FilterConfigSubscriptionSharedPtr& subscription,
                                   const std::set<std::string>& require_type_urls,
                                   Server::Configuration::FactoryContext& factory_context);
   ~DynamicFilterConfigProviderImpl() override;
@@ -39,8 +39,7 @@ public:
   // Config::ExtensionConfigProvider
   const std::string& name() override;
   absl::optional<Envoy::Http::FilterFactoryCb> config() override;
-  void validateConfig(const ProtobufWkt::Any& proto_config,
-                      Server::Configuration::NamedHttpFilterConfigFactory&) override;
+  void validateConfig(const std::string& type_url) override;
   void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&,
                       Config::ConfigAppliedCb cb) override;
 
@@ -98,6 +97,9 @@ public:
 
   const Init::SharedTargetImpl& initTarget() { return init_target_; }
   const std::string& name() { return filter_config_name_; }
+  const absl::optional<Envoy::Http::FilterFactoryCb>& lastConfig() { return last_config_; }
+  const std::string& lastTypeUrl() { return last_type_url_; }
+  const std::string& lastVersionInfo() { return last_version_info_; }
 
 private:
   void start();
@@ -113,6 +115,9 @@ private:
 
   const std::string filter_config_name_;
   uint64_t last_config_hash_{0ul};
+  absl::optional<Envoy::Http::FilterFactoryCb> last_config_{absl::nullopt};
+  std::string last_type_url_;
+  std::string last_version_info_;
   Server::Configuration::FactoryContext& factory_context_;
   ProtobufMessage::ValidationVisitor& validator_;
 
@@ -146,10 +151,7 @@ public:
   // Config::ExtensionConfigProvider
   const std::string& name() override { return filter_config_name_; }
   absl::optional<Envoy::Http::FilterFactoryCb> config() override { return config_; }
-  void validateConfig(const ProtobufWkt::Any&,
-                      Server::Configuration::NamedHttpFilterConfigFactory&) override {
-    NOT_REACHED_GCOVR_EXCL_LINE;
-  }
+  void validateConfig(const std::string&) override { NOT_REACHED_GCOVR_EXCL_LINE; }
   void onConfigUpdate(Envoy::Http::FilterFactoryCb, const std::string&,
                       Config::ConfigAppliedCb) override {
     NOT_REACHED_GCOVR_EXCL_LINE;
@@ -164,13 +166,13 @@ private:
  * An implementation of FilterConfigProviderManager.
  */
 class FilterConfigProviderManagerImpl : public FilterConfigProviderManager,
-                                        public Singleton::Instance {
+                                        public Singleton::Instance,
+                                        Logger::Loggable<Logger::Id::filter> {
 public:
   FilterConfigProviderPtr createDynamicFilterConfigProvider(
-      const envoy::config::core::v3::ConfigSource& config_source,
-      const std::string& filter_config_name, const std::set<std::string>& require_type_urls,
-      Server::Configuration::FactoryContext& factory_context, const std::string& stat_prefix,
-      bool apply_without_warming) override;
+      const envoy::config::core::v3::ExtensionConfigSource& config_source,
+      const std::string& filter_config_name, Server::Configuration::FactoryContext& factory_context,
+      const std::string& stat_prefix) override;
 
   FilterConfigProviderPtr
   createStaticFilterConfigProvider(const Envoy::Http::FilterFactoryCb& config,

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -69,7 +69,8 @@ private:
  */
 #define ALL_EXTENSION_CONFIG_DISCOVERY_STATS(COUNTER)                                              \
   COUNTER(config_reload)                                                                           \
-  COUNTER(config_fail)
+  COUNTER(config_fail)                                                                             \
+  COUNTER(config_conflict)
 
 /**
  * Struct definition for all extension config discovery stats. @see stats_macros.h
@@ -101,6 +102,7 @@ public:
   const absl::optional<Envoy::Http::FilterFactoryCb>& lastConfig() { return last_config_; }
   const std::string& lastTypeUrl() { return last_type_url_; }
   const std::string& lastVersionInfo() { return last_version_info_; }
+  void incrementConflictCounter();
 
 private:
   void start();

--- a/source/common/filter/http/filter_config_discovery_impl.h
+++ b/source/common/filter/http/filter_config_discovery_impl.h
@@ -32,14 +32,15 @@ using FilterConfigSubscriptionSharedPtr = std::shared_ptr<FilterConfigSubscripti
 class DynamicFilterConfigProviderImpl : public FilterConfigProvider {
 public:
   DynamicFilterConfigProviderImpl(FilterConfigSubscriptionSharedPtr& subscription,
-                                  const std::set<std::string>& require_type_urls,
+                                  const absl::flat_hash_set<std::string>& require_type_urls,
                                   Server::Configuration::FactoryContext& factory_context);
   ~DynamicFilterConfigProviderImpl() override;
+
+  void validateTypeUrl(const std::string& type_url) const;
 
   // Config::ExtensionConfigProvider
   const std::string& name() override;
   absl::optional<Envoy::Http::FilterFactoryCb> config() override;
-  void validateConfig(const std::string& type_url) override;
   void onConfigUpdate(Envoy::Http::FilterFactoryCb config, const std::string&,
                       Config::ConfigAppliedCb cb) override;
 
@@ -50,7 +51,7 @@ private:
   };
 
   FilterConfigSubscriptionSharedPtr subscription_;
-  const std::set<std::string> require_type_urls_;
+  const absl::flat_hash_set<std::string> require_type_urls_;
   // Currently applied configuration to ensure that the main thread deletes the last reference to
   // it.
   absl::optional<Envoy::Http::FilterFactoryCb> current_config_{absl::nullopt};
@@ -151,7 +152,6 @@ public:
   // Config::ExtensionConfigProvider
   const std::string& name() override { return filter_config_name_; }
   absl::optional<Envoy::Http::FilterFactoryCb> config() override { return config_; }
-  void validateConfig(const std::string&) override { NOT_REACHED_GCOVR_EXCL_LINE; }
   void onConfigUpdate(Envoy::Http::FilterFactoryCb, const std::string&,
                       Config::ConfigAppliedCb) override {
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/test/integration/extension_discovery_integration_test.cc
+++ b/test/integration/extension_discovery_integration_test.cc
@@ -409,6 +409,8 @@ TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfig) {
   response->waitForEndStream();
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
+  test_server_->waitForCounterEq("http.config_test.extension_config_discovery.foo.config_conflict",
+                                 0);
 }
 
 TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfigInvalid) {
@@ -446,6 +448,8 @@ TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfigInvalid) {
   response->waitForEndStream();
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("403", response->headers().getStatusValue());
+  test_server_->waitForCounterGe("http.config_test.extension_config_discovery.foo.config_conflict",
+                                 1);
 }
 
 TEST_P(ExtensionDiscoveryIntegrationTest, BasicFailWithDefault) {

--- a/test/integration/extension_discovery_integration_test.cc
+++ b/test/integration/extension_discovery_integration_test.cc
@@ -140,6 +140,29 @@ public:
               ->mutable_direct_response()
               ->set_status(200);
         });
+    // Use gRPC LDS instead of default file LDS.
+    use_lds_ = false;
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* lds_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      lds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      lds_cluster->set_name("lds_cluster");
+      ConfigHelper::setHttp2(*lds_cluster);
+    });
+    // Must be the last since it nukes static listeners.
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      listener_config_.Swap(bootstrap.mutable_static_resources()->mutable_listeners(0));
+      listener_config_.set_name(listener_name_);
+      ENVOY_LOG_MISC(error, "listener config: {}", listener_config_.DebugString());
+      bootstrap.mutable_static_resources()->mutable_listeners()->Clear();
+      auto* lds_config_source = bootstrap.mutable_dynamic_resources()->mutable_lds_config();
+      lds_config_source->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+      auto* lds_api_config_source = lds_config_source->mutable_api_config_source();
+      lds_api_config_source->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+      lds_api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
+      envoy::config::core::v3::GrpcService* grpc_service =
+          lds_api_config_source->add_grpc_services();
+      setGrpcService(*grpc_service, "lds_cluster", getLdsFakeUpstream().localAddress());
+    });
     HttpIntegrationTest::initialize();
   }
 
@@ -157,15 +180,37 @@ public:
     HttpIntegrationTest::createUpstreams();
     // Create the extension config discovery upstream (fake_upstreams_[1]).
     addFakeUpstream(FakeHttpConnection::Type::HTTP2);
+    // Create the listener config discovery upstream (fake_upstreams_[2]).
+    addFakeUpstream(FakeHttpConnection::Type::HTTP2);
   }
 
   void waitXdsStream() {
-    auto& upstream = getEcdsFakeUpstream();
-    AssertionResult result = upstream.waitForHttpConnection(*dispatcher_, ecds_connection_);
+    // Wait for LDS stream.
+    auto& lds_upstream = getLdsFakeUpstream();
+    AssertionResult result = lds_upstream.waitForHttpConnection(*dispatcher_, lds_connection_);
+    RELEASE_ASSERT(result, result.message());
+    result = lds_connection_->waitForNewStream(*dispatcher_, lds_stream_);
+    RELEASE_ASSERT(result, result.message());
+    lds_stream_->startGrpcStream();
+
+    // Response with initial LDS.
+    sendLdsResponse("initial");
+
+    // Wait for ECDS stream.
+    auto& ecds_upstream = getEcdsFakeUpstream();
+    result = ecds_upstream.waitForHttpConnection(*dispatcher_, ecds_connection_);
     RELEASE_ASSERT(result, result.message());
     result = ecds_connection_->waitForNewStream(*dispatcher_, ecds_stream_);
     RELEASE_ASSERT(result, result.message());
     ecds_stream_->startGrpcStream();
+  }
+
+  void sendLdsResponse(const std::string& version) {
+    envoy::service::discovery::v3::DiscoveryResponse response;
+    response.set_version_info(version);
+    response.set_type_url(Config::TypeUrl::get().Listener);
+    response.add_resources()->PackFrom(listener_config_);
+    lds_stream_->sendGrpcMessage(response);
   }
 
   void sendXdsResponse(const std::string& name, const std::string& version,
@@ -197,9 +242,17 @@ public:
   }
 
   FakeUpstream& getEcdsFakeUpstream() const { return *fake_upstreams_[1]; }
+  FakeUpstream& getLdsFakeUpstream() const { return *fake_upstreams_[2]; }
 
+  // gRPC ECDS set-up
   FakeHttpConnectionPtr ecds_connection_{nullptr};
   FakeStreamPtr ecds_stream_{nullptr};
+
+  // gRPC LDS set-up
+  envoy::config::listener::v3::Listener listener_config_;
+  std::string listener_name_{"testing-listener-0"};
+  FakeHttpConnectionPtr lds_connection_{nullptr};
+  FakeStreamPtr lds_stream_{nullptr};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, ExtensionDiscoveryIntegrationTest,
@@ -320,6 +373,72 @@ TEST_P(ExtensionDiscoveryIntegrationTest, BasicDefaultMatcher) {
   response->waitForEndStream();
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfig) {
+  on_server_init_function_ = [&]() { waitXdsStream(); };
+  addDynamicFilter("foo", false);
+  initialize();
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 1);
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
+  registerTestServerPorts({"http"});
+  sendXdsResponse("foo", "1", allowAllConfig());
+  test_server_->waitForCounterGe("http.config_test.extension_config_discovery.foo.config_reload",
+                                 1);
+  test_server_->waitUntilListenersReady();
+  test_server_->waitForGaugeGe("listener_manager.workers_started", 1);
+
+  // Update listener and expect it to be warm and use active configuration from the subscription
+  // instead of the default config.
+  listener_config_.set_traffic_direction(envoy::config::core::v3::TrafficDirection::OUTBOUND);
+  sendLdsResponse("updated");
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 2);
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_warming", 0);
+
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfigInvalid) {
+  on_server_init_function_ = [&]() { waitXdsStream(); };
+  addDynamicFilter("foo", false);
+  initialize();
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 1);
+  EXPECT_EQ(test_server_->server().initManager().state(), Init::Manager::State::Initializing);
+  registerTestServerPorts({"http"});
+  sendXdsResponseWithFullYaml("foo", "1", denyPrivateConfigWithMatcher());
+  test_server_->waitForCounterGe("http.config_test.extension_config_discovery.foo.config_reload",
+                                 1);
+  test_server_->waitUntilListenersReady();
+  test_server_->waitForGaugeGe("listener_manager.workers_started", 1);
+
+  // Remove matcher filter type URL, invalidating the subscription last config.
+  auto hcm_config = MessageUtil::anyConvert<
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager>(
+      listener_config_.filter_chains(0).filters(0).typed_config());
+  hcm_config.mutable_http_filters(0)->mutable_config_discovery()->mutable_type_urls()->Clear();
+  hcm_config.mutable_http_filters(0)->mutable_config_discovery()->add_type_urls(
+      "type.googleapis.com/test.integration.filters.SetResponseCodeFilterConfig");
+  listener_config_.mutable_filter_chains(0)->mutable_filters(0)->mutable_typed_config()->PackFrom(
+      hcm_config);
+
+  sendLdsResponse("updated");
+  test_server_->waitForCounterGe("listener_manager.lds.update_success", 2);
+  test_server_->waitForGaugeEq("listener_manager.total_listeners_warming", 0);
+
+  // Should be using the default config (403)
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  response->waitForEndStream();
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("403", response->headers().getStatusValue());
 }
 
 TEST_P(ExtensionDiscoveryIntegrationTest, BasicFailWithDefault) {

--- a/test/integration/extension_discovery_integration_test.cc
+++ b/test/integration/extension_discovery_integration_test.cc
@@ -174,6 +174,13 @@ public:
       RELEASE_ASSERT(result, result.message());
       ecds_connection_.reset();
     }
+    if (lds_connection_ != nullptr) {
+      AssertionResult result = lds_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = lds_connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      lds_connection_.reset();
+    }
   }
 
   void createUpstreams() override {
@@ -244,15 +251,15 @@ public:
   FakeUpstream& getEcdsFakeUpstream() const { return *fake_upstreams_[1]; }
   FakeUpstream& getLdsFakeUpstream() const { return *fake_upstreams_[2]; }
 
-  // gRPC ECDS set-up
-  FakeHttpConnectionPtr ecds_connection_{nullptr};
-  FakeStreamPtr ecds_stream_{nullptr};
-
   // gRPC LDS set-up
   envoy::config::listener::v3::Listener listener_config_;
   std::string listener_name_{"testing-listener-0"};
   FakeHttpConnectionPtr lds_connection_{nullptr};
   FakeStreamPtr lds_stream_{nullptr};
+
+  // gRPC ECDS set-up
+  FakeHttpConnectionPtr ecds_connection_{nullptr};
+  FakeStreamPtr ecds_stream_{nullptr};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, ExtensionDiscoveryIntegrationTest,

--- a/test/integration/extension_discovery_integration_test.cc
+++ b/test/integration/extension_discovery_integration_test.cc
@@ -382,6 +382,11 @@ TEST_P(ExtensionDiscoveryIntegrationTest, BasicDefaultMatcher) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Validate that a listener update reuses the extension configuration. Prior
+// to https://github.com/envoyproxy/envoy/pull/15371, the updated listener
+// would not use the subscribed extension configuration and would not trigger a
+// fresh xDS request. See issue
+// https://github.com/envoyproxy/envoy/issues/14934.
 TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfig) {
   on_server_init_function_ = [&]() { waitXdsStream(); };
   addDynamicFilter("foo", false);
@@ -413,6 +418,8 @@ TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfig) {
                                  0);
 }
 
+// Validate that a listener update falls back to the default extension configuration
+// if the subscribed extension configuration fails to satisfy the type URL constraint.
 TEST_P(ExtensionDiscoveryIntegrationTest, ReuseExtensionConfigInvalid) {
   on_server_init_function_ = [&]() { waitXdsStream(); };
   addDynamicFilter("foo", false);


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: Fix a bug with LDS not picking up last ECDS change. This was because the logic applied the default config from the extension config source regardless of the whether subscription has been initialized with a filter config. There is a tricky edge case if the listener restricts the type URLs that makes the subscription invalid. In this case, we continue using the default config, and log a message.
Risk Level: low (bugfix)
Testing: integration
Docs Changes: none
Release Notes: fix a bug with ECDS using the default config in multiple listeners subscribed to the same filter config resource
Fixes: https://github.com/envoyproxy/envoy/issues/14934

cc @bianpengyuan @snowp 