### PR TITLE
Add option to disable fault filter stats that trace downstream server name

### DIFF
--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -54,7 +54,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 16]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.HTTPFault";
@@ -141,4 +141,6 @@ message HTTPFault {
   // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
   // runtime. The default is: fault.http.abort.grpc_status
   string abort_grpc_status_runtime = 14;
+
+  bool disable_downstream_server_tracing = 15;
 }

--- a/api/envoy/extensions/filters/http/fault/v4alpha/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v4alpha/fault.proto
@@ -54,7 +54,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 16]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.fault.v3.HTTPFault";
@@ -141,4 +141,6 @@ message HTTPFault {
   // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
   // runtime. The default is: fault.http.abort.grpc_status
   string abort_grpc_status_runtime = 14;
+
+  bool disable_downstream_server_tracing = 15;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -54,7 +54,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 16]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.HTTPFault";
@@ -141,4 +141,6 @@ message HTTPFault {
   // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
   // runtime. The default is: fault.http.abort.grpc_status
   string abort_grpc_status_runtime = 14;
+
+  bool disable_downstream_server_tracing = 15;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v4alpha/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v4alpha/fault.proto
@@ -54,7 +54,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 16]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.fault.v3.HTTPFault";
@@ -141,4 +141,6 @@ message HTTPFault {
   // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
   // runtime. The default is: fault.http.abort.grpc_status
   string abort_grpc_status_runtime = 14;
+
+  bool disable_downstream_server_tracing = 15;
 }

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -76,6 +76,12 @@ FaultSettings::FaultSettings(const envoy::extensions::filters::http::fault::v3::
     response_rate_limit_ =
         std::make_unique<Filters::Common::Fault::FaultRateLimitConfig>(fault.response_rate_limit());
   }
+
+
+  if (fault.has_disable_downstream_server_tracing()) {
+    disable_downstream_server_tracing_ = fault.disable_downstream_server_tracing();
+  }
+
 }
 
 FaultFilterConfig::FaultFilterConfig(
@@ -89,8 +95,10 @@ FaultFilterConfig::FaultFilterConfig(
       stats_prefix_(stat_name_set_->add(absl::StrCat(stats_prefix, "fault"))) {}
 
 void FaultFilterConfig::incCounter(Stats::StatName downstream_cluster, Stats::StatName stat_name) {
-  Stats::Utility::counterFromStatNames(scope_, {stats_prefix_, downstream_cluster, stat_name})
-      .inc();
+  if (!settings_.disable_downstream_server_tracing_) {
+    Stats::Utility::counterFromStatNames(scope_, {stats_prefix_, downstream_cluster, stat_name})
+        .inc();
+  }
 }
 
 FaultFilter::FaultFilter(FaultFilterConfigSharedPtr config) : config_(config) {}

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -74,7 +74,7 @@ public:
   const std::string& responseRateLimitPercentRuntime() const {
     return response_rate_limit_percent_runtime_;
   }
-  bool disable_downstream_server_tracing_{false};
+  bool disableDownstreamServerTracing() const { return disable_downstream_server_tracing_; }
 
 private:
   class RuntimeKeyValues {
@@ -106,6 +106,7 @@ private:
   const std::string abort_grpc_status_runtime_;
   const std::string max_active_faults_runtime_;
   const std::string response_rate_limit_percent_runtime_;
+  const bool disable_downstream_server_tracing_;
 };
 
 /**

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -74,6 +74,7 @@ public:
   const std::string& responseRateLimitPercentRuntime() const {
     return response_rate_limit_percent_runtime_;
   }
+  bool disable_downstream_server_tracing_{false};
 
 private:
   class RuntimeKeyValues {
@@ -96,6 +97,7 @@ private:
   const std::vector<Http::HeaderUtility::HeaderDataPtr> fault_filter_headers_;
   absl::flat_hash_set<std::string> downstream_nodes_{}; // Inject failures for specific downstream
   absl::optional<uint64_t> max_active_faults_;
+
   Filters::Common::Fault::FaultRateLimitConfigPtr response_rate_limit_;
   const std::string delay_percent_runtime_;
   const std::string abort_percent_runtime_;

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -48,6 +48,26 @@ typed_config:
       numerator: 100
 )EOF";
 
+  const std::string disable_tracing_fault_config_ =
+      R"EOF(
+name: fault
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+  abort:
+    header_abort: {}
+    percentage:
+      numerator: 100
+  delay:
+    header_delay: {}
+    percentage:
+      numerator: 100
+  response_rate_limit:
+    header_limit: {}
+    percentage:
+      numerator: 100
+  disable_downstream_server_tracing: true
+)EOF";
+
   const std::string abort_grpc_fault_config_ =
       R"EOF(
 name: fault
@@ -171,6 +191,56 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfig) {
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
   EXPECT_EQ(0UL, test_server_->gauge("http.config_test.fault.active_faults")->value());
+}
+
+// Request abort controlled via header configuration.
+TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfigEnableTracing) {
+  initializeFilter(header_fault_config_);
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-envoy-fault-abort-request", "429"},
+                                     {"x-envoy-downstream-service-cluster", "superman"}});
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Envoy::Http::HttpStatusIs("429"));
+
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
+  EXPECT_EQ(0UL, test_server_->gauge("http.config_test.fault.active_faults")->value());
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.superman.aborts_injected")->value());
+  EXPECT_EQ(nullptr, test_server_->counter("http.config_test.fault.superman.delays_injected"));
+}
+
+// Request abort controlled via header configuration.
+TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfigDisableTracing) {
+  initializeFilter(disable_tracing_fault_config_);
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-envoy-fault-abort-request", "429"},
+                                     {"x-envoy-downstream-service-cluster", "superman"}});
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Envoy::Http::HttpStatusIs("429"));
+
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
+  EXPECT_EQ(0UL, test_server_->gauge("http.config_test.fault.active_faults")->value());
+  EXPECT_EQ(nullptr, test_server_->counter("http.config_test.fault.superman.aborts_injected"));
+  EXPECT_EQ(nullptr, test_server_->counter("http.config_test.fault.superman.delays_injected"));
 }
 
 // Request faults controlled via header configuration.

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -193,7 +193,7 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfig) {
   EXPECT_EQ(0UL, test_server_->gauge("http.config_test.fault.active_faults")->value());
 }
 
-// Request abort controlled via header configuration.
+// Request abort controlled via header configuration and enable downstream server tracing.
 TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfigEnableTracing) {
   initializeFilter(header_fault_config_);
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
@@ -218,7 +218,7 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfigEnableTracing) {
   EXPECT_EQ(nullptr, test_server_->counter("http.config_test.fault.superman.delays_injected"));
 }
 
-// Request abort controlled via header configuration.
+// Request abort controlled via header configuration and disable downstream server tracing.
 TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortConfigDisableTracing) {
   initializeFilter(disable_tracing_fault_config_);
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -66,6 +66,15 @@ public:
     fixed_delay: 5s
   )EOF";
 
+  const std::string fixed_delay_only_disable_tracing_yaml = R"EOF(
+  delay:
+    percentage:
+      numerator: 100
+      denominator: HUNDRED
+    fixed_delay: 5s
+  disable_downstream_server_tracing: true
+  )EOF";
+
   const std::string abort_only_yaml = R"EOF(
   abort:
     percentage:
@@ -714,6 +723,55 @@ TEST_F(FaultFilterTest, DelayForDownstreamCluster) {
   EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
   EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
   EXPECT_EQ(1UL, stats_.counter("prefix.fault.cluster.delays_injected").value());
+  EXPECT_EQ(0UL, stats_.counter("prefix.fault.cluster.aborts_injected").value());
+}
+
+TEST_F(FaultFilterTest, DelayForDownstreamClusterDisableTracing) {
+  setUpTest(fixed_delay_only_disable_tracing_yaml);
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
+  request_headers_.addCopy("x-envoy-downstream-service-cluster", "cluster");
+
+  // Delay related calls.
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("fault.http.cluster.delay.fixed_delay_percent",
+                     testing::Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.delay.fixed_duration_ms", 5000))
+      .WillOnce(Return(125UL));
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.cluster.delay.fixed_duration_ms", 125UL))
+      .WillOnce(Return(500UL));
+  expectDelayTimer(500UL);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  // Delay only case, no aborts.
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.cluster.abort.http_status", _)).Times(0);
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", _)).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_, encodeHeaders_(_, _)).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected))
+      .Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding());
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(data_, false));
+
+  EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(decoder_filter_callbacks_.dispatcher_, popTrackedObject(_));
+  timer_->invokeCallback();
+
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+
+  EXPECT_EQ(1UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().aborts_injected_.value());
+  EXPECT_EQ(0UL, stats_.counter("prefix.fault.cluster.delays_injected").value());
   EXPECT_EQ(0UL, stats_.counter("prefix.fault.cluster.aborts_injected").value());
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: Currently the fault filter will create a stats storage for each http request with "x-envoy-downstream-service-cluster" field set, which introduce unbounded memory usage. By adding a flag to control whether downstream server name should be traced in stats, envoy can be protected from downstream servers that send requests header setting different downstream cluster names.
Additional Description:
Risk Level: low
Testing: add unit test and integration test.
Docs Changes: will change doc for fault filter
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
