### PR TITLE
http: removing envoy.reloadable_features.unify_grpc_handling

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -29,6 +29,7 @@ Removed Config or Runtime
 
 * http: removed `envoy.reloadable_features.hcm_stream_error_on_invalid_message` for disabling closing HTTP/1.1 connections on error. Connection-closing can still be disabled by setting the HTTP/1 configuration :ref:`override_stream_error_on_invalid_http_message <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.override_stream_error_on_invalid_http_message>`.
 * http: removed `envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2`; Envoy will now always send GOAWAY to HTTP2 downstreams when the :ref:`disable_keepalive <config_overload_manager_overload_actions>` overload action is active.
+* http: removed `envoy.reloadable_features.unify_grpc_handling` runtime guard and legacy code paths.
 * tls: removed `envoy.reloadable_features.tls_use_io_handle_bio` runtime guard and legacy code path.
 
 New Features

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -829,16 +829,14 @@ void FilterManager::onLocalReply(StreamFilterBase::LocalReplyData& data) {
   state_.under_on_local_reply_ = false;
 }
 
+// TODO(alyssawilk) update sendLocalReply interface.
 void FilterManager::sendLocalReply(
-    bool old_was_grpc_request, Code code, absl::string_view body,
+    bool, Code code, absl::string_view body,
     const std::function<void(ResponseHeaderMap& headers)>& modify_headers,
     const absl::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
   ASSERT(!state_.under_on_local_reply_);
   const bool is_head_request = state_.is_head_request_;
-  bool is_grpc_request = old_was_grpc_request;
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.unify_grpc_handling")) {
-    is_grpc_request = state_.is_grpc_request_;
-  }
+  const bool is_grpc_request = state_.is_grpc_request_;
 
   stream_info_.setResponseCodeDetails(details);
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -92,7 +92,6 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.use_observable_cluster_name",
     "envoy.reloadable_features.vhds_heartbeats",
     "envoy.reloadable_features.wasm_cluster_name_envoy_grpc",
-    "envoy.reloadable_features.unify_grpc_handling",
     "envoy.reloadable_features.upstream_http2_flood_checks",
     "envoy.restart_features.use_apple_api_for_dns_lookups",
     "envoy.reloadable_features.header_map_correctly_coalesce_cookies",


### PR DESCRIPTION
Risk Level: Low (removing deprecated flag)
Testing: n/a 
Docs Changes: n/a
Release Notes: inline
Fixes #16014