### PR TITLE
[WIP]: Split dns resolver implementation for main thread and filter

### DIFF
--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -306,3 +306,4 @@ void DnsResolverImpl::PendingResolution::getAddrInfo(int family) {
 
 } // namespace Network
 } // namespace Envoy
+

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -306,4 +306,3 @@ void DnsResolverImpl::PendingResolution::getAddrInfo(int family) {
 
 } // namespace Network
 } // namespace Envoy
-

--- a/source/common/network/dns_impl.cc
+++ b/source/common/network/dns_impl.cc
@@ -173,7 +173,8 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
       //  We can't add a main thread assertion here because both this code is reused by dns filter
       //  and executed in both main thread and worker thread. Maybe split the code for filter and
       //  main thread.
-      TRY_ASSERT_MAIN_THREAD { callback_(resolution_status, std::move(address_list)); } END_TRY
+      TRY_ASSERT_MAIN_THREAD { callback_(resolution_status, std::move(address_list)); }
+      END_TRY
       catch (const EnvoyException& e) {
         ENVOY_LOG(critical, "EnvoyException in c-ares callback: {}", e.what());
         dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -113,4 +113,3 @@ private:
 
 } // namespace Network
 } // namespace Envoy
-

--- a/source/common/network/dns_impl.h
+++ b/source/common/network/dns_impl.h
@@ -113,3 +113,4 @@ private:
 
 } // namespace Network
 } // namespace Envoy
+

--- a/source/extensions/filters/udp/dns_filter/BUILD
+++ b/source/extensions/filters/udp/dns_filter/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
     ],
     external_deps = ["ares"],
     deps = [
+        ":dns_lib",
         "//include/envoy/buffer:buffer_interface",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:address_interface",
@@ -61,4 +62,22 @@ envoy_cc_extension(
         "//include/envoy/server:filter_config_interface",
         "@envoy_api//envoy/extensions/filters/udp/dns_filter/v3alpha:pkg_cc_proto",
     ],
+)
+
+
+envoy_cc_library(
+    name = "dns_lib",
+    srcs = ["dns_impl.cc"],
+    hdrs = ["dns_impl.h"],
+    external_deps = ["ares"],
+    deps = [
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
+        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/event:file_event_interface",
+        "//include/envoy/network:dns_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:linked_object",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/source/extensions/filters/udp/dns_filter/BUILD
+++ b/source/extensions/filters/udp/dns_filter/BUILD
@@ -69,7 +69,6 @@ envoy_cc_library(
     srcs = ["dns_impl.cc"],
     hdrs = ["dns_impl.h"],
     external_deps = ["ares"],
-    visibility = ["//visibility:public"],
     deps = [
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:file_event_interface",

--- a/source/extensions/filters/udp/dns_filter/BUILD
+++ b/source/extensions/filters/udp/dns_filter/BUILD
@@ -64,20 +64,19 @@ envoy_cc_extension(
     ],
 )
 
-
 envoy_cc_library(
     name = "dns_lib",
     srcs = ["dns_impl.cc"],
     hdrs = ["dns_impl.h"],
     external_deps = ["ares"],
+    visibility = ["//visibility:public"],
     deps = [
-        "//source/common/network:address_lib",
-        "//source/common/network:utility_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/event:file_event_interface",
         "//include/envoy/network:dns_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:linked_object",
+        "//source/common/network:address_lib",
+        "//source/common/network:utility_lib",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/source/extensions/filters/udp/dns_filter/dns_filter.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.h
@@ -145,6 +145,11 @@ public:
    */
   bool isKnownDomain(const absl::string_view domain_name);
 
+
+  void setResolver(const Network::DnsResolverSharedPtr & resolver) {
+    resolver_->setResolver(resolver);
+  }
+
 private:
   /**
    * Prepare the response buffer and send it to the client
@@ -338,6 +343,8 @@ private:
       break;
     }
   }
+
+
 
   /**
    * @brief Helper function to retrieve the Endpoint configuration for a requested domain

--- a/source/extensions/filters/udp/dns_filter/dns_filter.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter.h
@@ -145,8 +145,7 @@ public:
    */
   bool isKnownDomain(const absl::string_view domain_name);
 
-
-  void setResolver(const Network::DnsResolverSharedPtr & resolver) {
+  void setResolver(const Network::DnsResolverSharedPtr& resolver) {
     resolver_->setResolver(resolver);
   }
 
@@ -343,8 +342,6 @@ private:
       break;
     }
   }
-
-
 
   /**
    * @brief Helper function to retrieve the Endpoint configuration for a requested domain

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
@@ -3,8 +3,8 @@
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/dns.h"
 
-#include "extensions/filters/udp/dns_filter/dns_parser.h"
 #include "extensions/filters/udp/dns_filter/dns_impl.h"
+#include "extensions/filters/udp/dns_filter/dns_parser.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -23,7 +23,8 @@ public:
                     std::chrono::milliseconds timeout, Event::Dispatcher& dispatcher,
                     uint64_t max_pending_lookups)
       : timeout_(timeout), dispatcher_(dispatcher),
-        resolver_(DnsResolverImpl::createDnsResolver(dispatcher, resolvers, false /* use_tcp_for_dns_lookups */)),
+        resolver_(DnsResolverImpl::createDnsResolver(dispatcher, resolvers,
+                                                     false /* use_tcp_for_dns_lookups */)),
         callback_(callback), max_pending_lookups_(max_pending_lookups) {}
   /**
    * @brief entry point to resolve the name in a DnsQueryRecord
@@ -35,9 +36,7 @@ public:
    * @param domain_query the query record object containing the name for which we are resolving
    */
   void resolveExternalQuery(DnsQueryContextPtr context, const DnsQueryRecord* domain_query);
-  void setResolver(const Network::DnsResolverSharedPtr & resolver) {
-    resolver_ = resolver;
-  }
+  void setResolver(const Network::DnsResolverSharedPtr& resolver) { resolver_ = resolver; }
 
 private:
   struct LookupContext {

--- a/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_resolver.h
@@ -4,6 +4,7 @@
 #include "envoy/network/dns.h"
 
 #include "extensions/filters/udp/dns_filter/dns_parser.h"
+#include "extensions/filters/udp/dns_filter/dns_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -22,7 +23,7 @@ public:
                     std::chrono::milliseconds timeout, Event::Dispatcher& dispatcher,
                     uint64_t max_pending_lookups)
       : timeout_(timeout), dispatcher_(dispatcher),
-        resolver_(dispatcher.createDnsResolver(resolvers, false /* use_tcp_for_dns_lookups */)),
+        resolver_(DnsResolverImpl::createDnsResolver(dispatcher, resolvers, false /* use_tcp_for_dns_lookups */)),
         callback_(callback), max_pending_lookups_(max_pending_lookups) {}
   /**
    * @brief entry point to resolve the name in a DnsQueryRecord
@@ -34,6 +35,9 @@ public:
    * @param domain_query the query record object containing the name for which we are resolving
    */
   void resolveExternalQuery(DnsQueryContextPtr context, const DnsQueryRecord* domain_query);
+  void setResolver(const Network::DnsResolverSharedPtr & resolver) {
+    resolver_ = resolver;
+  }
 
 private:
   struct LookupContext {
@@ -63,7 +67,7 @@ private:
 
   std::chrono::milliseconds timeout_;
   Event::Dispatcher& dispatcher_;
-  const Network::DnsResolverSharedPtr resolver_;
+  Network::DnsResolverSharedPtr resolver_;
   DnsFilterResolverCallback& callback_;
   absl::flat_hash_map<const DnsQueryRecord*, LookupContext> lookups_;
   uint64_t max_pending_lookups_;

--- a/source/extensions/filters/udp/dns_filter/dns_impl.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_impl.cc
@@ -17,7 +17,6 @@
 #include "absl/strings/str_join.h"
 #include "ares.h"
 
-
 namespace Envoy {
 namespace Extensions {
 namespace UdpFilters {
@@ -140,7 +139,7 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
 
           address_list.emplace_back(
               Network::DnsResponse(std::make_shared<const Network::Address::Ipv4Instance>(&address),
-                          std::chrono::seconds(ai->ai_ttl)));
+                                   std::chrono::seconds(ai->ai_ttl)));
         }
       } else if (addrinfo->nodes->ai_family == AF_INET6) {
         for (const ares_addrinfo_node* ai = addrinfo->nodes; ai != nullptr; ai = ai->ai_next) {
@@ -151,7 +150,7 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
           address.sin6_addr = reinterpret_cast<sockaddr_in6*>(ai->ai_addr)->sin6_addr;
           address_list.emplace_back(
               Network::DnsResponse(std::make_shared<const Network::Address::Ipv6Instance>(address),
-                          std::chrono::seconds(ai->ai_ttl)));
+                                   std::chrono::seconds(ai->ai_ttl)));
         }
       }
     }
@@ -176,16 +175,15 @@ void DnsResolverImpl::PendingResolution::onAresGetAddrInfoCallback(int status, i
       //  We can't add a main thread assertion here because both this code is reused by dns filter
       //  and executed in both main thread and worker thread. Maybe split the code for filter and
       //  main thread.
-      try { callback_(resolution_status, std::move(address_list)); }
-      catch (const EnvoyException& e) {
+      try {
+        callback_(resolution_status, std::move(address_list));
+      } catch (const EnvoyException& e) {
         ENVOY_LOG(critical, "EnvoyException in c-ares callback: {}", e.what());
         dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
-      }
-      catch (const std::exception& e) {
+      } catch (const std::exception& e) {
         ENVOY_LOG(critical, "std::exception in c-ares callback: {}", e.what());
         dispatcher_.post([s = std::string(e.what())] { throw EnvoyException(s); });
-      }
-      catch (...) {
+      } catch (...) {
         ENVOY_LOG(critical, "Unknown exception in c-ares callback");
         dispatcher_.post([] { throw EnvoyException("unknown"); });
       }
@@ -248,7 +246,8 @@ void DnsResolverImpl::onAresSocketStateChange(os_fd_t fd, int read, int write) {
 }
 
 Network::ActiveDnsQuery* DnsResolverImpl::resolve(const std::string& dns_name,
-                                         Network::DnsLookupFamily dns_lookup_family, ResolveCb callback) {
+                                                  Network::DnsLookupFamily dns_lookup_family,
+                                                  ResolveCb callback) {
   // TODO(hennna): Add DNS caching which will allow testing the edge case of a
   // failed initial call to getAddrInfo followed by a synchronous IPv4
   // resolution.

--- a/source/extensions/filters/udp/dns_filter/dns_impl.h
+++ b/source/extensions/filters/udp/dns_filter/dns_impl.h
@@ -120,9 +120,9 @@ bool dirty_channel_{};
 const bool use_tcp_for_dns_lookups_;
 absl::node_hash_map<int, Event::FileEventPtr> events_;
 const absl::optional<std::string> resolvers_csv_;
-}; // namespace DnsFilter
+};
 
+} // namespace DnsFilter
 } // namespace UdpFilters
 } // namespace Extensions
-} // namespace Envoy
 } // namespace Envoy

--- a/source/extensions/filters/udp/dns_filter/dns_impl.h
+++ b/source/extensions/filters/udp/dns_filter/dns_impl.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "envoy/common/platform.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/file_event.h"
+#include "envoy/network/dns.h"
+
+#include "common/common/linked_object.h"
+#include "common/common/logger.h"
+#include "common/common/utility.h"
+
+#include "absl/container/node_hash_map.h"
+#include "ares.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace UdpFilters {
+namespace DnsFilter {
+
+/**
+ * Implementation of DnsResolver that uses c-ares. All calls and callbacks are assumed to
+ * happen on the thread that owns the creating dispatcher.
+ */
+class DnsResolverImpl : public Network::DnsResolver,
+                        protected Logger::Loggable<Logger::Id::upstream> {
+public:
+  DnsResolverImpl(Event::Dispatcher& dispatcher,
+                  const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers,
+                  const bool use_tcp_for_dns_lookups);
+  ~DnsResolverImpl() override;
+
+  // Network::DnsResolver
+  Network::ActiveDnsQuery* resolve(const std::string& dns_name,
+                                   Network::DnsLookupFamily dns_lookup_family,
+                                   ResolveCb callback) override;
+
+  static Network::DnsResolverSharedPtr
+  createDnsResolver(Event::Dispatcher& dispatcher,
+                    const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers,
+                    const bool use_tcp_for_dns_lookups) {
+#ifdef __APPLE__
+    return dispatcher.createDnsResolver(resolvers, use_tcp_for_dns_lookups);
+  }
+#endif
+  return std::make_shared<DnsResolverImpl>(dispatcher, resolvers, use_tcp_for_dns_lookups);
+}
+
+private : struct PendingResolution : public Network::ActiveDnsQuery {
+  // Network::ActiveDnsQuery
+  PendingResolution(DnsResolverImpl& parent, ResolveCb callback, Event::Dispatcher& dispatcher,
+                    ares_channel channel, const std::string& dns_name)
+      : parent_(parent), callback_(callback), dispatcher_(dispatcher), channel_(channel),
+        dns_name_(dns_name) {}
+
+  void cancel() override {
+    // c-ares only supports channel-wide cancellation, so we just allow the
+    // network events to continue but don't invoke the callback on completion.
+    cancelled_ = true;
+  }
+
+  /**
+   * ares_getaddrinfo query callback.
+   * @param status return status of call to ares_getaddrinfo.
+   * @param timeouts the number of times the request timed out.
+   * @param addrinfo structure to store address info.
+   */
+  void onAresGetAddrInfoCallback(int status, int timeouts, ares_addrinfo* addrinfo);
+  /**
+   * wrapper function of call to ares_getaddrinfo.
+   * @param family currently AF_INET and AF_INET6 are supported.
+   */
+  void getAddrInfo(int family);
+
+  DnsResolverImpl& parent_;
+  // Caller supplied callback to invoke on query completion or error.
+  const ResolveCb callback_;
+  // Dispatcher to post any callback_ exceptions to.
+  Event::Dispatcher& dispatcher_;
+  // Does the object own itself? Resource reclamation occurs via self-deleting
+  // on query completion or error.
+  bool owned_ = false;
+  // Has the query completed? Only meaningful if !owned_;
+  bool completed_ = false;
+  // Was the query cancelled via cancel()?
+  bool cancelled_ = false;
+  // If dns_lookup_family is "fallback", fallback to v4 address if v6
+  // resolution failed.
+  bool fallback_if_failed_ = false;
+  const ares_channel channel_;
+  const std::string dns_name_;
+};
+
+struct AresOptions {
+  ares_options options_;
+  int optmask_;
+};
+
+static absl::optional<std::string>
+maybeBuildResolversCsv(const std::vector<Network::Address::InstanceConstSharedPtr>& resolvers);
+
+// Callback for events on sockets tracked in events_.
+void onEventCallback(os_fd_t fd, uint32_t events);
+// c-ares callback when a socket state changes, indicating that libevent
+// should listen for read/write events.
+void onAresSocketStateChange(os_fd_t fd, int read, int write);
+// Initialize the channel.
+void initializeChannel(ares_options* options, int optmask);
+// Update timer for c-ares timeouts.
+void updateAresTimer();
+// Return default AresOptions.
+AresOptions defaultAresOptions();
+
+Event::Dispatcher& dispatcher_;
+Event::TimerPtr timer_;
+ares_channel channel_;
+bool dirty_channel_{};
+const bool use_tcp_for_dns_lookups_;
+absl::node_hash_map<int, Event::FileEventPtr> events_;
+const absl::optional<std::string> resolvers_csv_;
+}; // namespace DnsFilter
+
+} // namespace UdpFilters
+} // namespace Extensions
+} // namespace Envoy
+} // namespace Envoy

--- a/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
@@ -639,8 +639,6 @@ TEST_F(DnsFilterTest, LocalTypeAAAAQuerySuccess) {
 TEST_F(DnsFilterTest, ExternalResolutionReturnSingleAddress) {
   InSequence s;
 
-
-
   const std::string expected_address("130.207.244.251");
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
@@ -692,8 +690,6 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnSingleAddress) {
 
 TEST_F(DnsFilterTest, ExternalResolutionIpv6SingleAddress) {
   InSequence s;
-
-
 
   const std::string expected_address("2a04:4e42:d::323");
   const std::string domain("www.foobaz.com");
@@ -748,7 +744,6 @@ TEST_F(DnsFilterTest, ExternalResolutionIpv6SingleAddress) {
 TEST_F(DnsFilterTest, ExternalResolutionReturnMultipleAddresses) {
   InSequence s;
 
-
   const std::list<std::string> expected_address{"130.207.244.251", "130.207.244.252",
                                                 "130.207.244.253", "130.207.244.254"};
   const std::string domain("www.foobaz.com");
@@ -802,8 +797,6 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnMultipleAddresses) {
 
 TEST_F(DnsFilterTest, ExternalResolutionReturnNoAddresses) {
   InSequence s;
-
-
 
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);

--- a/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_test.cc
@@ -77,10 +77,11 @@ public:
     ON_CALL(listener_factory_, random()).WillByDefault(ReturnRef(random_));
 
     resolver_ = std::make_shared<Network::MockDnsResolver>();
-    ON_CALL(dispatcher_, createDnsResolver(_, _)).WillByDefault(Return(resolver_));
+    // ON_CALL(dispatcher_, createDnsResolver(_, _)).WillByDefault(Return(resolver_));
 
     config_ = std::make_shared<DnsFilterEnvoyConfig>(listener_factory_, config);
     filter_ = std::make_unique<DnsFilter>(callbacks_, config_);
+    filter_->setResolver(resolver_);
   }
 
   void sendQueryFromClient(const std::string& peer_address, const std::string& buffer) {
@@ -638,12 +639,14 @@ TEST_F(DnsFilterTest, LocalTypeAAAAQuerySuccess) {
 TEST_F(DnsFilterTest, ExternalResolutionReturnSingleAddress) {
   InSequence s;
 
-  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
+
 
   const std::string expected_address("130.207.244.251");
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string query =
       Utils::buildQueryForDomain(domain, DNS_RECORD_TYPE_A, DNS_RECORD_CLASS_IN);
@@ -690,13 +693,15 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnSingleAddress) {
 TEST_F(DnsFilterTest, ExternalResolutionIpv6SingleAddress) {
   InSequence s;
 
-  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
+
 
   const std::string expected_address("2a04:4e42:d::323");
   const std::string domain("www.foobaz.com");
 
   setup(forward_query_on_config);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   // Verify that we are calling the resolver with the expected name
   Network::DnsResolver::ResolveCb resolve_cb;
@@ -743,13 +748,14 @@ TEST_F(DnsFilterTest, ExternalResolutionIpv6SingleAddress) {
 TEST_F(DnsFilterTest, ExternalResolutionReturnMultipleAddresses) {
   InSequence s;
 
-  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::list<std::string> expected_address{"130.207.244.251", "130.207.244.252",
                                                 "130.207.244.253", "130.207.244.254"};
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   // Verify that we are calling the resolver with the expected name
   Network::DnsResolver::ResolveCb resolve_cb;
@@ -797,11 +803,13 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnMultipleAddresses) {
 TEST_F(DnsFilterTest, ExternalResolutionReturnNoAddresses) {
   InSequence s;
 
-  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
+
 
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   // Verify that we are calling the resolver with the expected name
   Network::DnsResolver::ResolveCb resolve_cb;
@@ -840,11 +848,11 @@ TEST_F(DnsFilterTest, ExternalResolutionReturnNoAddresses) {
 TEST_F(DnsFilterTest, ExternalResolutionTimeout) {
   InSequence s;
 
-  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
-
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string query =
       Utils::buildQueryForDomain(domain, DNS_RECORD_TYPE_A, DNS_RECORD_CLASS_IN);
@@ -879,11 +887,11 @@ TEST_F(DnsFilterTest, ExternalResolutionTimeout) {
 TEST_F(DnsFilterTest, ExternalResolutionTimeout2) {
   InSequence s;
 
-  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
-  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
-
   const std::string domain("www.foobaz.com");
   setup(forward_query_on_config);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(_, _));
 
   const std::string query =
       Utils::buildQueryForDomain(domain, DNS_RECORD_TYPE_A, DNS_RECORD_CLASS_IN);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: This is part of the effort to remove C++ exception from data plane by adding assertion that the code is executed in main thread when an exception is caught.(#14320) Currently we can't add main thread assertion because dns resolver is used in both main thread and dns filter. This pr split the implementation for main thread and filter so that we can add main thread assertion to the exception catching code in core codebase.
Additional Description:
Risk Level: low
Testing: modify dns filter test to reflect the new change
Docs Changes:none
Release Notes:none
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
