### PR TITLE
test: more fast-timeouts.

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -629,7 +629,7 @@ TEST_P(ExtProcIntegrationTest, GetAndRespondImmediatelyOnResponseBody) {
 
   // The stream should have been reset here before the complete
   // response was received.
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
 }
 
 // Send a request, but wait longer than the "message timeout" before sending a response

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -1351,7 +1351,7 @@ TEST_P(Http2FloodMitigationTest, UpstreamEmptyData) {
   }
 
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_EQ("200", response->headers().getStatusValue());
   EXPECT_EQ(1,
             test_server_->counter("cluster.cluster_0.http2.inbound_empty_frames_flood")->value());
@@ -1417,7 +1417,7 @@ TEST_P(Http2FloodMitigationTest, UpstreamPriorityOneOpenStream) {
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
   // Downstream client should get stream reset since upstream sent headers but did not complete the
   // stream
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_EQ(
       1, test_server_->counter("cluster.cluster_0.http2.inbound_priority_frames_flood")->value());
 }
@@ -1475,7 +1475,7 @@ TEST_P(Http2FloodMitigationTest, UpstreamRstStreamOnStreamIdleTimeout) {
   // Verify that when RST_STREAM overflows upstream queue it is handled correctly
   // by causing upstream connection to be disconnected.
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   //  EXPECT_EQ("408", response->headers().getStatusValue());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http2.outbound_control_flood")->value());
   EXPECT_EQ(1, test_server_->counter("http.config_test.downstream_rq_idle_timeout")->value());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -693,7 +693,7 @@ void HttpIntegrationTest::testRouterUpstreamDisconnectBeforeResponseComplete(
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     codec_client_->close();
   }
 
@@ -1144,7 +1144,7 @@ void HttpIntegrationTest::testLargeRequestUrl(uint32_t url_size, uint32_t max_he
       EXPECT_TRUE(response->complete());
       EXPECT_EQ("431", response->headers().Status()->value().getStringView());
     } else {
-      response->waitForReset();
+      ASSERT_TRUE(response->waitForReset());
       codec_client_->close();
     }
   } else {
@@ -1192,7 +1192,7 @@ void HttpIntegrationTest::testLargeRequestHeaders(uint32_t size, uint32_t count,
       EXPECT_TRUE(response->complete());
       EXPECT_EQ("431", response->headers().getStatusValue());
     } else {
-      response->waitForReset();
+      ASSERT_TRUE(response->waitForReset());
       codec_client_->close();
     }
   } else {
@@ -1235,7 +1235,7 @@ void HttpIntegrationTest::testLargeRequestTrailers(uint32_t size, uint32_t max_s
     } else {
       // Expect a stream reset when the size of the trailers is larger than the maximum
       // limit.
-      response->waitForReset();
+      ASSERT_TRUE(response->waitForReset());
       codec_client_->close();
       EXPECT_FALSE(response->complete());
     }
@@ -1432,7 +1432,7 @@ void HttpIntegrationTest::testMaxStreamDuration() {
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     codec_client_->close();
   }
 }
@@ -1477,7 +1477,7 @@ void HttpIntegrationTest::testMaxStreamDurationWithRetry(bool invoke_retry_upstr
     if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
       ASSERT_TRUE(codec_client_->waitForDisconnect());
     } else {
-      response->waitForReset();
+      ASSERT_TRUE(response->waitForEndStream());
       codec_client_->close();
     }
 

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -211,7 +211,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpst
 
   ASSERT_TRUE(upstream_request_->waitForReset(std::chrono::seconds(15)));
 
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
 
   codec_client_->close();
 

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -71,7 +71,7 @@ public:
     if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
       ASSERT_TRUE(codec_client_->waitForDisconnect());
     } else {
-      response.waitForReset();
+      ASSERT_TRUE(response.waitForReset());
       codec_client_->close();
     }
     if (!stat_name.empty()) {

--- a/test/integration/integration_stream_decoder.cc
+++ b/test/integration/integration_stream_decoder.cc
@@ -69,11 +69,17 @@ AssertionResult IntegrationStreamDecoder::waitForEndStream(std::chrono::millisec
   return AssertionSuccess();
 }
 
-void IntegrationStreamDecoder::waitForReset() {
+AssertionResult IntegrationStreamDecoder::waitForReset(std::chrono::milliseconds timeout) {
   if (!saw_reset_) {
+    Event::TimerPtr timer(dispatcher_.createTimer([this]() -> void { dispatcher_.exit(); }));
+    timer->enableTimer(timeout);
     waiting_for_reset_ = true;
     dispatcher_.run(Event::Dispatcher::RunType::Block);
+    if (!timer->enabled()) {
+      return AssertionFailure() << "Timed out waiting for reset.";
+    }
   }
+  return AssertionSuccess();
 }
 
 void IntegrationStreamDecoder::decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) {

--- a/test/integration/integration_stream_decoder.h
+++ b/test/integration/integration_stream_decoder.h
@@ -42,7 +42,8 @@ public:
   void waitForBodyData(uint64_t size);
   testing::AssertionResult
   waitForEndStream(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
-  void waitForReset();
+  testing::AssertionResult
+  waitForReset(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
   void clearBody() { body_.clear(); }
 
   // Http::StreamDecoder

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -142,7 +142,7 @@ TEST_P(Http2IntegrationTest, CodecStreamIdleTimeout) {
   upstream_request_->encodeHeaders(default_response_headers_, false);
   upstream_request_->encodeData(70000, true);
   test_server_->waitForCounterEq("http2.tx_flush_timeout", 1);
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
 }
 
 TEST_P(Http2IntegrationTest, Http2DownstreamKeepalive) {
@@ -171,7 +171,7 @@ TEST_P(Http2IntegrationTest, Http2DownstreamKeepalive) {
   test_server_->waitForCounterEq("http2.keepalive_timeout", 1,
                                  std::chrono::milliseconds(timeout_ms * 2));
 
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
 }
 
 static std::string response_metadata_filter = R"EOF(
@@ -299,7 +299,7 @@ TEST_P(Http2MetadataIntegrationTest, ProxyMetadataInResponse) {
   upstream_request_->encodeResetStream();
 
   // Verifies stream is reset.
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   ASSERT_FALSE(response->complete());
 }
 
@@ -502,7 +502,7 @@ TEST_P(Http2MetadataIntegrationTest, ProxyMultipleMetadataReachSizeLimit) {
   upstream_request_->encodeData(12, true);
 
   // Verifies reset is received.
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   ASSERT_FALSE(response->complete());
 }
 
@@ -882,8 +882,8 @@ TEST_P(Http2IntegrationTest, CodecErrorAfterStreamStart) {
   Buffer::OwnedImpl bogus_data("some really bogus data");
   codec_client_->rawConnection().write(bogus_data, false);
 
-  // Verifies reset is received.
-  response->waitForReset();
+  // Verifies error is received.
+  ASSERT_TRUE(response->waitForEndStream());
 }
 
 TEST_P(Http2IntegrationTest, Http2BadMagic) {
@@ -1690,7 +1690,7 @@ TEST_P(Http2IntegrationTest, OnLocalReply) {
   {
     default_request_headers_.addCopy("reset", "yes");
     auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     ASSERT_FALSE(response->complete());
   }
 }

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -184,7 +184,7 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
 
   // Reset the stream.
   upstream_request_->encodeResetStream();
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_FALSE(response->complete());
 }
 
@@ -386,7 +386,7 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
   // Ensure the streams are all reset successfully.
   for (uint32_t i = 1; i < num_requests; ++i) {
-    responses[i]->waitForReset();
+    ASSERT_TRUE(responses[i]->waitForReset());
   }
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1192,7 +1192,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HeadersWithUnderscoresCauseRequestReje
     ASSERT_TRUE(response->complete());
     EXPECT_EQ("400", response->headers().getStatusValue());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     codec_client_->close();
     ASSERT_TRUE(response->reset());
     EXPECT_EQ(Http::StreamResetReason::RemoteReset, response->resetReason());
@@ -1257,7 +1257,7 @@ TEST_P(ProtocolIntegrationTest, 304WithBody) {
   // 304-with-body, is there a protocol error on the active stream.
   if (downstream_protocol_ >= Http::CodecClient::Type::HTTP2 &&
       upstreamProtocol() >= FakeHttpConnection::Type::HTTP2) {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
   }
 }
 
@@ -1438,7 +1438,7 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidContentLengthAllowed) {
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     codec_client_->close();
   }
 
@@ -1497,7 +1497,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MultipleContentLengthsAllowed) {
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     codec_client_->close();
   }
 
@@ -1553,7 +1553,7 @@ name: local-reply-during-encode-data
 
   // Response was aborted after headers were sent to the client.
   // The stream was reset. Client does not receive body or trailers.
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_FALSE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
   EXPECT_EQ(0, response->body().length());
@@ -1622,7 +1622,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersRejected) {
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("431", response->headers().getStatusValue());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     codec_client_->close();
   }
 }
@@ -2193,8 +2193,7 @@ TEST_P(DownstreamProtocolIntegrationTest, BasicMaxStreamTimeout) {
   ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
 
   test_server_->waitForCounterGe("http.config_test.downstream_rq_max_duration_reached", 1);
-  response->waitForReset();
-  EXPECT_TRUE(response->complete());
+  ASSERT_TRUE(response->waitForEndStream());
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, BasicMaxStreamTimeoutLegacy) {
@@ -2214,7 +2213,7 @@ TEST_P(DownstreamProtocolIntegrationTest, BasicMaxStreamTimeoutLegacy) {
   ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
 
   test_server_->waitForCounterGe("http.config_test.downstream_rq_max_duration_reached", 1);
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_FALSE(response->complete());
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("max_duration_timeout"));
 }
@@ -2259,7 +2258,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectIsBlocked) {
     EXPECT_EQ("404", response->headers().getStatusValue());
     EXPECT_TRUE(response->complete());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   }
 }
@@ -2288,7 +2287,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
   auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "CONNECT"}, {":path", "/"}, {":authority", "host"}});
 
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_FALSE(codec_client_->disconnected());
 }
 
@@ -2321,7 +2320,7 @@ TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnectLegacy) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
     EXPECT_FALSE(response->complete());
   } else {
-    response->waitForReset();
+    ASSERT_TRUE(response->waitForReset());
     EXPECT_FALSE(response->complete());
   }
 }

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -364,7 +364,7 @@ TEST_P(QuicHttpIntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
 
   ASSERT_TRUE(response->waitForEndStream());
   // The delayed close timeout should trigger since client is not closing the connection.
-  EXPECT_TRUE(codec_client_->waitForDisconnect(std::chrono::milliseconds(5000)));
+  EXPECT_TRUE(codec_client_->waitForDisconnect(std::chrono::milliseconds(10000)));
   EXPECT_EQ(codec_client_->lastConnectionEvent(), Network::ConnectionEvent::RemoteClose);
   EXPECT_EQ(test_server_->counter("http.config_test.downstream_cx_delayed_close_timeout")->value(),
             1);
@@ -544,7 +544,7 @@ TEST_P(QuicHttpIntegrationTest, Reset101SwitchProtocolResponse) {
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
 
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "101"}}, false);
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   codec_client_->close();
   EXPECT_FALSE(response->complete());
 }

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -169,7 +169,7 @@ TEST_P(ConnectTerminationIntegrationTest, UpstreamClose) {
 
   // Tear down by closing the upstream connection.
   ASSERT_TRUE(fake_raw_upstream_connection_->close());
-  response_->waitForReset();
+  ASSERT_TRUE(response_->waitForReset());
 }
 
 TEST_P(ConnectTerminationIntegrationTest, TestTimeout) {
@@ -179,7 +179,7 @@ TEST_P(ConnectTerminationIntegrationTest, TestTimeout) {
   setUpConnection();
 
   // Wait for the timeout to close the connection.
-  response_->waitForReset();
+  ASSERT_TRUE(response_->waitForReset());
   ASSERT_TRUE(fake_raw_upstream_connection_->waitForHalfClose());
 }
 
@@ -229,7 +229,7 @@ TEST_P(ConnectTerminationIntegrationTest, BasicMaxStreamDuration) {
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     ASSERT_TRUE(codec_client_->waitForDisconnect());
   } else {
-    response_->waitForReset();
+    ASSERT_TRUE(response_->waitForReset());
     codec_client_->close();
   }
 }

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -691,7 +691,7 @@ TEST_P(VhdsIntegrationTest, VhdsOnDemandUpdateHttpConnectionCloses) {
   vhds_stream_->sendGrpcMessage(vhds_update);
 
   codec_client_->sendReset(encoder);
-  response->waitForReset();
+  ASSERT_TRUE(response->waitForReset());
   EXPECT_TRUE(codec_client_->connected());
 
   cleanupUpstreamAndDownstream();

--- a/test/integration/websocket_integration_test.h
+++ b/test/integration/websocket_integration_test.h
@@ -40,7 +40,7 @@ protected:
   void waitForClientDisconnectOrReset(
       Http::StreamResetReason reason = Http::StreamResetReason::RemoteReset) {
     if (downstreamProtocol() != Http::CodecClient::Type::HTTP1) {
-      response_->waitForReset();
+      ASSERT_TRUE(response_->waitForReset());
       ASSERT_EQ(reason, response_->resetReason());
     } else {
       ASSERT_TRUE(codec_client_->waitForDisconnect());


### PR DESCRIPTION
H2 waitForReset also picks up end stream, while H2 doesn't, so a bunch of QUIC tests
were actually spinning on waitForReset until disconnect happened.

Fixing it and fixing it forward by having a faster timeout which catches if we're waiting for the wrong thing.

Risk Level: n/a 
Testing: passes locally at least =P
Docs Changes: n/a
Release Notes: n/a