### PR TITLE
aws_lambda filter in json mode should use content-type header from json response

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,6 +38,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* aws_lambda: in JSON mode, the downstream response content-type header will now be set from the content-type entry in the JSON response's headers map, if present.
 * http: port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
 * http: raise max configurable max_request_headers_kb limit to 8192 KiB (8MiB) from 96 KiB in http connection manager.
 * listener: fix the crash which could happen when the ongoing filter chain only listener update is followed by the listener removal or full listener update.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -38,7 +38,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
-* aws_lambda: in JSON mode, the downstream response content-type header will now be set from the content-type entry in the JSON response's headers map, if present.
+* aws_lambda: if `payload_passthrough` is set to ``false``, the downstream response content-type header will now be set from the content-type entry in the JSON response's headers map, if present.
 * http: port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
 * http: raise max configurable max_request_headers_kb limit to 8192 KiB (8MiB) from 96 KiB in http connection manager.
 * listener: fix the crash which could happen when the ongoing filter chain only listener update is followed by the listener removal or full listener update.

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -333,8 +333,8 @@ void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::I
     return;
   }
 
-  // Use JSON as the default content-type. If the JSON response headers has a
-  // content-type key, it will override.
+  // Use JSON as the default content-type. If the response headers have a different content-type
+  // set, that will be used instead.
   headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
 
   for (auto&& kv : json_resp.headers()) {

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -333,6 +333,10 @@ void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::I
     return;
   }
 
+  // Use JSON as the default content-type. If the JSON response headers has a
+  // content-type key, it will override.
+  headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
+
   for (auto&& kv : json_resp.headers()) {
     // ignore H2 pseudo-headers (if any)
     if (kv.first[0] == ':') {
@@ -348,7 +352,6 @@ void Filter::dejsonizeResponse(Http::ResponseHeaderMap& headers, const Buffer::I
   if (json_resp.status_code() != 0) {
     headers.setStatus(json_resp.status_code());
   }
-  headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
   if (!json_resp.body().empty()) {
     if (json_resp.is_base64_encoded()) {
       body.add(Base64::decode(json_resp.body()));

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -533,7 +533,7 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
 }
 
 /**
- * encodeData() data in JSON mode should use respect content-type header.
+ * encodeData() data in JSON mode should respect content-type header.
  */
 TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeContentTypeHeader) {
   setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/});

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -519,6 +519,7 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
 
   EXPECT_FALSE(headers.has(":other"));
   EXPECT_EQ("awesome value", headers.get_("x-awesome-header"));
+  EXPECT_EQ("application/json", headers.get_("content-type"));
 
   std::vector<std::string> cookies;
   headers.iterate([&cookies](const Http::HeaderEntry& entry) {
@@ -529,6 +530,40 @@ TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeTransformToHttp) {
   });
 
   EXPECT_THAT(cookies, ElementsAre("session-id=42; Secure; HttpOnly", "user=joe"));
+}
+
+/**
+ * encodeData() data in JSON mode should use respect content-type header.
+ */
+TEST_F(AwsLambdaFilterTest, EncodeDataJsonModeContentTypeHeader) {
+  setupFilter({arn_, InvocationMode::Synchronous, false /*passthrough*/});
+  filter_->resolveSettings();
+  Http::TestResponseHeaderMapImpl headers;
+  headers.setStatus(200);
+  filter_->encodeHeaders(headers, false /*end_stream*/);
+
+  constexpr auto json_response = R"EOF(
+  {
+      "statusCode": 201,
+      "headers": {"content-type": "text/plain"}
+  }
+  )EOF";
+
+  Buffer::OwnedImpl encoded_buf;
+  encoded_buf.add(json_response);
+  auto on_modify_encoding_buffer = [&encoded_buf](std::function<void(Buffer::Instance&)> cb) {
+    cb(encoded_buf);
+  };
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer).WillRepeatedly(Return(&encoded_buf));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer)
+      .WillRepeatedly(Invoke(on_modify_encoding_buffer));
+
+  auto result = filter_->encodeData(encoded_buf, true /*end_stream*/);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, result);
+
+  ASSERT_NE(nullptr, headers.Status());
+  EXPECT_EQ("201", headers.getStatusValue());
+  EXPECT_EQ("text/plain", headers.get_("content-type"));
 }
 
 /**


### PR DESCRIPTION
Commit Message: aws_lambda filter in json mode should use content-type header from json response
Additional Description: fixes #16615 
Risk Level: Low
Testing: unit tested
Docs Changes: None - the new behavior conforms to the existing docs.
Release Notes: Bug fix mentioned in version history
Platform Specific Features: None
Fixes #16615 