### PR TITLE
xds: reset type version upon TTL expiry and schedule new request for SotW

### DIFF
--- a/test/common/config/grpc_mux_impl_test.cc
+++ b/test/common/config/grpc_mux_impl_test.cc
@@ -476,7 +476,7 @@ TEST_F(GrpcMuxImplTest, ResourceTTL) {
   ttl_timer->invokeCallback();
 
   // Increment the time beyond the second resource. This should not send another request since we
-  // alredy have one pending for the empty resource.
+  // already have one pending for the empty resource.
   time_system_.setSystemTime(std::chrono::seconds(100));
   EXPECT_CALL(callbacks_, onConfigUpdate(_, _, ""))
       .WillOnce(Invoke([](auto, const auto& removed, auto) {


### PR DESCRIPTION
This ensures that Envoy attempts to refetch the SotW xDS state for a type
once one of its resources have expired. Additionally this ensures
that if Envoy expires resources while a control plane is unavailable,
it will reset the version on the first request back, ensuring that the
expired resources can be restored.

Risk Level: Medium, changes to SotW logic
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
