### PR TITLE
DEVELOPER.md: add link to vscode docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,7 +9,7 @@ To generate a coverage report, there is a [coverage build script](https://github
 
 If you plan to contribute to Envoy, you may find it useful to install the Envoy [development support toolchain](https://github.com/envoyproxy/envoy/blob/main/support/README.md), which helps automate parts of the development process, particularly those involving code review.
 
-If you want to set up a local development environment with Visual Studio Code, please follow with [vscode setup](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md).
+If you want to set up a local development environment with Visual Studio Code, please see [vscode setup](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md).
 
 Below is a list of additional documentation to aid the development process:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,7 +9,7 @@ To generate a coverage report, there is a [coverage build script](https://github
 
 If you plan to contribute to Envoy, you may find it useful to install the Envoy [development support toolchain](https://github.com/envoyproxy/envoy/blob/main/support/README.md), which helps automate parts of the development process, particularly those involving code review.
 
-If you want to setup local development environment with Visual Studio Code, please follow with [vscode setup](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md).
+If you want to set up a local development environment with Visual Studio Code, please follow with [vscode setup](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md).
 
 Below is a list of additional documentation to aid the development process:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,8 +9,6 @@ To generate a coverage report, there is a [coverage build script](https://github
 
 If you plan to contribute to Envoy, you may find it useful to install the Envoy [development support toolchain](https://github.com/envoyproxy/envoy/blob/main/support/README.md), which helps automate parts of the development process, particularly those involving code review.
 
-If you want to set up a local development environment with Visual Studio Code, please see [vscode setup](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md).
-
 Below is a list of additional documentation to aid the development process:
 
 - [General build and installation documentation](https://www.envoyproxy.io/docs/envoy/latest/start/start)
@@ -20,6 +18,8 @@ Below is a list of additional documentation to aid the development process:
 - [Managing external dependencies with Bazel](https://github.com/envoyproxy/envoy/blob/main/bazel/EXTERNAL_DEPS.md)
 
 - [Guide to Envoy Bazel rules (managing `BUILD` files)](https://github.com/envoyproxy/envoy/blob/main/bazel/DEVELOPER.md)
+
+- [Guide to setup development environment with Visual Studio Code](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md)
 
 - [Using Docker for building and testing](https://github.com/envoyproxy/envoy/tree/main/ci)
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,6 +9,8 @@ To generate a coverage report, there is a [coverage build script](https://github
 
 If you plan to contribute to Envoy, you may find it useful to install the Envoy [development support toolchain](https://github.com/envoyproxy/envoy/blob/main/support/README.md), which helps automate parts of the development process, particularly those involving code review.
 
+If you want to setup local development environment with Visual Studio Code, please follow with [vscode setup](https://github.com/envoyproxy/envoy/blob/main/tools/vscode/README.md).
+
 Below is a list of additional documentation to aid the development process:
 
 - [General build and installation documentation](https://www.envoyproxy.io/docs/envoy/latest/start/start)


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:

It is hard for new developers to find how to setup vscode env, so add it.

Additional Description:
Risk Level: Low
Testing:
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
