### PR TITLE
docs: clarification in hot restart intro

### DIFF
--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -5,8 +5,8 @@ Hot restart
 
 Ease of operation is one of the primary goals of Envoy. In addition to robust statistics and a local
 administration interface, Envoy has the ability to “hot” or “live” restart itself. This means that
-Envoy can fully reload itself (both code and configuration) without dropping any connections. The
-hot restart functionality has the following general architecture:
+Envoy can fully reload itself (both code and configuration) without *immediately* dropping connections.
+The hot restart functionality has the following general architecture:
 
 * Statistics and some locks are kept in a shared memory region. This means that gauges will be
   consistent across both processes as restart is taking place.

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -5,8 +5,9 @@ Hot restart
 
 Ease of operation is one of the primary goals of Envoy. In addition to robust statistics and a local
 administration interface, Envoy has the ability to “hot” or “live” restart itself. This means that
-Envoy can fully reload itself (both code and configuration) without *immediately* dropping connections.
-The hot restart functionality has the following general architecture:
+Envoy can fully reload itself (both code and configuration) without dropping existing connections
+during the :ref:`drain process <arch_overview_draining>`. The hot restart functionality has the
+following general architecture:
 
 * Statistics and some locks are kept in a shared memory region. This means that gauges will be
   consistent across both processes as restart is taking place.


### PR DESCRIPTION
Commit Message: docs: clarification in hot restart intro

Additional Description: 
Accompanying discussion in envoy user's forum: https://groups.google.com/g/envoy-users/c/KmVo_Md9xiE
TL;DR: from reading the first paragraph in this hot restart doc I got the impression connection state is replicated to the new instance.  I tested it and found that wasn't the case.  Coming back to the doc and reading further down it became obvious that's not what hot restart does.  I imagine there's other like me who don't always read on, so a small change in wording here could help.

Risk Level: low
Testing: none
Docs Changes: yes
Release Notes:
Platform Specific Features: non

