### PR TITLE
Use ABSL_GUARDED_BY everywhere

### DIFF
--- a/test/test_common/file_system_for_test.h
+++ b/test/test_common/file_system_for_test.h
@@ -12,7 +12,7 @@ namespace Filesystem {
 
 struct MemFileInfo {
   absl::Mutex lock_;
-  std::string data_ GUARDED_BY(lock_);
+  std::string data_ ABSL_GUARDED_BY(lock_);
 };
 
 class MemfileImpl : public FileSharedImpl {


### PR DESCRIPTION
For some reason struct MemFileInfo only used GUARDED_BY instead of
ABSL_GUARDED_BY.

Signed-off-by: Justin Mazzola Paluska <justinmp@google.com>

Risk Level: Low
Testing: bazel build //test/test_common:file_system_for_test_lib
Docs Changes: N/A
Release Notes: N/A
