### PR TITLE
backport 1.15: ci: Fix macosx install flake (#15310)

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -39,7 +39,7 @@ if ! retry brew update; then
   echo "Failed to update homebrew"
 fi
 
-DEPS="automake cmake coreutils go libtool wget ninja"
+DEPS="automake cmake coreutils libtool wget ninja"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"


### PR DESCRIPTION
Commit Message: ci: Fix macosx install flake

Signed-off-by: Ryan Northey <ryan@synca.io>
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
