### PR TITLE
Fix warning in the docs

### DIFF
--- a/docs/_ext/powershell_lexer.py
+++ b/docs/_ext/powershell_lexer.py
@@ -1,4 +1,5 @@
 from pygments.lexers import get_lexer_by_name, PowerShellLexer
 
+
 def setup(app):
     app.add_lexer('powershell', PowerShellLexer)

--- a/docs/_ext/powershell_lexer.py
+++ b/docs/_ext/powershell_lexer.py
@@ -1,5 +1,4 @@
-from pygments.lexers import get_lexer_by_name
-
+from pygments.lexers import get_lexer_by_name, PowerShellLexer
 
 def setup(app):
-    app.add_lexer('powershell', get_lexer_by_name('powershell'))
+    app.add_lexer('powershell', PowerShellLexer)

--- a/docs/_ext/powershell_lexer.py
+++ b/docs/_ext/powershell_lexer.py
@@ -1,4 +1,4 @@
-from pygments.lexers import get_lexer_by_name, PowerShellLexer
+from pygments.lexers import PowerShellLexer
 
 
 def setup(app):


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
Commit Message:

Fix warning:
```
/home/davinci/envoy/generated/rst/_ext/powershell_lexer.py:5: RemovedInSphinx40Warning: app.add_lexer() API changed; Please give lexer class instead of instance
  app.add_lexer('powershell', get_lexer_by_name('powershell'))
```

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
