### PR TITLE
[safe_memcpy_test] Explicit type for arguments of the vector constructor

### DIFF
--- a/test/common/common/safe_memcpy_test.cc
+++ b/test/common/common/safe_memcpy_test.cc
@@ -37,7 +37,7 @@ TEST(SafeMemcpyUnsafeDstTest, PrependGrpcFrameHeader) {
   uint8_t* dst = new uint8_t[4];
   memset(dst, 0, 4);
   safeMemcpyUnsafeDst(dst, &src);
-  EXPECT_THAT(std::vector(dst, dst + sizeof(src)), ElementsAre(1, 2, 3, 4));
+  EXPECT_THAT(std::vector<uint8_t>(dst, dst + sizeof(src)), ElementsAre(1, 2, 3, 4));
   delete[] dst;
 }
 


### PR DESCRIPTION
Signed-off-by: rialg <grial@google.com>

Commit Message: Explicit type for arguments of the vector constructor
Additional Description: Issue #16542 
Risk Level: N/A
