### PR TITLE
[Windows] Remove `fails_on_windows` from `quic_protocol_integration_test`

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1666,8 +1666,6 @@ envoy_cc_test(
     data = ["//test/config/integration/certs"],
     shard_count = 8,
     tags = [
-        "fails_on_clang_cl",
-        "fails_on_windows",
         "nofips",
     ],
     deps = envoy_select_enable_http3([


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
Commit Message:

Remove `fails_on_windows` from `quic_protocol_integration_test`. I have validated this with a couple of thousand runs. I am greedily enabling this test and if this goes south I will mark it as `flaky_on_windows`

Risk Level: Low (Test only)
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
