### PR TITLE
api: fix go importpath for OT dep

### DIFF
--- a/api/bazel/external_proto_deps.bzl
+++ b/api/bazel/external_proto_deps.bzl
@@ -14,7 +14,7 @@ EXTERNAL_PROTO_IMPORT_BAZEL_DEP_MAP = {
     "metrics.proto": "@prometheus_metrics_model//:client_model",
     "opencensus/proto/trace/v1/trace.proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto",
     "opencensus/proto/trace/v1/trace_config.proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto",
-    "opentelemetry/proto/common/v1/common.proto": "@opentelemetry_proto//:logs",
+    "opentelemetry/proto/common/v1/common.proto": "@opentelemetry_proto//:common",
 }
 
 # This maps from the Bazel proto_library target to the Go language binding target for external dependencies.
@@ -24,6 +24,7 @@ EXTERNAL_PROTO_GO_BAZEL_DEP_MAP = {
     "@opencensus_proto//opencensus/proto/trace/v1:trace_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_go",
     "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_and_config_proto_go",
     "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_go_proto",
+    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_go_proto",
 }
 
 # This maps from the Bazel proto_library target to the C++ language binding target for external dependencies.
@@ -33,6 +34,7 @@ EXTERNAL_PROTO_CC_BAZEL_DEP_MAP = {
     "@opencensus_proto//opencensus/proto/trace/v1:trace_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_cc",
     "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto_cc",
     "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_cc_proto",
+    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_cc_proto",
 }
 
 # This maps from the Bazel proto_library target to the Python language binding target for external dependencies.
@@ -42,4 +44,5 @@ EXTERNAL_PROTO_PY_BAZEL_DEP_MAP = {
     "@opencensus_proto//opencensus/proto/trace/v1:trace_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_py",
     "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto_py",
     "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_py_proto",
+    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_py_proto",
 }

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -128,6 +128,8 @@ go_proto_library(
     visibility = ["//visibility:public"],
 )
 
+# TODO(snowp): Generating one Go package from all of these protos could cause problems in the future,
+# but nothing references symbols from collector or resource so we're fine for now.
 api_cc_py_proto_library(
     name = "logs",
     srcs = [

--- a/api/bazel/repositories.bzl
+++ b/api/bazel/repositories.bzl
@@ -114,19 +114,36 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 api_cc_py_proto_library(
+    name = "common",
+    srcs = [
+        "opentelemetry/proto/common/v1/common.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "common_go_proto",
+    importpath = "go.opentelemetry.io/proto/otlp/common/v1",
+    proto = ":common",
+    visibility = ["//visibility:public"],
+)
+
+api_cc_py_proto_library(
     name = "logs",
     srcs = [
         "opentelemetry/proto/collector/logs/v1/logs_service.proto",
-        "opentelemetry/proto/common/v1/common.proto",
         "opentelemetry/proto/logs/v1/logs.proto",
         "opentelemetry/proto/resource/v1/resource.proto",
+    ],
+    deps = [
+        "//:common",
     ],
     visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "logs_go_proto",
-    importpath = "logs",
+    importpath = "go.opentelemetry.io/proto/otlp/logs/v1",
     proto = ":logs",
     visibility = ["//visibility:public"],
 )

--- a/api/envoy/extensions/access_loggers/open_telemetry/v3alpha/BUILD
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v3alpha/BUILD
@@ -8,6 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/extensions/access_loggers/grpc/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@opentelemetry_proto//:logs",
+        "@opentelemetry_proto//:common",
     ],
 )

--- a/api/envoy/extensions/access_loggers/open_telemetry/v4alpha/BUILD
+++ b/api/envoy/extensions/access_loggers/open_telemetry/v4alpha/BUILD
@@ -9,6 +9,6 @@ api_proto_package(
         "//envoy/extensions/access_loggers/grpc/v4alpha:pkg",
         "//envoy/extensions/access_loggers/open_telemetry/v3alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@opentelemetry_proto//:logs",
+        "@opentelemetry_proto//:common",
     ],
 )

--- a/generated_api_shadow/bazel/external_proto_deps.bzl
+++ b/generated_api_shadow/bazel/external_proto_deps.bzl
@@ -14,7 +14,7 @@ EXTERNAL_PROTO_IMPORT_BAZEL_DEP_MAP = {
     "metrics.proto": "@prometheus_metrics_model//:client_model",
     "opencensus/proto/trace/v1/trace.proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto",
     "opencensus/proto/trace/v1/trace_config.proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto",
-    "opentelemetry/proto/common/v1/common.proto": "@opentelemetry_proto//:logs",
+    "opentelemetry/proto/common/v1/common.proto": "@opentelemetry_proto//:common",
 }
 
 # This maps from the Bazel proto_library target to the Go language binding target for external dependencies.
@@ -24,6 +24,7 @@ EXTERNAL_PROTO_GO_BAZEL_DEP_MAP = {
     "@opencensus_proto//opencensus/proto/trace/v1:trace_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_go",
     "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_and_config_proto_go",
     "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_go_proto",
+    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_go_proto",
 }
 
 # This maps from the Bazel proto_library target to the C++ language binding target for external dependencies.
@@ -33,6 +34,7 @@ EXTERNAL_PROTO_CC_BAZEL_DEP_MAP = {
     "@opencensus_proto//opencensus/proto/trace/v1:trace_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_cc",
     "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto_cc",
     "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_cc_proto",
+    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_cc_proto",
 }
 
 # This maps from the Bazel proto_library target to the Python language binding target for external dependencies.
@@ -42,4 +44,5 @@ EXTERNAL_PROTO_PY_BAZEL_DEP_MAP = {
     "@opencensus_proto//opencensus/proto/trace/v1:trace_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_proto_py",
     "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto": "@opencensus_proto//opencensus/proto/trace/v1:trace_config_proto_py",
     "@opentelemetry_proto//:logs": "@opentelemetry_proto//:logs_py_proto",
+    "@opentelemetry_proto//:common": "@opentelemetry_proto//:common_py_proto",
 }

--- a/generated_api_shadow/bazel/repositories.bzl
+++ b/generated_api_shadow/bazel/repositories.bzl
@@ -128,6 +128,8 @@ go_proto_library(
     visibility = ["//visibility:public"],
 )
 
+# TODO(snowp): Generating one Go package from all of these protos could cause problems in the future,
+# but nothing references symbols from collector or resource so we're fine for now.
 api_cc_py_proto_library(
     name = "logs",
     srcs = [

--- a/generated_api_shadow/bazel/repositories.bzl
+++ b/generated_api_shadow/bazel/repositories.bzl
@@ -114,19 +114,36 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 api_cc_py_proto_library(
+    name = "common",
+    srcs = [
+        "opentelemetry/proto/common/v1/common.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "common_go_proto",
+    importpath = "go.opentelemetry.io/proto/otlp/common/v1",
+    proto = ":common",
+    visibility = ["//visibility:public"],
+)
+
+api_cc_py_proto_library(
     name = "logs",
     srcs = [
         "opentelemetry/proto/collector/logs/v1/logs_service.proto",
-        "opentelemetry/proto/common/v1/common.proto",
         "opentelemetry/proto/logs/v1/logs.proto",
         "opentelemetry/proto/resource/v1/resource.proto",
+    ],
+    deps = [
+        "//:common",
     ],
     visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "logs_go_proto",
-    importpath = "logs",
+    importpath = "go.opentelemetry.io/proto/otlp/logs/v1",
     proto = ":logs",
     visibility = ["//visibility:public"],
 )

--- a/generated_api_shadow/envoy/extensions/access_loggers/open_telemetry/v3alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/access_loggers/open_telemetry/v3alpha/BUILD
@@ -8,6 +8,6 @@ api_proto_package(
     deps = [
         "//envoy/extensions/access_loggers/grpc/v3:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@opentelemetry_proto//:logs",
+        "@opentelemetry_proto//:common",
     ],
 )

--- a/generated_api_shadow/envoy/extensions/access_loggers/open_telemetry/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/access_loggers/open_telemetry/v4alpha/BUILD
@@ -9,6 +9,6 @@ api_proto_package(
         "//envoy/extensions/access_loggers/grpc/v4alpha:pkg",
         "//envoy/extensions/access_loggers/open_telemetry/v3alpha:pkg",
         "@com_github_cncf_udpa//udpa/annotations:pkg",
-        "@opentelemetry_proto//:logs",
+        "@opentelemetry_proto//:common",
     ],
 )


### PR DESCRIPTION
Fixes a few issues with the generated Go protobuf code:

a) the OT protos are not copied over, which means that their importpath
needs to reference a path where the go toolchain can pull the protos down.
 The "logs" importpath was nonsensical and couldn't be resolved
b) Bunching several proto packages into one target did not work well
with the go package system. This splits the common protos out into its
own target so that it can reference a different importpath than the
other logs protos

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, build only
Testing: Verified that go-control-plane builds with new protos
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
Fixes #15817 