### PR TITLE
WIP: api: Add cache keys and a way of filtering on them in subscription requests

### DIFF
--- a/api/envoy/service/discovery/v3/cache_keys.proto
+++ b/api/envoy/service/discovery/v3/cache_keys.proto
@@ -19,14 +19,19 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // resource is appropriate for a given client.
 message CacheKeyConstraints {
   message Constraint {
-    // Numeric range.
-    // At least one of *min_value* or *max_value* must be set.
-    message Range {
-      // If specified, value may not be less than this.
-      uint64 min_value = 1;
+    // A list of one or more numeric ranges.
+    // A value is considered to match if it falls in any of the ranges.
+    message RangeList {
+      // At least one of *min_value* or *max_value* must be set.
+      message Range {
+        // If specified, value may not be less than this.
+        uint64 min_value = 1;
 
-      // If specified, value may not be greater than this.
-      uint64 max_value = 2;
+        // If specified, value may not be greater than this.
+        uint64 max_value = 2;
+      }
+
+      repeated Range range = 1;
     }
 
     message Exists {
@@ -36,8 +41,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within this range.
-      Range range = 2;
+      // The cache key's value must be numeric and within one of the ranges in this list.
+      RangeList range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;

--- a/api/envoy/service/discovery/v3/cache_keys.proto
+++ b/api/envoy/service/discovery/v3/cache_keys.proto
@@ -19,9 +19,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // resource is appropriate for a given client.
 message CacheKeyConstraints {
   message Constraint {
-    // A list of one or more numeric ranges.
+    // A list of one or more integer ranges.
     // A value is considered to match if it falls in any of the ranges.
-    message RangeList {
+    message IntegerRangeList {
       // At least one of *min_value* or *max_value* must be set.
       message Range {
         // If specified, value may not be less than this.
@@ -41,8 +41,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within one of the ranges in this list.
-      RangeList range_list = 2;
+      // The cache key's value must be integers and within one of the ranges in this list.
+      IntegerRangeList integer_range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;
@@ -56,7 +56,7 @@ message CacheKeyConstraints {
   string key = 1;
 
   // A list of one or more constraints on the value of the cache key.
-  // All constraints must match.
+  // All constraints must be met.
   repeated Constraint constraints = 2;
 
   // If specified, the cache key is optional (i.e., a cache entry will match

--- a/api/envoy/service/discovery/v3/cache_keys.proto
+++ b/api/envoy/service/discovery/v3/cache_keys.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v3;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v3";
+option java_outer_classname = "CacheKeysProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Discovery Resource Cache Key Constraints]
+
+// The cache key for each xDS resource contains the resource's name and a map of
+// key/value pairs. This message represents a set of constraints on those
+// key/value pairs that can be used when subscribing to a resource. This
+// allows xDS servers and caching proxies to determine which variant of a
+// resource is appropriate for a given client.
+message CacheKeyConstraints {
+  message Constraint {
+    // Numeric range.
+    // At least one of *min_value* or *max_value* must be set.
+    message Range {
+      // If specified, value may not be less than this.
+      uint64 min_value = 1;
+
+      // If specified, value may not be greater than this.
+      uint64 max_value = 2;
+    }
+
+    message Exists {
+    }
+
+    oneof constraint {
+      // The cache key must have this specific value.
+      string value = 1;
+
+      // The cache key's value must be numeric and within this range.
+      Range range = 2;
+
+      // The cache key exists.
+      Exists exists = 3;
+    }
+
+    // If true, the constraint is inverted (i.e., logical-not of the constraint).
+    bool invert = 4;
+  }
+
+  // The name of the cache key.
+  string key = 1;
+
+  // A list of one or more constraints on the value of the cache key.
+  // All constraints must match.
+  repeated Constraint constraints = 2;
+
+  // If specified, the cache key is optional (i.e., a cache entry will match
+  // even if it does not have the specified cache key).
+  bool is_optional = 3;
+}
+
+message ResourceCacheKeyConstraints {
+  // Cache key constraints to be used for a given resource type.
+  message ResourceTypeCacheKeyConstraints {
+    repeated CacheKeyConstraints cache_key_constraints = 1;
+  }
+
+  // Key is resource type name (e.g., "envoy.config.cluster.v3.Cluster").
+  map<string, ResourceTypeCacheKeyConstraints> resource_type_cache_key_constraints = 1;
+}

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -64,6 +64,7 @@ message DiscoveryRequest {
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.
@@ -206,6 +207,7 @@ message DeltaDiscoveryRequest {
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.

--- a/api/envoy/service/discovery/v3/discovery.proto
+++ b/api/envoy/service/discovery/v3/discovery.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.service.discovery.v3;
 
 import "envoy/config/core/v3/base.proto";
+import "envoy/service/discovery/v3/cache_keys.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
@@ -20,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DiscoveryRequest";
 
@@ -62,6 +63,11 @@ message DiscoveryRequest {
   // internal exception related to the failure. It is only intended for consumption during manual
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 7;
 }
 
 // [#next-free-field: 7]
@@ -140,7 +146,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DeltaDiscoveryRequest";
 
@@ -199,6 +205,11 @@ message DeltaDiscoveryRequest {
   // failed to update configuration. The *message* field in *error_details*
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 8;
 }
 
 // [#next-free-field: 8]
@@ -243,6 +254,9 @@ message Resource {
     // Note that this does not apply to clients other than xDS proxies, which must cache resources
     // for their own use, regardless of the value of this field.
     bool do_not_cache = 1;
+
+    // Cache keys associated with this resource, to be used by caching xDS proxies.
+    map<string, string> cache_keys = 2;
   }
 
   // The resource's name, to distinguish it from others of the same type of resource.

--- a/api/envoy/service/discovery/v4alpha/cache_keys.proto
+++ b/api/envoy/service/discovery/v4alpha/cache_keys.proto
@@ -25,17 +25,25 @@ message CacheKeyConstraints {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.service.discovery.v3.CacheKeyConstraints.Constraint";
 
-    // Numeric range.
-    // At least one of *min_value* or *max_value* must be set.
-    message Range {
+    // A list of one or more numeric ranges.
+    // A value is considered to match if it falls in any of the ranges.
+    message RangeList {
       option (udpa.annotations.versioning).previous_message_type =
-          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.Range";
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList";
 
-      // If specified, value may not be less than this.
-      uint64 min_value = 1;
+      // At least one of *min_value* or *max_value* must be set.
+      message Range {
+        option (udpa.annotations.versioning).previous_message_type =
+            "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList.Range";
 
-      // If specified, value may not be greater than this.
-      uint64 max_value = 2;
+        // If specified, value may not be less than this.
+        uint64 min_value = 1;
+
+        // If specified, value may not be greater than this.
+        uint64 max_value = 2;
+      }
+
+      repeated Range range = 1;
     }
 
     message Exists {
@@ -47,8 +55,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within this range.
-      Range range = 2;
+      // The cache key's value must be numeric and within one of the ranges in this list.
+      RangeList range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;

--- a/api/envoy/service/discovery/v4alpha/cache_keys.proto
+++ b/api/envoy/service/discovery/v4alpha/cache_keys.proto
@@ -1,0 +1,87 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v4alpha;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v4alpha";
+option java_outer_classname = "CacheKeysProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Discovery Resource Cache Key Constraints]
+
+// The cache key for each xDS resource contains the resource's name and a map of
+// key/value pairs. This message represents a set of constraints on those
+// key/value pairs that can be used when subscribing to a resource. This
+// allows xDS servers and caching proxies to determine which variant of a
+// resource is appropriate for a given client.
+message CacheKeyConstraints {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.CacheKeyConstraints";
+
+  message Constraint {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.discovery.v3.CacheKeyConstraints.Constraint";
+
+    // Numeric range.
+    // At least one of *min_value* or *max_value* must be set.
+    message Range {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.Range";
+
+      // If specified, value may not be less than this.
+      uint64 min_value = 1;
+
+      // If specified, value may not be greater than this.
+      uint64 max_value = 2;
+    }
+
+    message Exists {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.Exists";
+    }
+
+    oneof constraint {
+      // The cache key must have this specific value.
+      string value = 1;
+
+      // The cache key's value must be numeric and within this range.
+      Range range = 2;
+
+      // The cache key exists.
+      Exists exists = 3;
+    }
+
+    // If true, the constraint is inverted (i.e., logical-not of the constraint).
+    bool invert = 4;
+  }
+
+  // The name of the cache key.
+  string key = 1;
+
+  // A list of one or more constraints on the value of the cache key.
+  // All constraints must match.
+  repeated Constraint constraints = 2;
+
+  // If specified, the cache key is optional (i.e., a cache entry will match
+  // even if it does not have the specified cache key).
+  bool is_optional = 3;
+}
+
+message ResourceCacheKeyConstraints {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.ResourceCacheKeyConstraints";
+
+  // Cache key constraints to be used for a given resource type.
+  message ResourceTypeCacheKeyConstraints {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.discovery.v3.ResourceCacheKeyConstraints.ResourceTypeCacheKeyConstraints";
+
+    repeated CacheKeyConstraints cache_key_constraints = 1;
+  }
+
+  // Key is resource type name (e.g., "envoy.config.cluster.v3.Cluster").
+  map<string, ResourceTypeCacheKeyConstraints> resource_type_cache_key_constraints = 1;
+}

--- a/api/envoy/service/discovery/v4alpha/cache_keys.proto
+++ b/api/envoy/service/discovery/v4alpha/cache_keys.proto
@@ -25,16 +25,16 @@ message CacheKeyConstraints {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.service.discovery.v3.CacheKeyConstraints.Constraint";
 
-    // A list of one or more numeric ranges.
+    // A list of one or more integer ranges.
     // A value is considered to match if it falls in any of the ranges.
-    message RangeList {
+    message IntegerRangeList {
       option (udpa.annotations.versioning).previous_message_type =
-          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList";
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.IntegerRangeList";
 
       // At least one of *min_value* or *max_value* must be set.
       message Range {
         option (udpa.annotations.versioning).previous_message_type =
-            "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList.Range";
+            "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.IntegerRangeList.Range";
 
         // If specified, value may not be less than this.
         uint64 min_value = 1;
@@ -55,8 +55,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within one of the ranges in this list.
-      RangeList range_list = 2;
+      // The cache key's value must be integers and within one of the ranges in this list.
+      IntegerRangeList integer_range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;
@@ -70,7 +70,7 @@ message CacheKeyConstraints {
   string key = 1;
 
   // A list of one or more constraints on the value of the cache key.
-  // All constraints must match.
+  // All constraints must be met.
   repeated Constraint constraints = 2;
 
   // If specified, the cache key is optional (i.e., a cache entry will match

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -65,6 +65,7 @@ message DiscoveryRequest {
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.
@@ -209,6 +210,7 @@ message DeltaDiscoveryRequest {
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.

--- a/api/envoy/service/discovery/v4alpha/discovery.proto
+++ b/api/envoy/service/discovery/v4alpha/discovery.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.service.discovery.v4alpha;
 
 import "envoy/config/core/v4alpha/base.proto";
+import "envoy/service/discovery/v4alpha/cache_keys.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
@@ -20,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.DiscoveryRequest";
@@ -63,6 +64,11 @@ message DiscoveryRequest {
   // internal exception related to the failure. It is only intended for consumption during manual
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 7;
 }
 
 // [#next-free-field: 7]
@@ -142,7 +148,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.DeltaDiscoveryRequest";
@@ -202,6 +208,11 @@ message DeltaDiscoveryRequest {
   // failed to update configuration. The *message* field in *error_details*
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 8;
 }
 
 // [#next-free-field: 8]
@@ -250,6 +261,9 @@ message Resource {
     // Note that this does not apply to clients other than xDS proxies, which must cache resources
     // for their own use, regardless of the value of this field.
     bool do_not_cache = 1;
+
+    // Cache keys associated with this resource, to be used by caching xDS proxies.
+    map<string, string> cache_keys = 2;
   }
 
   // The resource's name, to distinguish it from others of the same type of resource.

--- a/generated_api_shadow/envoy/service/discovery/v3/cache_keys.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/cache_keys.proto
@@ -19,14 +19,19 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // resource is appropriate for a given client.
 message CacheKeyConstraints {
   message Constraint {
-    // Numeric range.
-    // At least one of *min_value* or *max_value* must be set.
-    message Range {
-      // If specified, value may not be less than this.
-      uint64 min_value = 1;
+    // A list of one or more numeric ranges.
+    // A value is considered to match if it falls in any of the ranges.
+    message RangeList {
+      // At least one of *min_value* or *max_value* must be set.
+      message Range {
+        // If specified, value may not be less than this.
+        uint64 min_value = 1;
 
-      // If specified, value may not be greater than this.
-      uint64 max_value = 2;
+        // If specified, value may not be greater than this.
+        uint64 max_value = 2;
+      }
+
+      repeated Range range = 1;
     }
 
     message Exists {
@@ -36,8 +41,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within this range.
-      Range range = 2;
+      // The cache key's value must be numeric and within one of the ranges in this list.
+      RangeList range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;

--- a/generated_api_shadow/envoy/service/discovery/v3/cache_keys.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/cache_keys.proto
@@ -19,9 +19,9 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // resource is appropriate for a given client.
 message CacheKeyConstraints {
   message Constraint {
-    // A list of one or more numeric ranges.
+    // A list of one or more integer ranges.
     // A value is considered to match if it falls in any of the ranges.
-    message RangeList {
+    message IntegerRangeList {
       // At least one of *min_value* or *max_value* must be set.
       message Range {
         // If specified, value may not be less than this.
@@ -41,8 +41,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within one of the ranges in this list.
-      RangeList range_list = 2;
+      // The cache key's value must be integers and within one of the ranges in this list.
+      IntegerRangeList integer_range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;
@@ -56,7 +56,7 @@ message CacheKeyConstraints {
   string key = 1;
 
   // A list of one or more constraints on the value of the cache key.
-  // All constraints must match.
+  // All constraints must be met.
   repeated Constraint constraints = 2;
 
   // If specified, the cache key is optional (i.e., a cache entry will match

--- a/generated_api_shadow/envoy/service/discovery/v3/cache_keys.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/cache_keys.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v3;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v3";
+option java_outer_classname = "CacheKeysProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: Discovery Resource Cache Key Constraints]
+
+// The cache key for each xDS resource contains the resource's name and a map of
+// key/value pairs. This message represents a set of constraints on those
+// key/value pairs that can be used when subscribing to a resource. This
+// allows xDS servers and caching proxies to determine which variant of a
+// resource is appropriate for a given client.
+message CacheKeyConstraints {
+  message Constraint {
+    // Numeric range.
+    // At least one of *min_value* or *max_value* must be set.
+    message Range {
+      // If specified, value may not be less than this.
+      uint64 min_value = 1;
+
+      // If specified, value may not be greater than this.
+      uint64 max_value = 2;
+    }
+
+    message Exists {
+    }
+
+    oneof constraint {
+      // The cache key must have this specific value.
+      string value = 1;
+
+      // The cache key's value must be numeric and within this range.
+      Range range = 2;
+
+      // The cache key exists.
+      Exists exists = 3;
+    }
+
+    // If true, the constraint is inverted (i.e., logical-not of the constraint).
+    bool invert = 4;
+  }
+
+  // The name of the cache key.
+  string key = 1;
+
+  // A list of one or more constraints on the value of the cache key.
+  // All constraints must match.
+  repeated Constraint constraints = 2;
+
+  // If specified, the cache key is optional (i.e., a cache entry will match
+  // even if it does not have the specified cache key).
+  bool is_optional = 3;
+}
+
+message ResourceCacheKeyConstraints {
+  // Cache key constraints to be used for a given resource type.
+  message ResourceTypeCacheKeyConstraints {
+    repeated CacheKeyConstraints cache_key_constraints = 1;
+  }
+
+  // Key is resource type name (e.g., "envoy.config.cluster.v3.Cluster").
+  map<string, ResourceTypeCacheKeyConstraints> resource_type_cache_key_constraints = 1;
+}

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -64,6 +64,7 @@ message DiscoveryRequest {
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.
@@ -206,6 +207,7 @@ message DeltaDiscoveryRequest {
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.

--- a/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v3/discovery.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.service.discovery.v3;
 
 import "envoy/config/core/v3/base.proto";
+import "envoy/service/discovery/v3/cache_keys.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
@@ -20,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DiscoveryRequest";
 
@@ -62,6 +63,11 @@ message DiscoveryRequest {
   // internal exception related to the failure. It is only intended for consumption during manual
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 7;
 }
 
 // [#next-free-field: 7]
@@ -140,7 +146,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.DeltaDiscoveryRequest";
 
@@ -199,6 +205,11 @@ message DeltaDiscoveryRequest {
   // failed to update configuration. The *message* field in *error_details*
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 8;
 }
 
 // [#next-free-field: 8]
@@ -243,6 +254,9 @@ message Resource {
     // Note that this does not apply to clients other than xDS proxies, which must cache resources
     // for their own use, regardless of the value of this field.
     bool do_not_cache = 1;
+
+    // Cache keys associated with this resource, to be used by caching xDS proxies.
+    map<string, string> cache_keys = 2;
   }
 
   // The resource's name, to distinguish it from others of the same type of resource.

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/cache_keys.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/cache_keys.proto
@@ -25,17 +25,25 @@ message CacheKeyConstraints {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.service.discovery.v3.CacheKeyConstraints.Constraint";
 
-    // Numeric range.
-    // At least one of *min_value* or *max_value* must be set.
-    message Range {
+    // A list of one or more numeric ranges.
+    // A value is considered to match if it falls in any of the ranges.
+    message RangeList {
       option (udpa.annotations.versioning).previous_message_type =
-          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.Range";
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList";
 
-      // If specified, value may not be less than this.
-      uint64 min_value = 1;
+      // At least one of *min_value* or *max_value* must be set.
+      message Range {
+        option (udpa.annotations.versioning).previous_message_type =
+            "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList.Range";
 
-      // If specified, value may not be greater than this.
-      uint64 max_value = 2;
+        // If specified, value may not be less than this.
+        uint64 min_value = 1;
+
+        // If specified, value may not be greater than this.
+        uint64 max_value = 2;
+      }
+
+      repeated Range range = 1;
     }
 
     message Exists {
@@ -47,8 +55,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within this range.
-      Range range = 2;
+      // The cache key's value must be numeric and within one of the ranges in this list.
+      RangeList range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/cache_keys.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/cache_keys.proto
@@ -1,0 +1,87 @@
+syntax = "proto3";
+
+package envoy.service.discovery.v4alpha;
+
+import "udpa/annotations/status.proto";
+import "udpa/annotations/versioning.proto";
+
+option java_package = "io.envoyproxy.envoy.service.discovery.v4alpha";
+option java_outer_classname = "CacheKeysProto";
+option java_multiple_files = true;
+option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSION_CANDIDATE;
+
+// [#protodoc-title: Discovery Resource Cache Key Constraints]
+
+// The cache key for each xDS resource contains the resource's name and a map of
+// key/value pairs. This message represents a set of constraints on those
+// key/value pairs that can be used when subscribing to a resource. This
+// allows xDS servers and caching proxies to determine which variant of a
+// resource is appropriate for a given client.
+message CacheKeyConstraints {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.CacheKeyConstraints";
+
+  message Constraint {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.discovery.v3.CacheKeyConstraints.Constraint";
+
+    // Numeric range.
+    // At least one of *min_value* or *max_value* must be set.
+    message Range {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.Range";
+
+      // If specified, value may not be less than this.
+      uint64 min_value = 1;
+
+      // If specified, value may not be greater than this.
+      uint64 max_value = 2;
+    }
+
+    message Exists {
+      option (udpa.annotations.versioning).previous_message_type =
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.Exists";
+    }
+
+    oneof constraint {
+      // The cache key must have this specific value.
+      string value = 1;
+
+      // The cache key's value must be numeric and within this range.
+      Range range = 2;
+
+      // The cache key exists.
+      Exists exists = 3;
+    }
+
+    // If true, the constraint is inverted (i.e., logical-not of the constraint).
+    bool invert = 4;
+  }
+
+  // The name of the cache key.
+  string key = 1;
+
+  // A list of one or more constraints on the value of the cache key.
+  // All constraints must match.
+  repeated Constraint constraints = 2;
+
+  // If specified, the cache key is optional (i.e., a cache entry will match
+  // even if it does not have the specified cache key).
+  bool is_optional = 3;
+}
+
+message ResourceCacheKeyConstraints {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.service.discovery.v3.ResourceCacheKeyConstraints";
+
+  // Cache key constraints to be used for a given resource type.
+  message ResourceTypeCacheKeyConstraints {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.service.discovery.v3.ResourceCacheKeyConstraints.ResourceTypeCacheKeyConstraints";
+
+    repeated CacheKeyConstraints cache_key_constraints = 1;
+  }
+
+  // Key is resource type name (e.g., "envoy.config.cluster.v3.Cluster").
+  map<string, ResourceTypeCacheKeyConstraints> resource_type_cache_key_constraints = 1;
+}

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/cache_keys.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/cache_keys.proto
@@ -25,16 +25,16 @@ message CacheKeyConstraints {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.service.discovery.v3.CacheKeyConstraints.Constraint";
 
-    // A list of one or more numeric ranges.
+    // A list of one or more integer ranges.
     // A value is considered to match if it falls in any of the ranges.
-    message RangeList {
+    message IntegerRangeList {
       option (udpa.annotations.versioning).previous_message_type =
-          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList";
+          "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.IntegerRangeList";
 
       // At least one of *min_value* or *max_value* must be set.
       message Range {
         option (udpa.annotations.versioning).previous_message_type =
-            "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.RangeList.Range";
+            "envoy.service.discovery.v3.CacheKeyConstraints.Constraint.IntegerRangeList.Range";
 
         // If specified, value may not be less than this.
         uint64 min_value = 1;
@@ -55,8 +55,8 @@ message CacheKeyConstraints {
       // The cache key must have this specific value.
       string value = 1;
 
-      // The cache key's value must be numeric and within one of the ranges in this list.
-      RangeList range_list = 2;
+      // The cache key's value must be integers and within one of the ranges in this list.
+      IntegerRangeList integer_range_list = 2;
 
       // The cache key exists.
       Exists exists = 3;
@@ -70,7 +70,7 @@ message CacheKeyConstraints {
   string key = 1;
 
   // A list of one or more constraints on the value of the cache key.
-  // All constraints must match.
+  // All constraints must be met.
   repeated Constraint constraints = 2;
 
   // If specified, the cache key is optional (i.e., a cache entry will match

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -65,6 +65,7 @@ message DiscoveryRequest {
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.
@@ -209,6 +210,7 @@ message DeltaDiscoveryRequest {
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
 
+  // [#not-implemented-hide:]
   // Constraints on the set of cache keys for resources of type *type_url*.
   // Populated only on the first request for a given resource type and
   // when the constraints change.

--- a/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
+++ b/generated_api_shadow/envoy/service/discovery/v4alpha/discovery.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.service.discovery.v4alpha;
 
 import "envoy/config/core/v4alpha/base.proto";
+import "envoy/service/discovery/v4alpha/cache_keys.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
@@ -20,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // A DiscoveryRequest requests a set of versioned resources of the same type for
 // a given Envoy node on some API.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message DiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.DiscoveryRequest";
@@ -63,6 +64,11 @@ message DiscoveryRequest {
   // internal exception related to the failure. It is only intended for consumption during manual
   // debugging, the string provided is not guaranteed to be stable across Envoy versions.
   google.rpc.Status error_detail = 6;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 7;
 }
 
 // [#next-free-field: 7]
@@ -142,7 +148,7 @@ message DiscoveryResponse {
 // In particular, initial_resource_versions being sent at the "start" of every
 // gRPC stream actually entails a message for each type_url, each with its own
 // initial_resource_versions.
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message DeltaDiscoveryRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.service.discovery.v3.DeltaDiscoveryRequest";
@@ -202,6 +208,11 @@ message DeltaDiscoveryRequest {
   // failed to update configuration. The *message* field in *error_details*
   // provides the Envoy internal exception related to the failure.
   google.rpc.Status error_detail = 7;
+
+  // Constraints on the set of cache keys for resources of type *type_url*.
+  // Populated only on the first request for a given resource type and
+  // when the constraints change.
+  repeated CacheKeyConstraints cache_key_constraints = 8;
 }
 
 // [#next-free-field: 8]
@@ -250,6 +261,9 @@ message Resource {
     // Note that this does not apply to clients other than xDS proxies, which must cache resources
     // for their own use, regardless of the value of this field.
     bool do_not_cache = 1;
+
+    // Cache keys associated with this resource, to be used by caching xDS proxies.
+    map<string, string> cache_keys = 2;
   }
 
   // The resource's name, to distinguish it from others of the same type of resource.


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: api: Add cache keys and a way of filtering on them in subscription requests
Additional Description: This provides a cache key mechanism for use in dynamic resource selection.  For context, see https://docs.google.com/document/d/11XyabQ9mgdXil7ssRTKyovxUWIjj1CzJmgTAwmRqJx0/edit?usp=sharing.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @htuch @stevenzzzz 