### PR TITLE
ci: Separate format checks

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -13,8 +13,22 @@ pr: none
 stages:
   - stage: precheck
     jobs:
+      - job: format_pre
+        dependsOn: []
+        pool:
+          vmImage: "ubuntu-18.04"
+        steps:
+          - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format_pre'
+            workingDirectory: $(Build.SourcesDirectory)
+            env:
+              ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
+              BAZEL_REMOTE_CACHE: grpcs://remotebuildexecution.googleapis.com
+              BAZEL_REMOTE_INSTANCE: projects/envoy-ci/instances/default_instance
+              GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
+            displayName: "Run format pre-checks"
+
       - job: format
-        dependsOn: [] # this removes the implicit dependency on previous stage and causes this to run in parallel.
+        dependsOn: ["format_pre"]
         pool:
           vmImage: "ubuntu-18.04"
         steps:

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -97,6 +97,7 @@ BAZEL_BUILD_OPTIONS=(
   "--show_task_finish"
   "--experimental_generate_json_trace_profile"
   "--test_output=errors"
+  "--noshow_progress"
   "--repository_cache=${BUILD_DIR}/repository_cache"
   "--experimental_repository_cache_hardlinks"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -98,6 +98,7 @@ BAZEL_BUILD_OPTIONS=(
   "--experimental_generate_json_trace_profile"
   "--test_output=errors"
   "--noshow_progress"
+  "--noshow_loading_progress"
   "--repository_cache=${BUILD_DIR}/repository_cache"
   "--experimental_repository_cache_hardlinks"
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"

--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -E
+
+# Pre-checks for validation and linting
+#
+# These checks do not provide a fix and are quicker to run,
+# allowing CI to fail quickly on basic linting or validation errors
+
+FAILED=()
+CURRENT=""
+
+read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
+
+
+trap_errors () {
+    local frame=0 command line sub file
+    if [[ -n "$CURRENT" ]]; then
+        command=" (${CURRENT})"
+    fi
+    set +v
+    while read -r line sub file < <(caller "$frame"); do
+        if [[ "$frame" -ne "0" ]]; then
+            FAILED+=("  > ${sub}@ ${file} :${line}")
+        else
+            FAILED+=("${sub}@ ${file} :${line}${command}")
+        fi
+        ((frame++))
+    done
+    set -v
+}
+
+trap trap_errors ERR
+trap exit 1 INT
+
+CURRENT=shellcheck
+./tools/code_format/check_shellcheck_format.sh check
+
+CURRENT=configs
+bazel run "${BAZEL_BUILD_OPTIONS[@]}" //configs:example_configs_validation
+
+CURRENT=flake8
+bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/code_format:python_flake8 "$(pwd)"
+
+if [[ "${#FAILED[@]}" -ne "0" ]]; then
+    echo "TESTS FAILED:" >&2
+    for failed in "${FAILED[@]}"; do
+        echo "  $failed" >&2
+    done
+    exit 1
+fi

--- a/tools/api_versioning/generate_api_version_header.py
+++ b/tools/api_versioning/generate_api_version_header.py
@@ -20,7 +20,7 @@ constexpr ApiVersion oldest_api_version = {$oldest_major, $oldest_minor, $oldest
 } // namespace Envoy""")
 
 
-def GenerateHeaderFile(input_path):
+def generate_header_file(input_path):
     """Generates a c++ header file containing the api_version variable with the
   correct value.
 
@@ -35,7 +35,7 @@ def GenerateHeaderFile(input_path):
 
     # Mapping each field to int verifies it is a valid version
     version = ApiVersion(*map(int, lines[0].split('.')))
-    oldest_version = ComputeOldestApiVersion(version)
+    oldest_version = compute_oldest_api_version(version)
 
     header_file_contents = FILE_TEMPLATE.substitute({
         'major': version.major,
@@ -48,7 +48,7 @@ def GenerateHeaderFile(input_path):
     return header_file_contents
 
 
-def ComputeOldestApiVersion(current_version: ApiVersion):
+def compute_oldest_api_version(current_version: ApiVersion):
     """Computest the oldest API version the client supports. According to the
   specification (see: api/API_VERSIONING.md), Envoy supports up to 2 most
   recent minor versions. Therefore if the latest API version "X.Y.Z", Envoy's
@@ -68,6 +68,6 @@ def ComputeOldestApiVersion(current_version: ApiVersion):
 
 if __name__ == '__main__':
     input_path = sys.argv[1]
-    output = GenerateHeaderFile(input_path)
+    output = generate_header_file(input_path)
     # Print output to stdout
     print(output)

--- a/tools/api_versioning/generate_api_version_header_test.py
+++ b/tools/api_versioning/generate_api_version_header_test.py
@@ -33,7 +33,7 @@ constexpr ApiVersion oldest_api_version = {$oldest_major, $oldest_minor, $oldest
 
     # General success pattern when valid file contents is detected.
     def successful_test_template(self, output_string, current_version: ApiVersion,
-                               oldest_version: ApiVersion):
+                                 oldest_version: ApiVersion):
         pathlib.Path(self._temp_fname).write_text(output_string)
 
         # Read the string from the file, and parse the version.

--- a/tools/api_versioning/generate_api_version_header_test.py
+++ b/tools/api_versioning/generate_api_version_header_test.py
@@ -32,12 +32,12 @@ constexpr ApiVersion oldest_api_version = {$oldest_major, $oldest_minor, $oldest
         pathlib.Path(self._temp_fname).unlink()
 
     # General success pattern when valid file contents is detected.
-    def SuccessfulTestTemplate(self, output_string, current_version: ApiVersion,
+    def successful_test_template(self, output_string, current_version: ApiVersion,
                                oldest_version: ApiVersion):
         pathlib.Path(self._temp_fname).write_text(output_string)
 
         # Read the string from the file, and parse the version.
-        output = generate_api_version_header.GenerateHeaderFile(self._temp_fname)
+        output = generate_api_version_header.generate_header_file(self._temp_fname)
         expected_output = GenerateApiVersionHeaderTest.EXPECTED_TEMPLATE.substitute({
             'major': current_version.major,
             'minor': current_version.minor,
@@ -49,33 +49,33 @@ constexpr ApiVersion oldest_api_version = {$oldest_major, $oldest_minor, $oldest
         self.assertEqual(expected_output, output)
 
     # General failure pattern when invalid file contents is detected.
-    def FailedTestTemplate(self, output_string, assertion_error_type):
+    def failed_test_template(self, output_string, assertion_error_type):
         pathlib.Path(self._temp_fname).write_text(output_string)
 
         # Read the string from the file, and expect version parsing to fail.
         with self.assertRaises(
                 assertion_error_type,
-                msg='The call to GenerateHeaderFile should have thrown an exception'):
-            generate_api_version_header.GenerateHeaderFile(self._temp_fname)
+                msg='The call to generate_header_file should have thrown an exception'):
+            generate_api_version_header.generate_header_file(self._temp_fname)
 
     def test_valid_version(self):
-        self.SuccessfulTestTemplate('1.2.3', ApiVersion(1, 2, 3), ApiVersion(1, 1, 0))
+        self.successful_test_template('1.2.3', ApiVersion(1, 2, 3), ApiVersion(1, 1, 0))
 
     def test_valid_version_newline(self):
-        self.SuccessfulTestTemplate('3.2.1\n', ApiVersion(3, 2, 1), ApiVersion(3, 1, 0))
+        self.successful_test_template('3.2.1\n', ApiVersion(3, 2, 1), ApiVersion(3, 1, 0))
 
     def test_invalid_version_string(self):
-        self.FailedTestTemplate('1.2.abc3', ValueError)
+        self.failed_test_template('1.2.abc3', ValueError)
 
     def test_invalid_version_partial(self):
-        self.FailedTestTemplate('1.2.', ValueError)
+        self.failed_test_template('1.2.', ValueError)
 
     def test_empty_file(self):
         # Not writing anything to the file
-        self.FailedTestTemplate('', AssertionError)
+        self.failed_test_template('', AssertionError)
 
     def test_invalid_multiple_lines(self):
-        self.FailedTestTemplate('1.2.3\n1.2.3', AssertionError)
+        self.failed_test_template('1.2.3\n1.2.3', AssertionError)
 
     def test_valid_oldest_api_version(self):
         expected_latest_oldest_pairs = [(ApiVersion(3, 2, 2), ApiVersion(3, 1, 0)),
@@ -85,7 +85,7 @@ constexpr ApiVersion oldest_api_version = {$oldest_major, $oldest_minor, $oldest
 
         for latest_version, expected_oldest_version in expected_latest_oldest_pairs:
             self.assertEqual(expected_oldest_version,
-                             generate_api_version_header.ComputeOldestApiVersion(latest_version))
+                             generate_api_version_header.compute_oldest_api_version(latest_version))
 
 
 if __name__ == '__main__':

--- a/tools/code_format/python_flake8.py
+++ b/tools/code_format/python_flake8.py
@@ -4,20 +4,17 @@ import sys
 FLAKE8_CONFIG = "tools/code_format/flake8.conf"
 
 # explicitly use python3 linter
-FLAKE8_COMMAND = (
-    "python3", "-m", "flake8", "--config", FLAKE8_CONFIG, ".")
+FLAKE8_COMMAND = ("python3", "-m", "flake8", "--config", FLAKE8_CONFIG, ".")
+
 
 def main():
-    resp = subprocess.run(
-        FLAKE8_COMMAND,
-        capture_output=True,
-        cwd=sys.argv[1])
+    resp = subprocess.run(FLAKE8_COMMAND, capture_output=True, cwd=sys.argv[1])
     if resp.returncode:
         # stdout and stderr are dumped to ensure we capture all errors
-        raise SystemExit(
-            "ERROR: flake8 linting failed: \n"
-            f"{resp.stdout.decode('utf-8')}\n"
-            f"{resp.stderr.decode('utf-8')}")
+        raise SystemExit("ERROR: flake8 linting failed: \n"
+                         f"{resp.stdout.decode('utf-8')}\n"
+                         f"{resp.stderr.decode('utf-8')}")
+
 
 if __name__ == "__main__":
     main()

--- a/tools/code_format/python_flake8.py
+++ b/tools/code_format/python_flake8.py
@@ -1,11 +1,23 @@
 import subprocess
 import sys
 
+FLAKE8_CONFIG = "tools/code_format/flake8.conf"
+
+# explicitly use python3 linter
+FLAKE8_COMMAND = (
+    "python3", "-m", "flake8", "--config", FLAKE8_CONFIG, ".")
 
 def main():
-    subprocess.run(f"python -m flake8 --config tools/code_format/flake8.conf .".split(),
-                   cwd=sys.argv[1])
-
+    resp = subprocess.run(
+        FLAKE8_COMMAND,
+        capture_output=True,
+        cwd=sys.argv[1])
+    if resp.returncode:
+        # stdout and stderr are dumped to ensure we capture all errors
+        raise SystemExit(
+            "ERROR: flake8 linting failed: \n"
+            f"{resp.stdout.decode('utf-8')}\n"
+            f"{resp.stderr.decode('utf-8')}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Separate format checks
Additional Description:

This PR resolves a few CI issues

- fixes broken flake8 test in CI
- adds a cleanup for python linting that should have failed
- improves error feedback for config validation fail 
- splits format checks that do not currently provide any autofixes
- adds `noshow_progress` and `noshow_loading_progress` flags to bazel in ci (see https://kevin.burke.dev/kevin/bazel-tests-on-travis-ci/)

it also provides a place to add general checks for text (code) files #15442 

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #15313 Fix #15456 Fix #15552 
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
