### PR TITLE
upstreams: initial boilerplate/skeleton for metadata upstream

### DIFF
--- a/source/extensions/upstreams/http/metadata/BUILD
+++ b/source/extensions/upstreams/http/metadata/BUILD
@@ -1,0 +1,21 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "upstream_request_lib",
+    srcs = ["upstream_request.cc"],
+    hdrs = ["upstream_request.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//include/envoy/http:codec_interface",
+        "//include/envoy/router:router_interface",
+        "//source/extensions/upstreams/http/http:upstream_request_lib",
+    ],
+)

--- a/source/extensions/upstreams/http/metadata/BUILD
+++ b/source/extensions/upstreams/http/metadata/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_library",
+    "envoy_cc_extension",
     "envoy_extension_package",
 )
 
@@ -8,10 +8,13 @@ licenses(["notice"])  # Apache 2
 
 envoy_extension_package()
 
-envoy_cc_library(
+envoy_cc_extension(
     name = "upstream_request_lib",
     srcs = ["upstream_request.cc"],
     hdrs = ["upstream_request.h"],
+    category = "envoy.upstreams",
+    security_posture = "unknown",
+    status = "wip",
     visibility = ["//visibility:public"],
     deps = [
         "//include/envoy/http:codec_interface",

--- a/source/extensions/upstreams/http/metadata/upstream_request.cc
+++ b/source/extensions/upstreams/http/metadata/upstream_request.cc
@@ -1,0 +1,3 @@
+#include "extensions/upstreams/http/metadata/upstream_request.h"
+
+namespace Envoy {}

--- a/source/extensions/upstreams/http/metadata/upstream_request.h
+++ b/source/extensions/upstreams/http/metadata/upstream_request.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "envoy/http/codec.h"
+#include "envoy/router/router.h"
+
+#include "extensions/upstreams/http/http/upstream_request.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Upstreams {
+namespace Http {
+namespace Metadata {
+
+class MetadataUpstream : public Upstreams::Http::Http::HttpUpstream {
+public:
+  MetadataUpstream(Router::UpstreamToDownstream& upstream_request,
+                   Envoy::Http::RequestEncoder* encoder)
+      : HttpUpstream(upstream_request, encoder) {}
+};
+
+} // namespace Metadata
+} // namespace Http
+} // namespace Upstreams
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/upstreams/http/metadata/BUILD
+++ b/test/extensions/upstreams/http/metadata/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+# TODO(tbarrella): Use envoy_extension_cc_test once config.cc exists.
 envoy_cc_test(
     name = "upstream_request_test",
     srcs = ["upstream_request_test.cc"],

--- a/test/extensions/upstreams/http/metadata/BUILD
+++ b/test/extensions/upstreams/http/metadata/BUILD
@@ -1,0 +1,21 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "upstream_request_test",
+    srcs = ["upstream_request_test.cc"],
+    deps = [
+        "//source/extensions/upstreams/http/metadata:upstream_request_lib",
+        "//test/common/http:common_lib",
+        "//test/mocks/http:stream_encoder_mock",
+        "//test/mocks/router:router_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/test/extensions/upstreams/http/metadata/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/metadata/upstream_request_test.cc
@@ -1,0 +1,36 @@
+#include <memory>
+
+#include "extensions/upstreams/http/metadata/upstream_request.h"
+
+#include "test/common/http/common.h"
+#include "test/mocks/http/stream_encoder.h"
+#include "test/mocks/router/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Upstreams {
+namespace Http {
+namespace Metadata {
+
+class MetadataUpstreamTest : public ::testing::Test {
+protected:
+  Router::MockUpstreamToDownstream upstream_to_downstream_;
+  ::testing::NiceMock<Envoy::Http::MockRequestEncoder> encoder_;
+};
+
+TEST_F(MetadataUpstreamTest, Basic) {
+  Envoy::Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  auto upstream = std::make_unique<MetadataUpstream>(upstream_to_downstream_, &encoder_);
+  EXPECT_TRUE(upstream->encodeHeaders(headers, false).ok());
+}
+
+} // namespace Metadata
+} // namespace Http
+} // namespace Upstreams
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Commit Message:
upstreams: initial boilerplate/skeleton for metadata upstream

Signed-off-by: Taylor Barrella <tabarr@google.com>

Additional Description:

A small commit so that it's easier to review. This is meant to be the smallest testable unit, establishing the code location and some naming

cc @lambdai

Risk Level: Low
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
#15472