### PR TITLE
codeql: improve Ubuntu dependency installation

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -34,7 +34,8 @@ jobs:
     - name: Install deps
       shell: bash
       run: |
-       sudo apt-get update && sudo apt-get install libtool cmake automake autoconf make ninja-build curl unzip virtualenv openjdk-11-jdk build-essential libc++1
+       sudo apt-get update --error-on=any
+       sudo apt-get install --yes libtool cmake automake autoconf make ninja-build curl unzip virtualenv openjdk-11-jdk build-essential libc++1
        mkdir -p bin/clang11
        cd bin/clang11
        wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -42,7 +42,8 @@ jobs:
     - name: Install deps
       shell: bash
       run: |
-       sudo apt-get update && sudo apt-get install libtool cmake automake autoconf make ninja-build curl unzip virtualenv openjdk-11-jdk build-essential libc++1
+       sudo apt-get update --error-on=any
+       sudo apt-get install --yes libtool cmake automake autoconf make ninja-build curl unzip virtualenv openjdk-11-jdk build-essential libc++1
        mkdir -p bin/clang11
        cd bin/clang11
        wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/clang+llvm-11.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz


### PR DESCRIPTION
Commit Message:

If apt can't update the package index, it doesn't exit with an error
by default, so add the `--error-on=any` flag to force an error.

Pass the `--yes` flag to the install to force non-interactive mode.

Additional Description: This change ought to make the CI error in #16541 more obvious.
Risk Level: Low
Testing: None
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
