### PR TITLE
Fix tests that link all extensions so that gcc can compile them

### DIFF
--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -67,7 +67,7 @@ envoy_cc_test(
     ],
     deps = [
         "//source/common/api:api_lib",
-        "//source/exe:main_common_lib",
+        "//source/exe:envoy_main_common_with_core_extensions_lib",
         "//source/exe:platform_impl_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/test_common:contention_lib",
@@ -79,10 +79,13 @@ envoy_cc_test(
     name = "extra_extensions_test",
     srcs = ["extra_extensions_test.cc"],
     deps = [
-        # This dependency MUST be main_common_lib to meet the purpose of this test
-        "//source/exe:main_common_lib",
         "//test/test_common:environment_lib",
-    ],
+    ] + select({
+        # gcc RBE build has trouble compiling target with all extensions
+        "//bazel:gcc_build": ["//source/exe:envoy_main_common_with_core_extensions_lib"],
+        # This dependency MUST be main_common_lib to meet the purpose of this test
+        "//conditions:default": ["//source/exe:main_common_lib"],
+    }),
 )
 
 envoy_cc_test(


### PR DESCRIPTION
Additional Description:
The `main_common_test` test does not need all extensions and works with just core extensions.
The `extra_extensions_test` tests that kill_request is disabled by default. This PR effectively disables it for the gcc build. It is however enough to validate this on clang.

Risk Level: Low, Test Only
Testing: Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: The `extra_extensions_test` is effectively disabled on gcc.

Signed-off-by: Yan Avlasov <yavlasov@google.com>
