### PR TITLE
grid: Minor refactor of ConnectivityGrid

### DIFF
--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -51,6 +51,9 @@ public:
 
       ConnectionPool::Instance& pool() { return **pool_it_; }
 
+      void cancel(Envoy::ConnectionPool::CancelPolicy cancel_policy);
+
+    private:
       // A pointer back up to the parent.
       WrapperCallbacks& parent_;
       // The pool for this connection attempt.
@@ -75,6 +78,18 @@ public:
     // Returns true if there is a failover pool and a connection has been
     // attempted, false if all pools have been tried.
     bool tryAnotherConnection();
+
+    // Called by a ConnectionAttempt when the underlying pool fails.
+    void onConnectionAttemptFailed(ConnectionAttemptCallbacks* attempt,
+                                   ConnectionPool::PoolFailureReason reason,
+                                   absl::string_view transport_failure_reason,
+                                   Upstream::HostDescriptionConstSharedPtr host);
+
+    // Called by a ConnectionAttempt when the underlying pool is ready.
+    void onConnectionAttemptReady(ConnectionAttemptCallbacks* attempt, RequestEncoder& encoder,
+                                  Upstream::HostDescriptionConstSharedPtr host,
+                                  const StreamInfo::StreamInfo& info,
+                                  absl::optional<Http::Protocol> protocol);
 
   private:
     // Tracks all the connection attempts which currently in flight.


### PR DESCRIPTION
Make members of ConnectionAttemptCallbacks private.
Move logic for handling connection ready/failue from
ConnectionAttemptCallbacks to WrapperCallbacks to avoid
accessing private members of other classes.

Signed-off-by: Ryan Hamilton <rch@google.com>


Risk Level: low (refactor only)
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A