### PR TITLE
docs: replace broken link in api/README.md

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,6 +18,6 @@ The API tree can be found at two locations:
 
 * [API style guide](STYLE.md)
 * [API versioning guide](API_VERSIONING.md)
-* [API overview for users](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/v2_overview#)
+* [API overview for users](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/overview)
 * [xDS protocol overview](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol)
 * [Contributing guide](CONTRIBUTING.md)


### PR DESCRIPTION
Commit Message:
In the api README a link is given for "API overview for users" that
leads to a 404.  It looks to be pointing to a v2_overview page that no
longer exists.  I replaced this link with the current overview at:
https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/overview

Additional Description: N/A
Risk Level: Low
Testing: Manual
Docs Changes: outlined in commit message.
Release Notes: N/A
Platform Specific Features: N/A

