### PR TITLE
server: avoid flushing while a flush is in progress

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -89,7 +89,7 @@ InstanceImpl::InstanceImpl(
                                                   : nullptr),
       grpc_context_(store.symbolTable()), http_context_(store.symbolTable()),
       router_context_(store.symbolTable()), process_context_(std::move(process_context)),
-      hooks_(hooks), server_contexts_(*this) {
+      hooks_(hooks), server_contexts_(*this), stats_flush_in_progress_(false) {
   TRY_ASSERT_MAIN_THREAD {
     if (!options.logPath().empty()) {
       TRY_ASSERT_MAIN_THREAD {
@@ -206,6 +206,12 @@ void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, S
 }
 
 void InstanceImpl::flushStats() {
+  if (stats_flush_in_progress_) {
+    ENVOY_LOG(debug, "skipping stats flush as flush is already in progress");
+    return;
+  }
+
+  stats_flush_in_progress_ = true;
   ENVOY_LOG(debug, "flushing stats");
   // If Envoy is not fully initialized, workers will not be started and mergeHistograms
   // completion callback is not called immediately. As a result of this server stats will
@@ -256,6 +262,8 @@ void InstanceImpl::flushStatsInternal() {
   if (stat_flush_timer_ != nullptr) {
     stat_flush_timer_->enableTimer(stats_config.flushInterval());
   }
+
+  stats_flush_in_progress_ = false;
 }
 
 bool InstanceImpl::healthCheckFailed() { return !live_.load(); }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -208,6 +208,7 @@ void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, S
 void InstanceImpl::flushStats() {
   if (stats_flush_in_progress_) {
     ENVOY_LOG(debug, "skipping stats flush as flush is already in progress");
+    server_stats_->dropped_stat_flushes_.inc();
     return;
   }
 

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -385,6 +385,8 @@ private:
 
   ServerFactoryContextImpl server_contexts_;
 
+  bool stats_flush_in_progress_ : 1;
+
   template <class T>
   class LifecycleCallbackHandle : public ServerLifecycleNotifier::Handle, RaiiListElement<T> {
   public:

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -71,6 +71,7 @@ struct ServerCompilationSettingsStats {
   COUNTER(envoy_bug_failures)                                                                      \
   COUNTER(dynamic_unknown_fields)                                                                  \
   COUNTER(static_unknown_fields)                                                                   \
+  COUNTER(dropped_stat_flushes)                                                                    \
   GAUGE(concurrency, NeverImport)                                                                  \
   GAUGE(days_until_first_cert_expiring, Accumulate)                                                \
   GAUGE(seconds_until_first_ocsp_response_expiring, Accumulate)                                    \

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -375,11 +375,13 @@ public:
   void shutdownThreading() override {}
   void mergeHistograms(PostMergeCb cb) override { merge_cb_ = cb; }
 
-  PostMergeCb merge_cb_;
-
+  void runMergeCallback() {
+    merge_cb_();
+  }
 private:
   mutable Thread::MutexBasicLockable lock_;
   IsolatedStoreImpl store_;
+  PostMergeCb merge_cb_;
 };
 
 } // namespace Stats

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -375,9 +375,8 @@ public:
   void shutdownThreading() override {}
   void mergeHistograms(PostMergeCb cb) override { merge_cb_ = cb; }
 
-  void runMergeCallback() {
-    merge_cb_();
-  }
+  void runMergeCallback() { merge_cb_(); }
+
 private:
   mutable Thread::MutexBasicLockable lock_;
   IsolatedStoreImpl store_;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -373,7 +373,9 @@ public:
   void setHistogramSettings(HistogramSettingsConstPtr&&) override {}
   void initializeThreading(Event::Dispatcher&, ThreadLocal::Instance&) override {}
   void shutdownThreading() override {}
-  void mergeHistograms(PostMergeCb) override {}
+  void mergeHistograms(PostMergeCb cb) override { merge_cb_ = cb; }
+
+  PostMergeCb merge_cb_;
 
 private:
   mutable Thread::MutexBasicLockable lock_;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -744,7 +744,7 @@ TEST_P(ServerInstanceImplTest, ConcurrentFlushes) {
   EXPECT_TRUE(
       TestUtility::waitForCounterEq(stats_store_, "server.dropped_stat_flushes", 2, time_system_));
 
-  server_->dispatcher().post([&] { stats_store_.merge_cb_(); });
+  server_->dispatcher().post([&] { stats_store_.runMergeCallback(); });
 
   EXPECT_TRUE(TestUtility::waitForCounterEq(stats_store_, "stats.flushed", 1, time_system_));
 
@@ -752,7 +752,7 @@ TEST_P(ServerInstanceImplTest, ConcurrentFlushes) {
   // be recorded.
   server_->dispatcher().post([&] { server_->flushStats(); });
 
-  server_->dispatcher().post([&] { stats_store_.merge_cb_(); });
+  server_->dispatcher().post([&] { stats_store_.runMergeCallback(); });
 
   EXPECT_TRUE(TestUtility::waitForCounterEq(stats_store_, "stats.flushed", 2, time_system_));
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -748,11 +748,9 @@ TEST_P(ServerInstanceImplTest, ConcurrentFlushes) {
 
   EXPECT_TRUE(TestUtility::waitForCounterEq(stats_store_, "stats.flushed", 1, time_system_));
 
-  // Trigger another flush after the first one finished. This should go through an no drops should be
-  // recorded.
-  server_->dispatcher().post([&] {
-    server_->flushStats();
-  });
+  // Trigger another flush after the first one finished. This should go through an no drops should
+  // be recorded.
+  server_->dispatcher().post([&] { server_->flushStats(); });
 
   server_->dispatcher().post([&] { stats_store_.merge_cb_(); });
 


### PR DESCRIPTION
In order to support calls to `Server::Instance::flushStats` (let's call this an "external flush") while also having a flush timer activated we need to handle an external flush being requested while in the process of doing a periodic flush. As it stands,
this currently runs the risk of triggering an ASSERT due to the histogram merging being async. See https://github.com/envoyproxy/envoy-mobile/issues/748 for an example of this happening.

This PR proposes a simple solution where we simply ignore calls to flushStats when we're still in the process of merging
histograms. 

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: UTs
Docs Changes: n/a
Release Notes: n/a

