### PR TITLE
jwt_authn refactory: move threadlocal from JwksCache into JwksDataImpl

### DIFF
--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -11,16 +11,16 @@ namespace Extensions {
 namespace HttpFilters {
 namespace JwtAuthn {
 
-FilterConfigImpl::FilterConfigImpl(envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
-                                   const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
-    : proto_config_(std::move(proto_config)),
-      stats_(generateStats(stats_prefix, context.scope())),
-      cm_(context.clusterManager()),
-      time_source_(context.dispatcher().timeSource())) {
+FilterConfigImpl::FilterConfigImpl(
+    envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
+    : proto_config_(std::move(proto_config)), stats_(generateStats(stats_prefix, context.scope())),
+      cm_(context.clusterManager()), time_source_(context.dispatcher().timeSource()) {
 
   ENVOY_LOG(debug, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
 
-  jwks_cache_ = JwksCache::create(proto_config_, time_source_, context.api(), context.threadLocal());
+  jwks_cache_ =
+      JwksCache::create(proto_config_, time_source_, context.api(), context.threadLocal());
 
   std::vector<std::string> names;
   for (const auto& it : proto_config_.requirement_map()) {

--- a/source/extensions/filters/http/jwt_authn/filter_config.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_config.cc
@@ -11,17 +11,16 @@ namespace Extensions {
 namespace HttpFilters {
 namespace JwtAuthn {
 
-void FilterConfigImpl::init() {
+FilterConfigImpl::FilterConfigImpl(envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
+                                   const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
+    : proto_config_(std::move(proto_config)),
+      stats_(generateStats(stats_prefix, context.scope())),
+      cm_(context.clusterManager()),
+      time_source_(context.dispatcher().timeSource())) {
+
   ENVOY_LOG(debug, "Loaded JwtAuthConfig: {}", proto_config_.DebugString());
 
-  // Note: `this` and `context` have a a lifetime of the listener.
-  // That may be shorter of the tls callback if the listener is torn shortly after it is created.
-  // We use a shared pointer to make sure this object outlives the tls callbacks.
-  auto shared_this = shared_from_this();
-  tls_->set([shared_this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-    return std::make_shared<ThreadLocalCache>(shared_this->proto_config_, shared_this->time_source_,
-                                              shared_this->api_);
-  });
+  jwks_cache_ = JwksCache::create(proto_config_, time_source_, context.api(), context.threadLocal());
 
   std::vector<std::string> names;
   for (const auto& it : proto_config_.requirement_map()) {

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -19,27 +19,6 @@ namespace HttpFilters {
 namespace JwtAuthn {
 
 /**
- * Making cache as a thread local object, its read/write operations don't need to be protected.
- * Now it only has jwks_cache, but in the future, it will have token cache: to cache the tokens
- * with their verification results.
- */
-class ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
-public:
-  // Load the config from envoy config.
-  ThreadLocalCache(const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& config,
-                   TimeSource& time_source, Api::Api& api) {
-    jwks_cache_ = JwksCache::create(config, time_source, api);
-  }
-
-  // Get the JwksCache object.
-  JwksCache& getJwksCache() { return *jwks_cache_; }
-
-private:
-  // The JwksCache object.
-  JwksCachePtr jwks_cache_;
-};
-
-/**
  * All stats for the Jwt Authn filter. @see stats_macros.h
  */
 #define ALL_JWT_AUTHN_FILTER_STATS(COUNTER)                                                        \
@@ -97,24 +76,15 @@ using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
  */
 class FilterConfigImpl : public Logger::Loggable<Logger::Id::jwt>,
                          public FilterConfig,
-                         public AuthFactory,
-                         public std::enable_shared_from_this<FilterConfigImpl> {
+                         public AuthFactory {
 public:
+  FilterConfigImpl(envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
+                   const std::string& stats_prefix, Server::Configuration::FactoryContext& context);
+
   ~FilterConfigImpl() override = default;
 
-  // Finds the matcher that matched the header
-  static std::shared_ptr<FilterConfigImpl>
-  create(envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
-         const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-    // We can't use make_shared here because the constructor of this class is private.
-    std::shared_ptr<FilterConfigImpl> ptr(
-        new FilterConfigImpl(proto_config, stats_prefix, context));
-    ptr->init();
-    return ptr;
-  }
-
-  // Get per-thread cache object.
-  ThreadLocalCache& getCache() const { return tls_->getTyped<ThreadLocalCache>(); }
+  // Get the JwksCache object.
+  JwksCache& getJwksCache() { return *jwks_cache_; }
 
   Upstream::ClusterManager& cm() const { return cm_; }
   TimeSource& timeSource() const { return time_source_; }
@@ -152,20 +122,11 @@ public:
                           const absl::optional<std::string>& provider, bool allow_failed,
                           bool allow_missing) const override {
     return Authenticator::create(check_audience, provider, allow_failed, allow_missing,
-                                 getCache().getJwksCache(), cm(), Common::JwksFetcher::create,
+                                 getJwksCache(), cm(), Common::JwksFetcher::create,
                                  timeSource());
   }
 
-private:
-  FilterConfigImpl(envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config,
-                   const std::string& stats_prefix, Server::Configuration::FactoryContext& context)
-      : proto_config_(std::move(proto_config)),
-        stats_(generateStats(stats_prefix, context.scope())),
-        tls_(context.threadLocal().allocateSlot()), cm_(context.clusterManager()),
-        time_source_(context.dispatcher().timeSource()), api_(context.api()) {}
-
-  void init();
-
+ private:
   JwtAuthnFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
     const std::string final_prefix = prefix + "jwt_authn.";
     return {ALL_JWT_AUTHN_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -178,12 +139,13 @@ private:
     VerifierConstPtr verifier_;
   };
 
+
   // The proto config.
   envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config_;
   // The stats for the filter.
   JwtAuthnFilterStats stats_;
-  // Thread local slot to store per-thread auth store
-  ThreadLocal::SlotPtr tls_;
+  // JwksCache
+  JwksCachePtr jwks_cache_;
   // the cluster manager object.
   Upstream::ClusterManager& cm_;
   // The list of rule matchers.
@@ -197,7 +159,6 @@ private:
   // all requirement_names for debug
   std::string all_requirement_names_;
   TimeSource& time_source_;
-  Api::Api& api_;
 };
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/filter_config.h
+++ b/source/extensions/filters/http/jwt_authn/filter_config.h
@@ -84,7 +84,7 @@ public:
   ~FilterConfigImpl() override = default;
 
   // Get the JwksCache object.
-  JwksCache& getJwksCache() { return *jwks_cache_; }
+  JwksCache& getJwksCache() const { return *jwks_cache_; }
 
   Upstream::ClusterManager& cm() const { return cm_; }
   TimeSource& timeSource() const { return time_source_; }
@@ -122,11 +122,10 @@ public:
                           const absl::optional<std::string>& provider, bool allow_failed,
                           bool allow_missing) const override {
     return Authenticator::create(check_audience, provider, allow_failed, allow_missing,
-                                 getJwksCache(), cm(), Common::JwksFetcher::create,
-                                 timeSource());
+                                 getJwksCache(), cm(), Common::JwksFetcher::create, timeSource());
   }
 
- private:
+private:
   JwtAuthnFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
     const std::string final_prefix = prefix + "jwt_authn.";
     return {ALL_JWT_AUTHN_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -138,7 +137,6 @@ public:
     MatcherConstPtr matcher_;
     VerifierConstPtr verifier_;
   };
-
 
   // The proto config.
   envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication proto_config_;

--- a/source/extensions/filters/http/jwt_authn/filter_factory.cc
+++ b/source/extensions/filters/http/jwt_authn/filter_factory.cc
@@ -45,7 +45,7 @@ FilterFactory::createFilterFactoryFromProtoTyped(const JwtAuthentication& proto_
                                                  const std::string& prefix,
                                                  Server::Configuration::FactoryContext& context) {
   validateJwtConfig(proto_config, context.api());
-  auto filter_config = FilterConfigImpl::create(proto_config, prefix, context);
+  auto filter_config = std::make_shared<FilterConfigImpl>(proto_config, prefix, context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<Filter>(filter_config));
   };

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -168,7 +168,7 @@ private:
 JwksCachePtr
 JwksCache::create(const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& config,
                   TimeSource& time_source, Api::Api& api, ThreadLocal::SlotAllocator& tls) {
-  return JwksCachePtr(new JwksCacheImpl(config, time_source, api, tls));
+  return std::make_unique<JwksCacheImpl>(config, time_source, api, tls);
 }
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.cc
@@ -26,25 +26,30 @@ namespace {
 // Default cache expiration time in 5 minutes.
 constexpr int PubkeyCacheExpirationSec = 600;
 
+using JwksSharedPtr = std::shared_ptr<::google::jwt_verify::Jwks>;
+
 class JwksDataImpl : public JwksCache::JwksData, public Logger::Loggable<Logger::Id::jwt> {
 public:
-  JwksDataImpl(const JwtProvider& jwt_provider, TimeSource& time_source, Api::Api& api)
-      : jwt_provider_(jwt_provider), time_source_(time_source) {
+  JwksDataImpl(const JwtProvider& jwt_provider, TimeSource& time_source, Api::Api& api, ThreadLocal::SlotAllocator& tls) :
+      : jwt_provider_(jwt_provider), time_source_(time_source), tls_(tls) {
+
     std::vector<std::string> audiences;
     for (const auto& aud : jwt_provider_.audiences()) {
       audiences.push_back(aud);
     }
     audiences_ = std::make_unique<::google::jwt_verify::CheckAudience>(audiences);
 
+    tls_.set(
+      [](Envoy::Event::Dispatcher&) { return std::make_shared<ThreadLocalCache>(); });
+
     const auto inline_jwks = Config::DataSource::read(jwt_provider_.local_jwks(), true, api);
     if (!inline_jwks.empty()) {
-      auto ptr = setKey(
-          ::google::jwt_verify::Jwks::createFrom(inline_jwks, ::google::jwt_verify::Jwks::JWKS),
-          std::chrono::steady_clock::time_point::max());
-      if (ptr->getStatus() != Status::Ok) {
+      auto jwks = ::google::jwt_verify::Jwks::createFrom(inline_jwks, ::google::jwt_verify::Jwks::JWKS);
+      if (jwks->getStatus() != Status::Ok) {
         ENVOY_LOG(warn, "Invalid inline jwks for issuer: {}, jwks: {}", jwt_provider_.issuer(),
                   inline_jwks);
-        jwks_obj_.reset(nullptr);
+      } else {
+        setJwksToAllThreads(jwks, std::chrono::steady_clock::time_point::max());
       }
     }
   }
@@ -55,15 +60,35 @@ public:
     return audiences_->areAudiencesAllowed(jwt_audiences);
   }
 
-  const Jwks* getJwksObj() const override { return jwks_obj_.get(); }
+  const Jwks* getJwksObj() const override { return tls_->jwks_.get(); }
 
-  bool isExpired() const override { return time_source_.monotonicTime() >= expiration_time_; }
+  bool isExpired() const override { return time_source_.monotonicTime() >= tls_->expire_; }
 
   const ::google::jwt_verify::Jwks* setRemoteJwks(::google::jwt_verify::JwksPtr&& jwks) override {
-    return setKey(std::move(jwks), getRemoteJwksExpirationTime());
+    // convert unique_ptr to shared_ptr
+    JwksSharedPtr shared_jwks(jwks.release());
+    tls_->jwks_ = shared_jwks;
+    tls_->expire_ = getRemoteJwksExpirationTime();
+    return shared_jwks.get();
   }
 
 private:
+  struct ThreadLocalCache : public ThreadLocal::ThreadLocalObject {
+    // The jwks object.
+    JwksSharedPtr  jwks_;
+    // The pubkey expiration time.
+    MonotonicTime expire_;
+  };
+
+  // Set jwks shared_ptr to all threads.
+  const void setJwksToAllThreads(::google::jwt_verify::JwksPtr&& jwks, std::chrono::steady_clock::time_point expire) {
+    JwksSharedPtr shared_jwks(jwks.release());
+    tls_.runOnAllThreads([shared_jwks, expire](OptRef<ThreadLocalCache> obj) {
+      obj->jwks_ = shared_jwks;
+      obj->expire_ = expire;
+    });
+  }
+
   // Get the expiration time for a remote Jwks
   std::chrono::steady_clock::time_point getRemoteJwksExpirationTime() const {
     auto expire = time_source_.monotonicTime();
@@ -76,31 +101,24 @@ private:
     return expire;
   }
 
-  const ::google::jwt_verify::Jwks* setKey(::google::jwt_verify::JwksPtr&& jwks,
-                                           MonotonicTime expire) {
-    jwks_obj_ = std::move(jwks);
-    expiration_time_ = expire;
-    return jwks_obj_.get();
-  }
-
   // The jwt provider config.
   const JwtProvider& jwt_provider_;
   // Check audience object
   ::google::jwt_verify::CheckAudiencePtr audiences_;
-  // The generated jwks object.
-  ::google::jwt_verify::JwksPtr jwks_obj_;
+  // the time source
   TimeSource& time_source_;
-  // The pubkey expiration time.
-  MonotonicTime expiration_time_;
+  // the thread local slot for cache
+  ThreadLocal::TypedSlot<ThreadLocalCache> tls_;
 };
+
 
 class JwksCacheImpl : public JwksCache {
 public:
   // Load the config from envoy config.
-  JwksCacheImpl(const JwtAuthentication& config, TimeSource& time_source, Api::Api& api) {
+  JwksCacheImpl(const JwtAuthentication& config, TimeSource& time_source, Api::Api& api, ThreadLocal::SlotAllocator& tls) {
     for (const auto& it : config.providers()) {
       const auto& provider = it.second;
-      jwks_data_map_.emplace(it.first, JwksDataImpl(provider, time_source, api));
+      jwks_data_map_.emplace(it.first, JwksDataImpl(provider, time_source, api, tls));
       if (issuer_ptr_map_.find(provider.issuer()) == issuer_ptr_map_.end()) {
         issuer_ptr_map_.emplace(provider.issuer(), findByProvider(it.first));
       }
@@ -144,8 +162,8 @@ private:
 
 JwksCachePtr
 JwksCache::create(const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& config,
-                  TimeSource& time_source, Api::Api& api) {
-  return JwksCachePtr(new JwksCacheImpl(config, time_source, api));
+                  TimeSource& time_source, Api::Api& api, ThreadLocal::SlotAllocator& tls) {
+  return JwksCachePtr(new JwksCacheImpl(config, time_source, api, tls));
 }
 
 } // namespace JwtAuthn

--- a/source/extensions/filters/http/jwt_authn/jwks_cache.h
+++ b/source/extensions/filters/http/jwt_authn/jwks_cache.h
@@ -4,6 +4,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 #include "envoy/extensions/filters/http/jwt_authn/v3/config.pb.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "jwt_verify_lib/jwks.h"
 
@@ -69,7 +70,7 @@ public:
   // Factory function to create an instance.
   static JwksCachePtr
   create(const envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication& config,
-         TimeSource& time_source, Api::Api& api);
+         TimeSource& time_source, Api::Api& api, ThreadLocal::SlotAllocator& tls);
 };
 
 } // namespace JwtAuthn

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -89,6 +89,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/common:jwks_fetcher_lib",
         "//source/extensions/filters/http/jwt_authn:jwks_cache_lib",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",
+        "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/all_verifier_test.cc
@@ -73,7 +73,7 @@ public:
   }
 
   void createVerifier() {
-    filter_config_ = FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_);
+    filter_config_ = std::make_shared<FilterConfigImpl>(proto_config_, "", mock_factory_ctx_);
     verifier_ = Verifier::create(proto_config_.rules(0).requires(), proto_config_.providers(),
                                  *filter_config_);
   }

--- a/test/extensions/filters/http/jwt_authn/authenticator_test.cc
+++ b/test/extensions/filters/http/jwt_authn/authenticator_test.cc
@@ -43,13 +43,12 @@ public:
       ::google::jwt_verify::CheckAudience* check_audience = nullptr,
       const absl::optional<std::string>& provider = absl::make_optional<std::string>(ProviderName),
       bool allow_failed = false, bool allow_missing = false) {
-    filter_config_ = FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_);
+    filter_config_ = std::make_unique<FilterConfigImpl>(proto_config_, "", mock_factory_ctx_);
     raw_fetcher_ = new MockJwksFetcher;
     fetcher_.reset(raw_fetcher_);
     auth_ = Authenticator::create(
-        check_audience, provider, allow_failed, allow_missing,
-        filter_config_->getCache().getJwksCache(), filter_config_->cm(),
-        [this](Upstream::ClusterManager&) { return std::move(fetcher_); },
+        check_audience, provider, allow_failed, allow_missing, filter_config_->getJwksCache(),
+        filter_config_->cm(), [this](Upstream::ClusterManager&) { return std::move(fetcher_); },
         filter_config_->timeSource());
     jwks_ = Jwks::createFrom(PublicKey, Jwks::JWKS);
     EXPECT_TRUE(jwks_->getStatus() == Status::Ok);

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -40,7 +40,7 @@ rules:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
+  auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
 
   StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filter_conf->findVerifier(
@@ -74,7 +74,7 @@ rules:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
+  auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
 
   StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filter_conf->findVerifier(
@@ -104,7 +104,7 @@ requirement_map:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_THROW_WITH_MESSAGE(FilterConfigImpl::create(proto_config, "", context), EnvoyException,
+  EXPECT_THROW_WITH_MESSAGE(FilterConfigImpl(proto_config, "", context), EnvoyException,
                             "Wrong requirement_name: rr. It should be one of [r1]");
 }
 
@@ -137,7 +137,7 @@ requirement_map:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
+  auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
   StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::FilterChain);
 
   EXPECT_TRUE(filter_conf->findVerifier(
@@ -182,7 +182,7 @@ rules:
 
     JwtAuthentication proto_config;
     TestUtility::loadFromYaml(config, proto_config);
-    auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
+    auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
   }
 
   // Even though filter_conf is now de-allocated, using a reference to it might still work, as its
@@ -222,7 +222,7 @@ filter_state_rules:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
+  auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
 
   // Empty filter_state
   StreamInfo::FilterStateImpl filter_state1(StreamInfo::FilterState::LifeSpan::FilterChain);
@@ -276,7 +276,7 @@ requirement_map:
   TestUtility::loadFromYaml(config, proto_config);
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  auto filter_conf = FilterConfigImpl::create(proto_config, "", context);
+  auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
 
   PerRouteConfig per_route;
   const Verifier* verifier;

--- a/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwks_cache_test.cc
@@ -9,6 +9,7 @@
 #include "extensions/filters/http/jwt_authn/jwks_cache.h"
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
+#include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
@@ -31,7 +32,7 @@ protected:
 
   void setupCache(const std::string& config_str) {
     TestUtility::loadFromYaml(config_str, config_);
-    cache_ = JwksCache::create(config_, time_system_, *api_);
+    cache_ = JwksCache::create(config_, time_system_, *api_, tls_);
   }
 
   Event::SimulatedTimeSystem time_system_;
@@ -39,6 +40,7 @@ protected:
   JwksCachePtr cache_;
   google::jwt_verify::JwksPtr jwks_;
   Api::ApiPtr api_;
+  ::testing::NiceMock<ThreadLocal::MockInstance> tls_;
 };
 
 // Test findByProvider
@@ -82,7 +84,7 @@ TEST_F(JwksCacheTest, TestSetRemoteJwks) {
   auto& provider0 = (*config_.mutable_providers())[std::string(ProviderName)];
   // Set cache_duration to 1 second to test expiration
   provider0.mutable_remote_jwks()->mutable_cache_duration()->set_seconds(1);
-  cache_ = JwksCache::create(config_, time_system_, *api_);
+  cache_ = JwksCache::create(config_, time_system_, *api_, tls_);
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);
@@ -101,7 +103,7 @@ TEST_F(JwksCacheTest, TestSetRemoteJwksWithDefaultCacheDuration) {
   auto& provider0 = (*config_.mutable_providers())[std::string(ProviderName)];
   // Clear cache_duration to use default one.
   provider0.mutable_remote_jwks()->clear_cache_duration();
-  cache_ = JwksCache::create(config_, time_system_, *api_);
+  cache_ = JwksCache::create(config_, time_system_, *api_, tls_);
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);
@@ -118,7 +120,7 @@ TEST_F(JwksCacheTest, TestGoodInlineJwks) {
   auto local_jwks = provider0.mutable_local_jwks();
   local_jwks->set_inline_string(PublicKey);
 
-  cache_ = JwksCache::create(config_, time_system_, *api_);
+  cache_ = JwksCache::create(config_, time_system_, *api_, tls_);
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_FALSE(jwks->getJwksObj() == nullptr);
@@ -132,7 +134,7 @@ TEST_F(JwksCacheTest, TestBadInlineJwks) {
   auto local_jwks = provider0.mutable_local_jwks();
   local_jwks->set_inline_string("BAD-JWKS");
 
-  cache_ = JwksCache::create(config_, time_system_, *api_);
+  cache_ = JwksCache::create(config_, time_system_, *api_, tls_);
 
   auto jwks = cache_->findByIssuer("https://example.com");
   EXPECT_TRUE(jwks->getJwksObj() == nullptr);

--- a/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
+++ b/test/extensions/filters/http/jwt_authn/provider_verifier_test.cc
@@ -37,7 +37,7 @@ public:
   }
 
   void createVerifier() {
-    filter_config_ = FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_);
+    filter_config_ = std::make_unique<FilterConfigImpl>(proto_config_, "", mock_factory_ctx_);
     verifier_ = Verifier::create(proto_config_.rules(0).requires(), proto_config_.providers(),
                                  *filter_config_);
   }
@@ -181,7 +181,7 @@ TEST_F(ProviderVerifierTest, TestRequiresNonexistentProvider) {
   TestUtility::loadFromYaml(ExampleConfig, proto_config_);
   proto_config_.mutable_rules(0)->mutable_requires()->set_provider_name("nosuchprovider");
 
-  EXPECT_THROW(FilterConfigImpl::create(proto_config_, "", mock_factory_ctx_), EnvoyException);
+  EXPECT_THROW(FilterConfigImpl(proto_config_, "", mock_factory_ctx_), EnvoyException);
 }
 
 } // namespace


### PR DESCRIPTION
This change will not change the functionality,  it just changes the internal implementation detail. 

JwKsCache holds both config and cache.  Currently,  the whole JwksCache object is in the thread local slot, but actually, only the  cache data needs to be in in the thread local.

This change will move the thread local data inside JwksDataImpl,  only stores its {jwks, and expire} into thread local. Move JwksCache object out of thread local. 

This change is in preparation to support async fetch of remote_jwks proposed in https://github.com/envoyproxy/envoy/issues/14556#issuecomment-754203164.

Detail changes:
* Created `tls` for {jwks, expire} inside JwksDataImpl
* Removed `tls` for JwksCache in FilterConfigImpl
* Removed `enable_shared_from_this` from FilterConfigImpl

Risk Level:  Low
Testing:  Unit-tested.
Docs Changes: None
Release Notes: None
