### PR TITLE
docs: record distroless images

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,11 +82,15 @@ extlinks = {
 
 # Setup global substitutions
 if 'pre-release' in release_level:
-    substitutions = [('|envoy_docker_image|', 'envoy-dev:{}'.format(blob_sha)),
-                     ('|envoy_windows_docker_image|', 'envoy-windows-dev:{}'.format(blob_sha))]
+    substitutions = [
+        ('|envoy_docker_image|', 'envoy-dev:{}'.format(blob_sha)),
+        ('|envoy_windows_docker_image|', 'envoy-windows-dev:{}'.format(blob_sha)),
+        ('|envoy_distroless_docker_image|', 'envoy-distroless-dev:{}'.format(blob_sha))
+    ]
 else:
     substitutions = [('|envoy_docker_image|', 'envoy:{}'.format(blob_sha)),
-                     ('|envoy_windows_docker_image|', 'envoy-windows:{}'.format(blob_sha))]
+                     ('|envoy_windows_docker_image|', 'envoy-windows:{}'.format(blob_sha)),
+                     ('|envoy_distroless_docker_image|', 'envoy-distroless:{}'.format(blob_sha))]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -208,6 +208,18 @@ The following table shows the available Docker images
      - |DOCKER_IMAGE_TAG_NAME|
      -
      -
+   * - `envoyproxy/envoy-distroless <https://hub.docker.com/r/envoyproxy/envoy-distroless/tags/>`_
+     - Release binary with symbols stripped on top of a distroless Debain base.
+     -
+     -
+     - See Docker Hub
+     - See Docker Hub
+   * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
+     - Release binary with symbols stripped on top of a distroless Debain base.
+     -
+     -
+     - See Docker Hub
+     - See Docker Hub
    * - `envoyproxy/envoy-alpine <https://hub.docker.com/r/envoyproxy/envoy-alpine/tags/>`_
      - Release binary with symbols stripped on top of a **glibc** alpine base.
      - |DOCKER_IMAGE_TAG_NAME|
@@ -252,18 +264,6 @@ The following table shows the available Docker images
      -
    * - `envoyproxy/envoy-build-ubuntu <https://hub.docker.com/r/envoyproxy/envoy-build-ubuntu/tags/>`_
      - Build image which includes tools for building multi-arch Envoy and containers.
-     -
-     -
-     - See Docker Hub
-     - See Docker Hub
-   * - `envoyproxy/envoy-distroless <https://hub.docker.com/r/envoyproxy/envoy-distroless/tags/>`_
-     - Build image on top of distroless images.
-     -
-     -
-     - See Docker Hub
-     - See Docker Hub
-   * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
-     - Build image on top of distroless images.
      -
      -
      - See Docker Hub

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -159,6 +159,13 @@ The following commands will pull and show the Envoy version of current images.
          $ docker pull envoyproxy/|envoy_docker_image|
          $ docker run --rm envoyproxy/|envoy_docker_image| --version
 
+   .. tab:: Envoy (distroless)
+
+      .. substitution-code-block:: console
+
+         $ docker pull envoyproxy/|envoy_distroless_docker_image|
+         $ docker run --rm envoyproxy/|envoy_distroless_docker_image| --version
+
    .. tab:: Get Envoy
 
       .. code-block:: console
@@ -245,6 +252,18 @@ The following table shows the available Docker images
      -
    * - `envoyproxy/envoy-build-ubuntu <https://hub.docker.com/r/envoyproxy/envoy-build-ubuntu/tags/>`_
      - Build image which includes tools for building multi-arch Envoy and containers.
+     -
+     -
+     - See Docker Hub
+     - See Docker Hub
+   * - `envoyproxy/envoy-distroless <https://hub.docker.com/r/envoyproxy/envoy-distroless/tags/>`_
+     - Build image on top of distroless images.
+     -
+     -
+     - See Docker Hub
+     - See Docker Hub
+   * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
+     - Build image on top of distroless images.
      -
      -
      - See Docker Hub

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -210,10 +210,10 @@ The following table shows the available Docker images
      -
    * - `envoyproxy/envoy-distroless <https://hub.docker.com/r/envoyproxy/envoy-distroless/tags/>`_
      - Release binary with symbols stripped on top of a distroless base.
+     - |DOCKER_IMAGE_TAG_NAME|
      -
      -
-     - See Docker Hub
-     - See Docker Hub
+     -
    * - `envoyproxy/envoy-alpine <https://hub.docker.com/r/envoyproxy/envoy-alpine/tags/>`_
      - Release binary with symbols stripped on top of a **glibc** alpine base.
      - |DOCKER_IMAGE_TAG_NAME|
@@ -242,8 +242,8 @@ The following table shows the available Docker images
      - Release binary with symbols stripped on top of a distroless base.
      -
      -
-     - See Docker Hub
-     - See Docker Hub
+     - latest
+     -
    * - `envoyproxy/envoy-alpine-dev <https://hub.docker.com/r/envoyproxy/envoy-alpine-dev/tags/>`_
      - Release binary with symbols stripped on top of a **glibc** alpine base.
      -

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -209,13 +209,7 @@ The following table shows the available Docker images
      -
      -
    * - `envoyproxy/envoy-distroless <https://hub.docker.com/r/envoyproxy/envoy-distroless/tags/>`_
-     - Release binary with symbols stripped on top of a distroless Debain base.
-     -
-     -
-     - See Docker Hub
-     - See Docker Hub
-   * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
-     - Release binary with symbols stripped on top of a distroless Debain base.
+     - Release binary with symbols stripped on top of a distroless base.
      -
      -
      - See Docker Hub
@@ -244,6 +238,12 @@ The following table shows the available Docker images
      -
      - latest
      - latest
+   * - `envoyproxy/envoy-distroless-dev <https://hub.docker.com/r/envoyproxy/envoy-distroless-dev/tags/>`_
+     - Release binary with symbols stripped on top of a distroless base.
+     -
+     -
+     - See Docker Hub
+     - See Docker Hub
    * - `envoyproxy/envoy-alpine-dev <https://hub.docker.com/r/envoyproxy/envoy-alpine-dev/tags/>`_
      - Release binary with symbols stripped on top of a **glibc** alpine base.
      -


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

Commit Message:

Document addition of distroless Docker image:

- add to table of available docker images
- add in getting started > install > docker (in a separate tab - Envoy (distroless))

Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Partial fix for #16282
