### PR TITLE
Clean up unnecessary crumbs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -72,8 +72,6 @@ build:clang-asan --linkopt -fuse-ld=lld
 
 # macOS ASAN/UBSAN
 build:macos --cxxopt=-std=c++17
-build:macos --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build:macos --action_env=BAZEL_LINKOPTS=-lm
 
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932


### PR DESCRIPTION
Commit Message: Clean up unnecessary crumbs
Additional Description:

- mop up nohup.out crumb left over from PR 15374
- clean up noop flags from macos build per lizan from PR 15877

Risk Level: N/A
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
