### PR TITLE
Allow custom cluster types to read from and utilize eds_cluster_config

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -175,6 +175,9 @@ message Cluster {
     // See the supported cluster for further documentation.
     // [#extension-category: envoy.clusters]
     google.protobuf.Any typed_config = 2;
+
+    // If true, this cluster type supports EDS updates and is configured using eds_cluster_config.
+    bool uses_eds_config = 3;
   }
 
   // Only valid when discovery type is EDS.

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -176,6 +176,9 @@ message Cluster {
     // See the supported cluster for further documentation.
     // [#extension-category: envoy.clusters]
     google.protobuf.Any typed_config = 2;
+
+    // If true, this cluster type supports EDS updates and is configured using eds_cluster_config.
+    bool uses_eds_config = 3;
   }
 
   // Only valid when discovery type is EDS.

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -176,6 +176,9 @@ message Cluster {
     // See the supported cluster for further documentation.
     // [#extension-category: envoy.clusters]
     google.protobuf.Any typed_config = 2;
+
+    // If true, this cluster type supports EDS updates and is configured using eds_cluster_config.
+    bool uses_eds_config = 3;
   }
 
   // Only valid when discovery type is EDS.

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -177,6 +177,9 @@ message Cluster {
     // See the supported cluster for further documentation.
     // [#extension-category: envoy.clusters]
     google.protobuf.Any typed_config = 2;
+
+    // If true, this cluster type supports EDS updates and is configured using eds_cluster_config.
+    bool uses_eds_config = 3;
   }
 
   // Only valid when discovery type is EDS.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -827,7 +827,8 @@ ClusterInfoImpl::ClusterInfoImpl(
   }
 
   if (config.has_eds_cluster_config()) {
-    if (config.type() != envoy::config::cluster::v3::Cluster::EDS) {
+    if (config.type() != envoy::config::cluster::v3::Cluster::EDS &&
+        !config.cluster_type().uses_eds_config()) {
       throw EnvoyException("eds_cluster_config set in a non-EDS cluster");
     }
     eds_service_name_ = config.eds_cluster_config().service_name();

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2401,6 +2401,21 @@ TEST_F(ClusterInfoImplTest, EdsServiceNamePopulation) {
   )EOF";
   EXPECT_THROW_WITH_MESSAGE(makeCluster(unexpected_eds_config_yaml), EnvoyException,
                             "eds_cluster_config set in a non-EDS cluster");
+
+  // Custom clusters that use EDS for endpoint discovery can specify eds_cluster_config. This custom
+  // cluster type is registered by linking test/integration/custom/static_cluster.cc.
+  const std::string custom_cluster_using_eds_yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    cluster_type:
+      name: envoy.clusters.custom_static_with_lb
+      uses_eds_config: true
+    lb_policy: CLUSTER_PROVIDED
+    eds_cluster_config:
+      service_name: service_foo
+  )EOF";
+  auto custom_cluster = makeCluster(custom_cluster_using_eds_yaml);
+  EXPECT_EQ(custom_cluster->info()->edsServiceName(), "service_foo");
 }
 
 // Typed metadata loading throws exception.


### PR DESCRIPTION
Commit Message: Allow custom cluster types to read from and utilize eds_cluster_config
Additional Description:
Usage of eds_cluster_config is currently restricted to clusters that have type explicitly set to EDS. Envoy also uses this type for determining whether clusters are initialized during the primary or secondary phase, meaning it is not possible to write a custom cluster type that performs endpoint discovery via EDS.

This CL introduces uses_eds_config to the CustomClusterType proto and changes the requirement for having eds_cluster_config set to include the case in which a custom cluster type has this flag set. Custom clusters that utilize the EDS config are omitted from the primary initialization phase, similar to clusters of type EDS.

Risk Level: low (small optional feature)
Testing: unit test
Docs Changes: inline on new field in cluster.proto
Release Notes: Adds a boolean field to CustomClusterType indicating that the custom cluster type uses EDS for endpoint discovery, and permits the custom cluster type to specify eds_cluster_config if that field is set.
Fixes #15663
API Considerations: the default value of uses_eds_config (false) results in no behaviour change (the cluster will be initialized during the primary phase; the cluster cannot specify eds_cluster_config).

Signed-off-by: Eugene Chan <eugenechan@google.com>