### PR TITLE
Fix Win32 issue with config_validation test

### DIFF
--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -50,6 +50,7 @@ envoy_cc_test(
     ],
     deps = [
         "//source/extensions/filters/http/router:config",
+        "//source/extensions/filters/listener/original_dst:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/transport_sockets/tls:config",
         "//source/server/config_validation:server_lib",

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -134,12 +134,12 @@ TEST_P(ValidationServerTest, NoopLifecycleNotifier) {
 // as-is. (Note, /dev/stdout as an access log file is invalid on Windows, no equivalent /dev/
 // exists.)
 
-auto testing_values = ::testing::Values("front-proxy_front-envoy.yaml", "envoyproxy_io_proxy.yaml",
+auto testing_values =
+    ::testing::Values("front-proxy_front-envoy.yaml", "envoyproxy_io_proxy.yaml",
 #if defined(WIN32) && defined(SO_ORIGINAL_DST)
-                                        "configs_original-dst-cluster_proxy_config.yaml"
+                      "configs_original-dst-cluster_proxy_config.yaml",
 #endif
-                                        "grpc-bridge_server_envoy-proxy.yaml",
-                                        "front-proxy_service-envoy.yaml");
+                      "grpc-bridge_server_envoy-proxy.yaml", "front-proxy_service-envoy.yaml");
 
 INSTANTIATE_TEST_SUITE_P(ValidConfigs, ValidationServerTest, testing_values);
 


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
Commit Message:

As I was tinkering with the config validation test, I saw that one of the win32 tests do not work as expected. Updating now before the SDK update causes the issue.

Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
