### PR TITLE
cleanup: fix various clang-tidy issues

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -229,7 +229,7 @@ constexpr bool win32SupportsOriginalDestination() {
 #define UDP_SEGMENT 103
 #endif
 
-typedef int os_fd_t;
+typedef int os_fd_t;            // NOLINT(modernize-use-using)
 typedef int filesystem_os_id_t; // NOLINT(modernize-use-using)
 typedef int signal_t;           // NOLINT(modernize-use-using)
 

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -778,7 +778,7 @@ void Utility::extractHostPathFromUri(const absl::string_view& uri, absl::string_
   // Start position of the host
   const auto host_pos = (pos == std::string::npos) ? 0 : pos + 3;
   // Start position of the path
-  const auto path_pos = uri.find("/", host_pos);
+  const auto path_pos = uri.find('/', host_pos);
   if (path_pos == std::string::npos) {
     // If uri doesn't have "/", the whole string is treated as host.
     host = uri.substr(host_pos);

--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -421,7 +421,7 @@ void Utility::parsePortRangeList(absl::string_view string, std::list<PortRange>&
     uint32_t min = 0;
     uint32_t max = 0;
 
-    if (s.find("-") != std::string::npos) {
+    if (s.find('-') != std::string::npos) {
       char dash = 0;
       ss >> min;
       ss >> dash;

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -752,7 +752,7 @@ absl::string_view RouteEntryImplBase::processRequestHost(const Http::RequestHead
       host_end += 1; // advance to :
     }
   } else {
-    host_end = request_host.rfind(":");
+    host_end = request_host.rfind(':');
   }
 
   if (host_end != absl::string_view::npos) {

--- a/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.h
+++ b/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.h
@@ -45,7 +45,7 @@ private:
     }
   };
   struct LocalDescriptorHash {
-    using is_transparent = void; // NOLINT(readability-identifier-naming)t
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
     size_t operator()(const RateLimit::LocalDescriptor& d) const {
       return absl::Hash<std::vector<RateLimit::DescriptorEntry>>()(d.entries_);
     }

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -53,7 +53,7 @@ private:
     static uint64_t hash(const ViewTuple& key) { return absl::Hash<ViewTuple>()(key); }
 
   public:
-    using is_transparent = void;
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
 
     uint64_t operator()(const OwningKey& key) const { return hash(key); }
     uint64_t operator()(const ViewKey& key) const {
@@ -62,7 +62,7 @@ private:
   };
 
   struct MapEq {
-    using is_transparent = void;
+    using is_transparent = void; // NOLINT(readability-identifier-naming)
     bool operator()(const OwningKey& left, const OwningKey& right) const { return left == right; }
     bool operator()(const OwningKey& left, const ViewKey& right) const {
       return left == std::make_tuple(right.service_, right.method_);

--- a/source/extensions/filters/network/wasm/wasm_filter.h
+++ b/source/extensions/filters/network/wasm/wasm_filter.h
@@ -51,7 +51,7 @@ private:
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;
 };
 
-typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 } // namespace Wasm
 } // namespace NetworkFilters

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -41,8 +41,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
 
 OptionsImpl::OptionsImpl(std::vector<std::string> args,
                          const HotRestartVersionCb& hot_restart_version_cb,
-                         spdlog::level::level_enum default_log_level)
-    : signal_handling_enabled_(true) {
+                         spdlog::level::level_enum default_log_level) {
   std::string log_levels_string = fmt::format("Log levels: {}", allowedLogLevels());
   log_levels_string +=
       fmt::format("\nDefault is [{}]", spdlog::level::level_string_views[default_log_level]);

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -27,7 +27,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::Invoke;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -26,7 +26,6 @@
 #include "gtest/gtest.h"
 #include "udpa/type/v1/typed_struct.pb.h"
 
-using testing::_;
 using testing::Ref;
 using testing::Return;
 

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -34,7 +34,6 @@ using testing::Pointee;
 using testing::Ref;
 using testing::Return;
 using testing::ReturnRef;
-using testing::Throw;
 
 namespace Envoy {
 namespace Http {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -7,7 +7,6 @@ using testing::An;
 using testing::AnyNumber;
 using testing::AtLeast;
 using testing::Eq;
-using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -41,9 +41,7 @@ using namespace std::chrono_literals;
 
 namespace Envoy {
 
-using testing::AllOf;
 using testing::HasSubstr;
-using testing::Property;
 
 class RuntimeStatsHelper : public TestScopedRuntime {
 public:

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -61,7 +61,6 @@
 
 using testing::_;
 using testing::HasSubstr;
-using testing::Return;
 
 namespace quic {
 namespace {

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -51,10 +51,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::AnyNumber;
-using testing::AssertionFailure;
-using testing::AssertionResult;
-using testing::AssertionSuccess;
 using testing::AtLeast;
 using testing::Eq;
 using testing::InSequence;

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -25,7 +25,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -46,7 +46,7 @@ public:
 
 using testing::Types;
 
-typedef Types<Http1Upstream, Http2Upstream> Implementations;
+using Implementations = Types<Http1Upstream, Http2Upstream>;
 
 TYPED_TEST_SUITE(HttpUpstreamTest, Implementations);
 

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -20,7 +20,6 @@
 #include "test/test_common/test_runtime.h"
 
 using testing::_;
-using testing::AnyNumber;
 using testing::InSequence;
 using testing::Invoke;
 using testing::NiceMock;

--- a/test/extensions/bootstrap/wasm/test_data/speed_cpp.cc
+++ b/test/extensions/bootstrap/wasm/test_data/speed_cpp.cc
@@ -79,14 +79,17 @@ std::string base64Encode(const uint8_t* start, const uint8_t* end) {
 }
 
 bool base64Decode(const std::basic_string<char>& input, std::vector<uint8_t>* output) {
-  if (input.length() % 4)
+  if (input.length() % 4) {
     return false;
+  }
   size_t padding = 0;
   if (input.length()) {
-    if (input[input.length() - 1] == padCharacter)
+    if (input[input.length() - 1] == padCharacter) {
       padding++;
-    if (input[input.length() - 2] == padCharacter)
+    }
+    if (input[input.length() - 2] == padCharacter) {
       padding++;
+    }
   }
   // Setup a vector to hold the result
   std::vector<unsigned char> decodedBytes;
@@ -96,17 +99,17 @@ bool base64Decode(const std::basic_string<char>& input, std::vector<uint8_t>* ou
   while (cursor < input.end()) {
     for (size_t quantumPosition = 0; quantumPosition < 4; quantumPosition++) {
       temp <<= 6;
-      if (*cursor >= 0x41 && *cursor <= 0x5A) // This area will need tweaking if
-        temp |= *cursor - 0x41;               // you are using an alternate alphabet
-      else if (*cursor >= 0x61 && *cursor <= 0x7A)
+      if (*cursor >= 0x41 && *cursor <= 0x5A) { // This area will need tweaking if
+        temp |= *cursor - 0x41;                 // you are using an alternate alphabet
+      } else if (*cursor >= 0x61 && *cursor <= 0x7A) {
         temp |= *cursor - 0x47;
-      else if (*cursor >= 0x30 && *cursor <= 0x39)
+      } else if (*cursor >= 0x30 && *cursor <= 0x39) {
         temp |= *cursor + 0x04;
-      else if (*cursor == 0x2B)
+      } else if (*cursor == 0x2B) {
         temp |= 0x3E; // change to 0x2D for URL alphabet
-      else if (*cursor == 0x2F)
+      }  else if (*cursor == 0x2F) {
         temp |= 0x3F;                     // change to 0x5F for URL alphabet
-      else if (*cursor == padCharacter) { // pad
+      } else if (*cursor == padCharacter) { // pad
         switch (input.end() - cursor) {
         case 1: // One pad character
           decodedBytes.push_back((temp >> 16) & 0x000000FF);
@@ -118,8 +121,9 @@ bool base64Decode(const std::basic_string<char>& input, std::vector<uint8_t>* ou
         default:
           return false;
         }
-      } else
+      } else {
         return false;
+      }
       cursor++;
     }
     decodedBytes.push_back((temp >> 16) & 0x000000FF);

--- a/test/extensions/common/wasm/test_data/test_context_cpp.cc
+++ b/test/extensions/common/wasm/test_data/test_context_cpp.cc
@@ -58,7 +58,7 @@ bool TestRootContext::onDone() {
 
 // Null VM fails on nullptr.
 void TestRootContext::onTick() {
-  if (envoy_resolve_dns(0, 1, &dns_token_) != WasmResult::InvalidMemoryAccess) {
+  if (envoy_resolve_dns(nullptr, 1, &dns_token_) != WasmResult::InvalidMemoryAccess) {
     logInfo("resolve_dns should report invalid memory access");
   }
   if (envoy_resolve_dns("example.com", sizeof("example.com") - 1, nullptr) !=

--- a/test/extensions/common/wasm/test_data/test_cpp.cc
+++ b/test/extensions/common/wasm/test_data/test_cpp.cc
@@ -76,6 +76,7 @@ WASM_EXPORT(uint32_t, proxy_on_vm_start, (uint32_t context_id, uint32_t configur
     std::string message = "before badptr";
     proxy_log(LogLevel::error, message.c_str(), message.size());
     ::free(const_cast<void*>(reinterpret_cast<const void*>(configuration_ptr)));
+    configuration_ptr = nullptr;
     *badptr = 1;
     message = "after badptr";
     proxy_log(LogLevel::error, message.c_str(), message.size());
@@ -83,6 +84,7 @@ WASM_EXPORT(uint32_t, proxy_on_vm_start, (uint32_t context_id, uint32_t configur
     std::string message = "before div by zero";
     proxy_log(LogLevel::error, message.c_str(), message.size());
     ::free(const_cast<void*>(reinterpret_cast<const void*>(configuration_ptr)));
+    configuration_ptr = nullptr;
     int zero = context_id & 0x100000;
     message = "divide by zero: " + std::to_string(100 / zero);
     proxy_log(LogLevel::error, message.c_str(), message.size());

--- a/test/extensions/filters/http/original_src/original_src_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_test.cc
@@ -16,7 +16,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::_;
 using testing::SaveArg;
 using testing::StrictMock;
 

--- a/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
+++ b/test/extensions/filters/network/client_ssl_auth/client_ssl_auth_test.cc
@@ -23,7 +23,6 @@
 #include "gtest/gtest.h"
 
 using testing::_;
-using testing::Eq;
 using testing::InSequence;
 using testing::Invoke;
 using testing::Return;

--- a/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/conn_manager_test.cc
@@ -432,14 +432,12 @@ TEST_F(ConnectionManagerTest, OnDataHandlesProtocolErrorOnWrite) {
 
   // Start the read buffer
   writePartialHessianRequestMessage(buffer_, false, false, 0x0F, true);
-  uint64_t len = buffer_.length();
 
   DubboFilters::DecoderFilterCallbacks* callbacks{};
   EXPECT_CALL(*decoder_filter, setDecoderFilterCallbacks(_))
       .WillOnce(Invoke([&](DubboFilters::DecoderFilterCallbacks& cb) -> void { callbacks = &cb; }));
 
   EXPECT_EQ(conn_manager_->onData(buffer_, false), Network::FilterStatus::StopIteration);
-  len -= buffer_.length();
 
   // Disable sniffing
   writeInvalidRequestMessage(write_buffer_);

--- a/test/extensions/filters/network/ext_authz/ext_authz_fuzz_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_fuzz_test.cc
@@ -14,7 +14,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::ReturnRef;
 using testing::WithArgs;
 
 namespace Envoy {

--- a/test/extensions/tracers/lightstep/config_test.cc
+++ b/test/extensions/tracers/lightstep/config_test.cc
@@ -10,7 +10,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using testing::Eq;
 using testing::NiceMock;
 using testing::Return;
 

--- a/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
+++ b/test/extensions/tracers/lightstep/lightstep_tracer_impl_test.cc
@@ -34,7 +34,6 @@
 using testing::_;
 using testing::AtLeast;
 using testing::DoAll;
-using testing::Eq;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;

--- a/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
+++ b/test/extensions/tracers/zipkin/zipkin_tracer_impl_test.cc
@@ -29,7 +29,6 @@
 
 using testing::_;
 using testing::DoAll;
-using testing::Eq;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;

--- a/test/mocks/server/overload_manager.cc
+++ b/test/mocks/server/overload_manager.cc
@@ -10,8 +10,6 @@
 namespace Envoy {
 namespace Server {
 
-using ::testing::NiceMock;
-using ::testing::ReturnNew;
 using ::testing::ReturnRef;
 
 MockThreadLocalOverloadState::MockThreadLocalOverloadState()

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -9,8 +9,6 @@
 namespace Envoy {
 namespace Upstream {
 
-using ::testing::_;
-using ::testing::Eq;
 using ::testing::Return;
 using ::testing::ReturnRef;
 

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -27,11 +27,6 @@
 #include "gtest/gtest.h"
 
 using testing::HasSubstr;
-using testing::Invoke;
-using testing::NiceMock;
-using testing::Return;
-using testing::ReturnPointee;
-using testing::ReturnRef;
 
 namespace Envoy {
 namespace Server {

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -32,7 +32,6 @@
 
 using testing::NiceMock;
 using testing::Return;
-using testing::ReturnRef;
 
 namespace Envoy {
 namespace Server {


### PR DESCRIPTION
Commit Message:

Clean up a few trivial issues that clang-tidy raises.

Additional Description: N/A
Risk Level: Low
Testing: bazel test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
