### PR TITLE
xds: Relax the CHECK on factories for typed per-filter config

### DIFF
--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -10,6 +10,20 @@ namespace Envoy {
 namespace Router {
 
 /**
+ * All RDS stats. @see stats_macros.h
+ */
+#define ALL_RDS_STATS(COUNTER)                                                                     \
+  COUNTER(config_reload)                                                                           \
+  COUNTER(update_empty)
+
+/**
+ * Struct definition for all RDS stats. @see stats_macros.h
+ */
+struct RdsStats {
+  ALL_RDS_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
  * A provider for constant route configurations.
  */
 class RouteConfigProvider {

--- a/include/envoy/router/rds.h
+++ b/include/envoy/router/rds.h
@@ -14,7 +14,8 @@ namespace Router {
  */
 #define ALL_RDS_STATS(COUNTER)                                                                     \
   COUNTER(config_reload)                                                                           \
-  COUNTER(update_empty)
+  COUNTER(update_empty)                                                                            \
+  COUNTER(unknown_per_filter_typed_config_factory)
 
 /**
  * Struct definition for all RDS stats. @see stats_macros.h

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -43,6 +43,7 @@ envoy_cc_library(
         ":tls_context_match_criteria_lib",
         "//include/envoy/config:typed_metadata_interface",
         "//include/envoy/http:header_map_interface",
+        "//include/envoy/router:rds_interface",
         "//include/envoy/router:router_interface",
         "//include/envoy/runtime:runtime_interface",
         "//include/envoy/server:filter_config_interface",  # TODO(rodaine): break dependency on server

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1494,13 +1494,15 @@ VirtualHostImpl::virtualClusterFromEntries(const Http::HeaderMap& headers) const
 ConfigImpl::ConfigImpl(const envoy::config::route::v3::RouteConfiguration& config,
                        Server::Configuration::ServerFactoryContext& factory_context,
                        ProtobufMessage::ValidationVisitor& validator,
-                       bool validate_clusters_default)
+                       bool validate_clusters_default,
+                       RdsStats* rds_stats)
     : name_(config.name()), symbol_table_(factory_context.scope().symbolTable()),
       uses_vhds_(config.has_vhds()),
       most_specific_header_mutations_wins_(config.most_specific_header_mutations_wins()),
       max_direct_response_body_size_bytes_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_direct_response_body_size_bytes,
-                                          DEFAULT_MAX_DIRECT_RESPONSE_BODY_SIZE_BYTES)) {
+                                          DEFAULT_MAX_DIRECT_RESPONSE_BODY_SIZE_BYTES)),
+      rds_stats_(rds_stats) {
   route_matcher_ = std::make_unique<RouteMatcher>(
       config, *this, factory_context, validator,
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, validate_clusters, validate_clusters_default));

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -13,6 +13,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/route/v3/route.pb.h"
 #include "envoy/config/route/v3/route_components.pb.h"
+#include "envoy/router/rds.h"
 #include "envoy/router/router.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/filter_config.h"
@@ -1029,7 +1030,8 @@ class ConfigImpl : public Config {
 public:
   ConfigImpl(const envoy::config::route::v3::RouteConfiguration& config,
              Server::Configuration::ServerFactoryContext& factory_context,
-             ProtobufMessage::ValidationVisitor& validator, bool validate_clusters_default);
+             ProtobufMessage::ValidationVisitor& validator, bool validate_clusters_default,
+             RdsStats* rds_stats = nullptr);
 
   const HeaderParser& requestHeaderParser() const { return *request_headers_parser_; };
   const HeaderParser& responseHeaderParser() const { return *response_headers_parser_; };
@@ -1065,6 +1067,10 @@ public:
     return max_direct_response_body_size_bytes_;
   }
 
+  RdsStats* rdsStats() const {
+    return rds_stats_;
+  }
+
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;
   std::list<Http::LowerCaseString> internal_only_headers_;
@@ -1075,6 +1081,7 @@ private:
   const bool uses_vhds_;
   const bool most_specific_header_mutations_wins_;
   const uint32_t max_direct_response_body_size_bytes_;
+  RdsStats* rds_stats_;
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -73,6 +73,17 @@ public:
   const RouteSpecificFilterConfig* get(const std::string& name) const;
 
 private:
+  Server::Configuration::NamedHttpFilterConfigFactory*
+  getRouteSpecificFilterConfigFactory(const std::string& name,
+                                      const VirtualHostImpl& vhost);
+
+  RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfig(Server::Configuration::NamedHttpFilterConfigFactory* factory,
+                                  const std::string& name, const ProtobufWkt::Any& typed_config,
+                                  const ProtobufWkt::Struct& config,
+                                  Server::Configuration::ServerFactoryContext& factory_context,
+                                  ProtobufMessage::ValidationVisitor& validator);
+
   absl::node_hash_map<std::string, RouteSpecificFilterConfigConstSharedPtr> configs_;
 };
 

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -74,8 +74,7 @@ public:
 
 private:
   Server::Configuration::NamedHttpFilterConfigFactory*
-  getRouteSpecificFilterConfigFactory(const std::string& name,
-                                      const VirtualHostImpl& vhost);
+  getRouteSpecificFilterConfigFactory(const std::string& name, const VirtualHostImpl& vhost);
 
   RouteSpecificFilterConfigConstSharedPtr
   createRouteSpecificFilterConfig(Server::Configuration::NamedHttpFilterConfigFactory* factory,
@@ -1082,9 +1081,7 @@ public:
     return max_direct_response_body_size_bytes_;
   }
 
-  RdsStats* rdsStats() const {
-    return rds_stats_;
-  }
+  RdsStats* rdsStats() const { return rds_stats_; }
 
 private:
   std::unique_ptr<RouteMatcher> route_matcher_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -60,10 +60,13 @@ public:
   virtual bool supportsPathlessHeaders() const { return false; }
 };
 
+class VirtualHostImpl;
+
 class PerFilterConfigs : public Logger::Loggable<Logger::Id::http> {
 public:
   PerFilterConfigs(const Protobuf::Map<std::string, ProtobufWkt::Any>& typed_configs,
                    const Protobuf::Map<std::string, ProtobufWkt::Struct>& configs,
+                   const VirtualHostImpl& vhost,
                    Server::Configuration::ServerFactoryContext& factory_context,
                    ProtobufMessage::ValidationVisitor& validator);
 
@@ -729,7 +732,8 @@ private:
     WeightedClusterEntry(const RouteEntryImplBase* parent, const std::string& rutime_key,
                          Server::Configuration::ServerFactoryContext& factory_context,
                          ProtobufMessage::ValidationVisitor& validator,
-                         const envoy::config::route::v3::WeightedCluster::ClusterWeight& cluster);
+                         const envoy::config::route::v3::WeightedCluster::ClusterWeight& cluster,
+                         const VirtualHostImpl& vhost);
 
     uint64_t clusterWeight() const {
       return loader_.snapshot().getInteger(runtime_key_, cluster_weight_);

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -89,7 +89,7 @@ RdsRouteConfigSubscription::RdsRouteConfigSubscription(
           rds.config_source(), Grpc::Common::typeUrl(resource_name), *scope_, *this,
           resource_decoder_, {});
   local_init_manager_.add(local_init_target_);
-  config_update_info_ = std::make_unique<RouteConfigUpdateReceiverImpl>(factory_context);
+  config_update_info_ = std::make_unique<RouteConfigUpdateReceiverImpl>(factory_context, stats_);
 }
 
 RdsRouteConfigSubscription::~RdsRouteConfigSubscription() {
@@ -232,7 +232,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   ConfigConstSharedPtr initial_config;
   if (config_update_info_->configInfo().has_value()) {
     initial_config = std::make_shared<ConfigImpl>(config_update_info_->protobufConfiguration(),
-                                                  factory_context_, validator_, false);
+                                                  factory_context_, validator_, false, subscription->stats());
   } else {
     initial_config = std::make_shared<NullConfigImpl>();
   }

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -231,8 +231,9 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
       tls_(factory_context.threadLocal()) {
   ConfigConstSharedPtr initial_config;
   if (config_update_info_->configInfo().has_value()) {
-    initial_config = std::make_shared<ConfigImpl>(config_update_info_->protobufConfiguration(),
-                                                  factory_context_, validator_, false, &subscription->stats());
+    initial_config =
+        std::make_shared<ConfigImpl>(config_update_info_->protobufConfiguration(), factory_context_,
+                                     validator_, false, &subscription->stats());
   } else {
     initial_config = std::make_shared<NullConfigImpl>();
   }

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -232,7 +232,7 @@ RdsRouteConfigProviderImpl::RdsRouteConfigProviderImpl(
   ConfigConstSharedPtr initial_config;
   if (config_update_info_->configInfo().has_value()) {
     initial_config = std::make_shared<ConfigImpl>(config_update_info_->protobufConfiguration(),
-                                                  factory_context_, validator_, false, subscription->stats());
+                                                  factory_context_, validator_, false, &subscription->stats());
   } else {
     initial_config = std::make_shared<NullConfigImpl>();
   }

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -111,8 +111,8 @@ public:
   void maybeCreateInitManager(const std::string& version_info,
                               std::unique_ptr<Init::ManagerImpl>& init_manager,
                               std::unique_ptr<Cleanup>& resume_rds);
-  RdsStats* stats() {
-    return &stats_;
+  RdsStats& stats() {
+    return stats_;
   }
 
 private:

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -111,6 +111,9 @@ public:
   void maybeCreateInitManager(const std::string& version_info,
                               std::unique_ptr<Init::ManagerImpl>& init_manager,
                               std::unique_ptr<Cleanup>& resume_rds);
+  RdsStats* stats() {
+    return &stats_;
+  }
 
 private:
   // Config::SubscriptionCallbacks

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -111,9 +111,7 @@ public:
   void maybeCreateInitManager(const std::string& version_info,
                               std::unique_ptr<Init::ManagerImpl>& init_manager,
                               std::unique_ptr<Cleanup>& resume_rds);
-  RdsStats& stats() {
-    return stats_;
-  }
+  RdsStats& stats() { return stats_; }
 
 private:
   // Config::SubscriptionCallbacks

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -93,20 +93,6 @@ private:
   RouteConfigProviderManagerImpl& route_config_provider_manager_;
 };
 
-/**
- * All RDS stats. @see stats_macros.h
- */
-#define ALL_RDS_STATS(COUNTER)                                                                     \
-  COUNTER(config_reload)                                                                           \
-  COUNTER(update_empty)
-
-/**
- * Struct definition for all RDS stats. @see stats_macros.h
- */
-struct RdsStats {
-  ALL_RDS_STATS(GENERATE_COUNTER_STRUCT)
-};
-
 class RdsRouteConfigProviderImpl;
 
 /**

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -30,7 +30,7 @@ bool RouteConfigUpdateReceiverImpl::onRdsUpdate(
   rebuildRouteConfig(rds_virtual_hosts_, *vhds_virtual_hosts_, *route_config_proto_);
   config_ = std::make_shared<ConfigImpl>(
       *route_config_proto_, factory_context_,
-      factory_context_.messageValidationContext().dynamicValidationVisitor(), false);
+      factory_context_.messageValidationContext().dynamicValidationVisitor(), false, &stats_);
 
   onUpdateCommon(version_info);
   return true;
@@ -55,7 +55,7 @@ bool RouteConfigUpdateReceiverImpl::onVhdsUpdate(
 
   auto new_config = std::make_shared<ConfigImpl>(
       *route_config_after_this_update, factory_context_,
-      factory_context_.messageValidationContext().dynamicValidationVisitor(), false);
+      factory_context_.messageValidationContext().dynamicValidationVisitor(), false, &stats_);
 
   // No exception, route_config_after_this_update is valid, can update the state.
   vhds_virtual_hosts_ = std::move(vhosts_after_this_update);

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -18,13 +18,13 @@ namespace Router {
 
 class RouteConfigUpdateReceiverImpl : public RouteConfigUpdateReceiver {
 public:
-  RouteConfigUpdateReceiverImpl(Server::Configuration::ServerFactoryContext& factory_context)
+  RouteConfigUpdateReceiverImpl(Server::Configuration::ServerFactoryContext& factory_context, RdsStats& stats)
       : factory_context_(factory_context), time_source_(factory_context.timeSource()),
         route_config_proto_(std::make_unique<envoy::config::route::v3::RouteConfiguration>()),
         last_config_hash_(0ull), last_vhds_config_hash_(0ul),
         vhds_virtual_hosts_(
             std::make_unique<std::map<std::string, envoy::config::route::v3::VirtualHost>>()),
-        vhds_configuration_changed_(true) {}
+        vhds_configuration_changed_(true), stats_(stats) {}
 
   void initializeRdsVhosts(const envoy::config::route::v3::RouteConfiguration& route_configuration);
   bool removeVhosts(std::map<std::string, envoy::config::route::v3::VirtualHost>& vhosts,
@@ -75,6 +75,7 @@ private:
   std::set<std::string> resource_ids_in_last_update_;
   bool vhds_configuration_changed_;
   ConfigConstSharedPtr config_;
+  RdsStats& stats_;
 };
 
 } // namespace Router

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -18,7 +18,8 @@ namespace Router {
 
 class RouteConfigUpdateReceiverImpl : public RouteConfigUpdateReceiver {
 public:
-  RouteConfigUpdateReceiverImpl(Server::Configuration::ServerFactoryContext& factory_context, RdsStats& stats)
+  RouteConfigUpdateReceiverImpl(Server::Configuration::ServerFactoryContext& factory_context,
+                                RdsStats& stats)
       : factory_context_(factory_context), time_source_(factory_context.timeSource()),
         route_config_proto_(std::make_unique<envoy::config::route::v3::RouteConfiguration>()),
         last_config_hash_(0ull), last_vhds_config_hash_(0ul),

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -63,6 +63,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.allow_preconnect",
     "envoy.reloadable_features.allow_response_for_timeout",
     "envoy.reloadable_features.check_unsupported_typed_per_filter_config",
+    "envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory",
     "envoy.reloadable_features.check_ocsp_policy",
     "envoy.reloadable_features.disable_tls_inspector_injection",
     "envoy.reloadable_features.dont_add_content_length_for_bodiless_requests",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -7906,7 +7906,8 @@ virtual_hosts:
     per_filter_config: { unknown.filter: {} }
 )EOF";
   Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory", "false"}});
+      {{"envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory",
+        "false"}});
 
   EXPECT_THROW_WITH_MESSAGE(
       TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
@@ -7927,7 +7928,8 @@ virtual_hosts:
         "@type": type.googleapis.com/google.protobuf.Timestamp
 )EOF";
   Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory", "false"}});
+      {{"envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory",
+        "false"}});
 
   EXPECT_THROW_WITH_MESSAGE(
       TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_, true), EnvoyException,
@@ -7966,12 +7968,12 @@ virtual_hosts:
 )EOF";
 
   Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory", "false"}});
+      {{"envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory",
+        "false"}});
   factory_context_.cluster_manager_.initializeClusters({"baz"}, {});
   EXPECT_THROW_WITH_MESSAGE(
       TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true),
-      EnvoyException,
-      "Didn't find a registered implementation for name: 'unknown.filter'");
+      EnvoyException, "Didn't find a registered implementation for name: 'unknown.filter'");
 }
 
 TEST_F(PerFilterConfigsTest, DefaultFilterImplementationAnyPreRouteIgnoreCheck) {

--- a/test/integration/listener_lds_integration_test.cc
+++ b/test/integration/listener_lds_integration_test.cc
@@ -285,7 +285,10 @@ TEST_P(ListenerIntegrationTest, IgnoreUnknownTypedPerFilterConfig) {
             "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
 )EOF";
   sendRdsResponse(fmt::format(route_config_tmpl, route_table_name_, "cluster_0"), "1");
-  test_server_->waitForCounterGe(fmt::format("http.config_test.rds.{}.unknown_per_filter_typed_config_factory", route_table_name_), 1);
+  test_server_->waitForCounterGe(
+      fmt::format("http.config_test.rds.{}.unknown_per_filter_typed_config_factory",
+                  route_table_name_),
+      1);
 }
 
 // Tests that a LDS deletion before Server initManager been initialized will not block the Server


### PR DESCRIPTION
Commit Message: xds: Relax the CHECK on factories for typed per-filter config
Additional Description: 
Currently, if typed per-filter config includes an unknown filter, the exception will be raised. This PR aims to relax the check. A new runtime flag `envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory` is added, the default value is true. When it is true and unknown filter received from the rds API, instead of rejecting the update,  a warning log will be emitted and increases a new counter `unknown_per_filter_typed_config_factory`'s value.

Risk Level: low
Testing: unit tests and integration tests are added
Docs Changes:
Release Notes: add a note as a new feature
Runtime guard: "envoy.reloadable_features.ignore_check_unknown_typed_per_filter_config_factory"
Fixes #15770

