### PR TITLE
conn_pool: renaming a member variable for clarity

### DIFF
--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -79,7 +79,7 @@ struct ClusterConnectivityState {
   ~ClusterConnectivityState() {
     ASSERT(pending_streams_ == 0);
     ASSERT(active_streams_ == 0);
-    ASSERT(connecting_stream_capacity_ == 0);
+    ASSERT(connecting_and_connected_stream_capacity_ == 0);
   }
 
   template <class T> void checkAndDecrement(T& value, uint32_t delta) {
@@ -94,11 +94,11 @@ struct ClusterConnectivityState {
 
   void incrPendingStreams(uint32_t delta) { checkAndIncrement(pending_streams_, delta); }
   void decrPendingStreams(uint32_t delta) { checkAndDecrement(pending_streams_, delta); }
-  void incrConnectingStreamCapacity(uint32_t delta) {
-    checkAndIncrement(connecting_stream_capacity_, delta);
+  void incrConnectingAndConnectedStreamCapacity(uint32_t delta) {
+    checkAndIncrement(connecting_and_connected_stream_capacity_, delta);
   }
-  void decrConnectingStreamCapacity(uint32_t delta) {
-    checkAndDecrement(connecting_stream_capacity_, delta);
+  void decrConnectingAndConnectedStreamCapacity(uint32_t delta) {
+    checkAndDecrement(connecting_and_connected_stream_capacity_, delta);
   }
   void incrActiveStreams(uint32_t delta) { checkAndIncrement(active_streams_, delta); }
   void decrActiveStreams(uint32_t delta) { checkAndDecrement(active_streams_, delta); }
@@ -116,7 +116,7 @@ struct ClusterConnectivityState {
   // Note that if more HTTP/2 streams have been established than are allowed by
   // a late-received SETTINGS frame, this MAY BE NEGATIVE.
   // Note this tracks the sum of multiple 32 bit stream capacities so must remain 64 bit.
-  int64_t connecting_stream_capacity_{};
+  int64_t connecting_and_connected_stream_capacity_{};
 };
 
 /**

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -204,7 +204,9 @@ public:
   }
   bool hasPendingStreams() const { return !pending_streams_.empty(); }
 
-  void decrClusterStreamCapacity(uint32_t delta) { state_.decrConnectingStreamCapacity(delta); }
+  void decrClusterStreamCapacity(uint32_t delta) {
+    state_.decrConnectingAndConnectedStreamCapacity(delta);
+  }
   void dumpState(std::ostream& os, int indent_level = 0) const {
     const char* spaces = spacesForLevel(indent_level);
     os << spaces << "ConnPoolImplBase " << this << DUMP_MEMBER(ready_clients_.size())
@@ -258,12 +260,12 @@ protected:
 
   bool hasActiveStreams() const { return num_active_streams_ > 0; }
 
-  void incrConnectingStreamCapacity(uint32_t delta) {
-    state_.incrConnectingStreamCapacity(delta);
+  void incrConnectingAndConnectedStreamCapacity(uint32_t delta) {
+    state_.incrConnectingAndConnectedStreamCapacity(delta);
     connecting_stream_capacity_ += delta;
   }
-  void decrConnectingStreamCapacity(uint32_t delta) {
-    state_.decrConnectingStreamCapacity(delta);
+  void decrConnectingAndConnectedStreamCapacity(uint32_t delta) {
+    state_.decrConnectingAndConnectedStreamCapacity(delta);
     ASSERT(connecting_stream_capacity_ > delta);
     connecting_stream_capacity_ -= delta;
   }

--- a/source/common/http/mixed_conn_pool.cc
+++ b/source/common/http/mixed_conn_pool.cc
@@ -72,7 +72,8 @@ void HttpConnPoolImplMixed::onConnected(Envoy::ConnectionPool::ActiveClient& cli
   // it to reflect any difference between the TCP stream limits and HTTP/2
   // stream limits.
   if (new_client->effectiveConcurrentStreamLimit() > 1) {
-    state_.incrConnectingStreamCapacity(new_client->effectiveConcurrentStreamLimit() - 1);
+    state_.incrConnectingAndConnectedStreamCapacity(new_client->effectiveConcurrentStreamLimit() -
+                                                    1);
   }
   new_client->state_ = ActiveClient::State::CONNECTING;
   LinkedList::moveIntoList(std::move(new_client), owningList(new_client->state_));

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -155,8 +155,8 @@ public:
         uint64_t old_limit = connecting_client->effectiveConcurrentStreamLimit();
         connecting_client->remaining_streams_ = 1;
         if (connecting_client->effectiveConcurrentStreamLimit() < old_limit) {
-          decrConnectingStreamCapacity(old_limit -
-                                       connecting_client->effectiveConcurrentStreamLimit());
+          decrConnectingAndConnectedStreamCapacity(
+              old_limit - connecting_client->effectiveConcurrentStreamLimit());
         }
       }
     }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -874,8 +874,8 @@ void ClusterManagerImpl::maybePreconnect(
     // We anticipate the incoming stream here, because maybePreconnect is called
     // before a new stream is established.
     if (!ConnectionPool::ConnPoolImplBase::shouldConnect(
-            state.pending_streams_, state.active_streams_, state.connecting_stream_capacity_,
-            peekahead_ratio, true)) {
+            state.pending_streams_, state.active_streams_,
+            state.connecting_and_connected_stream_capacity_, peekahead_ratio, true)) {
       return;
     }
     ConnectionPool::Instance* preconnect_pool = pick_preconnect_pool();

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -74,7 +74,7 @@ public:
 #define CHECK_STATE(active, pending, capacity)                                                     \
   EXPECT_EQ(state_.pending_streams_, pending);                                                     \
   EXPECT_EQ(state_.active_streams_, active);                                                       \
-  EXPECT_EQ(state_.connecting_stream_capacity_, capacity)
+  EXPECT_EQ(state_.connecting_and_connected_stream_capacity_, capacity)
 
   uint32_t stream_limit_ = 100;
   uint32_t concurrent_streams_ = 1;

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -180,7 +180,7 @@ public:
 #define CHECK_STATE(active, pending, capacity)                                                     \
   EXPECT_EQ(state_.pending_streams_, pending);                                                     \
   EXPECT_EQ(state_.active_streams_, active);                                                       \
-  EXPECT_EQ(state_.connecting_stream_capacity_, capacity);
+  EXPECT_EQ(state_.connecting_and_connected_stream_capacity_, capacity);
 
   /**
    * Closes a test client.


### PR DESCRIPTION
It's confusing that both the pool and the per cluster state have similarly named variables with different use.
Renaming to something annoyingly verbose to avoid confusion

Risk Level: n/a (rename)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a