### PR TITLE
[utility] fix implementation of Primes::isPrime

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -577,7 +577,7 @@ std::string StringUtil::removeCharacters(const absl::string_view& str,
 }
 
 bool Primes::isPrime(uint32_t x) {
-  if (x < 4) {
+  if (x && x < 4) {
     return true; // eliminates special-casing 2.
   } else if ((x & 1) == 0) {
     return false; // eliminates even numbers >2.

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -562,6 +562,7 @@ TEST(AccessLogDateTimeFormatter, fromTime) {
 }
 
 TEST(Primes, isPrime) {
+  EXPECT_FALSE(Primes::isPrime(0));
   EXPECT_TRUE(Primes::isPrime(67));
   EXPECT_FALSE(Primes::isPrime(49));
   EXPECT_FALSE(Primes::isPrime(102));
@@ -569,6 +570,7 @@ TEST(Primes, isPrime) {
 }
 
 TEST(Primes, findPrimeLargerThan) {
+  EXPECT_EQ(1, Primes::findPrimeLargerThan(0));
   EXPECT_EQ(67, Primes::findPrimeLargerThan(62));
   EXPECT_EQ(107, Primes::findPrimeLargerThan(103));
   EXPECT_EQ(10007, Primes::findPrimeLargerThan(9991));

--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-6283006656512000
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-6283006656512000
@@ -1,0 +1,30 @@
+static_resources {
+  clusters {
+    name: "0"
+    connect_timeout {
+      nanos: 813
+    }
+    lb_policy: MAGLEV
+    dns_lookup_family: V6_ONLY
+    load_assignment {
+      cluster_name: "."
+      endpoints {
+        lb_endpoints {
+          endpoint {
+            address {
+              pipe {
+                path: "y"
+              }
+            }
+          }
+          health_status: TIMEOUT
+        }
+      }
+    }
+    use_tcp_for_dns_lookups: true
+    maglev_lb_config {
+      table_size {
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Fixes implementation of `Primes::isPrime` by handling the zero case. Correctly rejects maglev table size configuration when 0.
Risk Level: Low, config fix.
Testing: Added unit test and the maglev config regression test in the fuzzer.
Fixes
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31067
