### PR TITLE
Matcher: add a "not" matcher

### DIFF
--- a/api/envoy/config/common/matcher/v3/matcher.proto
+++ b/api/envoy/config/common/matcher/v3/matcher.proto
@@ -81,6 +81,9 @@ message Matcher {
 
         // A list of predicates to be AND-ed together.
         PredicateList and_matcher = 3;
+
+        // The invert of a predicate
+        Predicate not_matcher = 4;
       }
     }
 

--- a/api/envoy/config/common/matcher/v4alpha/matcher.proto
+++ b/api/envoy/config/common/matcher/v4alpha/matcher.proto
@@ -100,6 +100,9 @@ message Matcher {
 
         // A list of predicates to be AND-ed together.
         PredicateList and_matcher = 3;
+
+        // The invert of a predicate
+        Predicate not_matcher = 4;
       }
     }
 

--- a/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v3/matcher.proto
@@ -81,6 +81,9 @@ message Matcher {
 
         // A list of predicates to be AND-ed together.
         PredicateList and_matcher = 3;
+
+        // The invert of a predicate
+        Predicate not_matcher = 4;
       }
     }
 

--- a/generated_api_shadow/envoy/config/common/matcher/v4alpha/matcher.proto
+++ b/generated_api_shadow/envoy/config/common/matcher/v4alpha/matcher.proto
@@ -100,6 +100,9 @@ message Matcher {
 
         // A list of predicates to be AND-ed together.
         PredicateList and_matcher = 3;
+
+        // The invert of a predicate
+        Predicate not_matcher = 4;
       }
     }
 

--- a/source/common/matcher/field_matcher.h
+++ b/source/common/matcher/field_matcher.h
@@ -114,6 +114,26 @@ private:
 };
 
 /**
+ * A FieldMatcher that returns the invert of a FieldMatcher.
+ */
+template <class DataType> class NotFieldMatcher : public FieldMatcher<DataType> {
+public:
+  explicit NotFieldMatcher(FieldMatcherPtr<DataType> matcher) : matcher_(std::move(matcher)) {}
+
+  FieldMatchResult match(const DataType& data) override {
+    const auto result = matcher_->match(data);
+    if (result.match_state_ == MatchState::UnableToMatch) {
+      return result;
+    }
+
+    return {MatchState::MatchComplete, !result.result()};
+  }
+
+private:
+  const FieldMatcherPtr<DataType> matcher_;
+};
+
+/**
  * Implementation of a FieldMatcher that extracts an input value from the provided data and attempts
  * to match using an InputMatcher. absl::nullopt is returned whenever the data is not available or
  * if we failed to match and there is more data available.

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -118,6 +118,10 @@ private:
 
       return std::make_unique<AllFieldMatcher<DataType>>(std::move(sub_matchers));
     }
+    case (envoy::config::common::matcher::v3::Matcher::MatcherList::Predicate::kNotMatcher): {
+      return std::make_unique<NotFieldMatcher<DataType>>(
+          createFieldMatcher(field_predicate.not_matcher()));
+    }
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;
     }

--- a/test/common/matcher/field_matcher_test.cc
+++ b/test/common/matcher/field_matcher_test.cc
@@ -106,5 +106,22 @@ TEST_F(FieldMatcherTest, AllMatcher) {
       MatchState::UnableToMatch);
 }
 
+TEST_F(FieldMatcherTest, NotMatcher) {
+  EXPECT_TRUE(NotFieldMatcher<TestData>(
+                  std::make_unique<AllFieldMatcher<TestData>>(createMatchers({true, false})))
+                  .match(TestData())
+                  .result());
+
+  EXPECT_EQ(
+      NotFieldMatcher<TestData>(
+          std::make_unique<AllFieldMatcher<TestData>>(createMatchers(
+              {std::make_pair(false,
+                              DataInputGetResult::DataAvailability::MoreDataMightBeAvailable),
+               std::make_pair(false, DataInputGetResult::DataAvailability::AllDataAvailable)})))
+          .match(TestData())
+          .match_state_,
+      MatchState::UnableToMatch);
+}
+
 } // namespace Matcher
 } // namespace Envoy

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -273,6 +273,46 @@ matcher_tree:
   EXPECT_NE(result.on_match_->action_cb_, nullptr);
 }
 
+TEST_F(MatcherTest, TestNotMatcher) {
+  const std::string yaml = R"EOF(
+matcher_list:
+  matchers:
+  - on_match:
+      action:
+        name: test_action
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.StringValue
+          value: match!!
+    predicate:
+      not_matcher:
+        single_predicate:
+          input:
+            name: inner_input
+            typed_config:
+              "@type": type.googleapis.com/google.protobuf.StringValue
+          value_match:
+            exact: foo
+  )EOF";
+
+  envoy::config::common::matcher::v3::Matcher matcher;
+  MessageUtil::loadFromYaml(yaml, matcher, ProtobufMessage::getStrictValidationVisitor());
+
+  TestUtility::validate(matcher);
+
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
+  auto inner_factory = TestDataInputFactory("inner_input", "foo");
+  NeverMatchFactory match_factory;
+
+  EXPECT_CALL(validation_visitor_,
+              performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"));
+  auto match_tree = factory.create(matcher);
+
+  const auto result = match_tree->match(TestData());
+  EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
+  EXPECT_FALSE(result.on_match_.has_value());
+}
+
 TEST_F(MatcherTest, TestRecursiveMatcher) {
   const std::string yaml = R"EOF(
 matcher_list:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: This adds a "not_matcher" matching type to MatcherList.
Additional Description:
Risk Level: low
Testing: unit test (extended field_matcher_test.cc)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
