### PR TITLE
Update run_clang_tidy.sh to support bazel targets with '@repository' prefixes

### DIFF
--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -26,7 +26,7 @@ echo "Generating compilation database..."
 
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
-"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers
+"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers ${COMP_DB_TARGETS:+${COMP_DB_TARGETS[@]}}
 
 # Do not run clang-tidy against win32 impl
 # TODO(scw00): We should run clang-tidy against win32 impl once we have clang-cl support for Windows

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -26,7 +26,7 @@ echo "Generating compilation database..."
 
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
-"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers ${COMP_DB_TARGETS:+${COMP_DB_TARGETS[@]}}
+"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers ${COMP_DB_TARGETS:+$COMP_DB_TARGETS}
 
 # Do not run clang-tidy against win32 impl
 # TODO(scw00): We should run clang-tidy against win32 impl once we have clang-cl support for Windows

--- a/ci/run_clang_tidy.sh
+++ b/ci/run_clang_tidy.sh
@@ -26,7 +26,8 @@ echo "Generating compilation database..."
 
 # bazel build need to be run to setup virtual includes, generating files which are consumed
 # by clang-tidy
-"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers ${COMP_DB_TARGETS:+$COMP_DB_TARGETS}
+read -ra COMP_DB_TARGETS <<< "$COMP_DB_TARGETS"
+"${ENVOY_SRCDIR}/tools/gen_compilation_database.py" --include_headers "${COMP_DB_TARGETS[@]}"
 
 # Do not run clang-tidy against win32 impl
 # TODO(scw00): We should run clang-tidy against win32 impl once we have clang-cl support for Windows


### PR DESCRIPTION

__Commit Message:__

Support running `run_clang_tidy.sh` when Envoy is a sub-workspace within a
project (such as used when developing custom filters and nesting Envoy as a
git-submodule). This can be done by setting the compilation DB targets as an
environment variable:
```bash
COMP_DB_TARGETS="@envoy//source/... @envoy//test/... @envoy//tools/..."
```

__Additional Description:__ In order to build from the SRCDIR (not ENVOY_SRCDIR), such as with the envoy-filter-example, need to be able to specify a repository on the targets built by `gen_compilation_database.py`. Simplest way to enable this is to allow for specifying the comp-db targets.

__Risk Level:__ Low. Default maintains current behavior
__Testing:__ Tested manually in docker container with setup similar to envoy-filter-example repo via:
```bash
SRCDIR='/src' COMP_DB_TARGETS="@envoy//source/... @envoy//test/... @envoy//tools/... //filters/..." bash -ex ./envoy/ci/do_ci.sh 'bazel.clang_tidy' '//filters/...'
```
**Docs Changes:** n/a
**Release Notes:** n/a
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
