### PR TITLE
repokitteh: use randint() for random assignment.

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -1,3 +1,4 @@
+test
 syntax = "proto3";
 
 package envoy.config.core.v3;

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -1,4 +1,4 @@
-test
+test again
 syntax = "proto3";
 
 package envoy.config.core.v3;

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -1,3 +1,4 @@
+test again
 syntax = "proto3";
 
 package envoy.config.core.v3;

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -1,4 +1,3 @@
-test again
 syntax = "proto3";
 
 package envoy.config.core.v3;

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -204,9 +204,9 @@ def _comment(config, results, assignees, sender, force=False):
         if assignee in members:
           api_assignee = assignee
           break
-      # Otherwise, pick at "random" (we just use timestamp).
+      # Otherwise, pick at random.
       if not api_assignee:
-        api_assignee = members[now().second % len(members)]
+        api_assignee = members[random.randint(1000000) % len(members)]
       lines.append('API shepherd assignee is @%s' % api_assignee)
       github.issue_assign(api_assignee)
 


### PR DESCRIPTION
Since the original API shepherd assignment development, RK added a randint() method. Switching to
this to avoid time-of-day hackery and possibly assignment skews.

Signed-off-by: Harvey Tuch <htuch@google.com>