### PR TITLE
Fix bug in flaky test script

### DIFF
--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -102,18 +102,15 @@ def parse_and_print_test_suite_error(testsuite, log_path):
             # parsed into the XML metadata. Here we attempt to extract those names from the log by
             # finding the last test case to run. The expected format of that is:
             #     "[ RUN      ] <TestParams>/<TestSuite>.<TestCase>\n".
-            last_test_fullname = test_output.split('[ RUN      ]')[-1].splitlines()[0]
-            last_test_fullname_splitted_on_slash = last_test_fullname.split('/')
-            if len(last_test_fullname_splitted_on_slash) == 2:
-                last_testsuite = last_test_fullname_splitted_on_slash[1].split('.')[0]
-            else:
-                last_testsuite = "Could not retrieve last test suite"
 
+            last_test_fullname = test_output.split('[ RUN      ]')[-1].splitlines()[0]
             last_test_fullname_splitted_on_dot = last_test_fullname.split('.')
             if len(last_test_fullname_splitted_on_dot) == 2:
                 last_testcase = last_test_fullname_splitted_on_dot[1]
+                last_testsuite = last_test_fullname_splitted_on_dot[0].split('/')[-1]
             else:
                 last_testcase = "Could not retrieve last test case"
+                last_testsuite = "Could not retrieve last test suite"
 
     if error_msg != "":
         return print_test_suite_error(

--- a/ci/flaky_test/process_xml.py
+++ b/ci/flaky_test/process_xml.py
@@ -103,8 +103,17 @@ def parse_and_print_test_suite_error(testsuite, log_path):
             # finding the last test case to run. The expected format of that is:
             #     "[ RUN      ] <TestParams>/<TestSuite>.<TestCase>\n".
             last_test_fullname = test_output.split('[ RUN      ]')[-1].splitlines()[0]
-            last_testsuite = last_test_fullname.split('/')[1].split('.')[0]
-            last_testcase = last_test_fullname.split('.')[1]
+            last_test_fullname_splitted_on_slash = last_test_fullname.split('/')
+            if len(last_test_fullname_splitted_on_slash) == 2:
+                last_testsuite = last_test_fullname_splitted_on_slash[1].split('.')[0]
+            else:
+                last_testsuite = "Could not retrieve last test suite"
+
+            last_test_fullname_splitted_on_dot = last_test_fullname.split('.')
+            if len(last_test_fullname_splitted_on_dot) == 2:
+                last_testcase = last_test_fullname_splitted_on_dot[1]
+            else:
+                last_testcase = "Could not retrieve last test case"
 
     if error_msg != "":
         return print_test_suite_error(

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -42,9 +42,8 @@ fi
 # Environment setup.
 export TEST_TMPDIR=${BUILD_DIR}/tmp
 
-#[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
+[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
 
-BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
 BAZEL_STARTUP_OPTIONS+=("--output_base=${TEST_TMPDIR/\/c/c:}")
 BAZEL_BUILD_OPTIONS=(
     -c opt

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -42,7 +42,7 @@ fi
 # Environment setup.
 export TEST_TMPDIR=${BUILD_DIR}/tmp
 
-[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
+#[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
 
 BAZEL_STARTUP_OPTIONS+=("--output_base=${TEST_TMPDIR/\/c/c:}")
 BAZEL_BUILD_OPTIONS=(

--- a/ci/windows_ci_steps.sh
+++ b/ci/windows_ci_steps.sh
@@ -44,6 +44,7 @@ export TEST_TMPDIR=${BUILD_DIR}/tmp
 
 #[[ "${BUILD_REASON}" != "PullRequest" ]] && BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
 
+BAZEL_EXTRA_TEST_OPTIONS+=(--nocache_test_results)
 BAZEL_STARTUP_OPTIONS+=("--output_base=${TEST_TMPDIR/\/c/c:}")
 BAZEL_BUILD_OPTIONS=(
     -c opt


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Commit Message:

Fixes #15800

There are some errors such as `Error: No such container: rbe-container-453b391c-e65b-4035-bfa6-fee0cdb0cd00` where the split fails. Harden the accesses with length checks.

Additional Description:
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A