### PR TITLE
Envoy 1.17 crashing with validation context secret discovery in ads mode on start up #15517

### DIFF
--- a/source/common/config/grpc_subscription_impl.cc
+++ b/source/common/config/grpc_subscription_impl.cc
@@ -29,6 +29,10 @@ void GrpcSubscriptionImpl::start(const std::set<std::string>& resources,
     init_fetch_timeout_timer_->enableTimer(init_fetch_timeout_);
   }
 
+  // An alternative to RELEASE_ASSERT here is to test for a null and generate warning error.
+  // This could potentially lead to an envoy instance with unintended configuration being 
+  // created with opaque security issues. It is probably best to fail.
+  RELEASE_ASSERT(grpc_mux_ != nullptr, "grpc_mux_ initialized with null value");
   watch_ =
       grpc_mux_->addWatch(type_url_, resources, *this, resource_decoder_, use_namespace_matching);
 

--- a/source/common/config/grpc_subscription_impl.cc
+++ b/source/common/config/grpc_subscription_impl.cc
@@ -29,9 +29,6 @@ void GrpcSubscriptionImpl::start(const std::set<std::string>& resources,
     init_fetch_timeout_timer_->enableTimer(init_fetch_timeout_);
   }
 
-  // An alternative to RELEASE_ASSERT here is to test for a null and generate warning error.
-  // This could potentially lead to an envoy instance with unintended configuration being 
-  // created with opaque security issues. It is probably best to fail.
   RELEASE_ASSERT(grpc_mux_ != nullptr, "grpc_mux_ initialized with null value");
   watch_ =
       grpc_mux_->addWatch(type_url_, resources, *this, resource_decoder_, use_namespace_matching);

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -86,8 +86,12 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
     }
   }
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds: {
+     Config::GrpcMuxSharedPtr gmuxsp = cm_.adsMux();
+    if ( gmuxsp == nullptr ) {
+      throw EnvoyException("A configuration for dynamic_resources is required for ads");
+    } 
     return std::make_unique<GrpcSubscriptionImpl>(
-        cm_.adsMux(), callbacks, resource_decoder, stats, type_url, dispatcher_,
+        gmuxsp, callbacks, resource_decoder, stats, type_url, dispatcher_,
         Utility::configSourceInitialFetchTimeout(config), true);
   }
   default:

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -86,12 +86,11 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
     }
   }
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds: {
-    Config::GrpcMuxSharedPtr gmuxsp = cm_.adsMux();
-    if ( gmuxsp == nullptr ) {
-      throw EnvoyException("A configuration for dynamic resources is required for ads with a non primary cluster");
-    } 
+    if ( cm_.adsMux() == nullptr ) {
+      throw EnvoyException("Sub-components (like SDS) of a primary cluster cannot be configured via ADS");
+    }
     return std::make_unique<GrpcSubscriptionImpl>(
-        gmuxsp, callbacks, resource_decoder, stats, type_url, dispatcher_,
+        cm_.adsMux(), callbacks, resource_decoder, stats, type_url, dispatcher_,
         Utility::configSourceInitialFetchTimeout(config), true);
   }
   default:

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -86,9 +86,9 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
     }
   }
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds: {
-     Config::GrpcMuxSharedPtr gmuxsp = cm_.adsMux();
+    Config::GrpcMuxSharedPtr gmuxsp = cm_.adsMux();
     if ( gmuxsp == nullptr ) {
-      throw EnvoyException("A configuration for dynamic_resources is required for ads");
+      throw EnvoyException("A configuration for dynamic resources is required for ads with a non primary cluster");
     } 
     return std::make_unique<GrpcSubscriptionImpl>(
         gmuxsp, callbacks, resource_decoder, stats, type_url, dispatcher_,

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -86,8 +86,9 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
     }
   }
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds: {
-    if ( cm_.adsMux() == nullptr ) {
-      throw EnvoyException("Sub-components (like SDS) of a primary cluster cannot be configured via ADS");
+    if (cm_.adsMux() == nullptr) {
+      throw EnvoyException(
+          "Sub-components (like SDS) of a primary cluster cannot be configured via ADS");
     }
     return std::make_unique<GrpcSubscriptionImpl>(
         cm_.adsMux(), callbacks, resource_decoder, stats, type_url, dispatcher_,

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -355,8 +355,10 @@ ClusterManagerImpl::ClusterManagerImpl(
           bootstrap.dynamic_resources().ads_config().set_node_on_first_message_only());
     }
   } else {
-    // if an ads is configured with no dynamic resource declared a nullptr leads to inconsistency in the
-    // SubscriptionFactoryImpl case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds
+    // Without a dynamic resource configuration (bootstrap.dynamic_resources() == null)
+    // an ads_mux == nullptr will cause an error in the
+    // SubscriptionFactoryImpl::subscriptionFromConfigSource() for the
+    // envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds case.
     // TODO can this condition be caught here?
     ads_mux_ = std::make_unique<Config::NullGrpcMuxImpl>();
   }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -312,7 +312,6 @@ ClusterManagerImpl::ClusterManagerImpl(
       loadCluster(cluster, "", false, active_clusters_);
     }
   }
-
   // Now setup ADS if needed, this might rely on a primary cluster.
   // This is the only point where distinction between delta ADS and state-of-the-world ADS is made.
   // After here, we just have a GrpcMux interface held in ads_mux_, which hides

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -356,6 +356,9 @@ ClusterManagerImpl::ClusterManagerImpl(
           bootstrap.dynamic_resources().ads_config().set_node_on_first_message_only());
     }
   } else {
+    // if an ads is configured with no dynamic resource declared a nullptr leads to inconsistency in the
+    // SubscriptionFactoryImpl case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds
+    // TODO can this condition be caught here?
     ads_mux_ = std::make_unique<Config::NullGrpcMuxImpl>();
   }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1073,6 +1073,12 @@ TEST_P(ServerInstanceImplTest, BadSdsConfigSource) {
       "'sds-grpc' does not exist, was added via api, or is an EDS cluster");
 }
 
+TEST_P(ServerInstanceImplTest, BadSdsAdsConfigSource) {
+  EXPECT_THROW_WITH_MESSAGE(
+      initialize("test/server/test_data/server/bad_sds_ads_config_source.yaml"), EnvoyException,
+      "Sub-components (like SDS) of a primary cluster cannot be configured via ADS");
+}
+
 // Test for protoc-gen-validate constraint on invalid timeout entry of a health check config entry.
 TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidTimeout) {
   EXPECT_THROW_WITH_REGEX(

--- a/test/server/test_data/server/bad_sds_ads_config_source.yaml
+++ b/test/server/test_data/server/bad_sds_ads_config_source.yaml
@@ -1,0 +1,81 @@
+node:
+  id: TEST
+  cluster: test
+  locality:
+    region: tor
+    zone: dev
+static_resources:
+  clusters:
+  - name: ads_cluster
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: ads_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: localhost
+                port_value: 18000
+  - name: test
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: test
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    port_value: 8583
+    transport_socket:
+      name: "envoy.transport_sockets.tls"
+      typed_config:
+        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+        common_tls_context:
+          validation_context_sds_secret_config:
+            name: val_cert
+            sds_config:
+              ads: {}
+              resource_api_version: V3
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+      envoy_grpc:
+        cluster_name: "ads_cluster"
+    transport_api_version: V3
+#node:
+#  id: TEST
+#  cluster: test
+#  locality:
+#    region: tor
+#    zone: dev
+#static_resources:
+#  clusters:
+#    - name: test
+#      connect_timeout: 1s
+#      type: strict_dns
+#      lb_policy: round_robin
+#      load_assignment:
+#        cluster_name: test
+#        endpoints:
+#          - lb_endpoints:
+#              - endpoint:
+#                  address:
+#                    socket_address:
+#                      address: localhost
+#                      port_value: 12345
+#      transport_socket:
+#        name: envoy.transport_sockets.tls
+#        typed_config:
+#          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+#          common_tls_context:
+#            validation_context_sds_secret_config:
+#              name: val_cert
+#              sds_config:
+#                ads: {}


### PR DESCRIPTION
Fix for [#15517](https://github.com/envoyproxy/envoy/issues/15517)

Commit Message: Prevent crash in case of ads configuration with no dynamic_resource.
Additional Description: See [Changes](https://github.com/envoyproxy/envoy/issues/15517#issuecomment-808203584)
Risk Level: TBD
Testing: Existing ADS test run, investigating creating custom one for this case.
Docs Changes: None
Release Notes: 
Dynamic Resource is required for ads configuration.  An ads configuration is not supported for primary clusters.
Platform Specific Features:
