### PR TITLE
Adding distroless image to Envoy CI pipeline

### DIFF
--- a/ci/Dockerfile-envoy-distroless
+++ b/ci/Dockerfile-envoy-distroless
@@ -1,5 +1,4 @@
 FROM gcr.io/distroless/base-debian10:nonroot
-RUN mkdir -p /etc/envoy
 
 ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
 

--- a/ci/Dockerfile-envoy-distroless
+++ b/ci/Dockerfile-envoy-distroless
@@ -1,0 +1,11 @@
+FROM gcr.io/distroless/base-debian10:nonroot
+RUN mkdir -p /etc/envoy
+
+ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
+
+ARG ENVOY_BINARY_SUFFIX=_stripped
+ADD linux/amd64/build_release${ENVOY_BINARY_SUFFIX}/* /usr/local/bin/
+
+EXPOSE 10000
+
+CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -125,7 +125,7 @@ if is_windows; then
   BUILD_COMMAND=("build")
 else
   # "-google-vrp" must come afer "" to ensure we rebuild the local base image dependency.
-  BUILD_TYPES=("" "-debug" "-alpine" "-google-vrp")
+  BUILD_TYPES=("" "-debug" "-alpine" "-distroless" "-google-vrp")
 
   # Configure docker-buildx tools
   BUILD_COMMAND=("buildx" "build")


### PR DESCRIPTION
Commit Message: ci: adding distroless image to Envoy CI pipeline
Additional Description: 

In #16170 we came up to the conclusion that the best option is to add distroless based images.
I analyzed #15312 and came to the conclusion that it will take a lot of changes to add distroless images by using bazel's rules_docker. Instead of it using current CI pipeline to add distroless image is low hanging fruit. Conversion to rules_docker might be performed later.

Risk Level: Medium
Testing: Please guide what testing best to perform
Docs Changes: Please guide if there are any best location to document it
Release Notes: N/A
Platform Specific Features: N/A