### PR TITLE
grpc_json_transcoder: Switch tests to compare JSON objects

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -362,10 +362,16 @@ public:
    *
    * @param lhs JSON string on LHS.
    * @param rhs JSON string on RHS.
+   * @param support_root_array Whether to support parsing JSON arrays.
    * @return bool indicating whether the JSON strings are equal.
    */
-  static bool jsonStringEqual(const std::string& lhs, const std::string& rhs) {
-    return protoEqual(jsonToStruct(lhs), jsonToStruct(rhs));
+  static bool jsonStringEqual(const std::string& lhs, const std::string& rhs,
+                              bool support_root_array = false) {
+    if (!support_root_array) {
+      return protoEqual(jsonToStruct(lhs), jsonToStruct(rhs));
+    }
+
+    return protoEqual(jsonArrayToStruct(lhs), jsonArrayToStruct(rhs));
   }
 
   /**
@@ -637,6 +643,15 @@ public:
   static ProtobufWkt::Struct jsonToStruct(const std::string& json) {
     ProtobufWkt::Struct message;
     MessageUtil::loadFromJson(json, message);
+    return message;
+  }
+
+  static ProtobufWkt::Struct jsonArrayToStruct(const std::string& json) {
+    // Hacky: add a surrounding root message, allowing JSON to be parsed into a struct.
+    std::string root_message = absl::StrCat("{ \"testOnlyArrayRoot\": ", json, "}");
+
+    ProtobufWkt::Struct message;
+    MessageUtil::loadFromJson(root_message, message);
     return message;
   }
 

--- a/test/test_common/utility_test.cc
+++ b/test/test_common/utility_test.cc
@@ -149,4 +149,16 @@ TEST(BuffersEqual, NonAligned) {
   EXPECT_TRUE(TestUtility::buffersEqual(buffer1, buffer2));
 }
 
+TEST(JsonEquals, RootMessage) {
+  EXPECT_TRUE(TestUtility::jsonStringEqual(R"({ "a" : "b" })", R"({ "a" : "b" })"));
+  EXPECT_TRUE(TestUtility::jsonStringEqual(R"({ "a" : "b" })", R"({"a":"b"})"));
+}
+
+TEST(JsonEquals, RootArray) {
+  EXPECT_TRUE(TestUtility::jsonStringEqual(R"([{ "a" : "b" }, { "c" : "d" }])",
+                                           R"([{ "a" : "b" }, { "c" : "d" }])", true));
+  EXPECT_TRUE(TestUtility::jsonStringEqual(R"([{ "a" : "b" }, { "c" : "d" }])",
+                                           R"([{"a":"b"},{"c":"d"}])", true));
+}
+
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
grpc_json_transcoder: Switch tests to compare JSON objects

Additional Description:
- We should not using string comparisons for JSON equality. Switch to use the pre-existing JSON comparison function instead.
- Add a _hacky_ way to support parsing root-level JSON arrays. This is needed to compare some streaming JSON responses in the transcoder.

Risk Level: None
Testing: Unit tests for new utility function.
Docs Changes: None
Release Notes: None
Platform Specific Features: None

Signed-off-by: Teju Nareddy <nareddyt@google.com>
