### PR TITLE
test: add nofips tag to //test/integration/filters:pause_filter_for_quic_lib

### DIFF
--- a/test/integration/filters/BUILD
+++ b/test/integration/filters/BUILD
@@ -220,6 +220,7 @@ envoy_cc_test_library(
     srcs = [
         "pause_filter_for_quic.cc",
     ],
+    tags = ["nofips"],
     deps = [
         "//include/envoy/http:filter_interface",
         "//include/envoy/registry",


### PR DESCRIPTION
Commit Message: test: add nofips tag to //test/integration/filters:pause_filter_for_quic_lib

this test will not currently run with FIPS boringssl- this change marks this as such for exclusion.
Additional Description: this test is currently included in the default CI set, fails with fips boringssl, and isn't excluded even when using the suggested `--build_tag_filters=-nofips --test_tag_filters=-nofips --@envoy//bazel:http3=False` command line options. this correctly excludes it with the above flags.
Risk Level: Low
Testing: integration testing on ubuntu and centos.
Docs Changes: none
Release Notes: none
Platform Specific Features: none
