### PR TITLE
Remove superfluous min from priority level pseudocode

### DIFF
--- a/docs/root/intro/arch_overview/upstream/load_balancing/priority.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/priority.rst
@@ -98,7 +98,7 @@ To sum this up in pseudo algorithms:
 
   health(P_X) = min(100, 1.4 * 100 * healthy_P_X_backends / total_P_X_backends)
   normalized_total_health = min(100, Σ(health(P_0)...health(P_X)))
-  priority_load(P_0) = min(100, health(P_0) * 100 / normalized_total_health)
+  priority_load(P_0) = health(P_0) * 100 / normalized_total_health
   priority_load(P_X) = min(100 - Σ(priority_load(P_0)..priority_load(P_X-1)),
                            health(P_X) * 100 / normalized_total_health)
 


### PR DESCRIPTION
Commit Message: Remove superfluous min from priority level pseudocode
Additional Description: The `priority_load(P_0)` function in priority levels pseudocode documentation https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/priority uses a min function which is not needed as `health(P_0) * 100 / normalized_total_health` is always <=100
Risk Level: Low
Testing: N/A
Docs Changes: Remove the superfluous min function
Release Notes: N/A
Platform Specific Features: N/A
Fixes https://github.com/envoyproxy/envoy/issues/15824