### PR TITLE
Fix rate limit filter config transport_api_version crash

### DIFF
--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -28,13 +28,14 @@ Http::FilterFactoryCb RateLimitFilterConfig::createFilterFactoryFromProtoTyped(
   const std::chrono::milliseconds timeout =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, timeout, 20));
 
-  return [proto_config, &context, timeout,
-          filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+  return [proto_config, &context, timeout, filter_config,
+          transport_api_version =
+              Config::Utility::getAndCheckTransportVersion(proto_config.rate_limit_service())](
+             Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Filter>(
-        filter_config,
-        Filters::Common::RateLimit::rateLimitClient(
-            context, proto_config.rate_limit_service().grpc_service(), timeout,
-            Config::Utility::getAndCheckTransportVersion(proto_config.rate_limit_service()))));
+        filter_config, Filters::Common::RateLimit::rateLimitClient(
+                           context, proto_config.rate_limit_service().grpc_service(), timeout,
+                           transport_api_version)));
   };
 }
 

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -30,13 +30,13 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
   const std::chrono::milliseconds timeout =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, timeout, 20));
 
-  return [proto_config, &context, timeout,
-          filter_config](Network::FilterManager& filter_manager) -> void {
+  return [proto_config, &context, timeout, filter_config,
+          transport_api_version = Envoy::Config::Utility::getAndCheckTransportVersion(
+              proto_config.rate_limit_service())](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(std::make_shared<Filter>(
         filter_config, Filters::Common::RateLimit::rateLimitClient(
                            context, proto_config.rate_limit_service().grpc_service(), timeout,
-                           Envoy::Config::Utility::getAndCheckTransportVersion(
-                               proto_config.rate_limit_service()))));
+                           transport_api_version)));
   };
 }
 


### PR DESCRIPTION
Commit Message: Fixed Rate Limit Config factory to no longer crash on the request path.
Additional Description: Rate Limit Config factory was checking `transport_api_version` during the request path rather than the config path.
Risk Level: Low 
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A