### PR TITLE
api: unhiding and updating tunneling config

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -60,8 +60,8 @@ message TcpProxy {
   }
 
   // Configuration for tunneling TCP over other transports or application layers.
-  // Currently, only HTTP/2 is supported. When other options exist, HTTP/2 will
-  // remain the default.
+  // Tunneling is supported over both HTTP/1.1 and HTTP/2. Upstream protocol is
+  // determined by the cluster configuration.
   message TunnelingConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.tcp_proxy.v2.TcpProxy.TunnelingConfig";
@@ -70,7 +70,7 @@ message TcpProxy {
     string hostname = 1 [(validate.rules).string = {min_len: 1}];
 
     // Use POST method instead of CONNECT method to tunnel the TCP stream.
-    // The 'protocol: bytestream' header is also NOT set to comply with the HTTP spec.
+    // The 'protocol: bytestream' header is also NOT set for HTTP/2 to comply with the spec.
     //
     // The upstream proxy is expected to convert POST payload as raw TCP.
     bool use_post = 2;
@@ -142,10 +142,8 @@ message TcpProxy {
   // limited to 1.
   repeated type.v3.HashPolicy hash_policy = 11 [(validate.rules).repeated = {max_items: 1}];
 
-  // [#not-implemented-hide:] feature in progress
-  // If set, this configures tunneling, e.g. configuration options to tunnel multiple TCP
-  // payloads over a shared HTTP/2 tunnel. If this message is absent, the payload
-  // will be proxied upstream as per usual.
+  // If set, this configures tunneling, e.g. configuration options to tunnel TCP payload over
+  // HTTP CONNECT. If this message is absent, the payload will be proxied upstream as per usual.
   TunnelingConfig tunneling_config = 12;
 
   // The maximum duration of a connection. The duration is defined as the period since a connection

--- a/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
@@ -60,8 +60,8 @@ message TcpProxy {
   }
 
   // Configuration for tunneling TCP over other transports or application layers.
-  // Currently, only HTTP/2 is supported. When other options exist, HTTP/2 will
-  // remain the default.
+  // Tunneling is supported over both HTTP/1.1 and HTTP/2. Upstream protocol is
+  // determined by the cluster configuration.
   message TunnelingConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig";
@@ -70,7 +70,7 @@ message TcpProxy {
     string hostname = 1 [(validate.rules).string = {min_len: 1}];
 
     // Use POST method instead of CONNECT method to tunnel the TCP stream.
-    // The 'protocol: bytestream' header is also NOT set to comply with the HTTP spec.
+    // The 'protocol: bytestream' header is also NOT set for HTTP/2 to comply with the spec.
     //
     // The upstream proxy is expected to convert POST payload as raw TCP.
     bool use_post = 2;
@@ -142,10 +142,8 @@ message TcpProxy {
   // limited to 1.
   repeated type.v3.HashPolicy hash_policy = 11 [(validate.rules).repeated = {max_items: 1}];
 
-  // [#not-implemented-hide:] feature in progress
-  // If set, this configures tunneling, e.g. configuration options to tunnel multiple TCP
-  // payloads over a shared HTTP/2 tunnel. If this message is absent, the payload
-  // will be proxied upstream as per usual.
+  // If set, this configures tunneling, e.g. configuration options to tunnel TCP payload over
+  // HTTP CONNECT. If this message is absent, the payload will be proxied upstream as per usual.
   TunnelingConfig tunneling_config = 12;
 
   // The maximum duration of a connection. The duration is defined as the period since a connection

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -61,8 +61,8 @@ message TcpProxy {
   }
 
   // Configuration for tunneling TCP over other transports or application layers.
-  // Currently, only HTTP/2 is supported. When other options exist, HTTP/2 will
-  // remain the default.
+  // Tunneling is supported over both HTTP/1.1 and HTTP/2. Upstream protocol is
+  // determined by the cluster configuration.
   message TunnelingConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.tcp_proxy.v2.TcpProxy.TunnelingConfig";
@@ -71,7 +71,7 @@ message TcpProxy {
     string hostname = 1 [(validate.rules).string = {min_len: 1}];
 
     // Use POST method instead of CONNECT method to tunnel the TCP stream.
-    // The 'protocol: bytestream' header is also NOT set to comply with the HTTP spec.
+    // The 'protocol: bytestream' header is also NOT set for HTTP/2 to comply with the spec.
     //
     // The upstream proxy is expected to convert POST payload as raw TCP.
     bool use_post = 2;
@@ -163,10 +163,8 @@ message TcpProxy {
   // limited to 1.
   repeated type.v3.HashPolicy hash_policy = 11 [(validate.rules).repeated = {max_items: 1}];
 
-  // [#not-implemented-hide:] feature in progress
-  // If set, this configures tunneling, e.g. configuration options to tunnel multiple TCP
-  // payloads over a shared HTTP/2 tunnel. If this message is absent, the payload
-  // will be proxied upstream as per usual.
+  // If set, this configures tunneling, e.g. configuration options to tunnel TCP payload over
+  // HTTP CONNECT. If this message is absent, the payload will be proxied upstream as per usual.
   TunnelingConfig tunneling_config = 12;
 
   // The maximum duration of a connection. The duration is defined as the period since a connection

--- a/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/tcp_proxy/v4alpha/tcp_proxy.proto
@@ -60,8 +60,8 @@ message TcpProxy {
   }
 
   // Configuration for tunneling TCP over other transports or application layers.
-  // Currently, only HTTP/2 is supported. When other options exist, HTTP/2 will
-  // remain the default.
+  // Tunneling is supported over both HTTP/1.1 and HTTP/2. Upstream protocol is
+  // determined by the cluster configuration.
   message TunnelingConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig";
@@ -70,7 +70,7 @@ message TcpProxy {
     string hostname = 1 [(validate.rules).string = {min_len: 1}];
 
     // Use POST method instead of CONNECT method to tunnel the TCP stream.
-    // The 'protocol: bytestream' header is also NOT set to comply with the HTTP spec.
+    // The 'protocol: bytestream' header is also NOT set for HTTP/2 to comply with the spec.
     //
     // The upstream proxy is expected to convert POST payload as raw TCP.
     bool use_post = 2;
@@ -142,10 +142,8 @@ message TcpProxy {
   // limited to 1.
   repeated type.v3.HashPolicy hash_policy = 11 [(validate.rules).repeated = {max_items: 1}];
 
-  // [#not-implemented-hide:] feature in progress
-  // If set, this configures tunneling, e.g. configuration options to tunnel multiple TCP
-  // payloads over a shared HTTP/2 tunnel. If this message is absent, the payload
-  // will be proxied upstream as per usual.
+  // If set, this configures tunneling, e.g. configuration options to tunnel TCP payload over
+  // HTTP CONNECT. If this message is absent, the payload will be proxied upstream as per usual.
   TunnelingConfig tunneling_config = 12;
 
   // The maximum duration of a connection. The duration is defined as the period since a connection


### PR DESCRIPTION
Release notes linked to explanatory docs not API changes, so didn't catch it was still hidden.

h/t @ggreenway for noticing.