### PR TITLE
Use BytesValue::set_value overload that is friendly to absl::Cord and absl::string_view

### DIFF
--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1259,7 +1259,7 @@ TEST_F(ProtobufUtilityTest, AnyBytes) {
   }
   {
     ProtobufWkt::BytesValue source;
-    source.set_value({0x01, 0x02, 0x03});
+    source.set_value("\x01\x02\x03");
     ProtobufWkt::Any source_any;
     source_any.PackFrom(source);
     EXPECT_EQ(MessageUtil::anyToBytes(source_any), "\x01\x02\x03");


### PR DESCRIPTION
Additional Description:
Google internal version of protobuf does not have std::string overloads for BytesValue::set_value overload.

Risk Level: Low, Test Only
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>

