### PR TITLE
ci: Dont push distroless image yet

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -157,6 +157,9 @@ fi
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
+  if [[ "$BUILD_TYPE" == "distroless" ]]; then
+    continue
+  fi
   push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"
 
   # Only push latest on main builds.

--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -157,7 +157,7 @@ fi
 docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-  if [[ "$BUILD_TYPE" == "distroless" ]]; then
+  if [[ "$BUILD_TYPE" == "-distroless" ]]; then
     continue
   fi
   push_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Dont push distroless image yet
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
