### PR TITLE
Expose socket from NetworkFilterCallbacks

### DIFF
--- a/include/envoy/network/filter.h
+++ b/include/envoy/network/filter.h
@@ -20,6 +20,7 @@ namespace Network {
 
 class Connection;
 class ConnectionSocket;
+class Socket;
 class UdpListener;
 struct UdpRecvData;
 
@@ -44,6 +45,11 @@ public:
    * @return the connection that owns this filter.
    */
   virtual Connection& connection() PURE;
+
+  /**
+   * @return Socket the socket the filter is operating on.
+   */
+  virtual const Socket& socket() PURE;
 };
 
 /**

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -68,7 +68,7 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
                                StreamInfo::StreamInfo& stream_info, bool connected)
     : ConnectionImplBase(dispatcher, next_global_id_++),
       transport_socket_(std::move(transport_socket)), socket_(std::move(socket)),
-      stream_info_(stream_info), filter_manager_(*this),
+      stream_info_(stream_info), filter_manager_(*this, *socket_),
       write_buffer_(dispatcher.getWatermarkFactory().create(
           [this]() -> void { this->onWriteBufferLowWatermark(); },
           [this]() -> void { this->onWriteBufferHighWatermark(); },

--- a/source/common/network/filter_manager_impl.h
+++ b/source/common/network/filter_manager_impl.h
@@ -5,6 +5,7 @@
 
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
+#include "envoy/network/socket.h"
 
 #include "common/common/linked_object.h"
 
@@ -100,7 +101,8 @@ public:
  */
 class FilterManagerImpl {
 public:
-  FilterManagerImpl(FilterManagerConnection& connection) : connection_(connection) {}
+  FilterManagerImpl(FilterManagerConnection& connection, const Socket& socket)
+      : connection_(connection), socket_(socket) {}
 
   void addWriteFilter(WriteFilterSharedPtr filter);
   void addFilter(FilterSharedPtr filter);
@@ -116,6 +118,7 @@ private:
         : parent_(parent), filter_(filter) {}
 
     Connection& connection() override { return parent_.connection_; }
+    const Socket& socket() override { return parent_.socket_; }
     void continueReading() override { parent_.onContinueReading(this, parent_.connection_); }
     void injectReadDataToFilterChain(Buffer::Instance& data, bool end_stream) override {
       FixedReadBufferSource buffer_source{data, end_stream};
@@ -140,6 +143,7 @@ private:
         : parent_(parent), filter_(std::move(filter)) {}
 
     Connection& connection() override { return parent_.connection_; }
+    const Socket& socket() override { return parent_.socket_; }
     void injectWriteDataToFilterChain(Buffer::Instance& data, bool end_stream) override {
       FixedWriteBufferSource buffer_source{data, end_stream};
       parent_.onResumeWriting(this, buffer_source);
@@ -157,6 +161,7 @@ private:
   void onResumeWriting(ActiveWriteFilter* filter, WriteBufferSource& buffer_source);
 
   FilterManagerConnection& connection_;
+  const Socket& socket_;
   Upstream::HostDescriptionConstSharedPtr host_description_;
   std::list<ActiveReadFilterPtr> upstream_filters_;
   std::list<ActiveWriteFilterPtr> downstream_filters_;

--- a/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.cc
+++ b/source/extensions/quic_listeners/quiche/quic_filter_manager_connection_impl.cc
@@ -11,7 +11,7 @@ QuicFilterManagerConnectionImpl::QuicFilterManagerConnectionImpl(EnvoyQuicConnec
     // Using this for purpose other than logging is not safe. Because QUIC connection id can be
     // 18 bytes, so there might be collision when it's hashed to 8 bytes.
     : Network::ConnectionImplBase(dispatcher, /*id=*/connection.connection_id().Hash()),
-      quic_connection_(&connection), filter_manager_(*this),
+      quic_connection_(&connection), filter_manager_(*this, *connection.connectionSocket()),
       stream_info_(dispatcher.timeSource(),
                    connection.connectionSocket()->addressProviderSharedPtr()),
       write_buffer_watermark_simulation_(

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -68,6 +68,7 @@ protected:
       NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
     }
     Network::Connection& connection() override { return connection_; }
+    const Network::Socket& socket() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
     // Synthetic class that acts as a stub for the connection backing the
     // Network::ReadFilterCallbacks.

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -67,6 +67,7 @@ public:
   ~MockReadFilterCallbacks() override;
 
   MOCK_METHOD(Connection&, connection, ());
+  MOCK_METHOD(const Socket&, socket, ());
   MOCK_METHOD(void, continueReading, ());
   MOCK_METHOD(void, injectReadDataToFilterChain, (Buffer::Instance & data, bool end_stream));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, upstreamHost, ());
@@ -94,6 +95,7 @@ public:
   ~MockWriteFilterCallbacks() override;
 
   MOCK_METHOD(Connection&, connection, ());
+  MOCK_METHOD(const Socket&, socket, ());
   MOCK_METHOD(void, injectWriteDataToFilterChain, (Buffer::Instance & data, bool end_stream));
 
   testing::NiceMock<MockConnection> connection_;


### PR DESCRIPTION
Like the ListenerFilterCallbacks which exposes the ConnectionSocket to listener filters, this change exposes the Socket to network filters and will enable making socket options for the upstream connection accessible to access loggers (#13166).

Risk Level: low
Testing: unit tests

Signed-off-by: Elisha Ziskind <eziskind@google.com>
