### PR TITLE
udp: create common UDP socket config message

### DIFF
--- a/api/envoy/config/core/v3/udp_socket_config.proto
+++ b/api/envoy/config/core/v3/udp_socket_config.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "UdpSocketConfigProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: UDP socket config]
+
+// Generic UDP socket configuration.
+message UdpSocketConfig {
+  // The maximum size of received UDP datagrams. Using a larger size will cause Envoy to allocate
+  // more memory per socket. Received datagrams above this size will be dropped. If not set
+  // defaults to 1500 bytes.
+  google.protobuf.UInt64Value max_rx_datagram_size = 1
+      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+}

--- a/api/envoy/config/core/v4alpha/udp_socket_config.proto
+++ b/api/envoy/config/core/v4alpha/udp_socket_config.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package envoy.config.core.v4alpha;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
+option java_outer_classname = "UdpSocketConfigProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: UDP socket config]
+
+// Generic UDP socket configuration.
+message UdpSocketConfig {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.core.v3.UdpSocketConfig";
+
+  // The maximum size of received UDP datagrams. Using a larger size will cause Envoy to allocate
+  // more memory per socket. Received datagrams above this size will be dropped. If not set
+  // defaults to 1500 bytes.
+  google.protobuf.UInt64Value max_rx_datagram_size = 1
+      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+}

--- a/api/envoy/config/listener/v3/udp_listener_config.proto
+++ b/api/envoy/config/listener/v3/udp_listener_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.listener.v3;
 
 import "envoy/config/core/v3/extension.proto";
+import "envoy/config/core/v3/udp_socket_config.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
@@ -35,11 +36,8 @@ message UdpListenerConfig {
   // [#comment:TODO(#12829): Remove this as an extension point.]
   core.v3.TypedExtensionConfig listener_config = 4;
 
-  // The maximum size of received downstream UDP datagrams. Using a larger size will cause Envoy to allocate
-  // more memory per listener. Received datagrams above this size will be dropped. If not set
-  // defaults to 1500 bytes.
-  google.protobuf.UInt64Value max_downstream_rx_datagram_size = 5
-      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+  // UDP socket configuration for the listener.
+  core.v3.UdpSocketConfig downstream_socket_config = 5;
 
   // If the protocol in the listener socket address in :ref:`protocol
   // <envoy_api_field_config.core.v3.SocketAddress.protocol>` is :ref:`UDP

--- a/api/envoy/config/listener/v4alpha/udp_listener_config.proto
+++ b/api/envoy/config/listener/v4alpha/udp_listener_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.listener.v4alpha;
 
 import "envoy/config/core/v4alpha/extension.proto";
+import "envoy/config/core/v4alpha/udp_socket_config.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
@@ -35,11 +36,8 @@ message UdpListenerConfig {
   // [#comment:TODO(#12829): Remove this as an extension point.]
   core.v4alpha.TypedExtensionConfig listener_config = 4;
 
-  // The maximum size of received downstream UDP datagrams. Using a larger size will cause Envoy to allocate
-  // more memory per listener. Received datagrams above this size will be dropped. If not set
-  // defaults to 1500 bytes.
-  google.protobuf.UInt64Value max_downstream_rx_datagram_size = 5
-      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+  // UDP socket configuration for the listener.
+  core.v4alpha.UdpSocketConfig downstream_socket_config = 5;
 
   // If the protocol in the listener socket address in :ref:`protocol
   // <envoy_api_field_config.core.v4alpha.SocketAddress.protocol>` is :ref:`UDP

--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/udp/udp_proxy/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/api/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.udp.udp_proxy.v3;
 
+import "envoy/config/core/v3/udp_socket_config.proto";
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -70,9 +72,6 @@ message UdpProxyConfig {
   // limited to 1.
   repeated HashPolicy hash_policies = 5 [(validate.rules).repeated = {max_items: 1}];
 
-  // The maximum size of received upstream UDP datagrams. Using a larger size will cause Envoy to allocate
-  // more memory per listener. Received datagrams above this size will be dropped. If not set
-  // defaults to 1500 bytes.
-  google.protobuf.UInt64Value max_upstream_rx_datagram_size = 6
-      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+  // UDP socket configuration for upstream sockets.
+  config.core.v3.UdpSocketConfig upstream_socket_config = 6;
 }

--- a/docs/root/api-v3/common_messages/common_messages.rst
+++ b/docs/root/api-v3/common_messages/common_messages.rst
@@ -17,6 +17,7 @@ Common messages
   ../config/core/v3/grpc_method_list.proto
   ../config/core/v3/http_uri.proto
   ../config/core/v3/socket_option.proto
+  ../config/core/v3/udp_socket_config.proto
   ../config/core/v3/substitution_format_string.proto
   ../extensions/common/ratelimit/v3/ratelimit.proto
   ../extensions/filters/common/fault/v3/fault.proto

--- a/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
+++ b/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
@@ -15,14 +15,16 @@ static_resources:
         address: 127.0.0.1
         port_value: 1234
     udp_listener_config:
-      max_downstream_rx_datagram_size: 9000
+      downstream_socket_config:
+        max_rx_datagram_size: 9000
     listener_filters:
     - name: envoy.filters.udp_listener.udp_proxy
       typed_config:
         '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
         stat_prefix: service
         cluster: service_udp
-        max_upstream_rx_datagram_size: 9000
+        upstream_socket_config:
+          max_rx_datagram_size: 9000
   clusters:
   - name: service_udp
     connect_timeout: 0.25s

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -149,9 +149,9 @@ New Features
   <arch_overview_tracing_context_propagation>` for more information.
 * udp: added :ref:`downstream <config_listener_stats_udp>` and
   :ref:`upstream <config_udp_listener_filters_udp_proxy_stats>` statistics for dropped datagrams.
-* udp: added :ref:`max_downstream_rx_datagram_size <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.max_downstream_rx_datagram_size>`
+* udp: added :ref:`downstream_socket_config <envoy_v3_api_field_config.listener.v3.UdpListenerConfig.downstream_socket_config>`
   listener configuration to allow configuration of downstream max UDP datagram size. Also added
-  :ref:`max_upstream_rx_datagram_size <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.max_upstream_rx_datagram_size>`
+  :ref:`upstream_socket_config <envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.upstream_socket_config>`
   UDP proxy configuration to allow configuration of upstream max UDP datagram size. The defaults for
   both remain 1500 bytes.
 

--- a/generated_api_shadow/envoy/config/core/v3/udp_socket_config.proto
+++ b/generated_api_shadow/envoy/config/core/v3/udp_socket_config.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package envoy.config.core.v3;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v3";
+option java_outer_classname = "UdpSocketConfigProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: UDP socket config]
+
+// Generic UDP socket configuration.
+message UdpSocketConfig {
+  // The maximum size of received UDP datagrams. Using a larger size will cause Envoy to allocate
+  // more memory per socket. Received datagrams above this size will be dropped. If not set
+  // defaults to 1500 bytes.
+  google.protobuf.UInt64Value max_rx_datagram_size = 1
+      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+}

--- a/generated_api_shadow/envoy/config/core/v4alpha/udp_socket_config.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/udp_socket_config.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package envoy.config.core.v4alpha;
+
+import "google/protobuf/wrappers.proto";
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+import "validate/validate.proto";
+
+option java_package = "io.envoyproxy.envoy.config.core.v4alpha";
+option java_outer_classname = "UdpSocketConfigProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: UDP socket config]
+
+// Generic UDP socket configuration.
+message UdpSocketConfig {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.core.v3.UdpSocketConfig";
+
+  // The maximum size of received UDP datagrams. Using a larger size will cause Envoy to allocate
+  // more memory per socket. Received datagrams above this size will be dropped. If not set
+  // defaults to 1500 bytes.
+  google.protobuf.UInt64Value max_rx_datagram_size = 1
+      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+}

--- a/generated_api_shadow/envoy/config/listener/v3/udp_listener_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/udp_listener_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.listener.v3;
 
 import "envoy/config/core/v3/extension.proto";
+import "envoy/config/core/v3/udp_socket_config.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
@@ -34,11 +35,8 @@ message UdpListenerConfig {
   // [#comment:TODO(#12829): Remove this as an extension point.]
   core.v3.TypedExtensionConfig listener_config = 4;
 
-  // The maximum size of received downstream UDP datagrams. Using a larger size will cause Envoy to allocate
-  // more memory per listener. Received datagrams above this size will be dropped. If not set
-  // defaults to 1500 bytes.
-  google.protobuf.UInt64Value max_downstream_rx_datagram_size = 5
-      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+  // UDP socket configuration for the listener.
+  core.v3.UdpSocketConfig downstream_socket_config = 5;
 
   // If the protocol in the listener socket address in :ref:`protocol
   // <envoy_api_field_config.core.v3.SocketAddress.protocol>` is :ref:`UDP

--- a/generated_api_shadow/envoy/config/listener/v4alpha/udp_listener_config.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/udp_listener_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.config.listener.v4alpha;
 
 import "envoy/config/core/v4alpha/extension.proto";
+import "envoy/config/core/v4alpha/udp_socket_config.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
@@ -35,11 +36,8 @@ message UdpListenerConfig {
   // [#comment:TODO(#12829): Remove this as an extension point.]
   core.v4alpha.TypedExtensionConfig listener_config = 4;
 
-  // The maximum size of received downstream UDP datagrams. Using a larger size will cause Envoy to allocate
-  // more memory per listener. Received datagrams above this size will be dropped. If not set
-  // defaults to 1500 bytes.
-  google.protobuf.UInt64Value max_downstream_rx_datagram_size = 5
-      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+  // UDP socket configuration for the listener.
+  core.v4alpha.UdpSocketConfig downstream_socket_config = 5;
 
   // If the protocol in the listener socket address in :ref:`protocol
   // <envoy_api_field_config.core.v4alpha.SocketAddress.protocol>` is :ref:`UDP

--- a/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
+++ b/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/config/core/v3:pkg",
         "//envoy/config/filter/udp/udp_proxy/v2alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
     ],

--- a/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.udp.udp_proxy.v3;
 
+import "envoy/config/core/v3/udp_socket_config.proto";
+
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -70,9 +72,6 @@ message UdpProxyConfig {
   // limited to 1.
   repeated HashPolicy hash_policies = 5 [(validate.rules).repeated = {max_items: 1}];
 
-  // The maximum size of received upstream UDP datagrams. Using a larger size will cause Envoy to allocate
-  // more memory per listener. Received datagrams above this size will be dropped. If not set
-  // defaults to 1500 bytes.
-  google.protobuf.UInt64Value max_upstream_rx_datagram_size = 6
-      [(validate.rules).uint64 = {lt: 65536 gt: 0}];
+  // UDP socket configuration for upstream sockets.
+  config.core.v3.UdpSocketConfig upstream_socket_config = 6;
 }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -72,8 +72,9 @@ public:
         session_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, idle_timeout, 60 * 1000)),
         use_original_src_ip_(config.use_original_src_ip()),
         stats_(generateStats(config.stat_prefix(), root_scope)),
-        max_upstream_rx_datagram_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-            config, max_upstream_rx_datagram_size, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE)) {
+        max_upstream_rx_datagram_size_(
+            PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.upstream_socket_config(), max_rx_datagram_size,
+                                            Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE)) {
     if (use_original_src_ip_ && !Api::OsSysCallsSingleton::get().supportsIpTransparent()) {
       ExceptionUtil::throwEnvoyException(
           "The platform does not support either IP_TRANSPARENT or IPV6_TRANSPARENT. Or the envoy "

--- a/source/server/active_udp_listener.cc
+++ b/source/server/active_udp_listener.cc
@@ -65,10 +65,10 @@ void ActiveUdpListenerBase::onData(Network::UdpRecvData&& data) {
 
 Event::Dispatcher::CreateUdpListenerParams
 ActiveUdpListenerBase::configToUdpListenerParams(Network::ListenerConfig& config) {
+  const auto& udp_socket_config = config.udpListenerConfig()->config().downstream_socket_config();
   Event::Dispatcher::CreateUdpListenerParams params;
   params.max_rx_datagram_size_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-      config.udpListenerConfig()->config(), max_downstream_rx_datagram_size,
-      Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
+      udp_socket_config, max_rx_datagram_size, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
   return params;
 }
 

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
@@ -44,7 +44,8 @@ public:
               bootstrap.mutable_static_resources()
                   ->mutable_listeners(0)
                   ->mutable_udp_listener_config()
-                  ->mutable_max_downstream_rx_datagram_size()
+                  ->mutable_downstream_socket_config()
+                  ->mutable_max_rx_datagram_size()
                   ->set_value(max_rx_datagram_size.value());
             });
       }
@@ -55,7 +56,8 @@ typed_config:
   '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.UdpProxyConfig
   stat_prefix: foo
   cluster: cluster_0
-  max_upstream_rx_datagram_size: {}
+  upstream_socket_config:
+    max_rx_datagram_size: {}
 )EOF",
                                                    max_rx_datagram_size.value()));
     } else {

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -523,8 +523,9 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {
   if (config.udp_fake_upstream_.has_value() &&
       config.udp_fake_upstream_->max_rx_datagram_size_.has_value()) {
-    listener_.udp_listener_config_.config_.mutable_max_downstream_rx_datagram_size()->set_value(
-        config.udp_fake_upstream_->max_rx_datagram_size_.value());
+    listener_.udp_listener_config_.config_.mutable_downstream_socket_config()
+        ->mutable_max_rx_datagram_size()
+        ->set_value(config.udp_fake_upstream_->max_rx_datagram_size_.value());
   }
   thread_ = api_->threadFactory().createThread([this]() -> void { threadRoutine(); });
   server_initialized_.waitReady();


### PR DESCRIPTION
This is a fast follow from https://github.com/envoyproxy/envoy/pull/15388.
I realized that I made a mistake in not using a common configuration
message. There will be more configuration options such as GRO, etc. that
will be configured similarly in multiple places. I'm correcting this
mistake now since the other change just landed within the last couple of
days.

Risk Level: Low
Testing: Existing tests
Docs Changes: Fixed
Release Notes: Fixed
Platform Specific Features: N/A
