### PR TITLE
dns_cache: Remove getCacheManager()

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache.h
@@ -220,15 +220,6 @@ public:
 using DnsCacheManagerSharedPtr = std::shared_ptr<DnsCacheManager>;
 
 /**
- * Get the singleton cache manager for the entire server.
- */
-DnsCacheManagerSharedPtr getCacheManager(Singleton::Manager& manager,
-                                         Event::Dispatcher& main_thread_dispatcher,
-                                         ThreadLocal::SlotAllocator& tls,
-                                         Random::RandomGenerator& random, Runtime::Loader& loader,
-                                         Stats::Scope& root_scope);
-
-/**
  * Factory for getting a DNS cache manager.
  */
 class DnsCacheManagerFactory {

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.cc
@@ -33,16 +33,11 @@ DnsCacheSharedPtr DnsCacheManagerImpl::getCache(
   return new_cache;
 }
 
-DnsCacheManagerSharedPtr getCacheManager(Singleton::Manager& singleton_manager,
-                                         Event::Dispatcher& main_thread_dispatcher,
-                                         ThreadLocal::SlotAllocator& tls,
-                                         Random::RandomGenerator& random, Runtime::Loader& loader,
-                                         Stats::Scope& root_scope) {
-  return singleton_manager.getTyped<DnsCacheManager>(
-      SINGLETON_MANAGER_REGISTERED_NAME(dns_cache_manager),
-      [&main_thread_dispatcher, &tls, &random, &loader, &root_scope] {
-        return std::make_shared<DnsCacheManagerImpl>(main_thread_dispatcher, tls, random, loader,
-                                                     root_scope);
+DnsCacheManagerSharedPtr DnsCacheManagerFactoryImpl::get() {
+  return singleton_manager_.getTyped<DnsCacheManager>(
+      SINGLETON_MANAGER_REGISTERED_NAME(dns_cache_manager), [this] {
+        return std::make_shared<DnsCacheManagerImpl>(dispatcher_, tls_, random_, loader_,
+                                                     root_scope_);
       });
 }
 

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_manager_impl.h
@@ -49,9 +49,7 @@ public:
       : singleton_manager_(singleton_manager), dispatcher_(dispatcher), tls_(tls), random_(random),
         loader_(loader), root_scope_(root_scope) {}
 
-  DnsCacheManagerSharedPtr get() override {
-    return getCacheManager(singleton_manager_, dispatcher_, tls_, random_, loader_, root_scope_);
-  }
+  DnsCacheManagerSharedPtr get() override;
 
 private:
   Singleton::Manager& singleton_manager_;


### PR DESCRIPTION
dns_cache: Remove getCacheManager()
    
Remove the function getCacheManager() which was declared in dns_cache.h,
defined in dns_cache_manager_impl.cc and called in dns_cache_manager_impl.h.
Instead, simply inline this method into DnsCacheManagerFactoryImpl::get()
which was the only place it was called.

Risk Level: Low
Testing: N/A - no code behavior change
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A