### PR TITLE
test: remove deprecated constructor

### DIFF
--- a/ci/filter_example_setup.sh
+++ b/ci/filter_example_setup.sh
@@ -5,7 +5,7 @@
 set -e
 
 # This is the hash on https://github.com/envoyproxy/envoy-filter-example.git we pin to.
-ENVOY_FILTER_EXAMPLE_GITSHA="30e5df3b73aec14ca3b70e4537e0b42f2e9d7fd0"
+ENVOY_FILTER_EXAMPLE_GITSHA="8f0f8bba38868e875613b74f57df38f543e764ba"
 ENVOY_FILTER_EXAMPLE_SRCDIR="${BUILD_DIR}/envoy-filter-example"
 
 # shellcheck disable=SC2034

--- a/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
@@ -34,7 +34,7 @@ class AdmissionControlIntegrationTest : public Event::TestUsingSimulatedTime,
                                         public HttpIntegrationTest {
 public:
   AdmissionControlIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
   void SetUp() override {}
 

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -43,16 +43,12 @@ struct ApiFilesystemConfig {
  */
 class BaseIntegrationTest : protected Logger::Loggable<Logger::Id::testing> {
 public:
-  using TestTimeSystemPtr = std::unique_ptr<Event::TestTimeSystem>;
   using InstanceConstSharedPtrFn = std::function<Network::Address::InstanceConstSharedPtr(int)>;
 
   // Creates a test fixture with an upstream bound to INADDR_ANY on an unspecified port using the
   // provided IP |version|.
   BaseIntegrationTest(Network::Address::IpVersion version,
                       const std::string& config = ConfigHelper::httpProxyConfig());
-  BaseIntegrationTest(Network::Address::IpVersion version, TestTimeSystemPtr,
-                      const std::string& config = ConfigHelper::httpProxyConfig())
-      : BaseIntegrationTest(version, config) {}
   // Creates a test fixture with a specified |upstream_address| function that provides the IP and
   // port to use.
   BaseIntegrationTest(const InstanceConstSharedPtrFn& upstream_address_fn,

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -60,10 +60,6 @@ public:
                       const std::string& config = ConfigHelper::httpProxyConfig());
   virtual ~BaseIntegrationTest() = default;
 
-  // TODO(jmarantz): Remove this once
-  // https://github.com/envoyproxy/envoy-filter-example/pull/69 is reverted.
-  static TestTimeSystemPtr realTime() { return TestTimeSystemPtr(); }
-
   // Initialize the basic proto configuration, create fake upstreams, and start Envoy.
   virtual void initialize();
   // Set up the fake upstream connections. This is called by initialize() and

--- a/test/integration/custom_cluster_integration_test.cc
+++ b/test/integration/custom_cluster_integration_test.cc
@@ -19,7 +19,7 @@ class CustomClusterIntegrationTest : public testing::TestWithParam<Network::Addr
                                      public HttpIntegrationTest {
 public:
   CustomClusterIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(), realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
   void initialize() override {
     setUpstreamCount(1);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -88,13 +88,6 @@ using IntegrationCodecClientPtr = std::unique_ptr<IntegrationCodecClient>;
  */
 class HttpIntegrationTest : public BaseIntegrationTest {
 public:
-  // TODO(jmarantz): Remove this once
-  // https://github.com/envoyproxy/envoy-filter-example/pull/69 is reverted.
-  HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,
-                      Network::Address::IpVersion version, TestTimeSystemPtr,
-                      const std::string& config = ConfigHelper::httpProxyConfig())
-      : HttpIntegrationTest(downstream_protocol, version, config) {}
-
   HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,
                       Network::Address::IpVersion version,
                       const std::string& config = ConfigHelper::httpProxyConfig());

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -31,7 +31,7 @@ protected:
   };
 
   ListenerIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion(), realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
 
   ~ListenerIntegrationTest() override { resetConnections(); }
 

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -30,8 +30,7 @@ protected:
     absl::flat_hash_map<std::string, FakeStreamPtr> stream_by_resource_name_;
   };
 
-  ListenerIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
+  ListenerIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
 
   ~ListenerIntegrationTest() override { resetConnections(); }
 

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -30,7 +30,7 @@ protected:
   };
 
   ScopedRdsIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion(), realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
 
   ~ScopedRdsIntegrationTest() override { resetConnections(); }
 

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -29,8 +29,7 @@ protected:
     absl::flat_hash_map<std::string, FakeStreamPtr> stream_by_resource_name_;
   };
 
-  ScopedRdsIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
+  ScopedRdsIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
 
   ~ScopedRdsIntegrationTest() override { resetConnections(); }
 

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -152,7 +152,7 @@ class VhdsInitializationTest : public HttpIntegrationTest,
                                public Grpc::GrpcClientIntegrationParamTest {
 public:
   VhdsInitializationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), realTime(), config()) {
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), config()) {
     use_lds_ = false;
   }
 
@@ -249,7 +249,7 @@ class VhdsIntegrationTest : public HttpIntegrationTest,
                             public Grpc::GrpcClientIntegrationParamTest {
 public:
   VhdsIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), realTime(), config()) {
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion(), config()) {
     use_lds_ = false;
   }
 


### PR DESCRIPTION
Commit Message: test: clean out a TODO for dead code
Additional Description: https://github.com/envoyproxy/envoy-filter-example/pull/69 was reverted by https://github.com/envoyproxy/envoy-filter-example/pull/79
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Derek Argueta <darguetap@gmail.com>