### PR TITLE
fix: tools vscode refreshcompd.sh fails on VSCode remote-ssh 

### DIFF
--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -6,4 +6,4 @@
 TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py
 
 # Kill clangd to reload the compilation database
-killall -v /opt/llvm/bin/clangd
+pkill clangd


### PR DESCRIPTION
**Commit Message**: the script (`tools/vscode/refresh_compdb.sh `) is failing when vscode remote-ssh is used. It's better to use name to kill the clangd process as it may not be always available at `/opt/llvm/bin/clangd` . When using VSCode remote-ssh debug the clangd will be at `/home/ubuntu/.vscode-server/data/User/globalStorage/llvm-vs-code-extensions.vscode-clangd/install/11.0.0/clangd_11.0.0/bin/clangd`

**Additional Description**: changed killall to pkill [name]

**Risk Level**: Low
**Testing**: manual testing
**Docs Changes**: N/A
**Release Notes**: N/A
**Platform Specific Features**: N/A