### PR TITLE
http: retroactively add runtime flag for timeout change

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1190,7 +1190,9 @@ void ConnectionManagerImpl::ActiveStream::refreshDurationTimeout() {
       const auto max_stream_duration = connection_manager_.config_.maxStreamDuration();
       if (max_stream_duration.has_value() && max_stream_duration.value().count()) {
         timeout = max_stream_duration.value();
-      } else if (route->timeout().count() != 0) {
+      } else if (Runtime::runtimeFeatureEnabled(
+                     "envoy.reloadable_features.use_route_timeout_for_stream_timeout") &&
+                 route->timeout().count() != 0) {
         // If max stream duration is not set either at route/HCM level, use the route timeout.
         timeout = route->timeout();
       } else {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -90,6 +90,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure",
     "envoy.reloadable_features.upstream_host_weight_change_causes_rebuild",
     "envoy.reloadable_features.use_observable_cluster_name",
+    "envoy.reloadable_features.use_route_timeout_for_stream_timeout",
     "envoy.reloadable_features.vhds_heartbeats",
     "envoy.reloadable_features.wasm_cluster_name_envoy_grpc",
     "envoy.reloadable_features.unify_grpc_handling",


### PR DESCRIPTION
Adds a runtime flag for disabling the behavior introduced in #15585 until we can solve this problem more holistically (#16129)

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: UTs
Docs Changes: n/a
Release Notes: n/a (not sure where this would go?)
