### PR TITLE
protos: Remove -x from bash script

### DIFF
--- a/tools/proto_format/proto_format.sh
+++ b/tools/proto_format/proto_format.sh
@@ -3,7 +3,6 @@
 # Reformat API protos to canonical proto style using protoxform.
 
 set -e
-set -x
 
 read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
 


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: protos: Remove -x from bash script
Additional Description:

currently the proto_format.sh is set to `-x` which outputs a lot of unhelpful debug logging

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
