### PR TITLE
api: Update xds_protocol doc to remove v2 and cleanup

### DIFF
--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -300,7 +300,7 @@ An example EDS request might be:
     resource_names:
     - foo
     - bar
-    "@type": type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    type_url: type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     response_nonce:
 
 The management server may reply either immediately or when the requested
@@ -312,7 +312,7 @@ resources are available with a :ref:`DiscoveryResponse <envoy_v3_api_msg_service
     resources:
     - foo ClusterLoadAssignment proto encoding
     - bar ClusterLoadAssignment proto encoding
-    "@type": type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
+    type_url: type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     nonce: A
 
 After processing the :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`, Envoy will send a new

--- a/api/xds_protocol.rst
+++ b/api/xds_protocol.rst
@@ -8,9 +8,9 @@ querying one or more management servers. Collectively, these discovery
 services and their corresponding APIs are referred to as *xDS*.
 Resources are requested via *subscriptions*, by specifying a filesystem
 path to watch, initiating gRPC streams, or polling a REST-JSON URL. The
-latter two methods involve sending requests with a :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>`
+latter two methods involve sending requests with a :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>`
 proto payload. Resources are delivered in a
-:ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+:ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`
 proto payload in all methods. We discuss each type of subscription
 below.
 
@@ -20,17 +20,6 @@ Resource Types
 Every configuration resource in the xDS API has a type associated with it. Resource types follow a
 :repo:`versioning scheme <api/API_VERSIONING.md>`. Resource types are versioned independent of the
 transports described below.
-
-The following v2 xDS resource types are supported:
-
--  :ref:`envoy.api.v2.Listener <envoy_api_msg_Listener>`
--  :ref:`envoy.api.v2.RouteConfiguration <envoy_api_msg_RouteConfiguration>`
--  :ref:`envoy.api.v2.ScopedRouteConfiguration <envoy_api_msg_ScopedRouteConfiguration>`
--  :ref:`envoy.api.v2.route.VirtualHost <envoy_api_msg_route.VirtualHost>`
--  :ref:`envoy.api.v2.Cluster <envoy_api_msg_Cluster>`
--  :ref:`envoy.api.v2.ClusterLoadAssignment <envoy_api_msg_ClusterLoadAssignment>`
--  :ref:`envoy.api.v2.Auth.Secret <envoy_api_msg_Auth.Secret>`
--  :ref:`envoy.service.discovery.v2.Runtime <envoy_api_msg_service.discovery.v2.Runtime>`
 
 The following v3 xDS resource types are supported:
 
@@ -44,8 +33,8 @@ The following v3 xDS resource types are supported:
 -  :ref:`envoy.service.runtime.v3.Runtime <envoy_v3_api_msg_service.runtime.v3.Runtime>`
 
 The concept of `type URLs <https://developers.google.com/protocol-buffers/docs/proto3#any>`_
-appears below, and takes the form `type.googleapis.com/<resource type>` -- e.g.,
-`type.googleapis.com/envoy.api.v2.Cluster` for a `Cluster` resource. In various requests from
+appears below, and takes the form ``type.googleapis.com/<resource type>`` -- e.g.,
+``type.googleapis.com/envoy.config.cluster.v3.Cluster`` for a ``Cluster`` resource. In various requests from
 Envoy and responses by the management server, the resource type URL is stated.
 
 
@@ -53,13 +42,13 @@ Filesystem subscriptions
 ------------------------
 
 The simplest approach to delivering dynamic configuration is to place it
-at a well known path specified in the :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>`.
-Envoy will use `inotify` (`kqueue` on macOS) to monitor the file for
+at a well known path specified in the :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>`.
+Envoy will use ``inotify`` (``kqueue`` on macOS) to monitor the file for
 changes and parse the
-:ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` proto in the file on update.
+:ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` proto in the file on update.
 Binary protobufs, JSON, YAML and proto text are supported formats for
 the
-:ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`.
+:ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`.
 
 There is no mechanism available for filesystem subscriptions to ACK/NACK
 updates beyond stats counters and logs. The last valid configuration for
@@ -75,20 +64,20 @@ API flow
 ~~~~~~~~
 
 For typical HTTP routing scenarios, the core resource types for the client's configuration are
-`Listener`, `RouteConfiguration`, `Cluster`, and `ClusterLoadAssignment`. Each `Listener` resource
-may point to a `RouteConfiguration` resource, which may point to one or more `Cluster` resources,
-and each `Cluster` resource may point to a `ClusterLoadAssignment` resource.
+``Listener``, ``RouteConfiguration``, ``Cluster``, and ``ClusterLoadAssignment``. Each ``Listener`` resource
+may point to a ``RouteConfiguration`` resource, which may point to one or more ``Cluster`` resources,
+and each ``Cluster`` resource may point to a ``ClusterLoadAssignment`` resource.
 
-Envoy fetches all `Listener` and `Cluster` resources at startup. It then fetches whatever
-`RouteConfiguration` and `ClusterLoadAssignment` resources that are required by the `Listener` and
-`Cluster` resources. In effect, every `Listener` or `Cluster` resource is a root to part of Envoy's
+Envoy fetches all ``Listener`` and ``Cluster`` resources at startup. It then fetches whatever
+``RouteConfiguration`` and ``ClusterLoadAssignment`` resources that are required by the ``Listener`` and
+``Cluster`` resources. In effect, every ``Listener`` or ``Cluster`` resource is a root to part of Envoy's
 configuration tree.
 
-A non-proxy client such as gRPC might start by fetching only the specific `Listener` resources
-that it is interested in. It then fetches the `RouteConfiguration` resources required by those
-`Listener` resources, followed by whichever `Cluster` resources are required by those
-`RouteConfiguration` resources, followed by the `ClusterLoadAssignment` resources required
-by the `Cluster` resources. In effect, the original `Listener` resources are the roots to
+A non-proxy client such as gRPC might start by fetching only the specific ``Listener`` resources
+that it is interested in. It then fetches the ``RouteConfiguration`` resources required by those
+``Listener`` resources, followed by whichever ``Cluster`` resources are required by those
+``RouteConfiguration`` resources, followed by the ``ClusterLoadAssignment`` resources required
+by the ``Cluster`` resources. In effect, the original ``Listener`` resources are the roots to
 the client's configuration tree.
 
 Variants of the xDS Transport Protocol
@@ -170,52 +159,52 @@ stream. The RPC service and methods for the aggregated protocol variants are:
 -  Incremental: AggregatedDiscoveryService.DeltaAggregatedResources
 
 For all of the SotW methods, the request type is :ref:`DiscoveryRequest
-<envoy_api_msg_DiscoveryRequest>` and the response type is :ref:`DiscoveryResponse
-<envoy_api_msg_DiscoveryResponse>`.
+<envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` and the response type is :ref:`DiscoveryResponse
+<envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`.
 
 For all of the incremental methods, the request type is :ref:`DeltaDiscoveryRequest
-<envoy_api_msg_DeltaDiscoveryRequest>` and the response type is :ref:`DeltaDiscoveryResponse
-<envoy_api_msg_DeltaDiscoveryResponse>`.
+<envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>` and the response type is :ref:`DeltaDiscoveryResponse
+<envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryResponse>`.
 
 Configuring Which Variant to Use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the xDS API, the :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` message indicates how to
-obtain resources of a particular type. If the :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>`
-contains a gRPC :ref:`ApiConfigSource <envoy_api_msg_core.ApiConfigSource>`, it points to an
+In the xDS API, the :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>` message indicates how to
+obtain resources of a particular type. If the :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>`
+contains a gRPC :ref:`ApiConfigSource <envoy_v3_api_msg_config.core.v3.ApiConfigSource>`, it points to an
 upstream cluster for the management server; this will initiate an independent bidirectional gRPC
 stream for each xDS resource type, potentially to distinct management servers. If the
-:ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` contains a :ref:`AggregatedConfigSource
-<envoy_api_msg_core.AggregatedConfigSource>`, it tells the client to use :ref:`ADS
+:ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>` contains a :ref:`AggregatedConfigSource
+<envoy_v3_api_msg_config.core.v3.AggregatedConfigSource>`, it tells the client to use :ref:`ADS
 <xds_protocol_ads>`.
 
 Currently, the client is expected to be given some local configuration that tells it how to obtain
-the :ref:`Listener <envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>` resources.
-:ref:`Listener <envoy_api_msg_Listener>` resources may include a
-:ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` that indicates how the
-:ref:`RouteConfiguration <envoy_api_msg_RouteConfiguration>` resources are obtained, and
-:ref:`Cluster <envoy_api_msg_Cluster>` resources may include a
-:ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` that indicates how the
-:ref:`ClusterLoadAssignment <envoy_api_msg_ClusterLoadAssignment>` resources are obtained.
+the :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resources.
+:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` resources may include a
+:ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>` that indicates how the
+:ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` resources are obtained, and
+:ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resources may include a
+:ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>` that indicates how the
+:ref:`ClusterLoadAssignment <envoy_v3_api_msg_config.endpoint.v3.ClusterLoadAssignment>` resources are obtained.
 
 Client Configuration
 """"""""""""""""""""
 
-In Envoy, the bootstrap file contains two :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>`
-messages, one indicating how :ref:`Listener <envoy_api_msg_Listener>` resources are obtained and
-another indicating how :ref:`Cluster <envoy_api_msg_Cluster>` resources are obtained. It also
-contains a separate :ref:`ApiConfigSource <envoy_api_msg_core.ApiConfigSource>` message indicating
+In Envoy, the bootstrap file contains two :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>`
+messages, one indicating how :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` resources are obtained and
+another indicating how :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resources are obtained. It also
+contains a separate :ref:`ApiConfigSource <envoy_v3_api_msg_config.core.v3.ApiConfigSource>` message indicating
 how to contact the ADS server, which will be used whenever a :ref:`ConfigSource
-<envoy_api_msg_core.ConfigSource>` message (either in the bootstrap file or in a :ref:`Listener
-<envoy_api_msg_Listener>` or :ref:`Cluster <envoy_api_msg_Cluster>` resource obtained from a
+<envoy_v3_api_msg_config.core.v3.ConfigSource>` message (either in the bootstrap file or in a :ref:`Listener
+<envoy_v3_api_msg_config.listener.v3.Listener>` or :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource obtained from a
 management server) contains an :ref:`AggregatedConfigSource
-<envoy_api_msg_core.AggregatedConfigSource>` message.
+<envoy_v3_api_msg_config.core.v3.AggregatedConfigSource>` message.
 
 In a gRPC client that uses xDS, only ADS is supported, and the bootstrap file contains the name of
 the ADS server, which will be used for all resources. The :ref:`ConfigSource
-<envoy_api_msg_core.ConfigSource>` messages in the :ref:`Listener <envoy_api_msg_Listener>` and
-:ref:`Cluster <envoy_api_msg_Cluster>` resources must contain :ref:`AggregatedConfigSource
-<envoy_api_msg_core.AggregatedConfigSource>` messages.
+<envoy_v3_api_msg_config.core.v3.ConfigSource>` messages in the :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and
+:ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resources must contain :ref:`AggregatedConfigSource
+<envoy_v3_api_msg_config.core.v3.AggregatedConfigSource>` messages.
 
 The xDS transport Protocol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -225,20 +214,20 @@ Transport API version
 
 In addition the resource type version described above, the xDS wire protocol has a
 transport version associated with it. This provides type versioning for messages such as
-:ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` and :ref:`DiscoveryResponse
-<envoy_api_msg_DiscoveryResponse>`. It is also encoded in the gRPC method name, so a server
+:ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` and :ref:`DiscoveryResponse
+<envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`. It is also encoded in the gRPC method name, so a server
 can determine which version a client is speaking based on which method it calls.
 
 Basic Protocol Overview
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Each xDS stream begins with a :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` from the
+Each xDS stream begins with a :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` from the
 client, which specifies the list of resources to subscribe to, the type URL corresponding to the
 subscribed resources, the node identifier, and an optional resource type instance version
 indicating the most recent version of the resource type that the client has already seen (see
 :ref:`ACK/NACK and resource type instance version <xds_ack_nack>` for details).
 
-The server will then send a :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` containing
+The server will then send a :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` containing
 any resources that the client has subscribed to that have changed since the last resource type
 instance version that the client indicated it has seen. The server may send additional responses
 at any time when the subscribed resources change.
@@ -247,9 +236,9 @@ Whenever the client receives a new response, it will send another request indica
 not the resources in the response were valid (see
 :ref:`ACK/NACK and resource type instance version <xds_ack_nack>` for details).
 
-All server responses will contain a :ref:`nonce<envoy_api_field_DiscoveryResponse.nonce>`, and
+All server responses will contain a :ref:`nonce<envoy_v3_api_field_service.discovery.v3.DiscoveryResponse.nonce>`, and
 all subsequent requests from the client must set the
-:ref:`response_nonce <envoy_api_field_DiscoveryRequest.response_nonce>` field to the most recent
+:ref:`response_nonce <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.response_nonce>` field to the most recent
 nonce received from the server on that stream. This allows servers to determine which response a
 given request is associated with, which avoids various race conditions in the SotW protocol
 variants. Note that the nonce is valid only in the context of an individual xDS stream; it does
@@ -271,15 +260,15 @@ Every xDS resource type has a version string that indicates the version for that
 Whenever one resource of that type changes, the version is changed.
 
 In a response sent by the xDS server, the
-:ref:`version_info<envoy_api_field_DiscoveryResponse.version_info>` field indicates the current
+:ref:`version_info<envoy_v3_api_field_service.discovery.v3.DiscoveryResponse.version_info>` field indicates the current
 version for that resource type. The client then sends another request to the server with the
-:ref:`version_info<envoy_api_field_DiscoveryRequest.version_info>` field indicating the most
+:ref:`version_info<envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.version_info>` field indicating the most
 recent valid version seen by the client. This provides a way for the server to determine when
 it sends a version that the client considers invalid.
 
 (In the :ref:`incremental protocol variants <xds_protocol_delta>`, the resource type instance
 version is sent by the server in the
-:ref:`system_version_info<envoy_api_field_DeltaDiscoveryResponse.system_version_info>` field.
+:ref:`system_version_info<envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.system_version_info>` field.
 However, this information is not actually used by the client to communicate which resources are
 valid, because the incremental API variants have a separate mechanism for that.)
 
@@ -288,7 +277,7 @@ protocol variants, each resource type has its own version even though all resour
 sent on the same stream.
 
 The resource type instance version is also separate for each xDS server (where an xDS server is
-identified by a unique :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>`). When obtaining
+identified by a unique :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>`). When obtaining
 resources of a given type from multiple xDS servers, each xDS server will have a different notion
 of version.
 
@@ -311,11 +300,11 @@ An example EDS request might be:
     resource_names:
     - foo
     - bar
-    type_url: type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    "@type": type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     response_nonce:
 
 The management server may reply either immediately or when the requested
-resources are available with a :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`, e.g.:
+resources are available with a :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`, e.g.:
 
 .. code:: yaml
 
@@ -323,10 +312,10 @@ resources are available with a :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryR
     resources:
     - foo ClusterLoadAssignment proto encoding
     - bar ClusterLoadAssignment proto encoding
-    type_url: type.googleapis.com/envoy.api.v2.ClusterLoadAssignment
+    "@type": type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment
     nonce: A
 
-After processing the :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`, Envoy will send a new
+After processing the :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`, Envoy will send a new
 request on the stream, specifying the last version successfully applied
 and the nonce provided by the management server. The version provides Envoy and the
 management server a shared notion of the currently applied configuration,
@@ -336,7 +325,7 @@ ACK
 ^^^
 
 If the update was successfully applied, the
-:ref:`version_info <envoy_api_field_DiscoveryRequest.version_info>` will be **X**, as indicated
+:ref:`version_info <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.version_info>` will be **X**, as indicated
 in the sequence diagram:
 
 .. figure:: diagrams/simple-ack.svg
@@ -346,9 +335,9 @@ NACK
 ^^^^
 
 If Envoy had instead rejected configuration
-update **X**, it would reply with :ref:`error_detail <envoy_api_field_DiscoveryRequest.error_detail>`
+update **X**, it would reply with :ref:`error_detail <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.error_detail>`
 populated and its previous version, which in this case was the empty
-initial version. The :ref:`error_detail <envoy_api_field_DiscoveryRequest.error_detail>` has
+initial version. The :ref:`error_detail <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.error_detail>` has
 more details around the exact error message populated in the message field:
 
 .. figure:: diagrams/simple-nack.svg
@@ -366,7 +355,7 @@ After a NACK, an API update may succeed at a new version **Y**:
    :alt: ACK after NACK
 
 The preferred mechanism for a server to detect a NACK is to look for the presence of the
-:ref:`error_detail <envoy_api_field_DiscoveryRequest.error_detail>` field in the request sent by
+:ref:`error_detail <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.error_detail>` field in the request sent by
 the client. Some older servers may instead detect a NACK by looking at both the version and the
 nonce in the request: if the version in the request is not equal to the one sent by the server with
 that nonce, then the client has rejected the most recent version. However, this approach does not
@@ -381,16 +370,16 @@ consider the following example:
 ACK and NACK semantics summary
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- The xDS client should ACK or NACK every :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+- The xDS client should ACK or NACK every :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`
   received from the management server. The :ref:`response_nonce
-  <envoy_api_field_DiscoveryRequest.response_nonce>` field tells the server which of its responses
+  <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.response_nonce>` field tells the server which of its responses
   the ACK or NACK is associated with.
 - ACK signifies successful configuration update and contains the
-  :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>` from the
-  :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`.
+  :ref:`version_info <envoy_v3_api_field_service.discovery.v3.DiscoveryResponse.version_info>` from the
+  :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`.
 - NACK signifies unsuccessful configuration and is indicated by the presence of the
-  :ref:`error_detail <envoy_api_field_DiscoveryRequest.error_detail>` field. The :ref:`version_info
-  <envoy_api_field_DiscoveryResponse.version_info>` indicates the most recent version that the
+  :ref:`error_detail <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.error_detail>` field. The :ref:`version_info
+  <envoy_v3_api_field_service.discovery.v3.DiscoveryResponse.version_info>` indicates the most recent version that the
   client is using, although that may not be an older version in the case where the client has
   subscribed to a new resource from an existing version and that new resource is invalid (see
   example above).
@@ -401,17 +390,17 @@ When to send an update
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The management server should only send updates to the Envoy client when
-the resources in the :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` have changed. Envoy replies
-to any :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` with a :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` containing the
+the resources in the :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` have changed. Envoy replies
+to any :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` with a :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` containing the
 ACK/NACK immediately after it has been either accepted or rejected. If
 the management server provides the same set of resources rather than
 waiting for a change to occur, it will cause needless work on both the client and the management
 server, which could have a severe performance impact.
 
-Within a stream, new :ref:`DiscoveryRequests <envoy_api_msg_DiscoveryRequest>` supersede any prior
-:ref:`DiscoveryRequests <envoy_api_msg_DiscoveryRequest>` having the same resource type. This means that
+Within a stream, new :ref:`DiscoveryRequests <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` supersede any prior
+:ref:`DiscoveryRequests <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` having the same resource type. This means that
 the management server only needs to respond to the latest
-:ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` on each stream for any given resource type.
+:ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` on each stream for any given resource type.
 
 .. _xds_protocol_resource_hints:
 
@@ -420,13 +409,13 @@ How the client specifies what resources to return
 
 xDS requests allow the client to specify a set of resource names as a hint to the server about
 which resources the client is interested in. In the SotW protocol variants, this is done via the
-:ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` specified in the
-:ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>`; in the incremental protocol variants,
+:ref:`resource_names <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.resource_names>` specified in the
+:ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>`; in the incremental protocol variants,
 this is done via the :ref:`resource_names_subscribe
-<envoy_api_field_DeltaDiscoveryRequest.resource_names_subscribe>` and
+<envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_subscribe>` and
 :ref:`resource_names_unsubscribe
-<envoy_api_field_DeltaDiscoveryRequest.resource_names_unsubscribe>` fields in the
-:ref:`DeltaDiscoveryRequest <envoy_api_msg_DeltaDiscoveryRequest>`.
+<envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_unsubscribe>` fields in the
+:ref:`DeltaDiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>`.
 
 Normally (see below for exceptions), requests must specify the set of resource names that the
 client is interested in. The management server must supply the requested resources if they exist.
@@ -437,11 +426,11 @@ been asked for them and the resources have not changed since that time. If the l
 names becomes empty, that means that the client is no longer interested in any resources of the
 specified type.
 
-For :ref:`Listener <envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>` resource
+For :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource
 types, there is also a "wildcard" mode, which is triggered when the initial request on the stream
 for that resource type contains no resource names. In this case, the server should use
 site-specific business logic to determine the full set of resources that the client is interested
-in, typically based on the client's :ref:`node <envoy_api_msg_Core.Node>` identification. Note
+in, typically based on the client's :ref:`node <envoy_v3_api_msg_config.core.v3.Node>` identification. Note
 that once a stream has entered wildcard mode for a given resource type, there is no way to change
 the stream out of wildcard mode; resource names specified in any subsequent request on the stream
 will be ignored.
@@ -449,8 +438,8 @@ will be ignored.
 Client Behavior
 """""""""""""""
 
-Envoy will always use wildcard mode for :ref:`Listener <envoy_api_msg_Listener>` and
-:ref:`Cluster <envoy_api_msg_Cluster>` resources. However, other xDS clients (such as gRPC clients
+Envoy will always use wildcard mode for :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and
+:ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resources. However, other xDS clients (such as gRPC clients
 that use xDS) may specify explicit resource names for these resource types, for example if they
 only have a singleton listener and already know its name from some out-of-band configuration.
 
@@ -463,9 +452,9 @@ may send a response containing only the changed resource; it does not need to re
 resources that have not changed, and the client must not delete the unchanged resources.
 
 In the SotW protocol variants, all resource types except for :ref:`Listener
-<envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>` are grouped into responses
+<envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` are grouped into responses
 in the same way as in the incremental protocol variants. However,
-:ref:`Listener <envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>` resource types
+:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource types
 are handled differently: the server must include the complete state of the world, meaning that all
 resources of the relevant type that are needed by the client must be included, even if they did
 not change since the last response. This means that if the server has previously sent 100
@@ -487,21 +476,21 @@ Deleting Resources
 ^^^^^^^^^^^^^^^^^^
 
 In the incremental proocol variants, the server signals the client that a resource should be
-deleted via the :ref:`removed_resources <envoy_api_field_DeltaDiscoveryResponse.removed_resources>`
+deleted via the :ref:`removed_resources <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.removed_resources>`
 field of the response. This tells the client to remove the resource from its local cache.
 
 In the SotW protocol variants, the criteria for deleting resources is more complex. For
-:ref:`Listener <envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>` resource types,
+:ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource types,
 if a previously seen resource is not present in a new response, that indicates that the resource
 has been removed, and the client must delete it; a response containing no resources means to delete
 all resources of that type. However, for other resource types, the API provides no mechanism for
 the server to tell the client that resources have been deleted; instead, deletions are indicated
 implicitly by parent resources being changed to no longer refer to a child resource. For example,
-when the client receives an LDS update removing a :ref:`Listener <envoy_api_msg_Listener>`
-that was previously pointing to :ref:`RouteConfiguration <envoy_api_msg_RouteConfiguration>` A,
-if no other :ref:`Listener <envoy_api_msg_Listener>` is pointing to :ref:`RouteConfiguration
-<envoy_api_msg_RouteConfiguration>` A, then the client may delete A. For those resource types,
-an empty :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` is effectively a no-op
+when the client receives an LDS update removing a :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>`
+that was previously pointing to :ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A,
+if no other :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` is pointing to :ref:`RouteConfiguration
+<envoy_v3_api_msg_config.route.v3.RouteConfiguration>` A, then the client may delete A. For those resource types,
+an empty :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` is effectively a no-op
 from the client's perspective.
 
 .. _xds_protocol_resource_not_existed:
@@ -512,7 +501,7 @@ Knowing When a Requested Resource Does Not Exist
 The SotW protocol variants do not provide any explicit mechanism to determine when a requested
 resource does not exist.
 
-Responses for :ref:`Listener <envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>`
+Responses for :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`
 resource types must include all resources requested by the client. However, it may not be possible
 for the client to know that a resource does not exist based solely on its absence in a response,
 because the delivery of the updates is eventually consistent: if the client initially sends a
@@ -529,12 +518,12 @@ previously.
 As a result, clients are expected to use a timeout (recommended duration is 15 seconds) after
 sending a request for a new resource, after which they will consider the requested resource to
 not exist if they have not received the resource. In Envoy, this is done for
-:ref:`RouteConfiguration <envoy_api_msg_RouteConfiguration>` and :ref:`ClusterLoadAssignment
-<envoy_api_msg_ClusterLoadAssignment>` resources during :ref:`resource warming
+:ref:`RouteConfiguration <envoy_v3_api_msg_config.route.v3.RouteConfiguration>` and :ref:`ClusterLoadAssignment
+<envoy_v3_api_msg_config.endpoint.v3.ClusterLoadAssignment>` resources during :ref:`resource warming
 <xds_protocol_resource_warming>`.
 
 Note that this timeout is not strictly necessary when using wildcard mode for :ref:`Listener
-<envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>` resource types, because
+<envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` resource types, because
 in that case every response will contain all existing resources that are relevant to the
 client, so the client can know that a resource does not exist by its absence in the next
 response it sees. However, using a timeout is still recommended in this case, since it protects
@@ -551,16 +540,16 @@ Unsubscribing From Resources
 
 In the incremental protocol variants, resources can be unsubscribed to via the
 :ref:`resource_names_unsubscribe
-<envoy_api_field_DeltaDiscoveryRequest.resource_names_unsubscribe>` field.
+<envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_unsubscribe>` field.
 
 In the SotW protocol variants, each request must contain the full list of resource names being
-subscribed to in the :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` field,
+subscribed to in the :ref:`resource_names <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.resource_names>` field,
 so unsubscribing to a set of resources is done by sending a new request containing all resource
 names that are still being subscribed to but not containing the resource names being unsubscribed
 to. For example, if the client had previously been subscribed to resources A and B but wishes to
 unsubscribe from B, it must send a new request containing only resource A.
 
-Note that for :ref:`Listener <envoy_api_msg_Listener>` and :ref:`Cluster <envoy_api_msg_Cluster>`
+Note that for :ref:`Listener <envoy_v3_api_msg_config.listener.v3.Listener>` and :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>`
 resource types where the stream is in "wildcard" mode (see :ref:`How the client specifies what
 resources to return <xds_protocol_resource_hints>` for details), the set of resources being
 subscribed to is determined by the server instead of the client, so there is no mechanism
@@ -570,14 +559,14 @@ Requesting Multiple Resources on a Single Stream
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For EDS/RDS, Envoy may either generate a distinct stream for each
-resource of a given type (e.g. if each :ref:`ConfigSource <envoy_api_msg_core.ConfigSource>` has its own
+resource of a given type (e.g. if each :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>` has its own
 distinct upstream cluster for a management server), or may combine
 together multiple resource requests for a given resource type when they
 are destined for the same management server. While this is left to
 implementation specifics, management servers should be capable of
-handling one or more :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` for a given resource type in
+handling one or more :ref:`resource_names <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.resource_names>` for a given resource type in
 each request. Both sequence diagrams below are valid for fetching two
-EDS resources `{foo, bar}`:
+EDS resources ``{foo, bar}``:
 
 |Multiple EDS requests on the same stream| |Multiple EDS requests on
 distinct streams|
@@ -585,15 +574,15 @@ distinct streams|
 Resource updates
 ^^^^^^^^^^^^^^^^
 
-As discussed above, Envoy may update the list of :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` it
-presents to the management server in each :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` that
-ACK/NACKs a specific :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`. In addition, Envoy may later
-issue additional :ref:`DiscoveryRequests <envoy_api_msg_DiscoveryRequest>` at a given :ref:`version_info <envoy_api_field_DiscoveryRequest.version_info>` to
+As discussed above, Envoy may update the list of :ref:`resource_names <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.resource_names>` it
+presents to the management server in each :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` that
+ACK/NACKs a specific :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`. In addition, Envoy may later
+issue additional :ref:`DiscoveryRequests <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` at a given :ref:`version_info <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.version_info>` to
 update the management server with new resource hints. For example, if
 Envoy is at EDS version **X** and knows only about cluster ``foo``, but
 then receives a CDS update and learns about ``bar`` in addition, it may
-issue an additional :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` for **X** with `{foo,bar}` as
-`resource_names`.
+issue an additional :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` for **X** with ``{foo,bar}`` as
+``resource_names``.
 
 .. figure:: diagrams/cds-eds-resources.svg
    :alt: CDS response leads to EDS resource hint update
@@ -602,26 +591,26 @@ There is a race condition that may arise here; if after a resource hint
 update is issued by Envoy at **X**, but before the management server
 processes the update it replies with a new version **Y**, the resource
 hint update may be interpreted as a rejection of **Y** by presenting an
-**X** :ref:`version_info <envoy_api_field_DiscoveryResponse.version_info>`. To avoid this, the management server provides a
-``nonce`` that Envoy uses to indicate the specific :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
-each :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` corresponds to:
+**X** :ref:`version_info <envoy_v3_api_field_service.discovery.v3.DiscoveryResponse.version_info>`. To avoid this, the management server provides a
+``nonce`` that Envoy uses to indicate the specific :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`
+each :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` corresponds to:
 
 .. figure:: diagrams/update-race.svg
    :alt: EDS update race motivates nonces
 
-The management server should not send a :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` for any
-:ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` that has a stale nonce. A nonce becomes stale
+The management server should not send a :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` for any
+:ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` that has a stale nonce. A nonce becomes stale
 following a newer nonce being presented to Envoy in a
-:ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`. A management server does not need to send an
+:ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`. A management server does not need to send an
 update until it determines a new version is available. Earlier requests
 at a version then also become stale. It may process multiple
-:ref:`DiscoveryRequests <envoy_api_msg_DiscoveryRequest>` at a version until a new version is ready.
+:ref:`DiscoveryRequests <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` at a version until a new version is ready.
 
 .. figure:: diagrams/stale-requests.svg
    :alt: Requests become stale
 
 An implication of the above resource update sequencing is that Envoy
-does not expect a :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` for every :ref:`DiscoveryRequests <envoy_api_msg_DiscoveryRequest>`
+does not expect a :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` for every :ref:`DiscoveryRequests <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>`
 it issues.
 
 .. _xds_protocol_resource_warming:
@@ -633,10 +622,10 @@ Resource warming
 :ref:`Listeners <config_listeners_lds>`
 go through warming before they can serve requests. This process
 happens both during :ref:`Envoy initialization <arch_overview_initialization>`
-and when the `Cluster` or `Listener` is updated. Warming of
-`Cluster` is completed only when a `ClusterLoadAssignment` response
-is supplied by management server. Similarly, warming of `Listener` is
-completed only when a `RouteConfiguration` is supplied by management
+and when the ``Cluster`` or ``Listener`` is updated. Warming of
+``Cluster`` is completed only when a ``ClusterLoadAssignment`` response
+is supplied by management server. Similarly, warming of ``Listener`` is
+completed only when a ``RouteConfiguration`` is supplied by management
 server if the listener refers to an RDS configuration. Management server
 is expected to provide the EDS/RDS updates during warming. If management
 server does not provide EDS/RDS responses, Envoy will not initialize
@@ -650,7 +639,7 @@ Eventual consistency considerations
 
 Since Envoy's xDS APIs are eventually consistent, traffic may drop
 briefly during updates. For example, if only cluster **X** is known via
-CDS/EDS, a `RouteConfiguration` references cluster **X** and is then
+CDS/EDS, a ``RouteConfiguration`` references cluster **X** and is then
 adjusted to cluster **Y** just before the CDS/EDS update providing
 **Y**, traffic will be blackholed until **Y** is known about by the
 Envoy instance.
@@ -695,7 +684,7 @@ be used, for example, to terminate a fault injection test when the management se
 be reached.
 
 For clients that support the *xds.config.supports-resource-ttl* client feature, A TTL field may
-be specified on each :ref:`Resource <envoy_api_msg_Resource>`. Each resource will have its own TTL
+be specified on each :ref:`Resource <envoy_v3_api_msg_service.discovery.v3.Resource>`. Each resource will have its own TTL
 expiry time, at which point the resource will be expired. Each xDS type may have different ways of
 handling such an expiry.
 
@@ -703,7 +692,7 @@ To update the TTL associated with a *Resource*, the management server resends th
 new TTL. To remove the TTL, the management server resends the resource with the TTL field unset.
 
 To allow for lightweight TTL updates ("heartbeats"), a response can be sent that provides a
-:ref:`Resource <envoy_api_msg_Resource>` with the :ref:`resource <envoy_api_field_Resource.resource>`
+:ref:`Resource <envoy_v3_api_msg_service.discovery.v3.Resource>` with the :ref:`resource <envoy_v3_api_msg_service.discovery.v3.Resource>`
 unset and version matching the most recently sent version can be used to update the TTL. These
 resources will not be treated as resource updates, but only as TTL updates.
 
@@ -711,7 +700,7 @@ SotW TTL
 ^^^^^^^^
 
 In order to use TTL with SotW xDS, the relevant resources must be wrapped in a
-:ref:`Resource <envoy_api_msg_Resource>`. This allows setting the same TTL field that is used for
+:ref:`Resource <envoy_v3_api_msg_service.discovery.v3.Resource>`. This allows setting the same TTL field that is used for
 Delta xDS with SotW, without changing the SotW API. Heartbeats are supported for SotW as well:
 any resource within the response that look like a heartbeat resource will only be used to update the TTL.
 
@@ -727,9 +716,9 @@ traffic drop when management servers are distributed. ADS allow a single
 management server, via a single gRPC stream, to deliver all API updates.
 This provides the ability to carefully sequence updates to avoid traffic
 drop. With ADS, a single stream is used with multiple independent
-:ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>`/:ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` sequences multiplexed via the
+:ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>`/:ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` sequences multiplexed via the
 type URL. For any given type URL, the above sequencing of
-:ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` and :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` messages applies. An
+:ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` and :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` messages applies. An
 example update sequence might look like:
 
 .. figure:: diagrams/ads.svg
@@ -739,42 +728,7 @@ A single ADS stream is available per Envoy instance.
 
 An example minimal ``bootstrap.yaml`` fragment for ADS configuration is:
 
-.. code:: yaml
-
-    node:
-      id: <node identifier>
-    dynamic_resources:
-      cds_config: {ads: {}}
-      lds_config: {ads: {}}
-      ads_config:
-        api_type: GRPC
-        grpc_services:
-          envoy_grpc:
-            cluster_name: ads_cluster
-    static_resources:
-      clusters:
-      - name: ads_cluster
-        connect_timeout: { seconds: 5 }
-        type: STATIC
-        hosts:
-        - socket_address:
-            address: <ADS management server IP address>
-            port_value: <ADS management server port>
-        lb_policy: ROUND_ROBIN
-        # It is recommended to configure either HTTP/2 or TCP keepalives in order to detect
-        # connection issues, and allow Envoy to reconnect. TCP keepalive is less expensive, but
-        # may be inadequate if there is a TCP proxy between Envoy and the management server.
-        # HTTP/2 keepalive is slightly more expensive, but may detect issues through more types
-        # of intermediate proxies.
-        http2_protocol_options:
-          connection_keepalive:
-            interval: 30s
-            timeout: 5s
-        upstream_connection_options:
-          tcp_keepalive:
-            ...
-    admin:
-      ...
+.. literalinclude:: ../_include/ads.yaml
 
 .. _xds_protocol_delta:
 
@@ -798,16 +752,16 @@ state of xDS clients connected to it. There is no REST version of
 Incremental xDS yet.
 
 In the delta xDS wire protocol, the nonce field is required and used to
-pair a :ref:`DeltaDiscoveryResponse <envoy_api_msg_DeltaDiscoveryResponse>`
-to a :ref:`DeltaDiscoveryRequest <envoy_api_msg_DeltaDiscoveryRequest>`
-ACK or NACK. Optionally, a response message level :ref:`system_version_info <envoy_api_field_DeltaDiscoveryResponse.system_version_info>`
+pair a :ref:`DeltaDiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryResponse>`
+to a :ref:`DeltaDiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>`
+ACK or NACK. Optionally, a response message level :ref:`system_version_info <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryResponse.system_version_info>`
 is present for debugging purposes only.
 
-:ref:`DeltaDiscoveryRequest <envoy_api_msg_DeltaDiscoveryRequest>` can be sent in the following situations:
+:ref:`DeltaDiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>` can be sent in the following situations:
 
 - Initial message in a xDS bidirectional gRPC stream.
-- As an ACK or NACK response to a previous :ref:`DeltaDiscoveryResponse <envoy_api_msg_DeltaDiscoveryResponse>`. In this case the :ref:`response_nonce <envoy_api_field_DiscoveryRequest.response_nonce>` is set to the nonce value in the Response. ACK or NACK is determined by the absence or presence of :ref:`error_detail <envoy_api_field_DiscoveryRequest.error_detail>`.
-- Spontaneous :ref:`DeltaDiscoveryRequests <envoy_api_msg_DeltaDiscoveryRequest>` from the client. This can be done to dynamically add or remove elements from the tracked :ref:`resource_names <envoy_api_field_DiscoveryRequest.resource_names>` set. In this case :ref:`response_nonce <envoy_api_field_DiscoveryRequest.response_nonce>` must be omitted.
+- As an ACK or NACK response to a previous :ref:`DeltaDiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryResponse>`. In this case the :ref:`response_nonce <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.response_nonce>` is set to the nonce value in the Response. ACK or NACK is determined by the absence or presence of :ref:`error_detail <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.error_detail>`.
+- Spontaneous :ref:`DeltaDiscoveryRequests <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>` from the client. This can be done to dynamically add or remove elements from the tracked :ref:`resource_names <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.resource_names>` set. In this case :ref:`response_nonce <envoy_v3_api_field_service.discovery.v3.DiscoveryRequest.response_nonce>` must be omitted.
 
 In this first example the client connects and receives a first update
 that it ACKs. The second update fails and the client NACKs the update.
@@ -830,9 +784,9 @@ Resource names
 
 Resources are identified by a resource name or an alias. Aliases of a
 resource, if present, can be identified by the alias field in the
-resource of a :ref:`DeltaDiscoveryResponse <envoy_api_msg_DeltaDiscoveryResponse>`. The resource name will be
+resource of a :ref:`DeltaDiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryResponse>`. The resource name will be
 returned in the name field in the resource of a
-:ref:`DeltaDiscoveryResponse <envoy_api_msg_DeltaDiscoveryResponse>`.
+:ref:`DeltaDiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryResponse>`.
 
 .. _xds_protocol_delta_subscribe:
 
@@ -840,12 +794,12 @@ Subscribing to Resources
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The client can send either an alias or the name of a resource in the
-:ref:`resource_names_subscribe <envoy_api_field_DeltaDiscoveryRequest.resource_names_subscribe>` field of a :ref:`DeltaDiscoveryRequest <envoy_api_msg_DeltaDiscoveryRequest>` in
+:ref:`resource_names_subscribe <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_subscribe>` field of a :ref:`DeltaDiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>` in
 order to subscribe to a resource. Both the names and aliases of
 resources should be checked in order to determine whether the entity in
 question has been subscribed to.
 
-A :ref:`resource_names_subscribe <envoy_api_field_DeltaDiscoveryRequest.resource_names_subscribe>` field may contain resource names that the
+A :ref:`resource_names_subscribe <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_subscribe>` field may contain resource names that the
 server believes the client is already subscribed to, and furthermore has
 the most recent versions of. However, the server *must* still provide
 those resources in the response; due to implementation details hidden
@@ -858,11 +812,11 @@ Unsubscribing from Resources
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When a client loses interest in some resources, it will indicate that
-with the :ref:`resource_names_unsubscribe <envoy_api_field_DeltaDiscoveryRequest.resource_names_unsubscribe>` field of a
-:ref:`DeltaDiscoveryRequest <envoy_api_msg_DeltaDiscoveryRequest>`. As with :ref:`resource_names_subscribe <envoy_api_field_DeltaDiscoveryRequest.resource_names_subscribe>`, these
+with the :ref:`resource_names_unsubscribe <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_unsubscribe>` field of a
+:ref:`DeltaDiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DeltaDiscoveryRequest>`. As with :ref:`resource_names_subscribe <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_subscribe>`, these
 may be resource names or aliases.
 
-A :ref:`resource_names_unsubscribe <envoy_api_field_DeltaDiscoveryRequest.resource_names_unsubscribe>` field may contain superfluous resource
+A :ref:`resource_names_unsubscribe <envoy_v3_api_field_service.discovery.v3.DeltaDiscoveryRequest.resource_names_unsubscribe>` field may contain superfluous resource
 names, which the server thought the client was already not subscribed
 to. The server must cleanly process such a request; it can simply ignore
 these phantom unsubscriptions.
@@ -871,8 +825,8 @@ Knowing When a Requested Resource Does Not Exist
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When a resource subscribed to by a client does not exist, the server will send a :ref:`Resource
-<envoy_api_msg_Resource>` whose :ref:`name <envoy_api_field_Resource.name>` field matches the
-name that the client subscribed to and whose :ref:`resource <envoy_api_field_Resource.resource>`
+<envoy_v3_api_msg_service.discovery.v3.Resource>` whose :ref:`name <envoy_v3_api_field_service.discovery.v3.Resource.name>` field matches the
+name that the client subscribed to and whose :ref:`resource <envoy_v3_api_msg_service.discovery.v3.Resource>`
 field is unset. This allows the client to quickly determine when a resource does not exist without
 waiting for a timeout, as would be done in the SotW protocol variants. However, clients are still
 encouraged to use a timeout to protect against the case where the management server fails to send
@@ -888,12 +842,12 @@ expected that there is only a single outstanding request at any point in
 time, and as a result the response nonce is optional in REST-JSON. The
 `JSON canonical transform of
 proto3 <https://developers.google.com/protocol-buffers/docs/proto3#json>`__
-is used to encode :ref:`DiscoveryRequest <envoy_api_msg_DiscoveryRequest>` and :ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>`
+is used to encode :ref:`DiscoveryRequest <envoy_v3_api_msg_service.discovery.v3.DiscoveryRequest>` and :ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>`
 messages. ADS is not available for REST-JSON polling.
 
 When the poll period is set to a small value, with the intention of long
 polling, then there is also a requirement to avoid sending a
-:ref:`DiscoveryResponse <envoy_api_msg_DiscoveryResponse>` unless a change to the underlying resources has
+:ref:`DiscoveryResponse <envoy_v3_api_msg_service.discovery.v3.DiscoveryResponse>` unless a change to the underlying resources has
 occurred via a :ref:`resource update <xds_protocol_resource_update>`.
 
 .. |Multiple EDS requests on the same stream| image:: diagrams/eds-same-stream.svg

--- a/docs/root/_include/ads.yaml
+++ b/docs/root/_include/ads.yaml
@@ -1,0 +1,51 @@
+node:
+  # set <cluster identifier>
+  cluster: envoy_cluster
+  # set <node identifier>
+  id: envoy_node
+
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: ads_cluster
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+
+static_resources:
+  clusters:
+  - name: ads_cluster
+    connect_timeout: 5s
+    type: STRICT_DNS
+    load_assignment:
+      cluster_name: ads_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                # set <ADS management server address>
+                address: my-control-plane
+                # set <ADS management server port>
+                port_value: 777
+    # It is recommended to configure either HTTP/2 or TCP keepalives in order to detect
+    # connection issues, and allow Envoy to reconnect. TCP keepalive is less expensive, but
+    # may be inadequate if there is a TCP proxy between Envoy and the management server.
+    # HTTP/2 keepalive is slightly more expensive, but may detect issues through more types
+    # of intermediate proxies.
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options:
+            connection_keepalive:
+              interval: 30s
+              timeout: 5s
+    upstream_connection_options:
+      tcp_keepalive: {}


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: api: Update xds_protocol doc to remove v2 and cleanup
Additional Description:

Breakout PR from #16077 

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
