### PR TITLE
Build win32_scm_test with just core extensions

### DIFF
--- a/test/exe/BUILD
+++ b/test/exe/BUILD
@@ -107,7 +107,7 @@ envoy_cc_test(
     ],
     deps = [
         "//source/common/api:api_lib",
-        "//source/exe:main_common_lib",
+        "//source/exe:envoy_main_common_with_core_extensions_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/test_common:contention_lib",
         "//test/test_common:environment_lib",


### PR DESCRIPTION
Signed-off-by: Yan Avlasov <yavlasov@google.com>

