### PR TITLE
Speed from O(N) to O(1) in ~GrpcMuxWatchImpl() and update().

### DIFF
--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -116,9 +116,9 @@ private:
     GrpcMuxImpl& parent_;
 
   private:
-    using GrpcMuxWatchImplList = std::list<GrpcMuxWatchImpl*>;
-    GrpcMuxWatchImplList& watches_;
-    GrpcMuxWatchImplList::iterator iter_;
+    using WatchList = std::list<GrpcMuxWatchImpl*>;
+    WatchList& watches_;
+    WatchList::iterator iter_;
   };
 
   // Per muxed API state.

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -86,27 +86,25 @@ private:
         : callbacks_(callbacks), resource_decoder_(resource_decoder), type_url_(type_url),
           parent_(parent), watches_(parent.apiStateFor(type_url).watches_) {
       std::copy(resources.begin(), resources.end(), std::inserter(resources_, resources_.begin()));
-      watches_.emplace(watches_.begin(), this);
-      it_ = watches_.begin();
+      iter_ = watches_.emplace(watches_.begin(), this);
     }
 
     ~GrpcMuxWatchImpl() override {
-      watches_.erase(it_);
+      watches_.erase(iter_);
       if (!resources_.empty()) {
         parent_.queueDiscoveryRequest(type_url_);
       }
     }
 
     void update(const absl::flat_hash_set<std::string>& resources) override {
-      watches_.erase(it_);
+      watches_.erase(iter_);
       if (!resources_.empty()) {
         parent_.queueDiscoveryRequest(type_url_);
       }
       resources_.clear();
       std::copy(resources.begin(), resources.end(), std::inserter(resources_, resources_.begin()));
       // move this watch to the beginning of the list
-      watches_.emplace(watches_.begin(), this);
-      it_ = watches_.begin();
+      iter_ = watches_.emplace(watches_.begin(), this);
       parent_.queueDiscoveryRequest(type_url_);
     }
 
@@ -118,8 +116,9 @@ private:
     GrpcMuxImpl& parent_;
 
   private:
-    std::list<GrpcMuxWatchImpl*>& watches_;
-    std::list<GrpcMuxWatchImpl*>::iterator it_;
+    using GrpcMuxWatchImplList = std::list<GrpcMuxWatchImpl*>;
+    GrpcMuxWatchImplList& watches_;
+    GrpcMuxWatchImplList::iterator iter_;
   };
 
   // Per muxed API state.

--- a/source/common/config/grpc_mux_impl.h
+++ b/source/common/config/grpc_mux_impl.h
@@ -87,17 +87,18 @@ private:
           parent_(parent), watches_(parent.apiStateFor(type_url).watches_) {
       std::copy(resources.begin(), resources.end(), std::inserter(resources_, resources_.begin()));
       watches_.emplace(watches_.begin(), this);
+      it_ = watches_.begin();
     }
 
     ~GrpcMuxWatchImpl() override {
-      watches_.remove(this);
+      watches_.erase(it_);
       if (!resources_.empty()) {
         parent_.queueDiscoveryRequest(type_url_);
       }
     }
 
     void update(const absl::flat_hash_set<std::string>& resources) override {
-      watches_.remove(this);
+      watches_.erase(it_);
       if (!resources_.empty()) {
         parent_.queueDiscoveryRequest(type_url_);
       }
@@ -105,6 +106,7 @@ private:
       std::copy(resources.begin(), resources.end(), std::inserter(resources_, resources_.begin()));
       // move this watch to the beginning of the list
       watches_.emplace(watches_.begin(), this);
+      it_ = watches_.begin();
       parent_.queueDiscoveryRequest(type_url_);
     }
 
@@ -117,6 +119,7 @@ private:
 
   private:
     std::list<GrpcMuxWatchImpl*>& watches_;
+    std::list<GrpcMuxWatchImpl*>::iterator it_;
   };
 
   // Per muxed API state.


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>

Commit Message: Speed from O(N) to O(1) in ~GrpcMuxWatchImpl() and update().
Additional Description: Please see https://github.com/envoyproxy/envoy/issues/15528
Risk Level: 
Testing: Format and Unit
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features:
Fixes #15528
 