### PR TITLE
redis proxy: fix redis auth error when using eds

### DIFF
--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -97,6 +97,8 @@ InstanceImpl::ThreadLocalPool::ThreadLocalPool(std::shared_ptr<InstanceImpl> par
     auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster->info(), parent->api_);
     auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster->info(), parent->api_);
     onClusterAddOrUpdateNonVirtual(*cluster);
+  } else {
+    ENVOY_LOG(debug, "Redis connection pool init without password");
   }
 }
 
@@ -127,6 +129,12 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
     // Treat an update as a removal followed by an add.
     ThreadLocalPool::onClusterRemoval(cluster_name_);
   }
+  auto parent = parent_.lock();
+  if (parent == nullptr) {
+    return;
+  }
+  auth_username_ = ProtocolOptionsConfigImpl::authUsername(cluster.info(), parent->api_);
+  auth_password_ = ProtocolOptionsConfigImpl::authPassword(cluster.info(), parent->api_);
 
   ASSERT(cluster_ == nullptr);
   cluster_ = &cluster;


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
fix #15659.
I think this is cause by current logic on `onClusterAddOrUpdateNonVirtual` not update the `auth_username_, auth_password_` when cluster is updated.

Commit Message: fix auth error when redis cluster using cds.
Additional Description: 
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]