### PR TITLE
docs: Fix subtitle format

### DIFF
--- a/docs/root/configuration/listeners/listener_filters/original_dst_filter.rst
+++ b/docs/root/configuration/listeners/listener_filters/original_dst_filter.rst
@@ -4,14 +4,14 @@ Original Destination
 ====================
 
 Linux
-===============
+-----
 
 Original destination listener filter reads the SO_ORIGINAL_DST socket option set when a connection
 has been redirected by an iptables REDIRECT target, or by an iptables TPROXY target in combination
 with setting the listener's :ref:`transparent <envoy_v3_api_field_config.listener.v3.Listener.transparent>` option.
 
 Windows
-===============
+-------
 
 Original destination listener filter reads the SO_ORIGINAL_DST socket option set when a connection has been redirected by an
 `HNS <https://docs.microsoft.com/en-us/virtualization/windowscontainers/container-networking/architecture#container-network-management-with-host-network-service>`_


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
Signed-off-by: luckyxiaoqiang <xiaoqiangding@126.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message: docs: Fix subtitle format
Additional Description: Fix format of subtitle in `original_dst_filter.rst`.  To view the old wrong format we can view [this page](https://www.envoyproxy.io/docs/envoy/v1.18.3/configuration/listeners/listener_filters/listener_filters) . Subtitle `Linux` and `Windows` should be child of `Original Destination`.
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
