### PR TITLE
quiche: remove unnecessary backtrace

### DIFF
--- a/source/common/quic/envoy_quic_proof_source_base.h
+++ b/source/common/quic/envoy_quic_proof_source_base.h
@@ -23,7 +23,6 @@
 
 #include "openssl/ssl.h"
 #include "envoy/network/filter.h"
-#include "server/backtrace.h"
 #include "common/common/logger.h"
 
 namespace Envoy {


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: remove dependency on server/backtrace.h which is added accidentally during debugging.
