### PR TITLE
lb: add hash_key support to envoy.lb endpoint metadata

### DIFF
--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
@@ -71,7 +71,16 @@ mapped onto a circle (the "ring") by hashing its address; each request is then r
 hashing some property of the request, and finding the nearest corresponding host clockwise around
 the ring. This technique is also commonly known as `"Ketama" <https://github.com/RJ/ketama>`_
 hashing, and like all hash-based load balancers, it is only effective when protocol routing is used
-that specifies a value to hash on.
+that specifies a value to hash on. If you want something other than the host's address to be used
+as the hash key (e.g. the semantic name of your host in a Kubernetes StatefulSet), then you can specify it 
+in the ``"envoy.lb"`` :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: 
+.. code-block:: yaml
+
+    filter_metadata:
+      envoy.lb:
+        hash_key: "YOUR HASH KEY"
+
+This will override :ref:`use_hostname_for_hashing<envoy_api_field_Cluster.CommonLbConfig.consistent_hashing_lb_config>`.
 
 Each host is hashed and placed on the ring some number of times proportional to its weight. For
 example, if host A has a weight of 1 and host B has a weight of 2, then there might be three entries
@@ -101,7 +110,16 @@ with a fixed table size of 65537 (see section 5.3 of the same paper). Maglev can
 in replacement for the :ref:`ring hash load balancer <arch_overview_load_balancing_types_ring_hash>`
 any place in which consistent hashing is desired. Like the ring hash load balancer, a consistent
 hashing load balancer is only effective when protocol routing is used that specifies a value to
-hash on.
+hash on. If you want something other than the host's address to be used as the hash key (e.g. the 
+semantic name of your host in a Kubernetes StatefulSet), then you can specify it in the ``"envoy.lb"``
+:ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: 
+.. code-block:: yaml
+
+    filter_metadata:
+      envoy.lb:
+        hash_key: "YOUR HASH KEY"
+
+This will override :ref:`use_hostname_for_hashing<envoy_api_field_Cluster.CommonLbConfig.consistent_hashing_lb_config>`.
 
 The table construction algorithm places each host in the table some number of times proportional
 to its weight, until the table is completely filled. For example, if host A has a weight of 1 and

--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
@@ -74,6 +74,7 @@ hashing, and like all hash-based load balancers, it is only effective when proto
 that specifies a value to hash on. If you want something other than the host's address to be used
 as the hash key (e.g. the semantic name of your host in a Kubernetes StatefulSet), then you can specify it 
 in the ``"envoy.lb"`` :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: 
+
 .. validated-code-block:: yaml
   :type-name: envoy.config.core.v3.Metadata
 
@@ -114,6 +115,7 @@ hashing load balancer is only effective when protocol routing is used that speci
 hash on. If you want something other than the host's address to be used as the hash key (e.g. the 
 semantic name of your host in a Kubernetes StatefulSet), then you can specify it in the ``"envoy.lb"``
 :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: 
+
 .. validated-code-block:: yaml
   :type-name: envoy.config.core.v3.Metadata
 

--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
@@ -74,7 +74,8 @@ hashing, and like all hash-based load balancers, it is only effective when proto
 that specifies a value to hash on. If you want something other than the host's address to be used
 as the hash key (e.g. the semantic name of your host in a Kubernetes StatefulSet), then you can specify it 
 in the ``"envoy.lb"`` :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: 
-.. code-block:: yaml
+.. validated-code-block:: yaml
+  :type-name: envoy.config.core.v3.Metadata
 
     filter_metadata:
       envoy.lb:
@@ -113,7 +114,8 @@ hashing load balancer is only effective when protocol routing is used that speci
 hash on. If you want something other than the host's address to be used as the hash key (e.g. the 
 semantic name of your host in a Kubernetes StatefulSet), then you can specify it in the ``"envoy.lb"``
 :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: 
-.. code-block:: yaml
+.. validated-code-block:: yaml
+  :type-name: envoy.config.core.v3.Metadata
 
     filter_metadata:
       envoy.lb:

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -122,6 +122,7 @@ New Features
 * http: change frame flood and abuse checks to the upstream HTTP/2 codec to ON by default. It can be disabled by setting the `envoy.reloadable_features.upstream_http2_flood_checks` runtime key to false.
 * json: introduced new JSON parser (https://github.com/nlohmann/json) to replace RapidJSON. The new parser is disabled by default. To test the new RapidJSON parser, enable the runtime feature `envoy.reloadable_features.remove_legacy_json`.
 * kill_request: :ref:`Kill Request <config_http_filters_kill_request>` Now supports bidirection killing.
+* loadbalancer: added the ability to specify the hash_key for a host when using a consistent hashing loadbalancer (ringhash, maglev) using the :ref:`LbEndpoint.Metadata <envoy_api_field_endpoint.LbEndpoint.metadata>` e.g.: ``"envoy.lb": {"hash_key": "..."}``.
 * log: added a new custom flag ``%j`` to the log pattern to print the actual message to log as JSON escaped string.
 * oauth filter: added the optional parameter :ref:`resources <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.resources>`. Set this value to add multiple "resource" parameters in the Authorization request sent to the OAuth provider. This acts as an identifier representing the protected resources the client is requesting a token for.
 * original_dst: added support for :ref:`Original Destination <config_listener_filters_original_dst>` on Windows. This enables the use of Envoy as a sidecar proxy on Windows.

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -24,8 +24,6 @@
 #include "common/common/hash.h"
 #include "common/common/hex.h"
 #include "common/common/utility.h"
-#include "common/config/metadata.h"
-#include "common/config/well_known_names.h"
 #include "common/grpc/common.h"
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
@@ -496,21 +494,6 @@ public:
                                                                   random);
     }
     return std::make_unique<FixedBackOffStrategy>(dns_refresh_rate_ms);
-  }
-
-  /**
-   * Return the hash_key value inside the envoy.lb metadata filter value.
-   * @param metadata the metadata filters.
-   * @throws EnvoyException if there the value is not empty or a string type.
-   */
-  static std::string getHashKeyMetadataValue(const envoy::config::core::v3::Metadata* metadata) {
-    const ProtobufWkt::Value& val = Metadata::metadataValue(
-        metadata, MetadataFilters::get().ENVOY_LB, MetadataEnvoyLbKeys::get().HASH_KEY);
-    if (val.kind_case() != val.kStringValue && val.kind_case() != val.KIND_NOT_SET) {
-      ExceptionUtil::throwEnvoyException(
-          fmt::format("hash_key must be string type, got: {}", val.kind_case()));
-    }
-    return val.string_value();
   }
 };
 

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -24,6 +24,8 @@
 #include "common/common/hash.h"
 #include "common/common/hex.h"
 #include "common/common/utility.h"
+#include "common/config/metadata.h"
+#include "common/config/well_known_names.h"
 #include "common/grpc/common.h"
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
@@ -494,6 +496,21 @@ public:
                                                                   random);
     }
     return std::make_unique<FixedBackOffStrategy>(dns_refresh_rate_ms);
+  }
+
+  /**
+   * Return the hash_key value inside the envoy.lb metadata filter value.
+   * @param metadata the metadata filters.
+   * @throws EnvoyException if there the value is not empty or a string type.
+   */
+  static std::string getHashKeyMetadataValue(const envoy::config::core::v3::Metadata* metadata) {
+    const ProtobufWkt::Value& val = Metadata::metadataValue(
+        metadata, MetadataFilters::get().ENVOY_LB, MetadataEnvoyLbKeys::get().HASH_KEY);
+    if (val.kind_case() != val.kStringValue && val.kind_case() != val.KIND_NOT_SET) {
+      ExceptionUtil::throwEnvoyException(
+          fmt::format("hash_key must be string type, got: {}", val.kind_case()));
+    }
+    return val.string_value();
   }
 };
 

--- a/source/common/config/well_known_names.h
+++ b/source/common/config/well_known_names.h
@@ -43,6 +43,8 @@ class MetadataEnvoyLbKeyValues {
 public:
   // Key in envoy.lb filter namespace for endpoint canary bool value.
   const std::string CANARY = "canary";
+  // Key in envoy.lb filter namespace for the key to use to hash an endpoint.
+  const std::string HASH_KEY = "hash_key";
 };
 
 using MetadataEnvoyLbKeys = ConstSingleton<MetadataEnvoyLbKeyValues>;

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -340,8 +340,7 @@ envoy_cc_library(
     external_deps = ["abseil_synchronization"],
     deps = [
         ":load_balancer_lib",
-        "//source/common/config:metadata_lib",
-        "//source/common/config:well_known_names",
+        "//source/common/config:utility_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -340,7 +340,8 @@ envoy_cc_library(
     external_deps = ["abseil_synchronization"],
     deps = [
         ":load_balancer_lib",
-        "//source/common/config:utility_lib",
+        "//source/common/config:metadata_lib",
+        "//source/common/config:well_known_names",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -340,6 +340,7 @@ envoy_cc_library(
     external_deps = ["abseil_synchronization"],
     deps = [
         ":load_balancer_lib",
+        "//source/common/common:minimal_logger_lib",
         "//source/common/config:metadata_lib",
         "//source/common/config:well_known_names",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -340,6 +340,8 @@ envoy_cc_library(
     external_deps = ["abseil_synchronization"],
     deps = [
         ":load_balancer_lib",
+        "//source/common/config:metadata_lib",
+        "//source/common/config:well_known_names",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -20,7 +20,7 @@ MaglevTable::MaglevTable(const NormalizedHostWeightVector& normalized_host_weigh
   table_build_entries.reserve(normalized_host_weights.size());
   for (const auto& host_weight : normalized_host_weights) {
     const auto& host = host_weight.first;
-    const std::string key_to_hash = hashKey(host, use_hostname_for_hashing);
+    const absl::string_view key_to_hash = hashKey(host, use_hostname_for_hashing);
     ASSERT(!key_to_hash.empty());
     table_build_entries.emplace_back(host, HashUtil::xxHash64(key_to_hash) % table_size_,
                                      (HashUtil::xxHash64(key_to_hash, 1) % (table_size_ - 1)) + 1,
@@ -66,7 +66,7 @@ MaglevTable::MaglevTable(const NormalizedHostWeightVector& normalized_host_weigh
 
   if (ENVOY_LOG_CHECK_LEVEL(trace)) {
     for (uint64_t i = 0; i < table_.size(); i++) {
-      const std::string key_to_hash = hashKey(table_[i], use_hostname_for_hashing);
+      const absl::string_view key_to_hash = hashKey(table_[i], use_hostname_for_hashing);
       ENVOY_LOG(trace, "maglev: i={} address={} host={}", i, table_[i]->address()->asString(),
                 key_to_hash);
     }

--- a/source/common/upstream/maglev_lb.cc
+++ b/source/common/upstream/maglev_lb.cc
@@ -20,11 +20,10 @@ MaglevTable::MaglevTable(const NormalizedHostWeightVector& normalized_host_weigh
   table_build_entries.reserve(normalized_host_weights.size());
   for (const auto& host_weight : normalized_host_weights) {
     const auto& host = host_weight.first;
-    const std::string& address =
-        use_hostname_for_hashing ? host->hostname() : host->address()->asString();
-    ASSERT(!address.empty());
-    table_build_entries.emplace_back(host, HashUtil::xxHash64(address) % table_size_,
-                                     (HashUtil::xxHash64(address, 1) % (table_size_ - 1)) + 1,
+    const std::string key_to_hash = hashKey(host, use_hostname_for_hashing);
+    ASSERT(!key_to_hash.empty());
+    table_build_entries.emplace_back(host, HashUtil::xxHash64(key_to_hash) % table_size_,
+                                     (HashUtil::xxHash64(key_to_hash, 1) % (table_size_ - 1)) + 1,
                                      host_weight.second);
   }
 
@@ -67,9 +66,9 @@ MaglevTable::MaglevTable(const NormalizedHostWeightVector& normalized_host_weigh
 
   if (ENVOY_LOG_CHECK_LEVEL(trace)) {
     for (uint64_t i = 0; i < table_.size(); i++) {
-      ENVOY_LOG(trace, "maglev: i={} host={}", i,
-                use_hostname_for_hashing ? table_[i]->hostname()
-                                         : table_[i]->address()->asString());
+      const std::string key_to_hash = hashKey(table_[i], use_hostname_for_hashing);
+      ENVOY_LOG(trace, "maglev: i={} address={} host={}", i, table_[i]->address()->asString(),
+                key_to_hash);
     }
   }
 }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -149,7 +149,7 @@ RingHashLoadBalancer::Ring::Ring(const NormalizedHostWeightVector& normalized_ho
   uint64_t max_hashes_per_host = 0;
   for (const auto& entry : normalized_host_weights) {
     const auto& host = entry.first;
-    const std::string key_to_hash = hashKey(host, use_hostname_for_hashing);
+    const absl::string_view key_to_hash = hashKey(host, use_hostname_for_hashing);
     ASSERT(!key_to_hash.empty());
 
     hash_key_buffer.assign(key_to_hash.begin(), key_to_hash.end());
@@ -187,7 +187,7 @@ RingHashLoadBalancer::Ring::Ring(const NormalizedHostWeightVector& normalized_ho
   });
   if (ENVOY_LOG_CHECK_LEVEL(trace)) {
     for (const auto& entry : ring_) {
-      const std::string key_to_hash = hashKey(entry.host_, use_hostname_for_hashing);
+      const absl::string_view key_to_hash = hashKey(entry.host_, use_hostname_for_hashing);
       ENVOY_LOG(trace, "ring hash: host={} hash={}", key_to_hash, entry.hash_);
     }
   }

--- a/source/common/upstream/ring_hash_lb.cc
+++ b/source/common/upstream/ring_hash_lb.cc
@@ -149,11 +149,10 @@ RingHashLoadBalancer::Ring::Ring(const NormalizedHostWeightVector& normalized_ho
   uint64_t max_hashes_per_host = 0;
   for (const auto& entry : normalized_host_weights) {
     const auto& host = entry.first;
-    const std::string& address_string =
-        use_hostname_for_hashing ? host->hostname() : host->address()->asString();
-    ASSERT(!address_string.empty());
+    const std::string key_to_hash = hashKey(host, use_hostname_for_hashing);
+    ASSERT(!key_to_hash.empty());
 
-    hash_key_buffer.assign(address_string.begin(), address_string.end());
+    hash_key_buffer.assign(key_to_hash.begin(), key_to_hash.end());
     hash_key_buffer.emplace_back('_');
     auto offset_start = hash_key_buffer.end();
 
@@ -188,10 +187,8 @@ RingHashLoadBalancer::Ring::Ring(const NormalizedHostWeightVector& normalized_ho
   });
   if (ENVOY_LOG_CHECK_LEVEL(trace)) {
     for (const auto& entry : ring_) {
-      ENVOY_LOG(trace, "ring hash: host={} hash={}",
-                use_hostname_for_hashing ? entry.host_->hostname()
-                                         : entry.host_->address()->asString(),
-                entry.hash_);
+      const std::string key_to_hash = hashKey(entry.host_, use_hostname_for_hashing);
+      ENVOY_LOG(trace, "ring hash: host={} hash={}", key_to_hash, entry.hash_);
     }
   }
 

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -3,7 +3,8 @@
 #include "envoy/common/callback.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
-#include "common/config/utility.h"
+#include "common/config/metadata.h"
+#include "common/config/well_known_names.h"
 #include "common/upstream/load_balancer_impl.h"
 
 #include "absl/synchronization/mutex.h"
@@ -29,7 +30,11 @@ public:
     virtual ~HashingLoadBalancer() = default;
     virtual HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const PURE;
     const std::string hashKey(HostConstSharedPtr host, bool use_hostname) {
-      std::string hash_key = Config::Utility::getHashKeyMetadataValue(host->metadata().get());
+      std::string hash_key = Config::Metadata::metadataValue(
+                                 host->metadata().get(), Config::MetadataFilters::get().ENVOY_LB,
+                                 Config::MetadataEnvoyLbKeys::get().HASH_KEY)
+                                 .string_value();
+
       if (hash_key.empty()) {
         hash_key = use_hostname ? host->hostname() : host->address()->asString();
       }

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -8,6 +8,7 @@
 #include "common/config/well_known_names.h"
 #include "common/upstream/load_balancer_impl.h"
 
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 
 namespace Envoy {
@@ -30,14 +31,14 @@ public:
   public:
     virtual ~HashingLoadBalancer() = default;
     virtual HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const PURE;
-    const std::string hashKey(HostConstSharedPtr host, bool use_hostname) {
+    const absl::string_view hashKey(HostConstSharedPtr host, bool use_hostname) {
       const ProtobufWkt::Value& val = Config::Metadata::metadataValue(
           host->metadata().get(), Config::MetadataFilters::get().ENVOY_LB,
           Config::MetadataEnvoyLbKeys::get().HASH_KEY);
       if (val.kind_case() != val.kStringValue && val.kind_case() != val.KIND_NOT_SET) {
         FANCY_LOG(debug, "hash_key must be string type, got: {}", val.kind_case());
       }
-      std::string hash_key = val.string_value();
+      absl::string_view hash_key = val.string_value();
       if (hash_key.empty()) {
         hash_key = use_hostname ? host->hostname() : host->address()->asString();
       }

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -3,6 +3,8 @@
 #include "envoy/common/callback.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
+#include "common/config/metadata.h"
+#include "common/config/well_known_names.h"
 #include "common/upstream/load_balancer_impl.h"
 
 #include "absl/synchronization/mutex.h"
@@ -27,6 +29,17 @@ public:
   public:
     virtual ~HashingLoadBalancer() = default;
     virtual HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const PURE;
+    const std::string hashKey(HostConstSharedPtr host, bool use_hostname) {
+      std::string hash_key = Config::Metadata::metadataValue(
+                                 host->metadata().get(), Config::MetadataFilters::get().ENVOY_LB,
+                                 Config::MetadataEnvoyLbKeys::get().HASH_KEY)
+                                 .string_value();
+
+      if (hash_key.empty()) {
+        hash_key = use_hostname ? host->hostname() : host->address()->asString();
+      }
+      return hash_key;
+    }
   };
   using HashingLoadBalancerSharedPtr = std::shared_ptr<HashingLoadBalancer>;
 

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -3,8 +3,7 @@
 #include "envoy/common/callback.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
-#include "common/config/metadata.h"
-#include "common/config/well_known_names.h"
+#include "common/config/utility.h"
 #include "common/upstream/load_balancer_impl.h"
 
 #include "absl/synchronization/mutex.h"
@@ -30,11 +29,7 @@ public:
     virtual ~HashingLoadBalancer() = default;
     virtual HostConstSharedPtr chooseHost(uint64_t hash, uint32_t attempt) const PURE;
     const std::string hashKey(HostConstSharedPtr host, bool use_hostname) {
-      std::string hash_key = Config::Metadata::metadataValue(
-                                 host->metadata().get(), Config::MetadataFilters::get().ENVOY_LB,
-                                 Config::MetadataEnvoyLbKeys::get().HASH_KEY)
-                                 .string_value();
-
+      std::string hash_key = Config::Utility::getHashKeyMetadataValue(host->metadata().get());
       if (hash_key.empty()) {
         hash_key = use_hostname ? host->hostname() : host->address()->asString();
       }

--- a/test/common/upstream/bounded_load_hlb_test.cc
+++ b/test/common/upstream/bounded_load_hlb_test.cc
@@ -116,7 +116,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
       "tcp://127.0.0.1:90", simTime());
   EXPECT_EQ(hlb_->hashKey(host, false), "hash_key");
 
-  // other type(int) metadata
+  // other type(int) metadata throws exception
   envoy::config::core::v3::Metadata int_metadata;
   Config::Metadata::mutableMetadataValue(int_metadata, Config::MetadataFilters::get().ENVOY_LB,
                                          Config::MetadataEnvoyLbKeys::get().HASH_KEY)
@@ -124,7 +124,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
   host = makeTestHostWithMetadata(
       info_, std::make_shared<const envoy::config::core::v3::Metadata>(int_metadata),
       "tcp://127.0.0.1:90", simTime());
-  EXPECT_EQ(hlb_->hashKey(host, false), "127.0.0.1:90");
+  EXPECT_THROW(hlb_->hashKey(host, false), EnvoyException);
 };
 
 // Works correctly without any hosts.

--- a/test/common/upstream/bounded_load_hlb_test.cc
+++ b/test/common/upstream/bounded_load_hlb_test.cc
@@ -116,7 +116,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
       "tcp://127.0.0.1:90", simTime());
   EXPECT_EQ(hlb_->hashKey(host, false), "hash_key");
 
-  // other type(int) metadata throws exception
+  // other type(int) metadata
   envoy::config::core::v3::Metadata int_metadata;
   Config::Metadata::mutableMetadataValue(int_metadata, Config::MetadataFilters::get().ENVOY_LB,
                                          Config::MetadataEnvoyLbKeys::get().HASH_KEY)
@@ -124,7 +124,7 @@ TEST_F(HashingLoadBalancerTest, HashKey) {
   host = makeTestHostWithMetadata(
       info_, std::make_shared<const envoy::config::core::v3::Metadata>(int_metadata),
       "tcp://127.0.0.1:90", simTime());
-  EXPECT_THROW(hlb_->hashKey(host, false), EnvoyException);
+  EXPECT_EQ(hlb_->hashKey(host, false), "127.0.0.1:90");
 };
 
 // Works correctly without any hosts.

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -347,6 +347,81 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
   EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
 }
 
+// Expect reasonable results with metadata hash_key.
+TEST_P(RingHashLoadBalancerTest, BasicWithMetadataHashKey) {
+  hostSet().hosts_ = {makeTestHostWithHashKey(info_, "90", "tcp://127.0.0.1:90", simTime()),
+                      makeTestHostWithHashKey(info_, "91", "tcp://127.0.0.1:91", simTime()),
+                      makeTestHostWithHashKey(info_, "92", "tcp://127.0.0.1:92", simTime()),
+                      makeTestHostWithHashKey(info_, "93", "tcp://127.0.0.1:93", simTime()),
+                      makeTestHostWithHashKey(info_, "94", "tcp://127.0.0.1:94", simTime()),
+                      makeTestHostWithHashKey(info_, "95", "tcp://127.0.0.1:95", simTime())};
+  hostSet().healthy_hosts_ = hostSet().hosts_;
+  hostSet().runCallbacks({}, {});
+
+  config_ = envoy::config::cluster::v3::Cluster::RingHashLbConfig();
+  config_.value().mutable_minimum_ring_size()->set_value(12);
+
+  common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
+  auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
+  chc.set_use_hostname_for_hashing(true);
+  common_config_.set_allocated_consistent_hashing_lb_config(&chc);
+
+  init();
+  common_config_.release_consistent_hashing_lb_config();
+
+  EXPECT_EQ("ring_hash_lb.size", lb_->stats().size_.name());
+  EXPECT_EQ("ring_hash_lb.min_hashes_per_host", lb_->stats().min_hashes_per_host_.name());
+  EXPECT_EQ("ring_hash_lb.max_hashes_per_host", lb_->stats().max_hashes_per_host_.name());
+  EXPECT_EQ(12, lb_->stats().size_.value());
+  EXPECT_EQ(2, lb_->stats().min_hashes_per_host_.value());
+  EXPECT_EQ(2, lb_->stats().max_hashes_per_host_.value());
+
+  // hash ring:
+  // host | position
+  // ---------------------------
+  // 95 | 1975508444536362413
+  // 95 | 2376063919839173711
+  // 93 | 2386806903309390596
+  // 94 | 6749904478991551885
+  // 93 | 6803900775736438537
+  // 92 | 7225015537174310577
+  // 90 | 8787465352164086522
+  // 92 | 11282020843382717940
+  // 91 | 13723418369486627818
+  // 90 | 13776502110861797421
+  // 91 | 14338313586354474791
+  // 94 | 15364271037087512980
+
+  LoadBalancerPtr lb = lb_->factory()->create();
+  {
+    TestLoadBalancerContext context(0);
+    EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
+  }
+  {
+    TestLoadBalancerContext context(std::numeric_limits<uint64_t>::max());
+    EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
+  }
+  {
+    TestLoadBalancerContext context(7225015537174310577);
+    EXPECT_EQ(hostSet().hosts_[2], lb->chooseHost(&context));
+  }
+  {
+    TestLoadBalancerContext context(6803900775736438537);
+    EXPECT_EQ(hostSet().hosts_[3], lb->chooseHost(&context));
+  }
+  { EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(nullptr)); }
+  EXPECT_EQ(0UL, stats_.lb_healthy_panic_.value());
+
+  hostSet().healthy_hosts_.clear();
+  hostSet().runCallbacks({}, {});
+  lb = lb_->factory()->create();
+  {
+    TestLoadBalancerContext context(0);
+    EXPECT_EQ(hostSet().hosts_[5], lb->chooseHost(&context));
+  }
+  EXPECT_EQ(1UL, stats_.lb_healthy_panic_.value());
+}
+
 // Test the same ring as Basic but exercise retry host predicate behavior.
 TEST_P(RingHashLoadBalancerTest, BasicWithRetryHostPredicate) {
   hostSet().hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", simTime()),

--- a/test/common/upstream/utility.h
+++ b/test/common/upstream/utility.h
@@ -9,6 +9,8 @@
 #include "envoy/upstream/upstream.h"
 
 #include "common/common/utility.h"
+#include "common/config/metadata.h"
+#include "common/config/well_known_names.h"
 #include "common/json/json_loader.h"
 #include "common/network/utility.h"
 #include "common/upstream/upstream_impl.h"
@@ -115,6 +117,32 @@ makeTestHost(ClusterInfoConstSharedPtr cluster, const std::string& url,
   return std::make_shared<HostImpl>(cluster, "", Network::Utility::resolveUrl(url), nullptr, weight,
                                     envoy::config::core::v3::Locality(), health_check_config, 0,
                                     envoy::config::core::v3::UNKNOWN, time_source);
+}
+
+inline HostSharedPtr makeTestHostWithHashKey(ClusterInfoConstSharedPtr cluster,
+                                             const std::string& hash_key, const std::string& url,
+                                             TimeSource& time_source, uint32_t weight = 1) {
+  envoy::config::core::v3::Metadata metadata;
+  Config::Metadata::mutableMetadataValue(metadata, Config::MetadataFilters::get().ENVOY_LB,
+                                         Config::MetadataEnvoyLbKeys::get().HASH_KEY)
+      .set_string_value(hash_key);
+  return std::make_shared<HostImpl>(
+      cluster, "", Network::Utility::resolveUrl(url),
+      std::make_shared<const envoy::config::core::v3::Metadata>(metadata), weight,
+      envoy::config::core::v3::Locality(),
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
+      envoy::config::core::v3::UNKNOWN, time_source);
+}
+
+inline HostSharedPtr makeTestHostWithMetadata(ClusterInfoConstSharedPtr cluster,
+                                              MetadataConstSharedPtr metadata,
+                                              const std::string& url, TimeSource& time_source,
+                                              uint32_t weight = 1) {
+  return std::make_shared<HostImpl>(
+      cluster, "", Network::Utility::resolveUrl(url), metadata, weight,
+      envoy::config::core::v3::Locality(),
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
+      envoy::config::core::v3::UNKNOWN, time_source);
 }
 
 inline HostDescriptionConstSharedPtr makeTestHostDescription(ClusterInfoConstSharedPtr cluster,


### PR DESCRIPTION
Fixes #13862
Adds hash_key filter in the envoy.lb metadata key for an endpoint
If this key is set, then consistent hashing loadbalancers (maglev,
ring hash) will use its value to hash the corresponding host
Risk Level: Low
Testing: Unit testing
Docs Changes: Unknown
Release Notes: Unknown