### PR TITLE
python: Switch to exclusive list for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,8 @@
 
 [flake8]
 
-# TODO(phlax): make this an exclusive list and enable most tests
-select = N802,F401,E111,F821,E9,F63,F72,F82
+# TODO(phlax): ignore less
+ignore = W503,W504,E121,E126,E241,E125,E127,E129,E251,E265,E303,E306,E402,E501,E502,E711,E713,E722,E741,F523,F541,F841,N803,N806,N817,W605
 
 # TODO(phlax): exclude less
 exclude = build_docs,.git,generated,test,examples,venv


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: python: Switch to exclusive list for flake8
Additional Description:

This switches flake8 from an inclusive list to an exclusive one

*Any* current warnings/errors are excluded - ie it does the same thing as now

The benefits are:

- new types of error wont be added
- we can start picking off some of these problems

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
