### PR TITLE
Support using downstream TCP destination port for SNI dynamic forward proxy upstream connection

### DIFF
--- a/api/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
+++ b/api/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
@@ -28,10 +28,4 @@ message FilterConfig {
   // <envoy_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.dns_cache_config>`.
   common.dynamic_forward_proxy.v3.DnsCacheConfig dns_cache_config = 1
       [(validate.rules).message = {required: true}];
-
-  oneof port_specifier {
-    // The port number to connect to the upstream. The destination port of the downstream TCP
-    // connection will be used if this is unset.
-    uint32 port_value = 2 [(validate.rules).uint32 = {lte: 65535 gt: 0}];
-  }
 }

--- a/api/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
+++ b/api/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
@@ -30,7 +30,8 @@ message FilterConfig {
       [(validate.rules).message = {required: true}];
 
   oneof port_specifier {
-    // The port number to connect to the upstream.
+    // The port number to connect to the upstream. The destination port of the downstream TCP
+    // connection will be used if this is unset.
     uint32 port_value = 2 [(validate.rules).uint32 = {lte: 65535 gt: 0}];
   }
 }

--- a/docs/root/configuration/listeners/network_filters/_include/sni-dynamic-forward-proxy-filter.yaml
+++ b/docs/root/configuration/listeners/network_filters/_include/sni-dynamic-forward-proxy-filter.yaml
@@ -19,7 +19,6 @@ static_resources:
           - name: envoy.filters.network.sni_dynamic_forward_proxy
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3alpha.FilterConfig
-              port_value: 443
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: V4_ONLY

--- a/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
@@ -14,7 +14,7 @@ Envoy supports SNI based dynamic forward proxy. The implementation works just li
 :ref:`HTTP dynamic forward proxy <arch_overview_http_dynamic_forward_proxy>`, but using the value in
 SNI as target host instead. In addition, whereas the HTTP dynamic forward proxy uses the port
 embedded in the Host header for the destination port of the upstream TCP connection, the SNI dynamic
-forward proxy uses the destination port of the downstream TCP connection as the destination port of
+forward proxy uses the destination port of the downstream TCP connection as the destination port for
 the upstream TCP connection.
 
 The following is a complete configuration that configures both this filter

--- a/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter.rst
@@ -12,7 +12,10 @@ this network filter and the
 :ref:`dynamic forward proxy cluster <envoy_api_msg_config.cluster.dynamic_forward_proxy.v2alpha.ClusterConfig>`,
 Envoy supports SNI based dynamic forward proxy. The implementation works just like the
 :ref:`HTTP dynamic forward proxy <arch_overview_http_dynamic_forward_proxy>`, but using the value in
-SNI as target host instead.
+SNI as target host instead. In addition, whereas the HTTP dynamic forward proxy uses the port
+embedded in the Host header for the destination port of the upstream TCP connection, the SNI dynamic
+forward proxy uses the destination port of the downstream TCP connection as the destination port of
+the upstream TCP connection.
 
 The following is a complete configuration that configures both this filter
 as well as the :ref:`dynamic forward proxy cluster

--- a/generated_api_shadow/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
@@ -28,10 +28,4 @@ message FilterConfig {
   // <envoy_api_field_extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig.dns_cache_config>`.
   common.dynamic_forward_proxy.v3.DnsCacheConfig dns_cache_config = 1
       [(validate.rules).message = {required: true}];
-
-  oneof port_specifier {
-    // The port number to connect to the upstream. The destination port of the downstream TCP
-    // connection will be used if this is unset.
-    uint32 port_value = 2 [(validate.rules).uint32 = {lte: 65535 gt: 0}];
-  }
 }

--- a/generated_api_shadow/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3alpha/sni_dynamic_forward_proxy.proto
@@ -30,7 +30,8 @@ message FilterConfig {
       [(validate.rules).message = {required: true}];
 
   oneof port_specifier {
-    // The port number to connect to the upstream.
+    // The port number to connect to the upstream. The destination port of the downstream TCP
+    // connection will be used if this is unset.
     uint32 port_value = 2 [(validate.rules).uint32 = {lte: 65535 gt: 0}];
   }
 }

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -161,16 +161,18 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return nullptr;
   }
 
+  std::string sni;
   absl::string_view host;
   if (context->downstreamHeaders()) {
     host = context->downstreamHeaders()->getHostValue();
   } else if (context->downstreamConnection()) {
     // Embed downstream TCP connection destination port into SNI hostname. This is not necessary
-    // when using the Host header since the port is embeded by the client
+    // when using the Host header since the port is embedded by the client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-    host = absl::StrCat(
-      context->downstreamConnection()->requestedServerName(), ":",
+    sni = std::string(context->downstreamConnection()->requestedServerName()).c_str();
+    absl::StrAppend(&sni, ":",
       context->downstreamConnection()->addressProvider().localAddress()->ip()->port());
+    host = sni;
   }
 
   if (host.empty()) {

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -170,8 +170,8 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     // when using the Host header since the port is embedded by the client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
     sni = std::string(context->downstreamConnection()->requestedServerName()).c_str();
-    absl::StrAppend(&sni, ":",
-      context->downstreamConnection()->addressProvider().localAddress()->ip()->port());
+    absl::StrAppend(
+        &sni, ":", context->downstreamConnection()->addressProvider().localAddress()->ip()->port());
     host = sni;
   }
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -161,18 +161,16 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return nullptr;
   }
 
-  std::string sni;
-  absl::string_view host;
+  std::string host;
   if (context->downstreamHeaders()) {
     host = context->downstreamHeaders()->getHostValue();
   } else if (context->downstreamConnection()) {
     // Embed downstream TCP connection destination port into SNI hostname. This is not necessary
     // when using the Host header since the port is embedded by the client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-    sni = std::string(context->downstreamConnection()->requestedServerName()).c_str();
-    absl::StrAppend(
-        &sni, ":", context->downstreamConnection()->addressProvider().localAddress()->ip()->port());
-    host = sni;
+    host = absl::StrCat(
+        context->downstreamConnection()->requestedServerName(), ":",
+        context->downstreamConnection()->addressProvider().localAddress()->ip()->port());
   }
 
   if (host.empty()) {

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -161,11 +161,18 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return nullptr;
   }
 
+  std::string sni;
   absl::string_view host;
   if (context->downstreamHeaders()) {
     host = context->downstreamHeaders()->getHostValue();
   } else if (context->downstreamConnection()) {
-    host = context->downstreamConnection()->requestedServerName();
+    // Embed downstream TCP connection destination port into SNI hostname. This is not necessary
+    // when using the Host header since the port is embeded by the client
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+    sni = std::string(context->downstreamConnection()->requestedServerName()).c_str();
+    uint32_t port = context->downstreamConnection()->addressProvider().localAddress()->ip()->port();
+    absl::StrAppend(&sni, ":", port);
+    host = sni;
   }
 
   if (host.empty()) {

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -161,7 +161,6 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return nullptr;
   }
 
-  std::string sni;
   absl::string_view host;
   if (context->downstreamHeaders()) {
     host = context->downstreamHeaders()->getHostValue();
@@ -169,10 +168,9 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     // Embed downstream TCP connection destination port into SNI hostname. This is not necessary
     // when using the Host header since the port is embeded by the client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-    sni = std::string(context->downstreamConnection()->requestedServerName()).c_str();
-    uint32_t port = context->downstreamConnection()->addressProvider().localAddress()->ip()->port();
-    absl::StrAppend(&sni, ":", port);
-    host = sni;
+    host = absl::StrCat(
+      context->downstreamConnection()->requestedServerName(), ":",
+      context->downstreamConnection()->addressProvider().localAddress()->ip()->port());
   }
 
   if (host.empty()) {

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -16,8 +16,7 @@ ProxyFilterConfig::ProxyFilterConfig(
     const FilterConfig& proto_config,
     Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactory& cache_manager_factory,
     Upstream::ClusterManager&)
-    : port_(static_cast<uint16_t>(proto_config.port_value())),
-      dns_cache_manager_(cache_manager_factory.get()),
+    : dns_cache_manager_(cache_manager_factory.get()),
       dns_cache_(dns_cache_manager_->getCache(proto_config.dns_cache_config())) {}
 
 ProxyFilter::ProxyFilter(ProxyFilterConfigSharedPtr config) : config_(std::move(config)) {}
@@ -45,9 +44,8 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
   // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
   // when using the HTTP dynamic forward proxy since the port is embedded by the client
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-  std::string host = std::string(sni).c_str();
-  absl::StrAppend(&host, ":",
-                  read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
+  std::string host = absl::StrCat(
+      sni, ":", read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
 
   auto result = config_->cache().loadDnsCacheEntry(host, 0, *this);
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -45,12 +45,12 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
 
   std::string host = std::string(sni).c_str();
   if (default_port == 0) {
-    // Emded downstream TCP connection destination port into SNI hostname. This is necessary to
+    // Embed downstream TCP connection destination port into SNI hostname. This is necessary to
     // differentiate DNS cache entries for the same hostname on different ports. This is not
     // necessary when using the HTTP dynamic forward proxy since the port is embedded by the client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
     absl::StrAppend(&host, ":",
-      read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
+                    read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
   }
 
   auto result = config_->cache().loadDnsCacheEntry(host, default_port, *this);

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -41,19 +41,19 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
     return Network::FilterStatus::StopIteration;
   }
 
-  uint32_t default_port = config_->port();
-
-  std::string host = std::string(sni).c_str();
-  if (default_port == 0) {
-    // Embed downstream TCP connection destination port into SNI hostname. This is necessary to
-    // differentiate DNS cache entries for the same hostname on different ports. This is not
-    // necessary when using the HTTP dynamic forward proxy since the port is embedded by the client
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-    absl::StrAppend(&host, ":",
-                    read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
+  uint32_t port = config_->port();
+  if (port == 0) {
+    port = read_callbacks_->connection().addressProvider().localAddress()->ip()->port()
   }
 
-  auto result = config_->cache().loadDnsCacheEntry(host, default_port, *this);
+  // Embed downstream TCP connection destination port into SNI hostname. This is necessary to
+  // differentiate DNS cache entries for the same hostname on different ports. This is not
+  // necessary when using the HTTP dynamic forward proxy since the port is embedded by the client
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+  std::string host = std::string(sni).c_str();
+  absl::StrAppend(&host, ":", port);
+
+  auto result = config_->cache().loadDnsCacheEntry(host, 0, *this);
 
   cache_load_handle_ = std::move(result.handle_);
   if (cache_load_handle_ == nullptr) {

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -43,13 +43,13 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
 
   uint32_t default_port = config_->port();
 
-  // Emded downstream TCP connection destination port into SNI hostname. This is necessary to
-  // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
-  // when using the HTTP dynamic forward proxy since the port is embeded by the client
-  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
   absl::string_view host = sni;
   if (default_port == 0) {
-    host = absl::StrAppend(sni, ":",
+    // Emded downstream TCP connection destination port into SNI hostname. This is necessary to
+    // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
+    // when using the HTTP dynamic forward proxy since the port is embeded by the client
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+    host = absl::StrCat(sni, ":",
       read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
   }
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -43,6 +43,10 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
 
   uint32_t default_port = config_->port();
 
+  if (default_port == 0) {
+    default_port = read_callbacks_->connection().addressProvider().localAddress()->ip()->port();
+  }
+
   auto result = config_->cache().loadDnsCacheEntry(sni, default_port, *this);
 
   cache_load_handle_ = std::move(result.handle_);

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -47,8 +47,8 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
   // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
   // when using the HTTP dynamic forward proxy since the port is embeded by the client
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-  absl::string_view host = sni
-  if (default_port == 0 && !absl::StrContains(host, ":")) {
+  absl::string_view host = sni;
+  if (default_port == 0) {
     host = absl::StrAppend(sni, ":",
       read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
   }

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -43,13 +43,13 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
 
   uint32_t default_port = config_->port();
 
-  absl::string_view host = sni;
+  std::string host = std::string(sni).c_str();
   if (default_port == 0) {
     // Emded downstream TCP connection destination port into SNI hostname. This is necessary to
-    // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
-    // when using the HTTP dynamic forward proxy since the port is embeded by the client
+    // differentiate DNS cache entries for the same hostname on different ports. This is not
+    // necessary when using the HTTP dynamic forward proxy since the port is embedded by the client
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-    host = absl::StrCat(sni, ":",
+    absl::StrAppend(&host, ":",
       read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
   }
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -41,17 +41,13 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
     return Network::FilterStatus::StopIteration;
   }
 
-  uint32_t port = config_->port();
-  if (port == 0) {
-    port = read_callbacks_->connection().addressProvider().localAddress()->ip()->port()
-  }
-
-  // Embed downstream TCP connection destination port into SNI hostname. This is necessary to
-  // differentiate DNS cache entries for the same hostname on different ports. This is not
-  // necessary when using the HTTP dynamic forward proxy since the port is embedded by the client
+  // Embed destination port of downstream TCP connection into the SNI hostname. This is necessary to
+  // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
+  // when using the HTTP dynamic forward proxy since the port is embedded by the client
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
   std::string host = std::string(sni).c_str();
-  absl::StrAppend(&host, ":", port);
+  absl::StrAppend(&host, ":",
+                  read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
 
   auto result = config_->cache().loadDnsCacheEntry(host, 0, *this);
 

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.cc
@@ -47,10 +47,10 @@ Network::FilterStatus ProxyFilter::onNewConnection() {
   // differentiate DNS cache entries for the same hostname on different ports. This is not necessary
   // when using the HTTP dynamic forward proxy since the port is embeded by the client
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
-  std::string host = std::string(sni).c_str();
+  absl::string_view host = sni
   if (default_port == 0 && !absl::StrContains(host, ":")) {
-    uint32_t port = read_callbacks_->connection().addressProvider().localAddress()->ip()->port();
-    absl::StrAppend(&host, ":", port);
+    host = absl::StrAppend(sni, ":",
+      read_callbacks_->connection().addressProvider().localAddress()->ip()->port());
   }
 
   auto result = config_->cache().loadDnsCacheEntry(host, default_port, *this);

--- a/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter.h
@@ -24,10 +24,8 @@ public:
       Upstream::ClusterManager& cluster_manager);
 
   Extensions::Common::DynamicForwardProxy::DnsCache& cache() { return *dns_cache_; }
-  uint32_t port() { return port_; }
 
 private:
-  const uint32_t port_;
   const Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr dns_cache_manager_;
   const Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr dns_cache_;
 };

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -36,8 +36,7 @@ public:
       bootstrap.mutable_dynamic_resources()->mutable_cds_config()->set_path(cds_helper_.cds_path());
       bootstrap.mutable_static_resources()->clear_clusters();
 
-      const std::string filter =
-          fmt::format(R"EOF(
+      const std::string filter = fmt::format(R"EOF(
 name: envoy.filters.http.dynamic_forward_proxy
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3alpha.FilterConfig
@@ -47,10 +46,9 @@ typed_config:
     max_hosts: {}
     dns_cache_circuit_breaker:
       max_pending_requests: {}
-  port_value: {}
 )EOF",
-                      Network::Test::ipVersionToDnsFamily(GetParam()), max_hosts,
-                      max_pending_requests, fake_upstreams_[0]->localAddress()->ip()->port());
+                                             Network::Test::ipVersionToDnsFamily(GetParam()),
+                                             max_hosts, max_pending_requests);
       config_helper_.addNetworkFilter(filter);
     });
 

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -76,8 +76,12 @@ TEST_F(SniDynamicProxyFilterTest, LoadDnsCache) {
       .WillOnce(Return(circuit_breakers_));
   Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle* handle =
       new Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle();
-  EXPECT_CALL(*dns_cache_manager_->dns_cache_,
-              loadDnsCacheEntry_(Eq("foo"), fake_upstreams_[0]->localAddress()->ip()->port(), _))
+  EXPECT_CALL(
+      *dns_cache_manager_->dns_cache_,
+      loadDnsCacheEntry_(
+          Eq(absl::StrCat("foo:",
+                          callbacks_.connection().addressProvider().localAddress()->ip()->port())),
+          0, _))
       .WillOnce(Return(
           MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Loading, handle, absl::nullopt}));
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
@@ -95,8 +99,12 @@ TEST_F(SniDynamicProxyFilterTest, LoadDnsInCache) {
       new Upstream::ResourceAutoIncDec(pending_requests_)};
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_())
       .WillOnce(Return(circuit_breakers_));
-  EXPECT_CALL(*dns_cache_manager_->dns_cache_,
-              loadDnsCacheEntry_(Eq("foo"), fake_upstreams_[0]->localAddress()->ip()->port(), _))
+  EXPECT_CALL(
+      *dns_cache_manager_->dns_cache_,
+      loadDnsCacheEntry_(
+          Eq(absl::StrCat("foo:",
+                          callbacks_.connection().addressProvider().localAddress()->ip()->port())),
+          0, _))
       .WillOnce(Return(
           MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::InCache, nullptr, absl::nullopt}));
 
@@ -110,8 +118,12 @@ TEST_F(SniDynamicProxyFilterTest, CacheOverflow) {
       new Upstream::ResourceAutoIncDec(pending_requests_)};
   EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_())
       .WillOnce(Return(circuit_breakers_));
-  EXPECT_CALL(*dns_cache_manager_->dns_cache_,
-              loadDnsCacheEntry_(Eq("foo"), fake_upstreams_[0]->localAddress()->ip()->port(), _))
+  EXPECT_CALL(
+      *dns_cache_manager_->dns_cache_,
+      loadDnsCacheEntry_(
+          Eq(absl::StrCat("foo:",
+                          callbacks_.connection().addressProvider().localAddress()->ip()->port())),
+          0, _))
       .WillOnce(Return(
           MockLoadDnsCacheEntryResult{LoadDnsCacheEntryStatus::Overflow, nullptr, absl::nullopt}));
   EXPECT_CALL(connection_, close(Network::ConnectionCloseType::NoFlush));


### PR DESCRIPTION
Commit Message: Support using downstream TCP destination port for SNI dynamic forward proxy upstream connection
Additional Description: This change removes the need for users to set the `port_value` in the SNI forward proxy configuration and instead rely on the downstream TCP connection using the correct destination port.
Risk Level: Medium
Testing: With address based on feedback
Docs Changes: Remove `port_value` from example configuration since I think this should no longer be needed in most cases
Release Notes: Support using downstream TCP destination port for [SNI dynamic forward proxy](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/sni_dynamic_forward_proxy_filter) upstream connection
Platform Specific Features: N/A
Fixes https://github.com/envoyproxy/envoy/issues/16048

This works by appending the downstream TCP connection destination port to the SNI host to use in the DNS cache. This is not necessary for the HTTP dynamic forward proxy since this happens by default if the port isn't 80 (https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23).