### PR TITLE
[1.18] backport of skywalking: fix string_view UB while span reporting (#16264)

### DIFF
--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -18,14 +18,14 @@ const Http::LowerCaseString& skywalkingPropagationHeaderKey() {
 
 void Span::setTag(absl::string_view name, absl::string_view value) {
   if (name == Tracing::Tags::get().HttpUrl) {
-    span_entity_->addTag(UrlTag.data(), value.data());
+    span_entity_->addTag(UrlTag.data(), std::string(value));
   } else if (name == Tracing::Tags::get().HttpStatusCode) {
-    span_entity_->addTag(StatusCodeTag.data(), value.data());
+    span_entity_->addTag(StatusCodeTag.data(), std::string(value));
   } else if (name == Tracing::Tags::get().Error) {
     span_entity_->setErrorStatus();
-    span_entity_->addTag(name.data(), value.data());
+    span_entity_->addTag(std::string(name), std::string(value));
   } else {
-    span_entity_->addTag(name.data(), value.data());
+    span_entity_->addTag(std::string(name), std::string(value));
   }
 }
 

--- a/test/extensions/tracers/skywalking/tracer_test.cc
+++ b/test/extensions/tracers/skywalking/tracer_test.cc
@@ -1,3 +1,5 @@
+#include "common/tracing/http_tracer_impl.h"
+
 #include "extensions/tracers/skywalking/tracer.h"
 
 #include "test/extensions/tracers/skywalking/skywalking_test_helper.h"
@@ -122,6 +124,11 @@ TEST_F(TracerTest, TracerTestCreateNewSpanWithNoPropagationHeaders) {
     EXPECT_EQ(1, span->spanEntity()->logs().size());
     EXPECT_LT(0, span->spanEntity()->logs().at(0).time());
     EXPECT_EQ("abc", span->spanEntity()->logs().at(0).data().at(0).value());
+
+    absl::string_view sample{"GETxx"};
+    sample.remove_suffix(2);
+    span->setTag(Tracing::Tags::get().HttpMethod, sample);
+    EXPECT_EQ("GET", span->spanEntity()->tags().at(5).second);
   }
 
   {


### PR DESCRIPTION
Backport of https://github.com/envoyproxy/envoy/pull/16264