### PR TITLE
examples/verify-common.sh: hide grep output

### DIFF
--- a/examples/verify-common.sh
+++ b/examples/verify-common.sh
@@ -89,7 +89,7 @@ responds_with () {
     local expected
     expected="$1"
     shift
-    _curl "${@}" | grep "$expected" || {
+    _curl "${@}" | grep -q "$expected" || {
         echo "ERROR: curl expected (${*}): $expected" >&2
         return 1
     }
@@ -109,7 +109,7 @@ responds_with_header () {
     local expected
     expected="$1"
     shift
-    _curl --head "${@}" | grep "$expected"  || {
+    _curl --head "${@}" | grep -q "$expected"  || {
         echo "ERROR: curl header (${*}): $expected" >&2
         return 1
     }


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

Commit Message:

Hide grep output since it is what we expected, no need to print again.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
