### PR TITLE
doc: add patch dependence on ubuntu 

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -62,7 +62,8 @@ for how to update or override dependencies.
        ninja-build \
        curl \
        unzip \
-       virtualenv
+       virtualenv \
+       patch
     ```
 
     ### Fedora


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
When exec `bazel build //source/exe:envoy-static`, envoy depends on some external packages like `com_googlesource_chromium_v8`, when building it, bazel will patch `wee8.patch`. https://github.com/envoyproxy/envoy/blob/40964cc30d4e691df5c5f0c32a449a7b4462115a/bazel/genrule_repository.bzl#L12
Not all ubuntu distributions have the `patch` software, just now I tested on the ubuntu:16.04 from docker hub, there is no `patch`. So it's necessary to add this dependence.

Commit Message: improve envoy build guide doc
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
