### PR TITLE
docs: adds more detailed instructions on cpu profiling with perf

### DIFF
--- a/bazel/PPROF.md
+++ b/bazel/PPROF.md
@@ -197,8 +197,9 @@ is also understood by recent enough versions of `pprof`:
 $ pprof -http=localhost:9999 /path/to/envoy perf.data
 ```
 
-Note that in order to handle symbolization you need to pass an Envoy binary with debug symbols retained
-in version matching the profiled Envoy. You can get it from [envoyproxy/envoy-debug](https://hub.docker.com/r/envoyproxy/envoy-debug).
+Note that to see correct function names you need to pass an Envoy binary with debug symbols retained.
+Its version must be the same as the version of the profiled Envoy binary.
+You can get it from [envoyproxy/envoy-debug](https://hub.docker.com/r/envoyproxy/envoy-debug).
 
 Alternatively, you can use [allegro/envoy-perf-pprof](https://github.com/allegro/envoy-perf-pprof) which
 wraps the pprof setup mentioned above (installing perf_to_profile, pprof and getting

--- a/bazel/PPROF.md
+++ b/bazel/PPROF.md
@@ -190,11 +190,20 @@ $ perf record -g -F 99 -p `pgrep envoy`
 [ perf record: Captured and wrote 0.694 MB perf.data (1532 samples) ]
 ```
 
-The program will store the collected sampling data in the file `perf.data` whose
-format is also understood by recent enough versions of `pprof`:
+The program will store the collected sampling data in the file `perf.data`. After installing
+[perf_to_profile](https://github.com/google/perf_data_converter) this format
+is also understood by recent enough versions of `pprof`:
 ```
-$ pprof -http=localhost:9999 perf.data
+$ pprof -http=localhost:9999 /path/to/envoy perf.data
 ```
+
+Note that in order to handle symbolization you need to pass an Envoy binary with debug symbols retained
+in version matching the profiled Envoy. You can get it from [envoyproxy/envoy-debug](https://hub.docker.com/r/envoyproxy/envoy-debug).
+
+Alternatively, you can use [allegro/envoy-perf-pprof](https://github.com/allegro/envoy-perf-pprof) which
+wraps the pprof setup mentioned above (installing perf_to_profile, pprof and getting
+the proper Envoy debug version) in a Dockerfile.
+
 ## Memory analysis
 
 Unfortunately `perf` doesn't support heap profiling analogous to `gperftools`, but still


### PR DESCRIPTION
It took me some time to get on-CPU analysis with `perf` working as the existing docs didn't cover all the details. The change captures my experience in setting it up, the docs should now be complete.

Note that I'm also linking [allegro/envoy-perf-pprof](https://github.com/allegro/envoy-perf-pprof), a small tool I've published that wraps the required `pprof` setup in a Dockerfile. Let me know if it's OK for you.

Commit Message: docs: adds more detailed instructions on cpu profiling with perf
Risk Level: none
Docs Changes: develops bazel/PPROF.md cpu profiling with perf (not the main docs)