### PR TITLE
Revert "AsyncClientFactory: use getThreadLocalCluster for thread safe…

### DIFF
--- a/include/envoy/grpc/async_client_manager.h
+++ b/include/envoy/grpc/async_client_manager.h
@@ -22,8 +22,6 @@ public:
 
 using AsyncClientFactoryPtr = std::unique_ptr<AsyncClientFactory>;
 
-enum class AsyncClientFactoryClusterChecks { Skip, ValidateStatic, ValidateStaticDuringBootstrap };
-
 // Singleton gRPC client manager. Grpc::AsyncClientManager can be used to create per-service
 // Grpc::AsyncClientFactory instances. All manufactured Grpc::AsyncClients must
 // be destroyed before the AsyncClientManager can be safely destructed.
@@ -36,16 +34,14 @@ public:
    * will raise an exception on failure.
    * @param grpc_service envoy::config::core::v3::GrpcService configuration.
    * @param scope stats scope.
-   * @param checks Skip will skip checking cluster validity, ValidateStatic checks for
-   * cluster presence and being statically configured, ValidateStaticDuringBootstrap checks for
-   * cluster presence and being statically configured with methods that are not threadsafe but can
-   * be used during bootstrap.
+   * @param skip_cluster_check if set to true skips checks for cluster presence and being statically
+   * configured.
    * @return AsyncClientFactoryPtr factory for grpc_service.
    * @throws EnvoyException when grpc_service validation fails.
    */
   virtual AsyncClientFactoryPtr
   factoryForGrpcService(const envoy::config::core::v3::GrpcService& grpc_service,
-                        Stats::Scope& scope, AsyncClientFactoryClusterChecks checks) PURE;
+                        Stats::Scope& scope, bool skip_cluster_check) PURE;
 };
 
 using AsyncClientManagerPtr = std::unique_ptr<AsyncClientManager>;

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -251,10 +251,7 @@ Grpc::AsyncClientFactoryPtr Utility::factoryForGrpcApiConfigSource(
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.MergeFrom(api_config_source.grpc_services(0));
 
-  return async_client_manager.factoryForGrpcService(
-      grpc_service, scope,
-      skip_cluster_check ? Grpc::AsyncClientFactoryClusterChecks::Skip
-                         : Grpc::AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap);
+  return async_client_manager.factoryForGrpcService(grpc_service, scope, skip_cluster_check);
 }
 
 envoy::config::endpoint::v3::ClusterLoadAssignment Utility::translateClusterHosts(

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -28,35 +28,20 @@ bool validateGrpcHeaderChars(absl::string_view key) {
 
 AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
                                                const envoy::config::core::v3::GrpcService& config,
-                                               AsyncClientFactoryClusterChecks checks,
-                                               TimeSource& time_source)
+                                               bool skip_cluster_check, TimeSource& time_source)
     : cm_(cm), config_(config), time_source_(time_source) {
+  if (skip_cluster_check) {
+    return;
+  }
+
   const std::string& cluster_name = config.envoy_grpc().cluster_name();
-  switch (checks) {
-  case AsyncClientFactoryClusterChecks::Skip:
-    return;
-  case AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap: {
-    ASSERT(Thread::MainThread::isMainThread());
-    auto all_clusters = cm_.clusters();
-    const auto& it = all_clusters.active_clusters_.find(cluster_name);
-    if (it == all_clusters.active_clusters_.end()) {
-      throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
-    }
-    if (it->second.get().info()->addedViaApi()) {
-      throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
-    }
-    return;
+  auto all_clusters = cm_.clusters();
+  const auto& it = all_clusters.active_clusters_.find(cluster_name);
+  if (it == all_clusters.active_clusters_.end()) {
+    throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
   }
-  case AsyncClientFactoryClusterChecks::ValidateStatic: {
-    const auto cluster = cm_.getThreadLocalCluster(cluster_name);
-    if (!cluster) {
-      throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
-    }
-    if (cluster->info()->addedViaApi()) {
-      throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
-    }
-    return;
-  }
+  if (it->second.get().info()->addedViaApi()) {
+    throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
   }
 }
 
@@ -118,11 +103,10 @@ RawAsyncClientPtr GoogleAsyncClientFactoryImpl::create() {
 
 AsyncClientFactoryPtr
 AsyncClientManagerImpl::factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
-                                              Stats::Scope& scope,
-                                              AsyncClientFactoryClusterChecks checks) {
+                                              Stats::Scope& scope, bool skip_cluster_check) {
   switch (config.target_specifier_case()) {
   case envoy::config::core::v3::GrpcService::TargetSpecifierCase::kEnvoyGrpc:
-    return std::make_unique<AsyncClientFactoryImpl>(cm_, config, checks, time_source_);
+    return std::make_unique<AsyncClientFactoryImpl>(cm_, config, skip_cluster_check, time_source_);
   case envoy::config::core::v3::GrpcService::TargetSpecifierCase::kGoogleGrpc:
     return std::make_unique<GoogleAsyncClientFactoryImpl>(tls_, google_tls_slot_.get(), scope,
                                                           config, api_, stat_names_);

--- a/source/common/grpc/async_client_manager_impl.h
+++ b/source/common/grpc/async_client_manager_impl.h
@@ -17,7 +17,7 @@ class AsyncClientFactoryImpl : public AsyncClientFactory {
 public:
   AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
                          const envoy::config::core::v3::GrpcService& config,
-                         AsyncClientFactoryClusterChecks check, TimeSource& time_source);
+                         bool skip_cluster_check, TimeSource& time_source);
 
   RawAsyncClientPtr create() override;
 
@@ -53,7 +53,7 @@ public:
   // Grpc::AsyncClientManager
   AsyncClientFactoryPtr factoryForGrpcService(const envoy::config::core::v3::GrpcService& config,
                                               Stats::Scope& scope,
-                                              AsyncClientFactoryClusterChecks checks) override;
+                                              bool skip_cluster_check) override;
 
 private:
   Upstream::ClusterManager& cm_;

--- a/source/common/grpc/google_async_client_cache.h
+++ b/source/common/grpc/google_async_client_cache.h
@@ -29,8 +29,8 @@ private:
   struct ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
     ThreadLocalCache(AsyncClientManager& async_client_manager, Stats::Scope& scope,
                      const ::envoy::config::core::v3::GrpcService& grpc_proto_config) {
-      const AsyncClientFactoryPtr factory = async_client_manager.factoryForGrpcService(
-          grpc_proto_config, scope, AsyncClientFactoryClusterChecks::Skip);
+      const AsyncClientFactoryPtr factory =
+          async_client_manager.factoryForGrpcService(grpc_proto_config, scope, true);
       async_client_ = factory->create();
     }
     RawAsyncClientSharedPtr async_client_;

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -287,8 +287,8 @@ public:
     if (it != cache.access_loggers_.end()) {
       return it->second;
     }
-    const Grpc::AsyncClientFactoryPtr factory = async_client_manager_.factoryForGrpcService(
-        config.grpc_service(), scope_, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic);
+    const Grpc::AsyncClientFactoryPtr factory =
+        async_client_manager_.factoryForGrpcService(config.grpc_service(), scope_, false);
     const auto logger = createLogger(
         config, factory->create(),
         std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(config, buffer_flush_interval, 1000)),

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1000,11 +1000,11 @@ WasmResult Context::grpcCall(absl::string_view grpc_service, absl::string_view s
   auto& handler = grpc_call_request_[token];
   handler.context_ = this;
   handler.token_ = token;
-  auto grpc_client = clusterManager()
-                         .grpcAsyncClientManager()
-                         .factoryForGrpcService(service_proto, *wasm()->scope_,
-                                                Grpc::AsyncClientFactoryClusterChecks::Skip)
-                         ->create();
+  auto grpc_client =
+      clusterManager()
+          .grpcAsyncClientManager()
+          .factoryForGrpcService(service_proto, *wasm()->scope_, true /* skip_cluster_check */)
+          ->create();
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
   // set default hash policy to be based on :authority to enable consistent hash
@@ -1058,11 +1058,11 @@ WasmResult Context::grpcStream(absl::string_view grpc_service, absl::string_view
   auto& handler = grpc_stream_[token];
   handler.context_ = this;
   handler.token_ = token;
-  auto grpc_client = clusterManager()
-                         .grpcAsyncClientManager()
-                         .factoryForGrpcService(service_proto, *wasm()->scope_,
-                                                Grpc::AsyncClientFactoryClusterChecks::Skip)
-                         ->create();
+  auto grpc_client =
+      clusterManager()
+          .grpcAsyncClientManager()
+          .factoryForGrpcService(service_proto, *wasm()->scope_, true /* skip_cluster_check */)
+          ->create();
   grpc_initial_metadata_ = buildRequestHeaderMapFromPairs(initial_metadata);
 
   // set default hash policy to be based on :authority to enable consistent hash

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -130,7 +130,7 @@ ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
   // requests.
   const auto async_client_factory =
       context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-          grpc_service, context.scope(), Grpc::AsyncClientFactoryClusterChecks::Skip);
+          grpc_service, context.scope(), true);
   return std::make_unique<Filters::Common::RateLimit::GrpcClientImpl>(
       async_client_factory->create(), timeout, transport_api_version);
 }

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -82,7 +82,7 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
                    Http::FilterChainFactoryCallbacks& callbacks) {
       const auto async_client_factory =
           context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, context.scope(), Grpc::AsyncClientFactoryClusterChecks::Skip);
+              grpc_service, context.scope(), true);
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
           async_client_factory->create(), std::chrono::milliseconds(timeout_ms),
           transport_api_version);

--- a/source/extensions/filters/http/ext_proc/client_impl.cc
+++ b/source/extensions/filters/http/ext_proc/client_impl.cc
@@ -11,8 +11,7 @@ static constexpr char kExternalMethod[] =
 ExternalProcessorClientImpl::ExternalProcessorClientImpl(
     Grpc::AsyncClientManager& client_manager,
     const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope) {
-  factory_ = client_manager.factoryForGrpcService(grpc_service, scope,
-                                                  Grpc::AsyncClientFactoryClusterChecks::Skip);
+  factory_ = client_manager.factoryForGrpcService(grpc_service, scope, true);
 }
 
 ExternalProcessorStreamPtr

--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -32,7 +32,7 @@ Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoType
           timeout_ms](Network::FilterManager& filter_manager) -> void {
     auto async_client_factory =
         context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-            grpc_service, context.scope(), Grpc::AsyncClientFactoryClusterChecks::Skip);
+            grpc_service, context.scope(), true);
 
     auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
         async_client_factory->create(), std::chrono::milliseconds(timeout_ms),

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -34,7 +34,7 @@ MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
                                       envoy::service::metrics::v3::StreamMetricsResponse>>
       grpc_metrics_streamer = std::make_shared<GrpcMetricsStreamerImpl>(
           server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, server.scope(), Grpc::AsyncClientFactoryClusterChecks::ValidateStatic),
+              grpc_service, server.scope(), false),
           server.localInfo(), transport_api_version);
 
   return std::make_unique<MetricsServiceSink<envoy::service::metrics::v3::StreamMetricsMessage,

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -37,8 +37,7 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
   tls_slot_ptr_->set([proto_config, &factory_context, this](Event::Dispatcher& dispatcher) {
     TracerPtr tracer = std::make_unique<Tracer>(std::make_unique<TraceSegmentReporter>(
         factory_context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-            proto_config.grpc_service(), factory_context.scope(),
-            Grpc::AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap),
+            proto_config.grpc_service(), factory_context.scope(), false),
         dispatcher, factory_context.api().randomGenerator(), tracing_stats_,
         config_.delayed_buffer_size(), config_.token()));
     return std::make_shared<TlsTracer>(std::move(tracer));

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -138,8 +138,7 @@ TEST_F(SubscriptionFactoryTest, GrpcClusterSingleton) {
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
   EXPECT_CALL(cm_.async_client_manager_,
               factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         auto async_client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
         EXPECT_CALL(*async_client_factory, create()).WillOnce(Invoke([] {
           return std::make_unique<Grpc::MockAsyncClient>();
@@ -318,8 +317,7 @@ TEST_F(SubscriptionFactoryTest, GrpcSubscription) {
   EXPECT_CALL(cm_, grpcAsyncClientManager()).WillOnce(ReturnRef(cm_.async_client_manager_));
   EXPECT_CALL(cm_.async_client_manager_,
               factoryForGrpcService(ProtoEq(expected_grpc_service), _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         auto async_client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
         EXPECT_CALL(*async_client_factory, create()).WillOnce(Invoke([] {
           return std::make_unique<NiceMock<Grpc::MockAsyncClient>>();

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -231,9 +231,7 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     envoy::config::core::v3::GrpcService expected_grpc_service;
     expected_grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
     EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(
-                    ProtoEq(expected_grpc_service), Ref(scope),
-                    Grpc::AsyncClientFactoryClusterChecks::ValidateStaticDuringBootstrap));
+                factoryForGrpcService(ProtoEq(expected_grpc_service), Ref(scope), false));
     Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope, false);
   }
 
@@ -241,9 +239,9 @@ TEST(UtilityTest, FactoryForGrpcApiConfigSource) {
     envoy::config::core::v3::ApiConfigSource api_config_source;
     api_config_source.set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
     api_config_source.add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("foo");
-    EXPECT_CALL(async_client_manager,
-                factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope),
-                                      Grpc::AsyncClientFactoryClusterChecks::Skip));
+    EXPECT_CALL(
+        async_client_manager,
+        factoryForGrpcService(ProtoEq(api_config_source.grpc_services(0)), Ref(scope), true));
     Utility::factoryForGrpcApiConfigSource(async_client_manager, api_config_source, scope, true);
   }
 }

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -13,7 +13,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using ::testing::Eq;
 using ::testing::Return;
 
 namespace Envoy {
@@ -39,40 +38,40 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcOk) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
-  std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
-      std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
-  EXPECT_CALL(cm_, getThreadLocalCluster(Eq("foo"))).WillOnce(Return(cluster.get()));
-  EXPECT_CALL(*cluster, info());
-  EXPECT_CALL(*cluster->cluster_.info_, addedViaApi());
+  Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
+  Upstream::MockClusterMockPrioritySet cluster;
+  cluster_maps.active_clusters_.emplace("foo", cluster);
+  EXPECT_CALL(cm_, clusters()).WillOnce(Return(cluster_maps));
+  EXPECT_CALL(cluster, info());
+  EXPECT_CALL(*cluster.info_, addedViaApi());
 
-  async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                              AsyncClientFactoryClusterChecks::ValidateStatic);
+  async_client_manager_.factoryForGrpcService(grpc_service, scope_, false);
 }
 
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknown) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
-  EXPECT_CALL(cm_, getThreadLocalCluster("foo"));
+  EXPECT_CALL(cm_, clusters());
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
-      EnvoyException, "Unknown gRPC client cluster 'foo'");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Unknown gRPC client cluster 'foo'");
 }
 
 TEST_F(AsyncClientManagerImplTest, EnvoyGrpcDynamicCluster) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
-  std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
-      std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
-  EXPECT_CALL(cm_, getThreadLocalCluster(Eq("foo"))).WillOnce(Return(cluster.get()));
-  EXPECT_CALL(*cluster, info());
-  EXPECT_CALL(*cluster->cluster_.info_, addedViaApi()).WillOnce(Return(true));
+  Upstream::ClusterManager::ClusterInfoMap cluster_map;
+  Upstream::MockClusterMockPrioritySet cluster;
+  cluster_map.emplace("foo", cluster);
+  EXPECT_CALL(cm_, clusters())
+      .WillOnce(Return(Upstream::ClusterManager::ClusterInfoMaps{cluster_map, {}}));
+  EXPECT_CALL(cluster, info());
+  EXPECT_CALL(*cluster.info_, addedViaApi()).WillOnce(Return(true));
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
-      EnvoyException, "gRPC client cluster 'foo' is not static");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "gRPC client cluster 'foo' is not static");
 }
 
 TEST_F(AsyncClientManagerImplTest, GoogleGrpc) {
@@ -81,13 +80,11 @@ TEST_F(AsyncClientManagerImplTest, GoogleGrpc) {
   grpc_service.mutable_google_grpc()->set_stat_prefix("foo");
 
 #ifdef ENVOY_GOOGLE_GRPC
-  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(
-                         grpc_service, scope_, AsyncClientFactoryClusterChecks::ValidateStatic));
+  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(grpc_service, scope_, false));
 #else
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
-      EnvoyException, "Google C++ gRPC client is not linked");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Google C++ gRPC client is not linked");
 #endif
 }
 
@@ -102,14 +99,12 @@ TEST_F(AsyncClientManagerImplTest, GoogleGrpcIllegalChars) {
 
 #ifdef ENVOY_GOOGLE_GRPC
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
-      EnvoyException, "Illegal characters in gRPC initial metadata.");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Illegal characters in gRPC initial metadata.");
 #else
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
-      EnvoyException, "Google C++ gRPC client is not linked");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Google C++ gRPC client is not linked");
 #endif
 }
 
@@ -123,13 +118,11 @@ TEST_F(AsyncClientManagerImplTest, LegalGoogleGrpcChar) {
   metadata.set_value("value");
 
 #ifdef ENVOY_GOOGLE_GRPC
-  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(
-                         grpc_service, scope_, AsyncClientFactoryClusterChecks::ValidateStatic));
+  EXPECT_NE(nullptr, async_client_manager_.factoryForGrpcService(grpc_service, scope_, false));
 #else
   EXPECT_THROW_WITH_MESSAGE(
-      async_client_manager_.factoryForGrpcService(grpc_service, scope_,
-                                                  AsyncClientFactoryClusterChecks::ValidateStatic),
-      EnvoyException, "Google C++ gRPC client is not linked");
+      async_client_manager_.factoryForGrpcService(grpc_service, scope_, false), EnvoyException,
+      "Google C++ gRPC client is not linked");
 #endif
 }
 
@@ -137,9 +130,8 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcUnknownOk) {
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
 
-  EXPECT_CALL(cm_, getThreadLocalCluster(Eq("foo"))).Times(0);
-  ASSERT_NO_THROW(async_client_manager_.factoryForGrpcService(
-      grpc_service, scope_, AsyncClientFactoryClusterChecks::Skip));
+  EXPECT_CALL(cm_, clusters()).Times(0);
+  ASSERT_NO_THROW(async_client_manager_.factoryForGrpcService(grpc_service, scope_, true));
 }
 
 } // namespace

--- a/test/common/grpc/google_async_client_cache_test.cc
+++ b/test/common/grpc/google_async_client_cache_test.cc
@@ -18,10 +18,8 @@ public:
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
     async_client_ = new Grpc::MockAsyncClient;
-    EXPECT_CALL(async_client_manager_,
-                factoryForGrpcService(_, _, AsyncClientFactoryClusterChecks::Skip))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                                AsyncClientFactoryClusterChecks) {
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, true))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -343,10 +343,8 @@ public:
   void expectClientCreation() {
     factory_ = new Grpc::MockAsyncClientFactory;
     async_client_ = new Grpc::MockAsyncClient;
-    EXPECT_CALL(async_client_manager_,
-                factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                                Grpc::AsyncClientFactoryClusterChecks) {
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_impl_test.cc
@@ -129,10 +129,8 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_,
-                factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                                Grpc::AsyncClientFactoryClusterChecks) {
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/access_loggers/grpc/http_config_test.cc
+++ b/test/extensions/access_loggers/grpc/http_config_test.cc
@@ -33,8 +33,7 @@ public:
     ASSERT_NE(nullptr, message_);
 
     EXPECT_CALL(context_.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                            Grpc::AsyncClientFactoryClusterChecks) {
+        .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
         }));
 

--- a/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/grpc_access_log_impl_test.cc
@@ -152,10 +152,8 @@ public:
       : async_client_(new Grpc::MockAsyncClient), factory_(new Grpc::MockAsyncClientFactory),
         logger_cache_(async_client_manager_, scope_, tls_, local_info_),
         grpc_access_logger_impl_test_helper_(local_info_, async_client_) {
-    EXPECT_CALL(async_client_manager_,
-                factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::ValidateStatic))
-        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                                Grpc::AsyncClientFactoryClusterChecks) {
+    EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, false))
+        .WillOnce(Invoke([this](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
             return Grpc::RawAsyncClientPtr{async_client_};
           }));

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -53,8 +53,7 @@ void expectCorrectProtoGrpc(envoy::config::core::v3::ApiVersion api_version) {
   EXPECT_CALL(context, runtime());
   EXPECT_CALL(context, scope()).Times(2);
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   Http::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, "stats", context);

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -44,8 +44,7 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -867,10 +867,10 @@ TEST_P(WasmHttpFilterTest, GrpcCall) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
-                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
+        return std::move(client_factory);
+      }));
   EXPECT_CALL(rootContext(), log_(spdlog::level::debug, Eq("response")));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -910,10 +910,10 @@ TEST_P(WasmHttpFilterTest, GrpcCallBadCall) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
-                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
+        return std::move(client_factory);
+      }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, true));
 }
@@ -951,10 +951,10 @@ TEST_P(WasmHttpFilterTest, GrpcCallFailure) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
-                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
+        return std::move(client_factory);
+      }));
   EXPECT_CALL(rootContext(), log_(spdlog::level::debug, Eq("failure bad")));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -1013,10 +1013,10 @@ TEST_P(WasmHttpFilterTest, GrpcCallCancel) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
-                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
+        return std::move(client_factory);
+      }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter().decodeHeaders(request_headers, false));
@@ -1057,10 +1057,10 @@ TEST_P(WasmHttpFilterTest, GrpcCallClose) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
-                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
+        return std::move(client_factory);
+      }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
             filter().decodeHeaders(request_headers, false));
@@ -1101,10 +1101,10 @@ TEST_P(WasmHttpFilterTest, GrpcCallAfterDestroyed) {
   }));
   EXPECT_CALL(cluster_manager_, grpcAsyncClientManager())
       .WillOnce(Invoke([&]() -> Grpc::AsyncClientManager& { return client_manager; }));
-  EXPECT_CALL(client_manager,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, Grpc::AsyncClientFactoryClusterChecks)
-                           -> Grpc::AsyncClientFactoryPtr { return std::move(client_factory); }));
+  EXPECT_CALL(client_manager, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
+        return std::move(client_factory);
+      }));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
@@ -1134,11 +1134,9 @@ void WasmHttpFilterTest::setupGrpcStreamTest(Grpc::RawAsyncStreamCallbacks*& cal
   setupTest("grpc_stream");
   setupFilter();
 
-  EXPECT_CALL(async_client_manager_,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
+  EXPECT_CALL(async_client_manager_, factoryForGrpcService(_, _, _))
       .WillRepeatedly(
-          Invoke([&](const GrpcService&, Stats::Scope&,
-                     Grpc::AsyncClientFactoryClusterChecks) -> Grpc::AsyncClientFactoryPtr {
+          Invoke([&](const GrpcService&, Stats::Scope&, bool) -> Grpc::AsyncClientFactoryPtr {
             auto client_factory = std::make_unique<Grpc::MockAsyncClientFactory>();
             EXPECT_CALL(*client_factory, create)
                 .WillRepeatedly(Invoke([&]() -> Grpc::RawAsyncClientPtr {

--- a/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_per_readfilter.cc
@@ -77,8 +77,7 @@ void UberFilterFuzzer::perFilterSetup(const std::string& filter_name) {
 
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_manager_,
                 factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                             Grpc::AsyncClientFactoryClusterChecks) {
+        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           return std::move(async_client_factory_);
         }));
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setLocalAddress(
@@ -111,8 +110,7 @@ void UberFilterFuzzer::perFilterSetup(const std::string& filter_name) {
 
     EXPECT_CALL(factory_context_.cluster_manager_.async_client_manager_,
                 factoryForGrpcService(_, _, _))
-        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                             Grpc::AsyncClientFactoryClusterChecks) {
+        .WillOnce(Invoke([&](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
           return std::move(async_client_factory_);
         }));
     read_filter_callbacks_->connection_.stream_info_.downstream_address_provider_->setLocalAddress(

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -43,10 +43,8 @@ void expectCorrectProto(envoy::config::core::v3::ApiVersion api_version) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_CALL(context.cluster_manager_.async_client_manager_,
-              factoryForGrpcService(_, _, Grpc::AsyncClientFactoryClusterChecks::Skip))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+  EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
   Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(*proto_config, context);

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -49,8 +49,7 @@ TEST(RateLimitFilterConfigTest, CorrectProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/config_test.cc
@@ -52,8 +52,7 @@ rate_limit_service:
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   EXPECT_CALL(context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
-      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                          Grpc::AsyncClientFactoryClusterChecks) {
+      .WillOnce(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 

--- a/test/mocks/grpc/mocks.cc
+++ b/test/mocks/grpc/mocks.cc
@@ -26,8 +26,7 @@ MockAsyncClientFactory::~MockAsyncClientFactory() = default;
 
 MockAsyncClientManager::MockAsyncClientManager() {
   ON_CALL(*this, factoryForGrpcService(_, _, _))
-      .WillByDefault(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&,
-                               AsyncClientFactoryClusterChecks) {
+      .WillByDefault(Invoke([](const envoy::config::core::v3::GrpcService&, Stats::Scope&, bool) {
         return std::make_unique<testing::NiceMock<Grpc::MockAsyncClientFactory>>();
       }));
 }

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -107,7 +107,7 @@ public:
 
   MOCK_METHOD(AsyncClientFactoryPtr, factoryForGrpcService,
               (const envoy::config::core::v3::GrpcService& grpc_service, Stats::Scope& scope,
-               AsyncClientFactoryClusterChecks checks));
+               bool skip_cluster_check));
 };
 
 MATCHER_P(ProtoBufferEq, expected, "") {


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:
Additional Description: reverts #15227 due to #15447
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
