### PR TITLE
http: fix the transfer-encoding header check in case of multiple values

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -183,6 +183,19 @@ bool HeaderUtility::headerValueIsValid(const absl::string_view header_value) {
                                     header_value.size()) != 0;
 }
 
+bool HeaderUtility::headerValueContainsIgnoreCase(const absl::string_view header_value,
+                                                  const absl::string_view value,
+                                                  absl::string_view delimiter) {
+  std::vector<absl::string_view> sub_values =
+      StringUtil::splitToken(header_value, delimiter, true, true);
+  for (auto& sub_val : sub_values) {
+    if (absl::EqualsIgnoreCase(sub_val, value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool HeaderUtility::headerNameContainsUnderscore(const absl::string_view header_name) {
   return header_name.find('_') != absl::string_view::npos;
 }

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -125,6 +125,15 @@ public:
   static bool headerValueIsValid(const absl::string_view header_value);
 
   /**
+   * Checks if a header value str with multiple sub-values separated by a delimiter contains
+   * a specified one, ignoring case.
+   * @return bool true if the header values contains the value, false otherwise.
+   */
+  static bool headerValueContainsIgnoreCase(const absl::string_view header_value,
+                                            const absl::string_view value,
+                                            absl::string_view delimiter = ",");
+
+  /**
    * Checks if header name contains underscore characters.
    * Underscore character is allowed in header names by the RFC-7230 and this check is implemented
    * as a security measure due to systems that treat '_' and '-' as interchangeable. Envoy by

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -742,7 +742,8 @@ StatusOr<ParserStatus> ConnectionImpl::onHeadersComplete() {
   // CONNECT request has no defined semantics, and may be rejected.
   if (request_or_response_headers.TransferEncoding()) {
     const absl::string_view encoding = request_or_response_headers.getTransferEncodingValue();
-    if (!absl::EqualsIgnoreCase(encoding, header_values.TransferEncodingValues.Chunked) ||
+    if (!HeaderUtility::headerValueContainsIgnoreCase(
+            encoding, header_values.TransferEncodingValues.Chunked) ||
         parser_->methodName() == header_values.MethodValues.Connect) {
       error_code_ = Http::Code::NotImplemented;
       RETURN_IF_ERROR(sendProtocolError(Http1ResponseCodeDetails::get().InvalidTransferEncoding));


### PR DESCRIPTION
For http chunked encoding, currently envoy needs the value of the TE header to be exactly `chunked`.
In our production env, it has led the following two unexpected stream resets.

1. Some legacy http servers respond duplicate headers. If two TE headers with the same value "chunked" are received,  envoy will concat them with a `,` into `chunked,chunked`,  while later this check fails on this value.
2. For TE headers with multiple values (e.g. 'gzip, chunked'), envoy also resets the stream because of this check.

We have also tested with nginx, which allows the above two cases. After this fix, now envoy acts properly as expected.

Commit Message: fix the transfer-encoding header check in case of multiple values
Additional Description:
Risk Level: Medium
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A