### PR TITLE
ext_proc: Fix a potential crash on gRPC failure

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -25,6 +25,7 @@ using Http::ResponseHeaderMap;
 static const std::string kErrorPrefix = "ext_proc error";
 
 Filter::StreamOpenState Filter::openStream() {
+  ENVOY_BUG(!processing_complete_, "openStream should not have been called");
   if (!stream_) {
     ENVOY_LOG(debug, "Opening gRPC stream to external processor");
     stream_ = client_->start(*this);

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -90,6 +90,18 @@ class Filter : public Logger::Loggable<Logger::Id::filter>,
     BufferedBody,
   };
 
+  // The result of an attempt to open the stream
+  enum class StreamOpenState {
+    // The stream was opened successfully
+    Ok,
+    // The stream was not opened successfully and an error was delivered
+    // downstream -- processing should stop
+    Error,
+    // The stream was not opened successfully but processing should
+    // continue as if the stream was already closed.
+    IgnoreError,
+  };
+
 public:
   Filter(const FilterConfigSharedPtr& config, ExternalProcessorClientPtr&& client)
       : config_(config), client_(std::move(client)), stats_(config->stats()),
@@ -115,7 +127,7 @@ public:
   void onGrpcClose() override;
 
 private:
-  void openStream();
+  StreamOpenState openStream();
   void startMessageTimer(Event::TimerPtr& timer);
   void onMessageTimeout();
   void cleanUpTimers();

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -152,6 +152,10 @@ private:
   // failed.
   bool processing_complete_ = false;
 
+  // Set to true when an "immediate response" has been delivered. This helps us
+  // know what response to return from certain failures.
+  bool sent_immediate_response_ = false;
+
   // The headers that we'll be expected to modify. They are set when
   // received and reset to nullptr when they are no longer valid.
   Http::RequestHeaderMap* request_headers_ = nullptr;


### PR DESCRIPTION
Commit Message: If the external processing server used by the ext_proc filter is unavailable, it is possible that an error delivered while trying to start the gRPC stream would result in a crash. 

Additional Description: This depends on the result of a race condition and is not always reproducable. I already checked with the envoy-security group.

Risk Level: Low: This fixes a possible crash bug. 

Testing: Extended existing unit tests, and tested manually as well to verify.

Docs Changes:
Release Notes:
Platform Specific Features:
Signed-off-by: Gregory Brail <gregbrail@google.com>
