### PR TITLE
Document that python3-pip is a build dependency.

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -54,22 +54,33 @@ for how to update or override dependencies.
     On Ubuntu, run the following:
     ```console
     sudo apt-get install \
-       libtool \
-       cmake \
-       automake \
        autoconf \
+       automake \
+       cmake \
+       curl \
+       libtool \
        make \
        ninja-build \
-       curl \
+       patch \
+       python3-pip \
        unzip \
-       virtualenv \
-       patch
+       virtualenv
     ```
 
     ### Fedora
     On Fedora (maybe also other red hat distros), run the following:
     ```console
-    dnf install cmake libtool libstdc++ libstdc++-static libatomic ninja-build lld patch aspell-en
+    dnf install \
+        aspell-en \
+        cmake \
+        libatomic \
+        libstdc++ \
+        libstdc++-static \
+        libtool \
+        lld \
+        ninja-build \
+        patch \
+        python3-pip
     ```
 
     ### Linux


### PR DESCRIPTION
Commit Message:

The python3-pip package is needed on both Ubuntu and Fedora.

Additional Description:
Risk Level: Low
Testing: None
Docs Changes: Y
Release Notes: N
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
