### PR TITLE
api: adjust the behavior of header's present_match

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -1885,8 +1885,8 @@ message HeaderMatcher {
     //   "-1somestring"
     type.v3.Int64Range range_match = 6;
 
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
+    // If specified as true, header match will be performed based on whether the header is in the
+    // request. If specified as false, header match will be performed based on whether the header is absent.
     bool present_match = 7;
 
     // If specified, header match will be performed based on the prefix of the header value.

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -1837,8 +1837,8 @@ message HeaderMatcher {
     //   "-1somestring"
     type.v3.Int64Range range_match = 6;
 
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
+    // If specified as true, header match will be performed based on whether the header is in the
+    // request. If specified as false, header match will be performed based on whether the header is absent.
     bool present_match = 7;
 
     // If specified, header match will be performed based on the prefix of the header value.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -29,7 +29,8 @@ Minor Behavior Changes
   ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers``
   (do not send 1xx or 204 responses with these headers). Both are true by default.
 * http: serve HEAD requests from cache.
-* http: the behavior of the present_match in route header matcher changed. The value of present_match is ignored in the past. The new behavior is present match performed when value is true. absent match performed when the value is false.
+* http: the behavior of the present_match in route header matcher changed. The value of present_match is ignored in the past. The new behavior is present match performed when value is true. absent match performed when the value is false. Please reference :ref:`present_match
+  <envoy_v3_api_field_config.route.v3.HeaderMatcher.present_match>`.
 * listener: respect the :ref:`connection balance config <envoy_v3_api_field_config.listener.v3.Listener.connection_balance_config>`
   defined within the listener where the sockets are redirected to. Clear that field to restore the previous behavior.
 * tcp: switched to the new connection pool by default. Any unexpected behavioral changes can be reverted by setting runtime guard ``envoy.reloadable_features.new_tcp_connection_pool`` to false.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -29,10 +29,10 @@ Minor Behavior Changes
   ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers``
   (do not send 1xx or 204 responses with these headers). Both are true by default.
 * http: serve HEAD requests from cache.
+* http: the behavior of the present_match in route header matcher changed. The value of present_match is ignored in the past. The new behavior is present match performed when value is true. absent match performed when the value is false.
 * listener: respect the :ref:`connection balance config <envoy_v3_api_field_config.listener.v3.Listener.connection_balance_config>`
   defined within the listener where the sockets are redirected to. Clear that field to restore the previous behavior.
 * tcp: switched to the new connection pool by default. Any unexpected behavioral changes can be reverted by setting runtime guard ``envoy.reloadable_features.new_tcp_connection_pool`` to false.
-
 
 Bug Fixes
 ---------

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -29,7 +29,7 @@ Minor Behavior Changes
   ``envoy.reloadable_features.send_strict_1xx_and_204_response_headers``
   (do not send 1xx or 204 responses with these headers). Both are true by default.
 * http: serve HEAD requests from cache.
-* http: the behavior of the present_match in route header matcher changed. The value of present_match is ignored in the past. The new behavior is present match performed when value is true. absent match performed when the value is false. Please reference :ref:`present_match
+* http: the behavior of the *present_match* in route header matcher changed. The value of *present_match* is ignored in the past. The new behavior is *present_match* performed when value is true. absent match performed when the value is false. Please reference :ref:`present_match
   <envoy_v3_api_field_config.route.v3.HeaderMatcher.present_match>`.
 * listener: respect the :ref:`connection balance config <envoy_v3_api_field_config.listener.v3.Listener.connection_balance_config>`
   defined within the listener where the sockets are redirected to. Clear that field to restore the previous behavior.

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -1916,8 +1916,8 @@ message HeaderMatcher {
     //   "-1somestring"
     type.v3.Int64Range range_match = 6;
 
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
+    // If specified as true, header match will be performed based on whether the header is in the
+    // request. If specified as false, header match will be performed based on whether the header is absent.
     bool present_match = 7;
 
     // If specified, header match will be performed based on the prefix of the header value.

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -1915,8 +1915,8 @@ message HeaderMatcher {
     //   "-1somestring"
     type.v3.Int64Range range_match = 6;
 
-    // If specified, header match will be performed based on whether the header is in the
-    // request.
+    // If specified as true, header match will be performed based on whether the header is in the
+    // request. If specified as false, header match will be performed based on whether the header is absent.
     bool present_match = 7;
 
     // If specified, header match will be performed based on the prefix of the header value.

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -66,6 +66,7 @@ public:
     Regex::CompiledMatcherPtr regex_;
     envoy::type::v3::Int64Range range_;
     const bool invert_match_;
+    bool present_;
 
     // HeaderMatcher
     bool matchesHeaders(const HeaderMap& headers) const override {

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -495,6 +495,8 @@ invert_match: true
   EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
+// Test the case present_match is true. Expected true when
+// header matched, expected false when no header matched.
 TEST(MatchHeadersTest, HeaderPresentMatchWithTrueValue) {
   TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
   TestRequestHeaderMapImpl unmatching_headers{{"nonmatch-header", "1234"},
@@ -512,6 +514,8 @@ present_match: true
   EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
+// Test the case present_match is false. Expected false when
+// header matched, expected true when no header matched.
 TEST(MatchHeadersTest, HeaderPresentMatchWithFalseValue) {
   TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
   TestRequestHeaderMapImpl unmatching_headers{{"nonmatch-header", "1234"},
@@ -529,6 +533,8 @@ present_match: false
   EXPECT_TRUE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
+// Test the case present_match is true and invert_match is true. Expected true when
+// no header matched, expected false when header matched.
 TEST(MatchHeadersTest, HeaderPresentInverseMatchWithTrueValue) {
   TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
   TestRequestHeaderMapImpl matching_headers{{"nonmatch-header", "1234"},
@@ -547,6 +553,8 @@ invert_match: true
   EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
+// Test the case present_match is true and invert_match is true. Expected false when
+// no header matched, expected true when header matched.
 TEST(MatchHeadersTest, HeaderPresentInverseMatchWithFalseValue) {
   TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
   TestRequestHeaderMapImpl matching_headers{{"nonmatch-header", "1234"},

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -495,7 +495,7 @@ invert_match: true
   EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
-TEST(MatchHeadersTest, HeaderPresentMatch) {
+TEST(MatchHeadersTest, HeaderPresentMatchWithTrueValue) {
   TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
   TestRequestHeaderMapImpl unmatching_headers{{"nonmatch-header", "1234"},
                                               {"other-nonmatch-header", "123.456"}};
@@ -512,7 +512,24 @@ present_match: true
   EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
-TEST(MatchHeadersTest, HeaderPresentInverseMatch) {
+TEST(MatchHeadersTest, HeaderPresentMatchWithFalseValue) {
+  TestRequestHeaderMapImpl matching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl unmatching_headers{{"nonmatch-header", "1234"},
+                                              {"other-nonmatch-header", "123.456"}};
+
+  const std::string yaml = R"EOF(
+name: match-header
+present_match: false
+  )EOF";
+
+  std::vector<HeaderUtility::HeaderDataPtr> header_data;
+  header_data.push_back(
+      std::make_unique<HeaderUtility::HeaderData>(parseHeaderMatcherFromYaml(yaml)));
+  EXPECT_FALSE(HeaderUtility::matchHeaders(matching_headers, header_data));
+  EXPECT_TRUE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
+}
+
+TEST(MatchHeadersTest, HeaderPresentInverseMatchWithTrueValue) {
   TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
   TestRequestHeaderMapImpl matching_headers{{"nonmatch-header", "1234"},
                                             {"other-nonmatch-header", "123.456"}};
@@ -528,6 +545,24 @@ invert_match: true
       std::make_unique<HeaderUtility::HeaderData>(parseHeaderMatcherFromYaml(yaml)));
   EXPECT_TRUE(HeaderUtility::matchHeaders(matching_headers, header_data));
   EXPECT_FALSE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
+}
+
+TEST(MatchHeadersTest, HeaderPresentInverseMatchWithFalseValue) {
+  TestRequestHeaderMapImpl unmatching_headers{{"match-header", "123"}};
+  TestRequestHeaderMapImpl matching_headers{{"nonmatch-header", "1234"},
+                                            {"other-nonmatch-header", "123.456"}};
+
+  const std::string yaml = R"EOF(
+name: match-header
+present_match: false
+invert_match: true
+  )EOF";
+
+  std::vector<HeaderUtility::HeaderDataPtr> header_data;
+  header_data.push_back(
+      std::make_unique<HeaderUtility::HeaderData>(parseHeaderMatcherFromYaml(yaml)));
+  EXPECT_FALSE(HeaderUtility::matchHeaders(matching_headers, header_data));
+  EXPECT_TRUE(HeaderUtility::matchHeaders(unmatching_headers, header_data));
 }
 
 TEST(MatchHeadersTest, HeaderPrefixMatch) {


### PR DESCRIPTION
Commit Message: api: adjust the behavior of header's present_match

Additional Description:
Currently, envoy ignores the value of present match. This commit adjust
envoy's behavior. When the value is True, envoy will check the header
present. When the value is False, envoy will check the header absent.
Risk Level: low
Testing: unit test added
Docs Changes: api doc updated
Release Notes: minor behavior change
Fixes #14656

Signed-off-by: He Jie Xu <hejie.xu@intel.com>