### PR TITLE
Construct empty string from "" not nullptr

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -373,7 +373,7 @@ ProtobufUtil::Status JsonTranscoderConfig::createTranscoder(
   if (method_info->request_type_is_http_body_) {
     request_translator = std::make_unique<RequestMessageTranslator>(*type_helper_->Resolver(),
                                                                     false, std::move(request_info));
-    request_translator->Input().StartObject(nullptr)->EndObject();
+    request_translator->Input().StartObject("")->EndObject();
   } else {
     json_request_translator = std::make_unique<JsonRequestTranslator>(
         type_helper_->Resolver(), &request_input, std::move(request_info),


### PR DESCRIPTION
When building locally, I got a clang-tidy error saying that
“constructing string from nullptr is undefined behaviour”.  Indeed, as
far as I can tell, it is.
https://groups.google.com/a/isocpp.org/g/std-proposals/c/PGdx39Iy8pg

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

Risk Level: Low
Testing: bazel test //test/extensions/filters/http/grpc_json_transcoder/...
Docs Changes: N/A
Release Notes: N/A
