### PR TITLE
examples: fix import path for resource.go override file

### DIFF
--- a/examples/dynamic-config-cp/resource.go
+++ b/examples/dynamic-config-cp/resource.go
@@ -25,8 +25,8 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/envoyproxy/go-control-plane/pkg/resource"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 )
 


### PR DESCRIPTION
With the removal of V2 the version is no longer part of the package
name.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Commit Message:
Additional Description:
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
