### PR TITLE
stats: skip symbolizing empty tokens

### DIFF
--- a/source/common/stats/symbol_table_impl.cc
+++ b/source/common/stats/symbol_table_impl.cc
@@ -214,11 +214,13 @@ void SymbolTableImpl::addTokensToEncoding(const absl::string_view name, Encoding
     Thread::LockGuard lock(lock_);
     recent_lookups_.lookup(name);
     for (auto& token : tokens) {
-      // TODO(jmarantz): consider using StatNameDynamicStorage for tokens with
-      // length below some threshold, say 4 bytes. It might be preferable not to
-      // reserve Symbols for every 3 digit number found (for example) in ipv4
-      // addresses.
-      symbols.push_back(toSymbol(token));
+      if (!token.empty()) {
+        // TODO(jmarantz): consider using StatNameDynamicStorage for tokens with
+        // length below some threshold, say 4 bytes. It might be preferable not to
+        // reserve Symbols for every 3 digit number found (for example) in ipv4
+        // addresses.
+        symbols.push_back(toSymbol(token));
+      }
     }
   }
 

--- a/test/common/http/codes_test.cc
+++ b/test/common/http/codes_test.cc
@@ -229,6 +229,19 @@ TEST_F(CodeUtilityTest, PerZoneStats) {
   EXPECT_EQ(1U, cluster_scope_.counter("prefix.zone.from_az.to_az.upstream_rq_2xx").value());
 }
 
+TEST_F(CodeUtilityTest, EmptyPerZoneStats) {
+  // Empty from-zone / to-zone stats should not be emitted.
+  addResponse(200, false, false, "", "", "from_az");
+  EXPECT_EQ(0U, cluster_scope_.counter("prefix.zone.from_az..upstream_rq_completed").value());
+  EXPECT_EQ(0U, cluster_scope_.counter("prefix.zone.from_az..upstream_rq_200").value());
+  EXPECT_EQ(0U, cluster_scope_.counter("prefix.zone.from_az..upstream_rq_2xx").value());
+
+  addResponse(200, false, false, "", "", "", "to_az");
+  EXPECT_EQ(0U, cluster_scope_.counter("prefix.zone..to_az.upstream_rq_completed").value());
+  EXPECT_EQ(0U, cluster_scope_.counter("prefix.zone..to_az.upstream_rq_200").value());
+  EXPECT_EQ(0U, cluster_scope_.counter("prefix.zone..to_az.upstream_rq_2xx").value());
+}
+
 TEST_F(CodeUtilityTest, ResponseTimingTest) {
   Stats::MockStore global_store;
   Stats::MockStore cluster_scope;

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -94,7 +94,7 @@ TEST_F(StatNameTest, SerializeStrings) {
 TEST_F(StatNameTest, AllocFree) { encodeDecode("hello.world"); }
 
 TEST_F(StatNameTest, TestArbitrarySymbolRoundtrip) {
-  const std::vector<std::string> stat_names = {"", " ", "  ", ",", "\t", "$", "%", "`", ".x"};
+  const std::vector<std::string> stat_names = {"", " ", "  ", ",", "\t", "$", "%", "`"};
   for (auto& stat_name : stat_names) {
     EXPECT_EQ(stat_name, encodeDecode(stat_name));
   }
@@ -207,11 +207,16 @@ TEST_F(StatNameTest, TestLongSequence) {
 }
 
 TEST_F(StatNameTest, TestUnusualDelimitersRoundtrip) {
-  const std::vector<std::string> stat_names = {".x",   "..x",    "...x",    "foo",     "foo.x",
-                                               ".foo", ".foo.x", ".foo..x", "..foo.x", "..foo..x"};
-  for (auto& stat_name : stat_names) {
-    EXPECT_EQ(stat_name, encodeDecode(stat_name));
-  }
+  EXPECT_EQ("x", encodeDecode(".x"));
+  EXPECT_EQ("x", encodeDecode("..x"));
+  EXPECT_EQ("x", encodeDecode("...x"));
+  EXPECT_EQ("foo", encodeDecode("foo"));
+  EXPECT_EQ("foo.x", encodeDecode("foo.x"));
+  EXPECT_EQ("foo", encodeDecode(".foo"));
+  EXPECT_EQ("foo.x", encodeDecode(".foo.x"));
+  EXPECT_EQ("foo.x", encodeDecode(".foo..x"));
+  EXPECT_EQ("foo.x", encodeDecode("..foo.x"));
+  EXPECT_EQ("foo.x", encodeDecode("..foo..x"));
 }
 
 TEST_F(StatNameTest, TestSuccessfulDoubleLookup) {


### PR DESCRIPTION
Commit Message: Prevents stats with invalid metric formats, where there are consecutive `..` from being emitted.
Additional Description: For example, drop stats with the format `cluster.egress_dynamodb_iad.zone.1a..upstream_rq_2xx`
Risk Level: Medium
Testing: Unit
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes  #15541
