### PR TITLE
Minor fix: Fix protoleak.

### DIFF
--- a/test/common/upstream/maglev_lb_test.cc
+++ b/test/common/upstream/maglev_lb_test.cc
@@ -141,11 +141,8 @@ TEST_F(MaglevLoadBalancerTest, BasicWithHostName) {
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
-  auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
-  chc.set_use_hostname_for_hashing(true);
-  common_config_.set_allocated_consistent_hashing_lb_config(&chc);
+  common_config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
   init(7);
-  common_config_.release_consistent_hashing_lb_config();
 
   EXPECT_EQ("maglev_lb.min_entries_per_host", lb_->stats().min_entries_per_host_.name());
   EXPECT_EQ("maglev_lb.max_entries_per_host", lb_->stats().max_entries_per_host_.name());
@@ -179,11 +176,8 @@ TEST_F(MaglevLoadBalancerTest, BasicWithMetadataHashKey) {
   host_set_.healthy_hosts_ = host_set_.hosts_;
   host_set_.runCallbacks({}, {});
   common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
-  auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
-  chc.set_use_hostname_for_hashing(true);
-  common_config_.set_allocated_consistent_hashing_lb_config(&chc);
+  common_config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
   init(7);
-  common_config_.release_consistent_hashing_lb_config();
 
   EXPECT_EQ("maglev_lb.min_entries_per_host", lb_->stats().min_entries_per_host_.name());
   EXPECT_EQ("maglev_lb.max_entries_per_host", lb_->stats().max_entries_per_host_.name());

--- a/test/common/upstream/ring_hash_lb_test.cc
+++ b/test/common/upstream/ring_hash_lb_test.cc
@@ -287,12 +287,9 @@ TEST_P(RingHashLoadBalancerTest, BasicWithHostname) {
   config_.value().mutable_minimum_ring_size()->set_value(12);
 
   common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
-  auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
-  chc.set_use_hostname_for_hashing(true);
-  common_config_.set_allocated_consistent_hashing_lb_config(&chc);
+  common_config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
 
   init();
-  common_config_.release_consistent_hashing_lb_config();
 
   EXPECT_EQ("ring_hash_lb.size", lb_->stats().size_.name());
   EXPECT_EQ("ring_hash_lb.min_hashes_per_host", lb_->stats().min_hashes_per_host_.name());
@@ -362,12 +359,9 @@ TEST_P(RingHashLoadBalancerTest, BasicWithMetadataHashKey) {
   config_.value().mutable_minimum_ring_size()->set_value(12);
 
   common_config_ = envoy::config::cluster::v3::Cluster::CommonLbConfig();
-  auto chc = envoy::config::cluster::v3::Cluster::CommonLbConfig::ConsistentHashingLbConfig();
-  chc.set_use_hostname_for_hashing(true);
-  common_config_.set_allocated_consistent_hashing_lb_config(&chc);
+  common_config_.mutable_consistent_hashing_lb_config()->set_use_hostname_for_hashing(true);
 
   init();
-  common_config_.release_consistent_hashing_lb_config();
 
   EXPECT_EQ("ring_hash_lb.size", lb_->stats().size_.name());
   EXPECT_EQ("ring_hash_lb.min_hashes_per_host", lb_->stats().min_hashes_per_host_.name());


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

Commit Message: Fixed proto leaks.
Additional Description:  Let protos manage memory themselves vs explicitly handling it with `set_foo` and `release_foo` 
Risk Level: Low
Testing: NA
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
