### PR TITLE
common/filesystem/posix: Fix illegalPath check to add trailing slashes

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -163,9 +163,9 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (absl::StartsWith(canonical_path.rc_, "/dev") ||
-      absl::StartsWith(canonical_path.rc_, "/sys") ||
-      absl::StartsWith(canonical_path.rc_, "/proc")) {
+  if (absl::StartsWith(canonical_path.rc_, "/dev/") ||
+      absl::StartsWith(canonical_path.rc_, "/sys/") ||
+      absl::StartsWith(canonical_path.rc_, "/proc/")) {
     return true;
   }
   return false;


### PR DESCRIPTION
Fixes for example opening configuration from /system/envoy.yaml but
still prevents opening files from /sys/, /proc/ and /dev/.

Signed-off-by: Hannu Ylitalo <hannu@ylitalo.eu>
