### PR TITLE
Use /c/build/ as HOME consistent with envoy linux docker env

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -27,7 +27,7 @@ if is_windows; then
   BUILD_DIR_MOUNT_DEST=C:/build
   SOURCE_DIR=$(echo "${PWD}" | sed -E "s#^/([a-zA-Z])/#\1:/#")
   SOURCE_DIR_MOUNT_DEST=C:/source
-  START_COMMAND=("bash" "-c" "cd source && $*")
+  START_COMMAND=("bash" "-c" "cd /c/source && export HOME=/c/build && $*")
 else
   [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME="envoyproxy/envoy-build-ubuntu"
   # We run as root and later drop permissions. This is required to setup the USER


### PR DESCRIPTION
Commit Message: Use /c/build/ as HOME consistent with envoy linux docker environment

Additional Description:

This will persist changes and notes made in `$HOME`, e.g. `/c/build/, between docker 
invocations and allow developers to manage desired constants such as .bazelrc,
as is currently true of the linux docker environment.

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>

Risk Level: low
Testing: local and PR's CI pass
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
