### PR TITLE
Bootstrap agent

### DIFF
--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -420,11 +420,11 @@ void InstanceImpl::initialize(const Options& options,
 
   // If user has set user_agent_version in the bootstrap config, use it.
   // Default to the internal server version.
-  if (bootstrap_.node().user_agent_version().empty()) {
-    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
-  } else {
-    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
+  if (!bootstrap_.node().user_agent_version().empty()) {
+      bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
         bootstrap_.node().user_agent_version());
+  } else {
+      bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
   }
 
   // If user has set user_agent_build_version in the bootstrap config, use it.

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -414,7 +414,7 @@ void InstanceImpl::initialize(const Options& options,
 
   // If user has set user_agent_name in the bootstrap config, use it.
   // Default to "envoy" if unset.
-  if (bootstrap_.node().user_agent_name().empty() ) {
+  if (bootstrap_.node().user_agent_name().empty()) {
     bootstrap_.mutable_node()->set_user_agent_name("envoy");
   }
 
@@ -422,8 +422,7 @@ void InstanceImpl::initialize(const Options& options,
   // Default to the internal server version.
   if (bootstrap_.node().user_agent_version().empty()) {
     bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
-  }
-  else {
+  } else {
     bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
         bootstrap_.node().user_agent_version());
   }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -421,8 +421,8 @@ void InstanceImpl::initialize(const Options& options,
   // If user has set user_agent_version in the bootstrap config, use it.
   // Default to the internal server version.
   if (!bootstrap_.node().user_agent_version().empty()) {
-    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
-        bootstrap_.node().user_agent_version());
+    std::string user_agent_version = bootstrap_.node().user_agent_version();
+    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(user_agent_version);
   } else {
     bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
   }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -421,10 +421,10 @@ void InstanceImpl::initialize(const Options& options,
   // If user has set user_agent_version in the bootstrap config, use it.
   // Default to the internal server version.
   if (!bootstrap_.node().user_agent_version().empty()) {
-      bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
+    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
         bootstrap_.node().user_agent_version());
   } else {
-      bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
+    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
   }
 
   // If user has set user_agent_build_version in the bootstrap config, use it.

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -412,30 +412,32 @@ void InstanceImpl::initialize(const Options& options,
     server_compilation_settings_stats_->fips_mode_.set(1);
   }
 
-  // Check to see if bootstrap has set user_agent_name.  If yes, use that.  
+  // Check to see if bootstrap has set user_agent_name. If yes, use that.
   // If not, use "envoy"
-  std::string user_agent_name = bootstrap_.node().user_agent_name();
-  if (user_agent_name == "" ) {
-    user_agent_name = "envoy";
+  if (bootstrap_.node().user_agent_name().empty()) {
+    bootstrap_.mutable_node()->set_user_agent_name("envoy");
+  } else {
+    bootstrap_.mutable_node()->set_user_agent_name(bootstrap_.node().user_agent_name());
   }
-  bootstrap_.mutable_node()->set_user_agent_name(user_agent_name);
 
-  // Check to see if bootstrap has set user_agent_version.  If yes, use that.  
+  // Check to see if bootstrap has set user_agent_version. If yes, use that.
   // If not, use the internal server version
-  std::string user_agent_version = bootstrap_.node().user_agent_version();
-  if (user_agent_version == "" ) {
-    user_agent_version = VersionInfo::version();
+  if (bootstrap_.node().user_agent_version().empty()) {
+    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
+  } else {
+    bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
+        bootstrap_.node().user_agent_version());
   }
-  bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(user_agent_version);
 
-  // Same, but for build version
-  ::envoy::config::core::v3::BuildVersion user_agent_build_version = bootstrap_.node().user_agent_build_version();
-  if (!user_agent_build_version.has_version()) {
-    user_agent_build_version = VersionInfo::buildVersion();
+  // Check to see if bootstrap has set user_agent_build_version. If yes, use that.
+  // If not, use the internal server version
+  if (bootstrap_.node().user_agent_build_version().has_version()) {
+    *bootstrap_.mutable_node()->mutable_user_agent_build_version() =
+        bootstrap_.node().user_agent_build_version();
+  } else {
+    *bootstrap_.mutable_node()->mutable_user_agent_build_version() = VersionInfo::buildVersion();
   }
-  *bootstrap_.mutable_node()->mutable_user_agent_build_version() = user_agent_build_version;
 
-  *bootstrap_.mutable_node()->mutable_user_agent_build_version() = VersionInfo::buildVersion();
   for (const auto& ext : Envoy::Registry::FactoryCategoryRegistry::registeredFactories()) {
     for (const auto& name : ext.second->allRegisteredNames()) {
       auto* extension = bootstrap_.mutable_node()->add_extensions();

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -412,29 +412,25 @@ void InstanceImpl::initialize(const Options& options,
     server_compilation_settings_stats_->fips_mode_.set(1);
   }
 
-  // Check to see if bootstrap has set user_agent_name. If yes, use that.
-  // If not, use "envoy"
-  if (bootstrap_.node().user_agent_name().empty()) {
+  // If user has set user_agent_name in the bootstrap config, use it.
+  // Default to "envoy" if unset.
+  if (bootstrap_.node().user_agent_name().empty() ) {
     bootstrap_.mutable_node()->set_user_agent_name("envoy");
-  } else {
-    bootstrap_.mutable_node()->set_user_agent_name(bootstrap_.node().user_agent_name());
   }
 
-  // Check to see if bootstrap has set user_agent_version. If yes, use that.
-  // If not, use the internal server version
+  // If user has set user_agent_version in the bootstrap config, use it.
+  // Default to the internal server version.
   if (bootstrap_.node().user_agent_version().empty()) {
     bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(VersionInfo::version());
-  } else {
+  }
+  else {
     bootstrap_.mutable_node()->set_hidden_envoy_deprecated_build_version(
         bootstrap_.node().user_agent_version());
   }
 
-  // Check to see if bootstrap has set user_agent_build_version. If yes, use that.
-  // If not, use the internal server version
-  if (bootstrap_.node().user_agent_build_version().has_version()) {
-    *bootstrap_.mutable_node()->mutable_user_agent_build_version() =
-        bootstrap_.node().user_agent_build_version();
-  } else {
+  // If user has set user_agent_build_version in the bootstrap config, use it.
+  // Default to the internal server version.
+  if (!bootstrap_.node().user_agent_build_version().has_version()) {
     *bootstrap_.mutable_node()->mutable_user_agent_build_version() = VersionInfo::buildVersion();
   }
 

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -871,17 +871,16 @@ TEST_P(ServerInstanceImplTest, UserAgentOverrideFromNode) {
   initialize("test/server/test_data/server/node_bootstrap_agent_override.yaml");
   EXPECT_EQ("test-ci-user-agent", server_->localInfo().node().user_agent_name());
   EXPECT_TRUE(server_->localInfo().node().has_user_agent_build_version());
-  EXPECT_EQ(9, server_->localInfo().node().user_agent_build_version().major_number());
-  EXPECT_EQ(8, server_->localInfo().node().user_agent_build_version().minor_number());
-  EXPECT_EQ(7, server_->localInfo().node().user_agent_build_version().patch());
+  EXPECT_EQ(9, server_->localInfo().node().user_agent_build_version().version().major_number());
+  EXPECT_EQ(8, server_->localInfo().node().user_agent_build_version().version().minor_number());
+  EXPECT_EQ(7, server_->localInfo().node().user_agent_build_version().version().patch());
 }
 
 // Validate deprecated user agent version field from bootstrap Node.
-TEST_P(ServerInstanceImplTest, UserAgentBuildDeprecatedOverrideFromNode) {
+TEST_P(ServerInstanceImplTest, DEPRECATED_FEATURE_TEST(UserAgentBuildDeprecatedOverrideFromNode)) {
   initialize("test/server/test_data/server/node_bootstrap_agent_deprecated_override.yaml");
   EXPECT_EQ("test-ci-user-agent", server_->localInfo().node().user_agent_name());
-  EXPECT_TRUE(server_->localInfo().node().has_user_agent_build_version());
-  EXPECT_EQ("test", server_->localInfo().node().user_agent_version());
+  EXPECT_EQ("test", server_->localInfo().node().hidden_envoy_deprecated_build_version());
 }
 
 // Validate that bootstrap with v2 dynamic transport is rejected when --bootstrap-version is not

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -866,6 +866,24 @@ TEST_P(ServerInstanceImplTest, ZoneStatNameFromOption) {
             stats_store_.symbolTable().toString(server_->localInfo().zoneStatName()));
 }
 
+// Validate user agent information from bootstrap Node.
+TEST_P(ServerInstanceImplTest, UserAgentOverrideFromNode) {
+  initialize("test/server/test_data/server/node_bootstrap_agent_override.yaml");
+  EXPECT_EQ("test-ci-user-agent", server_->localInfo().node().user_agent_name());
+  EXPECT_TRUE(server_->localInfo().node().has_user_agent_build_version());
+  EXPECT_EQ(9, server_->localInfo().node().user_agent_build_version().major_number());
+  EXPECT_EQ(8, server_->localInfo().node().user_agent_build_version().minor_number());
+  EXPECT_EQ(7, server_->localInfo().node().user_agent_build_version().patch());
+}
+
+// Validate deprecated user agent version field from bootstrap Node.
+TEST_P(ServerInstanceImplTest, UserAgentBuildDeprecatedOverrideFromNode) {
+  initialize("test/server/test_data/server/node_bootstrap_agent_deprecated_override.yaml");
+  EXPECT_EQ("test-ci-user-agent", server_->localInfo().node().user_agent_name());
+  EXPECT_TRUE(server_->localInfo().node().has_user_agent_build_version());
+  EXPECT_EQ("test", server_->localInfo().node().user_agent_version());
+}
+
 // Validate that bootstrap with v2 dynamic transport is rejected when --bootstrap-version is not
 // set.
 TEST_P(ServerInstanceImplTest,

--- a/test/server/test_data/server/node_bootstrap_agent_deprecated_override.yaml
+++ b/test/server/test_data/server/node_bootstrap_agent_deprecated_override.yaml
@@ -1,0 +1,11 @@
+node:
+  id: bootstrap_id
+  cluster: bootstrap_cluster
+  user_agent_name: test-ci-user-agent
+  user_agent_version: test
+admin:
+  access_log_path: {{ null_device_path }}
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0

--- a/test/server/test_data/server/node_bootstrap_agent_override.yaml
+++ b/test/server/test_data/server/node_bootstrap_agent_override.yaml
@@ -1,0 +1,15 @@
+node:
+  id: bootstrap_id
+  cluster: bootstrap_cluster
+  user_agent_name: test-ci-user-agent
+  user_agent_build_version:
+    version:
+      major_number: 9
+      minor_number: 8
+      patch: 7
+admin:
+  access_log_path: {{ null_device_path }}
+  address:
+    socket_address:
+      address: {{ ntop_ip_loopback_address }}
+      port_value: 0


### PR DESCRIPTION
Commit Message: allow user_agent fields to be overridden from bootstrap config

Additional Description: `user_agent_name`, `user_agent_version` and `user_agent_build_version` all look like they're settable from the docs, but the server just sets these values from the internals.  This allows the users to override them if desired, but falls back to the default behavior. 

Risk Level: low

Testing: Added integration tests for using the values from the fields.  But to test manually: update any of those 3 fields in the bootstrap node config to whatever valid values you want, then verify that they show up in the /config_dump output.  If you omit them, the current defaults will still be populated.  

Docs Changes:

Release Notes: 

Platform Specific Features:

Fixes #16471 
