### PR TITLE
thrift_proxy router: fix bug when charging upstream rq_time before requestCompletes

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -584,7 +584,7 @@ void Router::UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason re
 }
 
 void Router::UpstreamRequest::chargeResponseTiming() {
-  if (charged_response_timing_) {
+  if (charged_response_timing_ || !request_complete_) {
     return;
   }
   charged_response_timing_ = true;

--- a/test/extensions/filters/network/thrift_proxy/router_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/router_test.cc
@@ -953,10 +953,12 @@ TEST_F(ThriftRouterTest, PoolTimeoutUpstreamTimeMeasurement) {
 
   dispatcher_.time_system_.advanceTimeWait(std::chrono::milliseconds(500));
   EXPECT_CALL(cluster_scope,
-              histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds));
+              histogram("thrift.upstream_rq_time", Stats::Histogram::Unit::Milliseconds))
+      .Times(0);
   EXPECT_CALL(cluster_scope,
               deliverHistogramToSinks(
-                  testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), 500));
+                  testing::Property(&Stats::Metric::name, "thrift.upstream_rq_time"), 500))
+      .Times(0);
   EXPECT_CALL(callbacks_, sendLocalReply(_, _))
       .WillOnce(Invoke([&](const DirectResponse& response, bool end_stream) -> void {
         auto& app_ex = dynamic_cast<const AppException&>(response);


### PR DESCRIPTION
Signed-off-by: William Fu <wfu@pinterest.com>

Commit Message:
We charge `upstream_rq_time` latencies after responses are received but also when an upstreamRequest destroys early, to submit proper data points during events such as timeouts.
However if we experience a stream reset before `requestCompletes` calls, we will be recording a latency value that is calculated against an initial value of time_after_epoch() = 0. This will occasionally cause extreme outliers in the histogram.

Additional Description:
Risk Level: Low, fixing a bug
Testing: Updated existing unit test that handled onEvent
Docs Changes:
Release Notes:
Platform Specific Features: