### PR TITLE
network: fix comment

### DIFF
--- a/source/common/network/utility.h
+++ b/source/common/network/utility.h
@@ -147,7 +147,7 @@ public:
 
   /**
    * Parse an internet host address (IPv4 or IPv6) and create an Instance from it. The address must
-   * not include a port number. Throws EnvoyException if unable to parse the address.
+   * not include a port number.
    * @param ip_address string to be parsed as an internet address.
    * @param port optional port to include in Instance created from ip_address, 0 by default.
    * @param v6only disable IPv4-IPv6 mapping for IPv6 addresses?


### PR DESCRIPTION
parseInternetAddressNoThrow() doesn't throw.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
