### PR TITLE
apple dns: fix crash on invalid dns name

### DIFF
--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -302,8 +302,6 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
             "error_code={}, hostname={}",
             dns_name_, flags, flags & kDNSServiceFlagsMoreComing ? "yes" : "no",
             flags & kDNSServiceFlagsAdd ? "yes" : "no", interface_index, error_code, hostname);
-  RELEASE_ASSERT(interface_index == 0,
-                 fmt::format("unexpected interface_index={}", interface_index));
 
   if (!pending_cb_) {
     pending_cb_ = {ResolutionStatus::Success, {}};
@@ -325,6 +323,9 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
     // object upon resolution.
     return;
   }
+
+  RELEASE_ASSERT(interface_index == 0,
+                 fmt::format("unexpected interface_index={}", interface_index));
 
   // Only add this address to the list if kDNSServiceFlagsAdd is set. Callback targets are only
   // additive.

--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -324,8 +324,7 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
     return;
   }
 
-  ENVOY_BUG(interface_index == 0,
-            fmt::format("unexpected interface_index={}", interface_index));
+  ENVOY_BUG(interface_index == 0, fmt::format("unexpected interface_index={}", interface_index));
 
   // Only add this address to the list if kDNSServiceFlagsAdd is set. Callback targets are only
   // additive.

--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -324,8 +324,8 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
     return;
   }
 
-  RELEASE_ASSERT(interface_index == 0,
-                 fmt::format("unexpected interface_index={}", interface_index));
+  ENVOY_BUG(interface_index == 0,
+            fmt::format("unexpected interface_index={}", interface_index));
 
   // Only add this address to the list if kDNSServiceFlagsAdd is set. Callback targets are only
   // additive.

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -364,12 +364,12 @@ TEST_F(AppleDnsImplFakeApiTest, SynchronousErrorInGetAddrInfo) {
   // The Query's sd ref will be deallocated.
   EXPECT_CALL(dns_service_, dnsServiceRefDeallocate(_));
 
-  EXPECT_EQ(nullptr,
-            resolver_->resolve("foo.com", Network::DnsLookupFamily::Auto,
-                               [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void {
-                                 // This callback should never be executed.
-                                 FAIL();
-                               }));
+  EXPECT_EQ(nullptr, resolver_->resolve(
+                         "foo.com", Network::DnsLookupFamily::Auto,
+                         [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void {
+                           // This callback should never be executed.
+                           FAIL();
+                         }));
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {
@@ -442,7 +442,7 @@ TEST_F(AppleDnsImplFakeApiTest, IncorrectInterfaceIndexReturned) {
 
   resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QueryCompletedWithError) {
@@ -799,7 +799,7 @@ TEST_F(AppleDnsImplFakeApiTest, ResultWithNullAddress) {
 
   auto query = resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
   ASSERT_NE(nullptr, query);
 
   EXPECT_DEATH(reply_callback(nullptr, kDNSServiceFlagsAdd, 0, kDNSServiceErr_NoError,

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -364,12 +364,13 @@ TEST_F(AppleDnsImplFakeApiTest, SynchronousErrorInGetAddrInfo) {
   // The Query's sd ref will be deallocated.
   EXPECT_CALL(dns_service_, dnsServiceRefDeallocate(_));
 
-  EXPECT_EQ(nullptr, resolver_->resolve(
-                         "foo.com", Network::DnsLookupFamily::Auto,
-                         [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void {
-                           // This callback should never be executed.
-                           FAIL();
-                         }));
+  EXPECT_EQ(nullptr,
+            resolver_->resolve("foo.com", Network::DnsLookupFamily::Auto,
+                               [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void {
+                                 // This callback should never be executed.
+                                 FAIL();
+                               }));
+
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {
@@ -442,7 +443,7 @@ TEST_F(AppleDnsImplFakeApiTest, IncorrectInterfaceIndexReturned) {
 
   resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QueryCompletedWithError) {
@@ -799,7 +800,7 @@ TEST_F(AppleDnsImplFakeApiTest, ResultWithNullAddress) {
 
   auto query = resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
   ASSERT_NE(nullptr, query);
 
   EXPECT_DEATH(reply_callback(nullptr, kDNSServiceFlagsAdd, 0, kDNSServiceErr_NoError,

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -370,7 +370,6 @@ TEST_F(AppleDnsImplFakeApiTest, SynchronousErrorInGetAddrInfo) {
                                  // This callback should never be executed.
                                  FAIL();
                                }));
-
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {


### PR DESCRIPTION
Commit Message: apple dns: fix crash on invalid dns name.
Additional Description: The release assert in question was ahead of verifying the return code. 
Risk Level: low - most (possibly all) envoy production usage does not happen on apple hardware.
Testing: added new test that repro.

Fixes https://github.com/envoyproxy/envoy/issues/16021

Signed-off-by: Jose Nino <jnino@lyft.com>
