### PR TITLE
[WIP] protodoc: Use type URLs for referencing extensions

### DIFF
--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -58,7 +58,7 @@ DATA_PLANE_API_URL_FMT = 'https://github.com/envoyproxy/envoy/blob/{}/api/%s#L%d
 EXTENSION_TEMPLATE = Template("""
 .. _extension_{{extension}}:
 
-This extension may be referenced by the qualified name *{{extension}}*
+This extension may be referenced with the type url: ``{{type_url}}``
 
 .. note::
   {{status}}
@@ -239,6 +239,7 @@ def FormatExtension(extension):
   return EXTENSION_TEMPLATE.render(extension=extension,
                                    status=status,
                                    security_posture=security_posture,
+                                   type_url=f"type.googleapis.com/{NormalizeTypeContextName(extension)}",
                                    categories=categories)
 
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: protodoc: Use type URLs for referencing extensions
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
