### PR TITLE
quic: add quic downstream stats in hcm

### DIFF
--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -26,6 +26,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "quic_stats_lib",
+    srcs = ["quic_stats.cc"],
+    hdrs = ["quic_stats.h"],
+    tags = ["nofips"],
+    deps = [
+        "//include/envoy/stats:stats_interface",
+        "//source/common/stats:symbol_table_lib",
+        "@com_googlesource_quiche//:quic_core_error_codes_lib",
+        "@com_googlesource_quiche//:quic_core_types_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "envoy_quic_alarm_factory_lib",
     srcs = ["envoy_quic_alarm_factory.cc"],
     hdrs = ["envoy_quic_alarm_factory.h"],
@@ -193,6 +206,7 @@ envoy_cc_library(
     deps = [
         ":envoy_quic_simulated_watermark_buffer_lib",
         ":quic_network_connection_lib",
+        ":quic_stats_lib",
         ":send_buffer_monitor_lib",
         "//include/envoy/event:dispatcher_interface",
         "//include/envoy/network:connection_interface",

--- a/source/common/quic/codec_impl.cc
+++ b/source/common/quic/codec_impl.cc
@@ -21,13 +21,14 @@ bool QuicHttpConnectionImplBase::wantsToWrite() { return quic_session_.bytesToSe
 QuicHttpServerConnectionImpl::QuicHttpServerConnectionImpl(
     EnvoyQuicServerSession& quic_session, Http::ServerConnectionCallbacks& callbacks,
     Http::Http3::CodecStats& stats,
-    const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
+    const envoy::config::core::v3::Http3ProtocolOptions& http3_options, QuicStats& quic_stats,
     const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
     envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
         headers_with_underscores_action)
     : QuicHttpConnectionImplBase(quic_session, stats), quic_server_session_(quic_session) {
   quic_session.setCodecStats(stats);
   quic_session.setHttp3Options(http3_options);
+  quic_session.setQuicStats(quic_stats);
   quic_session.setHeadersWithUnderscoreAction(headers_with_underscores_action);
   quic_session.setHttpConnectionCallbacks(callbacks);
   quic_session.setMaxIncomingHeadersCount(max_request_headers_count);

--- a/source/common/quic/codec_impl.h
+++ b/source/common/quic/codec_impl.h
@@ -42,7 +42,7 @@ public:
   QuicHttpServerConnectionImpl(
       EnvoyQuicServerSession& quic_session, Http::ServerConnectionCallbacks& callbacks,
       Http::Http3::CodecStats& stats,
-      const envoy::config::core::v3::Http3ProtocolOptions& http3_options,
+      const envoy::config::core::v3::Http3ProtocolOptions& http3_options, QuicStats& quic_stats,
       const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
       envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
           headers_with_underscores_action);

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -82,6 +82,8 @@ void EnvoyQuicServerSession::setUpRequestDecoder(EnvoyQuicServerStream& stream) 
 void EnvoyQuicServerSession::OnConnectionClosed(const quic::QuicConnectionCloseFrame& frame,
                                                 quic::ConnectionCloseSource source) {
   quic::QuicServerSessionBase::OnConnectionClosed(frame, source);
+  ASSERT(quic_stats_.has_value());
+  quic_stats_->get().chargeQuicConnectionCloseStats(frame.quic_error_code, source);
   onConnectionCloseEvent(frame, source);
 }
 

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -82,8 +82,9 @@ void EnvoyQuicServerSession::setUpRequestDecoder(EnvoyQuicServerStream& stream) 
 void EnvoyQuicServerSession::OnConnectionClosed(const quic::QuicConnectionCloseFrame& frame,
                                                 quic::ConnectionCloseSource source) {
   quic::QuicServerSessionBase::OnConnectionClosed(frame, source);
-  ASSERT(quic_stats_.has_value());
-  quic_stats_->get().chargeQuicConnectionCloseStats(frame.quic_error_code, source);
+  if (quic_stats_.has_value()) {
+    quic_stats_->chargeQuicConnectionCloseStats(frame.quic_error_code, source);
+  }
   onConnectionCloseEvent(frame, source);
 }
 

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -23,6 +23,7 @@
 #include "common/network/connection_impl_base.h"
 #include "common/quic/quic_network_connection.h"
 #include "common/quic/envoy_quic_simulated_watermark_buffer.h"
+#include "common/quic/quic_stats.h"
 #include "common/quic/send_buffer_monitor.h"
 #include "common/stream_info/stream_info_impl.h"
 
@@ -143,6 +144,8 @@ public:
     codec_stats_ = std::reference_wrapper<Http::Http3::CodecStats>(stats);
   }
 
+  void setQuicStats(QuicStats& stats) { quic_stats_ = std::reference_wrapper<QuicStats>(stats); }
+
   uint32_t maxIncomingHeadersCount() { return max_headers_count_; }
 
   void setMaxIncomingHeadersCount(uint32_t max_headers_count) {
@@ -167,6 +170,7 @@ protected:
   absl::optional<std::reference_wrapper<Http::Http3::CodecStats>> codec_stats_;
   absl::optional<std::reference_wrapper<const envoy::config::core::v3::Http3ProtocolOptions>>
       http3_options_;
+  absl::optional<std::reference_wrapper<QuicStats>> quic_stats_;
   bool initialized_{false};
 
 private:

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -144,7 +144,7 @@ public:
     codec_stats_ = std::reference_wrapper<Http::Http3::CodecStats>(stats);
   }
 
-  void setQuicStats(QuicStats& stats) { quic_stats_ = std::reference_wrapper<QuicStats>(stats); }
+  void setQuicStats(QuicStats& stats) { quic_stats_ = stats; }
 
   uint32_t maxIncomingHeadersCount() { return max_headers_count_; }
 
@@ -170,7 +170,7 @@ protected:
   absl::optional<std::reference_wrapper<Http::Http3::CodecStats>> codec_stats_;
   absl::optional<std::reference_wrapper<const envoy::config::core::v3::Http3ProtocolOptions>>
       http3_options_;
-  absl::optional<std::reference_wrapper<QuicStats>> quic_stats_;
+  OptRef<QuicStats> quic_stats_;
   bool initialized_{false};
 
 private:

--- a/source/common/quic/quic_stats.cc
+++ b/source/common/quic/quic_stats.cc
@@ -1,0 +1,38 @@
+#include "common/quic/quic_stats.h"
+
+namespace Envoy {
+namespace Quic {
+
+QuicStats::QuicStats(Stats::Scope& scope, bool is_upstream)
+    : scope_(scope), stat_name_pool_(scope.symbolTable()), symbol_table_(scope.symbolTable()),
+      direction_(is_upstream ? stat_name_pool_.add("upstream") : stat_name_pool_.add("downstream")),
+      from_self_(stat_name_pool_.add("self")), from_peer_(stat_name_pool_.add("peer")) {
+  // Preallocate most used counters
+  connectionCloseStatName(quic::QUIC_NETWORK_IDLE_TIMEOUT);
+}
+
+void QuicStats::incCounter(const Stats::StatNameVec& names) {
+  Stats::SymbolTable::StoragePtr stat_name_storage = symbol_table_.join(names);
+  scope_.counterFromStatName(Stats::StatName(stat_name_storage.get())).inc();
+}
+
+void QuicStats::chargeQuicConnectionCloseStats(quic::QuicErrorCode error_code,
+                                               quic::ConnectionCloseSource source) {
+  const Stats::StatName connection_close = connectionCloseStatName(error_code);
+  incCounter({direction_,
+              source == quic::ConnectionCloseSource::FROM_SELF ? from_self_ : from_peer_,
+              connection_close});
+}
+
+Stats::StatName QuicStats::connectionCloseStatName(quic::QuicErrorCode error_code) {
+  ASSERT(error_code < quic::QUIC_LAST_ERROR);
+
+  return Stats::StatName(
+      connection_error_stat_names_.get(error_code, [this, error_code]() -> const uint8_t* {
+        return stat_name_pool_.addReturningStorage(
+            absl::StrCat("quic_connection_close_error_code_", QuicErrorCodeToString(error_code)));
+      }));
+}
+
+} // namespace Quic
+} // namespace Envoy

--- a/source/common/quic/quic_stats.h
+++ b/source/common/quic/quic_stats.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "envoy/stats/scope.h"
+
+#include "common/common/thread.h"
+#include "common/stats/symbol_table_impl.h"
+
+#include "quiche/quic/core/quic_error_codes.h"
+#include "quiche/quic/core/quic_types.h"
+
+namespace Envoy {
+namespace Quic {
+
+class QuicStats {
+public:
+  QuicStats(Stats::Scope& scope, bool is_upstream);
+
+  void chargeQuicConnectionCloseStats(quic::QuicErrorCode error_code,
+                                      quic::ConnectionCloseSource source);
+
+private:
+  void incCounter(const Stats::StatNameVec& names);
+
+  Stats::StatName connectionCloseStatName(quic::QuicErrorCode error_code);
+
+  Stats::Scope& scope_;
+  Stats::StatNamePool stat_name_pool_;
+  Stats::SymbolTable& symbol_table_;
+  const Stats::StatName direction_;
+  const Stats::StatName from_self_;
+  const Stats::StatName from_peer_;
+  Thread::AtomicPtrArray<const uint8_t, quic::QUIC_LAST_ERROR,
+                         Thread::AtomicPtrAllocMode::DoNotDelete>
+      connection_error_stat_names_;
+};
+
+} // namespace Quic
+} // namespace Envoy

--- a/source/common/quic/quic_stats.h
+++ b/source/common/quic/quic_stats.h
@@ -11,6 +11,8 @@
 namespace Envoy {
 namespace Quic {
 
+// This class is responsible for logging important QUIC error codes and tracking the dynamically
+// created stat tokens.
 class QuicStats {
 public:
   QuicStats(Stats::Scope& scope, bool is_upstream);

--- a/source/extensions/filters/network/http_connection_manager/BUILD
+++ b/source/extensions/filters/network/http_connection_manager/BUILD
@@ -68,6 +68,7 @@ envoy_cc_extension(
         "@envoy_api//envoy/type/v3:pkg_cc_proto",
     ] + envoy_select_enable_http3([
         "//source/common/quic:codec_lib",
+        "//source/common/quic:quic_stats_lib",
     ]),
 )
 

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -244,7 +244,6 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     Filter::Http::FilterConfigProviderManager& filter_config_provider_manager)
     : context_(context), stats_prefix_(fmt::format("http.{}.", config.stat_prefix())),
       stats_(Http::ConnectionManagerImpl::generateStats(stats_prefix_, context_.scope())),
-      quic_stats_(context_.scope(), false),
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, context_.scope())),
       use_remote_address_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_remote_address, false)),

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -244,6 +244,7 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     Filter::Http::FilterConfigProviderManager& filter_config_provider_manager)
     : context_(context), stats_prefix_(fmt::format("http.{}.", config.stat_prefix())),
       stats_(Http::ConnectionManagerImpl::generateStats(stats_prefix_, context_.scope())),
+      quic_stats_(context_.scope(), false),
       tracing_stats_(
           Http::ConnectionManagerImpl::generateTracingStats(stats_prefix_, context_.scope())),
       use_remote_address_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, use_remote_address, false)),
@@ -687,7 +688,8 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
     return std::make_unique<Quic::QuicHttpServerConnectionImpl>(
         dynamic_cast<Quic::EnvoyQuicServerSession&>(connection), callbacks,
         Http::Http3::CodecStats::atomicGet(http3_codec_stats_, context_.scope()), http3_options_,
-        maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction());
+        quic_stats_, maxRequestHeadersKb(), maxRequestHeadersCount(),
+        headersWithUnderscoresAction());
 #else
     // Should be blocked by configuration checking at an earlier point.
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -27,7 +27,6 @@
 #include "common/http/http3/codec_stats.h"
 #include "common/json/json_loader.h"
 #include "common/local_reply/local_reply.h"
-#include "common/quic/quic_stats.h"
 #include "common/router/rds_impl.h"
 #include "common/router/scoped_rds.h"
 #include "common/tracing/http_tracer_impl.h"
@@ -35,6 +34,10 @@
 #include "extensions/filters/network/common/factory_base.h"
 #include "extensions/filters/network/http_connection_manager/dependency_manager.h"
 #include "extensions/filters/network/well_known_names.h"
+
+#ifdef ENVOY_ENABLE_QUIC
+#include "common/quic/quic_stats.h"
+#endif
 
 namespace Envoy {
 namespace Extensions {
@@ -228,7 +231,9 @@ private:
   mutable Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
   mutable Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   mutable Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
-  mutable Quic::QuicStats quic_stats_;
+#ifdef ENVOY_ENABLE_QUIC
+  mutable Quic::QuicStats quic_stats_ = Quic::QuicStats(context_.scope(), false);
+#endif
   Http::ConnectionManagerTracingStats tracing_stats_;
   const bool use_remote_address_{};
   const std::unique_ptr<Http::InternalAddressConfig> internal_address_config_;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -27,6 +27,7 @@
 #include "common/http/http3/codec_stats.h"
 #include "common/json/json_loader.h"
 #include "common/local_reply/local_reply.h"
+#include "common/quic/quic_stats.h"
 #include "common/router/rds_impl.h"
 #include "common/router/scoped_rds.h"
 #include "common/tracing/http_tracer_impl.h"
@@ -227,6 +228,7 @@ private:
   mutable Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
   mutable Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   mutable Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
+  mutable Quic::QuicStats quic_stats_;
   Http::ConnectionManagerTracingStats tracing_stats_;
   const bool use_remote_address_{};
   const std::unique_ptr<Http::InternalAddressConfig> internal_address_config_;

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -39,6 +39,18 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "quic_stats_test",
+    srcs = ["quic_stats_test.cc"],
+    tags = ["nofips"],
+    deps = [
+        "//source/common/quic:quic_stats_lib",
+        "//source/common/stats:stats_lib",
+        "//test/mocks/stats:stats_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "envoy_quic_proof_source_test",
     srcs = ["envoy_quic_proof_source_test.cc"],
     external_deps = ["quiche_quic_platform"],

--- a/test/common/quic/quic_stats_test.cc
+++ b/test/common/quic/quic_stats_test.cc
@@ -1,0 +1,29 @@
+#include <string>
+
+#include "common/quic/quic_stats.h"
+
+#include "test/mocks/stats/mocks.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Quic {
+
+class QuicStatsTest : public testing::Test {
+public:
+  QuicStatsTest() : scope_(*symbol_table_), quic_stats_(scope_, false) {}
+
+  Stats::TestUtil::TestSymbolTable symbol_table_;
+  Stats::TestUtil::TestStore scope_;
+  QuicStats quic_stats_;
+};
+
+TEST_F(QuicStatsTest, QuicConnectionCloseStats) {
+  quic_stats_.chargeQuicConnectionCloseStats(quic::QUIC_NO_ERROR,
+                                             quic::ConnectionCloseSource::FROM_SELF);
+  EXPECT_EQ(
+      1U, scope_.counter("downstream.self.quic_connection_close_error_code_QUIC_NO_ERROR").value());
+}
+
+} // namespace Quic
+} // namespace Envoy

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -346,8 +346,8 @@ FakeHttpConnection::FakeHttpConnection(
     Http::Http3::CodecStats& stats = fake_upstream.http3CodecStats();
     codec_ = std::make_unique<Quic::QuicHttpServerConnectionImpl>(
         dynamic_cast<Quic::EnvoyQuicServerSession&>(shared_connection_.connection()), *this, stats,
-        fake_upstream.http3Options(), max_request_headers_kb, max_request_headers_count,
-        headers_with_underscores_action);
+        fake_upstream.http3Options(), fake_upstream.quicStats(), max_request_headers_kb,
+        max_request_headers_count, headers_with_underscores_action);
 #else
     ASSERT(false, "running a QUIC integration test without compiling QUIC");
 #endif

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -37,6 +37,7 @@
 
 #if defined(ENVOY_ENABLE_QUIC)
 #include "common/quic/active_quic_listener.h"
+#include "common/quic/quic_stats.h"
 #endif
 
 #include "server/active_raw_udp_listener_config.h"
@@ -664,6 +665,10 @@ public:
     return Http::Http3::CodecStats::atomicGet(http3_codec_stats_, stats_store_);
   }
 
+#if defined(ENVOY_ENABLE_QUIC)
+  Quic::QuicStats& quicStats() { return quic_stats_; }
+#endif
+
   // Write into the outbound buffer of the network connection at the specified index.
   // Note: that this write bypasses any processing by the upstream codec.
   ABSL_MUST_USE_RESULT
@@ -829,6 +834,9 @@ private:
   Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
   Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
+#if defined(ENVOY_ENABLE_QUIC)
+  Quic::QuicStats quic_stats_ = Quic::QuicStats(stats_store_, false);
+#endif
 };
 
 using FakeUpstreamPtr = std::unique_ptr<FakeUpstream>;

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -35,7 +35,7 @@
 #include "common/network/udp_packet_writer_handler_impl.h"
 #include "common/stats/isolated_store_impl.h"
 
-#if defined(ENVOY_ENABLE_QUIC)
+#ifdef ENVOY_ENABLE_QUIC
 #include "common/quic/active_quic_listener.h"
 #include "common/quic/quic_stats.h"
 #endif
@@ -665,7 +665,7 @@ public:
     return Http::Http3::CodecStats::atomicGet(http3_codec_stats_, stats_store_);
   }
 
-#if defined(ENVOY_ENABLE_QUIC)
+#ifdef ENVOY_ENABLE_QUIC
   Quic::QuicStats& quicStats() { return quic_stats_; }
 #endif
 
@@ -744,7 +744,7 @@ private:
     FakeListener(FakeUpstream& parent, bool is_quic = false)
         : parent_(parent), name_("fake_upstream"), init_manager_(nullptr) {
       if (is_quic) {
-#if defined(ENVOY_ENABLE_QUIC)
+#ifdef ENVOY_ENABLE_QUIC
         udp_listener_config_.listener_factory_ = std::make_unique<Quic::ActiveQuicListenerFactory>(
             envoy::config::listener::v3::QuicProtocolOptions(), 1);
 #else
@@ -834,7 +834,7 @@ private:
   Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
   Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
-#if defined(ENVOY_ENABLE_QUIC)
+#ifdef ENVOY_ENABLE_QUIC
   Quic::QuicStats quic_stats_ = Quic::QuicStats(stats_store_, false);
 #endif
 };


### PR DESCRIPTION
Commit Message: Introduce QuicStats and add Quic connection close stats for downstream connections.
Risk Level: Low
Testing: unit tests
Docs Changes: n/a
Release Notes: n/a.
Platform Specific Features: n/a.