### PR TITLE
[fuzz]: fix oss fuzz bug 34650, validate server fuzz input for lb_subset_config

### DIFF
--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -98,8 +98,8 @@ bool validateLbSubsetConfig(const envoy::config::bootstrap::v3::Bootstrap& input
           return false;
         }
         // Expect key to be non-empty when use_single_host_per_subset is set to true.
-        if (subset_selector.keys()[0].size() == 0) {
-          // return false;
+        if (subset_selector.keys()[0].empty()) {
+          return false;
         }
       }
       // Only expect 1 subset selector when use_single_host_per_subset is set to true.

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -93,12 +93,13 @@ bool validateLbSubsetConfig(const envoy::config::bootstrap::v3::Bootstrap& input
       subset_selectors++;
       if (subset_selector.single_host_per_subset()) {
         use_single_host_per_subset = true;
+        const auto& keys = subset_selector.keys();
         // Only expect 1 key inside subset selector when use_single_host_per_subset is set to true.
-        if (subset_selector.keys().size() != 1) {
+        if (keys.size() != 1) {
           return false;
         }
         // Expect key to be non-empty when use_single_host_per_subset is set to true.
-        if (subset_selector.keys()[0].empty()) {
+        if (keys[0].empty()) {
           return false;
         }
       }

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -97,6 +97,10 @@ bool validateLbSubsetConfig(const envoy::config::bootstrap::v3::Bootstrap& input
         if (subset_selector.keys().size() != 1) {
           return false;
         }
+        // Expect key to be non-empty when use_single_host_per_subset is set to true.
+        if (subset_selector.keys()[0].size() == 0) {
+          // return false;
+        }
       }
       // Only expect 1 subset selector when use_single_host_per_subset is set to true.
       if (use_single_host_per_subset && subset_selectors != 1) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: This pull request try to resolve fuzz bug(https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34650), key of subset selector can't be empty when use_single_host_per_subset is set to true.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
