### PR TITLE
Pending changes from #13770

### DIFF
--- a/source/common/common/mem_block_builder.h
+++ b/source/common/common/mem_block_builder.h
@@ -121,7 +121,7 @@ public:
   /**
    * @return the populated data as an absl::Span.
    */
-  absl::Span<T> span() const { return absl::MakeSpan(data_, write_span_.data()); }
+  absl::Span<T> span() const { return absl::MakeSpan(owned_data_.get(), write_span_.data()); }
 
   /**
    * @return The number of elements the have been added to the builder.


### PR DESCRIPTION
* Commit message: Initial commit
* Additional Description:

Allow the clients of `MemBlockBuilder` to supply a reference to memory that has already been allocated.  

After doing this, change the classes that allocate their own storage to simply delegate that responsibility to `MemBlockBuilder`, which can be used as an instance variable.

* Risk Level: None
* Testing: N/A
* Docs Changes: N/A