### PR TITLE
Cleanup: Remove setWatermarks(low,high).

### DIFF
--- a/source/common/buffer/watermark_buffer.cc
+++ b/source/common/buffer/watermark_buffer.cc
@@ -90,8 +90,7 @@ void WatermarkBuffer::appendSliceForTest(absl::string_view data) {
   appendSliceForTest(data.data(), data.size());
 }
 
-void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_watermark) {
-  ASSERT(low_watermark < high_watermark || (high_watermark == 0 && low_watermark == 0));
+void WatermarkBuffer::setWatermarks(uint32_t high_watermark) {
   uint32_t overflow_watermark_multiplier =
       Runtime::getInteger("envoy.buffer.overflow_multiplier", 0);
   if (overflow_watermark_multiplier > 0 &&
@@ -101,7 +100,7 @@ void WatermarkBuffer::setWatermarks(uint32_t low_watermark, uint32_t high_waterm
                           "high_watermark is overflowing. Disabling overflow watermark.");
     overflow_watermark_multiplier = 0;
   }
-  low_watermark_ = low_watermark;
+  low_watermark_ = high_watermark / 2;
   high_watermark_ = high_watermark;
   overflow_watermark_ = overflow_watermark_multiplier * high_watermark;
   checkHighAndOverflowWatermarks();

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -39,8 +39,7 @@ public:
   void appendSliceForTest(const void* data, uint64_t size) override;
   void appendSliceForTest(absl::string_view data) override;
 
-  void setWatermarks(uint32_t watermark) override { setWatermarks(watermark / 2, watermark); }
-  void setWatermarks(uint32_t low_watermark, uint32_t high_watermark);
+  void setWatermarks(uint32_t high_watermark) override;
   uint32_t highWatermark() const override { return high_watermark_; }
   // Returns true if the high watermark callbacks have been called more recently
   // than the low watermark callbacks.

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -136,7 +136,7 @@ ConnectionImpl::StreamImpl::StreamImpl(ConnectionImpl& parent, uint32_t buffer_l
       pending_send_buffer_high_watermark_called_(false), reset_due_to_messaging_error_(false) {
   parent_.stats_.streams_active_.inc();
   if (buffer_limit > 0) {
-    setWriteBufferWatermarks(buffer_limit / 2, buffer_limit);
+    setWriteBufferWatermarks(buffer_limit);
   }
 }
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -257,9 +257,9 @@ protected:
       }
     }
 
-    void setWriteBufferWatermarks(uint32_t low_watermark, uint32_t high_watermark) {
-      pending_recv_data_.setWatermarks(low_watermark, high_watermark);
-      pending_send_data_.setWatermarks(low_watermark, high_watermark);
+    void setWriteBufferWatermarks(uint32_t high_watermark) {
+      pending_recv_data_.setWatermarks(high_watermark);
+      pending_send_data_.setWatermarks(high_watermark);
     }
 
     // If the receive buffer encounters watermark callbacks, enable/disable reads on this stream.

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1419,7 +1419,7 @@ TEST_P(Http2CodecImplFlowControlTest, FlowControlPendingRecvData) {
   // the recv buffer can be overrun by a client which negotiates a larger
   // SETTINGS_MAX_FRAME_SIZE but there's no current easy way to tweak that in
   // envoy (without sending raw HTTP/2 frames) so we lower the buffer limit instead.
-  server_->getStream(1)->setWriteBufferWatermarks(10, 20);
+  server_->getStream(1)->setWriteBufferWatermarks(20);
 
   EXPECT_CALL(request_decoder_, decodeData(_, false));
   Buffer::OwnedImpl data(std::string(40, 'a'));

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -17,7 +17,7 @@ public:
   MOCK_METHOD(void, removeCallbacks, (StreamCallbacks & callbacks));
   MOCK_METHOD(void, resetStream, (StreamResetReason reason));
   MOCK_METHOD(void, readDisable, (bool disable));
-  MOCK_METHOD(void, setWriteBufferWatermarks, (uint32_t, uint32_t));
+  MOCK_METHOD(void, setWriteBufferWatermarks, (uint32_t));
   MOCK_METHOD(uint32_t, bufferLimit, ());
   MOCK_METHOD(const Network::Address::InstanceConstSharedPtr&, connectionLocalAddress, ());
   MOCK_METHOD(void, setFlushTimeout, (std::chrono::milliseconds timeout));


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: Remove setWatermarkers(low,high).
Additional Description: The driving motivation behind this is due to https://github.com/envoyproxy/envoy/pull/16218#discussion_r625456833.  `setWatermark(low,high)` is only used for low = high / 2 which the single arg version exposes.
Risk Level: low
Testing: Changed tests
Docs Changes: na
Release Notes: na
Platform Specific Features:
Related Issue #15791
