### PR TITLE
docs: remove extra period from "Life of Request" doc

### DIFF
--- a/docs/root/intro/life_of_a_request.rst
+++ b/docs/root/intro/life_of_a_request.rst
@@ -508,7 +508,7 @@ downstream transport socket extensions.
 
 The request, consisting of headers, and optional body and trailers, is proxied upstream, and the
 response is proxied downstream. The response passes through the HTTP and network filters in the
-:ref:`opposite order <arch_overview_http_filters_ordering>`. from the request.
+:ref:`opposite order <arch_overview_http_filters_ordering>` from the request.
 
 Various callbacks for decoder/encoder request lifecycle events will be invoked in HTTP filters, e.g.
 when response trailers are being forwarded or the request body is streamed. Similarly, read/write


### PR DESCRIPTION
Signed-off-by: Kevin Kelani <kkelani@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: Remove extra period from "Life of Request" doc
Additional Description: N/A
Risk Level: Low
Testing: N/A
Docs Changes: Removes extra period
Release Notes: N/A
Platform Specific Features: N/A
