### PR TITLE
test: clean up upstream protocols

### DIFF
--- a/test/integration/alpn_integration_test.cc
+++ b/test/integration/alpn_integration_test.cc
@@ -32,11 +32,10 @@ public:
   }
   void createUpstreams() override {
     for (uint32_t i = 0; i < fake_upstreams_count_; ++i) {
-      setUpstreamProtocol(protocols_[i]);
-      Network::TransportSocketFactoryPtr factory = createUpstreamTlsContext();
-      auto endpoint = upstream_address_fn_(i);
       auto config = upstreamConfig();
       config.upstream_protocol_ = protocols_[i];
+      Network::TransportSocketFactoryPtr factory = createUpstreamTlsContext(config);
+      auto endpoint = upstream_address_fn_(i);
       fake_upstreams_.emplace_back(new AutonomousUpstream(std::move(factory), endpoint, config,
                                                           autonomous_allow_incomplete_streams_));
     }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -448,18 +448,17 @@ FakeUpstream::FakeUpstream(const std::string& uds_path, const FakeUpstreamConfig
     : FakeUpstream(Network::Test::createRawBufferSocketFactory(),
                    Network::SocketPtr{new Network::UdsListenSocket(
                        std::make_shared<Network::Address::PipeInstance>(uds_path))},
-                   config) {
-  ENVOY_LOG(info, "starting fake server on unix domain socket {}", uds_path);
-}
+                   config) {}
 
 static Network::SocketPtr
 makeTcpListenSocket(const Network::Address::InstanceConstSharedPtr& address) {
   return std::make_unique<Network::TcpListenSocket>(address, nullptr, true);
 }
 
-static Network::SocketPtr makeTcpListenSocket(uint32_t port, Network::Address::IpVersion version) {
-  return makeTcpListenSocket(Network::Utility::parseInternetAddress(
-      Network::Test::getLoopbackAddressString(version), port));
+static Network::Address::InstanceConstSharedPtr makeAddress(uint32_t port,
+                                                            Network::Address::IpVersion version) {
+  return Network::Utility::parseInternetAddress(Network::Test::getLoopbackAddressString(version),
+                                                port);
 }
 
 static Network::SocketPtr
@@ -482,31 +481,19 @@ makeListenSocket(const FakeUpstreamConfig& config,
 FakeUpstream::FakeUpstream(uint32_t port, Network::Address::IpVersion version,
                            const FakeUpstreamConfig& config)
     : FakeUpstream(Network::Test::createRawBufferSocketFactory(),
-                   makeTcpListenSocket(port, version), config) {
-  ASSERT(!config.udp_fake_upstream_.has_value());
-  ENVOY_LOG(info, "starting fake server on port {}. Address version is {}",
-            localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
-}
+                   makeListenSocket(config, makeAddress(port, version)), config) {}
 
 FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
                            const Network::Address::InstanceConstSharedPtr& address,
                            const FakeUpstreamConfig& config)
     : FakeUpstream(std::move(transport_socket_factory), makeListenSocket(config, address), config) {
-  ENVOY_LOG(info, "starting fake server on socket {}:{}. Address version is {}. UDP={}",
-            address->ip()->addressAsString(), address->ip()->port(),
-            Network::Test::addressVersionAsString(address->ip()->version()),
-            config.udp_fake_upstream_.has_value());
 }
 
 FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
                            uint32_t port, Network::Address::IpVersion version,
                            const FakeUpstreamConfig& config)
-    : FakeUpstream(std::move(transport_socket_factory), makeTcpListenSocket(port, version),
-                   config) {
-  ASSERT(!config.udp_fake_upstream_.has_value());
-  ENVOY_LOG(info, "starting fake server on port {}. Address version is {}",
-            localAddress()->ip()->port(), Network::Test::addressVersionAsString(version));
-}
+    : FakeUpstream(std::move(transport_socket_factory),
+                   makeListenSocket(config, makeAddress(port, version)), config) {}
 
 FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
                            Network::SocketPtr&& listen_socket, const FakeUpstreamConfig& config)
@@ -520,6 +507,9 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
       read_disable_on_new_connection_(true), enable_half_close_(config.enable_half_close_),
       listener_(*this, http_type_ == FakeHttpConnection::Type::HTTP3),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {
+  ENVOY_LOG(info, "starting fake server at {}. UDP={} codec={}",
+            localAddress()->ip()->addressAsString(), config.udp_fake_upstream_.has_value(),
+            FakeHttpConnection::typeToString(http_type_));
   if (config.udp_fake_upstream_.has_value() &&
       config.udp_fake_upstream_->max_rx_datagram_size_.has_value()) {
     listener_.udp_listener_config_.config_.mutable_downstream_socket_config()

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -507,9 +507,8 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
       read_disable_on_new_connection_(true), enable_half_close_(config.enable_half_close_),
       listener_(*this, http_type_ == FakeHttpConnection::Type::HTTP3),
       filter_chain_(Network::Test::createEmptyFilterChain(std::move(transport_socket_factory))) {
-  ENVOY_LOG(info, "starting fake server at {}. UDP={} codec={}",
-            localAddress()->ip()->addressAsString(), config.udp_fake_upstream_.has_value(),
-            FakeHttpConnection::typeToString(http_type_));
+  ENVOY_LOG(info, "starting fake server at {}. UDP={} codec={}", localAddress()->asString(),
+            config.udp_fake_upstream_.has_value(), FakeHttpConnection::typeToString(http_type_));
   if (config.udp_fake_upstream_.has_value() &&
       config.udp_fake_upstream_->max_rx_datagram_size_.has_value()) {
     listener_.udp_listener_config_.config_.mutable_downstream_socket_config()

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -414,6 +414,17 @@ protected:
 class FakeHttpConnection : public Http::ServerConnectionCallbacks, public FakeConnectionBase {
 public:
   enum class Type { HTTP1, HTTP2, HTTP3 };
+  static absl::string_view typeToString(Type type) {
+    switch (type) {
+    case Type::HTTP1:
+      return "http1";
+    case Type::HTTP2:
+      return "http2";
+    case Type::HTTP3:
+      return "http3";
+    }
+    return "invalid";
+  }
 
   FakeHttpConnection(FakeUpstream& fake_upstream, SharedConnectionWrapper& shared_connection,
                      Type type, Event::TestTimeSystem& time_system, uint32_t max_request_headers_kb,

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -62,10 +62,10 @@ public:
 
     // Endpoint connections
     if (tls_hosts_) {
-      host_upstream_ =
-          &addFakeUpstream(HttpIntegrationTest::createUpstreamTlsContext(), http_conn_type_);
-      host2_upstream_ =
-          &addFakeUpstream(HttpIntegrationTest::createUpstreamTlsContext(), http_conn_type_);
+      host_upstream_ = &addFakeUpstream(
+          HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()), http_conn_type_);
+      host2_upstream_ = &addFakeUpstream(
+          HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()), http_conn_type_);
     } else {
       host_upstream_ = &addFakeUpstream(http_conn_type_);
       host2_upstream_ = &addFakeUpstream(http_conn_type_);

--- a/test/integration/ssl_utility.h
+++ b/test/integration/ssl_utility.h
@@ -72,7 +72,7 @@ createClientSslTransportSocketFactory(const ClientSslTransportOptions& options,
                                       ContextManager& context_manager, Api::Api& api);
 
 Network::TransportSocketFactoryPtr createUpstreamSslContext(ContextManager& context_manager,
-                                                            Api::Api& api);
+                                                            Api::Api& api, bool use_http3 = false);
 
 Network::TransportSocketFactoryPtr
 createFakeUpstreamSslContext(const std::string& upstream_cert_name, ContextManager& context_manager,

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1320,7 +1320,7 @@ public:
   void createUpstreams() override {
     for (uint32_t i = 0; i < fake_upstreams_count_; ++i) {
       Network::TransportSocketFactoryPtr factory =
-          upstream_tls_ ? createUpstreamTlsContext()
+          upstream_tls_ ? createUpstreamTlsContext(upstreamConfig())
                         : Network::Test::createRawBufferSocketFactory();
       auto endpoint = upstream_address_fn_(i);
       fake_upstreams_.emplace_back(

--- a/test/integration/transport_socket_match_integration_test.cc
+++ b/test/integration/transport_socket_match_integration_test.cc
@@ -119,7 +119,7 @@ transport_socket:
       auto endpoint = upstream_address_fn_(i);
       if (isTLSUpstream(i)) {
         fake_upstreams_.emplace_back(new AutonomousUpstream(
-            HttpIntegrationTest::createUpstreamTlsContext(), endpoint->ip()->port(),
+            HttpIntegrationTest::createUpstreamTlsContext(upstreamConfig()), endpoint->ip()->port(),
             endpoint->ip()->version(), upstreamConfig(), false));
       } else {
         fake_upstreams_.emplace_back(new AutonomousUpstream(


### PR DESCRIPTION
Making it a bit easier to mix and match protocols and doing so more cleanly for the H3/H2 alpn tests.

Risk Level: n/a (test only)
Testing: tests pass
Docs Changes: n/a
Release Notes: n/a 