### PR TITLE
[fuzz] use memfiles in the e2e fuzzers

### DIFF
--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -321,9 +321,6 @@ most_specific_header_mutations_wins: {0}
     return fmt::format(yaml, most_specific_wins);
   }
 
-  // TODO(asraa) remove this when flipping fuzzers on.
-  Filesystem::ScopedUseMemfiles use_memfiles_{true};
-
   Stats::TestUtil::TestSymbolTable symbol_table_;
   Api::ApiPtr api_;
   NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;

--- a/test/integration/h1_fuzz.h
+++ b/test/integration/h1_fuzz.h
@@ -17,6 +17,9 @@ public:
   void initialize() override;
   void replay(const test::integration::CaptureFuzzTestCase&, bool ignore_response);
   const std::chrono::milliseconds max_wait_ms_{10};
+
+private:
+  Filesystem::ScopedUseMemfiles use_memfiles_{true};
 };
 
 } // namespace Envoy

--- a/test/integration/h2_fuzz.h
+++ b/test/integration/h2_fuzz.h
@@ -23,5 +23,7 @@ public:
 private:
   void sendFrame(const test::integration::H2TestFrame&,
                  std::function<void(const Envoy::Http::Http2::Http2Frame&)>);
+
+  Filesystem::ScopedUseMemfiles use_memfiles_{true};
 };
 } // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Use memfiles in the e2e fuzzers  when creating bootstrap files.
Risk Level: Low
Testing: Tested to observe memfiles
Fixes:
Hopefully some OSS-Fuzz flakes!
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31626

@chaoqin-li1123 @adisuissa 
