### PR TITLE
Use RELEASE_ASSERT instead of raise(SIGABRT) in kill_request filter

### DIFF
--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -68,7 +68,7 @@ Http::FilterHeadersStatus KillRequestFilter::decodeHeaders(Http::RequestHeaderMa
 
   if (is_kill_request && is_correct_direction && isKillRequestEnabled()) {
     // Crash Envoy.
-    raise(SIGABRT);
+    RELEASE_ASSERT(false, "KillRequestFilter is crashing Envoy!!!");
   }
 
   return Http::FilterHeadersStatus::Continue;
@@ -81,7 +81,7 @@ Http::FilterHeadersStatus KillRequestFilter::encodeHeaders(Http::ResponseHeaderM
 
   if (isKillRequest(headers) && isKillRequestEnabled()) {
     // Crash Envoy.
-    raise(SIGABRT);
+    RELEASE_ASSERT(false, "KillRequestFilter is crashing Envoy!!!");
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
@@ -43,7 +43,7 @@ TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoy) {
                                                  {"x-envoy-kill-request", "true"}};
 
   EXPECT_DEATH(sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 1024),
-               "");
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 // Request crash Envoy controlled via response.
@@ -70,7 +70,8 @@ TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyOnResp
   Http::TestResponseHeaderMapImpl kill_response_headers = default_response_headers_;
   kill_response_headers.addCopy("x-envoy-kill-request", "true");
 
-  EXPECT_DEATH(sendRequestAndWaitForResponse(request_headers, 0, kill_response_headers, 1024), "");
+  EXPECT_DEATH(sendRequestAndWaitForResponse(request_headers, 0, kill_response_headers, 1024),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyWithCustomKillHeader) {
@@ -93,7 +94,7 @@ typed_config:
                                                  {"x-custom-kill-request", "true"}};
 
   EXPECT_DEATH(sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 1024),
-               "");
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestDisabledWhenHeaderIsMissing) {

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -48,7 +48,8 @@ TEST_F(KillRequestFilterTest, KillRequestCrashEnvoy) {
   request_headers_.addCopy("x-envoy-kill-request", "true");
 
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
-  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 TEST_F(KillRequestFilterTest, KillRequestCrashEnvoyWithCustomKillHeader) {
@@ -59,7 +60,8 @@ TEST_F(KillRequestFilterTest, KillRequestCrashEnvoyWithCustomKillHeader) {
   request_headers_.addCopy("x-custom-kill-request", "true");
 
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
-  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 TEST_F(KillRequestFilterTest, KillRequestWithMillionDenominatorCrashEnvoy) {
@@ -70,7 +72,8 @@ TEST_F(KillRequestFilterTest, KillRequestWithMillionDenominatorCrashEnvoy) {
   request_headers_.addCopy("x-envoy-kill-request", "yes");
 
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
-  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 TEST_F(KillRequestFilterTest, KillRequestDisabledWhenIsKillRequestEnabledReturnsFalse) {
@@ -101,7 +104,8 @@ TEST_F(KillRequestFilterTest, KillRequestEnabledFromRouteLevelConfiguration) {
   ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
           perFilterConfig(Extensions::HttpFilters::HttpFilterNames::get().KillRequest))
       .WillByDefault(Return(&kill_settings));
-  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 // Kill request should be disabled when isKillRequestEnabled returns false
@@ -184,7 +188,8 @@ TEST_F(KillRequestFilterTest, CanKillOnResponse) {
   // We should crash on the OUTBOUND request
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
   response_headers_.addCopy("x-envoy-kill-request", "true");
-  EXPECT_DEATH(filter_->encodeHeaders(response_headers_, false), "");
+  EXPECT_DEATH(filter_->encodeHeaders(response_headers_, false),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 TEST_F(KillRequestFilterTest, KillsBasedOnDirection) {
@@ -201,7 +206,8 @@ TEST_F(KillRequestFilterTest, KillsBasedOnDirection) {
   // We should crash on the RESPONSE kill request
   ON_CALL(random_generator_, random()).WillByDefault(Return(0));
   response_headers_.addCopy("x-envoy-kill-request", "true");
-  EXPECT_DEATH(filter_->encodeHeaders(response_headers_, false), "");
+  EXPECT_DEATH(filter_->encodeHeaders(response_headers_, false),
+               "KillRequestFilter is crashing Envoy!!!");
 }
 
 } // namespace

--- a/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_test.cc
@@ -104,8 +104,7 @@ TEST_F(KillRequestFilterTest, KillRequestEnabledFromRouteLevelConfiguration) {
   ON_CALL(decoder_filter_callbacks_.route_->route_entry_,
           perFilterConfig(Extensions::HttpFilters::HttpFilterNames::get().KillRequest))
       .WillByDefault(Return(&kill_settings));
-  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false),
-               "KillRequestFilter is crashing Envoy!!!");
+  EXPECT_DEATH(filter_->decodeHeaders(request_headers_, false), "");
 }
 
 // Kill request should be disabled when isKillRequestEnabled returns false


### PR DESCRIPTION
Commit Message: Use `RELEASE_ASSERT` instead of `raise(SIGABRT)` in kill_request filter to provide better logging when the filter is crashing Envoy.
Additional Description: N/A
Risk Level: low
Testing: unit test, integration test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

/assign @antoniovicente 
