### PR TITLE
Refactor ip_detection_extensions to avoid cross extension dependencies.

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -214,7 +214,8 @@ envoy_cc_test(
     ],
     shard_count = 3,
     deps = [
-        ":ip_detection_extensions_lib",
+        ":custom_header_extension_lib",
+        ":xff_extension_lib",
         "//source/common/http:conn_manager_lib",
         "//source/common/http:context_lib",
         "//source/extensions/access_loggers/common:file_access_log_lib",
@@ -239,7 +240,8 @@ envoy_cc_test(
     name = "conn_manager_utility_test",
     srcs = ["conn_manager_utility_test.cc"],
     deps = [
-        ":ip_detection_extensions_lib",
+        ":custom_header_extension_lib",
+        ":xff_extension_lib",
         "//source/common/common:random_generator_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/http:conn_manager_lib",
@@ -497,11 +499,19 @@ envoy_cc_fuzz_test(
 )
 
 envoy_cc_test_library(
-    name = "ip_detection_extensions_lib",
-    srcs = ["ip_detection_extensions.cc"],
-    hdrs = ["ip_detection_extensions.h"],
+    name = "custom_header_extension_lib",
+    srcs = ["custom_header_extension.cc"],
+    hdrs = ["custom_header_extension.h"],
     deps = [
         "//source/extensions/http/original_ip_detection/custom_header:custom_header_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "xff_extension_lib",
+    srcs = ["xff_extension.cc"],
+    hdrs = ["xff_extension.h"],
+    deps = [
         "//source/extensions/http/original_ip_detection/xff:xff_lib",
     ],
 )

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -1,5 +1,5 @@
 #include "test/common/http/conn_manager_impl_test_base.h"
-#include "test/common/http/ip_detection_extensions.h"
+#include "test/common/http/custom_header_extension.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/test_runtime.h"
 

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -2,7 +2,7 @@
 
 #include "extensions/request_id/uuid/config.h"
 
-#include "test/common/http/ip_detection_extensions.h"
+#include "test/common/http/xff_extension.h"
 
 using testing::AtLeast;
 using testing::InSequence;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -14,7 +14,8 @@
 
 #include "extensions/request_id/uuid/config.h"
 
-#include "test/common/http/ip_detection_extensions.h"
+#include "test/common/http/custom_header_extension.h"
+#include "test/common/http/xff_extension.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"

--- a/test/common/http/custom_header_extension.cc
+++ b/test/common/http/custom_header_extension.cc
@@ -1,13 +1,8 @@
-#include "ip_detection_extensions.h"
+#include "test/common/http/custom_header_extension.h"
 
 #include "extensions/http/original_ip_detection/custom_header/custom_header.h"
-#include "extensions/http/original_ip_detection/xff/xff.h"
 
 namespace Envoy {
-
-Http::OriginalIPDetectionSharedPtr getXFFExtension(uint32_t hops) {
-  return std::make_shared<Extensions::Http::OriginalIPDetection::Xff::XffIPDetection>(hops);
-}
 
 Http::OriginalIPDetectionSharedPtr getCustomHeaderExtension(const std::string& header_name) {
   return std::make_shared<

--- a/test/common/http/custom_header_extension.h
+++ b/test/common/http/custom_header_extension.h
@@ -5,7 +5,6 @@
 // This helper is used to escape namespace pollution issues.
 namespace Envoy {
 
-Http::OriginalIPDetectionSharedPtr getXFFExtension(uint32_t hops);
 Http::OriginalIPDetectionSharedPtr getCustomHeaderExtension(const std::string& header_name);
 Http::OriginalIPDetectionSharedPtr
 getCustomHeaderExtension(const std::string& header_name,

--- a/test/common/http/xff_extension.cc
+++ b/test/common/http/xff_extension.cc
@@ -1,0 +1,11 @@
+#include "test/common/http/xff_extension.h"
+
+#include "extensions/http/original_ip_detection/xff/xff.h"
+
+namespace Envoy {
+
+Http::OriginalIPDetectionSharedPtr getXFFExtension(uint32_t hops) {
+  return std::make_shared<Extensions::Http::OriginalIPDetection::Xff::XffIPDetection>(hops);
+}
+
+} // namespace Envoy

--- a/test/common/http/xff_extension.h
+++ b/test/common/http/xff_extension.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "envoy/http/original_ip_detection.h"
+
+// This helper is used to escape namespace pollution issues.
+namespace Envoy {
+
+Http::OriginalIPDetectionSharedPtr getXFFExtension(uint32_t hops);
+
+} // namespace Envoy


### PR DESCRIPTION
Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:Refactor ip_detection_extensions to avoid cross extension dependencies.
Additional Description:
Risk Level: n/a test only
Testing: ran unit test
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA

I thought about putting this in the corresponding test/extension directories, but that'd require changing visibility of the packages which I haven't found elsewhere in test/extensions.
