### PR TITLE
listener: switch reuse_port default to true

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -35,7 +35,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 28]
+// [#next-free-field: 29]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -244,17 +244,21 @@ message Listener {
   // worker threads.
   ConnectionBalanceConfig connection_balance_config = 20;
 
+  // Deprecated. Use `enable_reuse_port` instead.
+  bool reuse_port = 21 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
   // When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
   // create one socket for each worker thread. This makes inbound connections
   // distribute among worker threads roughly evenly in cases where there are a high number
-  // of connections. When this flag is set to false, all worker threads share one socket.
+  // of connections. When this flag is set to false, all worker threads share one socket. This field
+  // defaults to true.
   //
   // Before Linux v4.19-rc1, new TCP connections may be rejected during hot restart
   // (see `3rd paragraph in 'soreuseport' commit message
   // <https://github.com/torvalds/linux/commit/c617f398edd4db2b8567a28e89>`_).
   // This issue was fixed by `tcp: Avoid TCP syncookie rejected by SO_REUSEPORT socket
   // <https://github.com/torvalds/linux/commit/40a1227ea845a37ab197dd1caffb60b047fa36b1>`_.
-  bool reuse_port = 21;
+  google.protobuf.BoolValue enable_reuse_port = 28;
 
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by this listener.

--- a/api/envoy/config/listener/v4alpha/listener.proto
+++ b/api/envoy/config/listener/v4alpha/listener.proto
@@ -37,7 +37,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 28]
+// [#next-free-field: 29]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.listener.v3.Listener";
 
@@ -97,9 +97,9 @@ message Listener {
         "envoy.config.listener.v3.Listener.InternalListenerConfig";
   }
 
-  reserved 14, 23, 7;
+  reserved 14, 23, 7, 21;
 
-  reserved "deprecated_v1";
+  reserved "deprecated_v1", "reuse_port";
 
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
@@ -249,14 +249,15 @@ message Listener {
   // When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
   // create one socket for each worker thread. This makes inbound connections
   // distribute among worker threads roughly evenly in cases where there are a high number
-  // of connections. When this flag is set to false, all worker threads share one socket.
+  // of connections. When this flag is set to false, all worker threads share one socket. This field
+  // defaults to true.
   //
   // Before Linux v4.19-rc1, new TCP connections may be rejected during hot restart
   // (see `3rd paragraph in 'soreuseport' commit message
   // <https://github.com/torvalds/linux/commit/c617f398edd4db2b8567a28e89>`_).
   // This issue was fixed by `tcp: Avoid TCP syncookie rejected by SO_REUSEPORT socket
   // <https://github.com/torvalds/linux/commit/40a1227ea845a37ab197dd1caffb60b047fa36b1>`_.
-  bool reuse_port = 21;
+  google.protobuf.BoolValue enable_reuse_port = 28;
 
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by this listener.

--- a/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
+++ b/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
@@ -7,7 +7,6 @@ admin:
 static_resources:
   listeners:
   - name: listener_0
-    reuse_port: true
     address:
       socket_address:
         protocol: UDP

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -56,6 +56,14 @@ Minor Behavior Changes
 * http: upstream flood and abuse checks increment the count of opened HTTP/2 streams when Envoy sends
   initial HEADERS frame for the new stream. Before the counter was incrementred when Envoy received
   response HEADERS frame with the END_HEADERS flag set from upstream server.
+* listener: added the :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`
+  field and changed the default for reuse port from false to true, as the feature is now well
+  supported on the majority of production kernels in use. The default change is aware of hot
+  restart, as otherwise the change would not be backwards compatible between restarts. This means
+  that hot restarting on to a new binary will retain the default of false until the binary undergoes
+  a full restart. To retain the previous behavior, either explicitly set the new configuration
+  field to false, or set the runtime feature flag `envoy.reloadable_features.listener_reuse_port_default_enabled`
+  to false.
 * lua: added function `timestamp` to provide millisecond resolution timestamps by passing in `EnvoyTimestampResolution.MILLISECOND`.
 * oauth filter: added the optional parameter :ref:`auth_scopes <envoy_v3_api_field_extensions.filters.http.oauth2.v3alpha.OAuth2Config.auth_scopes>` with default value of 'user' if not provided. Enables this value to be overridden in the Authorization request to the OAuth provider.
 * perf: allow reading more bytes per operation from raw sockets to improve performance.
@@ -182,4 +190,7 @@ Deprecated
 ----------
 
 * admin: :ref:`access_log_path <envoy_v3_api_field_config.bootstrap.v3.Admin.access_log_path>` is deprecated in favor for :ref:`access loggers <envoy_v3_api_msg_config.accesslog.v3.AccessLog>`.
+* listener: :ref:`reuse_port <envoy_v3_api_field_config.listener.v3.Listener.reuse_port>` has been
+  deprecated in favor of :ref:`enable_reuse_port <envoy_v3_api_field_config.listener.v3.Listener.enable_reuse_port>`.
+  At the same time, the default has been changed from false to true. See above for more information.
 

--- a/examples/udp/envoy.yaml
+++ b/examples/udp/envoy.yaml
@@ -1,7 +1,6 @@
 static_resources:
   listeners:
   - name: listener_0
-    reuse_port: true
     address:
       socket_address:
         protocol: UDP

--- a/generated_api_shadow/envoy/config/listener/v3/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v3/listener.proto
@@ -35,7 +35,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 28]
+// [#next-free-field: 29]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.Listener";
 
@@ -244,17 +244,21 @@ message Listener {
   // worker threads.
   ConnectionBalanceConfig connection_balance_config = 20;
 
+  // Deprecated. Use `enable_reuse_port` instead.
+  bool reuse_port = 21 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
   // When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
   // create one socket for each worker thread. This makes inbound connections
   // distribute among worker threads roughly evenly in cases where there are a high number
-  // of connections. When this flag is set to false, all worker threads share one socket.
+  // of connections. When this flag is set to false, all worker threads share one socket. This field
+  // defaults to true.
   //
   // Before Linux v4.19-rc1, new TCP connections may be rejected during hot restart
   // (see `3rd paragraph in 'soreuseport' commit message
   // <https://github.com/torvalds/linux/commit/c617f398edd4db2b8567a28e89>`_).
   // This issue was fixed by `tcp: Avoid TCP syncookie rejected by SO_REUSEPORT socket
   // <https://github.com/torvalds/linux/commit/40a1227ea845a37ab197dd1caffb60b047fa36b1>`_.
-  bool reuse_port = 21;
+  google.protobuf.BoolValue enable_reuse_port = 28;
 
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by this listener.

--- a/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
+++ b/generated_api_shadow/envoy/config/listener/v4alpha/listener.proto
@@ -38,7 +38,7 @@ message ListenerCollection {
   repeated xds.core.v3.CollectionEntry entries = 1;
 }
 
-// [#next-free-field: 28]
+// [#next-free-field: 29]
 message Listener {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.listener.v3.Listener";
 
@@ -249,17 +249,22 @@ message Listener {
   // worker threads.
   ConnectionBalanceConfig connection_balance_config = 20;
 
+  // Deprecated. Use `enable_reuse_port` instead.
+  bool hidden_envoy_deprecated_reuse_port = 21
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
   // When this flag is set to true, listeners set the *SO_REUSEPORT* socket option and
   // create one socket for each worker thread. This makes inbound connections
   // distribute among worker threads roughly evenly in cases where there are a high number
-  // of connections. When this flag is set to false, all worker threads share one socket.
+  // of connections. When this flag is set to false, all worker threads share one socket. This field
+  // defaults to true.
   //
   // Before Linux v4.19-rc1, new TCP connections may be rejected during hot restart
   // (see `3rd paragraph in 'soreuseport' commit message
   // <https://github.com/torvalds/linux/commit/c617f398edd4db2b8567a28e89>`_).
   // This issue was fixed by `tcp: Avoid TCP syncookie rejected by SO_REUSEPORT socket
   // <https://github.com/torvalds/linux/commit/40a1227ea845a37ab197dd1caffb60b047fa36b1>`_.
-  bool reuse_port = 21;
+  google.protobuf.BoolValue enable_reuse_port = 28;
 
   // Configuration for :ref:`access logs <arch_overview_access_logs>`
   // emitted by this listener.

--- a/include/envoy/server/hot_restart.h
+++ b/include/envoy/server/hot_restart.h
@@ -28,6 +28,11 @@ public:
     uint64_t parent_connections_ = 0;
   };
 
+  struct AdminShutdownResponse {
+    time_t original_start_time_;
+    bool enable_reuse_port_default_;
+  };
+
   virtual ~HotRestart() = default;
 
   /**
@@ -54,9 +59,9 @@ public:
   /**
    * Shutdown admin processing in the parent process if applicable. This allows admin processing
    * to start up in the new process.
-   * @param original_start_time will be filled with information from our parent, if retrieved.
+   * @return response if the parent is alive.
    */
-  virtual void sendParentAdminShutdownRequest(time_t& original_start_time) PURE;
+  virtual absl::optional<AdminShutdownResponse> sendParentAdminShutdownRequest() PURE;
 
   /**
    * Tell our parent process to gracefully terminate itself.

--- a/include/envoy/server/instance.h
+++ b/include/envoy/server/instance.h
@@ -255,6 +255,16 @@ public:
    */
   virtual void
   setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) PURE;
+
+  /**
+   * Return the default for whether reuse port is enabled or not. This was added as part of
+   * fixing https://github.com/envoyproxy/envoy/issues/15794. It is required to know what the
+   * default was of parent processes during hot restart was, because otherwise switching the
+   * default on the fly will break existing deployments.
+   * TODO(mattklein123): This can be removed when the version this was added in is no longer
+   * supported.
+   */
+  virtual bool enableReusePortDefault() PURE;
 };
 
 } // namespace Server

--- a/include/envoy/server/listener_manager.h
+++ b/include/envoy/server/listener_manager.h
@@ -35,7 +35,7 @@ public:
 using LdsApiPtr = std::unique_ptr<LdsApi>;
 
 struct ListenSocketCreationParams {
-  ListenSocketCreationParams(bool bind_to_port, bool duplicate_parent_socket = true)
+  ListenSocketCreationParams(bool bind_to_port, bool duplicate_parent_socket)
       : bind_to_port(bind_to_port), duplicate_parent_socket(duplicate_parent_socket) {}
 
   // For testing.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -70,6 +70,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.grpc_web_fix_non_proto_encoded_response_handling",
     "envoy.reloadable_features.grpc_json_transcoder_adhere_to_buffer_limits",
     "envoy.reloadable_features.hcm_stream_error_on_invalid_message",
+    "envoy.reloadable_features.header_map_correctly_coalesce_cookies",
     "envoy.reloadable_features.health_check.graceful_goaway_handling",
     "envoy.reloadable_features.health_check.immediate_failure_exclude_from_cluster",
     "envoy.reloadable_features.http_match_on_all_headers",
@@ -78,6 +79,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.http_upstream_wait_connect_response",
     "envoy.reloadable_features.http2_skip_encoding_empty_trailers",
     "envoy.reloadable_features.improved_stream_limit_handling",
+    "envoy.reloadable_features.listener_reuse_port_default_enabled",
     "envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2",
     "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing",
     "envoy.reloadable_features.preserve_downstream_scheme",
@@ -95,7 +97,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.unify_grpc_handling",
     "envoy.reloadable_features.upstream_http2_flood_checks",
     "envoy.restart_features.use_apple_api_for_dns_lookups",
-    "envoy.reloadable_features.header_map_correctly_coalesce_cookies",
 };
 
 // This is a section for officially sanctioned runtime features which are too

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -109,6 +109,7 @@ public:
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
   }
+  bool enableReusePortDefault() override { return true; }
 
   Configuration::StatsConfig& statsConfig() override { return config_.statsConfig(); }
   Configuration::ServerFactoryContext& serverFactoryContext() override { return server_contexts_; }

--- a/source/server/hot_restart.proto
+++ b/source/server/hot_restart.proto
@@ -32,6 +32,9 @@ message HotRestartMessage {
     }
     message ShutdownAdmin {
       uint64 original_start_time_unix_seconds = 1;
+      // See the comments on Server::Instance::enableReusePortDefault() for why this exists. The
+      // default is false for backwards compatibility.
+      bool enable_reuse_port_default = 2;
     }
     message Span {
       uint32 first = 1;

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -122,8 +122,8 @@ void HotRestartImpl::initialize(Event::Dispatcher& dispatcher, Server::Instance&
   as_parent_.initialize(dispatcher, server);
 }
 
-void HotRestartImpl::sendParentAdminShutdownRequest(time_t& original_start_time) {
-  as_child_.sendParentAdminShutdownRequest(original_start_time);
+absl::optional<HotRestart::AdminShutdownResponse> HotRestartImpl::sendParentAdminShutdownRequest() {
+  return as_child_.sendParentAdminShutdownRequest();
 }
 
 void HotRestartImpl::sendParentTerminateRequest() { as_child_.sendParentTerminateRequest(); }

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -105,7 +105,7 @@ public:
   void drainParentListeners() override;
   int duplicateParentListenSocket(const std::string& address) override;
   void initialize(Event::Dispatcher& dispatcher, Server::Instance& server) override;
-  void sendParentAdminShutdownRequest(time_t& original_start_time) override;
+  absl::optional<AdminShutdownResponse> sendParentAdminShutdownRequest() override;
   void sendParentTerminateRequest() override;
   ServerStatsFromParent mergeParentStatsIfAny(Stats::StoreRoot& stats_store) override;
   void shutdown() override;

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -19,7 +19,9 @@ public:
   void drainParentListeners() override {}
   int duplicateParentListenSocket(const std::string&) override { return -1; }
   void initialize(Event::Dispatcher&, Server::Instance&) override {}
-  void sendParentAdminShutdownRequest(time_t&) override {}
+  absl::optional<AdminShutdownResponse> sendParentAdminShutdownRequest() override {
+    return absl::nullopt;
+  }
   void sendParentTerminateRequest() override {}
   ServerStatsFromParent mergeParentStatsIfAny(Stats::StoreRoot&) override { return {}; }
   void shutdown() override {}

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -59,9 +59,10 @@ void HotRestartingChild::drainParentListeners() {
   sendHotRestartMessage(parent_address_, wrapped_request);
 }
 
-void HotRestartingChild::sendParentAdminShutdownRequest(time_t& original_start_time) {
+absl::optional<HotRestart::AdminShutdownResponse>
+HotRestartingChild::sendParentAdminShutdownRequest() {
   if (restart_epoch_ == 0 || parent_terminated_) {
-    return;
+    return absl::nullopt;
   }
 
   HotRestartMessage wrapped_request;
@@ -71,7 +72,10 @@ void HotRestartingChild::sendParentAdminShutdownRequest(time_t& original_start_t
   std::unique_ptr<HotRestartMessage> wrapped_reply = receiveHotRestartMessage(Blocking::Yes);
   RELEASE_ASSERT(replyIsExpectedType(wrapped_reply.get(), HotRestartMessage::Reply::kShutdownAdmin),
                  "Hot restart parent did not respond as expected to ShutdownParentAdmin.");
-  original_start_time = wrapped_reply->reply().shutdown_admin().original_start_time_unix_seconds();
+  return HotRestart::AdminShutdownResponse{
+      static_cast<time_t>(
+          wrapped_reply->reply().shutdown_admin().original_start_time_unix_seconds()),
+      wrapped_reply->reply().shutdown_admin().enable_reuse_port_default()};
 }
 
 void HotRestartingChild::sendParentTerminateRequest() {

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -18,7 +18,7 @@ public:
   int duplicateParentListenSocket(const std::string& address);
   std::unique_ptr<envoy::HotRestartMessage> getParentStats();
   void drainParentListeners();
-  void sendParentAdminShutdownRequest(time_t& original_start_time);
+  absl::optional<HotRestart::AdminShutdownResponse> sendParentAdminShutdownRequest();
   void sendParentTerminateRequest();
   void mergeParentStats(Stats::Store& stats_store,
                         const envoy::HotRestartMessage::Reply::Stats& stats_proto);

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -96,6 +96,8 @@ HotRestartMessage HotRestartingParent::Internal::shutdownAdmin() {
   HotRestartMessage wrapped_reply;
   wrapped_reply.mutable_reply()->mutable_shutdown_admin()->set_original_start_time_unix_seconds(
       server_->startTimeFirstEpoch());
+  wrapped_reply.mutable_reply()->mutable_shutdown_admin()->set_enable_reuse_port_default(
+      server_->enableReusePortDefault());
   return wrapped_reply;
 }
 

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -280,6 +280,8 @@ public:
   void setSocketAndOptions(const Network::SocketSharedPtr& socket);
   const Network::Socket::OptionsSharedPtr& listenSocketOptions() { return listen_socket_options_; }
   const std::string& versionInfo() const { return version_info_; }
+  static bool enableReusePort(Server::Instance& server,
+                              const envoy::config::listener::v3::Listener& config);
 
   // Network::ListenerConfig
   Network::FilterChainManager& filterChainManager() override { return filter_chain_manager_; }

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -523,7 +523,7 @@ bool ListenerManagerImpl::addOrUpdateListenerInternal(
             ? draining_listen_socket_factory
             : createListenSocketFactory(config.address(), *new_listener,
                                         (socket_type == Network::Socket::Type::Datagram) ||
-                                            config.reuse_port()));
+                                            ListenerImpl::enableReusePort(server_, config)));
     if (workers_started_) {
       new_listener->debugLog("add warming listener");
       warming_listeners_.emplace_back(std::move(new_listener));

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -908,6 +908,8 @@ bool InstanceImpl::enableReusePortDefault() {
     return Runtime::runtimeFeatureEnabled(
         "envoy.reloadable_features.listener_reuse_port_default_enabled");
   }
+
+  NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
 } // namespace Server

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -426,7 +426,16 @@ void InstanceImpl::initialize(const Options& options,
   Configuration::InitialImpl initial_config(bootstrap_, options, *this);
 
   // Learn original_start_time_ if our parent is still around to inform us of it.
-  restarter_.sendParentAdminShutdownRequest(original_start_time_);
+  const auto parent_admin_shutdown_response = restarter_.sendParentAdminShutdownRequest();
+  if (parent_admin_shutdown_response.has_value()) {
+    original_start_time_ = parent_admin_shutdown_response.value().original_start_time_;
+    enable_reuse_port_default_ = parent_admin_shutdown_response.value().enable_reuse_port_default_
+                                     ? ReusePortDefault::True
+                                     : ReusePortDefault::False;
+  } else {
+    // This is needed so that we don't read the value until runtime is fully initialized.
+    enable_reuse_port_default_ = ReusePortDefault::Runtime;
+  }
   admin_ = std::make_unique<AdminImpl>(initial_config.admin().profilePath(), *this);
 
   loadServerFlags(initial_config.flagsPath());
@@ -886,6 +895,19 @@ ProtobufTypes::MessagePtr InstanceImpl::dumpBootstrapConfig() {
   TimestampUtil::systemClockToTimestamp(bootstrap_config_update_time_,
                                         *(config_dump->mutable_last_updated()));
   return config_dump;
+}
+
+bool InstanceImpl::enableReusePortDefault() {
+  ASSERT(enable_reuse_port_default_.has_value());
+  switch (enable_reuse_port_default_.value()) {
+  case ReusePortDefault::True:
+    return true;
+  case ReusePortDefault::False:
+    return false;
+  case ReusePortDefault::Runtime:
+    return Runtime::runtimeFeatureEnabled(
+        "envoy.reloadable_features.listener_reuse_port_default_enabled");
+  }
 }
 
 } // namespace Server

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -273,22 +273,18 @@ public:
   LocalInfo::LocalInfo& localInfo() const override { return *local_info_; }
   TimeSource& timeSource() override { return time_source_; }
   void flushStats() override;
-
   Configuration::StatsConfig& statsConfig() override { return config_.statsConfig(); }
-
   Configuration::ServerFactoryContext& serverFactoryContext() override { return server_contexts_; }
-
   Configuration::TransportSocketFactoryContext& transportSocketFactoryContext() override {
     return server_contexts_;
   }
-
   ProtobufMessage::ValidationContext& messageValidationContext() override {
     return validation_context_;
   }
-
   void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) override {
     http_context_.setDefaultTracingConfig(tracing_config);
   }
+  bool enableReusePortDefault() override;
 
   // ServerLifecycleNotifier
   ServerLifecycleNotifier::HandlePtr registerCallback(Stage stage, StageCallback callback) override;
@@ -296,6 +292,8 @@ public:
   registerCallback(Stage stage, StageCallbackWithCompletion callback) override;
 
 private:
+  enum class ReusePortDefault { True, False, Runtime };
+
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
   void flushStatsInternal();
   void updateServerStats();
@@ -382,8 +380,8 @@ private:
   // whenever we have support for histogram merge across hot restarts.
   Stats::TimespanPtr initialization_timer_;
   ListenerHooks& hooks_;
-
   ServerFactoryContextImpl server_contexts_;
+  absl::optional<ReusePortDefault> enable_reuse_port_default_;
 
   template <class T>
   class LifecycleCallbackHandle : public ServerLifecycleNotifier::Handle, RaiiListElement<T> {

--- a/test/config/integration/server.yaml
+++ b/test/config/integration/server.yaml
@@ -4,7 +4,7 @@ static_resources:
       socket_address:
         address: {{ ip_loopback_address }}
         port_value: 0
-    reuse_port: {{ reuse_port }}
+    enable_reuse_port: {{ enable_reuse_port }}
     filter_chains:
     - filters:
       - name: http

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -1077,7 +1077,7 @@ void ConfigHelper::addSslConfig(const ServerSslOptions& options) {
   filter_chain->mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
 }
 
-void ConfigHelper::addQuicDownstreamTransportSocketConfig(bool reuse_port) {
+void ConfigHelper::addQuicDownstreamTransportSocketConfig() {
   envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport
       quic_transport_socket_config;
   auto tls_context = quic_transport_socket_config.mutable_downstream_tls_context();
@@ -1089,7 +1089,6 @@ void ConfigHelper::addQuicDownstreamTransportSocketConfig(bool reuse_port) {
       auto* filter_chain = listener.mutable_filter_chains(0);
       auto* transport_socket = filter_chain->mutable_transport_socket();
       transport_socket->mutable_typed_config()->PackFrom(quic_transport_socket_config);
-      listener.set_reuse_port(reuse_port);
     }
   }
 }

--- a/test/config/utility.h
+++ b/test/config/utility.h
@@ -234,7 +234,7 @@ public:
   void addSslConfig() { addSslConfig({}); }
 
   // Add the default SSL configuration for QUIC downstream.
-  void addQuicDownstreamTransportSocketConfig(bool resuse_port);
+  void addQuicDownstreamTransportSocketConfig();
 
   // Set the HTTP access log for the first HCM (if present) to a given file. The default is
   // the platform's null device.

--- a/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_integration_test.cc
@@ -75,7 +75,6 @@ static_resources:
   getListener0(Network::Address::InstanceConstSharedPtr& addr) {
     auto config = fmt::format(R"EOF(
 name: listener_0
-reuse_port: true
 address:
   socket_address:
     address: {}

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_integration_test.cc
@@ -120,6 +120,12 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, UdpProxyIntegrationTest,
 // > 1.
 TEST_P(UdpProxyIntegrationTest, NoReusePort) {
   concurrency_ = 2;
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    bootstrap.mutable_static_resources()
+        ->mutable_listeners(0)
+        ->mutable_enable_reuse_port()
+        ->set_value(false);
+  });
   // Do not wait for listeners to start as the listener will fail.
   defer_listener_finalization_ = true;
   setup(1);

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -26,7 +26,7 @@ if [[ -z "${ENVOY_IP_TEST_VERSIONS}" ]] || [[ "${ENVOY_IP_TEST_VERSIONS}" == "al
     sed -e "s#{{ test_rundir }}#$TEST_SRCDIR/envoy#" | \
     sed -e "s#{{ test_tmpdir }}#$TEST_TMPDIR#" | \
     sed -e "s#{{ ip_loopback_address }}#127.0.0.1#" | \
-    sed -e "s#{{ reuse_port }}#false#" | \
+    sed -e "s#{{ enable_reuse_port }}#false#" | \
     sed -e "s#{{ dns_lookup_family }}#V4_ONLY#" | \
     sed -e "s#{{ null_device_path }}#/dev/null#" | \
     cat > "${HOT_RESTART_JSON_V4}"
@@ -40,7 +40,7 @@ if [[ -z "${ENVOY_IP_TEST_VERSIONS}" ]] || [[ "${ENVOY_IP_TEST_VERSIONS}" == "al
     sed -e "s#{{ test_rundir }}#$TEST_SRCDIR/envoy#" | \
     sed -e "s#{{ test_tmpdir }}#$TEST_TMPDIR#" | \
     sed -e "s#{{ ip_loopback_address }}#::1#" | \
-    sed -e "s#{{ reuse_port }}#false#" | \
+    sed -e "s#{{ enable_reuse_port }}#false#" | \
     sed -e "s#{{ dns_lookup_family }}#v6_only#" | \
     sed -e "s#{{ null_device_path }}#/dev/null#" | \
     cat > "${HOT_RESTART_JSON_V6}"
@@ -64,7 +64,7 @@ sed -e "s#{{ upstream_. }}#0#g" "${TEST_SRCDIR}/envoy"/test/config/integration/s
   sed -e "s#{{ test_rundir }}#$TEST_SRCDIR/envoy#" | \
   sed -e "s#{{ test_tmpdir }}#$TEST_TMPDIR#" | \
   sed -e "s#{{ ip_loopback_address }}#127.0.0.1#" | \
-  sed -e "s#{{ reuse_port }}#true#" | \
+  sed -e "s#{{ enable_reuse_port }}#true#" | \
   sed -e "s#{{ dns_lookup_family }}#V4_ONLY#" | \
   sed -e "s#{{ null_device_path }}#/dev/null#" | \
   cat > "${HOT_RESTART_JSON_REUSE_PORT}"

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -324,7 +324,7 @@ void HttpIntegrationTest::initialize() {
 
   // Needed to config QUIC transport socket factory, and needs to be added before base class calls
   // initialize().
-  config_helper_.addQuicDownstreamTransportSocketConfig(set_reuse_port_);
+  config_helper_.addQuicDownstreamTransportSocketConfig();
 
   BaseIntegrationTest::initialize();
   registerTestServerPorts({"http"});

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -263,7 +263,6 @@ protected:
   std::string access_log_name_;
   testing::NiceMock<Random::MockRandomGenerator> random_;
 
-  bool set_reuse_port_{false};
   std::string san_to_match_{"spiffe://lyft.com/backend-team"};
 };
 

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -66,7 +66,6 @@ TEST_P(IntegrationTest, BadPrebindSocketOptionWithReusePort) {
 
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
-    listener->set_reuse_port(true);
     listener->mutable_address()->mutable_socket_address()->set_port_value(
         addr_socket.second->addressProvider().localAddress()->ip()->port());
     auto socket_option = listener->add_socket_options();
@@ -88,7 +87,6 @@ TEST_P(IntegrationTest, BadPostbindSocketOptionWithReusePort) {
 
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
     auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
-    listener->set_reuse_port(true);
     listener->mutable_address()->mutable_socket_address()->set_port_value(
         addr_socket.second->addressProvider().localAddress()->ip()->port());
     auto socket_option = listener->add_socket_options();

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -344,9 +344,6 @@ TEST_P(ListenerIntegrationTest, BasicSuccess) {
 TEST_P(ListenerIntegrationTest, MultipleLdsUpdatesSharingListenSocketFactory) {
   on_server_init_function_ = [&]() {
     createLdsStream();
-    // Set reuse_port so that a new socket is created by the
-    // ListenSocketFactory.
-    listener_config_.set_reuse_port(true);
     sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "1");
     createRdsStream(route_table_name_);
   };

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -207,7 +207,6 @@ public:
 
   void testMultipleQuicConnections() {
     concurrency_ = 8;
-    set_reuse_port_ = true;
     initialize();
     std::vector<IntegrationCodecClientPtr> codec_clients;
     for (size_t i = 1; i <= concurrency_; ++i) {
@@ -381,7 +380,6 @@ TEST_P(QuicHttpIntegrationTest, MultipleQuicConnectionsNoBPF) {
 
 TEST_P(QuicHttpIntegrationTest, ConnectionMigration) {
   concurrency_ = 2;
-  set_reuse_port_ = true;
   initialize();
   uint32_t old_port = lookupPort("http");
   codec_client_ = makeHttpConnection(old_port);

--- a/test/mocks/server/hot_restart.h
+++ b/test/mocks/server/hot_restart.h
@@ -18,7 +18,7 @@ public:
   MOCK_METHOD(int, duplicateParentListenSocket, (const std::string& address));
   MOCK_METHOD(std::unique_ptr<envoy::HotRestartMessage>, getParentStats, ());
   MOCK_METHOD(void, initialize, (Event::Dispatcher & dispatcher, Server::Instance& server));
-  MOCK_METHOD(void, sendParentAdminShutdownRequest, (time_t & original_start_time));
+  MOCK_METHOD(absl::optional<AdminShutdownResponse>, sendParentAdminShutdownRequest, ());
   MOCK_METHOD(void, sendParentTerminateRequest, ());
   MOCK_METHOD(ServerStatsFromParent, mergeParentStatsIfAny, (Stats::StoreRoot & stats_store));
   MOCK_METHOD(void, shutdown, ());

--- a/test/mocks/server/instance.cc
+++ b/test/mocks/server/instance.cc
@@ -50,6 +50,7 @@ MockInstance::MockInstance()
   ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(*server_factory_context_));
   ON_CALL(*this, transportSocketFactoryContext())
       .WillByDefault(ReturnRef(*transport_socket_factory_context_));
+  ON_CALL(*this, enableReusePortDefault()).WillByDefault(Return(true));
 }
 
 MockInstance::~MockInstance() = default;

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -86,6 +86,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(Configuration::ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Configuration::TransportSocketFactoryContext&, transportSocketFactoryContext, ());
+  MOCK_METHOD(bool, enableReusePortDefault, ());
 
   void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) override {
     http_context_.setDefaultTracingConfig(tracing_config);

--- a/test/server/listener_manager_impl_quic_only_test.cc
+++ b/test/server/listener_manager_impl_quic_only_test.cc
@@ -54,7 +54,6 @@ filter_chains:
             match_subject_alt_names:
             - exact: localhost
             - exact: 127.0.0.1
-reuse_port: true
 udp_listener_config:
   quic_options: {}
   )EOF",
@@ -156,7 +155,6 @@ filter_chains:
           match_subject_alt_names:
           - exact: localhost
           - exact: 127.0.0.1
-reuse_port: true
 udp_listener_config:
   quic_options: {}
   )EOF",

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -347,6 +347,7 @@ TEST_P(ServerInstanceImplTest, StatsFlushWhenServerIsStillInitializing) {
   EXPECT_EQ(3L, TestUtility::findGauge(stats_store_, "server.state")->value());
   EXPECT_EQ(Init::Manager::State::Initializing, server_->initManager().state());
 
+  EXPECT_TRUE(server_->enableReusePortDefault());
   server_->dispatcher().post([&] { server_->shutdown(); });
   server_thread->join();
 }
@@ -1060,6 +1061,7 @@ TEST_P(ServerInstanceImplTest, BootstrapNodeWithOptionsOverride) {
 TEST_P(ServerInstanceImplTest, BootstrapRuntime) {
   options_.service_cluster_name_ = "some_service";
   initialize("test/server/test_data/server/runtime_bootstrap.yaml");
+  EXPECT_FALSE(server_->enableReusePortDefault());
   EXPECT_EQ("bar", server_->runtime().snapshot().get("foo").value().get());
   // This should access via the override/some_service overlay.
   EXPECT_EQ("fozz", server_->runtime().snapshot().get("fizz").value().get());

--- a/test/server/test_data/server/runtime_bootstrap.yaml
+++ b/test/server/test_data/server/runtime_bootstrap.yaml
@@ -3,6 +3,7 @@ layered_runtime:
     - name: some_static_layer
       static_layer:
         foo: bar
+        envoy.reloadable_features.listener_reuse_port_default_enabled: false
     - name: base_disk_layer
       disk_layer: { symlink_root: {{ test_rundir }}/test/server/test_data/runtime/primary }
     - name: overlay_disk_layer


### PR DESCRIPTION
1) Deprecate existing reuse_port field
2) Add new enable_reuse_port field which uses a WKT
3) Make the new default hot restart aware so the default is
   not changed during hot restart.
4) Allow the default to be reverted using the
   "envoy.reloadable_features.listener_reuse_port_default_enabled"
   feature flag.

Fixes https://github.com/envoyproxy/envoy/issues/15794

Risk Level: Medium, scary stuff involving hot restart
Testing: New and existing tests. It was hard to get the tests to pass which gives me more confidence.
Docs Changes: N/A
Release Notes: Added
Platform Specific Features: N/A
