### PR TITLE
hcm config: Add dependency violation error message

### DIFF
--- a/source/extensions/filters/network/http_connection_manager/BUILD
+++ b/source/extensions/filters/network/http_connection_manager/BUILD
@@ -66,6 +66,10 @@ envoy_cc_library(
     name = "dependency_manager",
     srcs = ["dependency_manager.cc"],
     hdrs = ["dependency_manager.h"],
+    external_deps = [
+        "abseil_status",
+        # "abseil_strings",
+    ],
     deps = [
         "@envoy_api//envoy/extensions/filters/common/dependency/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/network/http_connection_manager/BUILD
+++ b/source/extensions/filters/network/http_connection_manager/BUILD
@@ -68,7 +68,6 @@ envoy_cc_library(
     hdrs = ["dependency_manager.h"],
     external_deps = [
         "abseil_status",
-        # "abseil_strings",
     ],
     deps = [
         "@envoy_api//envoy/extensions/filters/common/dependency/v3:pkg_cc_proto",

--- a/source/extensions/filters/network/http_connection_manager/dependency_manager.cc
+++ b/source/extensions/filters/network/http_connection_manager/dependency_manager.cc
@@ -1,20 +1,25 @@
 #include "extensions/filters/network/http_connection_manager/dependency_manager.h"
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/strings/substitute.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace HttpConnectionManager {
 
-bool DependencyManager::validDecodeDependencies() {
+using envoy::extensions::filters::common::dependency::v3::Dependency;
+
+absl::Status DependencyManager::validDecodeDependencies() {
   using DependencyTuple = std::tuple<const std::string&, int>;
   absl::flat_hash_set<DependencyTuple> satisfied;
 
   for (const auto& [name, dependencies] : filter_chain_) {
     for (const auto& requirement : dependencies.decode_required()) {
       if (!satisfied.contains({requirement.name(), requirement.type()})) {
-        return false;
+        return absl::NotFoundError(absl::Substitute(
+            "Dependency violation: filter '$0' requires a $1 named '$2'", name,
+            Dependency::DependencyType_Name(requirement.type()), requirement.name()));
       }
     }
     for (const auto& provided : dependencies.decode_provided()) {
@@ -22,7 +27,7 @@ bool DependencyManager::validDecodeDependencies() {
     }
   }
 
-  return true;
+  return absl::OkStatus();
 }
 
 } // namespace HttpConnectionManager

--- a/source/extensions/filters/network/http_connection_manager/dependency_manager.h
+++ b/source/extensions/filters/network/http_connection_manager/dependency_manager.h
@@ -41,7 +41,7 @@ public:
   absl::Status validDecodeDependencies();
 
 private:
-  // Ordered mapping of filter names to dependency specifications.
+  // Mapping of filter names to dependencies, in decode path order.
   std::vector<std::pair<std::string,
                         envoy::extensions::filters::common::dependency::v3::FilterDependencies>>
       filter_chain_;

--- a/source/extensions/filters/network/http_connection_manager/dependency_manager.h
+++ b/source/extensions/filters/network/http_connection_manager/dependency_manager.h
@@ -2,6 +2,8 @@
 
 #include "envoy/extensions/filters/common/dependency/v3/dependency.pb.h"
 
+#include "absl/status/status.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -21,9 +23,9 @@ public:
    * from the filter factory. Filters must be registered in decode path order.
    */
   void registerFilter(
-      const std::string& name,
+      const std::string& filter_name,
       const envoy::extensions::filters::common::dependency::v3::FilterDependencies& dependencies) {
-    filter_chain_.push_back({name, dependencies});
+    filter_chain_.push_back({filter_name, dependencies});
   }
 
   /**
@@ -34,9 +36,10 @@ public:
    * TODO(auni53): Change this to a general valid() that checks decode and
    * encode path.
    */
-  bool validDecodeDependencies();
+  absl::Status validDecodeDependencies();
 
 private:
+  // Ordered mapping of filter names to dependency specifications.
   std::vector<std::pair<std::string,
                         envoy::extensions::filters::common::dependency::v3::FilterDependencies>>
       filter_chain_;

--- a/source/extensions/filters/network/http_connection_manager/dependency_manager.h
+++ b/source/extensions/filters/network/http_connection_manager/dependency_manager.h
@@ -29,9 +29,11 @@ public:
   }
 
   /**
-   * Returns true if the decode path of the filter chain is valid. A filter
-   * chain is valid iff for each filter, every decode dependency has been
-   * provided by a previous filter.
+   * Returns StatusCode::kOk if the decode path of the filter chain is valid.
+   * A filter chain is valid iff for each filter, every decode dependency has
+   * been provided by a previous filter.
+   * Returns StatusCode::kNotFoundError if the decode path is invalid, with
+   * details of the first dependency violation found.
    *
    * TODO(auni53): Change this to a general valid() that checks decode and
    * encode path.

--- a/test/extensions/filters/network/http_connection_manager/dependency_manager_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/dependency_manager_test.cc
@@ -11,6 +11,7 @@ namespace {
 
 using envoy::extensions::filters::common::dependency::v3::Dependency;
 using envoy::extensions::filters::common::dependency::v3::FilterDependencies;
+using testing::HasSubstr;
 
 TEST(DependencyManagerTest, RegisterFilter) {
   DependencyManager manager;
@@ -27,7 +28,8 @@ TEST(DependencyManagerTest, RegisterFilterWithDependency) {
   provided->set_type(Dependency::FILTER_STATE_KEY);
   provided->set_name("potato");
   manager.registerFilter("ingredient", dependencies);
-  EXPECT_TRUE(manager.validDecodeDependencies());
+  auto result = manager.validDecodeDependencies();
+  EXPECT_TRUE(result.ok());
 }
 
 TEST(DependencyManagerTest, Valid) {
@@ -46,7 +48,8 @@ TEST(DependencyManagerTest, Valid) {
   manager.registerFilter("ingredient", d1);
   manager.registerFilter("chef", d2);
 
-  EXPECT_TRUE(manager.validDecodeDependencies());
+  auto result = manager.validDecodeDependencies();
+  EXPECT_TRUE(result.ok());
 }
 
 TEST(DependencyManagerTest, MissingProvidencyInvalid) {
@@ -57,7 +60,11 @@ TEST(DependencyManagerTest, MissingProvidencyInvalid) {
   required->set_type(Dependency::FILTER_STATE_KEY);
   required->set_name("potato");
   manager.registerFilter("chef", dependencies);
-  EXPECT_FALSE(manager.validDecodeDependencies());
+
+  auto result = manager.validDecodeDependencies();
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.message(),
+              HasSubstr("filter 'chef' requires a FILTER_STATE_KEY named 'potato'"));
 }
 
 TEST(DependencyManagerTest, WrongProvidencyTypeInvalid) {
@@ -76,7 +83,10 @@ TEST(DependencyManagerTest, WrongProvidencyTypeInvalid) {
   manager.registerFilter("ingredient", d1);
   manager.registerFilter("chef", d2);
 
-  EXPECT_FALSE(manager.validDecodeDependencies());
+  auto result = manager.validDecodeDependencies();
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.message(),
+              HasSubstr("filter 'chef' requires a FILTER_STATE_KEY named 'potato'"));
 }
 
 TEST(DependencyManagerTest, WrongProvidencyNameInvalid) {
@@ -95,7 +105,10 @@ TEST(DependencyManagerTest, WrongProvidencyNameInvalid) {
   manager.registerFilter("ingredient", d1);
   manager.registerFilter("chef", d2);
 
-  EXPECT_FALSE(manager.validDecodeDependencies());
+  auto result = manager.validDecodeDependencies();
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.message(),
+              HasSubstr("filter 'chef' requires a FILTER_STATE_KEY named 'potato'"));
 }
 
 TEST(DependencyManagerTest, MisorderedFiltersInvalid) {
@@ -114,7 +127,10 @@ TEST(DependencyManagerTest, MisorderedFiltersInvalid) {
   manager.registerFilter("chef", d2);
   manager.registerFilter("ingredient", d1);
 
-  EXPECT_FALSE(manager.validDecodeDependencies());
+  auto result = manager.validDecodeDependencies();
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.message(),
+              HasSubstr("filter 'chef' requires a FILTER_STATE_KEY named 'potato'"));
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Auni Ahsan <auni@google.com>

* Changer return type of decodeDependencidesValid() bool -> absl::Status
* Currently this will return the first dependency violation found, but in the future we could accumulate errors into one absl::Status

Risk Level: Low, library isn't used yet
Testing: Unit tested