### PR TITLE
zipkin: fix verbose mode

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -90,6 +90,7 @@ Bug Fixes
 * tls: fix issue where OCSP was inadvertently removed from SSL response in multi-context scenarios.
 * upstream: fix handling of moving endpoints between priorities when active health checks are enabled. Previously moving to a higher numbered priority was a NOOP, and moving to a lower numbered priority caused an abort.
 * upstream: retry budgets will now set default values for xDS configurations.
+* zipkin: fix 'verbose' mode to emit annotations for stream events. This was the documented behavior, but wasn't behaving as documented.
 
 Removed Config or Runtime
 -------------------------

--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -114,10 +114,13 @@ const std::vector<ProtobufWkt::Struct>
 JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& replacements) const {
   std::vector<ProtobufWkt::Struct> spans;
   spans.reserve(zipkin_span.annotations().size());
+
+  // This holds the annotation entries from logs.
+  std::vector<ProtobufWkt::Value> annotation_entries;
+
   for (const auto& annotation : zipkin_span.annotations()) {
     ProtobufWkt::Struct span;
     auto* fields = span.mutable_fields();
-
     if (annotation.value() == CLIENT_SEND) {
       (*fields)[SPAN_KIND] = ValueUtil::stringValue(KIND_CLIENT);
     } else if (annotation.value() == SERVER_RECV) {
@@ -126,6 +129,12 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
       }
       (*fields)[SPAN_KIND] = ValueUtil::stringValue(KIND_SERVER);
     } else {
+      ProtobufWkt::Struct annotation_entry;
+      auto* annotation_entry_fields = annotation_entry.mutable_fields();
+      (*annotation_entry_fields)[ANNOTATION_VALUE] = ValueUtil::stringValue(annotation.value());
+      (*annotation_entry_fields)[ANNOTATION_TIMESTAMP] =
+          Util::uint64Value(annotation.timestamp(), annotation.value(), replacements);
+      annotation_entries.push_back(ValueUtil::structValue(annotation_entry));
       continue;
     }
 
@@ -174,6 +183,15 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
 
     spans.push_back(std::move(span));
   }
+
+  // Fill up annotation entries from logs.
+  for (auto& span : spans) {
+    auto* fields = span.mutable_fields();
+    if (!annotation_entries.empty()) {
+      (*fields)[ANNOTATIONS] = ValueUtil::listValue(annotation_entries);
+    }
+  }
+
   return spans;
 }
 
@@ -214,6 +232,10 @@ std::string ProtobufSerializer::serialize(const std::vector<Span>& zipkin_spans)
 
 const zipkin::proto3::ListOfSpans ProtobufSerializer::toListOfSpans(const Span& zipkin_span) const {
   zipkin::proto3::ListOfSpans spans;
+
+  // This holds the annotation entries from logs.
+  std::vector<Annotation> annotation_entries;
+
   for (const auto& annotation : zipkin_span.annotations()) {
     zipkin::proto3::Span span;
     if (annotation.value() == CLIENT_SEND) {
@@ -222,6 +244,7 @@ const zipkin::proto3::ListOfSpans ProtobufSerializer::toListOfSpans(const Span& 
       span.set_shared(shared_span_context_ && zipkin_span.annotations().size() > 1);
       span.set_kind(zipkin::proto3::Span::SERVER);
     } else {
+      annotation_entries.push_back(annotation);
       continue;
     }
 
@@ -250,6 +273,16 @@ const zipkin::proto3::ListOfSpans ProtobufSerializer::toListOfSpans(const Span& 
     auto* mutable_span = spans.add_spans();
     mutable_span->MergeFrom(span);
   }
+
+  // Fill up annotation entries from logs.
+  for (auto& span : *spans.mutable_spans()) {
+    for (const auto& annotation_entry : annotation_entries) {
+      const auto entry = span.mutable_annotations()->Add();
+      entry->set_value(annotation_entry.value());
+      entry->set_timestamp(annotation_entry.timestamp());
+    }
+  }
+
   return spans;
 }
 

--- a/source/extensions/tracers/zipkin/zipkin_json_field_names.h
+++ b/source/extensions/tracers/zipkin/zipkin_json_field_names.h
@@ -24,6 +24,7 @@ constexpr char SPAN_ANNOTATIONS[] = "annotations";
 constexpr char SPAN_LOCAL_ENDPOINT[] = "localEndpoint";
 constexpr char SPAN_BINARY_ANNOTATIONS[] = "binaryAnnotations";
 
+constexpr char ANNOTATIONS[] = "annotations";
 constexpr char ANNOTATION_VALUE[] = "value";
 constexpr char ANNOTATION_ENDPOINT[] = "endpoint";
 constexpr char ANNOTATION_TIMESTAMP[] = "timestamp";


### PR DESCRIPTION
When verbose mode is true, Zipkin tracers need to serialize the data
collected by Span::log() as annotations.

Co-authored-by: Dhi Aurrahman <dio@tetrate.io>

Signed-off-by: James Mulcahy <jmulcahy@netflix.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: When verbose mode is true, Zipkin tracers need to serialize the data
collected by Span::log() as annotations.
Additional Description: **This PR was originally contributed by @dio, in PR #12541**.  Full credit goes to Dhi.  Unfortunately, that PR didn't get merged, and the documented functionality remains broken in the main branch.  I've verified this patch still fixes the issue, and am hoping we can get this merged as is.
Risk Level: Low
Testing: Includes additional unit tests, and has also been manually verified as emitting the additional span annotations when deployed in a real environment.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A (No issue exists to track this bug)
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
