### PR TITLE
[WIP] xds: add subscription ID to map subscribed resource locators to returned resources

### DIFF
--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -20,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DiscoveryRequest";
 
@@ -43,6 +43,14 @@ message DiscoveryRequest {
   // will then imply a number of resources that need to be fetched via EDS/RDS,
   // which will be explicitly enumerated in resource_names.
   repeated string resource_names = 3;
+
+  // An alternative to resource_names that specifies an optional subscription
+  // ID for each resource locator subscribed to. Resources that match
+  // each resource locator will be tagged with the associated subscription
+  // ID in the Resource.new_subscription_ids field in the response.
+  // Note that the client must be prepared for each resource in the
+  // response to be wrapped in a Resource message.
+  map<string, uint64> resource_locators = 7;
 
   // Type of the resource that is being requested, e.g.
   // "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment". This is implicit
@@ -140,7 +148,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DeltaDiscoveryRequest";
 
@@ -178,6 +186,12 @@ message DeltaDiscoveryRequest {
 
   // A list of Resource names to remove from the list of tracked resources.
   repeated string resource_names_unsubscribe = 4;
+
+  // An alternative to resource_names_subscribe that specifies an optional
+  // subscription ID for each resource locator subscribed to. Resources that
+  // match each resource locator will be tagged with the associated subscription
+  // ID in the Resource.new_subscription_ids field in the response.
+  map<string, uint64> resource_locators_subscribe = 8;
 
   // Informs the server of the versions of the resources the xDS client knows of, to enable the
   // client to continue the same logical xDS session even in the face of gRPC stream reconnection.
@@ -232,7 +246,7 @@ message DeltaDiscoveryResponse {
   config.core.v3.ControlPlane control_plane = 7;
 }
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message Resource {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Resource";
 
@@ -276,4 +290,17 @@ message Resource {
   // Cache control properties for the resource.
   // [#not-implemented-hide:]
   CacheControl cache_control = 7;
+
+  // The subscription ID(s) that this resource is associated with, if
+  // sent in the request when the client subscribes to a new resource.
+  // This needs to be populated only when (a) a resource is first sent
+  // to the client or (b) when the client subscribes to a new resource
+  // locator that matches a resource that the client is already
+  // subscribing to.
+  // Note that in case (b), the resource field does not need to be
+  // populated. This allows the server to tell the client that a
+  // resource that it had already been sent (because it matched a
+  // resource locator that the client had previously subscribed to) also
+  // matches another resource locator that the client has newly subscribed to.
+  repeated uint64 new_subscription_ids = 8;
 }


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: xds: add subscription ID to map subscribed esource locators to returned resources
Additional Description: This provides a way for the control plane to tell the client which of its subscriptions a given returned resource is intended to be associated with.  This will address ambiguity when we introduce flexible context parameter matching as part of the new xDS naming scheme.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A

CC @htuch @adisuissa 