### PR TITLE
doc: improve build guide doc

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -844,7 +844,9 @@ The compilation database could also be used to setup editors with cross referenc
 For example, you can use [You Complete Me](https://valloric.github.io/YouCompleteMe/) or
 [clangd](https://clangd.llvm.org/) with supported editors.
 
-This requires Python 3.8.0+, download from [here](https://www.python.org/downloads/) if you do not have one. Then, use following command to prepare a compilation database:
+This requires Python 3.8.0+, download from [here](https://www.python.org/downloads/) if you do no have it installed already.
+
+Use following command to prepare a compilation database:
 
 ```
 TEST_TMPDIR=/tmp tools/gen_compilation_database.py

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -844,7 +844,7 @@ The compilation database could also be used to setup editors with cross referenc
 For example, you can use [You Complete Me](https://valloric.github.io/YouCompleteMe/) or
 [clangd](https://clangd.llvm.org/) with supported editors.
 
-For example, use following command to prepare a compilation database:
+This requires Python 3.8.0+, download from [here](https://www.python.org/downloads/) if you do not have one. Then, use following command to prepare a compilation database:
 
 ```
 TEST_TMPDIR=/tmp tools/gen_compilation_database.py

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -844,9 +844,9 @@ The compilation database could also be used to setup editors with cross referenc
 For example, you can use [You Complete Me](https://valloric.github.io/YouCompleteMe/) or
 [clangd](https://clangd.llvm.org/) with supported editors.
 
-This requires Python 3.8.0+, download from [here](https://www.python.org/downloads/) if you do no have it installed already.
+This requires Python 3.8.0+, download from [here](https://www.python.org/downloads/) if you do not have it installed already.
 
-Use following command to prepare a compilation database:
+Use the following command to prepare a compilation database:
 
 ```
 TEST_TMPDIR=/tmp tools/gen_compilation_database.py


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

Due to recent update of python package , now only python version >3.8.0  can use `./tools/vscode/refresh_compdb.sh`, we should let developers know.

*related discussion*
https://envoyproxy.slack.com/archives/C78HA81DH/p1617087308144200

Commit Message: improve build guide doc
Additional Description:
Risk Level: Low
Testing: No
Docs Changes: Yes
Release Notes: No
Platform Specific Features: No
[Optional Runtime guard:]
[Optional Fixes #Issue] #15754
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
