### PR TITLE
docs: (take 2) Move external deps rst generation and cve scan to bazel

### DIFF
--- a/api/bazel/BUILD
+++ b/api/bazel/BUILD
@@ -2,6 +2,11 @@ load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 
 licenses(["notice"])  # Apache 2
 
+exports_files([
+    "repository_locations.bzl",
+    "repository_locations_utils.bzl",
+])
+
 go_proto_compiler(
     name = "pgv_plugin_go",
     options = ["lang=go"],

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -11,6 +11,7 @@ exports_files([
     "gen_sh_test_runner.sh",
     "sh_test_wrapper.sh",
     "test_for_benchmark_wrapper.sh",
+    "repository_locations.bzl",
 ])
 
 genrule(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,5 +1,4 @@
 # This should match the schema defined in external_deps.bzl.
-# MAKE IT FAIL!
 REPOSITORY_LOCATIONS_SPEC = dict(
     bazel_compdb = dict(
         project_name = "bazel-compilation-database",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,4 +1,5 @@
 # This should match the schema defined in external_deps.bzl.
+# MAKE IT FAIL!
 REPOSITORY_LOCATIONS_SPEC = dict(
     bazel_compdb = dict(
         project_name = "bazel-compilation-database",

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -451,16 +451,18 @@ elif [[ "$CI_TARGET" == "deps" ]]; then
   # Validate dependency relationships between core/extensions and external deps.
   ./tools/dependency/validate_test.py
   ./tools/dependency/validate.py
+
   # Validate the CVE scanner works. We do it here as well as in cve_scan, since this blocks
   # presubmits, but cve_scan only runs async.
-  python3.8 tools/dependency/cve_scan_test.py
+  bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/dependency:cve_scan_test
+
   # Validate repository metadata.
   ./ci/check_repository_locations.sh
   exit 0
 elif [[ "$CI_TARGET" == "cve_scan" ]]; then
   echo "scanning for CVEs in dependencies..."
-  python3.8 tools/dependency/cve_scan_test.py
-  python3.8 tools/dependency/cve_scan.py
+  bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/dependency:cve_scan_test
+  bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/dependency:cve_scan
   exit 0
 elif [[ "$CI_TARGET" == "verify_examples" ]]; then
   run_ci_verify "*" wasm-cc

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -77,11 +77,10 @@ BAZEL_BUILD_OPTIONS+=(
 
 # Generate RST for the lists of trusted/untrusted extensions in
 # intro/arch_overview/security docs.
-mkdir -p "${GENERATED_RST_DIR}"/intro/arch_overview/security
 bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/extensions:generate_extension_rst
 
 # Generate RST for external dependency docs in intro/arch_overview/security.
-PYTHONPATH=. ./docs/generate_external_dep_rst.py "${GENERATED_RST_DIR}"/intro/arch_overview/security
+bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/dependency:generate_external_dep_rst
 
 function generate_api_rst() {
   local proto_target

--- a/generated_api_shadow/bazel/BUILD
+++ b/generated_api_shadow/bazel/BUILD
@@ -2,6 +2,11 @@ load("@io_bazel_rules_go//proto:compiler.bzl", "go_proto_compiler")
 
 licenses(["notice"])  # Apache 2
 
+exports_files([
+    "repository_locations.bzl",
+    "repository_locations_utils.bzl",
+])
+
 go_proto_compiler(
     name = "pgv_plugin_go",
     options = ["lang=go"],

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -1,0 +1,40 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//bazel:envoy_build_system.bzl", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+py_binary(
+    name = "utils",
+    srcs = ["utils.py"],
+    data = [
+        "//bazel:repository_locations.bzl",
+        "@envoy_api_canonical//bazel:repository_locations.bzl",
+        "@envoy_api_canonical//bazel:repository_locations_utils.bzl",
+    ],
+)
+
+py_binary(
+    name = "generate_external_dep_rst",
+    srcs = ["generate_external_dep_rst.py"],
+    data = [
+        ":utils",
+    ],
+)
+
+py_binary(
+    name = "cve_scan",
+    srcs = ["cve_scan.py"],
+    data = [
+        ":utils",
+    ],
+)
+
+py_binary(
+    name = "cve_scan_test",
+    srcs = ["cve_scan_test.py"],
+    data = [
+        ":cve_scan",
+    ],
+)

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -6,8 +6,8 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 py_binary(
-    name = "utils",
-    srcs = ["utils.py"],
+    name = "exports",
+    srcs = ["exports.py"],
     data = [
         "//bazel:repository_locations.bzl",
         "@envoy_api_canonical//bazel:repository_locations.bzl",
@@ -17,17 +17,17 @@ py_binary(
 
 py_binary(
     name = "generate_external_dep_rst",
-    srcs = ["generate_external_dep_rst.py"],
+    srcs = ["generate_external_dep_rst.py", "utils.py"],
     data = [
-        ":utils",
+        ":exports",
     ],
 )
 
 py_binary(
     name = "cve_scan",
-    srcs = ["cve_scan.py"],
+    srcs = ["cve_scan.py", "utils.py"],
     data = [
-        ":utils",
+        ":exports",
     ],
 )
 

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -17,7 +17,10 @@ py_binary(
 
 py_binary(
     name = "generate_external_dep_rst",
-    srcs = ["generate_external_dep_rst.py", "utils.py"],
+    srcs = [
+        "generate_external_dep_rst.py",
+        "utils.py",
+    ],
     data = [
         ":exports",
     ],
@@ -25,7 +28,10 @@ py_binary(
 
 py_binary(
     name = "cve_scan",
-    srcs = ["cve_scan.py", "utils.py"],
+    srcs = [
+        "cve_scan.py",
+        "utils.py",
+    ],
     data = [
         ":exports",
     ],

--- a/tools/dependency/exports.py
+++ b/tools/dependency/exports.py
@@ -1,0 +1,22 @@
+# Modules exported from bazel
+
+import os
+
+
+# Shared Starlark/Python files must have a .bzl suffix for Starlark import, so
+# we are forced to do this workaround.
+def LoadModule(name, path):
+  spec = spec_from_loader(name, SourceFileLoader(name, path))
+  module = module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+api_path = os.getenv("API_PATH", "external/envoy_api_canonical")
+
+# Modules
+envoy_repository_locations = LoadModule('envoy_repository_locations',
+                                        'bazel/repository_locations.bzl')
+repository_locations_utils = LoadModule(
+    'repository_locations_utils', os.path.join(api_path, 'bazel/repository_locations_utils.bzl'))
+api_repository_locations = LoadModule('api_repository_locations',
+                                      os.path.join(api_path, 'bazel/repository_locations.bzl'))

--- a/tools/dependency/exports.py
+++ b/tools/dependency/exports.py
@@ -1,6 +1,8 @@
 # Modules exported from bazel
 
 import os
+from importlib.util import spec_from_loader, module_from_spec
+from importlib.machinery import SourceFileLoader
 
 
 # Shared Starlark/Python files must have a .bzl suffix for Starlark import, so
@@ -11,6 +13,9 @@ def LoadModule(name, path):
   spec.loader.exec_module(module)
   return module
 
+# this is the relative path in a bazel build
+# to call this module outside of a bazel build set the API_PATH first,
+# for example, to api/ if running from the envoy repo root
 api_path = os.getenv("API_PATH", "external/envoy_api_canonical")
 
 # Modules

--- a/tools/dependency/exports.py
+++ b/tools/dependency/exports.py
@@ -13,6 +13,7 @@ def LoadModule(name, path):
   spec.loader.exec_module(module)
   return module
 
+
 # this is the relative path in a bazel build
 # to call this module outside of a bazel build set the API_PATH first,
 # for example, to api/ if running from the envoy repo root

--- a/tools/dependency/exports.py
+++ b/tools/dependency/exports.py
@@ -15,8 +15,8 @@ def LoadModule(name, path):
 
 
 # this is the relative path in a bazel build
-# to call this module outside of a bazel build set the API_PATH first,
-# for example, to api/ if running from the envoy repo root
+# to call this module outside of a bazel build set the `API_PATH` first,
+# for example, if running from the envoy repo root: `export API_PATH=api/`
 api_path = os.getenv("API_PATH", "external/envoy_api_canonical")
 
 # Modules

--- a/tools/dependency/generate_external_dep_rst.py
+++ b/tools/dependency/generate_external_dep_rst.py
@@ -3,6 +3,7 @@
 # Generate RST lists of external dependencies.
 
 from collections import defaultdict, namedtuple
+import os
 import pathlib
 import sys
 import urllib.parse
@@ -67,7 +68,15 @@ def GetVersionUrl(metadata):
 
 
 if __name__ == '__main__':
-  security_rst_root = sys.argv[1]
+  try:
+    generated_rst_dir = os.getenv("GENERATED_RST_DIR") or sys.argv[1]
+  except IndexError:
+    raise SystemExit(
+        "Output dir path must be either specified as arg or with GENERATED_RST_DIR env var")
+
+  security_rst_root = os.path.join(generated_rst_dir, "intro/arch_overview/security")
+
+  pathlib.Path(security_rst_root).mkdir(parents=True, exist_ok=True)
 
   Dep = namedtuple('Dep', ['name', 'sort_name', 'version', 'cpe', 'release_date'])
   use_categories = defaultdict(lambda: defaultdict(list))

--- a/tools/dependency/ossf_scorecard.py
+++ b/tools/dependency/ossf_scorecard.py
@@ -24,6 +24,7 @@ import os
 import subprocess as sp
 import sys
 
+import exports
 import utils
 
 Scorecard = namedtuple('Scorecard', [
@@ -133,8 +134,8 @@ if __name__ == '__main__':
   path = sys.argv[1]
   scorecard_path = sys.argv[2]
   csv_output_path = sys.argv[3]
-  spec_loader = utils.repository_locations_utils.load_repository_locations_spec
-  path_module = utils.LoadModule('repository_locations', path)
+  spec_loader = exports.repository_locations_utils.load_repository_locations_spec
+  path_module = exports.LoadModule('repository_locations', path)
   try:
     results = Score(scorecard_path, spec_loader(path_module.REPOSITORY_LOCATIONS_SPEC))
     PrintCsvResults(csv_output_path, results)

--- a/tools/dependency/ossf_scorecard.py
+++ b/tools/dependency/ossf_scorecard.py
@@ -4,7 +4,8 @@
 #
 # Usage:
 #
-#   tools/dependency/ossf_scorecard.sh <path to repository_locations.bzl> \
+#   export API_PATH=api/
+#   tools/dependency/ossf_scorecard.py <path to repository_locations.bzl> \
 #       <path to scorecard binary> \
 #       <output CSV path>
 #

--- a/tools/dependency/release_dates.py
+++ b/tools/dependency/release_dates.py
@@ -16,6 +16,7 @@ import sys
 
 import github
 
+import exports
 import utils
 
 

--- a/tools/dependency/release_dates.py
+++ b/tools/dependency/release_dates.py
@@ -98,8 +98,8 @@ if __name__ == '__main__':
     print('Missing GITHUB_TOKEN')
     sys.exit(1)
   path = sys.argv[1]
-  spec_loader = utils.repository_locations_utils.load_repository_locations_spec
-  path_module = utils.LoadModule('repository_locations', path)
+  spec_loader = exports.repository_locations_utils.load_repository_locations_spec
+  path_module = exports.LoadModule('repository_locations', path)
   try:
     VerifyAndPrintReleaseDates(spec_loader(path_module.REPOSITORY_LOCATIONS_SPEC),
                                github.Github(access_token))

--- a/tools/dependency/release_dates.sh
+++ b/tools/dependency/release_dates.sh
@@ -4,4 +4,7 @@
 
 set -e
 
+# TODO(phlax): move this job to bazel and remove this
+export API_PATH=api/
+
 python_venv release_dates "$1"

--- a/tools/dependency/utils.py
+++ b/tools/dependency/utils.py
@@ -1,5 +1,6 @@
 # Utilities for reasoning about dependencies.
 
+import os
 from collections import namedtuple
 from importlib.util import spec_from_loader, module_from_spec
 from importlib.machinery import SourceFileLoader
@@ -14,16 +15,16 @@ def LoadModule(name, path):
   return module
 
 
-envoy_repository_locations = LoadModule('envoy_repository_locations',
-                                        'bazel/repository_locations.bzl')
-api_repository_locations = LoadModule('api_repository_locations',
-                                      'api/bazel/repository_locations.bzl')
-repository_locations_utils = LoadModule('repository_locations_utils',
-                                        'api/bazel/repository_locations_utils.bzl')
-
-
 # All repository location metadata in the Envoy repository.
 def RepositoryLocations():
+  api_path = os.getenv("API_PATH", "external/envoy_api_canonical")
+
+  envoy_repository_locations = LoadModule('envoy_repository_locations',
+                                          'bazel/repository_locations.bzl')
+  repository_locations_utils = LoadModule(
+      'repository_locations_utils', os.path.join(api_path, 'bazel/repository_locations_utils.bzl'))
+  api_repository_locations = LoadModule('api_repository_locations',
+                                        os.path.join(api_path, 'bazel/repository_locations.bzl'))
   spec_loader = repository_locations_utils.load_repository_locations_spec
   locations = spec_loader(envoy_repository_locations.REPOSITORY_LOCATIONS_SPEC)
   locations.update(spec_loader(api_repository_locations.REPOSITORY_LOCATIONS_SPEC))

--- a/tools/dependency/utils.py
+++ b/tools/dependency/utils.py
@@ -3,8 +3,8 @@
 import os
 from collections import namedtuple
 
-from exports import (
-  api_repository_locations, envoy_repository_locations, repository_locations_utils)
+from exports import (api_repository_locations, envoy_repository_locations,
+                     repository_locations_utils)
 
 
 # All repository location metadata in the Envoy repository.

--- a/tools/dependency/utils.py
+++ b/tools/dependency/utils.py
@@ -5,26 +5,12 @@ from collections import namedtuple
 from importlib.util import spec_from_loader, module_from_spec
 from importlib.machinery import SourceFileLoader
 
-
-# Shared Starlark/Python files must have a .bzl suffix for Starlark import, so
-# we are forced to do this workaround.
-def LoadModule(name, path):
-  spec = spec_from_loader(name, SourceFileLoader(name, path))
-  module = module_from_spec(spec)
-  spec.loader.exec_module(module)
-  return module
+from exports import (
+  api_repository_locations, envoy_repository_locations, repository_locations_utils)
 
 
 # All repository location metadata in the Envoy repository.
 def RepositoryLocations():
-  api_path = os.getenv("API_PATH", "external/envoy_api_canonical")
-
-  envoy_repository_locations = LoadModule('envoy_repository_locations',
-                                          'bazel/repository_locations.bzl')
-  repository_locations_utils = LoadModule(
-      'repository_locations_utils', os.path.join(api_path, 'bazel/repository_locations_utils.bzl'))
-  api_repository_locations = LoadModule('api_repository_locations',
-                                        os.path.join(api_path, 'bazel/repository_locations.bzl'))
   spec_loader = repository_locations_utils.load_repository_locations_spec
   locations = spec_loader(envoy_repository_locations.REPOSITORY_LOCATIONS_SPEC)
   locations.update(spec_loader(api_repository_locations.REPOSITORY_LOCATIONS_SPEC))

--- a/tools/dependency/utils.py
+++ b/tools/dependency/utils.py
@@ -2,8 +2,6 @@
 
 import os
 from collections import namedtuple
-from importlib.util import spec_from_loader, module_from_spec
-from importlib.machinery import SourceFileLoader
 
 from exports import (
   api_repository_locations, envoy_repository_locations, repository_locations_utils)

--- a/tools/extensions/generate_extension_rst.py
+++ b/tools/extensions/generate_extension_rst.py
@@ -35,6 +35,8 @@ if __name__ == '__main__':
     subprocess.run("tools/extensions/generate_extension_db".split(), check=True)
   extension_db = json.loads(pathlib.Path(extension_db_path).read_text())
 
+  pathlib.Path(security_rst_root).mkdir(parents=True, exist_ok=True)
+
   security_postures = defaultdict(list)
   for extension, metadata in extension_db.items():
     security_postures[metadata['security_posture']].append(extension)


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: (take 2) Move external deps rst generation and cve scan to bazel
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
