### PR TITLE
tools: allow generate_go_protobuf.py to skip syncing with go-control-…

### DIFF
--- a/ci/go_mirror.sh
+++ b/ci/go_mirror.sh
@@ -8,5 +8,5 @@ MAIN_BRANCH="refs/heads/main"
 . "$(dirname "$0")"/setup_cache.sh
 
 if [[ "${AZP_BRANCH}" == "${MAIN_BRANCH}" ]]; then
-  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS}" tools/api/generate_go_protobuf.py
+  BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS}" tools/api/generate_go_protobuf.py --sync
 fi

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -122,16 +122,14 @@ def updated(repo):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generate Go protobuf files and sync with go-control-plane')
-    parser.add_argument('--skip_sync', action='store_true')
+    parser.add_argument('--sync', action='store_true')
     parser.add_argument('--output_base', default='build_go')
     args = parser.parse_args()
 
     workspace = check_output(['bazel', 'info', 'workspace']).decode().strip()
     output = os.path.join(workspace, args.output_base)
     generate_protobufs(output)
-    if args.skip_sync:
-        print('Skipping sync with go-control-plane')
-    else:
+    if args.sync:
         repo = os.path.join(workspace, REPO_BASE)
         clone_go_protobufs(repo)
         sync_go_protobufs(output, repo)
@@ -142,3 +140,5 @@ if __name__ == "__main__":
             new_sha = changes[0]
             write_revision_info(repo, new_sha)
             publish_go_protobufs(repo, new_sha)
+    else:
+        print('Skipping sync with go-control-plane')

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -122,7 +122,8 @@ def updated(repo):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Generate Go protobuf files and sync with go-control-plane')
+    parser = argparse.ArgumentParser(
+        description='Generate Go protobuf files and sync with go-control-plane')
     parser.add_argument('--sync', action='store_true')
     parser.add_argument('--output_base', default='build_go')
     args = parser.parse_args()


### PR DESCRIPTION
Commit Message:

  Currently, it also syncs them with go_control_plane, but it can be
  useful for local development work to be able to just generate the
  code
 

Additional Description:
Risk Level: Low
Testing: I've manually invoked the scripted and tested out the code.  The existing behavior is retained as the default.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:] n/a
[Optional Fixes #Issue] n/a
[Optional Deprecated:] n/a
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] n/a
