### PR TITLE
docs: Fix bootstrap docs version link

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -35,7 +35,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Bootstrap]
 // This proto is supplied via the :option:`-c` CLI flag and acts as the root
-// of the Envoy v2 configuration. See the :ref:`v2 configuration overview
+// of the Envoy v3 configuration. See the :ref:`v3 configuration overview
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.

--- a/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -32,7 +32,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // [#protodoc-title: Bootstrap]
 // This proto is supplied via the :option:`-c` CLI flag and acts as the root
-// of the Envoy v2 configuration. See the :ref:`v2 configuration overview
+// of the Envoy v3 configuration. See the :ref:`v3 configuration overview
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.

--- a/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v3/bootstrap.proto
@@ -35,7 +35,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Bootstrap]
 // This proto is supplied via the :option:`-c` CLI flag and acts as the root
-// of the Envoy v2 configuration. See the :ref:`v2 configuration overview
+// of the Envoy v3 configuration. See the :ref:`v3 configuration overview
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.

--- a/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
+++ b/generated_api_shadow/envoy/config/bootstrap/v4alpha/bootstrap.proto
@@ -34,7 +34,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 
 // [#protodoc-title: Bootstrap]
 // This proto is supplied via the :option:`-c` CLI flag and acts as the root
-// of the Envoy v2 configuration. See the :ref:`v2 configuration overview
+// of the Envoy v3 configuration. See the :ref:`v3 configuration overview
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Fix bootstrap docs version link
Additional Description:
shift reference to v2 api -> v3

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
