### PR TITLE
tools: default to clang-format-11 in check_format.py

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -143,7 +143,7 @@ BUILD_URLS_ALLOWLIST = (
     "./api/bazel/envoy_http_archive.bzl",
 )
 
-CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-10")
+CLANG_FORMAT_PATH = os.getenv("CLANG_FORMAT", "clang-format-11")
 BUILDIFIER_PATH = paths.get_buildifier()
 BUILDOZER_PATH = paths.get_buildozer()
 ENVOY_BUILD_FIXER_PATH = os.path.join(


### PR DESCRIPTION
Signed-off-by: Florin Coras <fcoras@cisco.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a