### PR TITLE
wasm: use in_vm_context_created_ flag for http contexts.

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1653,7 +1653,6 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, absl::string_view 
 
 Http::FilterHeadersStatus Context::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
   onCreate();
-  http_request_started_ = true;
   request_headers_ = &headers;
   end_of_stream_ = end_stream;
   auto result = convertFilterHeadersStatus(onRequestHeaders(headerSize(&headers), end_stream));
@@ -1664,7 +1663,7 @@ Http::FilterHeadersStatus Context::decodeHeaders(Http::RequestHeaderMap& headers
 }
 
 Http::FilterDataStatus Context::decodeData(::Envoy::Buffer::Instance& data, bool end_stream) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterDataStatus::Continue;
   }
   request_body_buffer_ = &data;
@@ -1688,7 +1687,7 @@ Http::FilterDataStatus Context::decodeData(::Envoy::Buffer::Instance& data, bool
 }
 
 Http::FilterTrailersStatus Context::decodeTrailers(Http::RequestTrailerMap& trailers) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterTrailersStatus::Continue;
   }
   request_trailers_ = &trailers;
@@ -1700,7 +1699,7 @@ Http::FilterTrailersStatus Context::decodeTrailers(Http::RequestTrailerMap& trai
 }
 
 Http::FilterMetadataStatus Context::decodeMetadata(Http::MetadataMap& request_metadata) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterMetadataStatus::Continue;
   }
   request_metadata_ = &request_metadata;
@@ -1721,7 +1720,7 @@ Http::FilterHeadersStatus Context::encode100ContinueHeaders(Http::ResponseHeader
 
 Http::FilterHeadersStatus Context::encodeHeaders(Http::ResponseHeaderMap& headers,
                                                  bool end_stream) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterHeadersStatus::Continue;
   }
   response_headers_ = &headers;
@@ -1734,7 +1733,7 @@ Http::FilterHeadersStatus Context::encodeHeaders(Http::ResponseHeaderMap& header
 }
 
 Http::FilterDataStatus Context::encodeData(::Envoy::Buffer::Instance& data, bool end_stream) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterDataStatus::Continue;
   }
   response_body_buffer_ = &data;
@@ -1758,7 +1757,7 @@ Http::FilterDataStatus Context::encodeData(::Envoy::Buffer::Instance& data, bool
 }
 
 Http::FilterTrailersStatus Context::encodeTrailers(Http::ResponseTrailerMap& trailers) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterTrailersStatus::Continue;
   }
   response_trailers_ = &trailers;
@@ -1770,7 +1769,7 @@ Http::FilterTrailersStatus Context::encodeTrailers(Http::ResponseTrailerMap& tra
 }
 
 Http::FilterMetadataStatus Context::encodeMetadata(Http::MetadataMap& response_metadata) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
     return Http::FilterMetadataStatus::Continue;
   }
   response_metadata_ = &response_metadata;

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -414,7 +414,6 @@ protected:
   ::Envoy::Buffer::Instance* network_upstream_data_buffer_{};
 
   // HTTP filter state.
-  bool http_request_started_ = false; // When decodeHeaders() is called the request is "started".
   Http::RequestHeaderMap* request_headers_{};
   Http::ResponseHeaderMap* response_headers_{};
   ::Envoy::Buffer::Instance* request_body_buffer_{};


### PR DESCRIPTION
Removed `http_request_started_` and instead use the `in_vm_context_created_` in Proxy-Wasm C++ host since it has exactly the same meaning (indicating whether `onCreate` is called or not). Network filter is already using `in_vm_context_created_`.

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
