### PR TITLE
quic: reduce socket option header exposure

### DIFF
--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -8,15 +8,16 @@
 
 #include <vector>
 
-#include "common/runtime/runtime_features.h"
 #include "common/http/utility.h"
+#include "common/network/socket_option_impl.h"
 #include "common/quic/envoy_quic_alarm_factory.h"
 #include "common/quic/envoy_quic_connection_helper.h"
 #include "common/quic/envoy_quic_dispatcher.h"
+#include "common/quic/envoy_quic_packet_writer.h"
 #include "common/quic/envoy_quic_proof_source.h"
 #include "common/quic/envoy_quic_utils.h"
-#include "common/quic/envoy_quic_packet_writer.h"
 #include "common/quic/envoy_quic_utils.h"
+#include "common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Quic {

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -3,9 +3,9 @@
 #include "envoy/config/listener/v3/quic_config.pb.h"
 #include "envoy/network/connection_handler.h"
 #include "envoy/network/listener.h"
+#include "envoy/network/socket.h"
 #include "envoy/runtime/runtime.h"
 
-#include "common/network/socket_option_impl.h"
 #include "common/protobuf/utility.h"
 #include "common/quic/envoy_quic_dispatcher.h"
 #include "common/runtime/runtime_protos.h"


### PR DESCRIPTION
Commit Message:

This is a trivial cleanup that moves the inclusion of `socket_option_impl.h` from the header to the source file to reduce its exposure.

Additional Description: None
Risk Level: Low
Testing: bazel tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
