### PR TITLE
Use ProtobufWkt alias to get the well-known Type and Field protos

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -18,7 +18,7 @@ namespace {
 constexpr uint32_t ProtobufLengthDelimitedField = 2;
 
 bool parseMessageByFieldPath(CodedInputStream* input,
-                             absl::Span<const Protobuf::Field* const> field_path,
+                             absl::Span<const ProtobufWkt::Field* const> field_path,
                              Protobuf::Message* message) {
   if (field_path.empty()) {
     return message->MergeFromCodedStream(input);
@@ -50,9 +50,9 @@ bool parseMessageByFieldPath(CodedInputStream* input,
 }
 } // namespace
 
-bool HttpBodyUtils::parseMessageByFieldPath(ZeroCopyInputStream* stream,
-                                            const std::vector<const Protobuf::Field*>& field_path,
-                                            Protobuf::Message* message) {
+bool HttpBodyUtils::parseMessageByFieldPath(
+    ZeroCopyInputStream* stream, const std::vector<const ProtobufWkt::Field*>& field_path,
+    Protobuf::Message* message) {
   CodedInputStream input(stream);
   input.SetRecursionLimit(field_path.size());
 
@@ -61,7 +61,7 @@ bool HttpBodyUtils::parseMessageByFieldPath(ZeroCopyInputStream* stream,
 }
 
 void HttpBodyUtils::appendHttpBodyEnvelope(
-    Buffer::Instance& output, const std::vector<const Protobuf::Field*>& request_body_field_path,
+    Buffer::Instance& output, const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
     std::string content_type, uint64_t content_length) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded for wire format.
@@ -83,7 +83,7 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
     std::vector<uint32_t> message_sizes;
     message_sizes.reserve(request_body_field_path.size());
     for (auto it = request_body_field_path.rbegin(); it != request_body_field_path.rend(); ++it) {
-      const Protobuf::Field* field = *it;
+      const ProtobufWkt::Field* field = *it;
       const uint64_t message_size = envelope_size + content_length;
       const uint32_t field_number = (field->number() << 3) | ProtobufLengthDelimitedField;
       const uint64_t field_size = CodedOutputStream::VarintSize32(field_number) +
@@ -100,7 +100,7 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
 
     // Serialize body field definition manually to avoid the copy of the body.
     for (size_t i = 0; i < request_body_field_path.size(); ++i) {
-      const Protobuf::Field* field = request_body_field_path[i];
+      const ProtobufWkt::Field* field = request_body_field_path[i];
       const uint32_t field_number = (field->number() << 3) | ProtobufLengthDelimitedField;
       const uint64_t message_size = message_sizes[i];
       coded_stream.WriteTag(field_number);

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -254,9 +254,9 @@ void JsonTranscoderConfig::addBuiltinSymbolDescriptor(const std::string& symbol_
 
 Status JsonTranscoderConfig::resolveField(const Protobuf::Descriptor* descriptor,
                                           const std::string& field_path_str,
-                                          std::vector<const Protobuf::Field*>* field_path,
+                                          std::vector<const ProtobufWkt::Field*>* field_path,
                                           bool* is_http_body) {
-  const Protobuf::Type* message_type =
+  const ProtobufWkt::Type* message_type =
       type_helper_->Info()->GetTypeByTypeUrl(Grpc::Common::typeUrl(descriptor->full_name()));
   if (message_type == nullptr) {
     return ProtobufUtil::Status(Code::NOT_FOUND,
@@ -272,7 +272,7 @@ Status JsonTranscoderConfig::resolveField(const Protobuf::Descriptor* descriptor
   if (field_path->empty()) {
     *is_http_body = descriptor->full_name() == google::api::HttpBody::descriptor()->full_name();
   } else {
-    const Protobuf::Type* body_type =
+    const ProtobufWkt::Type* body_type =
         type_helper_->Info()->GetTypeByTypeUrl(field_path->back()->type_url());
     *is_http_body = body_type != nullptr &&
                     body_type->name() == google::api::HttpBody::descriptor()->full_name();

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -43,15 +43,15 @@ struct VariableBinding {
 
 struct MethodInfo {
   const Protobuf::MethodDescriptor* descriptor_ = nullptr;
-  std::vector<const Protobuf::Field*> request_body_field_path;
-  std::vector<const Protobuf::Field*> response_body_field_path;
+  std::vector<const ProtobufWkt::Field*> request_body_field_path;
+  std::vector<const ProtobufWkt::Field*> response_body_field_path;
   bool request_type_is_http_body_ = false;
   bool response_type_is_http_body_ = false;
 };
 using MethodInfoSharedPtr = std::shared_ptr<MethodInfo>;
 
 void createHttpBodyEnvelope(Buffer::Instance& output,
-                            const std::vector<const Protobuf::Field*>& request_body_field_path,
+                            const std::vector<const ProtobufWkt::Field*>& request_body_field_path,
                             std::string content_type, uint64_t content_length);
 
 /**
@@ -123,7 +123,7 @@ private:
   void addBuiltinSymbolDescriptor(const std::string& symbol_name);
   ProtobufUtil::Status resolveField(const Protobuf::Descriptor* descriptor,
                                     const std::string& field_path_str,
-                                    std::vector<const Protobuf::Field*>* field_path,
+                                    std::vector<const ProtobufWkt::Field*>* field_path,
                                     bool* is_http_body);
   ProtobufUtil::Status createMethodInfo(const Protobuf::MethodDescriptor* descriptor,
                                         const google::api::HttpRule& http_rule,

--- a/test/extensions/filters/http/grpc_json_transcoder/http_body_utils_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/http_body_utils_test.cc
@@ -20,7 +20,7 @@ public:
 
   void setBodyFieldPath(const std::vector<int>& body_field_path) {
     for (int field_number : body_field_path) {
-      Protobuf::Field field;
+      ProtobufWkt::Field field;
       field.set_number(field_number);
       raw_body_field_path_.emplace_back(std::move(field));
     }
@@ -76,8 +76,8 @@ public:
     EXPECT_FALSE(HttpBodyUtils::parseMessageByFieldPath(&stream, body_field_path_, &http_body));
   }
 
-  std::vector<Protobuf::Field> raw_body_field_path_;
-  std::vector<const Protobuf::Field*> body_field_path_;
+  std::vector<ProtobufWkt::Field> raw_body_field_path_;
+  std::vector<const ProtobufWkt::Field*> body_field_path_;
 };
 
 TEST_F(HttpBodyUtilsTest, EmptyFieldsList) {


### PR DESCRIPTION
That’s why ProtobufWkt exists, after all!

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

Risk Level: Low
Testing: bazel test //test/extensions/filters/http/grpc_json_transcoder/...
Docs Changes: N/A
Release Notes: N/A
