### PR TITLE
thrift proxy: add upstream_rq_time histograms to cluster metrics

### DIFF
--- a/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
@@ -25,7 +25,7 @@ The filter outputs generic routing error statistics in the *thrift.<stat_prefix>
   no_healthy_upstream, Counter, Total requests with no healthy upstream endpoints available.
 
 
-The filter is also responsible for cluster-level statistics derived from routed clusters.
+The filter is also responsible for cluster-level statistics derived from routed upstream clusters.
 Since these stats utilize the underlying cluster scope, we prefix with the `thrift` namespace.
 
 .. csv-table::
@@ -37,7 +37,7 @@ Since these stats utilize the underlying cluster scope, we prefix with the `thri
   thrift.upstream_rq_invalid_type, Counter, Total requests with an unsupported message type.
   thrift.upstream_resp_reply, Counter, Total responses with the "Reply" message type. Sums both Successses and Errors.
   thrift.upstream_resp_success, Counter, Total Replies that are considered "Successes".
-  thrift.upstream_resp_error, Counter, Total Replies that are considered "Errors". 
+  thrift.upstream_resp_error, Counter, Total Replies that are considered "Errors".
   thrift.upstream_resp_exception, Counter, Total responses with the "Exception" message type.
   thrift.upstream_resp_invalid_type, Counter, Total responses with an unsupported message type.
   thrift.upstream_rq_time, Histogram, total rq time from rq complete to resp complete; includes oneway messages.

--- a/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
+++ b/docs/root/configuration/other_protocols/thrift_filters/router_filter.rst
@@ -25,15 +25,19 @@ The filter outputs generic routing error statistics in the *thrift.<stat_prefix>
   no_healthy_upstream, Counter, Total requests with no healthy upstream endpoints available.
 
 
-The filter also outputs MessageType statistics in the upstream cluster's stat scope.
+The filter is also responsible for cluster-level statistics derived from routed clusters.
+Since these stats utilize the underlying cluster scope, we prefix with the `thrift` namespace.
 
 .. csv-table::
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  request_call, Counter, Total requests with the "Call" message type.
-  request_oneway, Counter, Total requests with the "Oneway" message type.
-  request_invalid_type, Counter, Total requests with an unsupported message type.
-  response_reply, Counter, Total responses with the "Reply" message type. Includes both successes and errors.
-  response_exception, Counter, Total responses with the "Exception" message type.
-  response_invalid_type, Counter, Total responses with an unsupported message type.
+  thrift.upstream_rq_call, Counter, Total requests with the "Call" message type.
+  thrift.upstream_rq_oneway, Counter, Total requests with the "Oneway" message type.
+  thrift.upstream_rq_invalid_type, Counter, Total requests with an unsupported message type.
+  thrift.upstream_resp_reply, Counter, Total responses with the "Reply" message type. Sums both Successses and Errors.
+  thrift.upstream_resp_success, Counter, Total Replies that are considered "Successes".
+  thrift.upstream_resp_error, Counter, Total Replies that are considered "Errors". 
+  thrift.upstream_resp_exception, Counter, Total responses with the "Exception" message type.
+  thrift.upstream_resp_invalid_type, Counter, Total responses with an unsupported message type.
+  thrift.upstream_rq_time, Histogram, total rq time from rq complete to resp complete; includes oneway messages.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -161,7 +161,8 @@ New Features
 * tcp_proxy: added a :ref:`use_post field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.use_post>` for using HTTP POST to proxy TCP streams.
 * tcp_proxy: added a :ref:`headers_to_add field <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.headers_to_add>` for setting additional headers to the HTTP requests for TCP proxing.
 * thrift_proxy: added a :ref:`max_requests_per_connection field <envoy_v3_api_field_extensions.filters.network.thrift_proxy.v3.ThriftProxy.max_requests_per_connection>` for setting maximum requests for per downstream connection.
-* thrift_proxy: added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for messagetype in request/response.
+* thrift_proxy: added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for messagetype counters in request/response.
+* thrift_proxy: added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request time histograms.
 * tls peer certificate validation: added :ref:`SPIFFE validator <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig>` for supporting isolated multiple trust bundles in a single listener or cluster.
 * tracing: added the :ref:`pack_trace_reason <envoy_v3_api_field_extensions.request_id.uuid.v3.UuidRequestIdConfig.pack_trace_reason>`
   field as well as explicit configuration for the built-in :ref:`UuidRequestIdConfig <envoy_v3_api_msg_extensions.request_id.uuid.v3.UuidRequestIdConfig>`

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -127,6 +127,7 @@ private:
     // ThriftFilters::DecoderFilterCallbacks
     uint64_t streamId() const override { return parent_.stream_id_; }
     const Network::Connection* connection() const override { return parent_.connection(); }
+    Event::Dispatcher& dispatcher() override { return parent_.dispatcher(); }
     void continueDecoding() override;
     Router::RouteConstSharedPtr route() override { return parent_.route(); }
     TransportType downstreamTransportType() const override {
@@ -206,6 +207,9 @@ private:
     // ThriftFilters::DecoderFilterCallbacks
     uint64_t streamId() const override { return stream_id_; }
     const Network::Connection* connection() const override;
+    Event::Dispatcher& dispatcher() override {
+      return parent_.read_callbacks_->connection().dispatcher();
+    }
     void continueDecoding() override { parent_.continueDecoding(); }
     Router::RouteConstSharedPtr route() override;
     TransportType downstreamTransportType() const override {

--- a/source/extensions/filters/network/thrift_proxy/filters/filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/filter.h
@@ -44,6 +44,11 @@ public:
   virtual const Network::Connection* connection() const PURE;
 
   /**
+   * @return Event::Dispatcher& the thread local dispatcher for allocating timers, etc.
+   */
+  virtual Event::Dispatcher& dispatcher() PURE;
+
+  /**
    * Continue iterating through the filter chain with buffered data. This routine can only be
    * called if the filter has previously returned StopIteration from one of the DecoderFilter
    * methods. The connection manager will callbacks to the next filter in the chain. Further note

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -535,6 +535,7 @@ void Router::UpstreamRequest::onResponseComplete() {
         std::chrono::duration_cast<std::chrono::milliseconds>(
             dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
     parent_.chargeResponseTiming(response_time);
+    charged_response_timing_ = true;
   }
 
   response_complete_ = true;
@@ -560,6 +561,7 @@ void Router::UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason re
         std::chrono::duration_cast<std::chrono::milliseconds>(
             dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
     parent_.chargeResponseTiming(response_time);
+    charged_response_timing_ = true;
   }
 
   switch (reason) {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -241,15 +241,15 @@ FilterStatus Router::messageBegin(MessageMetadataSharedPtr metadata) {
                    metadata->methodName());
   switch (metadata->messageType()) {
   case MessageType::Call:
-    incClusterScopeCounter(request_call_);
+    incClusterScopeCounter({thrift_, upstream_rq_call_});
     break;
 
   case MessageType::Oneway:
-    incClusterScopeCounter(request_oneway_);
+    incClusterScopeCounter({thrift_, upstream_rq_oneway_});
     break;
 
   default:
-    incClusterScopeCounter(request_invalid_type_);
+    incClusterScopeCounter({thrift_, upstream_rq_invalid_type_});
     break;
   }
 
@@ -353,20 +353,20 @@ void Router::onUpstreamData(Buffer::Instance& data, bool end_stream) {
       ENVOY_STREAM_LOG(debug, "response complete", *callbacks_);
       switch (callbacks_->responseMetadata()->messageType()) {
       case MessageType::Reply:
-        incClusterScopeCounter(response_reply_);
+        incClusterScopeCounter({thrift_, upstream_resp_reply_});
         if (callbacks_->responseSuccess()) {
-          incClusterScopeCounter(response_reply_success_);
+          incClusterScopeCounter({thrift_, upstream_resp_reply_success_});
         } else {
-          incClusterScopeCounter(response_reply_error_);
+          incClusterScopeCounter({thrift_, upstream_resp_reply_error_});
         }
         break;
 
       case MessageType::Exception:
-        incClusterScopeCounter(response_exception_);
+        incClusterScopeCounter({thrift_, upstream_resp_exception_});
         break;
 
       default:
-        incClusterScopeCounter(response_invalid_type_);
+        incClusterScopeCounter({thrift_, upstream_resp_invalid_type_});
         break;
       }
       upstream_request_->onResponseComplete();
@@ -522,9 +522,21 @@ void Router::UpstreamRequest::onRequestStart(bool continue_decoding) {
   }
 }
 
-void Router::UpstreamRequest::onRequestComplete() { request_complete_ = true; }
+void Router::UpstreamRequest::onRequestComplete() {
+  Event::Dispatcher& dispatcher = parent_.callbacks_->dispatcher();
+  downstream_request_complete_time_ = dispatcher.timeSource().monotonicTime();
+  request_complete_ = true;
+}
 
 void Router::UpstreamRequest::onResponseComplete() {
+  if (!charged_response_timing_) {
+    Event::Dispatcher& dispatcher = parent_.callbacks_->dispatcher();
+    const std::chrono::milliseconds response_time =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
+    parent_.chargeResponseTiming(response_time);
+  }
+
   response_complete_ = true;
   conn_state_ = nullptr;
   conn_data_.reset();
@@ -540,6 +552,14 @@ void Router::UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason re
     // an error.
     parent_.callbacks_->resetDownstreamConnection();
     return;
+  }
+
+  if (!charged_response_timing_) {
+    Event::Dispatcher& dispatcher = parent_.callbacks_->dispatcher();
+    const std::chrono::milliseconds response_time =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            dispatcher.timeSource().monotonicTime() - downstream_request_complete_time_);
+    parent_.chargeResponseTiming(response_time);
   }
 
   switch (reason) {

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -180,16 +180,17 @@ public:
          Stats::Scope& scope)
       : cluster_manager_(cluster_manager), stats_(generateStats(stat_prefix, scope)),
         stat_name_set_(scope.symbolTable().makeSet("thrift_proxy")),
-        symbol_table_(scope.symbolTable()), thrift_(stat_name_set_->add("thrift")),
-        upstream_rq_call_(stat_name_set_->add("upstream_rq_call")),
-        upstream_rq_oneway_(stat_name_set_->add("upstream_rq_oneway")),
-        upstream_rq_invalid_type_(stat_name_set_->add("upstream_rq_invalid_type")),
-        upstream_resp_reply_(stat_name_set_->add("upstream_resp_reply")),
-        upstream_resp_reply_success_(stat_name_set_->add("upstream_resp_success")),
-        upstream_resp_reply_error_(stat_name_set_->add("upstream_resp_error")),
-        upstream_resp_exception_(stat_name_set_->add("upstream_resp_exception")),
-        upstream_resp_invalid_type_(stat_name_set_->add("upstream_resp_invalid_type")),
-        upstream_rq_time_(stat_name_set_->add("upstream_rq_time")), passthrough_supported_(false) {}
+        symbol_table_(scope.symbolTable()),
+        upstream_rq_call_(stat_name_set_->add("thrift.upstream_rq_call")),
+        upstream_rq_oneway_(stat_name_set_->add("thrift.upstream_rq_oneway")),
+        upstream_rq_invalid_type_(stat_name_set_->add("thrift.upstream_rq_invalid_type")),
+        upstream_resp_reply_(stat_name_set_->add("thrift.upstream_resp_reply")),
+        upstream_resp_reply_success_(stat_name_set_->add("thrift.upstream_resp_success")),
+        upstream_resp_reply_error_(stat_name_set_->add("thrift.upstream_resp_error")),
+        upstream_resp_exception_(stat_name_set_->add("thrift.upstream_resp_exception")),
+        upstream_resp_invalid_type_(stat_name_set_->add("thrift.upstream_resp_invalid_type")),
+        upstream_rq_time_(stat_name_set_->add("thrift.upstream_rq_time")),
+        passthrough_supported_(false) {}
 
   ~Router() override = default;
 
@@ -197,26 +198,6 @@ public:
   void onDestroy() override;
   void setDecoderFilterCallbacks(ThriftFilters::DecoderFilterCallbacks& callbacks) override;
   bool passthroughSupported() const override { return passthrough_supported_; }
-
-  // Stats
-  void incClusterScopeCounter(const Stats::StatNameVec& names) const {
-    const Stats::SymbolTable::StoragePtr stat_name_storage = symbol_table_.join(names);
-    cluster_->statsScope().counterFromStatName(Stats::StatName(stat_name_storage.get())).inc();
-  }
-
-  void recordClusterScopeHistogram(const Stats::StatNameVec& names, Stats::Histogram::Unit unit,
-                                   uint64_t count) const {
-    const Stats::SymbolTable::StoragePtr stat_name_storage = symbol_table_.join(names);
-    cluster_->statsScope()
-        .histogramFromStatName(Stats::StatName(stat_name_storage.get()), unit)
-        .recordValue(count);
-  }
-
-  void chargeResponseTiming(const std::chrono::milliseconds response_time) const {
-    const uint64_t count = response_time.count();
-    recordClusterScopeHistogram({thrift_, upstream_rq_time_}, Stats::Histogram::Unit::Milliseconds,
-                                count);
-  }
 
   // ProtocolConverter
   FilterStatus transportBegin(MessageMetadataSharedPtr metadata) override;
@@ -261,6 +242,7 @@ private:
     void onResponseComplete();
     void onUpstreamHostSelected(Upstream::HostDescriptionConstSharedPtr host);
     void onResetStream(ConnectionPool::PoolFailureReason reason);
+    void chargeResponseTiming();
 
     Router& parent_;
     Tcp::ConnectionPool::Instance& conn_pool_;
@@ -282,6 +264,20 @@ private:
     MonotonicTime downstream_request_complete_time_;
   };
 
+  // Stats
+  void incClusterScopeCounter(const Stats::StatNameVec& names) const {
+    const Stats::SymbolTable::StoragePtr stat_name_storage = symbol_table_.join(names);
+    cluster_->statsScope().counterFromStatName(Stats::StatName(stat_name_storage.get())).inc();
+  }
+
+  void recordClusterScopeHistogram(const Stats::StatNameVec& names, Stats::Histogram::Unit unit,
+                                   uint64_t count) const {
+    const Stats::SymbolTable::StoragePtr stat_name_storage = symbol_table_.join(names);
+    cluster_->statsScope()
+        .histogramFromStatName(Stats::StatName(stat_name_storage.get()), unit)
+        .recordValue(count);
+  }
+
   void convertMessageBegin(MessageMetadataSharedPtr metadata);
   void cleanup();
   RouterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
@@ -294,7 +290,6 @@ private:
   RouterStats stats_;
   Stats::StatNameSetPtr stat_name_set_;
   Stats::SymbolTable& symbol_table_;
-  const Stats::StatName thrift_;
   const Stats::StatName upstream_rq_call_;
   const Stats::StatName upstream_rq_oneway_;
   const Stats::StatName upstream_rq_invalid_type_;

--- a/test/extensions/filters/network/thrift_proxy/mocks.h
+++ b/test/extensions/filters/network/thrift_proxy/mocks.h
@@ -246,6 +246,7 @@ public:
   // ThriftProxy::ThriftFilters::DecoderFilterCallbacks
   MOCK_METHOD(uint64_t, streamId, (), (const));
   MOCK_METHOD(const Network::Connection*, connection, (), (const));
+  MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(void, continueDecoding, ());
   MOCK_METHOD(Router::RouteConstSharedPtr, route, ());
   MOCK_METHOD(TransportType, downstreamTransportType, (), (const));


### PR DESCRIPTION
Signed-off-by: William Fu <wfu@pinterest.com>

Commit Message:
In #15668 we began supporting cluster level metrics for the thrift_proxy connection manager. These metrics were limited to messageType counters only; now that these are working OK we are comfortable moving to cluster level histograms for `upstream_rq_time`.

Additional Description:
One interesting design choice here that surfaced was the naming convention for thrift-related cluster metrics. Mirroring off HTTP as much as possible, we adopted the `upstream_` prefix, but to avoid conflating with the HTTP counterpart (in the event that we start supporting multi-protocol clusters) we opted to add `thrift` in the StatName.

Happy to revise this decision if desired.

Risk Level: Low, #15668 was successful
Testing: New unit tests
Docs Changes: Planning to update docs
