### PR TITLE
RaiiMapOfListElement: fix invalid reference due to rehashing instability 

### DIFF
--- a/test/common/common/cleanup_test.cc
+++ b/test/common/common/cleanup_test.cc
@@ -61,7 +61,7 @@ TEST(RaiiListElementTest, DeleteOnErase) {
 }
 
 TEST(RaiiMapOfListElement, DeleteOnDestruction) {
-  absl::node_hash_map<int, std::list<int>> map;
+  absl::flat_hash_map<int, std::list<int>> map;
   {
     EXPECT_EQ(map.size(), 0);
     RaiiMapOfListElement<int, int> element(map, 1, 1);
@@ -74,7 +74,7 @@ TEST(RaiiMapOfListElement, DeleteOnDestruction) {
 }
 
 TEST(RaiiMapOfListElementTest, CancelDelete) {
-  absl::node_hash_map<int, std::list<int>> map;
+  absl::flat_hash_map<int, std::list<int>> map;
 
   {
     EXPECT_EQ(map.size(), 0);
@@ -92,7 +92,7 @@ TEST(RaiiMapOfListElementTest, CancelDelete) {
 }
 
 TEST(RaiiMapOfListElement, MultipleEntriesSameKey) {
-  absl::node_hash_map<int, std::list<int>> map;
+  absl::flat_hash_map<int, std::list<int>> map;
   {
     EXPECT_EQ(map.size(), 0);
     RaiiMapOfListElement<int, int> element(map, 1, 1);
@@ -115,7 +115,7 @@ TEST(RaiiMapOfListElement, MultipleEntriesSameKey) {
 }
 
 TEST(RaiiMapOfListElement, DeleteAfterMapRehash) {
-  absl::node_hash_map<int, std::list<int>> map;
+  absl::flat_hash_map<int, std::list<int>> map;
   std::list<RaiiMapOfListElement<int, int>> list;
   // According to https://abseil.io/docs/cpp/guides/container the max load factor on
   // absl::flat_hash_map is 87.5%. Using bucket_count and multiplying by 2 should give us enough

--- a/test/common/common/cleanup_test.cc
+++ b/test/common/common/cleanup_test.cc
@@ -61,7 +61,7 @@ TEST(RaiiListElementTest, DeleteOnErase) {
 }
 
 TEST(RaiiMapOfListElement, DeleteOnDestruction) {
-  absl::flat_hash_map<int, std::list<int>> map;
+  absl::node_hash_map<int, std::list<int>> map;
   {
     EXPECT_EQ(map.size(), 0);
     RaiiMapOfListElement<int, int> element(map, 1, 1);
@@ -74,7 +74,7 @@ TEST(RaiiMapOfListElement, DeleteOnDestruction) {
 }
 
 TEST(RaiiMapOfListElementTest, CancelDelete) {
-  absl::flat_hash_map<int, std::list<int>> map;
+  absl::node_hash_map<int, std::list<int>> map;
 
   {
     EXPECT_EQ(map.size(), 0);
@@ -92,7 +92,7 @@ TEST(RaiiMapOfListElementTest, CancelDelete) {
 }
 
 TEST(RaiiMapOfListElement, MultipleEntriesSameKey) {
-  absl::flat_hash_map<int, std::list<int>> map;
+  absl::node_hash_map<int, std::list<int>> map;
   {
     EXPECT_EQ(map.size(), 0);
     RaiiMapOfListElement<int, int> element(map, 1, 1);
@@ -111,6 +111,26 @@ TEST(RaiiMapOfListElement, MultipleEntriesSameKey) {
     ASSERT_NE(map.end(), it);
     EXPECT_EQ(it->second.size(), 1);
   }
+  EXPECT_EQ(map.size(), 0);
+}
+
+TEST(RaiiMapOfListElement, DeleteAfterMapRehash) {
+  absl::node_hash_map<int, std::list<int>> map;
+  std::list<RaiiMapOfListElement<int, int>> list;
+  // According to https://abseil.io/docs/cpp/guides/container the max load factor on
+  // absl::flat_hash_map is 87.5%. Using bucket_count and multiplying by 2 should give us enough
+  // head room to cause rehashing.
+  int rehash_limit = (map.bucket_count() == 0 ? 1 : map.bucket_count()) * 2;
+
+  for (int i = 0; i <= rehash_limit; i++) {
+    list.emplace_back(map, i, i);
+    EXPECT_EQ(map.size(), i + 1);
+    auto it = map.find(i);
+    ASSERT_NE(map.end(), it);
+    EXPECT_EQ(it->second.size(), 1);
+  }
+
+  list.clear();
   EXPECT_EQ(map.size(), 0);
 }
 


### PR DESCRIPTION
Commit Message: fix invalid reference due to rehashing instability.
Risk Level: low - fixed repro.
Testing: new test to repro original issue.
