### PR TITLE
Added passing LLVM_ROOT env var to docker from run_envoy_docker.sh.

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -75,6 +75,7 @@ docker run --rm \
        -e BAZEL_EXTRA_TEST_OPTIONS \
        -e BAZEL_REMOTE_CACHE \
        -e ENVOY_STDLIB \
+       -e LLVM_ROOT \
        -e BUILD_REASON \
        -e BAZEL_REMOTE_INSTANCE \
        -e GCP_SERVICE_ACCOUNT_KEY \


### PR DESCRIPTION
Commit Message: Added passing LLVM_ROOT env var to docker from run_envoy_docker.sh. This allows building with containers that may have LLVM in a different location.
Additional Description: This allows building, using containers, which have LLVM in a different location. 
Risk Level: Trivial
Testing: Building of envoy using fedora 32 based container.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
