### PR TITLE
xDS: Record control plane identifier of delta xDS responses in stats

### DIFF
--- a/source/common/config/new_grpc_mux_impl.cc
+++ b/source/common/config/new_grpc_mux_impl.cc
@@ -78,9 +78,12 @@ void NewGrpcMuxImpl::registerVersionedTypeUrl(const std::string& type_url) {
 
 void NewGrpcMuxImpl::onDiscoveryResponse(
     std::unique_ptr<envoy::service::discovery::v3::DeltaDiscoveryResponse>&& message,
-    ControlPlaneStats&) {
+    ControlPlaneStats& control_plane_stats) {
   ENVOY_LOG(debug, "Received DeltaDiscoveryResponse for {} at version {}", message->type_url(),
             message->system_version_info());
+  if (message->has_control_plane()) {
+    control_plane_stats.identifier_.set(message->control_plane().identifier());
+  }
   auto sub = subscriptions_.find(message->type_url());
   // If this type url is not watched, try another version type url.
   if (enable_type_url_downgrade_and_upgrade_ && sub == subscriptions_.end()) {

--- a/test/common/config/new_grpc_mux_impl_test.cc
+++ b/test/common/config/new_grpc_mux_impl_test.cc
@@ -317,6 +317,7 @@ TEST_F(NewGrpcMuxImplTest, ConfigUpdateWithAliases) {
   auto response = std::make_unique<envoy::service::discovery::v3::DeltaDiscoveryResponse>();
   response->set_type_url(type_url);
   response->set_system_version_info("1");
+  response->mutable_control_plane()->set_identifier("HAL 9000");
 
   envoy::config::route::v3::VirtualHost vhost;
   vhost.set_name("vhost_1");
@@ -335,6 +336,7 @@ TEST_F(NewGrpcMuxImplTest, ConfigUpdateWithAliases) {
 
   EXPECT_TRUE(sub != subscriptions.end());
   watch->update({});
+  EXPECT_EQ("HAL 9000", stats_.textReadout("control_plane.identifier").value());
 }
 
 // DeltaDiscoveryResponse that comes in response to an on-demand request that couldn't be resolved


### PR DESCRIPTION
This is an already existing stat from the SotW xDS. Just completing this functionality for delta xDS

Risk Level: Low
Testing: Unit Tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes: #14891

Signed-off-by: Yan Avlasov <yavlasov@google.com>
