### PR TITLE
Upgrade security posture of grpc_json_transcoder

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/BUILD
+++ b/source/extensions/filters/http/grpc_json_transcoder/BUILD
@@ -63,7 +63,7 @@ envoy_cc_extension(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     category = "envoy.filters.http",
-    security_posture = "unknown",
+    security_posture = "robust_to_untrusted_downstream",
     deps = [
         "//include/envoy/registry",
         "//source/extensions/filters/http:well_known_names",


### PR DESCRIPTION
Commit Message:
Upgrade security posture of grpc_json_transcoder

Additional Description:
Follow-up on #9334 to upgrade the security posture of the filter to `robust_to_untrusted_downstream`.

Since the last discussion, we have:
- Added encoder and decoder buffer limits to the filter. #14906
- Improved test coverage to 95%.
- Improved fuzz coverage of the filter to 40% via the uber filter fuzzer.

Note the filter depends on the external library https://github.com/grpc-ecosystem/grpc-httpjson-transcoding. We followed the external dependency policy to add CI, add SECURITY.md, improve fuzz coverage, and update the library's dependencies.

Risk Level: N/A
Testing: None
Docs Changes: None
Release Notes: None
Platform Specific Features: None

Signed-off-by: Teju Nareddy <nareddyt@google.com>