### PR TITLE
ci: Add workaround for openssl cert gen bug

### DIFF
--- a/examples/double-proxy/verify.sh
+++ b/examples/double-proxy/verify.sh
@@ -9,6 +9,9 @@ export DELAY=5
 
 mkdir -p certs
 
+# openssl bug workaround
+touch ~/.rnd
+
 run_log "Create a cert authority"
 openssl genrsa -out certs/ca.key 4096
 openssl req -batch -x509 -new -nodes -key certs/ca.key -sha256 -days 1024 -out certs/ca.crt

--- a/examples/double-proxy/verify.sh
+++ b/examples/double-proxy/verify.sh
@@ -9,7 +9,8 @@ export DELAY=5
 
 mkdir -p certs
 
-# openssl bug workaround
+# TODO(phlax): remove openssl bug workaround when openssl/ubuntu are updated
+#    see #15555 for more info
 touch ~/.rnd
 
 run_log "Create a cert authority"

--- a/examples/tls-sni/verify.sh
+++ b/examples/tls-sni/verify.sh
@@ -6,7 +6,8 @@ export MANUAL=true
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
 
-# openssl bug workaround
+# TODO(phlax): remove openssl bug workaround when openssl/ubuntu are updated
+#    see #15555 for more info
 touch ~/.rnd
 
 create_self_signed_certs () {

--- a/examples/tls-sni/verify.sh
+++ b/examples/tls-sni/verify.sh
@@ -6,6 +6,8 @@ export MANUAL=true
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
 
+# openssl bug workaround
+touch ~/.rnd
 
 create_self_signed_certs () {
     local domain="$1"

--- a/examples/websocket/verify.sh
+++ b/examples/websocket/verify.sh
@@ -9,6 +9,8 @@ export MANUAL=true
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
 
+# openssl bug workaround
+touch ~/.rnd
 
 interact_ws () {
     local port="$1" \

--- a/examples/websocket/verify.sh
+++ b/examples/websocket/verify.sh
@@ -9,7 +9,8 @@ export MANUAL=true
 # shellcheck source=examples/verify-common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/../verify-common.sh"
 
-# openssl bug workaround
+# TODO(phlax): remove openssl bug workaround when openssl/ubuntu are updated
+#    see #15555 for more info
 touch ~/.rnd
 
 interact_ws () {


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Add workaround for openssl cert gen bug
Additional Description:
ci is throwing openssl issues about `~/.rnd` not being accessible

afaict here https://github.com/openssl/openssl/issues/7754#issuecomment-598808341 it is an openssl issue that can be worked around by touching the `.rnd` file before generating certs

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #15555
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
