### PR TITLE
filesystem/posix fix illegalPath check to only include /sys /proc /dev

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -167,8 +167,8 @@ bool InstanceImplPosix::protectedPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (absl::StartsWith(path, "/dev/") || path == "/dev" || absl::StartsWith(path, "/sys/") ||
-      path == "/sys" || absl::StartsWith(path, "/proc/") || path == "/proc") {
+  if (absl::StartsWith(path, "/dev/") || absl::StartsWith(path, "/sys/") ||
+      absl::StartsWith(path, "/proc/")) {
     return true;
   }
   return false;

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -163,9 +163,9 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (absl::StartsWith(canonical_path.rc_, "/dev") ||
-      absl::StartsWith(canonical_path.rc_, "/sys") ||
-      absl::StartsWith(canonical_path.rc_, "/proc")) {
+  if (absl::StartsWith(canonical_path.rc_, "/dev/") || canonical_path.rc_ == "/dev" ||
+      absl::StartsWith(canonical_path.rc_, "/sys/") || canonical_path.rc_ == "/sys" ||
+      absl::StartsWith(canonical_path.rc_, "/proc/") || canonical_path.rc_ == "/proc") {
     return true;
   }
   return false;

--- a/source/common/filesystem/posix/filesystem_impl.cc
+++ b/source/common/filesystem/posix/filesystem_impl.cc
@@ -158,14 +158,17 @@ bool InstanceImplPosix::illegalPath(const std::string& path) {
     return true;
   }
 
+  return protectedPath(canonical_path.rc_);
+}
+
+bool InstanceImplPosix::protectedPath(const std::string& path) {
   // Platform specific path sanity; we provide a convenience to avoid Envoy
   // instances poking in bad places. We may have to consider conditioning on
   // platform in the future, growing these or relaxing some constraints (e.g.
   // there are valid reasons to go via /proc for file paths).
   // TODO(htuch): Optimize this as a hash lookup if we grow any further.
-  if (absl::StartsWith(canonical_path.rc_, "/dev/") || canonical_path.rc_ == "/dev" ||
-      absl::StartsWith(canonical_path.rc_, "/sys/") || canonical_path.rc_ == "/sys" ||
-      absl::StartsWith(canonical_path.rc_, "/proc/") || canonical_path.rc_ == "/proc") {
+  if (absl::StartsWith(path, "/dev/") || path == "/dev" || absl::StartsWith(path, "/sys/") ||
+      path == "/sys" || absl::StartsWith(path, "/proc/") || path == "/proc") {
     return true;
   }
   return false;

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -40,6 +40,7 @@ public:
   std::string fileReadToEnd(const std::string& path) override;
   PathSplitResult splitPathFromFilename(absl::string_view path) override;
   bool illegalPath(const std::string& path) override;
+  bool protectedPath(const std::string& path);
 
 private:
   Api::SysCallStringResult canonicalPath(const std::string& path);

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -224,6 +224,29 @@ TEST_F(FileSystemImplTest, IllegalPath) {
 #endif
 }
 
+#ifndef WIN32
+TEST_F(FileSystemImplTest, ProtectedPath) {
+  EXPECT_TRUE(file_system_.protectedPath("/dev"));
+  EXPECT_TRUE(file_system_.protectedPath("/dev/"));
+  EXPECT_TRUE(file_system_.protectedPath("/dev/some/path"));
+  EXPECT_TRUE(file_system_.protectedPath("/sys"));
+  EXPECT_TRUE(file_system_.protectedPath("/sys/"));
+  EXPECT_TRUE(file_system_.protectedPath("/sys/some/path"));
+  EXPECT_TRUE(file_system_.protectedPath("/proc"));
+  EXPECT_TRUE(file_system_.protectedPath("/proc/"));
+  EXPECT_TRUE(file_system_.protectedPath("/proc/some/path"));
+  EXPECT_FALSE(file_system_.protectedPath("/devel"));
+  EXPECT_FALSE(file_system_.protectedPath("/devel/"));
+  EXPECT_FALSE(file_system_.protectedPath("/devel/some/path"));
+  EXPECT_FALSE(file_system_.protectedPath("/system"));
+  EXPECT_FALSE(file_system_.protectedPath("/system/"));
+  EXPECT_FALSE(file_system_.protectedPath("/system/some/path"));
+  EXPECT_FALSE(file_system_.protectedPath("/process"));
+  EXPECT_FALSE(file_system_.protectedPath("/process/"));
+  EXPECT_FALSE(file_system_.protectedPath("/process/some/path"));
+}
+#endif
+
 TEST_F(FileSystemImplTest, ConstructedFile) {
   const std::string new_file_path = TestEnvironment::temporaryPath("envoy_this_not_exist");
   ::unlink(new_file_path.c_str());

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -212,13 +212,10 @@ TEST_F(FileSystemImplTest, IllegalPath) {
   EXPECT_FALSE(file_system_.illegalPath("C:/i/COM0"));
   EXPECT_FALSE(file_system_.illegalPath("C:/i/COM"));
 #else
-  EXPECT_TRUE(file_system_.illegalPath("/dev"));
   EXPECT_TRUE(file_system_.illegalPath("/dev/"));
   // Exception to allow opening from file descriptors. See #7258.
   EXPECT_FALSE(file_system_.illegalPath("/dev/fd/0"));
-  EXPECT_TRUE(file_system_.illegalPath("/proc"));
   EXPECT_TRUE(file_system_.illegalPath("/proc/"));
-  EXPECT_TRUE(file_system_.illegalPath("/sys"));
   EXPECT_TRUE(file_system_.illegalPath("/sys/"));
   EXPECT_TRUE(file_system_.illegalPath("/_some_non_existent_file"));
 #endif
@@ -226,13 +223,10 @@ TEST_F(FileSystemImplTest, IllegalPath) {
 
 #ifndef WIN32
 TEST_F(FileSystemImplTest, ProtectedPath) {
-  EXPECT_TRUE(file_system_.protectedPath("/dev"));
   EXPECT_TRUE(file_system_.protectedPath("/dev/"));
   EXPECT_TRUE(file_system_.protectedPath("/dev/some/path"));
-  EXPECT_TRUE(file_system_.protectedPath("/sys"));
   EXPECT_TRUE(file_system_.protectedPath("/sys/"));
   EXPECT_TRUE(file_system_.protectedPath("/sys/some/path"));
-  EXPECT_TRUE(file_system_.protectedPath("/proc"));
   EXPECT_TRUE(file_system_.protectedPath("/proc/"));
   EXPECT_TRUE(file_system_.protectedPath("/proc/some/path"));
   EXPECT_FALSE(file_system_.protectedPath("/devel"));


### PR DESCRIPTION
This commit changes it to check if path is exactly /sys, /dev or /proc or starts
with /sys/, /dev/ or /proc/.

Original implementation failed when for example configuration lived under /system/config.yaml

Signed-off-by: Hannu Ylitalo <hannu@ylitalo.eu>
