### PR TITLE
stats: capture '.' character in grpc_bridge_service stat tag

### DIFF
--- a/source/common/config/well_known_names.cc
+++ b/source/common/config/well_known_names.cc
@@ -76,8 +76,8 @@ TagNameValues::TagNameValues() {
   // mongo.[<stat_prefix>.]cmd.(<cmd>.)*
   addTokenized(MONGO_CMD, "mongo.*.cmd.$.**");
 
-  // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.](<grpc_method>.)*
-  addTokenized(GRPC_BRIDGE_METHOD, "cluster.*.grpc.*.$.**");
+  // cluster.[<route_target_cluster>.]grpc.[<grpc_service>.].(<grpc_method_name>.)[<stat_name>]
+  addRe2(GRPC_BRIDGE_METHOD, R"(^cluster\..*?\.grpc\..*\.((.*)\.))");
 
   // http.[<stat_prefix>.]user_agent.(<user_agent>.)*
   addTokenized(HTTP_USER_AGENT, "http.*.user_agent.$.**");
@@ -94,8 +94,9 @@ TagNameValues::TagNameValues() {
   // cluster.[<cluster_name>.]ssl.ciphers.(<cipher>)
   addRe2(SSL_CIPHER_SUITE, R"(^cluster\.<NAME>\.ssl\.ciphers(\.(<CIPHER>))$)", ".ssl.ciphers.");
 
-  // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.)*
-  addTokenized(GRPC_BRIDGE_SERVICE, "cluster.*.grpc.$.**");
+  // cluster.[<route_target_cluster>.]grpc.(<grpc_service>.).[<grpc_method_name>].[<stat_name>]
+  // Trailing '\..*\.' matches the method name and metric name (if present)
+  addRe2(GRPC_BRIDGE_SERVICE, R"(^cluster\..*?\.grpc\.((.*)\.).*\.)");
 
   // tcp.(<stat_prefix>.)*
   addTokenized(TCP_PREFIX, "tcp.$.**");

--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -273,14 +273,15 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
 
   Tag grpc_service;
   grpc_service.name_ = tag_names.GRPC_BRIDGE_SERVICE;
-  grpc_service.value_ = "grpc_service_1";
+  grpc_service.value_ = "fully.qualified.grpc_service_1";
 
   Tag grpc_method;
   grpc_method.name_ = tag_names.GRPC_BRIDGE_METHOD;
   grpc_method.value_ = "grpc_method_1";
 
-  regex_tester.testRegex("cluster.grpc_cluster.grpc.grpc_service_1.grpc_method_1.success",
-                         "cluster.grpc.success", {grpc_cluster, grpc_method, grpc_service});
+  regex_tester.testRegex(
+      "cluster.grpc_cluster.grpc.fully.qualified.grpc_service_1.grpc_method_1.success",
+      "cluster.grpc.success", {grpc_cluster, grpc_method, grpc_service});
 
   // Virtual host and cluster
   Tag vhost;


### PR DESCRIPTION
Commit Message: Captures '.' characters in gRPC service names in the grpc_bridge_service tag, fixing bug where '.' characters were not captured (notably present when package is included in gRPC service name).
Additional Description:
Risk Level: Low
Testing: Update existing unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
Fixes envoyproxy#16384