### PR TITLE
WIP: Expose upstream socket by connection

### DIFF
--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -326,6 +326,8 @@ public:
    *  returned.
    */
   virtual absl::optional<std::chrono::milliseconds> lastRoundTripTime() const PURE;
+
+  virtual OptRef<const Network::Socket> socket() const PURE;
 };
 
 using ConnectionPtr = std::unique_ptr<Connection>;

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -128,6 +128,11 @@ public:
   // ScopeTrackedObject
   void dumpState(std::ostream& os, int indent_level) const override;
 
+  OptRef<const Network::Socket> socket() const override {
+    return socket_ == nullptr ? OptRef<const Network::Socket>()
+                              : OptRef<const Network::Socket>(*socket_);
+  }
+
 protected:
   // A convenience function which returns true if
   // 1) The read disable count is zero or

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -71,6 +71,12 @@ public:
 
   using quic::QuicSpdyClientSession::PerformActionOnActiveStreams;
 
+  OptRef<const Network::Socket> socket() const override {
+    return network_connection_ == nullptr
+               ? OptRef<const Network::Socket>()
+               : OptRef<const Network::Socket>(*network_connection_->connectionSocket());
+  }
+
 protected:
   // quic::QuicSpdyClientSession
   std::unique_ptr<quic::QuicSpdyClientStream> CreateClientStream() override;

--- a/source/common/quic/envoy_quic_server_session.h
+++ b/source/common/quic/envoy_quic_server_session.h
@@ -75,6 +75,12 @@ public:
     headers_with_underscores_action_ = headers_with_underscores_action;
   }
 
+  OptRef<const Network::Socket> socket() const override {
+    return quic_connection_ == nullptr
+               ? OptRef<const Network::Socket>()
+               : OptRef<const Network::Socket>(*quic_connection_->connectionSocket());
+  }
+
   using quic::QuicSession::PerformActionOnActiveStreams;
 
 protected:

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -151,6 +151,12 @@ public:
     max_headers_count_ = max_headers_count;
   }
 
+  OptRef<const Network::Socket> socket() const override {
+    return network_connection_ == nullptr
+               ? OptRef<const Network::Socket>()
+               : OptRef<const Network::Socket>(*network_connection_->connectionSocket());
+  }
+
 protected:
   // Propagate connection close to network_connection_callbacks_.
   void onConnectionCloseEvent(const quic::QuicConnectionCloseFrame& frame,

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -146,7 +146,7 @@ protected:
       absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override { return {}; };
       // ScopeTrackedObject
       void dumpState(std::ostream& os, int) const override { os << "SyntheticConnection"; }
-
+      OptRef<const Network::Socket> socket() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
       SyntheticReadCallbacks& parent_;
       Network::SocketAddressSetterSharedPtr address_provider_;
       StreamInfo::StreamInfoImpl stream_info_;

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -85,7 +85,8 @@ public:
   MOCK_METHOD(absl::string_view, transportFailureReason, (), (const));                             \
   MOCK_METHOD(bool, startSecureTransport, ());                                                     \
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, lastRoundTripTime, (), (const));          \
-  MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));
+  MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));                                     \
+  MOCK_METHOD(OptRef<const Network::Socket>, socket, (), (const))
 
 class MockConnection : public Connection, public MockConnectionBase {
 public:


### PR DESCRIPTION
Signed-off-by: Jonathan Salazar <yceraf@google.com>

Commit Message: network

Additional Description: 
Expose constant socket by connection implementation,
this is required to get extra information of stream connection, like current rtt by stream-scoped connection.
past filed bug https://github.com/envoyproxy/envoy/issues/12305

Risk Level: Low

Testing: Unit test

Docs Changes: N/A

Release Notes: N/A

Platform Specific Features: N/A

