### PR TITLE
build: fix crash in pre-commit-hooks

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -323,11 +323,15 @@ class FormatChecker:
     # look_path searches for the given executable in all directories in PATH
     # environment variable. If it cannot be found, empty string is returned.
     def look_path(self, executable):
+        if executable is None:
+            return ''
         return shutil.which(executable) or ''
 
     # path_exists checks whether the given path exists. This function assumes that
     # the path is absolute and evaluates environment variables.
     def path_exists(self, executable):
+        if executable is None:
+            return False
         return os.path.exists(os.path.expandvars(executable))
 
     # executable_by_others checks whether the given path has execute permission for


### PR DESCRIPTION
Signed-off-by: Justin Ely <justincely@gmail.com>

Commit Message: add defensive coding against None in pre-commit hook
Additional Description:  Fixes #16504 
Risk Level: low
Testing: After fixing, was able to run `git push` and have the pre-commit hook spit out the right errors rather than python stacktrace.

```
Running pre-push check; to skip this step use 'push --no-verify'
  Checking format for tools/code_format/check_format.py - ERROR: Command clang-format-11 not found. If you have clang-format in version 10.x.x installed, but the binary name is different or it's not available in PATH, please use CLANG_FORMAT environment variable to specify the path. Examples:
    export CLANG_FORMAT=clang-format-11.0.1
    export CLANG_FORMAT=/opt/bin/clang-format-11
    export CLANG_FORMAT=/usr/local/opt/llvm@11/bin/clang-format
ERROR: Command None not found. If you have buildifier installed, but the binary name is different or it's not available in $GOPATH/bin, please use BUILDIFIER_BIN environment variable to specify the path. Example:
    export BUILDIFIER_BIN=`which buildifier`
If you don't have buildifier installed, you can install it by:
    go get -u github.com/bazelbuild/buildtools/buildifier
ERROR: Command None not found. If you have buildozer installed, but the binary name is different or it's not available in $GOPATH/bin, please use BUILDOZER_BIN environment variable to specify the path. Example:
    export BUILDOZER_BIN=`which buildozer`
If you don't have buildozer installed, you can install it by:
    go get -u github.com/bazelbuild/buildtools/buildozer
```


Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
