### PR TITLE
tools: export stack decode

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -13,6 +13,7 @@ envoy_package()
 exports_files([
     "gen_git_sha.sh",
     "check_repositories.sh",
+    "stack_decode.py",
 ])
 
 envoy_py_test_binary(


### PR DESCRIPTION
This is needed in our build so that we can use rules_docker.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
