### PR TITLE
CDS: Fix member order in CdsApiImpl

### DIFF
--- a/source/common/upstream/cds_api_impl.h
+++ b/source/common/upstream/cds_api_impl.h
@@ -53,10 +53,10 @@ private:
   void runInitializeCallbackIfAny();
 
   ClusterManager& cm_;
+  Stats::ScopePtr scope_;
   Config::SubscriptionPtr subscription_;
   std::string system_version_info_;
   std::function<void()> initialize_callback_;
-  Stats::ScopePtr scope_;
 };
 
 } // namespace Upstream


### PR DESCRIPTION
Commit Message:
The scope_ member is passed to subscription_ as a reference, so scope_
should live longer than subscription_, otherwise we risk a use of a
dangling reference to scope_ inside subscription_. To make sure that
scope_ lives longer than subscription_ order scope_ before
subscription_. That way scope_ is constructed before subscription_ and
destroyed after it.

Additional Description:
I found it tricky to write a test for this issue. I had crashes in `OdCdsApiImpl` which had the same issue ([see the backtrace](https://github.com/envoyproxy/envoy/pull/15523#issuecomment-807762362)), but not with `CdsApiImpl`. The issue was quite involved (it was crashing on using an already-freed counter somewhere within `NewGrpcMuxImpl` because of `NewGrpcMuxImpl::WatchImpl` begin destroyed (caused by destruction of `GrpcSubscriptionImpl`). It does not look like a material for a unit test. Also, such a test could be flaky because of use-after-free being undefined behaviour.

Risk Level:
Low.

Testing:
As a part of #15523.

Docs Changes:
N/A.

Release Notes:
N/A.

Platform Specific Features:
N/A.
