### PR TITLE
win32 unnecessary logs

### DIFF
--- a/source/common/network/io_socket_error_impl.h
+++ b/source/common/network/io_socket_error_impl.h
@@ -9,7 +9,9 @@ namespace Network {
 
 class IoSocketError : public Api::IoError {
 public:
-  explicit IoSocketError(int sys_errno) : errno_(sys_errno) {}
+  explicit IoSocketError(int sys_errno) : errno_(sys_errno), error_code_(errorCodeFromErrno()) {}
+  explicit IoSocketError(int sys_errno, Api::IoError::IoErrorCode error_code)
+      : errno_(sys_errno), error_code_(error_code) {}
 
   ~IoSocketError() override = default;
 
@@ -31,6 +33,9 @@ public:
 
 private:
   int errno_;
+  Api::IoError::IoErrorCode error_code_;
+
+  Api::IoError::IoErrorCode errorCodeFromErrno() const;
 };
 
 } // namespace Network


### PR DESCRIPTION
Signed-off-by: davinci26 <sotirisnan@gmail.com>
Commit Message:

Cache the output of `IoSocketError::getErrorDetails` and in that way we don't log every time we use this function. 

Additional Description:

On Windows we use the `wouldBlock()` function which calls `getErrorCode()` internally. In case we get an error like remote host disconnect we log this entry 2 times for tcp and 3 times for udp/quic. This is both confusing and unessecary.

Risk Level: Low
Testing: Existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A