### PR TITLE
docs: Use repo role for repo links

### DIFF
--- a/tools/protodoc/protodoc.py
+++ b/tools/protodoc/protodoc.py
@@ -51,10 +51,6 @@ RPC_NAMESPACE_PREFIX = '.google.rpc.'
 # http://www.fileformat.info/info/unicode/char/2063/index.htm
 UNICODE_INVISIBLE_SEPARATOR = u'\u2063'
 
-# Template for data plane API URLs.
-DATA_PLANE_API_URL_FMT = 'https://github.com/envoyproxy/envoy/blob/{}/api/%s#L%d'.format(
-    os.environ['ENVOY_BLOB_SHA'])
-
 # Template for formating extension descriptions.
 EXTENSION_TEMPLATE = Template(
     """
@@ -149,7 +145,7 @@ def hide_not_implemented(comment):
     return annotations.NOT_IMPLEMENTED_HIDE_ANNOTATION in comment.annotations
 
 
-def github_url(type_context):
+def github_url(text, type_context):
     """Obtain data plane API Github URL by path from a TypeContext.
 
     Args:
@@ -158,10 +154,7 @@ def github_url(type_context):
     Returns:
         A string with a corresponding data plane API GitHub Url.
     """
-    if type_context.location is not None:
-        return DATA_PLANE_API_URL_FMT % (
-            type_context.source_code_info.name, type_context.location.span[0])
-    return ''
+    return f":repo:`{text} <api/{type_context.source_code_info.name}#L{type_context.location.span[0]}>`"
 
 
 def format_comment_with_annotations(comment, type_name=''):
@@ -679,8 +672,7 @@ class RstFormatVisitor(visitor.Visitor):
         normal_enum_type = normalize_type_context_name(type_context.name)
         anchor = format_anchor(enum_cross_ref_label(normal_enum_type))
         header = format_header('-', 'Enum %s' % normal_enum_type)
-        _github_url = github_url(type_context)
-        proto_link = format_external_link('[%s proto]' % normal_enum_type, _github_url) + '\n\n'
+        proto_link = github_url("f[{normal_enum_type} proto]", type_context) + '\n\n'
         leading_comment = type_context.leading_comment
         formatted_leading_comment = format_comment_with_annotations(leading_comment, 'enum')
         if hide_not_implemented(leading_comment):
@@ -695,8 +687,7 @@ class RstFormatVisitor(visitor.Visitor):
         normal_msg_type = normalize_type_context_name(type_context.name)
         anchor = format_anchor(message_cross_ref_label(normal_msg_type))
         header = format_header('-', normal_msg_type)
-        _github_url = github_url(type_context)
-        proto_link = format_external_link('[%s proto]' % normal_msg_type, _github_url) + '\n\n'
+        proto_link = github_url(f"[{normal_msg_type} proto]", type_context) + '\n\n'
         leading_comment = type_context.leading_comment
         formatted_leading_comment = format_comment_with_annotations(leading_comment, 'message')
         if hide_not_implemented(leading_comment):


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Use repo role for repo links
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
