### PR TITLE
AuthInfo:Authentication information is updated with the cluster update

### DIFF
--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -94,8 +94,6 @@ InstanceImpl::ThreadLocalPool::ThreadLocalPool(std::shared_ptr<InstanceImpl> par
   cluster_update_handle_ = parent->cm_.addThreadLocalClusterUpdateCallbacks(*this);
   Upstream::ThreadLocalCluster* cluster = parent->cm_.getThreadLocalCluster(cluster_name_);
   if (cluster != nullptr) {
-    auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster->info(), parent->api_);
-    auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster->info(), parent->api_);
     onClusterAddOrUpdateNonVirtual(*cluster);
   }
 }
@@ -130,6 +128,9 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
 
   ASSERT(cluster_ == nullptr);
   cluster_ = &cluster;
+  // Update username and password when cluster updates
+  auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster_->info(), parent_.lock()->api_);
+  auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster_->info(), parent_.lock()->api_);
   ASSERT(host_set_member_update_cb_handle_ == nullptr);
   host_set_member_update_cb_handle_ = cluster_->prioritySet().addMemberUpdateCb(
       [this](const std::vector<Upstream::HostSharedPtr>& hosts_added,

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -128,9 +128,9 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
 
   ASSERT(cluster_ == nullptr);
   cluster_ = &cluster;
-  // Update username and password when cluster updates
-  auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster_->info(), parent_.lock()->api_);
-  auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster_->info(), parent_.lock()->api_);
+  // Update username and password when cluster updates.
+  auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster_->info(), shared_parent->api_);
+  auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster_->info(), shared_parent->api_);
   ASSERT(host_set_member_update_cb_handle_ == nullptr);
   host_set_member_update_cb_handle_ = cluster_->prioritySet().addMemberUpdateCb(
       [this](const std::vector<Upstream::HostSharedPtr>& hosts_added,

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -533,13 +533,13 @@ TEST_F(RedisConnPoolImplTest, NoClusterAtConstruction) {
   update_callbacks_->onClusterRemoval("fake_cluster");
 }
 
-// ConnPool created when no cluster exists at creation time . Dynamic cluster
-// creation and removal work correctly . Username and password are updated with
-// dynamic cluster .
+// ConnPool created when no cluster exists at creation time. Dynamic cluster
+// creation and removal work correctly. Username and password are updated with
+// dynamic cluster.
 TEST_F(RedisConnPoolImplTest, AuthInfoUpdate) {
   InSequence s;
 
-  // Initialize username and password .
+  // Initialize username and password.
   auth_username_ = "testusername";
   auth_password_ = "testpassword";
 

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -157,6 +157,16 @@ public:
     EXPECT_NE(nullptr, request);
   }
 
+  std::string getAuthUsername() {
+    InstanceImpl* conn_pool_impl = dynamic_cast<InstanceImpl*>(conn_pool_.get());
+    return conn_pool_impl->tls_->getTyped<InstanceImpl::ThreadLocalPool>().auth_username_;
+  }
+
+  std::string getAuthPassword() {
+    InstanceImpl* conn_pool_impl = dynamic_cast<InstanceImpl*>(conn_pool_.get());
+    return conn_pool_impl->tls_->getTyped<InstanceImpl::ThreadLocalPool>().auth_password_;
+  }
+
   absl::node_hash_map<Upstream::HostConstSharedPtr, InstanceImpl::ThreadLocalActiveClientPtr>&
   clientMap() {
     InstanceImpl* conn_pool_impl = dynamic_cast<InstanceImpl*>(conn_pool_.get());
@@ -517,6 +527,44 @@ TEST_F(RedisConnPoolImplTest, NoClusterAtConstruction) {
   update_callbacks_->onClusterAddOrUpdate(cm_.thread_local_cluster_);
   // MurmurHash of "foo" is 9631199822919835226U
   makeSimpleRequest(true, "foo", 9631199822919835226U);
+
+  // Remove the cluster to make sure we safely destruct with no cluster.
+  EXPECT_CALL(*client_, close());
+  update_callbacks_->onClusterRemoval("fake_cluster");
+}
+
+// ConnPool created when no cluster exists at creation time . Dynamic cluster
+// creation and removal work correctly . Username and password are updated with
+// dynamic cluster .
+TEST_F(RedisConnPoolImplTest, AuthInfoUpdate) {
+  InSequence s;
+
+  // Initialize username and password .
+  auth_username_ = "testusername";
+  auth_password_ = "testpassword";
+
+  setup(false);
+
+  EXPECT_EQ(auth_username_, getAuthUsername());
+  EXPECT_EQ(auth_password_, getAuthPassword());
+
+  Common::Redis::RespValueSharedPtr value = std::make_shared<Common::Redis::RespValue>();
+  MockPoolCallbacks callbacks;
+  Common::Redis::Client::PoolRequest* request =
+      conn_pool_->makeRequest("hash_key", value, callbacks);
+  EXPECT_EQ(nullptr, request);
+
+  // The username and password will be updated to empty when cluster updates
+  auth_username_ = "";
+  auth_password_ = "";
+
+  // Now add the cluster. Request to the cluster should succeed.
+  update_callbacks_->onClusterAddOrUpdate(cm_.thread_local_cluster_);
+  // MurmurHash of "foo" is 9631199822919835226U
+  makeSimpleRequest(true, "foo", 9631199822919835226U);
+
+  EXPECT_EQ(auth_username_, getAuthUsername());
+  EXPECT_EQ(auth_password_, getAuthPassword());
 
   // Remove the cluster to make sure we safely destruct with no cluster.
   EXPECT_CALL(*client_, close());


### PR DESCRIPTION
Signed-off-by: littlegreyzhang <826999015@qq.com>

Commit Message: AuthInfo:Authentication information is updated with the cluster update

Additional Description:
This changes the authentication information code to update AuthInfo with the cluster update .
Fixes #15510 

Risk Level: Low
Testing: New and existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A