### PR TITLE
access log: support formatter extensions from json_format

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -124,6 +124,7 @@ New Features
 * access log: added the new response flag `NC` for upstream cluster not found. The error flag is set when the http or tcp route is found for the request but the cluster is not available.
 * access log: added the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point for custom formatters (command operators).
 * access log: added support for cross platform writing to :ref:`standard output <envoy_v3_api_msg_extensions.access_loggers.stdoutput.v3.StdoutputAccessLog>` and :ref:`standard error <envoy_v3_api_msg_extensions.access_loggers.stderror.v3.StderrorAccessLog>`.
+* access log: extended the :ref:`formatters <envoy_v3_api_field_config.core.v3.SubstitutionFormatString.formatters>` extension point to support json format.
 * access log: support command operator: %FILTER_CHAIN_NAME% for the downstream tcp and http request.
 * access log: support command operator: %REQUEST_HEADERS_BYTES%, %RESPONSE_HEADERS_BYTES%, and %RESPONSE_TRAILERS_BYTES%.
 * compression: add brotli :ref:`compressor <envoy_v3_api_msg_extensions.compression.brotli.compressor.v3.Brotli>` and :ref:`decompressor <envoy_v3_api_msg_extensions.compression.brotli.decompressor.v3.Brotli>`.

--- a/source/common/formatter/substitution_format_string.cc
+++ b/source/common/formatter/substitution_format_string.cc
@@ -12,7 +12,9 @@ namespace Formatter {
 FormatterPtr
 SubstitutionFormatStringUtils::createJsonFormatter(const ProtobufWkt::Struct& struct_format,
                                                    bool preserve_types, bool omit_empty_values) {
-  return std::make_unique<JsonFormatterImpl>(struct_format, preserve_types, omit_empty_values);
+  std::vector<CommandParserPtr> commands;
+  return std::make_unique<JsonFormatterImpl>(struct_format, preserve_types, omit_empty_values,
+                                             commands);
 }
 
 FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
@@ -25,6 +27,9 @@ FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
       throw EnvoyException(absl::StrCat("Formatter not found: ", formatter.name()));
     }
     auto parser = factory->createCommandParserFromProto(formatter.typed_config());
+    if (!parser) {
+      throw EnvoyException(absl::StrCat("Failed to create command parser: ", formatter.name()));
+    }
     commands.push_back(std::move(parser));
   }
 
@@ -32,15 +37,16 @@ FormatterPtr SubstitutionFormatStringUtils::fromProtoConfig(
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormat:
     return std::make_unique<FormatterImpl>(config.text_format(), config.omit_empty_values(),
                                            commands);
-  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat: {
-    return createJsonFormatter(config.json_format(), true, config.omit_empty_values());
+  case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat:
+    return std::make_unique<JsonFormatterImpl>(config.json_format(), true,
+                                               config.omit_empty_values(), commands);
   case envoy::config::core::v3::SubstitutionFormatString::FormatCase::kTextFormatSource:
     return std::make_unique<FormatterImpl>(
         Config::DataSource::read(config.text_format_source(), true, api), false, commands);
-  }
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
+
   return nullptr;
 }
 

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -149,10 +149,11 @@ std::string JsonFormatterImpl::format(const Http::RequestHeaderMap& request_head
 }
 
 StructFormatter::StructFormatter(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
-                                 bool omit_empty_values)
+                                 bool omit_empty_values,
+                                 const std::vector<CommandParserPtr>& commands)
     : omit_empty_values_(omit_empty_values), preserve_types_(preserve_types),
       empty_value_(omit_empty_values_ ? EMPTY_STRING : DefaultUnspecifiedValueString),
-      struct_output_format_(toFormatMapValue(format_mapping)) {}
+      commands_(commands), struct_output_format_(toFormatMapValue(format_mapping)) {}
 
 StructFormatter::StructFormatMapWrapper
 StructFormatter::toFormatMapValue(const ProtobufWkt::Struct& struct_format) const {
@@ -177,7 +178,7 @@ StructFormatter::toFormatMapValue(const ProtobufWkt::Struct& struct_format) cons
     }
   }
   return {std::move(output)};
-};
+}
 
 StructFormatter::StructFormatListWrapper
 StructFormatter::toFormatListValue(const ProtobufWkt::ListValue& list_value_format) const {
@@ -205,8 +206,8 @@ StructFormatter::toFormatListValue(const ProtobufWkt::ListValue& list_value_form
 
 std::vector<FormatterProviderPtr>
 StructFormatter::toFormatStringValue(const std::string& string_format) const {
-  return SubstitutionFormatParser::parse(string_format);
-};
+  return SubstitutionFormatParser::parse(string_format, commands_);
+}
 
 ProtobufWkt::Value StructFormatter::providersCallback(
     const std::vector<FormatterProviderPtr>& providers,

--- a/source/common/formatter/substitution_formatter.h
+++ b/source/common/formatter/substitution_formatter.h
@@ -134,7 +134,7 @@ template <class... Ts> StructFormatMapVisitorHelper(Ts...) -> StructFormatMapVis
 class StructFormatter {
 public:
   StructFormatter(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
-                  bool omit_empty_values);
+                  bool omit_empty_values, const std::vector<CommandParserPtr>& commands);
 
   ProtobufWkt::Struct format(const Http::RequestHeaderMap& request_headers,
                              const Http::ResponseHeaderMap& response_headers,
@@ -189,16 +189,18 @@ private:
   const bool omit_empty_values_;
   const bool preserve_types_;
   const std::string empty_value_;
+  // Note: don't use this ref beyond the constructor.
+  const std::vector<CommandParserPtr>& commands_;
   const StructFormatMapWrapper struct_output_format_;
-}; // namespace Formatter
+};
 
 using StructFormatterPtr = std::unique_ptr<StructFormatter>;
 
 class JsonFormatterImpl : public Formatter {
 public:
   JsonFormatterImpl(const ProtobufWkt::Struct& format_mapping, bool preserve_types,
-                    bool omit_empty_values)
-      : struct_formatter_(format_mapping, preserve_types, omit_empty_values) {}
+                    bool omit_empty_values, const std::vector<CommandParserPtr>& commands)
+      : struct_formatter_(format_mapping, preserve_types, omit_empty_values, commands) {}
 
   // Formatter::format
   std::string format(const Http::RequestHeaderMap& request_headers,


### PR DESCRIPTION
This was missed in #14512.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
