### PR TITLE
api: add NonForwardingAction route action type

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -202,7 +202,7 @@ message FilterAction {
 //
 //   Envoy supports routing on HTTP method via :ref:`header matching
 //   <envoy_api_msg_config.route.v3.HeaderMatcher>`.
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message Route {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.Route";
 
@@ -229,11 +229,18 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // If true, a filter will define the action (e.g., it could dynamically generate the
+    // A filter-defined action (e.g., it could dynamically generate the
     // RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;
+
+    // [#not-implemented-hide:]
+    // An action used when the route will generate a response directly,
+    // without forwarding to an upstream host. This will be used in non-proxy
+    // xDS clients like the gRPC server. It could also be used in the future
+    // in Envoy for a filter that directly generates responses for requests.
+    NonForwardingAction non_forwarding_action = 18;
   }
 
   // The Metadata field can be used to provide additional information
@@ -1467,6 +1474,10 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
   core.v3.DataSource body = 2;
+}
+
+// [#not-implemented-hide:]
+message NonForwardingAction {
 }
 
 message Decorator {

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -229,8 +229,7 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // A filter-defined action (e.g., it could dynamically generate the
-    // RouteAction).
+    // A filter-defined action (e.g., it could dynamically generate the RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -200,7 +200,7 @@ message FilterAction {
 //
 //   Envoy supports routing on HTTP method via :ref:`header matching
 //   <envoy_api_msg_config.route.v4alpha.HeaderMatcher>`.
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message Route {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.Route";
 
@@ -227,11 +227,18 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // If true, a filter will define the action (e.g., it could dynamically generate the
+    // A filter-defined action (e.g., it could dynamically generate the
     // RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;
+
+    // [#not-implemented-hide:]
+    // An action used when the route will generate a response directly,
+    // without forwarding to an upstream host. This will be used in non-proxy
+    // xDS clients like the gRPC server. It could also be used in the future
+    // in Envoy for a filter that directly generates responses for requests.
+    NonForwardingAction non_forwarding_action = 18;
   }
 
   // The Metadata field can be used to provide additional information
@@ -1409,6 +1416,12 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v4alpha.Route`, :ref:`envoy_api_msg_config.route.v4alpha.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v4alpha.VirtualHost`.
   core.v4alpha.DataSource body = 2;
+}
+
+// [#not-implemented-hide:]
+message NonForwardingAction {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.route.v3.NonForwardingAction";
 }
 
 message Decorator {

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -227,8 +227,7 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // A filter-defined action (e.g., it could dynamically generate the
-    // RouteAction).
+    // A filter-defined action (e.g., it could dynamically generate the RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -204,7 +204,7 @@ message FilterAction {
 //
 //   Envoy supports routing on HTTP method via :ref:`header matching
 //   <envoy_api_msg_config.route.v3.HeaderMatcher>`.
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message Route {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.Route";
 
@@ -229,11 +229,18 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // If true, a filter will define the action (e.g., it could dynamically generate the
+    // A filter-defined action (e.g., it could dynamically generate the
     // RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;
+
+    // [#not-implemented-hide:]
+    // An action used when the route will generate a response directly,
+    // without forwarding to an upstream host. This will be used in non-proxy
+    // xDS clients like the gRPC server. It could also be used in the future
+    // in Envoy for a filter that directly generates responses for requests.
+    NonForwardingAction non_forwarding_action = 18;
   }
 
   // The Metadata field can be used to provide additional information
@@ -1491,6 +1498,10 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
   core.v3.DataSource body = 2;
+}
+
+// [#not-implemented-hide:]
+message NonForwardingAction {
 }
 
 message Decorator {

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -229,8 +229,7 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // A filter-defined action (e.g., it could dynamically generate the
-    // RouteAction).
+    // A filter-defined action (e.g., it could dynamically generate the RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -228,8 +228,7 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // A filter-defined action (e.g., it could dynamically generate the
-    // RouteAction).
+    // A filter-defined action (e.g., it could dynamically generate the RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -201,7 +201,7 @@ message FilterAction {
 //
 //   Envoy supports routing on HTTP method via :ref:`header matching
 //   <envoy_api_msg_config.route.v4alpha.HeaderMatcher>`.
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message Route {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.route.v3.Route";
 
@@ -228,11 +228,18 @@ message Route {
     DirectResponseAction direct_response = 7;
 
     // [#not-implemented-hide:]
-    // If true, a filter will define the action (e.g., it could dynamically generate the
+    // A filter-defined action (e.g., it could dynamically generate the
     // RouteAction).
     // [#comment: TODO(samflattery): Remove cleanup in route_fuzz_test.cc when
     // implemented]
     FilterAction filter_action = 17;
+
+    // [#not-implemented-hide:]
+    // An action used when the route will generate a response directly,
+    // without forwarding to an upstream host. This will be used in non-proxy
+    // xDS clients like the gRPC server. It could also be used in the future
+    // in Envoy for a filter that directly generates responses for requests.
+    NonForwardingAction non_forwarding_action = 18;
   }
 
   // The Metadata field can be used to provide additional information
@@ -1481,6 +1488,12 @@ message DirectResponseAction {
   //   :ref:`envoy_api_msg_config.route.v4alpha.Route`, :ref:`envoy_api_msg_config.route.v4alpha.RouteConfiguration` or
   //   :ref:`envoy_api_msg_config.route.v4alpha.VirtualHost`.
   core.v4alpha.DataSource body = 2;
+}
+
+// [#not-implemented-hide:]
+message NonForwardingAction {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.config.route.v3.NonForwardingAction";
 }
 
 message Decorator {


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: add NonForwardingAction route action type
Additional Description: Adds a new type of route action that is used in cases when not forwarding the request to an upstream server.  This will be used by xDS-aware gRPC servers.  It could also be used in the future by Envoy if there is a filter that directly generates responses to requests.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

Continuing discussion from #13366.

CC @htuch @ejona86 @dfawley 