### PR TITLE
thrift proxy: relax logging errors

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/conn_manager.cc
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.cc
@@ -72,7 +72,7 @@ void ConnectionManager::dispatch() {
 
     return;
   } catch (const AppException& ex) {
-    ENVOY_LOG(error, "thrift application exception: {}", ex.what());
+    ENVOY_LOG(debug, "thrift application exception: {}", ex.what());
     if (rpcs_.empty()) {
       MessageMetadata metadata;
       sendLocalReply(metadata, ex, true);
@@ -80,7 +80,7 @@ void ConnectionManager::dispatch() {
       sendLocalReply(*(*rpcs_.begin())->metadata_, ex, true);
     }
   } catch (const EnvoyException& ex) {
-    ENVOY_CONN_LOG(error, "thrift error: {}", read_callbacks_->connection(), ex.what());
+    ENVOY_CONN_LOG(debug, "thrift error: {}", read_callbacks_->connection(), ex.what());
 
     if (rpcs_.empty()) {
       // Transport/protocol mismatch (including errors in automatic detection). Just hang up


### PR DESCRIPTION
For active thrift clusters, it's normal to see downstream connections
all the time so our logs are getting spammed with:

```
[C31770] thrift response error: downstream connection is closed
```

We could do one of two things when an Exception happens in
ConnectionManager::dispatch():

a) just treat them all as log debug events
b) do it only for downstream connection is closed

We are only really seeing downstream connection exceptions, so
doing it globally is probably fine.

While we are here - and even though it isn't currently a problem -
let's relax the level for the AppException log entry too.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
