### PR TITLE
protos: Shift http filters category annotation

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -301,7 +301,6 @@ message HttpConnectionManager {
   // A list of individual HTTP filters that make up the filter chain for
   // requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
   // as the filters are processed sequentially as request events happen.
-  // [#extension-category: envoy.filters.http]
   repeated HttpFilter http_filters = 5;
 
   // Whether the connection manager manipulates the :ref:`config_http_conn_man_headers_user-agent`
@@ -883,6 +882,7 @@ message HttpFilter {
   oneof config_type {
     // Filter specific configuration which depends on the filter being instantiated. See the supported
     // filters for further documentation.
+    // [#extension-category: envoy.filters.http]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery service.

--- a/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -304,7 +304,6 @@ message HttpConnectionManager {
   // A list of individual HTTP filters that make up the filter chain for
   // requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
   // as the filters are processed sequentially as request events happen.
-  // [#extension-category: envoy.filters.http]
   repeated HttpFilter http_filters = 5;
 
   // Whether the connection manager manipulates the :ref:`config_http_conn_man_headers_user-agent`
@@ -892,6 +891,7 @@ message HttpFilter {
   oneof config_type {
     // Filter specific configuration which depends on the filter being instantiated. See the supported
     // filters for further documentation.
+    // [#extension-category: envoy.filters.http]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery service.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -305,7 +305,6 @@ message HttpConnectionManager {
   // A list of individual HTTP filters that make up the filter chain for
   // requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
   // as the filters are processed sequentially as request events happen.
-  // [#extension-category: envoy.filters.http]
   repeated HttpFilter http_filters = 5;
 
   // Whether the connection manager manipulates the :ref:`config_http_conn_man_headers_user-agent`
@@ -888,6 +887,7 @@ message HttpFilter {
   oneof config_type {
     // Filter specific configuration which depends on the filter being instantiated. See the supported
     // filters for further documentation.
+    // [#extension-category: envoy.filters.http]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery service.

--- a/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/http_connection_manager/v4alpha/http_connection_manager.proto
@@ -304,7 +304,6 @@ message HttpConnectionManager {
   // A list of individual HTTP filters that make up the filter chain for
   // requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
   // as the filters are processed sequentially as request events happen.
-  // [#extension-category: envoy.filters.http]
   repeated HttpFilter http_filters = 5;
 
   // Whether the connection manager manipulates the :ref:`config_http_conn_man_headers_user-agent`
@@ -892,6 +891,7 @@ message HttpFilter {
   oneof config_type {
     // Filter specific configuration which depends on the filter being instantiated. See the supported
     // filters for further documentation.
+    // [#extension-category: envoy.filters.http]
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery service.


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: protos: Shift http filters category annotation
Additional Description:

some of the category annotations are not in the correct place - this is one of them

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
