### PR TITLE
WIP: Delay registration of custom headers in CacheFilter

### DIFF
--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -366,7 +366,7 @@ void CacheFilter::processSuccessfulValidation(Http::ResponseHeaderMap& response_
   // freshly served response from the origin, unless the 304 response has an Age header, which
   // means it was served by an upstream cache.
   // Remove any existing Age header in the cached response.
-  lookup_result_->headers_->removeInline(age_handle.handle());
+  lookup_result_->headers_->removeInline(age_handle().handle());
 
   // Add any missing headers from the cached response to the 304 response.
   lookup_result_->headers_->iterate([&response_headers](const Http::HeaderEntry& cached_header) {
@@ -404,8 +404,8 @@ bool CacheFilter::shouldUpdateCachedEntry(const Http::ResponseHeaderMap& respons
   // and assuming a single cached response per key:
   // If the 304 response contains a strong validator (etag) that does not match the cached response,
   // the cached response should not be updated.
-  const Http::HeaderEntry* response_etag = response_headers.getInline(etag_handle.handle());
-  const Http::HeaderEntry* cached_etag = lookup_result_->headers_->getInline(etag_handle.handle());
+  const Http::HeaderEntry* response_etag = response_headers.getInline(etag_handle().handle());
+  const Http::HeaderEntry* cached_etag = lookup_result_->headers_->getInline(etag_handle().handle());
   return !response_etag || (cached_etag && cached_etag->value().getStringView() ==
                                                response_etag->value().getStringView());
 }
@@ -417,24 +417,24 @@ void CacheFilter::injectValidationHeaders(Http::RequestHeaderMap& request_header
          "injectValidationHeaders precondition unsatisfied: the "
          "CacheFilter is not validating a cache lookup result");
 
-  const Http::HeaderEntry* etag_header = lookup_result_->headers_->getInline(etag_handle.handle());
+  const Http::HeaderEntry* etag_header = lookup_result_->headers_->getInline(etag_handle().handle());
   const Http::HeaderEntry* last_modified_header =
-      lookup_result_->headers_->getInline(last_modified_handle.handle());
+          lookup_result_->headers_->getInline(last_modified_handle().handle());
 
   if (etag_header) {
     absl::string_view etag = etag_header->value().getStringView();
-    request_headers.setInline(if_none_match_handle.handle(), etag);
+    request_headers.setInline(if_none_match_handle().handle(), etag);
   }
   if (DateUtil::timePointValid(CacheHeadersUtils::httpTime(last_modified_header))) {
     // Valid Last-Modified header exists.
     absl::string_view last_modified = last_modified_header->value().getStringView();
-    request_headers.setInline(if_modified_since_handle.handle(), last_modified);
+    request_headers.setInline(if_modified_since_handle().handle(), last_modified);
   } else {
     // Either Last-Modified is missing or invalid, fallback to Date.
     // A correct behaviour according to:
     // https://httpwg.org/specs/rfc7232.html#header.if-modified-since
     absl::string_view date = lookup_result_->headers_->getDateValue();
-    request_headers.setInline(if_modified_since_handle.handle(), date);
+    request_headers.setInline(if_modified_since_handle().handle(), date);
   }
 }
 

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -155,7 +155,7 @@ Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_
   const SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
 
   long age_value;
-  const absl::string_view age_header = response_headers.getInlineValue(age_handle.handle());
+  const absl::string_view age_header = response_headers.getInlineValue(age_handle().handle());
   if (!absl::SimpleAtoi(age_header, &age_value)) {
     age_value = 0;
   }

--- a/source/extensions/filters/http/cache/cacheability_utils.cc
+++ b/source/extensions/filters/http/cache/cacheability_utils.cc
@@ -50,7 +50,7 @@ bool CacheabilityUtils::isCacheableRequest(const Http::RequestHeaderMap& headers
 
   // TODO(toddmgreer): Also serve HEAD requests from cache.
   // Cache-related headers are checked in HttpCache::LookupRequest.
-  return headers.Path() && headers.Host() && !headers.getInline(authorization_handle.handle()) &&
+  return headers.Path() && headers.Host() && !headers.getInline(authorization_handle().handle()) &&
          (method == header_values.MethodValues.Get) &&
          (forwarded_proto == header_values.SchemeValues.Http ||
           forwarded_proto == header_values.SchemeValues.Https);
@@ -58,7 +58,7 @@ bool CacheabilityUtils::isCacheableRequest(const Http::RequestHeaderMap& headers
 
 bool CacheabilityUtils::isCacheableResponse(const Http::ResponseHeaderMap& headers,
                                             const VaryHeader& vary_allow_list) {
-  absl::string_view cache_control = headers.getInlineValue(response_cache_control_handle.handle());
+  absl::string_view cache_control = headers.getInlineValue(response_cache_control_handle().handle());
   ResponseCacheControl response_cache_control(cache_control);
 
   // Only cache responses with enough data to calculate freshness lifetime as per:
@@ -69,7 +69,7 @@ bool CacheabilityUtils::isCacheableResponse(const Http::ResponseHeaderMap& heade
   //    Both "Expires" and "Date" headers.
   const bool has_validation_data = response_cache_control.must_validate_ ||
                                    response_cache_control.max_age_.has_value() ||
-                                   (headers.Date() && headers.getInline(expires_handle.handle()));
+                                   (headers.Date() && headers.getInline(expires_handle().handle()));
 
   return !response_cache_control.no_store_ &&
          cacheableStatusCodes().contains((headers.getStatusValue())) && has_validation_data &&

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -1,6 +1,6 @@
 #include "extensions/filters/http/cache/config.h"
-
 #include "extensions/filters/http/cache/cache_filter.h"
+#include "extensions/filters/http/cache/inline_headers_handles.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -65,8 +65,8 @@ size_t localHashKey(const Key& key) { return stableHashKey(key); }
 
 void LookupRequest::initializeRequestCacheControl(const Http::RequestHeaderMap& request_headers) {
   const absl::string_view cache_control =
-      request_headers.getInlineValue(request_cache_control_handle.handle());
-  const absl::string_view pragma = request_headers.getInlineValue(pragma_handle.handle());
+          request_headers.getInlineValue(request_cache_control_handle().handle());
+  const absl::string_view pragma = request_headers.getInlineValue(pragma_handle().handle());
 
   if (!cache_control.empty()) {
     request_cache_control_ = RequestCacheControl(cache_control);
@@ -83,7 +83,7 @@ bool LookupRequest::requiresValidation(const Http::ResponseHeaderMap& response_h
   // TODO(yosrym93): Store parsed response cache-control in cache instead of parsing it on every
   // lookup.
   const absl::string_view cache_control =
-      response_headers.getInlineValue(response_cache_control_handle.handle());
+          response_headers.getInlineValue(response_cache_control_handle().handle());
   const ResponseCacheControl response_cache_control(cache_control);
 
   const bool request_max_age_exceeded = request_cache_control_.max_age_.has_value() &&
@@ -97,7 +97,7 @@ bool LookupRequest::requiresValidation(const Http::ResponseHeaderMap& response_h
 
   // CacheabilityUtils::isCacheableResponse(..) guarantees that any cached response satisfies this.
   ASSERT(response_cache_control.max_age_.has_value() ||
-             (response_headers.getInline(expires_handle.handle()) && response_headers.Date()),
+             (response_headers.getInline(expires_handle().handle()) && response_headers.Date()),
          "Cache entry does not have valid expiration data.");
 
   SystemTime::duration freshness_lifetime;
@@ -105,7 +105,7 @@ bool LookupRequest::requiresValidation(const Http::ResponseHeaderMap& response_h
     freshness_lifetime = response_cache_control.max_age_.value();
   } else {
     const SystemTime expires_value =
-        CacheHeadersUtils::httpTime(response_headers.getInline(expires_handle.handle()));
+            CacheHeadersUtils::httpTime(response_headers.getInline(expires_handle().handle()));
     const SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
     freshness_lifetime = expires_value - date_value;
   }
@@ -137,7 +137,7 @@ LookupResult LookupRequest::makeLookupResult(Http::ResponseHeaderMapPtr&& respon
   // Assumption: Cache lookup time is negligible. Therefore, now == timestamp_
   const Seconds age =
       CacheHeadersUtils::calculateAge(*response_headers, metadata.response_time_, timestamp_);
-  response_headers->setInline(age_handle.handle(), std::to_string(age.count()));
+  response_headers->setInline(age_handle().handle(), std::to_string(age.count()));
 
   result.cache_entry_status_ = requiresValidation(*response_headers, age)
                                    ? CacheEntryStatus::RequiresValidation

--- a/source/extensions/filters/http/cache/inline_headers_handles.h
+++ b/source/extensions/filters/http/cache/inline_headers_handles.h
@@ -9,46 +9,93 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
-// Request headers inline handles
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    authorization_handle(Http::CustomHeaders::get().Authorization);
+    authorization_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders> handle(Http::CustomHeaders::get().Authorization);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    pragma_handle(Http::CustomHeaders::get().Pragma);
+    pragma_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders> handle(Http::CustomHeaders::get().Pragma);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    request_cache_control_handle(Http::CustomHeaders::get().CacheControl);
+    request_cache_control_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+      handle(Http::CustomHeaders::get().CacheControl);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    if_match_handle(Http::CustomHeaders::get().IfMatch);
+    if_match_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+      handle(Http::CustomHeaders::get().IfMatch);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    if_none_match_handle(Http::CustomHeaders::get().IfNoneMatch);
+    if_none_match_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+      handle(Http::CustomHeaders::get().IfNoneMatch);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    if_modified_since_handle(Http::CustomHeaders::get().IfModifiedSince);
+    if_modified_since_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+      handle(Http::CustomHeaders::get().IfModifiedSince);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    if_unmodified_since_handle(Http::CustomHeaders::get().IfUnmodifiedSince);
+    if_unmodified_since_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+      handle(Http::CustomHeaders::get().IfUnmodifiedSince);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
-    if_range_handle(Http::CustomHeaders::get().IfRange);
+    if_range_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+      handle(Http::CustomHeaders::get().IfRange);
+  return handle;
+}
 
 // Response headers inline handles
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
-    response_cache_control_handle(Http::CustomHeaders::get().CacheControl);
+    response_cache_control_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+      handle(Http::CustomHeaders::get().CacheControl);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
-    last_modified_handle(Http::CustomHeaders::get().LastModified);
+    last_modified_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+      handle(Http::CustomHeaders::get().LastModified);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
-    etag_handle(Http::CustomHeaders::get().Etag);
+    etag_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
+      handle(Http::CustomHeaders::get().Etag);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
-    age_handle(Http::Headers::get().Age);
+    age_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders> handle(Http::Headers::get().Age);
+  return handle;
+}
 
 inline Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders>
-    expires_handle(Http::Headers::get().Expires);
+    expires_handle() {
+  static Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::ResponseHeaders> handle(Http::Headers::get().Expires);
+  return handle;
+}
 
 } // namespace Cache
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message:

Delay registration of custom headers in CacheFilter to ensure it does not cause HeaderValues to instantiate before setPrefix() is called during server init.

Signed-off-by: Josiah Kiehl <josiah@capoferro.net>

Risk Level: low
Testing: TODO
