### PR TITLE
[fuzz] disable all extension fuzzers in gcc builds for CI

### DIFF
--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -353,6 +353,7 @@ envoy_cc_fuzz_test(
     ] + select({
         "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
+        "//bazel:gcc_build": [],
         "//conditions:default": envoy_all_extensions(),
     }),
 )

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -90,6 +90,7 @@ envoy_cc_fuzz_test(
     ] + select({
         "//bazel:windows_x86_64": envoy_all_extensions(WINDOWS_SKIP_TARGETS),
         "//bazel:linux_ppc": envoy_all_extensions(PPC_SKIP_TARGETS),
+        "//bazel:gcc_build": [],
         "//conditions:default": envoy_all_extensions(),
     }),
 )


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Commit Message: Temporary CI fix before https://github.com/envoyproxy/envoy/pull/16074
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
