### PR TITLE
http: removing runtime guard allow_500_after_100

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -27,6 +27,7 @@ Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`
 
+* http: removed `envoy.reloadable_features.allow_500_after_100` runtime guard and the legacy code path.
 * http: removed `envoy.reloadable_features.hcm_stream_error_on_invalid_message` for disabling closing HTTP/1.1 connections on error. Connection-closing can still be disabled by setting the HTTP/1 configuration :ref:`override_stream_error_on_invalid_http_message <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.override_stream_error_on_invalid_http_message>`.
 * http: removed `envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2`; Envoy will now always send GOAWAY to HTTP2 downstreams when the :ref:`disable_keepalive <config_overload_manager_overload_actions>` overload action is active.
 * tls: removed `envoy.reloadable_features.tls_use_io_handle_bio` runtime guard and legacy code path.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -59,7 +59,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.always_apply_route_header_rules",
     "envoy.reloadable_features.activate_timers_next_event_loop",
     "envoy.reloadable_features.add_and_validate_scheme_header",
-    "envoy.reloadable_features.allow_500_after_100",
     "envoy.reloadable_features.allow_preconnect",
     "envoy.reloadable_features.allow_response_for_timeout",
     "envoy.reloadable_features.check_unsupported_typed_per_filter_config",

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2304,23 +2304,4 @@ TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnect) {
   EXPECT_EQ("503", response->headers().getStatusValue());
 }
 
-TEST_P(DownstreamProtocolIntegrationTest, Test100AndDisconnectLegacy) {
-  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_500_after_100", "false");
-
-  initialize();
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
-  waitForNextUpstreamRequest();
-  upstream_request_->encode100ContinueHeaders(Http::TestResponseHeaderMapImpl{{":status", "100"}});
-  ASSERT_TRUE(fake_upstream_connection_->close());
-
-  if (downstreamProtocol() == Http::CodecClient::Type::HTTP1) {
-    ASSERT_TRUE(codec_client_->waitForDisconnect());
-    EXPECT_FALSE(response->complete());
-  } else {
-    ASSERT_TRUE(response->waitForReset());
-    EXPECT_FALSE(response->complete());
-  }
-}
-
 } // namespace Envoy


### PR DESCRIPTION
Risk Level: low (removing deprecated flag)
Testing: n/a
Release Notes: inline
Fixes #16004