### PR TITLE
[fuzz]: fix oss fuzz 22106, envoy:codec_impl_fuzz_test: Crash in

### DIFF
--- a/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5766628005642240
+++ b/test/common/http/codec_impl_corpus/clusterfuzz-testcase-minimized-codec_impl_fuzz_test-5766628005642240
@@ -1,0 +1,192 @@
+actions {
+  server_drain {
+  }
+}
+actions {
+  new_stream {
+    request_headers {
+      headers {
+        key: ":method"
+        value: "GET"
+      }
+      headers {
+        key: ":path"
+        value: "/"
+      }
+      headers {
+        key: ":scheme"
+        value: "E"
+      }
+      headers {
+        key: ":authority"
+        value: "V"
+      }
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  swap_buffer {
+  }
+}
+actions {
+  swap_buffer {
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      headers {
+      }
+    }
+  }
+}
+actions {
+  server_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 1751212400
+    }
+  }
+}
+actions {
+  swap_buffer {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 8963
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 9
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 9
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3
+    }
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 0
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 9
+      end_stream: true
+    }
+  }
+}
+actions {
+  quiesce_drain {
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 3
+    }
+  }
+}
+actions {
+  client_drain {
+  }
+}
+actions {
+  stream_action {
+    request {
+      data: 7
+    }
+  }
+}
+actions {
+  stream_action {
+    stream_id: 2097152
+    response {
+      data: 9
+    }
+  }
+}
+actions {
+  stream_action {
+    response {
+      data: 0
+    }
+  }
+}
+actions {
+  mutate {
+  }
+}
+actions {
+  swap_buffer {
+  }
+}

--- a/test/common/http/codec_impl_fuzz_test.cc
+++ b/test/common/http/codec_impl_fuzz_test.cc
@@ -361,7 +361,13 @@ public:
         }
       }
       // Perform the stream action.
-      directionalAction(request_, stream_action.request());
+      // The request_.request_encoder_ is initialized from the response_.response_decoder_.
+      // Fuzz test codec_impl_fuzz_test-5766628005642240 created a situation where the response
+      // stream was in closed state leading to the state.request_encoder_ in directionalAction()
+      // kData case no longer being a valid address.
+      if (response_.stream_state_ != HttpStream::StreamState::Closed) {
+        directionalAction(request_, stream_action.request());
+      }
       break;
     }
     case test::common::http::StreamAction::kResponse: {


### PR DESCRIPTION
Signed-off-by: Tim Walsh <temporal.differential@gmail.com>

OSS-Fuzz envoy:codec_impl_fuzz_test: Crash in Envoy::Http::HttpStream::directionalAction

Commit Message: Update for oss-fuzz Issue 22106
Additional Description: Note that #4709 covers a number of oss-fuzz error This is part of the ongoing effort started for #4709.
Risk Level: Low
Testing: test/common/http
Docs Changes: None
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional API Considerations:]
