### PR TITLE
docs: remove unsupported regex path matching notice

### DIFF
--- a/docs/root/intro/arch_overview/http/http_routing.rst
+++ b/docs/root/intro/arch_overview/http/http_routing.rst
@@ -14,9 +14,8 @@ level the router takes an incoming HTTP request, matches it to an upstream clust
 request. The router filter supports the following features:
 
 * Virtual hosts that map domains/authorities to a set of routing rules.
-* Prefix and exact path matching rules (both :ref:`case sensitive
-  <envoy_v3_api_field_config.route.v3.RouteMatch.case_sensitive>` and case insensitive). 
-* :ref:`Regex path matching<envoy_v3_api_field_config.route.v3.RouteMatch.safe_regex` rules.
+* Prefix and exact path matching rules (both :ref:`case sensitive <envoy_v3_api_field_config.route.v3.RouteMatch.case_sensitive>` and case insensitive). 
+* :ref:`Regex path matching <envoy_v3_api_field_config.route.v3.RouteMatch.safe_regex` rules.
 * :ref:`TLS redirection <envoy_v3_api_field_config.route.v3.VirtualHost.require_tls>` at the virtual host
   level.
 * :ref:`Path <envoy_v3_api_field_config.route.v3.RedirectAction.path_redirect>`/:ref:`host

--- a/docs/root/intro/arch_overview/http/http_routing.rst
+++ b/docs/root/intro/arch_overview/http/http_routing.rst
@@ -15,11 +15,8 @@ request. The router filter supports the following features:
 
 * Virtual hosts that map domains/authorities to a set of routing rules.
 * Prefix and exact path matching rules (both :ref:`case sensitive
-  <envoy_v3_api_field_config.route.v3.RouteMatch.case_sensitive>` and case insensitive). Regex/slug
-  matching is not currently supported, mainly because it makes it difficult/impossible to
-  programmatically determine whether routing rules conflict with each other. For this reason we
-  don’t recommend regex/slug routing at the reverse proxy level, however we may add support in the
-  future depending on demand.
+  <envoy_v3_api_field_config.route.v3.RouteMatch.case_sensitive>` and case insensitive). 
+* :ref:`Regex path matching<envoy_v3_api_field_config.route.v3.RouteMatch.safe_regex` rules.
 * :ref:`TLS redirection <envoy_v3_api_field_config.route.v3.VirtualHost.require_tls>` at the virtual host
   level.
 * :ref:`Path <envoy_v3_api_field_config.route.v3.RedirectAction.path_redirect>`/:ref:`host

--- a/docs/root/intro/arch_overview/http/http_routing.rst
+++ b/docs/root/intro/arch_overview/http/http_routing.rst
@@ -14,8 +14,8 @@ level the router takes an incoming HTTP request, matches it to an upstream clust
 request. The router filter supports the following features:
 
 * Virtual hosts that map domains/authorities to a set of routing rules.
-* Prefix and exact path matching rules (both :ref:`case sensitive <envoy_v3_api_field_config.route.v3.RouteMatch.case_sensitive>` and case insensitive). 
-* :ref:`Regex path matching <envoy_v3_api_field_config.route.v3.RouteMatch.safe_regex` rules.
+* Prefix and exact path matching rules (both :ref:`case sensitive <envoy_v3_api_field_config.route.v3.RouteMatch.case_sensitive>` and case insensitive).
+* :ref:`Regex path matching <envoy_v3_api_field_config.route.v3.RouteMatch.safe_regex>` rules.
 * :ref:`TLS redirection <envoy_v3_api_field_config.route.v3.VirtualHost.require_tls>` at the virtual host
   level.
 * :ref:`Path <envoy_v3_api_field_config.route.v3.RedirectAction.path_redirect>`/:ref:`host


### PR DESCRIPTION


Signed-off-by: Keerthan Ekbote <saiskee@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: Remove old message from http routing intro docs saying that regex path matching isn't supported.
Additional Description: Adds additional note linking to regex path matching.
Risk Level: low
Testing: N/A
Docs Changes: Adds additional note linking to regex path matching.
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] 
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
