### PR TITLE
ci: exclude Google Test macros from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -59,6 +59,10 @@ CheckOptions:
   - key:             readability-identifier-naming.EnumConstantCase
     value:           'CamelCase'
 
+  # Ignore GoogleTest function macros.
+  - key:             readability-identifier-naming.FunctionIgnoredRegexp
+    value:           '(TEST|TEST_F|TEST_P|INSTANTIATE_TEST_SUITE_P|MOCK_METHOD|TYPED_TEST)'
+
   - key:             readability-identifier-naming.ParameterCase
     value:           'lower_case'
 


### PR DESCRIPTION
Commit Message:

Ignore the Google Test functional macros in the clang-tidy configuration.

Additional Description: N/A
Risk Level: Low
Testing: Manually ran `./ci/run_clang_tidy.sh` and observed lack of errors due to Google Test macros.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:  N/A

