### PR TITLE
configs: Remove unnecessary connect_timeouts

### DIFF
--- a/configs/envoy-demo.yaml
+++ b/configs/envoy-demo.yaml
@@ -37,7 +37,6 @@ static_resources:
           - name: envoy.filters.http.router
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/configs/envoy-tap-config.yaml
+++ b/configs/envoy-tap-config.yaml
@@ -37,7 +37,6 @@ static_resources:
           - name: envoy.filters.http.router
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/configs/envoy_double_proxy.template.yaml
+++ b/configs/envoy_double_proxy.template.yaml
@@ -112,7 +112,6 @@ static_resources:
   clusters:
   - name: statsd
     type: STATIC
-    connect_timeout: 0.25s
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: statsd
@@ -126,7 +125,6 @@ static_resources:
                 protocol: TCP
   - name: backhaul
     type: STRICT_DNS
-    connect_timeout: 1s
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: backhaul
@@ -165,7 +163,6 @@ static_resources:
           http2_protocol_options: {}
   - name: lightstep_saas
     type: LOGICAL_DNS
-    connect_timeout: 1s
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: lightstep_saas

--- a/docs/root/_include/ads.yaml
+++ b/docs/root/_include/ads.yaml
@@ -21,7 +21,6 @@ dynamic_resources:
 static_resources:
   clusters:
   - name: ads_cluster
-    connect_timeout: 5s
     type: STRICT_DNS
     load_assignment:
       cluster_name: ads_cluster

--- a/docs/root/configuration/best_practices/_include/edge.yaml
+++ b/docs/root/configuration/best_practices/_include/edge.yaml
@@ -78,7 +78,6 @@ static_resources:
                   idle_timeout: 15s # must be disabled for long-lived and streaming requests
   clusters:
   - name: service_foo
-    connect_timeout: 15s
     per_connection_buffer_limit_bytes: 32768 # 32 KiB
     load_assignment:
       cluster_name: some_service

--- a/docs/root/configuration/http/http_conn_man/_include/preserve-case.yaml
+++ b/docs/root/configuration/http/http_conn_man/_include/preserve-case.yaml
@@ -28,7 +28,6 @@ static_resources:
                             cluster: service_foo
   clusters:
     - name: service_foo
-      connect_timeout: 15s
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/docs/root/configuration/http/http_filters/_include/bandwidth-limit-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/bandwidth-limit-filter.yaml
@@ -38,7 +38,6 @@ static_resources:
 
   clusters:
   - name: service_protected_by_bandwidth_limit
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -51,7 +50,6 @@ static_resources:
                 address: web_service
                 port_value: 9000
   - name: web_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/docs/root/configuration/http/http_filters/_include/composite.yaml
+++ b/docs/root/configuration/http/http_filters/_include/composite.yaml
@@ -73,7 +73,6 @@ static_resources:
 
   clusters:
   - name: grpc
-    connect_timeout: 1.25s
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
     dns_lookup_family: V4_ONLY

--- a/docs/root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml
+++ b/docs/root/configuration/http/http_filters/_include/dns-cache-circuit-breaker.yaml
@@ -48,7 +48,6 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
   - name: dynamic_forward_proxy_cluster
-    connect_timeout: 1s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy

--- a/docs/root/configuration/http/http_filters/_include/grpc-reverse-bridge-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/grpc-reverse-bridge-filter.yaml
@@ -53,7 +53,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: other
-    connect_timeout: 5.00s
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
@@ -67,7 +66,6 @@ static_resources:
                   address: localhost
                   port_value: 4630
   - name: grpc
-    connect_timeout: 5.00s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/docs/root/configuration/http/http_filters/_include/grpc-transcoder-filter.yaml
+++ b/docs/root/configuration/http/http_filters/_include/grpc-transcoder-filter.yaml
@@ -39,7 +39,6 @@ static_resources:
 
   clusters:
   - name: grpc
-    connect_timeout: 1.25s
     type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
     dns_lookup_family: V4_ONLY

--- a/docs/root/configuration/listeners/network_filters/_include/sni-dynamic-forward-proxy-filter.yaml
+++ b/docs/root/configuration/listeners/network_filters/_include/sni-dynamic-forward-proxy-filter.yaml
@@ -30,7 +30,6 @@ static_resources:
               cluster: dynamic_forward_proxy_cluster
   clusters:
   - name: dynamic_forward_proxy_cluster
-    connect_timeout: 1s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy

--- a/docs/root/configuration/listeners/network_filters/_include/zookeeper-filter-proxy.yaml
+++ b/docs/root/configuration/listeners/network_filters/_include/zookeeper-filter-proxy.yaml
@@ -18,7 +18,6 @@ static_resources:
             cluster: local_zk_server
   clusters:
     - name: local_zk_server
-      connect_timeout: 120s
       type: LOGICAL_DNS
       lb_policy: ROUND_ROBIN
       typed_extension_protocol_options:

--- a/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
+++ b/docs/root/configuration/listeners/udp_filters/_include/udp-proxy.yaml
@@ -26,7 +26,6 @@ static_resources:
           max_rx_datagram_size: 9000
   clusters:
   - name: service_udp
-    connect_timeout: 0.25s
     type: STATIC
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/docs/root/intro/_include/life-of-a-request.yaml
+++ b/docs/root/intro/_include/life-of-a-request.yaml
@@ -58,7 +58,6 @@ static_resources:
             - name: envoy.filters.http.router
   clusters:
   - name: some_service
-    connect_timeout: 5s
     # Upstream TLS configuration.
     transport_socket:
       name: envoy.transport_sockets.tls
@@ -86,7 +85,6 @@ static_resources:
           http2_protocol_options:
             max_concurrent_streams: 100
   - name: some_statsd_sink
-    connect_timeout: 5s
     # The rest of the configuration for statsd sink cluster.
 # statsd sink.
 stats_sinks:

--- a/docs/root/intro/arch_overview/advanced/matching/_include/complicated.yaml
+++ b/docs/root/intro/arch_overview/advanced/matching/_include/complicated.yaml
@@ -81,7 +81,6 @@ static_resources:
                             cluster: service_foo
   clusters:
     - name: service_foo
-      connect_timeout: 15s
       load_assignment:
         cluster_name: some_service
         endpoints:

--- a/docs/root/intro/arch_overview/advanced/matching/_include/request_response.yaml
+++ b/docs/root/intro/arch_overview/advanced/matching/_include/request_response.yaml
@@ -67,7 +67,6 @@ static_resources:
                             cluster: service_foo
   clusters:
     - name: service_foo
-      connect_timeout: 15s
       load_assignment:
         cluster_name: some_service
         endpoints:

--- a/docs/root/intro/arch_overview/advanced/matching/_include/simple.yaml
+++ b/docs/root/intro/arch_overview/advanced/matching/_include/simple.yaml
@@ -55,7 +55,6 @@ static_resources:
                             cluster: service_foo
   clusters:
     - name: service_foo
-      connect_timeout: 15s
       load_assignment:
         cluster_name: some_service
         endpoints:

--- a/docs/root/intro/arch_overview/security/_include/ssl.yaml
+++ b/docs/root/intro/arch_overview/security/_include/ssl.yaml
@@ -29,7 +29,6 @@ static_resources:
                 filename: certs/cacert.pem
   clusters:
   - name: some_service
-    connect_timeout: 0.25s
     type: STATIC
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-client-auth.yaml
@@ -44,7 +44,6 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-sni.yaml
@@ -41,7 +41,6 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo-tls-validation.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls-validation.yaml
@@ -28,7 +28,6 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo-tls.yaml
@@ -38,7 +38,6 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-demo.yaml
@@ -32,7 +32,6 @@ static_resources:
 
   clusters:
   - name: service_envoyproxy_io
-    connect_timeout: 30s
     type: LOGICAL_DNS
     # Comment out the following line to test on v6 networks
     dns_lookup_family: V4_ONLY

--- a/docs/root/start/quick-start/_include/envoy-dynamic-cds-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-cds-demo.yaml
@@ -1,7 +1,6 @@
 resources:
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: example_proxy_cluster
-  connect_timeout: 1s
   type: STRICT_DNS
   typed_extension_protocol_options:
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/docs/root/start/quick-start/_include/envoy-dynamic-control-plane-demo.yaml
+++ b/docs/root/start/quick-start/_include/envoy-dynamic-control-plane-demo.yaml
@@ -18,8 +18,7 @@ dynamic_resources:
 
 static_resources:
   clusters:
-  - connect_timeout: 1s
-    type: STRICT_DNS
+  - type: STRICT_DNS
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/docs/root/start/quick-start/configuration-dynamic-control-plane.rst
+++ b/docs/root/start/quick-start/configuration-dynamic-control-plane.rst
@@ -69,6 +69,6 @@ The ``xds_cluster`` is configured to query a control plane at http://my-control-
 .. literalinclude:: _include/envoy-dynamic-control-plane-demo.yaml
     :language: yaml
     :linenos:
-    :lines: 17-39
+    :lines: 17-38
     :lineno-start: 17
-    :emphasize-lines: 3-21
+    :emphasize-lines: 3-20

--- a/docs/root/start/quick-start/configuration-dynamic-filesystem.rst
+++ b/docs/root/start/quick-start/configuration-dynamic-filesystem.rst
@@ -89,4 +89,4 @@ proxies over ``TLS`` to https://www.envoyproxy.io.
 .. literalinclude:: _include/envoy-dynamic-cds-demo.yaml
     :language: yaml
     :linenos:
-    :emphasize-lines: 12, 18-19, 23-24
+    :emphasize-lines: 11, 17-18, 22-23

--- a/docs/root/start/quick-start/configuration-static.rst
+++ b/docs/root/start/quick-start/configuration-static.rst
@@ -55,5 +55,5 @@ proxies over ``TLS`` to https://www.envoyproxy.io.
 .. literalinclude:: _include/envoy-demo.yaml
     :language: yaml
     :lineno-start: 29
-    :lines: 29-52
-    :emphasize-lines: 5-24
+    :lines: 29-51
+    :emphasize-lines: 5-23

--- a/docs/root/start/quick-start/securing.rst
+++ b/docs/root/start/quick-start/securing.rst
@@ -59,8 +59,8 @@ to the :ref:`transport_socket <extension_envoy.transport_sockets.tls>` of a
    :language: yaml
    :linenos:
    :lineno-start: 39
-   :lines: 39-57
-   :emphasize-lines: 16-19
+   :lines: 39-56
+   :emphasize-lines: 15-18
    :caption: :download:`envoy-demo-tls.yaml <_include/envoy-demo-tls.yaml>`
 
 .. _start_quick_start_securing_validation:
@@ -79,8 +79,8 @@ Firstly, you can ensure that the certificates are from a mutually trusted certif
 .. literalinclude:: _include/envoy-demo-tls-validation.yaml
    :language: yaml
    :linenos:
-   :lineno-start: 43
-   :lines: 43-53
+   :lineno-start: 42
+   :lines: 42-52
    :emphasize-lines: 6-9
    :caption: :download:`envoy-demo-tls-validation.yaml <_include/envoy-demo-tls-validation.yaml>`
 
@@ -92,8 +92,8 @@ certificate is valid for.
 .. literalinclude:: _include/envoy-demo-tls-validation.yaml
    :language: yaml
    :linenos:
-   :lineno-start: 43
-   :lines: 43-53
+   :lineno-start: 42
+   :lines: 42-52
    :emphasize-lines: 6-7, 10-11
    :caption: :download:`envoy-demo-tls-validation.yaml <_include/envoy-demo-tls-validation.yaml>`
 
@@ -154,9 +154,9 @@ When connecting to an upstream with client certificates you can set them as foll
 .. literalinclude:: _include/envoy-demo-tls-client-auth.yaml
    :language: yaml
    :linenos:
-   :lineno-start: 45
-   :lines: 45-69
-   :emphasize-lines: 21-25
+   :lineno-start: 44
+   :lines: 44-68
+   :emphasize-lines: 20-25
    :caption: :download:`envoy-demo-tls-client-auth.yaml <_include/envoy-demo-tls-client-auth.yaml>`
 
 .. _start_quick_start_securing_sni:
@@ -195,8 +195,8 @@ This will usually be the DNS name of the service you are connecting to.
 .. literalinclude:: _include/envoy-demo-tls-sni.yaml
    :language: yaml
    :linenos:
-   :lineno-start: 56
-   :lines: 56-61
+   :lineno-start: 55
+   :lines: 55-60
    :emphasize-lines: 6
    :caption: :download:`envoy-demo-tls-sni.yaml <_include/envoy-demo-tls-sni.yaml>`
 

--- a/docs/root/start/sandboxes/dynamic-configuration-filesystem.rst
+++ b/docs/root/start/sandboxes/dynamic-configuration-filesystem.rst
@@ -90,7 +90,7 @@ from ``service1`` to ``service2``:
 .. literalinclude:: _include/dynamic-config-fs/configs/cds.yaml
    :language: yaml
    :linenos:
-   :lines: 6-14
+   :lines: 6-13
    :lineno-start: 6
    :emphasize-lines: 8
 

--- a/examples/cache/front-envoy.yaml
+++ b/examples/cache/front-envoy.yaml
@@ -37,7 +37,6 @@ static_resources:
 
   clusters:
   - name: service1
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -50,7 +49,6 @@ static_resources:
                 address: service1
                 port_value: 8000
   - name: service2
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/cache/service-envoy.yaml
+++ b/examples/cache/service-envoy.yaml
@@ -27,7 +27,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/cors/backend/front-envoy.yaml
+++ b/examples/cors/backend/front-envoy.yaml
@@ -72,7 +72,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: backend_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/cors/backend/service-envoy.yaml
+++ b/examples/cors/backend/service-envoy.yaml
@@ -27,7 +27,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/cors/frontend/front-envoy.yaml
+++ b/examples/cors/frontend/front-envoy.yaml
@@ -33,7 +33,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: frontend_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/cors/frontend/service-envoy.yaml
+++ b/examples/cors/frontend/service-envoy.yaml
@@ -27,7 +27,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/csrf/crosssite/front-envoy.yaml
+++ b/examples/csrf/crosssite/front-envoy.yaml
@@ -31,7 +31,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: generic_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/csrf/samesite/front-envoy.yaml
+++ b/examples/csrf/samesite/front-envoy.yaml
@@ -103,7 +103,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: generic_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/csrf/service-envoy.yaml
+++ b/examples/csrf/service-envoy.yaml
@@ -27,7 +27,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/double-proxy/envoy-backend.yaml
+++ b/examples/double-proxy/envoy-backend.yaml
@@ -38,7 +38,6 @@ static_resources:
 
   clusters:
   - name: postgres_cluster
-    connect_timeout: 1s
     type: STRICT_DNS
     load_assignment:
       cluster_name: postgres_cluster

--- a/examples/double-proxy/envoy-frontend.yaml
+++ b/examples/double-proxy/envoy-frontend.yaml
@@ -19,7 +19,6 @@ static_resources:
 
   clusters:
   - name: postgres_cluster
-    connect_timeout: 1s
     type: STRICT_DNS
     load_assignment:
       cluster_name: postgres_cluster

--- a/examples/double-proxy/envoy.yaml
+++ b/examples/double-proxy/envoy.yaml
@@ -27,7 +27,6 @@ static_resources:
 
   clusters:
   - name: service1
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/dynamic-config-cp/envoy.yaml
+++ b/examples/dynamic-config-cp/envoy.yaml
@@ -18,8 +18,7 @@ dynamic_resources:
 
 static_resources:
   clusters:
-  - connect_timeout: 1s
-    type: STRICT_DNS
+  - type: STRICT_DNS
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/examples/dynamic-config-fs/configs/cds.yaml
+++ b/examples/dynamic-config-fs/configs/cds.yaml
@@ -1,7 +1,6 @@
 resources:
 - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
   name: example_proxy_cluster
-  connect_timeout: 1s
   type: STRICT_DNS
   load_assignment:
     cluster_name: example_proxy_cluster

--- a/examples/ext_authz/config/grpc-service/v3.yaml
+++ b/examples/ext_authz/config/grpc-service/v3.yaml
@@ -36,7 +36,6 @@ static_resources:
 
   clusters:
   - name: upstream-service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -50,7 +49,6 @@ static_resources:
                 port_value: 8080
 
   - name: ext_authz-grpc-service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/examples/ext_authz/config/http-service.yaml
+++ b/examples/ext_authz/config/http-service.yaml
@@ -41,7 +41,6 @@ static_resources:
 
   clusters:
   - name: upstream-service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -55,7 +54,6 @@ static_resources:
                 port_value: 8080
 
   - name: ext_authz-http-service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/ext_authz/config/opa-service/v3.yaml
+++ b/examples/ext_authz/config/opa-service/v3.yaml
@@ -36,7 +36,6 @@ static_resources:
 
   clusters:
   - name: upstream-service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -50,7 +49,6 @@ static_resources:
                 port_value: 8080
 
   - name: ext_authz-opa-service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/examples/fault-injection/envoy.yaml
+++ b/examples/fault-injection/envoy.yaml
@@ -44,7 +44,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/front-proxy/front-envoy.yaml
+++ b/examples/front-proxy/front-envoy.yaml
@@ -126,7 +126,6 @@ static_resources:
 
   clusters:
   - name: service1
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -139,7 +138,6 @@ static_resources:
                 address: service1
                 port_value: 8000
   - name: service2
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/front-proxy/service-envoy.yaml
+++ b/examples/front-proxy/service-envoy.yaml
@@ -27,7 +27,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/grpc-bridge/client/envoy-proxy.yaml
+++ b/examples/grpc-bridge/client/envoy-proxy.yaml
@@ -40,7 +40,6 @@ static_resources:
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
-    connect_timeout: 0.250s
     http_protocol_options: {}
     load_assignment:
       cluster_name: backend-proxy

--- a/examples/grpc-bridge/server/envoy-proxy.yaml
+++ b/examples/grpc-bridge/server/envoy-proxy.yaml
@@ -32,7 +32,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: backend_grpc_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/front-envoy-jaeger.yaml
@@ -52,7 +52,6 @@ static_resources:
           use_remote_address: true
   clusters:
   - name: service1
-    connect_timeout: 0.250s
     type: strict_dns
     lb_policy: round_robin
     load_assignment:

--- a/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service1-envoy-jaeger.yaml
@@ -78,7 +78,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: strict_dns
     lb_policy: round_robin
     load_assignment:
@@ -91,7 +90,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: service2
-    connect_timeout: 0.250s
     type: strict_dns
     lb_policy: round_robin
     load_assignment:

--- a/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-native-tracing/service2-envoy-jaeger.yaml
@@ -50,7 +50,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: strict_dns
     lb_policy: round_robin
     load_assignment:

--- a/examples/jaeger-tracing/front-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/front-envoy-jaeger.yaml
@@ -41,7 +41,6 @@ static_resources:
           use_remote_address: true
   clusters:
   - name: service1
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -54,7 +53,6 @@ static_resources:
                 address: service1
                 port_value: 8000
   - name: jaeger
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/jaeger-tracing/service1-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service1-envoy-jaeger.yaml
@@ -76,7 +76,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -89,7 +88,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: service2
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -102,7 +100,6 @@ static_resources:
                 address: service2
                 port_value: 8000
   - name: jaeger
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/jaeger-tracing/service2-envoy-jaeger.yaml
+++ b/examples/jaeger-tracing/service2-envoy-jaeger.yaml
@@ -39,7 +39,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -52,7 +51,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: jaeger
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/load-reporting-service/service-envoy-w-lrs.yaml
+++ b/examples/load-reporting-service/service-envoy-w-lrs.yaml
@@ -27,7 +27,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -40,7 +39,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8082
   - name: load_reporting_cluster
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/lua/envoy.yaml
+++ b/examples/lua/envoy.yaml
@@ -42,7 +42,6 @@ static_resources:
 
   clusters:
   - name: web_service
-    connect_timeout: 0.25s
     type: STRICT_DNS # static
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/mysql/envoy.yaml
+++ b/examples/mysql/envoy.yaml
@@ -19,7 +19,6 @@ static_resources:
 
   clusters:
   - name: mysql_cluster
-    connect_timeout: 1s
     type: STRICT_DNS
     load_assignment:
       cluster_name: mysql_cluster

--- a/examples/postgres/envoy.yaml
+++ b/examples/postgres/envoy.yaml
@@ -19,7 +19,6 @@ static_resources:
 
   clusters:
   - name: postgres_cluster
-    connect_timeout: 1s
     type: STRICT_DNS
     load_assignment:
       cluster_name: postgres_cluster

--- a/examples/redis/envoy.yaml
+++ b/examples/redis/envoy.yaml
@@ -18,7 +18,6 @@ static_resources:
               cluster: redis_cluster
   clusters:
   - name: redis_cluster
-    connect_timeout: 1s
     type: STRICT_DNS # static
     lb_policy: MAGLEV
     load_assignment:

--- a/examples/skywalking-tracing/front-envoy-skywalking.yaml
+++ b/examples/skywalking-tracing/front-envoy-skywalking.yaml
@@ -45,7 +45,6 @@ static_resources:
               start_child_span: true
   clusters:
   - name: service1
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:
@@ -63,7 +62,6 @@ static_resources:
                 address: service1
                 port_value: 8000
   - name: skywalking
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/examples/skywalking-tracing/service1-envoy-skywalking.yaml
+++ b/examples/skywalking-tracing/service1-envoy-skywalking.yaml
@@ -86,7 +86,6 @@ static_resources:
               start_child_span: true
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -99,7 +98,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: service2
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:
@@ -117,7 +115,6 @@ static_resources:
                 address: service2
                 port_value: 8000
   - name: skywalking
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/examples/skywalking-tracing/service2-envoy-skywalking.yaml
+++ b/examples/skywalking-tracing/service2-envoy-skywalking.yaml
@@ -44,7 +44,6 @@ static_resources:
               start_child_span: true
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -57,7 +56,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: skywalking
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     typed_extension_protocol_options:

--- a/examples/tls-inspector/envoy.yaml
+++ b/examples/tls-inspector/envoy.yaml
@@ -43,7 +43,6 @@ static_resources:
 
   clusters:
   - name: service-https-http2
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -56,7 +55,6 @@ static_resources:
                 address: service-https-http2
                 port_value: 443
   - name: service-https-http1.1
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -69,7 +67,6 @@ static_resources:
                 address: service-https-http1.1
                 port_value: 443
   - name: service-http
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/tls-sni/envoy-client.yaml
+++ b/examples/tls-sni/envoy-client.yaml
@@ -35,7 +35,6 @@ static_resources:
 
   clusters:
   - name: proxy-client-domain1
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -54,7 +53,6 @@ static_resources:
         sni: domain1.example.com
 
   - name: proxy-client-domain2
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -73,7 +71,6 @@ static_resources:
         sni: domain2.example.com
 
   - name: proxy-client-domain3
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/tls-sni/envoy.yaml
+++ b/examples/tls-sni/envoy.yaml
@@ -85,7 +85,6 @@ static_resources:
 
   clusters:
   - name: proxy-domain1
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -99,7 +98,6 @@ static_resources:
                 port_value: 80
 
   - name: proxy-domain2
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -113,7 +111,6 @@ static_resources:
                 port_value: 80
 
   - name: proxy-domain3
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/tls/envoy-http-https.yaml
+++ b/examples/tls/envoy-http-https.yaml
@@ -27,7 +27,6 @@ static_resources:
 
   clusters:
   - name: service-https
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/tls/envoy-https-http.yaml
+++ b/examples/tls/envoy-https-http.yaml
@@ -90,7 +90,6 @@ static_resources:
 
   clusters:
   - name: service-http
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/tls/envoy-https-https.yaml
+++ b/examples/tls/envoy-https-https.yaml
@@ -90,7 +90,6 @@ static_resources:
 
   clusters:
   - name: service-https
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/tls/envoy-https-passthrough.yaml
+++ b/examples/tls/envoy-https-passthrough.yaml
@@ -14,7 +14,6 @@ static_resources:
 
   clusters:
   - name: service-https
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/udp/envoy.yaml
+++ b/examples/udp/envoy.yaml
@@ -16,7 +16,6 @@ static_resources:
 
   clusters:
   - name: service_udp
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/wasm-cc/envoy.yaml
+++ b/examples/wasm-cc/envoy.yaml
@@ -47,7 +47,6 @@ static_resources:
 
   clusters:
   - name: web_service
-    connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin
     load_assignment:

--- a/examples/websocket/envoy-ws.yaml
+++ b/examples/websocket/envoy-ws.yaml
@@ -28,7 +28,6 @@ static_resources:
 
   clusters:
   - name: service_ws
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/websocket/envoy-wss-passthrough.yaml
+++ b/examples/websocket/envoy-wss-passthrough.yaml
@@ -14,7 +14,6 @@ static_resources:
 
   clusters:
   - name: service_wss_passthrough
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/websocket/envoy-wss.yaml
+++ b/examples/websocket/envoy-wss.yaml
@@ -91,7 +91,6 @@ static_resources:
 
   clusters:
   - name: service_wss
-    connect_timeout: 0.25s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/zipkin-tracing/front-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/front-envoy-zipkin.yaml
@@ -46,7 +46,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: service1
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -59,7 +58,6 @@ static_resources:
                 address: service1
                 port_value: 8000
   - name: zipkin
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/zipkin-tracing/service1-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service1-envoy-zipkin.yaml
@@ -74,7 +74,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -87,7 +86,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: service2
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -100,7 +98,6 @@ static_resources:
                 address: service2
                 port_value: 8000
   - name: zipkin
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:

--- a/examples/zipkin-tracing/service2-envoy-zipkin.yaml
+++ b/examples/zipkin-tracing/service2-envoy-zipkin.yaml
@@ -38,7 +38,6 @@ static_resources:
             typed_config: {}
   clusters:
   - name: local_service
-    connect_timeout: 0.250s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -51,7 +50,6 @@ static_resources:
                 address: 127.0.0.1
                 port_value: 8080
   - name: zipkin
-    connect_timeout: 1s
     type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: configs: Remove unnecessary connect_timeouts
Additional Description:

now that there is a default for `connect_timeout` we dont need to include it in all of the config examples

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
