### PR TITLE
quic: turning up 100 continue tests

### DIFF
--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -157,6 +157,7 @@ void QuicFilterManagerConnectionImpl::onConnectionCloseEvent(
     raiseConnectionEvent(source == quic::ConnectionCloseSource::FROM_PEER
                              ? Network::ConnectionEvent::RemoteClose
                              : Network::ConnectionEvent::LocalClose);
+    ASSERT(quic_connection_ != nullptr);
     quic_connection_ = nullptr;
   }
 }

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -157,6 +157,7 @@ void QuicFilterManagerConnectionImpl::onConnectionCloseEvent(
     raiseConnectionEvent(source == quic::ConnectionCloseSource::FROM_PEER
                              ? Network::ConnectionEvent::RemoteClose
                              : Network::ConnectionEvent::LocalClose);
+    quic_connection_ = nullptr;
   }
 }
 
@@ -166,7 +167,6 @@ void QuicFilterManagerConnectionImpl::closeConnectionImmediately() {
   }
   quic_connection_->CloseConnection(quic::QUIC_NO_ERROR, "Closed by application",
                                     quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
-  quic_connection_ = nullptr;
 }
 
 void QuicFilterManagerConnectionImpl::onSendBufferHighWatermark() {

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -958,8 +958,8 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
   if (disconnect_after_100) {
     response->waitForContinueHeaders();
     codec_client_->close();
-    ASSERT_TRUE(fake_upstream_connection_->close());
     EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("100"));
+    ASSERT_TRUE(fake_upstream_connection_->close());
     return;
   }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1051,7 +1051,6 @@ TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
 // connection error is not detected under these circumstances.
 #if !defined(__APPLE__)
 TEST_P(ProtocolIntegrationTest, 100ContinueAndClose) {
-  EXCLUDE_UPSTREAM_HTTP3; // CI fails with 503 in access logs.
   testEnvoyHandling100Continue(false, "", true);
 }
 #endif
@@ -2297,7 +2296,6 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/12131
 TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnect) {
-  EXCLUDE_UPSTREAM_HTTP3;
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
@@ -2312,7 +2310,6 @@ TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnect) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnectLegacy) {
-  EXCLUDE_UPSTREAM_HTTP3;
   config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_500_after_100", "false");
 
   initialize();


### PR DESCRIPTION
Fixing a bug where quic connections didn't raiseEvent() on close
Fixing a test bug where we didn't wait for downstream disconnect before sending upstream disconnect, so the order of disconnects could be detected in either order.

Risk Level: n/a (quic only)
Testing: yes
Docs Changes: n/a
Release Notes: n/a