### PR TITLE
Envoy 1.17 crashing with validation context secret discovery in ads mode on start up #15517

### DIFF
--- a/source/common/config/grpc_subscription_impl.cc
+++ b/source/common/config/grpc_subscription_impl.cc
@@ -36,6 +36,7 @@ void GrpcSubscriptionImpl::start(const absl::flat_hash_set<std::string>& resourc
     init_fetch_timeout_timer_->enableTimer(init_fetch_timeout_);
   }
 
+  RELEASE_ASSERT(grpc_mux_ != nullptr, "grpc_mux_ initialized with null value");
   watch_ = grpc_mux_->addWatch(type_url_, resources, *this, resource_decoder_, options_);
 
   // The attempt stat here is maintained for the purposes of having consistency between ADS and

--- a/source/common/config/subscription_factory_impl.cc
+++ b/source/common/config/subscription_factory_impl.cc
@@ -86,6 +86,10 @@ SubscriptionPtr SubscriptionFactoryImpl::subscriptionFromConfigSource(
     }
   }
   case envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds: {
+    if (cm_.adsMux() == nullptr) {
+      throw EnvoyException(
+          "Sub-components (like SDS) of a primary cluster cannot be configured via ADS");
+    }
     return std::make_unique<GrpcSubscriptionImpl>(
         cm_.adsMux(), callbacks, resource_decoder, stats, type_url, dispatcher_,
         Utility::configSourceInitialFetchTimeout(config), true, options);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -313,7 +313,6 @@ ClusterManagerImpl::ClusterManagerImpl(
       loadCluster(cluster, MessageUtil::hash(cluster), "", false, active_clusters_);
     }
   }
-
   // Now setup ADS if needed, this might rely on a primary cluster.
   // This is the only point where distinction between delta ADS and state-of-the-world ADS is made.
   // After here, we just have a GrpcMux interface held in ads_mux_, which hides
@@ -357,6 +356,11 @@ ClusterManagerImpl::ClusterManagerImpl(
           bootstrap.dynamic_resources().ads_config().set_node_on_first_message_only());
     }
   } else {
+    // Without a dynamic resource configuration (bootstrap.dynamic_resources() == null)
+    // an ads_mux == nullptr will cause an error in the
+    // SubscriptionFactoryImpl::subscriptionFromConfigSource() for the
+    // envoy::config::core::v3::ConfigSource::ConfigSourceSpecifierCase::kAds case.
+    // TODO can this condition be caught here?
     ads_mux_ = std::make_unique<Config::NullGrpcMuxImpl>();
   }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1147,6 +1147,12 @@ TEST_P(ServerInstanceImplTest, BadSdsConfigSource) {
       "'sds-grpc' does not exist, was added via api, or is an EDS cluster");
 }
 
+TEST_P(ServerInstanceImplTest, BadSdsAdsConfigSource) {
+  EXPECT_THROW_WITH_MESSAGE(
+      initialize("test/server/test_data/server/bad_sds_ads_config_source.yaml"), EnvoyException,
+      "Sub-components (like SDS) of a primary cluster cannot be configured via ADS");
+}
+
 // Test for protoc-gen-validate constraint on invalid timeout entry of a health check config entry.
 TEST_P(ServerInstanceImplTest, BootstrapClusterHealthCheckInvalidTimeout) {
   EXPECT_THROW_WITH_REGEX(

--- a/test/server/test_data/server/bad_sds_ads_config_source.yaml
+++ b/test/server/test_data/server/bad_sds_ads_config_source.yaml
@@ -1,0 +1,81 @@
+node:
+  id: TEST
+  cluster: test
+  locality:
+    region: tor
+    zone: dev
+static_resources:
+  clusters:
+  - name: ads_cluster
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: ads_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: localhost
+                port_value: 18000
+  - name: test
+    connect_timeout: 1s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: test
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    port_value: 8583
+    transport_socket:
+      name: "envoy.transport_sockets.tls"
+      typed_config:
+        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+        common_tls_context:
+          validation_context_sds_secret_config:
+            name: val_cert
+            sds_config:
+              ads: {}
+              resource_api_version: V3
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+      envoy_grpc:
+        cluster_name: "ads_cluster"
+    transport_api_version: V3
+#node:
+#  id: TEST
+#  cluster: test
+#  locality:
+#    region: tor
+#    zone: dev
+#static_resources:
+#  clusters:
+#    - name: test
+#      connect_timeout: 1s
+#      type: strict_dns
+#      lb_policy: round_robin
+#      load_assignment:
+#        cluster_name: test
+#        endpoints:
+#          - lb_endpoints:
+#              - endpoint:
+#                  address:
+#                    socket_address:
+#                      address: localhost
+#                      port_value: 12345
+#      transport_socket:
+#        name: envoy.transport_sockets.tls
+#        typed_config:
+#          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+#          common_tls_context:
+#            validation_context_sds_secret_config:
+#              name: val_cert
+#              sds_config:
+#                ads: {}


### PR DESCRIPTION
Test to prevent crashing with validation context secret discovery in ads mode on start up

Signed-off-by: Tim Walsh <temporal.differential@gmail.com>

Commit Message: Test to prevent crashing with validation context secret discovery in ads mode on start up
Additional Description:
Risk Level:
Testing: test/server/server_test.cc
Docs Changes: 
Release Notes: 
It is not possible to configure any component of a primary cluster over ADS
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
