### PR TITLE
docker: Use entrypoint for distroless image

### DIFF
--- a/ci/Dockerfile-envoy-distroless
+++ b/ci/Dockerfile-envoy-distroless
@@ -7,4 +7,4 @@ ADD linux/amd64/build_release${ENVOY_BINARY_SUFFIX}/* /usr/local/bin/
 
 EXPOSE 10000
 
-CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
+ENTRYPOINT ["envoy", "-c", "/etc/envoy/envoy.yaml"]

--- a/ci/Dockerfile-envoy-distroless
+++ b/ci/Dockerfile-envoy-distroless
@@ -7,4 +7,5 @@ ADD linux/amd64/build_release${ENVOY_BINARY_SUFFIX}/* /usr/local/bin/
 
 EXPOSE 10000
 
-ENTRYPOINT ["envoy", "-c", "/etc/envoy/envoy.yaml"]
+ENTRYPOINT ["envoy"]
+CMD ["-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docker: Use entrypoint for distroless image
Additional Description:

Use an `entrypoint` rather than `cmd` for starting distroless container. Allows custom args to be passed through.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
