### PR TITLE
ext_proc: Support clearing the route cache

### DIFF
--- a/api/envoy/service/ext_proc/v3alpha/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3alpha/external_processor.proto
@@ -264,7 +264,6 @@ message CommonResponse {
   // along with the CONTINUE_AND_REPLACE status.
   config.core.v3.HeaderMap trailers = 4;
 
-  // [#not-implemented-hide:]
   // Clear the route cache for the current request.
   // This is necessary if the remote server
   // modified headers that are used to calculate the route.

--- a/generated_api_shadow/envoy/service/ext_proc/v3alpha/external_processor.proto
+++ b/generated_api_shadow/envoy/service/ext_proc/v3alpha/external_processor.proto
@@ -264,7 +264,6 @@ message CommonResponse {
   // along with the CONTINUE_AND_REPLACE status.
   config.core.v3.HeaderMap trailers = 4;
 
-  // [#not-implemented-hide:]
   // Clear the route cache for the current request.
   // This is necessary if the remote server
   // modified headers that are used to calculate the route.

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -25,6 +25,9 @@ bool ProcessorState::handleHeadersResponse(const HeadersResponse& response) {
   if (callback_state_ == CallbackState::HeadersCallback) {
     ENVOY_LOG(debug, "applying headers response");
     MutationUtils::applyCommonHeaderResponse(response, *headers_);
+    if (response.response().clear_route_cache()) {
+      filter_callbacks_->clearRouteCache();
+    }
     callback_state_ = CallbackState::Idle;
     clearWatermark();
     message_timer_->disableTimer();
@@ -66,6 +69,9 @@ bool ProcessorState::handleBodyResponse(const BodyResponse& response) {
     modifyBufferedData([this, &response](Buffer::Instance& data) {
       MutationUtils::applyCommonBodyResponse(response, headers_, data);
     });
+    if (response.response().clear_route_cache()) {
+      filter_callbacks_->clearRouteCache();
+    }
     headers_ = nullptr;
     callback_state_ = CallbackState::Idle;
     message_timer_->disableTimer();


### PR DESCRIPTION
Commit Message: Support the clear_route_cache parameter on responses
from the remote server

Risk Level: Low. Only enabled if the flag is set.

Testing: New unit test to ensure that the method is called.

Docs Changes: Marked "clear_route_cache" in the API as no longer
"not-implemented".

Release Notes: If the clear_route_cache flag is set on a
response from the external processing server, then the filter will
call the "clearRouteCache" method on the filter state. Processors
should set this flag if they have changed any headers, such as
":path", which may affect routing after the filter runs.

Signed-off-by: Gregory Brail <gregbrail@google.com>
