### PR TITLE
tls validator: add declaration macro for default validator

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.cc
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "envoy/network/transport_socket.h"
-#include "envoy/registry/registry.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/ssl/private_key/private_key.h"

--- a/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/default_validator.h
@@ -8,6 +8,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/network/transport_socket.h"
+#include "envoy/registry/registry.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/ssl/private_key/private_key.h"
@@ -121,6 +122,8 @@ private:
   std::vector<std::string> verify_subject_alt_name_list_;
   bool verify_trusted_ca_{false};
 };
+
+DECLARE_FACTORY(DefaultCertValidatorFactory);
 
 } // namespace Tls
 } // namespace TransportSockets


### PR DESCRIPTION
Commit Message: tls validator - add declaration macro for default validator
Additional Description: necessary for iOS builds in Envoy Mobile now that cert validators are factory registered.
Risk Level: low
Testing: Envoy Mobile iOS build

Signed-off-by: Jose Nino <jnino@lyft.com>