### PR TITLE
router: add benchmarks for URL template path matcher

### DIFF
--- a/test/common/router/config_impl_speed_test.cc
+++ b/test/common/router/config_impl_speed_test.cc
@@ -68,6 +68,10 @@ static RouteConfiguration genRouteConfig(benchmark::State& state,
       regex->set_regex(absl::StrCat("^/shelves/[^\\\\/]+/route_", i, "$"));
       break;
     }
+    case RouteMatch::PathSpecifierCase::kUrlTemplate: {
+      match->set_url_template(absl::StrCat("/shelves/{shelf_id}/route_", i));
+      break;
+    }
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;
     }
@@ -126,19 +130,37 @@ static void bmRouteTableSizeWithExactPathMatch(benchmark::State& state) {
 
 /**
  * Benchmark a route table with regex path matchers in the form of:
+ * - ^/shelves/[^\\/]+/route_1$
+ * - ^/shelves/[^\\/]+/route_2$
+ * - etc.
+ *
+ * This represents OpenAPI path templates represented by regex.
+ * https://swagger.io/docs/specification/paths-and-operations/
  * - /shelves/{shelf_id}/route_1
  * - /shelves/{shelf_id}/route_2
  * - etc.
- *
- * This represents common OpenAPI path templating.
  */
 static void bmRouteTableSizeWithRegexMatch(benchmark::State& state) {
   bmRouteTableSize(state, RouteMatch::PathSpecifierCase::kSafeRegex);
 }
 
+/**
+ * Benchmark a route table with URL template path matchers in the form of:
+ * - /shelves/{shelf_id}/route_1
+ * - /shelves/{shelf_id}/route_2
+ * - etc.
+ *
+ * This represents syntax supported by `google/api/http.proto`.
+ * https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+ */
+static void bmRouteTableSizeWithUrlTemplateMatch(benchmark::State& state) {
+  bmRouteTableSize(state, RouteMatch::PathSpecifierCase::kUrlTemplate);
+}
+
 BENCHMARK(bmRouteTableSizeWithPathPrefixMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
 BENCHMARK(bmRouteTableSizeWithExactPathMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
 BENCHMARK(bmRouteTableSizeWithRegexMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
+BENCHMARK(bmRouteTableSizeWithUrlTemplateMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
 
 } // namespace
 } // namespace Router


### PR DESCRIPTION
DO NOT SUBMIT until #15299 is merged.

**Commit Message:**
router: add benchmarks for URL template path matcher

**Additional Description:**
Follow-up on #13320 and #15304 to measure the efficiency of the URL template path matcher.

Since we are not making use of the tree structure in the matcher to do route search, it has a higher performance overhead than regex route matching.

![image](https://user-images.githubusercontent.com/11142171/111199676-4c348b80-8597-11eb-94dd-5f5e19fa08fc.png)

```
/usr/bin/setsid --wait bazel run --tool_tag=ijwb:CLion --curses=no --color=yes --progress_in_terminal_title=no -c opt -- //test/common/router:config_impl_speed_test
Loading: 
Loading: 0 packages loaded
Analyzing: target //test/common/router:config_impl_speed_test (1 packages loaded, 0 targets configured)
INFO: Analyzed target //test/common/router:config_impl_speed_test (113 packages loaded, 1723 targets configured).
INFO: Found 1 target...
[0 / 4] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target //test/common/router:config_impl_speed_test up-to-date:
  bazel-bin/test/common/router/config_impl_speed_test
INFO: Elapsed time: 1.050s, Critical Path: 0.07s
INFO: 3 processes: 3 internal.
INFO: Build completed successfully, 3 total actions
INFO: Running command line: bazel-bin/test/common/router/config_impl_speed_test
INFO: Build completed successfully, 3 total actions
2021-03-15 10:48:17
Running /usr/local/google/home/nareddyt/.cache/bazel/_bazel_nareddyt/7e4e8176e5050c1fddf9f91f11a5012e/execroot/envoy/bazel-out/k8-opt/bin/test/common/router/config_impl_speed_test
Run on (12 X 4500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1024 KiB (x6)
  L3 Unified 8448 KiB (x1)
Load Average: 0.41, 2.14, 5.78
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
bmRouteTableSizeWithPathPrefixMatch/1             571 ns          570 ns      1234502
bmRouteTableSizeWithPathPrefixMatch/2             620 ns          620 ns      1162237
bmRouteTableSizeWithPathPrefixMatch/4             706 ns          706 ns       987271
bmRouteTableSizeWithPathPrefixMatch/8             892 ns          892 ns       782235
bmRouteTableSizeWithPathPrefixMatch/16           1377 ns         1377 ns       514631
bmRouteTableSizeWithPathPrefixMatch/32           2076 ns         2076 ns       337348
bmRouteTableSizeWithPathPrefixMatch/64           3563 ns         3562 ns       187665
bmRouteTableSizeWithPathPrefixMatch/128          6998 ns         6996 ns       102291
bmRouteTableSizeWithPathPrefixMatch/256         13476 ns        13473 ns        52259
bmRouteTableSizeWithPathPrefixMatch/512         31183 ns        31178 ns        22193
bmRouteTableSizeWithPathPrefixMatch/1024        69985 ns        69970 ns        10115
bmRouteTableSizeWithPathPrefixMatch/2048       163691 ns       163658 ns         4687
bmRouteTableSizeWithPathPrefixMatch/4096       526907 ns       526770 ns         1353
bmRouteTableSizeWithPathPrefixMatch/8192      1370992 ns      1370871 ns          518
bmRouteTableSizeWithPathPrefixMatch/16384     2890842 ns      2890059 ns          239
bmRouteTableSizeWithExactPathMatch/1              559 ns          559 ns      1257805
bmRouteTableSizeWithExactPathMatch/2              601 ns          601 ns      1166409
bmRouteTableSizeWithExactPathMatch/4              704 ns          704 ns      1002635
bmRouteTableSizeWithExactPathMatch/8              890 ns          889 ns       785273
bmRouteTableSizeWithExactPathMatch/16            1368 ns         1368 ns       512515
bmRouteTableSizeWithExactPathMatch/32            2096 ns         2095 ns       332810
bmRouteTableSizeWithExactPathMatch/64            3632 ns         3632 ns       191063
bmRouteTableSizeWithExactPathMatch/128           7285 ns         7284 ns       101202
bmRouteTableSizeWithExactPathMatch/256          13588 ns        13587 ns        51139
bmRouteTableSizeWithExactPathMatch/512          30877 ns        30877 ns        22592
bmRouteTableSizeWithExactPathMatch/1024         72026 ns        72018 ns        10156
bmRouteTableSizeWithExactPathMatch/2048        160554 ns       160539 ns         4509
bmRouteTableSizeWithExactPathMatch/4096        543931 ns       543806 ns         1310
bmRouteTableSizeWithExactPathMatch/8192       1383401 ns      1383020 ns          509
bmRouteTableSizeWithExactPathMatch/16384      2937507 ns      2936748 ns          232
bmRouteTableSizeWithRegexMatch/1                  669 ns          669 ns      1087890
bmRouteTableSizeWithRegexMatch/2                  799 ns          798 ns       867488
bmRouteTableSizeWithRegexMatch/4                 1099 ns         1099 ns       672321
bmRouteTableSizeWithRegexMatch/8                 1616 ns         1615 ns       434829
bmRouteTableSizeWithRegexMatch/16                3100 ns         3099 ns       235952
bmRouteTableSizeWithRegexMatch/32                5198 ns         5197 ns       135901
bmRouteTableSizeWithRegexMatch/64                9817 ns         9817 ns        71540
bmRouteTableSizeWithRegexMatch/128              20739 ns        20736 ns        35446
bmRouteTableSizeWithRegexMatch/256              44604 ns        44602 ns        14827
bmRouteTableSizeWithRegexMatch/512             133654 ns       133651 ns         5325
bmRouteTableSizeWithRegexMatch/1024            266279 ns       266272 ns         2588
bmRouteTableSizeWithRegexMatch/2048            784492 ns       784459 ns          832
bmRouteTableSizeWithRegexMatch/4096           2303077 ns      2302133 ns          290
bmRouteTableSizeWithRegexMatch/8192           5175619 ns      5173376 ns          135
bmRouteTableSizeWithRegexMatch/16384         11991523 ns     11990390 ns           43
bmRouteTableSizeWithUrlTemplateMatch/1           1205 ns         1204 ns       581983
bmRouteTableSizeWithUrlTemplateMatch/2           1977 ns         1977 ns       349463
bmRouteTableSizeWithUrlTemplateMatch/4           3551 ns         3549 ns       198810
bmRouteTableSizeWithUrlTemplateMatch/8           6756 ns         6755 ns       103910
bmRouteTableSizeWithUrlTemplateMatch/16         13297 ns        13295 ns        50184
bmRouteTableSizeWithUrlTemplateMatch/32         25642 ns        25594 ns        27782
bmRouteTableSizeWithUrlTemplateMatch/64         54870 ns        54840 ns        11004
bmRouteTableSizeWithUrlTemplateMatch/128       101063 ns       101043 ns         6949
bmRouteTableSizeWithUrlTemplateMatch/256       205487 ns       205479 ns         3394
bmRouteTableSizeWithUrlTemplateMatch/512       427092 ns       426997 ns         1635
bmRouteTableSizeWithUrlTemplateMatch/1024      903149 ns       903139 ns          781
bmRouteTableSizeWithUrlTemplateMatch/2048     1894054 ns      1893759 ns          353
bmRouteTableSizeWithUrlTemplateMatch/4096     4232847 ns      4232681 ns          164
bmRouteTableSizeWithUrlTemplateMatch/8192     9569902 ns      9568618 ns           77
bmRouteTableSizeWithUrlTemplateMatch/16384   18241829 ns     18239940 ns           40
```

**Risk Level:**
None

**Testing:**
Added benchmark

**Docs Changes:**
None

**Release Notes:**
None