### PR TITLE
[fuzz] OSS Fuzz Issue 30119: envoy:server_fuzz_test: ASSERT: not reached

### DIFF
--- a/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5391772077391872
+++ b/test/server/server_corpus/clusterfuzz-testcase-minimized-server_fuzz_test-5391772077391872
@@ -1,0 +1,12 @@
+node {
+  id: "`"
+  cluster: "8"
+}
+dynamic_resources {
+  cds_config {
+    api_config_source {
+      api_type: AGGREGATED_DELTA_GRPC
+      transport_api_version: V3
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Tim Walsh <temporal.differential@gmail.com>

Commit Message: Update for oss-fuzz Issue 30119
Additional Description: Note that #4709 covers a number of oss-fuzz error This is part of the ongoing effort started for #4709.
Risk Level: Low
Testing: test/common/stats
Docs Changes: None
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional API Considerations:]
