### PR TITLE
quiche: adjust test size of quic_http_integration_test

### DIFF
--- a/test/extensions/quic_listeners/quiche/integration/BUILD
+++ b/test/extensions/quic_listeners/quiche/integration/BUILD
@@ -32,9 +32,10 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "quic_http_integration_test",
-    size = "medium",
+    size = "large",
     srcs = ["quic_http_integration_test.cc"],
     data = ["//test/config/integration/certs"],
+    shard_count = 12,
     # TODO(envoyproxy/windows-dev): Diagnose failure shown only on clang-cl build, see:
     #   https://gist.github.com/wrowe/a152cb1d12c2f751916122aed39d8517
     # TODO(envoyproxy/windows-dev): Diagnose timeout, why opt build test under Windows GCP RBE

--- a/test/extensions/quic_listeners/quiche/integration/BUILD
+++ b/test/extensions/quic_listeners/quiche/integration/BUILD
@@ -35,7 +35,7 @@ envoy_cc_test(
     size = "large",
     srcs = ["quic_http_integration_test.cc"],
     data = ["//test/config/integration/certs"],
-    shard_count = 12,
+    shard_count = 6,
     # TODO(envoyproxy/windows-dev): Diagnose failure shown only on clang-cl build, see:
     #   https://gist.github.com/wrowe/a152cb1d12c2f751916122aed39d8517
     # TODO(envoyproxy/windows-dev): Diagnose timeout, why opt build test under Windows GCP RBE


### PR DESCRIPTION
Commit Message: Increase the test size as it doesn't have enough time to finish under TSAN.

Risk Level: low
Testing: n/a
Fixes #15407