### PR TITLE
backport 1.15: container: Only drop privs if user is root (#15115)

### DIFF
--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 set -e
 
+loglevel="${loglevel:-}"
+USERID=$(id -u)
+
 # if the first argument look like a parameter (i.e. start with '-'), run Envoy
 if [ "${1#-}" != "$1" ]; then
 	set -- envoy "$@"
@@ -13,7 +16,7 @@ if [ "$1" = 'envoy' ]; then
 	fi
 fi
 
-if [ "$ENVOY_UID" != "0" ]; then
+if [ "$ENVOY_UID" != "0" ] && [ "$USERID" = 0 ]; then
     if [ -n "$ENVOY_UID" ]; then
 	usermod -u "$ENVOY_UID" envoy
     fi


### PR DESCRIPTION
Signed-off-by: phlax <phlax@users.noreply.github.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
