### PR TITLE
redis proxy: fix redis auth error when using eds

### DIFF
--- a/examples/redis/Dockerfile-proxy
+++ b/examples/redis/Dockerfile-proxy
@@ -1,5 +1,8 @@
 FROM envoyproxy/envoy-dev:latest
 
-COPY ./envoy.yaml /etc/envoy.yaml
+COPY . /etc/
 RUN chmod go+r /etc/envoy.yaml
+RUN chmod go+r /etc/lds.yaml
+RUN chmod go+r /etc/cds.yaml
+
 CMD ["/usr/local/bin/envoy", "-c", "/etc/envoy.yaml", "-l", "debug", "--service-cluster", "proxy"]

--- a/examples/redis/Dockerfile-redis
+++ b/examples/redis/Dockerfile-redis
@@ -1,1 +1,3 @@
 FROM redis
+
+CMD ["redis-server", "--requirepass", "123"]

--- a/examples/redis/cds.yaml
+++ b/examples/redis/cds.yaml
@@ -1,0 +1,21 @@
+version_info: "0"
+resources:
+- "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+  name: redis_cluster
+  connect_timeout: 1s
+  type: STRICT_DNS # static
+  lb_policy: MAGLEV
+  typed_extension_protocol_options:
+    envoy.filters.network.redis_proxy:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProtocolOptions
+      auth_password:
+        inline_string: "123"
+  load_assignment:
+    cluster_name: redis_cluster
+    endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 6379

--- a/examples/redis/envoy-dynamic.yaml
+++ b/examples/redis/envoy-dynamic.yaml
@@ -1,0 +1,35 @@
+node:
+  id: id_1
+  cluster: test
+
+dynamic_resources:
+  cds_config:
+    path: "/etc/cds.yaml"
+
+static_resources:
+  listeners:
+  - name: redis_listener
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 1999
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.redis_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
+          stat_prefix: redis
+          prefix_routes: 
+            catch_all_route:
+              cluster: redis_cluster
+          settings:
+            op_timeout: 5s
+          downstream_auth_password:
+            inline_string: "123"
+  
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/examples/redis/envoy.yaml
+++ b/examples/redis/envoy.yaml
@@ -16,11 +16,18 @@ static_resources:
           prefix_routes:
             catch_all_route:
               cluster: redis_cluster
+          downstream_auth_password:
+            inline_string: "123"
   clusters:
   - name: redis_cluster
-    connect_timeout: 1s
-    type: STRICT_DNS # static
+    connect_timeout: 0.25s
+    type: strict_dns
     lb_policy: MAGLEV
+    typed_extension_protocol_options:
+      envoy.filters.network.redis_proxy:
+        "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProtocolOptions
+        auth_password:
+          inline_string: "123"
     load_assignment:
       cluster_name: redis_cluster
       endpoints:

--- a/examples/redis/lds.yaml
+++ b/examples/redis/lds.yaml
@@ -1,0 +1,21 @@
+version_info: "0"
+resources:
+- "@type": "type.googleapis.com/envoy.config.listener.v3.Listener"
+  name: listener_0
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 1999
+  filter_chains:
+  - filters:
+    - name: envoy.filters.network.redis_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.network.redis_proxy.v3.RedisProxy
+        stat_prefix: redis
+        prefix_routes: 
+          catch_all_route:
+            cluster: redis_cluster
+        settings:
+          op_timeout: 5s
+        downstream_auth_password:
+          inline_string: "123"

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -97,6 +97,8 @@ InstanceImpl::ThreadLocalPool::ThreadLocalPool(std::shared_ptr<InstanceImpl> par
     auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster->info(), parent->api_);
     auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster->info(), parent->api_);
     onClusterAddOrUpdateNonVirtual(*cluster);
+  } else {
+    ENVOY_LOG(debug, "Redis connection pool init without password");
   }
 }
 
@@ -127,6 +129,12 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
     // Treat an update as a removal followed by an add.
     ThreadLocalPool::onClusterRemoval(cluster_name_);
   }
+  auto parent = parent_.lock();
+  if (parent == nullptr) {
+    return;
+  }
+  auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster.info(), parent->api_);
+  auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster.info(), parent->api_);
 
   ASSERT(cluster_ == nullptr);
   cluster_ = &cluster;


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
fix #15659.
I think this is cause by current logic on `onClusterAddOrUpdateNonVirtual` not update the `auth_username_, auth_password_` when cluster is updated.

Commit Message: fix auth error when redis cluster using cds.
Additional Description: 
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
