### PR TITLE
[WIP] docs: Fix inline literals in API docs

### DIFF
--- a/api/envoy/type/http.proto
+++ b/api/envoy/type/http.proto
@@ -17,7 +17,7 @@ enum CodecClientType {
   HTTP2 = 1;
 
   // [#not-implemented-hide:] QUIC implementation is not production ready yet. Use this enum with
-  // caution to prevent accidental execution of QUIC code. I.e. `!= HTTP2` is no longer sufficient
+  // caution to prevent accidental execution of QUIC code. I.e. ``!= HTTP2`` is no longer sufficient
   // to distinguish HTTP1 and HTTP2 traffic.
   HTTP3 = 2;
 }

--- a/api/envoy/type/http/v3/path_transformation.proto
+++ b/api/envoy/type/http/v3/path_transformation.proto
@@ -34,7 +34,7 @@ message PathTransformation {
 
     // Determines if adjacent slashes are merged into one. A common use case is for a request path
     // header. Using this option in :ref:`PathNormalizationOptions
-    // <envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.PathNormalizationOptions>`
+    // <envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.normalize_path>`
     // will allow incoming requests with path ``//dir///file`` to match against route with ``prefix``
     // match set to ``/dir``. When using for header transformations, note that slash merging is not
     // part of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.

--- a/api/envoy/type/http/v3/path_transformation.proto
+++ b/api/envoy/type/http/v3/path_transformation.proto
@@ -33,10 +33,10 @@ message PathTransformation {
     }
 
     // Determines if adjacent slashes are merged into one. A common use case is for a request path
-    // header. Using this option in `:ref: PathNormalizationOptions
+    // header. Using this option in :ref:`PathNormalizationOptions
     // <envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.PathNormalizationOptions>`
-    // will allow incoming requests with path `//dir///file` to match against route with `prefix`
-    // match set to `/dir`. When using for header transformations, note that slash merging is not
+    // will allow incoming requests with path ``//dir///file`` to match against route with ``prefix``
+    // match set to ``/dir``. When using for header transformations, note that slash merging is not
     // part of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.
     message MergeSlashes {
     }

--- a/api/envoy/type/http_status.proto
+++ b/api/envoy/type/http_status.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // For more details: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 enum StatusCode {
   // Empty - This code not part of the HTTP status code specification, but it is needed for proto
-  // `enum` type.
+  // ``enum`` type.
   Empty = 0;
 
   Continue = 100;

--- a/api/envoy/type/matcher/metadata.proto
+++ b/api/envoy/type/matcher/metadata.proto
@@ -15,7 +15,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // [#protodoc-title: Metadata matcher]
 
 // MetadataMatcher provides a general interface to check if a given value is matched in
-// :ref:`Metadata <envoy_api_msg_core.Metadata>`. It uses `filter` and `path` to retrieve the value
+// :ref:`Metadata <envoy_api_msg_core.Metadata>`. It uses ``filter`` and ``path`` to retrieve the value
 // from the Metadata and then check if it's matched to the specified value.
 //
 // For example, for the following Metadata:

--- a/api/envoy/type/matcher/path.proto
+++ b/api/envoy/type/matcher/path.proto
@@ -19,7 +19,7 @@ message PathMatcher {
   oneof rule {
     option (validate.required) = true;
 
-    // The `path` must match the URL path portion of the :path header. The query and fragment
+    // The ``path`` must match the URL path portion of the :path header. The query and fragment
     // string (if present) are removed in the URL path portion.
     // For example, the path */data* will match the *:path* header */data#fragment?param=value*.
     StringMatcher path = 1 [(validate.rules).message = {required: true}];

--- a/api/envoy/type/matcher/regex.proto
+++ b/api/envoy/type/matcher/regex.proto
@@ -20,14 +20,14 @@ message RegexMatcher {
   // the documented `syntax <https://github.com/google/re2/wiki/Syntax>`_. The engine is designed
   // to complete execution in linear time as well as limit the amount of memory used.
   //
-  // Envoy supports program size checking via runtime. The runtime keys `re2.max_program_size.error_level`
-  // and `re2.max_program_size.warn_level` can be set to integers as the maximum program size or
+  // Envoy supports program size checking via runtime. The runtime keys ``re2.max_program_size.error_level``
+  // and ``re2.max_program_size.warn_level`` can be set to integers as the maximum program size or
   // complexity that a compiled regex can have before an exception is thrown or a warning is
-  // logged, respectively. `re2.max_program_size.error_level` defaults to 100, and
-  // `re2.max_program_size.warn_level` has no default if unset (will not check/log a warning).
+  // logged, respectively. ``re2.max_program_size.error_level`` defaults to 100, and
+  // ``re2.max_program_size.warn_level`` has no default if unset (will not check/log a warning).
   //
-  // Envoy emits two stats for tracking the program size of regexes: the histogram `re2.program_size`,
-  // which records the program size, and the counter `re2.exceeded_warn_level`, which is incremented
+  // Envoy emits two stats for tracking the program size of regexes: the histogram ``re2.program_size``,
+  // which records the program size, and the counter ``re2.exceeded_warn_level``, which is incremented
   // each time the program size exceeds the warn level threshold.
   message GoogleRE2 {
     // This field controls the RE2 "program size" which is a rough estimate of how complex a

--- a/api/envoy/type/matcher/string.proto
+++ b/api/envoy/type/matcher/string.proto
@@ -55,7 +55,7 @@ message StringMatcher {
     // * The regex ``\d{3}`` does not match the value *123.456*
     //
     // .. attention::
-    //   This field has been deprecated in favor of `safe_regex` as it is not safe for use with
+    //   This field has been deprecated in favor of ``safe_regex`` as it is not safe for use with
     //   untrusted input in all cases.
     string regex = 4 [
       deprecated = true,

--- a/api/envoy/type/matcher/struct.proto
+++ b/api/envoy/type/matcher/struct.proto
@@ -15,7 +15,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 // [#protodoc-title: Struct matcher]
 
 // StructMatcher provides a general interface to check if a given value is matched in
-// google.protobuf.Struct. It uses `path` to retrieve the value
+// google.protobuf.Struct. It uses ``path`` to retrieve the value
 // from the struct and then check if it's matched to the specified value.
 //
 // For example, for the following Struct:

--- a/api/envoy/type/matcher/v3/metadata.proto
+++ b/api/envoy/type/matcher/v3/metadata.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Metadata matcher]
 
 // MetadataMatcher provides a general interface to check if a given value is matched in
-// :ref:`Metadata <envoy_v3_api_msg_config.core.v3.Metadata>`. It uses `filter` and `path` to retrieve the value
+// :ref:`Metadata <envoy_v3_api_msg_config.core.v3.Metadata>`. It uses ``filter`` and ``path`` to retrieve the value
 // from the Metadata and then check if it's matched to the specified value.
 //
 // For example, for the following Metadata:

--- a/api/envoy/type/matcher/v3/path.proto
+++ b/api/envoy/type/matcher/v3/path.proto
@@ -22,7 +22,7 @@ message PathMatcher {
   oneof rule {
     option (validate.required) = true;
 
-    // The `path` must match the URL path portion of the :path header. The query and fragment
+    // The ``path`` must match the URL path portion of the :path header. The query and fragment
     // string (if present) are removed in the URL path portion.
     // For example, the path */data* will match the *:path* header */data#fragment?param=value*.
     StringMatcher path = 1 [(validate.rules).message = {required: true}];

--- a/api/envoy/type/matcher/v3/regex.proto
+++ b/api/envoy/type/matcher/v3/regex.proto
@@ -24,14 +24,14 @@ message RegexMatcher {
   // the documented `syntax <https://github.com/google/re2/wiki/Syntax>`_. The engine is designed
   // to complete execution in linear time as well as limit the amount of memory used.
   //
-  // Envoy supports program size checking via runtime. The runtime keys `re2.max_program_size.error_level`
-  // and `re2.max_program_size.warn_level` can be set to integers as the maximum program size or
+  // Envoy supports program size checking via runtime. The runtime keys ``re2.max_program_size.error_level``
+  // and ``re2.max_program_size.warn_level`` can be set to integers as the maximum program size or
   // complexity that a compiled regex can have before an exception is thrown or a warning is
-  // logged, respectively. `re2.max_program_size.error_level` defaults to 100, and
-  // `re2.max_program_size.warn_level` has no default if unset (will not check/log a warning).
+  // logged, respectively. ``re2.max_program_size.error_level`` defaults to 100, and
+  // ``re2.max_program_size.warn_level`` has no default if unset (will not check/log a warning).
   //
-  // Envoy emits two stats for tracking the program size of regexes: the histogram `re2.program_size`,
-  // which records the program size, and the counter `re2.exceeded_warn_level`, which is incremented
+  // Envoy emits two stats for tracking the program size of regexes: the histogram ``re2.program_size``,
+  // which records the program size, and the counter ``re2.exceeded_warn_level``, which is incremented
   // each time the program size exceeds the warn level threshold.
   message GoogleRE2 {
     option (udpa.annotations.versioning).previous_message_type =

--- a/api/envoy/type/matcher/v3/struct.proto
+++ b/api/envoy/type/matcher/v3/struct.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#protodoc-title: Struct matcher]
 
 // StructMatcher provides a general interface to check if a given value is matched in
-// google.protobuf.Struct. It uses `path` to retrieve the value
+// google.protobuf.Struct. It uses ``path`` to retrieve the value
 // from the struct and then check if it's matched to the specified value.
 //
 // For example, for the following Struct:

--- a/api/envoy/type/matcher/v4alpha/metadata.proto
+++ b/api/envoy/type/matcher/v4alpha/metadata.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // [#protodoc-title: Metadata matcher]
 
 // MetadataMatcher provides a general interface to check if a given value is matched in
-// :ref:`Metadata <envoy_v3_api_msg_config.core.v3.Metadata>`. It uses `filter` and `path` to retrieve the value
+// :ref:`Metadata <envoy_v3_api_msg_config.core.v3.Metadata>`. It uses ``filter`` and ``path`` to retrieve the value
 // from the Metadata and then check if it's matched to the specified value.
 //
 // For example, for the following Metadata:

--- a/api/envoy/type/matcher/v4alpha/path.proto
+++ b/api/envoy/type/matcher/v4alpha/path.proto
@@ -22,7 +22,7 @@ message PathMatcher {
   oneof rule {
     option (validate.required) = true;
 
-    // The `path` must match the URL path portion of the :path header. The query and fragment
+    // The ``path`` must match the URL path portion of the :path header. The query and fragment
     // string (if present) are removed in the URL path portion.
     // For example, the path */data* will match the *:path* header */data#fragment?param=value*.
     StringMatcher path = 1 [(validate.rules).message = {required: true}];

--- a/api/envoy/type/matcher/v4alpha/regex.proto
+++ b/api/envoy/type/matcher/v4alpha/regex.proto
@@ -23,14 +23,14 @@ message RegexMatcher {
   // the documented `syntax <https://github.com/google/re2/wiki/Syntax>`_. The engine is designed
   // to complete execution in linear time as well as limit the amount of memory used.
   //
-  // Envoy supports program size checking via runtime. The runtime keys `re2.max_program_size.error_level`
-  // and `re2.max_program_size.warn_level` can be set to integers as the maximum program size or
+  // Envoy supports program size checking via runtime. The runtime keys ``re2.max_program_size.error_level``
+  // and ``re2.max_program_size.warn_level`` can be set to integers as the maximum program size or
   // complexity that a compiled regex can have before an exception is thrown or a warning is
-  // logged, respectively. `re2.max_program_size.error_level` defaults to 100, and
-  // `re2.max_program_size.warn_level` has no default if unset (will not check/log a warning).
+  // logged, respectively. ``re2.max_program_size.error_level`` defaults to 100, and
+  // ``re2.max_program_size.warn_level`` has no default if unset (will not check/log a warning).
   //
-  // Envoy emits two stats for tracking the program size of regexes: the histogram `re2.program_size`,
-  // which records the program size, and the counter `re2.exceeded_warn_level`, which is incremented
+  // Envoy emits two stats for tracking the program size of regexes: the histogram ``re2.program_size``,
+  // which records the program size, and the counter ``re2.exceeded_warn_level``, which is incremented
   // each time the program size exceeds the warn level threshold.
   message GoogleRE2 {
     option (udpa.annotations.versioning).previous_message_type =

--- a/api/envoy/type/matcher/v4alpha/struct.proto
+++ b/api/envoy/type/matcher/v4alpha/struct.proto
@@ -16,7 +16,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // [#protodoc-title: Struct matcher]
 
 // StructMatcher provides a general interface to check if a given value is matched in
-// google.protobuf.Struct. It uses `path` to retrieve the value
+// google.protobuf.Struct. It uses ``path`` to retrieve the value
 // from the struct and then check if it's matched to the specified value.
 //
 // For example, for the following Struct:

--- a/api/envoy/type/metadata/v2/metadata.proto
+++ b/api/envoy/type/metadata/v2/metadata.proto
@@ -14,7 +14,7 @@ option (udpa.annotations.file_status).package_version_status = FROZEN;
 
 // [#protodoc-title: Metadata]
 
-// MetadataKey provides a general interface using `key` and `path` to retrieve value from
+// MetadataKey provides a general interface using ``key`` and ``path`` to retrieve value from
 // :ref:`Metadata <envoy_api_msg_core.Metadata>`.
 //
 // For example, for the following Metadata:

--- a/api/envoy/type/metadata/v3/metadata.proto
+++ b/api/envoy/type/metadata/v3/metadata.proto
@@ -13,7 +13,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Metadata]
 
-// MetadataKey provides a general interface using `key` and `path` to retrieve value from
+// MetadataKey provides a general interface using ``key`` and ``path`` to retrieve value from
 // :ref:`Metadata <envoy_v3_api_msg_config.core.v3.Metadata>`.
 //
 // For example, for the following Metadata:

--- a/api/envoy/type/token_bucket.proto
+++ b/api/envoy/type/token_bucket.proto
@@ -26,8 +26,8 @@ message TokenBucket {
   google.protobuf.UInt32Value tokens_per_fill = 2 [(validate.rules).uint32 = {gt: 0}];
 
   // The fill interval that tokens are added to the bucket. During each fill interval
-  // `tokens_per_fill` are added to the bucket. The bucket will never contain more than
-  // `max_tokens` tokens.
+  // ``tokens_per_fill`` are added to the bucket. The bucket will never contain more than
+  // ``max_tokens`` tokens.
   google.protobuf.Duration fill_interval = 3 [(validate.rules).duration = {
     required: true
     gt {}

--- a/api/envoy/type/v3/http.proto
+++ b/api/envoy/type/v3/http.proto
@@ -17,7 +17,7 @@ enum CodecClientType {
   HTTP2 = 1;
 
   // [#not-implemented-hide:] QUIC implementation is not production ready yet. Use this enum with
-  // caution to prevent accidental execution of QUIC code. I.e. `!= HTTP2` is no longer sufficient
+  // caution to prevent accidental execution of QUIC code. I.e. ``!= HTTP2`` is no longer sufficient
   // to distinguish HTTP1 and HTTP2 traffic.
   HTTP3 = 2;
 }

--- a/api/envoy/type/v3/http_status.proto
+++ b/api/envoy/type/v3/http_status.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // For more details: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 enum StatusCode {
   // Empty - This code not part of the HTTP status code specification, but it is needed for proto
-  // `enum` type.
+  // ``enum`` type.
   Empty = 0;
 
   Continue = 100;

--- a/api/envoy/type/v3/token_bucket.proto
+++ b/api/envoy/type/v3/token_bucket.proto
@@ -29,8 +29,8 @@ message TokenBucket {
   google.protobuf.UInt32Value tokens_per_fill = 2 [(validate.rules).uint32 = {gt: 0}];
 
   // The fill interval that tokens are added to the bucket. During each fill interval
-  // `tokens_per_fill` are added to the bucket. The bucket will never contain more than
-  // `max_tokens` tokens.
+  // ``tokens_per_fill`` are added to the bucket. The bucket will never contain more than
+  // ``max_tokens`` tokens.
   google.protobuf.Duration fill_interval = 3 [(validate.rules).duration = {
     required: true
     gt {}

--- a/generated_api_shadow/envoy/type/http/v3/path_transformation.proto
+++ b/generated_api_shadow/envoy/type/http/v3/path_transformation.proto
@@ -33,8 +33,8 @@ message PathTransformation {
     }
 
     // Determines if adjacent slashes are merged into one. A common use case is for a request path
-    // header. Using this option in `:ref: PathNormalizationOptions
-    // <envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.PathNormalizationOptions>`
+    // header. Using this option in :ref:`PathNormalizationOptions
+    // <envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.normalize_path>`
     // will allow incoming requests with path `//dir///file` to match against route with `prefix`
     // match set to `/dir`. When using for header transformations, note that slash merging is not
     // part of `HTTP spec <https://tools.ietf.org/html/rfc3986>`_ and is provided for convenience.


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Fix inline literals in API docs
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
