### PR TITLE
Update rules_apple

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -39,10 +39,10 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         project_name = "Apple Rules for Bazel",
         project_desc = "Bazel rules for Apple platforms",
         project_url = "https://github.com/bazelbuild/rules_apple",
-        version = "0.19.0",
-        sha256 = "7a7afdd4869bb201c9352eed2daf37294d42b093579b70423490c1b4d4f6ce42",
+        version = "0.31.2",
+        sha256 = "c84962b64d9ae4472adfb01ec2cf1aa73cb2ee8308242add55fa7cc38602d882",
         urls = ["https://github.com/bazelbuild/rules_apple/releases/download/{version}/rules_apple.{version}.tar.gz"],
-        release_date = "2019-10-10",
+        release_date = "2021-05-04",
         use_category = ["build"],
     ),
     rules_fuzzing = dict(


### PR DESCRIPTION
Commit Message: build: update rules_apple to the latest version
Additional Description: The current version of rules_apple is not compatible with future versions of Bazel and will cause breakages
Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A