### PR TITLE
ext_proc: Support CONTINUE_AND_REPLACE from header callbacks

### DIFF
--- a/api/envoy/service/ext_proc/v3alpha/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3alpha/external_processor.proto
@@ -231,15 +231,18 @@ message CommonResponse {
     // stream as normal. This is the default.
     CONTINUE = 0;
 
-    // [#not-implemented-hide:]
-    // Replace the request or response with the contents
-    // of this message. If header_mutation is set, apply it to the
-    // headers. If body_mutation is set and contains a body, then add that
-    // body to the request or response, even if one does not already exist --
-    // otherwise, clear the body. Any additional body and trailers
-    // received from downstream or upstream will be ignored.
-    // This can be used to add a body to a request or response that does not
-    // have one already.
+    // Apply the specified header mutation, replace the body with the body
+    // specified in the body mutation, (if present) and do not send any
+    // further messages for this request or response even if the processing
+    // mode is configured to do so.
+    //
+    // When used in response to a request_headers or response_headers message,
+    // this status makes it possible to either completely replace the body
+    // while discarding the original body, or to add a body to a message that
+    // formerly did not have one.
+    //
+    // In other words, this response makes it possible to turn an HTTP GET
+    // into a POST, PUT, or PATCH.
     CONTINUE_AND_REPLACE = 1;
   }
 

--- a/generated_api_shadow/envoy/service/ext_proc/v3alpha/external_processor.proto
+++ b/generated_api_shadow/envoy/service/ext_proc/v3alpha/external_processor.proto
@@ -231,15 +231,18 @@ message CommonResponse {
     // stream as normal. This is the default.
     CONTINUE = 0;
 
-    // [#not-implemented-hide:]
-    // Replace the request or response with the contents
-    // of this message. If header_mutation is set, apply it to the
-    // headers. If body_mutation is set and contains a body, then add that
-    // body to the request or response, even if one does not already exist --
-    // otherwise, clear the body. Any additional body and trailers
-    // received from downstream or upstream will be ignored.
-    // This can be used to add a body to a request or response that does not
-    // have one already.
+    // Apply the specified header mutation, replace the body with the body
+    // specified in the body mutation, (if present) and do not send any
+    // further messages for this request or response even if the processing
+    // mode is configured to do so.
+    //
+    // When used in response to a request_headers or response_headers message,
+    // this status makes it possible to either completely replace the body
+    // while discarding the original body, or to add a body to a message that
+    // formerly did not have one.
+    //
+    // In other words, this response makes it possible to turn an HTTP GET
+    // into a POST, PUT, or PATCH.
     CONTINUE_AND_REPLACE = 1;
   }
 

--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "//include/envoy/http:filter_interface",
         "//include/envoy/http:header_map_interface",
         "//include/envoy/stats:stats_macros",
+        "//source/common/buffer:buffer_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@com_google_absl//absl/strings:str_format",
         "@envoy_api//envoy/extensions/filters/http/ext_proc/v3alpha:pkg_cc_proto",

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -133,8 +133,8 @@ private:
   void sendImmediateResponse(const envoy::service::ext_proc::v3alpha::ImmediateResponse& response);
   void sendBodyChunk(ProcessorState& state, const Buffer::Instance& data, bool end_stream);
 
-  Http::FilterHeadersStatus onHeaders(ProcessorState& state, Http::HeaderMap& headers,
-                                      bool end_stream);
+  Http::FilterHeadersStatus onHeaders(ProcessorState& state,
+                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream);
   Http::FilterDataStatus onData(ProcessorState& state, Buffer::Instance& data, bool end_stream);
   Http::FilterTrailersStatus onTrailers(ProcessorState& state, Http::HeaderMap& trailers);
 

--- a/source/extensions/filters/http/ext_proc/mutation_utils.cc
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.cc
@@ -16,13 +16,14 @@ using Http::LowerCaseString;
 
 using envoy::service::ext_proc::v3alpha::BodyMutation;
 using envoy::service::ext_proc::v3alpha::BodyResponse;
+using envoy::service::ext_proc::v3alpha::CommonResponse;
 using envoy::service::ext_proc::v3alpha::HeaderMutation;
 using envoy::service::ext_proc::v3alpha::HeadersResponse;
 
-void MutationUtils::buildHttpHeaders(const Http::HeaderMap& headers_in,
-                                     envoy::config::core::v3::HeaderMap& headers_out) {
-  headers_in.iterate([&headers_out](const Http::HeaderEntry& e) -> Http::HeaderMap::Iterate {
-    auto* new_header = headers_out.add_headers();
+void MutationUtils::headersToProto(const Http::HeaderMap& headers_in,
+                                   envoy::config::core::v3::HeaderMap& proto_out) {
+  headers_in.iterate([&proto_out](const Http::HeaderEntry& e) -> Http::HeaderMap::Iterate {
+    auto* new_header = proto_out.add_headers();
     new_header->set_key(std::string(e.key().getStringView()));
     new_header->set_value(std::string(e.value().getStringView()));
     return Http::HeaderMap::Iterate::Continue;
@@ -34,12 +35,14 @@ void MutationUtils::applyCommonHeaderResponse(const HeadersResponse& response,
   if (response.has_response()) {
     const auto& common_response = response.response();
     if (common_response.has_header_mutation()) {
-      applyHeaderMutations(common_response.header_mutation(), headers);
+      applyHeaderMutations(common_response.header_mutation(), headers,
+                           common_response.status() == CommonResponse::CONTINUE_AND_REPLACE);
     }
   }
 }
 
-void MutationUtils::applyHeaderMutations(const HeaderMutation& mutation, Http::HeaderMap& headers) {
+void MutationUtils::applyHeaderMutations(const HeaderMutation& mutation, Http::HeaderMap& headers,
+                                         bool replacing_message) {
   for (const auto& remove_header : mutation.remove_headers()) {
     if (Http::HeaderUtility::isRemovableHeader(remove_header)) {
       ENVOY_LOG(trace, "Removing header {}", remove_header);
@@ -53,7 +56,7 @@ void MutationUtils::applyHeaderMutations(const HeaderMutation& mutation, Http::H
     if (!sh.has_header()) {
       continue;
     }
-    if (isSettableHeader(sh.header().key())) {
+    if (isSettableHeader(sh.header().key(), replacing_message)) {
       // Make "false" the default. This is logical and matches the ext_authz
       // filter. However, the router handles this same protobuf and uses "true"
       // as the default instead.
@@ -70,14 +73,20 @@ void MutationUtils::applyHeaderMutations(const HeaderMutation& mutation, Http::H
   }
 }
 
-void MutationUtils::applyCommonBodyResponse(const BodyResponse& response, Http::HeaderMap* headers,
+void MutationUtils::applyCommonBodyResponse(const BodyResponse& response,
+                                            Http::RequestOrResponseHeaderMap* headers,
                                             Buffer::Instance& buffer) {
   if (response.has_response()) {
     const auto& common_response = response.response();
     if (headers != nullptr && common_response.has_header_mutation()) {
-      applyHeaderMutations(common_response.header_mutation(), *headers);
+      applyHeaderMutations(common_response.header_mutation(), *headers,
+                           common_response.status() == CommonResponse::CONTINUE_AND_REPLACE);
     }
     if (common_response.has_body_mutation()) {
+      if (headers != nullptr) {
+        // Always clear content length if we can before modifying body
+        headers->removeContentLength();
+      }
       applyBodyMutations(common_response.body_mutation(), buffer);
     }
   }
@@ -87,10 +96,13 @@ void MutationUtils::applyBodyMutations(const BodyMutation& mutation, Buffer::Ins
   switch (mutation.mutation_case()) {
   case BodyMutation::MutationCase::kClearBody:
     if (mutation.clear_body()) {
+      ENVOY_LOG(trace, "Clearing HTTP body");
       buffer.drain(buffer.length());
     }
     break;
   case BodyMutation::MutationCase::kBody:
+    ENVOY_LOG(trace, "Replacing body of {} bytes with new body of {} bytes", buffer.length(),
+              mutation.body().size());
     buffer.drain(buffer.length());
     buffer.add(mutation.body());
     break;
@@ -103,11 +115,11 @@ void MutationUtils::applyBodyMutations(const BodyMutation& mutation, Buffer::Ins
 // Ignore attempts to set certain sensitive headers that can break later processing.
 // We may re-enable some of these after further testing. This logic is specific
 // to the ext_proc filter so it is not shared with HeaderUtils.
-bool MutationUtils::isSettableHeader(absl::string_view key) {
+bool MutationUtils::isSettableHeader(absl::string_view key, bool replacing_message) {
   const auto& headers = Headers::get();
   return !absl::EqualsIgnoreCase(key, headers.HostLegacy.get()) &&
          !absl::EqualsIgnoreCase(key, headers.Host.get()) &&
-         !absl::EqualsIgnoreCase(key, headers.Method.get()) &&
+         (!absl::EqualsIgnoreCase(key, headers.Method.get()) || replacing_message) &&
          !absl::EqualsIgnoreCase(key, headers.Scheme.get()) &&
          !absl::StartsWithIgnoreCase(key, headers.prefix());
 }

--- a/source/extensions/filters/http/ext_proc/mutation_utils.h
+++ b/source/extensions/filters/http/ext_proc/mutation_utils.h
@@ -14,8 +14,8 @@ namespace ExternalProcessing {
 class MutationUtils : public Logger::Loggable<Logger::Id::filter> {
 public:
   // Convert a header map until a protobuf
-  static void buildHttpHeaders(const Http::HeaderMap& headers_in,
-                               envoy::config::core::v3::HeaderMap& headers_out);
+  static void headersToProto(const Http::HeaderMap& headers_in,
+                             envoy::config::core::v3::HeaderMap& proto_out);
 
   // Apply mutations that are common to header responses.
   static void
@@ -25,19 +25,20 @@ public:
   // Modify header map based on a set of mutations from a protobuf
   static void
   applyHeaderMutations(const envoy::service::ext_proc::v3alpha::HeaderMutation& mutation,
-                       Http::HeaderMap& headers);
+                       Http::HeaderMap& headers, bool replacing_message);
 
   // Apply mutations that are common to body responses.
   // Mutations will be applied to the header map if it is not null.
   static void applyCommonBodyResponse(const envoy::service::ext_proc::v3alpha::BodyResponse& body,
-                                      Http::HeaderMap* headers, Buffer::Instance& buffer);
+                                      Http::RequestOrResponseHeaderMap* headers,
+                                      Buffer::Instance& buffer);
 
   // Modify a buffer based on a set of mutations from a protobuf
   static void applyBodyMutations(const envoy::service::ext_proc::v3alpha::BodyMutation& mutation,
                                  Buffer::Instance& buffer);
 
 private:
-  static bool isSettableHeader(absl::string_view key);
+  static bool isSettableHeader(absl::string_view key, bool replacing_message);
 };
 
 } // namespace ExternalProcessing

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -1,5 +1,8 @@
 #include "extensions/filters/http/ext_proc/processor_state.h"
 
+#include "common/buffer/buffer_impl.h"
+#include "common/protobuf/utility.h"
+
 #include "extensions/filters/http/ext_proc/ext_proc.h"
 #include "extensions/filters/http/ext_proc/mutation_utils.h"
 
@@ -11,6 +14,7 @@ namespace ExternalProcessing {
 using envoy::extensions::filters::http::ext_proc::v3alpha::ProcessingMode;
 
 using envoy::service::ext_proc::v3alpha::BodyResponse;
+using envoy::service::ext_proc::v3alpha::CommonResponse;
 using envoy::service::ext_proc::v3alpha::HeadersResponse;
 using envoy::service::ext_proc::v3alpha::TrailersResponse;
 
@@ -24,6 +28,7 @@ void ProcessorState::startMessageTimer(Event::TimerCb cb, std::chrono::milliseco
 bool ProcessorState::handleHeadersResponse(const HeadersResponse& response) {
   if (callback_state_ == CallbackState::HeadersCallback) {
     ENVOY_LOG(debug, "applying headers response");
+    const auto& common_response = response.response();
     MutationUtils::applyCommonHeaderResponse(response, *headers_);
     if (response.response().clear_route_cache()) {
       filter_callbacks_->clearRouteCache();
@@ -32,26 +37,52 @@ bool ProcessorState::handleHeadersResponse(const HeadersResponse& response) {
     clearWatermark();
     message_timer_->disableTimer();
 
-    if (body_mode_ == ProcessingMode::BUFFERED) {
-      if (complete_body_available_) {
-        // If we get here, then all the body data came in before the header message
-        // was complete, and the server wants the body. So, don't continue filter
-        // processing, but send the buffered request body now.
-        ENVOY_LOG(debug, "Sending buffered request body message");
-        filter_.sendBufferedData(*this, true);
+    if (common_response.status() == CommonResponse::CONTINUE_AND_REPLACE) {
+      ENVOY_LOG(debug, "Replacing complete message");
+      // Completely replace the body that may already exist.
+      if (common_response.has_body_mutation()) {
+        // Always remove the content-length header if changing the body.
+        // The proxy can restore it later if it needs to.
+        headers_->removeContentLength();
+        body_replaced_ = true;
+        if (bufferedData() == nullptr) {
+          Buffer::OwnedImpl new_body;
+          MutationUtils::applyBodyMutations(common_response.body_mutation(), new_body);
+          addBufferedData(new_body);
+        } else {
+          modifyBufferedData([&common_response](Buffer::Instance& buf) {
+            MutationUtils::applyBodyMutations(common_response.body_mutation(), buf);
+          });
+        }
       }
 
-      // Otherwise, we're not ready to continue processing because then
-      // we won't be able to modify the headers any more, so do nothing and
-      // let the doData callback handle body chunks until the end is reached.
-      return true;
-    }
+      // Once this message is received, we won't send anything more on this request
+      // or response to the processor. Clear flags to make sure.
+      body_mode_ = ProcessingMode::NONE;
+      send_trailers_ = false;
 
-    if (send_trailers_ && trailers_available_) {
-      // Trailers came in while we were waiting for this response, and the server
-      // is not interested in the body, so send them now.
-      filter_.sendTrailers(*this, *trailers_);
-      return true;
+    } else {
+      if (body_mode_ == ProcessingMode::BUFFERED) {
+        if (complete_body_available_) {
+          // If we get here, then all the body data came in before the header message
+          // was complete, and the server wants the body. So, don't continue filter
+          // processing, but send the buffered request body now.
+          ENVOY_LOG(debug, "Sending buffered request body message");
+          filter_.sendBufferedData(*this, true);
+        }
+
+        // Otherwise, we're not ready to continue processing because then
+        // we won't be able to modify the headers any more, so do nothing and
+        // let the doData callback handle body chunks until the end is reached.
+        return true;
+      }
+
+      if (send_trailers_ && trailers_available_) {
+        // Trailers came in while we were waiting for this response, and the server
+        // is not interested in the body, so send them now.
+        filter_.sendTrailers(*this, *trailers_);
+        return true;
+      }
     }
 
     // If we got here, then the processor doesn't care about the body or is not ready for
@@ -93,7 +124,7 @@ bool ProcessorState::handleTrailersResponse(const TrailersResponse& response) {
   if (callback_state_ == CallbackState::TrailersCallback) {
     ENVOY_LOG(debug, "Applying response to buffered trailers");
     if (response.has_header_mutation()) {
-      MutationUtils::applyHeaderMutations(response.header_mutation(), *trailers_);
+      MutationUtils::applyHeaderMutations(response.header_mutation(), *trailers_, false);
     }
     trailers_ = nullptr;
     callback_state_ = CallbackState::Idle;

--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -37,6 +37,7 @@ envoy_extension_cc_test(
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:test_runtime_lib",
+        "@envoy_api//envoy/service/ext_proc/v3alpha:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
+++ b/test/extensions/filters/http/ext_proc/mutation_utils_test.cc
@@ -28,7 +28,7 @@ TEST(MutationUtils, TestBuildHeaders) {
   headers.addCopy(LowerCaseString("x-number"), 9999);
 
   envoy::config::core::v3::HeaderMap proto_headers;
-  MutationUtils::buildHttpHeaders(headers, proto_headers);
+  MutationUtils::headersToProto(headers, proto_headers);
 
   Http::TestRequestHeaderMapImpl expected{{":method", "GET"},
                                           {":path", "/foo/the/bar?size=123"},
@@ -101,7 +101,7 @@ TEST(MutationUtils, TestApplyMutations) {
   s->mutable_header()->set_key("X-Envoy-StrangeThing");
   s->mutable_header()->set_value("Yes");
 
-  MutationUtils::applyHeaderMutations(mutation, headers);
+  MutationUtils::applyHeaderMutations(mutation, headers, false);
 
   Http::TestRequestHeaderMapImpl expected_headers{
       {":scheme", "https"},


### PR DESCRIPTION
Commit Message: Support the CONTINUE_AND_REPLACE status
for reponses from header callbacks

Additional Description: This makes it possible for a processor
to add a body to a request or response that does not have one,
or replace the entire body in the response from a header callback
without otherwise touching it.

Risk Level: Low. Not enabled by default.

Testing: New unit and integration tests.

Release Notes: The CONTINUE_AND_REPLACE processing status can be
used to replace the body or create a new body from inside the response
to a header callback.

Signed-off-by: Gregory Brail <gregbrail@google.com>
