### PR TITLE
docs: Improve style for inline literals and update contrib guidance

### DIFF
--- a/api/CONTRIBUTING.md
+++ b/api/CONTRIBUTING.md
@@ -72,7 +72,6 @@ The following are some general guidelines around documentation.
   // [#comment:TODO(mattklein123): Do something cooler]
   string foo_field = 3;
   ```
-
-* Prefer *italics* for emphasis as `backtick` emphasis is somewhat jarring in our Sphinx theme.
+* Please use *italics* (enclosed in asterisks `*emphasized word*`) for emphasis and `inline literals` for code quotation (enclosed in *double* backticks ` ``code`` `).
 * All documentation is expected to use proper English grammar with proper punctuation. If you are
   not a fluent English speaker please let us know and we will help out.

--- a/docs/root/_static/css/envoy.css
+++ b/docs/root/_static/css/envoy.css
@@ -28,3 +28,11 @@ table.docutils div.line-block {
 .rst-content .sidebar {
   clear: right;
 }
+
+/* make code.literals more muted - dont use red! */
+.rst-content code.literal {
+    color: #555;
+    background-color: rgba(27, 31, 35, 0.05);
+    padding: 2px 2px;
+    border: solid #eee 1px;
+}


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Improve style for inline literals and update contrib guidance
Additional Description:

- dont use red text for something that is not an error
- use more muted style for literals (a la github markdown)
- update contrib guidance on asterisks, backticks and inline literals

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
