### PR TITLE
tracing: fix zipkin annotation timestamp serialization issue

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -19,6 +19,8 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* zipkin: fix timestamp serializaiton in annotations. A prior bug fix exposed an issue with timestamps being serialized as strings.
+
 Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/tracers/zipkin/span_buffer.cc
+++ b/source/extensions/tracers/zipkin/span_buffer.cc
@@ -133,7 +133,7 @@ JsonV2Serializer::toListOfSpans(const Span& zipkin_span, Util::Replacements& rep
       auto* annotation_entry_fields = annotation_entry.mutable_fields();
       (*annotation_entry_fields)[ANNOTATION_VALUE] = ValueUtil::stringValue(annotation.value());
       (*annotation_entry_fields)[ANNOTATION_TIMESTAMP] =
-          Util::uint64Value(annotation.timestamp(), annotation.value(), replacements);
+          Util::uint64Value(annotation.timestamp(), ANNOTATION_TIMESTAMP, replacements);
       annotation_entries.push_back(ValueUtil::structValue(annotation_entry));
       continue;
     }

--- a/test/extensions/tracers/zipkin/span_buffer_test.cc
+++ b/test/extensions/tracers/zipkin/span_buffer_test.cc
@@ -23,9 +23,11 @@ namespace {
 // If this default timestamp is wrapped as double (using ValueUtil::numberValue()) and then it is
 // serialized using Protobuf::util::MessageToJsonString, it renders as: 1.58432429547687e+15.
 constexpr uint64_t DEFAULT_TEST_TIMESTAMP = 1584324295476870;
+constexpr uint64_t ANNOTATION_TEST_TIMESTAMP = 1584324295476871;
 constexpr uint64_t DEFAULT_TEST_DURATION = 2584324295476870;
 const Util::Replacements DEFAULT_TEST_REPLACEMENTS = {
-    {"DEFAULT_TEST_TIMESTAMP", std::to_string(DEFAULT_TEST_TIMESTAMP)}};
+    {"DEFAULT_TEST_TIMESTAMP", std::to_string(DEFAULT_TEST_TIMESTAMP)},
+    {"ANNOTATION_TEST_TIMESTAMP", std::to_string(ANNOTATION_TEST_TIMESTAMP)}};
 const Util::Replacements DEFAULT_TEST_DURATIONS = {
     {"DEFAULT_TEST_DURATION", std::to_string(DEFAULT_TEST_DURATION)}};
 
@@ -44,7 +46,7 @@ Endpoint createEndpoint(const IpType ip_type) {
 Annotation createAnnotation(const absl::string_view value, const IpType ip_type) {
   Annotation annotation;
   annotation.setValue(value.data());
-  annotation.setTimestamp(DEFAULT_TEST_TIMESTAMP);
+  annotation.setTimestamp(ANNOTATION_TEST_TIMESTAMP);
   annotation.setEndpoint(createEndpoint(ip_type));
   return annotation;
 }
@@ -53,7 +55,7 @@ Annotation createAnnotation(const absl::string_view value, const IpType ip_type)
 Annotation createLog(const absl::string_view value) {
   Annotation log;
   log.setValue(value.data());
-  log.setTimestamp(DEFAULT_TEST_TIMESTAMP);
+  log.setTimestamp(ANNOTATION_TEST_TIMESTAMP);
   return log;
 }
 
@@ -161,12 +163,12 @@ TEST(ZipkinSpanBufferTest, ConstructBuffer) {
                                       R"("name":"",)"
                                       R"("id":"0000000000000001",)"
                                       R"("duration":DEFAULT_TEST_DURATION,)"
-                                      R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("annotations":[{"timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                                       R"("value":"cs",)"
                                       R"("endpoint":{"ipv4":"1.2.3.4",)"
                                       R"("port":8080,)"
                                       R"("serviceName":"service1"}},)"
-                                      R"({"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"({"timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                                       R"("value":"sr",)"
                                       R"("endpoint":{"ipv4":"1.2.3.4",)"
                                       R"("port":8080,)"
@@ -179,12 +181,12 @@ TEST(ZipkinSpanBufferTest, ConstructBuffer) {
                                       R"("name":"",)"
                                       R"("id":"0000000000000001",)"
                                       R"("duration":DEFAULT_TEST_DURATION,)"
-                                      R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("annotations":[{"timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                                       R"("value":"cs",)"
                                       R"("endpoint":{"ipv4":"1.2.3.4",)"
                                       R"("port":8080,)"
                                       R"("serviceName":"service1"}},)"
-                                      R"({"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"({"timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                                       R"("value":"sr",)"
                                       R"("endpoint":{"ipv4":"1.2.3.4",)"
                                       R"("port":8080,)"
@@ -195,12 +197,12 @@ TEST(ZipkinSpanBufferTest, ConstructBuffer) {
                                       R"("name":"",)"
                                       R"("id":"0000000000000001",)"
                                       R"("duration":DEFAULT_TEST_DURATION,)"
-                                      R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"("annotations":[{"timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                                       R"("value":"cs",)"
                                       R"("endpoint":{"ipv4":"1.2.3.4",)"
                                       R"("port":8080,)"
                                       R"("serviceName":"service1"}},)"
-                                      R"({"timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                                      R"({"timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                                       R"("value":"sr",)"
                                       R"("endpoint":{"ipv4":"1.2.3.4",)"
                                       R"("port":8080,)"
@@ -229,13 +231,13 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                    R"("traceId":"0000000000000001",)"
                    R"("id":"0000000000000001",)"
                    R"("kind":"CLIENT",)"
-                   R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                   R"("timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                    R"("duration":DEFAULT_TEST_DURATION,)"
                    R"("localEndpoint":{)"
                    R"("serviceName":"service1",)"
                    R"("ipv4":"1.2.3.4",)"
                    R"("port":8080},)"
-                   R"("annotations":[{"timestamp":DEFAULT_TEST_TIMESTAMP,"value":"log_1"}],)"
+                   R"("annotations":[{"timestamp":ANNOTATION_TEST_TIMESTAMP,"value":"log_1"}],)"
                    R"("tags":{)"
                    R"("response_size":"DEFAULT_TEST_DURATION"},)"
                    "}]"),
@@ -247,7 +249,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                            R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
@@ -264,7 +266,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                            R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
@@ -276,7 +278,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"SERVER",)"
-                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                            R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
@@ -294,7 +296,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"CLIENT",)"
-                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                            R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
@@ -306,7 +308,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                            R"("traceId":"0000000000000001",)"
                            R"("id":"0000000000000001",)"
                            R"("kind":"SERVER",)"
-                           R"("timestamp":DEFAULT_TEST_TIMESTAMP,)"
+                           R"("timestamp":ANNOTATION_TEST_TIMESTAMP,)"
                            R"("duration":DEFAULT_TEST_DURATION,)"
                            R"("localEndpoint":{)"
                            R"("serviceName":"service1",)"
@@ -324,7 +326,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("traceId":"AAAAAAAAAAE=",)"
                                             R"("id":"AQAAAAAAAAA=",)"
                                             R"("kind":"CLIENT",)"
-                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
                                             R"("localEndpoint":{)"
                                             R"("serviceName":"service1",)"
@@ -343,13 +345,13 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                 R"("traceId":"AAAAAAAAAAE=",)"
                 R"("id":"AQAAAAAAAAA=",)"
                 R"("kind":"CLIENT",)"
-                R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                 R"("duration":"DEFAULT_TEST_DURATION",)"
                 R"("localEndpoint":{)"
                 R"("serviceName":"service1",)"
                 R"("ipv6":"IAENuIWjAAAAAIouA3BERA==",)"
                 R"("port":7334},)"
-                R"("annotations":[{"timestamp":"DEFAULT_TEST_TIMESTAMP","value":"log_1"}],)"
+                R"("annotations":[{"timestamp":"ANNOTATION_TEST_TIMESTAMP","value":"log_1"}],)"
                 R"("tags":{)"
                 R"("response_size":"DEFAULT_TEST_DURATION"})"
                 "}]}"),
@@ -362,7 +364,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("traceId":"AAAAAAAAAAE=",)"
                                             R"("id":"AQAAAAAAAAA=",)"
                                             R"("kind":"CLIENT",)"
-                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
                                             R"("localEndpoint":{)"
                                             R"("serviceName":"service1",)"
@@ -374,7 +376,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("traceId":"AAAAAAAAAAE=",)"
                                             R"("id":"AQAAAAAAAAA=",)"
                                             R"("kind":"SERVER",)"
-                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
                                             R"("localEndpoint":{)"
                                             R"("serviceName":"service1",)"
@@ -393,7 +395,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("traceId":"AAAAAAAAAAE=",)"
                                             R"("id":"AQAAAAAAAAA=",)"
                                             R"("kind":"CLIENT",)"
-                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
                                             R"("localEndpoint":{)"
                                             R"("serviceName":"service1",)"
@@ -405,7 +407,7 @@ TEST(ZipkinSpanBufferTest, SerializeSpan) {
                                             R"("traceId":"AAAAAAAAAAE=",)"
                                             R"("id":"AQAAAAAAAAA=",)"
                                             R"("kind":"SERVER",)"
-                                            R"("timestamp":"DEFAULT_TEST_TIMESTAMP",)"
+                                            R"("timestamp":"ANNOTATION_TEST_TIMESTAMP",)"
                                             R"("duration":"DEFAULT_TEST_DURATION",)"
                                             R"("localEndpoint":{)"
                                             R"("serviceName":"service1",)"
@@ -444,11 +446,11 @@ TEST(ZipkinSpanBufferTest, TestSerializeTimestampInTheFuture) {
   bufferDeprecatedJsonV1.addSpan(createSpan({"cs"}, IpType::V4));
   // We do "HasSubstr" here since we could not compare the serialized JSON of a ProtobufWkt::Struct
   // object, since the positions of keys are not consistent between calls.
-  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(), HasSubstr(R"("timestamp":1584324295476870)"));
+  EXPECT_THAT(bufferDeprecatedJsonV1.serialize(), HasSubstr(R"("timestamp":1584324295476871)"));
   EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
               Not(HasSubstr(R"("timestamp":1.58432429547687e+15)")));
   EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
-              Not(HasSubstr(R"("timestamp":"1584324295476870")")));
+              Not(HasSubstr(R"("timestamp":"1584324295476871")")));
   EXPECT_THAT(bufferDeprecatedJsonV1.serialize(), HasSubstr(R"("duration":2584324295476870)"));
   EXPECT_THAT(bufferDeprecatedJsonV1.serialize(),
               Not(HasSubstr(R"("duration":2.584324295476870e+15)")));
@@ -458,9 +460,9 @@ TEST(ZipkinSpanBufferTest, TestSerializeTimestampInTheFuture) {
   SpanBuffer bufferJsonV2(
       envoy::config::trace::v3::ZipkinConfig::hidden_envoy_deprecated_HTTP_JSON_V1, true, 2);
   bufferJsonV2.addSpan(createSpan({"cs"}, IpType::V4));
-  EXPECT_THAT(bufferJsonV2.serialize(), HasSubstr(R"("timestamp":1584324295476870)"));
+  EXPECT_THAT(bufferJsonV2.serialize(), HasSubstr(R"("timestamp":1584324295476871)"));
   EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("timestamp":1.58432429547687e+15)")));
-  EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("timestamp":"1584324295476870")")));
+  EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("timestamp":"1584324295476871")")));
   EXPECT_THAT(bufferJsonV2.serialize(), HasSubstr(R"("duration":2584324295476870)"));
   EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("duration":2.584324295476870e+15)")));
   EXPECT_THAT(bufferJsonV2.serialize(), Not(HasSubstr(R"("duration":"2584324295476870")")));


### PR DESCRIPTION
Commit Message: fix handling of timestamps in zipkin annotations / logs
Additional Description: the intended replacement from string to int was not happening as expected. this causes ingestion issues with non-lenient collectors, such as jaeger.  Augmented existing tests to use different timestamps for annotations to catch issue and prevent regression.
Risk Level: Low
Testing: Unit
Docs Changes: None
Release Notes: None
Platform Specific Features: None

Fixes #15960 

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>