### PR TITLE
test: Deflake tsan //test/integration:integration_test

### DIFF
--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1918,6 +1918,14 @@ TEST_P(IntegrationTest, Preconnect) {
     clients.front()->close();
     clients.pop_front();
   }
+
+  for (auto& connection : fake_connections) {
+    AssertionResult result = connection->close();
+    RELEASE_ASSERT(result, result.message());
+    result = connection->waitForDisconnect();
+    RELEASE_ASSERT(result, result.message());
+    connection.reset();
+  }
 }
 
 TEST_P(IntegrationTest, RandomPreconnect) {

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -1920,10 +1920,8 @@ TEST_P(IntegrationTest, Preconnect) {
   }
 
   for (auto& connection : fake_connections) {
-    AssertionResult result = connection->close();
-    RELEASE_ASSERT(result, result.message());
-    result = connection->waitForDisconnect();
-    RELEASE_ASSERT(result, result.message());
+    ASSERT_TRUE(connection->close());
+    ASSERT_TRUE(connection->waitForDisconnect());
     connection.reset();
   }
 }


### PR DESCRIPTION
Additional Description:
Proactively close fake upstream connections before deleting them to avoid racing with the dispatcher thread.

Risk Level: Low, Test Only
Testing: Not flaking after 10K runs

Signed-off-by: Yan Avlasov <yavlasov@google.com>
