### PR TITLE
examples: fix Env. variable

### DIFF
--- a/examples/jaeger-tracing/docker-compose.yaml
+++ b/examples/jaeger-tracing/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     environment:
-      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+      - COLLECTOR_ZIPKIN_HOST_PORT=9411
     networks:
       - envoymesh
     ports:


### PR DESCRIPTION
Commit Message: JAEGER environment variable name change
Additional Description: Fix example 'jaeger-tracing' that does not work due to the Jaeger environment variable name change.
Risk Level: Low
Testing: manual testing : run docker-compose
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
