### PR TITLE
bugfix: test fails to build on MacOS due to unused parameters

### DIFF
--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.cc
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.cc
@@ -46,7 +46,8 @@ void FakeConnectionSocket::setRequestedServerName(absl::string_view server_name)
 
 absl::string_view FakeConnectionSocket::requestedServerName() const { return server_name_; }
 
-Api::SysCallIntResult FakeConnectionSocket::getSocketOption(int level, int, void* optval,
+Api::SysCallIntResult FakeConnectionSocket::getSocketOption([[maybe_unused]] int level, int,
+                                                            [[maybe_unused]] void* optval,
                                                             socklen_t*) const {
 #ifdef SOL_IP
   switch (level) {


### PR DESCRIPTION
Commit Message: bugfix: test fails to build on MacOS due to unused parameters
Additional Description: Encountered with RBE test setup for MacOS.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>