### PR TITLE
python: Make protobuf loading explicit

### DIFF
--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -7,6 +7,7 @@ py_binary(
     srcs = ["merge_active_shadow.py"],
     deps = [
         "//tools/api_proto_plugin",
+        "//tools/type_whisperer:api_type_db_proto_py_proto",
         "@com_envoyproxy_protoc_gen_validate//validate:validate_py",
         "@com_github_cncf_udpa//udpa/annotations:pkg_py_proto",
         "@com_google_googleapis//google/api:annotations_py_proto",

--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -17,7 +17,7 @@ py_binary(
 
 py_test(
     name = "merge_active_shadow_test",
-    srcs = ["merge_active_shadow_test.py"],
+    srcs = ["merge_active_shadow_test.py", "utils.py"],
     deps = [
         ":merge_active_shadow",
         "//tools/api_proto_plugin",

--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -17,7 +17,10 @@ py_binary(
 
 py_test(
     name = "merge_active_shadow_test",
-    srcs = ["merge_active_shadow_test.py", "utils.py"],
+    srcs = [
+        "merge_active_shadow_test.py",
+        "utils.py",
+    ],
     deps = [
         ":merge_active_shadow",
         "//tools/api_proto_plugin",

--- a/tools/protoxform/BUILD
+++ b/tools/protoxform/BUILD
@@ -4,7 +4,10 @@ licenses(["notice"])  # Apache 2
 
 py_binary(
     name = "merge_active_shadow",
-    srcs = ["merge_active_shadow.py"],
+    srcs = [
+        "merge_active_shadow.py",
+        "utils.py",
+    ],
     deps = [
         "//tools/api_proto_plugin",
         "//tools/type_whisperer:api_type_db_proto_py_proto",
@@ -18,10 +21,7 @@ py_binary(
 
 py_test(
     name = "merge_active_shadow_test",
-    srcs = [
-        "merge_active_shadow_test.py",
-        "utils.py",
-    ],
+    srcs = ["merge_active_shadow_test.py"],
     deps = [
         ":merge_active_shadow",
         "//tools/api_proto_plugin",

--- a/tools/protoxform/merge_active_shadow.py
+++ b/tools/protoxform/merge_active_shadow.py
@@ -10,20 +10,15 @@ import pathlib
 import sys
 
 from tools.api_proto_plugin import type_context as api_type_context
+from tools.protoxform import utils
 
-from google.protobuf import descriptor_pb2
-from google.protobuf import text_format
+from google.protobuf import descriptor_pb2, text_format
+from envoy.annotations import deprecation_pb2
 
-# Note: we have to include those proto definitions for text_format sanity.
-from google.api import annotations_pb2 as _
-from validate import validate_pb2 as _
-from envoy.annotations import deprecation_pb2 as deprecation_pb2
-from envoy.annotations import resource_pb2 as _
-from udpa.annotations import migrate_pb2 as _
-from udpa.annotations import security_pb2 as _
-from udpa.annotations import sensitive_pb2 as _
-from udpa.annotations import status_pb2 as _
-from udpa.annotations import versioning_pb2 as _
+PROTO_PACKAGES = ("google.api.annotations", "validate.validate", "envoy.annotations.deprecation",
+                  "envoy.annotations.resource", "udpa.annotations.migrate",
+                  "udpa.annotations.security", "udpa.annotations.status",
+                  "udpa.annotations.sensitive", "udpa.annotations.versioning")
 
 
 # Set reserved_range in target_proto to reflect previous_reserved_range skipping
@@ -232,6 +227,9 @@ def merge_active_shadow_file(active_file_proto, shadow_file_proto):
 
 if __name__ == '__main__':
     active_src, shadow_src, dst = sys.argv[1:]
+
+    utils.load_protos(PROTO_PACKAGES)
+
     active_proto = descriptor_pb2.FileDescriptorProto()
     text_format.Merge(pathlib.Path(active_src).read_text(), active_proto)
     shadow_proto = descriptor_pb2.FileDescriptorProto()

--- a/tools/protoxform/merge_active_shadow_test.py
+++ b/tools/protoxform/merge_active_shadow_test.py
@@ -3,6 +3,7 @@ import unittest
 import merge_active_shadow
 
 from tools.api_proto_plugin import type_context as api_type_context
+from tools.protoxform import utils
 
 from google.protobuf import descriptor_pb2
 from google.protobuf import text_format
@@ -585,4 +586,5 @@ reserved_range {
 # TODO(htuch): add some test for recursion.
 
 if __name__ == '__main__':
+    utils.load_protos(merge_active_shadow.PROTO_PACKAGES)
     unittest.main()

--- a/tools/protoxform/protoxform.py
+++ b/tools/protoxform/protoxform.py
@@ -7,21 +7,16 @@
 import copy
 import functools
 
-from tools.api_proto_plugin import plugin
-from tools.api_proto_plugin import visitor
-from tools.protoxform import migrate
-from tools.protoxform import utils
+from tools.api_proto_plugin import plugin, visitor
+from tools.protoxform import migrate, utils
 
-# Note: we have to include those proto definitions to ensure we don't lose these
-# during FileDescriptorProto printing.
-from google.api import annotations_pb2 as _
-from validate import validate_pb2 as _
-from envoy_api_canonical.envoy.annotations import deprecation_pb2 as _
-from envoy_api_canonical.envoy.annotations import resource_pb2
-from udpa.annotations import migrate_pb2
-from udpa.annotations import security_pb2 as _
-from udpa.annotations import sensitive_pb2 as _
 from udpa.annotations import status_pb2
+
+PROTO_PACKAGES = ("google.api.annotations", "validate.validate",
+                  "envoy_api_canonical.envoy.annotations.deprecation",
+                  "envoy_api_canonical.envoy.annotations.resource", "udpa.annotations.migrate",
+                  "udpa.annotations.security", "udpa.annotations.status",
+                  "udpa.annotations.sensitive")
 
 
 class ProtoXformError(Exception):
@@ -79,6 +74,8 @@ class ProtoFormatVisitor(visitor.Visitor):
 
 
 def main():
+    utils.load_protos(PROTO_PACKAGES)
+
     plugin.plugin([
         plugin.direct_output_descriptor('.active_or_frozen.proto',
                                         functools.partial(ProtoFormatVisitor, True),

--- a/tools/protoxform/utils.py
+++ b/tools/protoxform/utils.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 
 from tools.type_whisperer.api_type_db_pb2 import TypeDb
@@ -17,3 +18,8 @@ def load_type_db(type_db_path):
     _typedb = TypeDb()
     with open(type_db_path, 'r') as f:
         text_format.Merge(f.read(), _typedb)
+
+
+def load_protos(packages):
+    for package in packages:
+        importlib.import_module(f"{package}_pb2")

--- a/tools/type_whisperer/file_descriptor_set_text_gen.py
+++ b/tools/type_whisperer/file_descriptor_set_text_gen.py
@@ -2,12 +2,12 @@
 # TODO(htuch): switch to base64 encoded binary output in the future,
 # this will avoid needing to deal with option preserving imports below.
 
+import importlib
 import sys
 
 from google.protobuf import descriptor_pb2
 
-# Needed to avoid annotation option stripping during pb_text generation.
-from udpa.annotations import migrate_pb2
+PROTO_PACKAGES = ("udpa.annotations.migrate",)
 
 
 def decode(path):
@@ -20,6 +20,11 @@ def decode(path):
 if __name__ == '__main__':
     output_path = sys.argv[1]
     input_paths = sys.argv[2:]
+
+    # Needed to avoid annotation option stripping during pb_text generation.
+    for package in PROTO_PACKAGES:
+        importlib.import_module(f"{package}_pb2")
+
     pb_text = '\n'.join(decode(path) for path in input_paths)
     with open(output_path, 'w') as f:
         f.write(pb_text)


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: python: Make protobuf loading explicit
Additional Description:

atm protobuf fields are loaded in some of the tools by importing the generated protobuf modules

this breaks python linting as the imports arent used and is not very explicit about the intent/necessity/purpose of importing the needed modules

this pr tries to address that and fix linting

separated from #15544  to make it easier to work on and review

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
