### PR TITLE
lightstep: rtrim data source

### DIFF
--- a/source/extensions/tracers/lightstep/config.cc
+++ b/source/extensions/tracers/lightstep/config.cc
@@ -24,8 +24,10 @@ Tracing::HttpTracerSharedPtr LightstepTracerFactory::createHttpTracerTyped(
     Server::Configuration::TracerFactoryContext& context) {
   auto opts = std::make_unique<lightstep::LightStepTracerOptions>();
   if (proto_config.has_access_token()) {
-    opts->access_token = Config::DataSource::read(proto_config.access_token(), true,
-                                                  context.serverFactoryContext().api());
+    const auto access_token_file = Config::DataSource::read(proto_config.access_token(), true,
+                                                            context.serverFactoryContext().api());
+    const auto access_token_sv = StringUtil::rtrim(access_token_file);
+    opts->access_token.assign(access_token_sv.data(), access_token_sv.size());
   } else {
     const auto access_token_file = context.serverFactoryContext().api().fileSystem().fileReadToEnd(
         proto_config.access_token_file());


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: rtrim data source to match the old behavior with the deprecated option (as reported by @moderation)
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
