### PR TITLE
api: add cluster timeout in tcp_proxy

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";
@@ -153,4 +153,9 @@ message TcpProxy {
   // is reached the connection will be closed. Duration must be at least 1ms.
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
+
+  // The maximum duration tcp_proxy waits for the active cluster. The duration is counted since the tcp_proxy starts to process the connection.
+  // If the timeout is not set or is reached, and the upstream cluster is not active yet, the tcp_proxy closes the downstream connection with error flag NC.
+  // [#not-implemented-hide:]
+  google.protobuf.Duration cluster_timeout = 14;
 }

--- a/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy";
@@ -153,4 +153,9 @@ message TcpProxy {
   // is reached the connection will be closed. Duration must be at least 1ms.
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
+
+  // The maximum duration tcp_proxy waits for the active cluster. The duration is counted since the tcp_proxy starts to process the connection.
+  // If the timeout is not set or is reached, and the upstream cluster is not active yet, the tcp_proxy closes the downstream connection with error flag NC.
+  // [#not-implemented-hide:]
+  google.protobuf.Duration cluster_timeout = 14;
 }

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.tcp_proxy.v2.TcpProxy";
@@ -174,6 +174,11 @@ message TcpProxy {
   // is reached the connection will be closed. Duration must be at least 1ms.
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
+
+  // The maximum duration tcp_proxy waits for the active cluster. The duration is counted since the tcp_proxy starts to process the connection.
+  // If the timeout is not set or is reached, and the upstream cluster is not active yet, the tcp_proxy closes the downstream connection with error flag NC.
+  // [#not-implemented-hide:]
+  google.protobuf.Duration cluster_timeout = 14;
 
   DeprecatedV1 hidden_envoy_deprecated_deprecated_v1 = 6 [deprecated = true];
 }

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // TCP Proxy :ref:`configuration overview <config_network_filters_tcp_proxy>`.
 // [#extension: envoy.filters.network.tcp_proxy]
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message TcpProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy";
@@ -153,4 +153,9 @@ message TcpProxy {
   // is reached the connection will be closed. Duration must be at least 1ms.
   google.protobuf.Duration max_downstream_connection_duration = 13
       [(validate.rules).duration = {gte {nanos: 1000000}}];
+
+  // The maximum duration tcp_proxy waits for the active cluster. The duration is counted since the tcp_proxy starts to process the connection.
+  // If the timeout is not set or is reached, and the upstream cluster is not active yet, the tcp_proxy closes the downstream connection with error flag NC.
+  // [#not-implemented-hide:]
+  google.protobuf.Duration cluster_timeout = 14;
 }


### PR DESCRIPTION

Commit Message:
Preparation for introducing async version of getting a cluster.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Additional Description:
The no cluster error code is introduced in #15448
This async version of the getCluster doesn't rely on On-demand CDS.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
