### PR TITLE
Fix pre-existing format errors

### DIFF
--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -25,10 +25,11 @@ public:
   // Returns a value that is as far from max as the original value is from min.
   // This guarantees that max().invert() == min() and min().invert() == max().
   ClosedIntervalValue invert() const {
-    return ClosedIntervalValue(value_ == Interval::max_value ? Interval::min_value
-                               : value_ == Interval::min_value
-                                   ? Interval::max_value
-                                   : Interval::max_value - (value_ - Interval::min_value));
+    return ClosedIntervalValue(value_ == Interval::max_value
+                                   ? Interval::min_value
+                                   : value_ == Interval::min_value
+                                         ? Interval::max_value
+                                         : Interval::max_value - (value_ - Interval::min_value));
   }
 
   // Comparisons are performed using the same operators on the underlying value

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -25,11 +25,12 @@ public:
   BodyFormatter(const envoy::config::core::v3::SubstitutionFormatString& config, Api::Api& api)
       : formatter_(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, api)),
         content_type_(
-            !config.content_type().empty() ? config.content_type()
-            : config.format_case() ==
-                    envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat
-                ? Http::Headers::get().ContentTypeValues.Json
-                : Http::Headers::get().ContentTypeValues.Text) {}
+            !config.content_type().empty()
+                ? config.content_type()
+                : config.format_case() ==
+                          envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat
+                      ? Http::Headers::get().ContentTypeValues.Json
+                      : Http::Headers::get().ContentTypeValues.Text) {}
 
   void format(const Http::RequestHeaderMap& request_headers,
               const Http::ResponseHeaderMap& response_headers,

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -364,12 +364,12 @@ TEST_F(AppleDnsImplFakeApiTest, SynchronousErrorInGetAddrInfo) {
   // The Query's sd ref will be deallocated.
   EXPECT_CALL(dns_service_, dnsServiceRefDeallocate(_));
 
-  EXPECT_EQ(nullptr,
-            resolver_->resolve("foo.com", Network::DnsLookupFamily::Auto,
-                               [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void {
-                                 // This callback should never be executed.
-                                 FAIL();
-                               }));
+  EXPECT_EQ(nullptr, resolver_->resolve(
+                         "foo.com", Network::DnsLookupFamily::Auto,
+                         [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void {
+                           // This callback should never be executed.
+                           FAIL();
+                         }));
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {
@@ -442,7 +442,7 @@ TEST_F(AppleDnsImplFakeApiTest, IncorrectInterfaceIndexReturned) {
 
   resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QueryCompletedWithError) {
@@ -799,7 +799,7 @@ TEST_F(AppleDnsImplFakeApiTest, ResultWithNullAddress) {
 
   auto query = resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
   ASSERT_NE(nullptr, query);
 
   EXPECT_DEATH(reply_callback(nullptr, kDNSServiceFlagsAdd, 0, kDNSServiceErr_NoError,

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -370,9 +370,9 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
   out_json_string = substitute(out_json_string, version);
 
   auto name = Filesystem::fileSystemForTest().splitPathFromFilename(path).file_;
-  const std::string extension = absl::EndsWith(name, ".yaml")      ? ".yaml"
-                                : absl::EndsWith(name, ".pb_text") ? ".pb_text"
-                                                                   : ".json";
+  const std::string extension = absl::EndsWith(name, ".yaml")
+                                    ? ".yaml"
+                                    : absl::EndsWith(name, ".pb_text") ? ".pb_text" : ".json";
   const std::string out_json_path =
       TestEnvironment::temporaryPath(name) + ".with.ports" + extension;
   {


### PR DESCRIPTION
This is the result of running ./tools/code_format/check_format.py fix on HEAD

Risk Level: Low, code format only
Testing: Unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
