### PR TITLE
mock host: Add default locality to mock host description

### DIFF
--- a/test/mocks/upstream/host.cc
+++ b/test/mocks/upstream/host.cc
@@ -37,6 +37,7 @@ MockHostDescription::MockHostDescription()
   ON_CALL(*this, address()).WillByDefault(Return(address_));
   ON_CALL(*this, outlierDetector()).WillByDefault(ReturnRef(outlier_detector_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));
+  ON_CALL(*this, locality()).WillByDefault(ReturnRef(locality_));
   ON_CALL(*this, cluster()).WillByDefault(ReturnRef(cluster_));
   ON_CALL(*this, healthChecker()).WillByDefault(ReturnRef(health_checker_));
   ON_CALL(*this, transportSocketFactory()).WillByDefault(ReturnRef(*socket_factory_));

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -113,6 +113,7 @@ public:
   Network::TransportSocketFactoryPtr socket_factory_;
   testing::NiceMock<MockClusterInfo> cluster_;
   HostStats stats_;
+  envoy::config::core::v3::Locality locality_;
   mutable Stats::TestUtil::TestSymbolTable symbol_table_;
   mutable std::unique_ptr<Stats::StatNameManagedStorage> locality_zone_stat_name_;
 };


### PR DESCRIPTION
Risk Level: Low, any existing usage should override the default locality that's been set here. 
Testing: Existing presubmits which exercise the mock.