### PR TITLE
Add Windows subsection to the installation section of the Envoy docs

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -128,6 +128,18 @@ You can install Envoy on Mac OSX using the official brew repositories, or from
 	 `Get Envoy <https://www.getenvoy.io/>`__ by adding the ``--HEAD`` flag to
 	 the install command.
 
+.. _start_install_windows:
+
+Install Envoy on Windows
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can run Envoy using the official Windows development Docker image.
+
+.. code-block:: console
+
+   $ docker pull envoyproxy/envoy-windows-dev:latest
+   $ docker run --rm envoyproxy/envoy-windows-dev:latest --version
+
 .. _start_install_docker:
 
 Install Envoy using Docker
@@ -219,6 +231,12 @@ The following table shows the available Docker images
      -
      - latest
      - latest
+   * - `envoyproxy/envoy-windows-dev <https://hub.docker.com/r/envoyproxy/envoy-windows-dev/tags/>`_
+     - Release binary with symbols stripped on top of a Windows 1809 base.
+     -
+     -
+     - latest
+     -
    * - `envoyproxy/envoy-build-ubuntu <https://hub.docker.com/r/envoyproxy/envoy-build-ubuntu/tags/>`_
      - Build image which includes tools for building multi-arch Envoy and containers.
      -


### PR DESCRIPTION
Commit Message:

Add Windows subsection to the installation section of the Envoy docs.

Risk Level: Low
Testing: Built the documentation.
Docs Changes: The installation section of the Envoy docs is missing Windows-specific instructions.  This PR adds a subsection for installing on Windows, which today only includes using the envoy-windows-dev Docker image.

Addresses #14605. 