### PR TITLE
http: remove envoy.reloadable_features.http_default_alpn runtime flag

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -112,6 +112,7 @@ Removed Config or Runtime
 * http: removed legacy HTTP/1.1 error reporting path and runtime guard `envoy.reloadable_features.early_errors_via_hcm`.
 * http: removed legacy sanitization path for upgrade response headers and runtime guard `envoy.reloadable_features.fix_upgrade_response`.
 * http: removed legacy date header overwriting logic and runtime guard `envoy.reloadable_features.preserve_upstream_date deprecation`.
+* http: removed legacy ALPN handling and runtime guard `envoy.reloadable_features.http_default_alpn`.
 * listener: removed legacy runtime guard `envoy.reloadable_features.listener_in_place_filterchain_update`.
 * router: removed `envoy.reloadable_features.consume_all_retry_headers` and legacy code path.
 * router: removed `envoy.reloadable_features.preserve_query_string_in_path_redirects` and legacy code path.

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -13,10 +13,6 @@ namespace Http {
 Network::TransportSocketOptionsSharedPtr
 wrapTransportSocketOptions(Network::TransportSocketOptionsSharedPtr transport_socket_options,
                            std::vector<Protocol> protocols) {
-  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http_default_alpn")) {
-    return transport_socket_options;
-  }
-
   std::vector<std::string> fallbacks;
   for (auto protocol : protocols) {
     // If configured to do so, we override the ALPN to use for the upstream connection to match the

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -72,7 +72,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.hcm_stream_error_on_invalid_message",
     "envoy.reloadable_features.health_check.graceful_goaway_handling",
     "envoy.reloadable_features.health_check.immediate_failure_exclude_from_cluster",
-    "envoy.reloadable_features.http_default_alpn",
     "envoy.reloadable_features.http_match_on_all_headers",
     "envoy.reloadable_features.http_set_copy_replace_all_headers",
     "envoy.reloadable_features.http_transport_failure_reason_in_body",


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: Deprecation note
Fixes #14646
