### PR TITLE
AsyncClientFactory: use getCluster instead of iterate directly

### DIFF
--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -35,12 +35,11 @@ AsyncClientFactoryImpl::AsyncClientFactoryImpl(Upstream::ClusterManager& cm,
   }
 
   const std::string& cluster_name = config.envoy_grpc().cluster_name();
-  auto all_clusters = cm_.clusters();
-  const auto& it = all_clusters.active_clusters_.find(cluster_name);
-  if (it == all_clusters.active_clusters_.end()) {
+  auto cluster = cm_.clusters().getCluster(cluster_name);
+  if (!cluster.has_value()) {
     throw EnvoyException(fmt::format("Unknown gRPC client cluster '{}'", cluster_name));
   }
-  if (it->second.get().info()->addedViaApi()) {
+  if (cluster->get().info()->addedViaApi()) {
     throw EnvoyException(fmt::format("gRPC client cluster '{}' is not static", cluster_name));
   }
 }


### PR DESCRIPTION
Commit Message: AsyncClientFactory: use getCluster instead of iterate directly
Additional Description: As part of investigation for #15447 it was determined that the AsyncClientFactory should be checking both active and warming clusters. The getCluster method does this.
Risk Level: low, the validation check should be less strict than previously
Testing: relying on existing tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
