### PR TITLE
Attempt to fix buildx/multiarch build flakiness

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -12,12 +12,14 @@ ENVOY_DOCKER_IMAGE_DIRECTORY="${ENVOY_DOCKER_IMAGE_DIRECTORY:-${BUILD_STAGINGDIR
 
 # Setting environments for buildx tools
 config_env() {
-  # Qemu configurations
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  # QEMU regression causes arm64 detection flakiness - https://github.com/docker/buildx/issues/542
+  docker run --rm --privileged tonistiigi/binfmt --uninstall qemu-aarch64
+  # Install QEMU emulators
+  docker run --rm --privileged tonistiigi/binfmt --install all
 
   # Remove older build instance
   docker buildx rm multi-builder || :
-  docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+  docker buildx create --use --name multi-builder
 }
 
 build_platforms() {

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -12,8 +12,6 @@ ENVOY_DOCKER_IMAGE_DIRECTORY="${ENVOY_DOCKER_IMAGE_DIRECTORY:-${BUILD_STAGINGDIR
 
 # Setting environments for buildx tools
 config_env() {
-  # QEMU regression causes arm64 detection flakiness - https://github.com/docker/buildx/issues/542
-  docker run --rm --privileged tonistiigi/binfmt --uninstall qemu-aarch64
   # Install QEMU emulators
   docker run --rm --privileged tonistiigi/binfmt --install all
 

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -17,7 +17,7 @@ config_env() {
 
   # Remove older build instance
   docker buildx rm multi-builder || :
-  docker buildx create --use --name multi-builder
+  docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
 }
 
 build_platforms() {


### PR DESCRIPTION
Hit this multiarch build issue on a seperate PR
https://github.com/envoyproxy/envoy/pull/15204#issuecomment-790880847

Fixes https://github.com/envoyproxy/envoy/issues/14971

Most likely relates to https://github.com/docker/buildx/issues/542

https://github.com/docker/buildx#building-multi-platform-images
recommends running `docker run --privileged --rm tonistiigi/binfmt
--install all` before setting up `buildx`

Signed-off-by: Arko Dasgupta <arko@tetrate.io>


Risk Level: Low
Testing: CI
