### PR TITLE
stats: Add quic connection close error code histogram.

### DIFF
--- a/include/envoy/network/connection.h
+++ b/include/envoy/network/connection.h
@@ -96,6 +96,10 @@ public:
     Stats::Counter* bind_errors_;
     // Optional counter. Delayed close timeouts will not be tracked if this is nullptr.
     Stats::Counter* delayed_close_timeouts_;
+    // Optional histogram, used to track quic self-initiated connection close error if not nullptr.
+    Stats::Histogram* quic_connection_self_close_error_;
+    // Optional histogram, used to track quic peer-initiated connection close error if not nullptr.
+    Stats::Histogram* quic_connection_peer_close_error_;
   };
 
   ~Connection() override = default;

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -588,7 +588,9 @@ public:
   GAUGE(upstream_rq_pending_active, Accumulate)                                                    \
   GAUGE(version, NeverImport)                                                                      \
   HISTOGRAM(upstream_cx_connect_ms, Milliseconds)                                                  \
-  HISTOGRAM(upstream_cx_length_ms, Milliseconds)
+  HISTOGRAM(upstream_cx_length_ms, Milliseconds)                                                   \
+  HISTOGRAM(upstream_quic_self_connection_close_error, Unspecified)                                \
+  HISTOGRAM(upstream_quic_peer_connection_close_error, Unspecified)
 
 /**
  * All cluster load report stats. These are only use for EDS load reporting and not sent to the

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -75,7 +75,9 @@ namespace Http {
   GAUGE(downstream_cx_upgrades_active, Accumulate)                                                 \
   GAUGE(downstream_rq_active, Accumulate)                                                          \
   HISTOGRAM(downstream_cx_length_ms, Milliseconds)                                                 \
-  HISTOGRAM(downstream_rq_time, Milliseconds)
+  HISTOGRAM(downstream_rq_time, Milliseconds)                                                      \
+  HISTOGRAM(downstream_quic_self_connection_close_error, Unspecified)                              \
+  HISTOGRAM(downstream_quic_peer_connection_close_error, Unspecified)
 
 /**
  * Wrapper struct for connection manager stats. @see stats_macros.h

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -140,7 +140,9 @@ void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCal
   read_callbacks_->connection().setConnectionStats(
       {stats_.named_.downstream_cx_rx_bytes_total_, stats_.named_.downstream_cx_rx_bytes_buffered_,
        stats_.named_.downstream_cx_tx_bytes_total_, stats_.named_.downstream_cx_tx_bytes_buffered_,
-       nullptr, &stats_.named_.downstream_cx_delayed_close_timeout_});
+       nullptr, &stats_.named_.downstream_cx_delayed_close_timeout_,
+       &stats_.named_.downstream_quic_self_connection_close_error_,
+       &stats_.named_.downstream_quic_peer_connection_close_error_});
 }
 
 ConnectionManagerImpl::~ConnectionManagerImpl() {

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -118,7 +118,9 @@ public:
          parent_.host()->cluster().stats().upstream_cx_rx_bytes_buffered_,
          parent_.host()->cluster().stats().upstream_cx_tx_bytes_total_,
          parent_.host()->cluster().stats().upstream_cx_tx_bytes_buffered_,
-         &parent_.host()->cluster().stats().bind_errors_, nullptr});
+         &parent_.host()->cluster().stats().bind_errors_, nullptr,
+         &parent_.host()->cluster().stats().upstream_quic_self_connection_close_error_,
+         &parent_.host()->cluster().stats().upstream_quic_peer_connection_close_error_});
   }
 
   absl::optional<Http::Protocol> protocol() const override { return codec_client_->protocol(); }

--- a/source/common/quic/quic_filter_manager_connection_impl.cc
+++ b/source/common/quic/quic_filter_manager_connection_impl.cc
@@ -161,6 +161,16 @@ void QuicFilterManagerConnectionImpl::onConnectionCloseEvent(
     const quic::QuicConnectionCloseFrame& frame, quic::ConnectionCloseSource source) {
   transport_failure_reason_ = absl::StrCat(quic::QuicErrorCodeToString(frame.quic_error_code),
                                            " with details: ", frame.error_details);
+
+  if (source == quic::ConnectionCloseSource::FROM_PEER && connection_stats_ &&
+      connection_stats_->quic_connection_peer_close_error_) {
+    connection_stats_->quic_connection_peer_close_error_->recordValue(frame.quic_error_code);
+  }
+  if (source == quic::ConnectionCloseSource::FROM_SELF && connection_stats_ &&
+      connection_stats_->quic_connection_self_close_error_) {
+    connection_stats_->quic_connection_self_close_error_->recordValue(frame.quic_error_code);
+  }
+
   if (network_connection_ != nullptr) {
     // Tell network callbacks about connection close if not detached yet.
     raiseConnectionEvent(source == quic::ConnectionCloseSource::FROM_PEER

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -29,7 +29,8 @@ ActiveTcpClient::ActiveTcpClient(Envoy::ConnectionPool::ConnPoolImplBase& parent
                                    host->cluster().stats().upstream_cx_rx_bytes_buffered_,
                                    host->cluster().stats().upstream_cx_tx_bytes_total_,
                                    host->cluster().stats().upstream_cx_tx_bytes_buffered_,
-                                   &host->cluster().stats().bind_errors_, nullptr});
+                                   &host->cluster().stats().bind_errors_, nullptr, nullptr,
+                                   nullptr});
   connection_->noDelay(true);
   connection_->connect();
 }

--- a/source/common/tcp/original_conn_pool.cc
+++ b/source/common/tcp/original_conn_pool.cc
@@ -396,7 +396,8 @@ OriginalConnPoolImpl::ActiveConn::ActiveConn(OriginalConnPoolImpl& parent)
                              parent_.host_->cluster().stats().upstream_cx_rx_bytes_buffered_,
                              parent_.host_->cluster().stats().upstream_cx_tx_bytes_total_,
                              parent_.host_->cluster().stats().upstream_cx_tx_bytes_buffered_,
-                             &parent_.host_->cluster().stats().bind_errors_, nullptr});
+                             &parent_.host_->cluster().stats().bind_errors_, nullptr, nullptr,
+                             nullptr});
 
   // We just universally set no delay on connections. Theoretically we might at some point want
   // to make this configurable.

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -262,7 +262,7 @@ void Filter::initialize(Network::ReadFilterCallbacks& callbacks, bool set_connec
         {config_->stats().downstream_cx_rx_bytes_total_,
          config_->stats().downstream_cx_rx_bytes_buffered_,
          config_->stats().downstream_cx_tx_bytes_total_,
-         config_->stats().downstream_cx_tx_bytes_buffered_, nullptr, nullptr});
+         config_->stats().downstream_cx_tx_bytes_buffered_, nullptr, nullptr, nullptr, nullptr});
   }
 }
 

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -56,7 +56,7 @@ void ProxyFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& ca
                                                config_->stats_.downstream_cx_rx_bytes_buffered_,
                                                config_->stats_.downstream_cx_tx_bytes_total_,
                                                config_->stats_.downstream_cx_tx_bytes_buffered_,
-                                               nullptr, nullptr});
+                                               nullptr, nullptr, nullptr, nullptr});
 }
 
 void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {

--- a/source/extensions/stat_sinks/common/statsd/statsd.cc
+++ b/source/extensions/stat_sinks/common/statsd/statsd.cc
@@ -302,7 +302,8 @@ void TcpStatsdSink::TlsSink::write(Buffer::Instance& buffer) {
                                      parent_.cluster_info_->stats().upstream_cx_rx_bytes_buffered_,
                                      parent_.cluster_info_->stats().upstream_cx_tx_bytes_total_,
                                      parent_.cluster_info_->stats().upstream_cx_tx_bytes_buffered_,
-                                     &parent_.cluster_info_->stats().bind_errors_, nullptr});
+                                     &parent_.cluster_info_->stats().bind_errors_, nullptr, nullptr,
+                                     nullptr});
     connection_->connect();
   }
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -558,8 +558,8 @@ TEST_P(ConnectionImplTest, SocketOptionsFailureTest) {
 
 struct MockConnectionStats {
   Connection::ConnectionStats toBufferStats() {
-    return {rx_total_,   rx_current_,   tx_total_,
-            tx_current_, &bind_errors_, &delayed_close_timeouts_};
+    return {rx_total_, rx_current_, tx_total_, tx_current_, &bind_errors_, &delayed_close_timeouts_,
+            nullptr,   nullptr};
   }
 
   StrictMock<Stats::MockCounter> rx_total_;
@@ -572,8 +572,8 @@ struct MockConnectionStats {
 
 struct NiceMockConnectionStats {
   Connection::ConnectionStats toBufferStats() {
-    return {rx_total_,   rx_current_,   tx_total_,
-            tx_current_, &bind_errors_, &delayed_close_timeouts_};
+    return {rx_total_, rx_current_, tx_total_, tx_current_, &bind_errors_, &delayed_close_timeouts_,
+            nullptr,   nullptr};
   }
 
   NiceMock<Stats::MockCounter> rx_total_;

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -191,7 +191,8 @@ public:
           read_filter->callbacks_->connection().addConnectionCallbacks(
               network_connection_callbacks);
           read_filter->callbacks_->connection().setConnectionStats(
-              {read_total, read_current, write_total, write_current, nullptr, nullptr});
+              {read_total, read_current, write_total, write_current, nullptr, nullptr, nullptr,
+               nullptr});
         }});
     EXPECT_CALL(listener_config_, filterChainManager()).WillOnce(ReturnRef(filter_chain_manager));
     EXPECT_CALL(filter_chain_manager, findFilterChain(_))
@@ -279,7 +280,8 @@ TEST_P(EnvoyQuicDispatcherTest, CloseConnectionDuringFilterInstallation) {
         filter_manager.addReadFilter(read_filter);
         read_filter->callbacks_->connection().addConnectionCallbacks(network_connection_callbacks);
         read_filter->callbacks_->connection().setConnectionStats(
-            {read_total, read_current, write_total, write_current, nullptr, nullptr});
+            {read_total, read_current, write_total, write_current, nullptr, nullptr, nullptr,
+             nullptr});
         // This will not close connection right away, but after it processes the first packet.
         read_filter->callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
       }});

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -198,8 +198,9 @@ public:
     EXPECT_EQ(envoy_quic_session_.id(), read_filter_->callbacks_->connection().id());
     EXPECT_EQ(&envoy_quic_session_, &read_filter_->callbacks_->connection());
     read_filter_->callbacks_->connection().addConnectionCallbacks(network_connection_callbacks_);
-    read_filter_->callbacks_->connection().setConnectionStats(
-        {read_total_, read_current_, write_total_, write_current_, nullptr, nullptr});
+    read_filter_->callbacks_->connection().setConnectionStats({read_total_, read_current_,
+                                                               write_total_, write_current_,
+                                                               nullptr, nullptr, nullptr, nullptr});
     EXPECT_EQ(&read_total_, &quic_connection_->connectionStats().read_total_);
     EXPECT_CALL(*read_filter_, onNewConnection()).WillOnce(Invoke([this]() {
       // Create ServerConnection instance and setup callbacks for it.

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -268,6 +268,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSize) {
   // 2020/08/11  12202    37061       38500   router: add new retry back-off strategy
   // 2020/09/11  12973                38993   upstream: predictive preconnect
   // 2020/10/02  13251                39326   switch to google tcmalloc
+  // 2021/05/05  16346    45710       45800   add quic connection close histogram
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -288,7 +289,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSize) {
     // https://github.com/envoyproxy/envoy/issues/12209
     // EXPECT_MEMORY_EQ(m_per_cluster, 37061);
   }
-  EXPECT_MEMORY_LE(m_per_cluster, 40000); // Round up to allow platform variations.
+  EXPECT_MEMORY_LE(m_per_cluster, 45800); // Round up to allow platform variations.
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@google.com>

Commit Message: Add connection close error code histograms for quic. This is the one of the most important metrics for quic experimentations.
Additional Description:
Risk Level: low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a
Fixes #10102 
