### PR TITLE
[fuzz] exclude unknown security extensions from fuzz tests

### DIFF
--- a/source/extensions/all_extensions.bzl
+++ b/source/extensions/all_extensions.bzl
@@ -9,7 +9,6 @@ _required_extensions = {
     "envoy.transport_sockets.tls": "//source/extensions/transport_sockets/tls:config",
 }
 
-
 # Return the extension cc_library target after select
 def _selected_extension_target(target):
     return target + "_envoy_extension"

--- a/source/extensions/all_extensions.bzl
+++ b/source/extensions/all_extensions.bzl
@@ -9,6 +9,7 @@ _required_extensions = {
     "envoy.transport_sockets.tls": "//source/extensions/transport_sockets/tls:config",
 }
 
+
 # Return the extension cc_library target after select
 def _selected_extension_target(target):
     return target + "_envoy_extension"

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -276,3 +276,31 @@ EXTENSIONS = {
 # need to directly reference Envoy extensions.
 EXTENSION_CONFIG_VISIBILITY = ["//:extension_config"]
 EXTENSION_PACKAGE_VISIBILITY = ["//:extension_library"]
+
+# Extensions with unknown security posture. This will be kept in sync by CI.
+# This is used to exclude while fuzzing.
+UNKNOWN_SECURITY_EXTENSIONS = [
+    "envoy.access_loggers.wasm",
+    "envoy.bootstrap.wasm",
+    "envoy.filters.http.adaptive_concurrency",
+    "envoy.filters.http.admission_control",
+    "envoy.filters.http.cdn_loop",
+    "envoy.filters.http.ext_proc",
+    "envoy.filters.http.grpc_http1_bridge",
+    "envoy.filters.http.grpc_http1_reverse_bridge",
+    "envoy.filters.http.grpc_stats",
+    "envoy.filters.http.local_ratelimit",
+    "envoy.filters.http.wasm",
+    "envoy.filters.network.direct_response",
+    "envoy.filters.network.echo",
+    "envoy.filters.network.sni_cluster",
+    "envoy.filters.network.sni_dynamic_forward_proxy",
+    "envoy.filters.network.wasm",
+    "envoy.io_socket.user_space",
+    "envoy.rate_limit_descriptors.expr",
+    "envoy.tls.cert_validator.spiffe",
+    "envoy.wasm.runtime.null",
+    "envoy.wasm.runtime.v8",
+    "envoy.wasm.runtime.wasmtime",
+    "envoy.wasm.runtime.wavm",
+]

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -1,5 +1,5 @@
 load(
-    "//bazel:envoy_build_system.bzl",
+65;6203;1c    "//bazel:envoy_build_system.bzl",
     "envoy_benchmark_test",
     "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
@@ -9,6 +9,7 @@ load(
     "envoy_select_hot_restart",
 )
 load("//source/extensions:all_extensions.bzl", "envoy_all_extensions")
+load("//source/extensions:extensions_build_config.bzl", "UNKNOWN_SECURITY_EXTENSIONS")
 load("//bazel:repositories.bzl", "PPC_SKIP_TARGETS", "WINDOWS_SKIP_TARGETS")
 
 licenses(["notice"])  # Apache 2
@@ -351,9 +352,9 @@ envoy_cc_fuzz_test(
         "//test/mocks/server:hot_restart_mocks",
         "//test/test_common:environment_lib",
     ] + select({
-        "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
-        "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
-        "//conditions:default": envoy_all_extensions(),
+        "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS + UNKNOWN_SECURITY_EXTENSIONS),
+        "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS + UNKNOWN_SECURITY_EXTENSIONS),
+        "//conditions:default": envoy_all_extensions(UNKNOWN_SECURITY_EXTENSIONS),
     }),
 )
 

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -1,5 +1,5 @@
 load(
-65;6203;1c    "//bazel:envoy_build_system.bzl",
+    "//bazel:envoy_build_system.bzl",
     "envoy_benchmark_test",
     "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -1,5 +1,6 @@
 load("//bazel:envoy_build_system.bzl", "envoy_cc_fuzz_test", "envoy_cc_test", "envoy_cc_test_library", "envoy_package", "envoy_proto_library")
 load("//source/extensions:all_extensions.bzl", "envoy_all_extensions")
+load("//source/extensions:extensions_build_config.bzl", "UNKNOWN_SECURITY_EXTENSIONS")
 load("//bazel:repositories.bzl", "PPC_SKIP_TARGETS", "WINDOWS_SKIP_TARGETS")
 
 licenses(["notice"])  # Apache 2
@@ -88,9 +89,9 @@ envoy_cc_fuzz_test(
         "//test/mocks/server:options_mocks",
         "//test/test_common:environment_lib",
     ] + select({
-        "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
-        "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
-        "//conditions:default": envoy_all_extensions(),
+        "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS + UNKNOWN_SECURITY_EXTENSIONS),
+        "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS + UNKNOWN_SECURITY_EXTENSIONS),
+        "//conditions:default": envoy_all_extensions(UNKNOWN_SECURITY_EXTENSIONS),
     }),
 )
 

--- a/tools/extensions/generate_extension_db.py
+++ b/tools/extensions/generate_extension_db.py
@@ -95,6 +95,7 @@ def get_extension_metadata(target):
         'categories': categories,
     }
 
+
 def validate_unknowns(unknown_extensions, extensions):
     for extension, data in extensions.items():
         if data['security_posture'] == 'unknown':

--- a/tools/extensions/generate_extension_db.py
+++ b/tools/extensions/generate_extension_db.py
@@ -95,6 +95,16 @@ def get_extension_metadata(target):
         'categories': categories,
     }
 
+def validate_unknowns(unknown_extensions, extensions):
+    for extension, data in extensions.items():
+        if data['security_posture'] == 'unknown':
+            if extension not in unknown_extensions:
+                return False
+        else:
+            if extension in unknown_extensions:
+                return False
+    return True
+
 
 if __name__ == '__main__':
     try:
@@ -109,6 +119,9 @@ if __name__ == '__main__':
     all_extensions.update(extensions_build_config.EXTENSIONS)
     for extension, target in all_extensions.items():
         extension_db[extension] = get_extension_metadata(target)
+    if not validate_unknowns(extensions_build_config.UNKNOWN_SECURITY_EXTENSIONS, extension_db):
+        raise ExtensionDbError(
+            'Check that _unknown_security_extensions in all_extensions.bzl is up to date')
     if num_robust_to_downstream_network_filters(extension_db) != num_read_filters_fuzzed():
         raise ExtensionDbError(
             'Check that all network filters robust against untrusted'


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: exclude extensions with unknown extensions from fuzz tests
Additional Description: this hopefully will help gcc builds that are breaking with too many args.

