### PR TITLE
Remove various Win32 #ifdefs

### DIFF
--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -46,6 +46,7 @@ private:
   friend class FileSystemImplTest;
 };
 
-InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplPosix>(); }
+using FileImpl = FileImplPosix;
+using InstanceImpl = InstanceImplPosix;
 } // namespace Filesystem
 } // namespace Envoy

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -46,5 +46,6 @@ private:
   friend class FileSystemImplTest;
 };
 
+static InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplPosix>(); }
 } // namespace Filesystem
 } // namespace Envoy

--- a/source/common/filesystem/posix/filesystem_impl.h
+++ b/source/common/filesystem/posix/filesystem_impl.h
@@ -46,6 +46,6 @@ private:
   friend class FileSystemImplTest;
 };
 
-static InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplPosix>(); }
+InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplPosix>(); }
 } // namespace Filesystem
 } // namespace Envoy

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -85,5 +85,6 @@ public:
   bool illegalPath(const std::string& path) override;
 };
 
+static InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplWin32>(); }
 } // namespace Filesystem
 } // namespace Envoy

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -85,6 +85,6 @@ public:
   bool illegalPath(const std::string& path) override;
 };
 
-static InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplWin32>(); }
+InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplWin32>(); }
 } // namespace Filesystem
 } // namespace Envoy

--- a/source/common/filesystem/win32/filesystem_impl.h
+++ b/source/common/filesystem/win32/filesystem_impl.h
@@ -85,6 +85,8 @@ public:
   bool illegalPath(const std::string& path) override;
 };
 
-InstancePtr makeFilesystemInstance() { return std::make_unique<InstanceImplWin32>(); }
+using FileImpl = FileImplWin32;
+using InstanceImpl = InstanceImplWin32;
+
 } // namespace Filesystem
 } // namespace Envoy

--- a/source/common/quic/platform/quic_file_utils_impl.cc
+++ b/source/common/quic/platform/quic_file_utils_impl.cc
@@ -46,8 +46,8 @@ std::vector<std::string> ReadFileContentsImpl(const std::string& dirname) {
 // Reads the contents of |filename| as a string into |contents|.
 // NOLINTNEXTLINE(readability-identifier-naming)
 void ReadFileContentsImpl(absl::string_view filename, std::string* contents) {
-  auto fs = Envoy::Filesystem::makeFilesystemInstance();
-  *contents = fs->fileReadToEnd(std::string(filename.data(), filename.size()));
+  Envoy::Filesystem::InstanceImpl fs;
+  *contents = fs.fileReadToEnd(std::string(filename.data(), filename.size()));
 }
 
 } // namespace quic

--- a/source/common/quic/platform/quic_file_utils_impl.cc
+++ b/source/common/quic/platform/quic_file_utils_impl.cc
@@ -46,12 +46,8 @@ std::vector<std::string> ReadFileContentsImpl(const std::string& dirname) {
 // Reads the contents of |filename| as a string into |contents|.
 // NOLINTNEXTLINE(readability-identifier-naming)
 void ReadFileContentsImpl(absl::string_view filename, std::string* contents) {
-#ifdef WIN32
-  Envoy::Filesystem::InstanceImplWin32 fs;
-#else
-  Envoy::Filesystem::InstanceImplPosix fs;
-#endif
-  *contents = fs.fileReadToEnd(std::string(filename.data(), filename.size()));
+  auto fs = Envoy::Filesystem::makeFilesystemInstance();
+  *contents = fs->fileReadToEnd(std::string(filename.data(), filename.size()));
 }
 
 } // namespace quic

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -4,6 +4,8 @@
 #include "common/common/json_escape_string.h"
 #include "common/common/logger.h"
 
+#include "test/test_common/environment.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -110,11 +112,8 @@ public:
 
     testing::internal::CaptureStderr();
     logger_->log(spdlog::details::log_msg("test", spdlog::level::info, message));
-#ifdef WIN32
-    EXPECT_EQ(expected + "\r\n", testing::internal::GetCapturedStderr());
-#else
-    EXPECT_EQ(expected + "\n", testing::internal::GetCapturedStderr());
-#endif
+    EXPECT_EQ(absl::StrCat(expected, TestEnvironment::newLine),
+              testing::internal::GetCapturedStderr());
   }
 
 protected:

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1356,13 +1356,6 @@ public:
     while (timer.enabled()) {
       time_system.advanceTimeAndRun(std::chrono::microseconds(1), dispatcher,
                                     Dispatcher::RunType::NonBlock);
-#ifdef WIN32
-      // The event loop runs for a single iteration in NonBlock mode on Windows. A few iterations
-      // are required to ensure that next iteration callbacks have a chance to run before time
-      // advances once again.
-      dispatcher.run(Dispatcher::RunType::NonBlock);
-      dispatcher.run(Dispatcher::RunType::NonBlock);
-#endif
     }
     return time_system.monotonicTime() - start;
   }

--- a/test/common/filesystem/filesystem_impl_test.cc
+++ b/test/common/filesystem/filesystem_impl_test.cc
@@ -21,22 +21,16 @@ static constexpr FlagSet DefaultFlags{
 class FileSystemImplTest : public testing::Test {
 protected:
   filesystem_os_id_t getFd(File* file) {
-#ifdef WIN32
-    auto file_impl = dynamic_cast<FileImplWin32*>(file);
-#else
-    auto file_impl = dynamic_cast<FileImplPosix*>(file);
-#endif
+    auto file_impl = dynamic_cast<FileImpl*>(file);
     RELEASE_ASSERT(file_impl != nullptr, "failed to cast File* to FileImpl*");
     return file_impl->fd_;
   }
-#ifdef WIN32
-  InstanceImplWin32 file_system_;
-#else
+#ifndef WIN32
   Api::SysCallStringResult canonicalPath(const std::string& path) {
     return file_system_.canonicalPath(path);
   }
-  InstanceImplPosix file_system_;
 #endif
+  InstanceImpl file_system_;
 };
 
 TEST_F(FileSystemImplTest, FileExists) {

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -11,15 +11,9 @@ namespace Envoy {
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
-
-#ifdef WIN32
-  Filesystem::InstanceImplWin32 file_system;
-#else
-  Filesystem::InstanceImplPosix file_system;
-#endif
-
+  auto file_system = Envoy::Filesystem::makeFilesystemInstance();
   const auto config_file_count = std::stoi(
-      file_system.fileReadToEnd(TestEnvironment::temporaryDirectory() + "/config-file-count.txt"));
+      file_system->fileReadToEnd(TestEnvironment::temporaryDirectory() + "/config-file-count.txt"));
 
   // Change working directory, otherwise we won't be able to read files using relative paths.
 #ifdef PATH_MAX

--- a/test/config_test/example_configs_test.cc
+++ b/test/config_test/example_configs_test.cc
@@ -11,9 +11,9 @@ namespace Envoy {
 TEST(ExampleConfigsTest, All) {
   TestEnvironment::exec(
       {TestEnvironment::runfilesPath("test/config_test/example_configs_test_setup.sh")});
-  auto file_system = Envoy::Filesystem::makeFilesystemInstance();
+  Filesystem::InstanceImpl file_system;
   const auto config_file_count = std::stoi(
-      file_system->fileReadToEnd(TestEnvironment::temporaryDirectory() + "/config-file-count.txt"));
+      file_system.fileReadToEnd(TestEnvironment::temporaryDirectory() + "/config-file-count.txt"));
 
   // Change working directory, otherwise we won't be able to read files using relative paths.
 #ifdef PATH_MAX

--- a/test/test_common/file_system_for_test.cc
+++ b/test/test_common/file_system_for_test.cc
@@ -7,7 +7,7 @@ namespace Envoy {
 namespace Filesystem {
 
 MemfileInstanceImpl::MemfileInstanceImpl()
-    : file_system_{std::move(Envoy::Filesystem::makeFilesystemInstance())}, use_memfiles_(false) {}
+    : file_system_{new InstanceImpl()}, use_memfiles_(false) {}
 
 MemfileInstanceImpl& fileSystemForTest() {
   static MemfileInstanceImpl* file_system = new MemfileInstanceImpl();

--- a/test/test_common/file_system_for_test.cc
+++ b/test/test_common/file_system_for_test.cc
@@ -7,13 +7,7 @@ namespace Envoy {
 namespace Filesystem {
 
 MemfileInstanceImpl::MemfileInstanceImpl()
-#ifdef WIN32
-    : file_system_{new InstanceImplWin32()},
-#else
-    : file_system_{new InstanceImplPosix()},
-#endif
-      use_memfiles_(false) {
-}
+    : file_system_{std::move(Envoy::Filesystem::makeFilesystemInstance())}, use_memfiles_(false) {}
 
 MemfileInstanceImpl& fileSystemForTest() {
   static MemfileInstanceImpl* file_system = new MemfileInstanceImpl();


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
Commit Message:

Remove various `#ifdef WIN32` to reduce some tech debt from the port effort.

Additional Description:
Risk Level: Low
Testing: Existing tests (No-op change)
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
