### PR TITLE
http: allowing the codec to access stream info

### DIFF
--- a/include/envoy/http/BUILD
+++ b/include/envoy/http/BUILD
@@ -37,6 +37,7 @@ envoy_cc_library(
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/grpc:status",
         "//include/envoy/network:address_interface",
+        "//include/envoy/stream_info:stream_info_interface",
         "//source/common/http:status_lib",
     ],
 )

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -11,6 +11,7 @@
 #include "envoy/http/metadata_interface.h"
 #include "envoy/http/protocol.h"
 #include "envoy/network/address.h"
+#include "envoy/stream_info/stream_info.h"
 
 #include "common/http/status.h"
 
@@ -213,6 +214,11 @@ public:
                               const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                               const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                               absl::string_view details) PURE;
+
+  /**
+   * @return StreamInfo::StreamInfo& the stream_info for this stream.
+   */
+  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
 };
 
 /**

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -160,13 +160,6 @@ private:
     void completeRequest();
 
     const Network::Connection* connection();
-    void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
-                        const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
-                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
-                        absl::string_view details) override {
-      return filter_manager_.sendLocalReply(is_grpc_request, code, body, modify_headers,
-                                            grpc_status, details);
-    }
     uint64_t streamId() { return stream_id_; }
 
     // This is a helper function for encodeHeaders and responseDataTooLarge which allows for
@@ -191,6 +184,16 @@ private:
     // Http::RequestDecoder
     void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override;
     void decodeTrailers(RequestTrailerMapPtr&& trailers) override;
+    const StreamInfo::StreamInfo& streamInfo() const override {
+      return filter_manager_.streamInfo();
+    }
+    void sendLocalReply(bool is_grpc_request, Code code, absl::string_view body,
+                        const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
+                        const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
+                        absl::string_view details) override {
+      return filter_manager_.sendLocalReply(is_grpc_request, code, body, modify_headers,
+                                            grpc_status, details);
+    }
 
     // Tracing::TracingConfig
     Tracing::OperationName operationName() const override;

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1501,8 +1501,9 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLog) {
       }));
 
   EXPECT_CALL(*handler, log(_, _, _, _))
-      .WillOnce(Invoke([](const HeaderMap*, const HeaderMap*, const HeaderMap*,
-                          const StreamInfo::StreamInfo& stream_info) {
+      .WillOnce(Invoke([&](const HeaderMap*, const HeaderMap*, const HeaderMap*,
+                           const StreamInfo::StreamInfo& stream_info) {
+        EXPECT_EQ(&decoder_->streamInfo(), &stream_info);
         EXPECT_TRUE(stream_info.responseCode());
         EXPECT_EQ(stream_info.responseCode().value(), uint32_t(200));
         EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().localAddress());

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -206,6 +206,10 @@ public:
   // Http::RequestDecoder
   void decodeHeaders(Http::RequestHeaderMapPtr&& headers, bool end_stream) override;
   void decodeTrailers(Http::RequestTrailerMapPtr&& trailers) override;
+  const StreamInfo::StreamInfo& streamInfo() const override {
+    RELEASE_ASSERT(false, "initialize if this is needed");
+    return *stream_info_;
+  }
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,
@@ -239,6 +243,7 @@ private:
   Event::TestTimeSystem& time_system_;
   Http::MetadataMap metadata_map_;
   absl::node_hash_map<std::string, uint64_t> duplicated_metadata_key_count_;
+  std::unique_ptr<StreamInfo::StreamInfo> stream_info_;
   bool received_data_{false};
 };
 

--- a/test/mocks/http/stream_decoder.h
+++ b/test/mocks/http/stream_decoder.h
@@ -21,6 +21,7 @@ public:
                const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
                const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                absl::string_view details));
+  MOCK_METHOD(const StreamInfo::StreamInfo&, streamInfo, (), (const));
 
   void decodeHeaders(RequestHeaderMapPtr&& headers, bool end_stream) override {
     decodeHeaders_(headers, end_stream);


### PR DESCRIPTION
This allows Envoy the mobile codec impl to have access to stream info

Risk Level: n/a (extending a C++ interface)
Testing: unit tested
Docs Changes: n/a
Release Notes: n/a