### PR TITLE
tools: update devcontainer Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,10 @@ ARG USER_GID=$USER_UID
 ENV BUILD_DIR=/build
 ENV ENVOY_STDLIB=libstdc++
 
+# Obtain a copy of PGP key from https://apt.kitware.com/.
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update \
   && apt-get -y install --no-install-recommends libpython2.7 net-tools psmisc vim 2>&1 \


### PR DESCRIPTION
Fix the following GPG error when building devcontainer image:

```
Get:25 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [11.4 kB]
Reading package lists...
W: GPG error: https://apt.kitware.com/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY DE19EB17684BA42D
E: The repository 'https://apt.kitware.com/ubuntu bionic InRelease' is not signed.
The command '/bin/sh -c apt-get -y update   && apt-get -y install --no-install-recommends libpython2.7 net-tools psmisc vim 2>&1   && groupadd --gid $USER_GID $USERNAME   && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME -G pcap -d /build   && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME   && chmod 0440 /etc/sudoers.d/$USERNAME' returned a non-zero code: 100
```

Commit Message: Update devcontainer Dockerfile to fix GPG error.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
