### PR TITLE
[Windows] build cleanups

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,8 +13,6 @@ startup --host_jvm_args=-Xmx2g
 build --workspace_status_command="bash bazel/get_workspace_status"
 build --experimental_strict_action_env=true
 build --host_force_python=PY3
-build --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build --action_env=BAZEL_LINKOPTS=-lm
 build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --enable_platform_specific_config
@@ -26,6 +24,8 @@ build:linux --cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
+build:linux --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
+build:linux --action_env=BAZEL_LINKOPTS=-lm
 
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1
@@ -72,6 +72,9 @@ build:clang-asan --linkopt -fuse-ld=lld
 
 # macOS ASAN/UBSAN
 build:macos --cxxopt=-std=c++17
+build:macos --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
+build:macos --action_env=BAZEL_LINKOPTS=-lm
+
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932
 build:macos-asan --copt -Wno-macro-redefined
@@ -352,7 +355,6 @@ build:clang-cl --copt="-Wno-builtin-macro-redefined"
 #     overrides a member function but is not marked 'override'
 #   MOCK_METHOD(void, addCallbacks, (StreamCallbacks & callbacks));
 build:clang-cl --copt="-Wno-inconsistent-missing-override"
-build:clang-cl --action_env=USE_CLANG_CL=1
 
 # Defaults to 'auto' - Off for windows, so override to linux behavior
 build:windows --enable_runfiles=yes

--- a/bazel/external/wee8.BUILD
+++ b/bazel/external/wee8.BUILD
@@ -24,6 +24,7 @@ cc_library(
         "wee8/include",
         "wee8/third_party",
     ],
+    tags = ["skip_on_windows"],
     visibility = ["//visibility:public"],
 )
 
@@ -38,4 +39,5 @@ genrule(
     ],
     cmd = genrule_cmd("@envoy//bazel/external:wee8.genrule_cmd"),
     exec_properties = LARGE_MACHINE,
+    tags = ["skip_on_windows"],
 )

--- a/bazel/foreign_cc/BUILD
+++ b/bazel/foreign_cc/BUILD
@@ -293,6 +293,7 @@ envoy_cmake_external(
             "libLLVMTextAPI.a",
         ],
     }),
+    tags = ["skip_on_windows"],
 )
 
 envoy_cmake_external(
@@ -341,6 +342,7 @@ envoy_cmake_external(
             "libWAVMUnwind.a",
         ],
     }),
+    tags = ["skip_on_windows"],
     deps = [":llvm"],
 )
 

--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -22,10 +22,10 @@ if is_windows; then
   # CI sets it to a Linux-specific value. Undo this once https://github.com/envoyproxy/envoy/issues/13272
   # is resolved.
   ENVOY_DOCKER_OPTIONS=()
-  DEFAULT_ENVOY_DOCKER_BUILD_DIR=C:/Windows/Temp/envoy-docker-build
+  # Replace MSYS style drive letter (/c/) with Windows drive letter designation (C:/)
+  DEFAULT_ENVOY_DOCKER_BUILD_DIR=$(echo "${TEMP}" | sed -E "s#^/([a-zA-Z])/#\1:/#")/envoy-docker-build
   BUILD_DIR_MOUNT_DEST=C:/build
-  # Replace MSYS style drive letter (/c/) with driver letter designation (C:/)
-  SOURCE_DIR=$(echo "${PWD}" | sed -E "s#/([a-zA-Z])/#\1:/#")
+  SOURCE_DIR=$(echo "${PWD}" | sed -E "s#^/([a-zA-Z])/#\1:/#")
   SOURCE_DIR_MOUNT_DEST=C:/source
   START_COMMAND=("bash" "-c" "cd source && $*")
 else

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -67,11 +67,9 @@ if [[ "${BAZEL_BUILD_EXTRA_OPTIONS[*]}" =~ "clang-cl" ]]; then
   FAIL_GROUP=clang_cl
 fi
 
-# Test to validate updates of all dependency libraries in bazel/external and bazel/foreign_cc
-# bazel "${BAZEL_STARTUP_OPTIONS[@]}" build "${BAZEL_BUILD_OPTIONS[@]}" //bazel/... --build_tag_filters=-skip_on_windows
-
-# Complete envoy-static build (nothing needs to be skipped, build failure indicates broken dependencies)
-bazel "${BAZEL_STARTUP_OPTIONS[@]}" build "${BAZEL_BUILD_OPTIONS[@]}" //source/exe:envoy-static
+# Pre-Validate updates of all dependency libraries in bazel/foreign_cc and bazel/external
+# and complete envoy-static build
+bazel "${BAZEL_STARTUP_OPTIONS[@]}" build "${BAZEL_BUILD_OPTIONS[@]}" //bazel/... //source/exe:envoy-static --build_tag_filters=-skip_on_windows
 
 # Copy binary to delivery directory
 cp -f bazel-bin/source/exe/envoy-static.exe "${ENVOY_DELIVERY_DIR}/envoy.exe"


### PR DESCRIPTION
Commit Message: [Windows] build cleanups
Additional Description:
 - Scope BAZEL_LINKLIBS/BAZEL_LINKOPTS to linux and macos, not windows
 - Discard duplicated USE_CLANG_CL=1 envvar
 - skip_on_windows wasm and wee8 dependencies which fail to build
 - Test build all bazel/... deps not tagged skip_on_windows,
   for earlier warning of newly problematic windows dependencies
 - Use TEMP env on Windows in place of hardcoded C:\Windows\Temp
   in the default build root
 - Use ^ anchor in /c/path fixup regexes

Risk Level: low
Testing: Local and CI pipeline
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Affects only windows build path
