### PR TITLE
http: consider per-virtualhost typed filter config instead of per-route only

### DIFF
--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -123,9 +123,8 @@ absl::optional<FilterSettings> Filter::getRouteSpecificSettings() const {
   if (!decoder_callbacks_->route() || !decoder_callbacks_->route()->routeEntry()) {
     return absl::nullopt;
   }
-  const auto* route_entry = decoder_callbacks_->route()->routeEntry();
-  const auto* settings = route_entry->mostSpecificPerFilterConfigTyped<FilterSettings>(
-      HttpFilterNames::get().AwsLambda);
+
+  const auto* settings = Http::Utility::resolveMostSpecificPerFilterConfig<FilterSettings>(HttpFilterNames::get().AwsLambda, decoder_callbacks_->route());
   if (!settings) {
     return absl::nullopt;
   }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -124,7 +124,8 @@ absl::optional<FilterSettings> Filter::getRouteSpecificSettings() const {
     return absl::nullopt;
   }
 
-  const auto* settings = Http::Utility::resolveMostSpecificPerFilterConfig<FilterSettings>(HttpFilterNames::get().AwsLambda, decoder_callbacks_->route());
+  const auto* settings = Http::Utility::resolveMostSpecificPerFilterConfig<FilterSettings>(
+      HttpFilterNames::get().AwsLambda, decoder_callbacks_->route());
   if (!settings) {
     return absl::nullopt;
   }

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -49,9 +49,8 @@ void BufferFilter::initConfig() {
     return;
   }
 
-  const std::string& name = HttpFilterNames::get().Buffer;
-  const auto* entry = callbacks_->route()->routeEntry();
-  const auto* route_local = entry->mostSpecificPerFilterConfigTyped<BufferFilterSettings>(name);
+  const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<BufferFilterSettings>(
+          HttpFilterNames::get().Buffer, callbacks_->route());
 
   settings_ = route_local ? route_local : settings_;
 }

--- a/source/extensions/filters/http/buffer/buffer_filter.cc
+++ b/source/extensions/filters/http/buffer/buffer_filter.cc
@@ -50,7 +50,7 @@ void BufferFilter::initConfig() {
   }
 
   const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<BufferFilterSettings>(
-          HttpFilterNames::get().Buffer, callbacks_->route());
+      HttpFilterNames::get().Buffer, callbacks_->route());
 
   settings_ = route_local ? route_local : settings_;
 }

--- a/source/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/source/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     hdrs = ["proxy_filter.h"],
     deps = [
         "//include/envoy/http:filter_interface",
+        "//source/common/http:header_utility_lib",
         "//source/extensions/clusters:well_known_names",
         "//source/extensions/common/dynamic_forward_proxy:dns_cache_interface",
         "//source/extensions/filters/http:well_known_names",

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -4,6 +4,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
 
+#include "common/http/utility.h"
 #include "extensions/clusters/well_known_names.h"
 #include "extensions/common/dynamic_forward_proxy/dns_cache.h"
 #include "extensions/filters/http/well_known_names.h"
@@ -87,8 +88,9 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
   }
 
   // Check for per route filter config.
-  const auto* config = route_entry->mostSpecificPerFilterConfigTyped<ProxyPerRouteConfig>(
-      HttpFilterNames::get().DynamicForwardProxy);
+  const auto* config = Http::Utility::resolveMostSpecificPerFilterConfig<ProxyPerRouteConfig>(
+          HttpFilterNames::get().DynamicForwardProxy, route);
+
   if (config != nullptr) {
     const auto& host_rewrite = config->hostRewrite();
     if (!host_rewrite.empty()) {

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -5,6 +5,7 @@
 #include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
 
 #include "common/http/utility.h"
+
 #include "extensions/clusters/well_known_names.h"
 #include "extensions/common/dynamic_forward_proxy/dns_cache.h"
 #include "extensions/filters/http/well_known_names.h"
@@ -89,7 +90,7 @@ Http::FilterHeadersStatus ProxyFilter::decodeHeaders(Http::RequestHeaderMap& hea
 
   // Check for per route filter config.
   const auto* config = Http::Utility::resolveMostSpecificPerFilterConfig<ProxyPerRouteConfig>(
-          HttpFilterNames::get().DynamicForwardProxy, route);
+      HttpFilterNames::get().DynamicForwardProxy, route);
 
   if (config != nullptr) {
     const auto& host_rewrite = config->hostRewrite();

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -114,11 +114,8 @@ Http::FilterHeadersStatus FaultFilter::decodeHeaders(Http::RequestHeaderMap& hea
   // configured at the filter level.
   fault_settings_ = config_->settings();
   if (decoder_callbacks_->route() && decoder_callbacks_->route()->routeEntry()) {
-    const std::string& name = Extensions::HttpFilters::HttpFilterNames::get().Fault;
-    const auto* route_entry = decoder_callbacks_->route()->routeEntry();
-
-    const auto* per_route_settings =
-        route_entry->mostSpecificPerFilterConfigTyped<FaultSettings>(name);
+    const auto* per_route_settings = Http::Utility::resolveMostSpecificPerFilterConfig<FaultSettings>(
+          Extensions::HttpFilters::HttpFilterNames::get().Fault, decoder_callbacks_->route());
     fault_settings_ = per_route_settings ? per_route_settings : fault_settings_;
   }
 

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -114,8 +114,9 @@ Http::FilterHeadersStatus FaultFilter::decodeHeaders(Http::RequestHeaderMap& hea
   // configured at the filter level.
   fault_settings_ = config_->settings();
   if (decoder_callbacks_->route() && decoder_callbacks_->route()->routeEntry()) {
-    const auto* per_route_settings = Http::Utility::resolveMostSpecificPerFilterConfig<FaultSettings>(
-          Extensions::HttpFilters::HttpFilterNames::get().Fault, decoder_callbacks_->route());
+    const auto* per_route_settings =
+        Http::Utility::resolveMostSpecificPerFilterConfig<FaultSettings>(
+            Extensions::HttpFilters::HttpFilterNames::get().Fault, decoder_callbacks_->route());
     fault_settings_ = per_route_settings ? per_route_settings : fault_settings_;
   }
 

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -424,9 +424,8 @@ void JsonTranscoderFilter::initPerRouteConfig() {
     return;
   }
 
-  const std::string& name = HttpFilterNames::get().GrpcJsonTranscoder;
-  const auto* entry = decoder_callbacks_->route()->routeEntry();
-  const auto* route_local = entry->mostSpecificPerFilterConfigTyped<JsonTranscoderConfig>(name);
+  const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<JsonTranscoderConfig>(
+          HttpFilterNames::get().GrpcJsonTranscoder, decoder_callbacks_->route());
 
   per_route_config_ = route_local ? route_local : &config_;
 }

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -425,7 +425,7 @@ void JsonTranscoderFilter::initPerRouteConfig() {
   }
 
   const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<JsonTranscoderConfig>(
-          HttpFilterNames::get().GrpcJsonTranscoder, decoder_callbacks_->route());
+      HttpFilterNames::get().GrpcJsonTranscoder, decoder_callbacks_->route());
 
   per_route_config_ = route_local ? route_local : &config_;
 }

--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -53,11 +53,8 @@ Http::FilterHeadersStatus KillRequestFilter::decodeHeaders(Http::RequestHeaderMa
 
   // Route-level configuration overrides filter-level configuration.
   if (decoder_callbacks_->route() && decoder_callbacks_->route()->routeEntry()) {
-    const std::string& name = Extensions::HttpFilters::HttpFilterNames::get().KillRequest;
-    const auto* route_entry = decoder_callbacks_->route()->routeEntry();
-
-    const auto* per_route_kill_settings =
-        route_entry->mostSpecificPerFilterConfigTyped<KillSettings>(name);
+    const auto* per_route_kill_settings = Http::Utility::resolveMostSpecificPerFilterConfig<KillSettings>(
+          Extensions::HttpFilters::HttpFilterNames::get().KillRequest, decoder_callbacks_->route());
 
     if (per_route_kill_settings) {
       is_correct_direction = per_route_kill_settings->getDirection() == KillRequest::REQUEST;

--- a/source/extensions/filters/http/kill_request/kill_request_filter.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_filter.cc
@@ -53,8 +53,10 @@ Http::FilterHeadersStatus KillRequestFilter::decodeHeaders(Http::RequestHeaderMa
 
   // Route-level configuration overrides filter-level configuration.
   if (decoder_callbacks_->route() && decoder_callbacks_->route()->routeEntry()) {
-    const auto* per_route_kill_settings = Http::Utility::resolveMostSpecificPerFilterConfig<KillSettings>(
-          Extensions::HttpFilters::HttpFilterNames::get().KillRequest, decoder_callbacks_->route());
+    const auto* per_route_kill_settings =
+        Http::Utility::resolveMostSpecificPerFilterConfig<KillSettings>(
+            Extensions::HttpFilters::HttpFilterNames::get().KillRequest,
+            decoder_callbacks_->route());
 
     if (per_route_kill_settings) {
       is_correct_direction = per_route_kill_settings->getDirection() == KillRequest::REQUEST;

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -30,8 +30,8 @@ RoleBasedAccessControlFilterConfig::engine(const Router::RouteConstSharedPtr rou
     return engine(mode);
   }
 
-  const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<RoleBasedAccessControlRouteSpecificFilterConfig>(
-          HttpFilterNames::get().Rbac, route);
+  const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<
+      RoleBasedAccessControlRouteSpecificFilterConfig>(HttpFilterNames::get().Rbac, route);
 
   if (route_local) {
     return route_local->engine(mode);

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -30,11 +30,8 @@ RoleBasedAccessControlFilterConfig::engine(const Router::RouteConstSharedPtr rou
     return engine(mode);
   }
 
-  const std::string& name = HttpFilterNames::get().Rbac;
-  const auto* entry = route->routeEntry();
-  const auto* route_local =
-      entry->mostSpecificPerFilterConfigTyped<RoleBasedAccessControlRouteSpecificFilterConfig>(
-          name);
+  const auto* route_local = Http::Utility::resolveMostSpecificPerFilterConfig<RoleBasedAccessControlRouteSpecificFilterConfig>(
+          HttpFilterNames::get().Rbac, route);
 
   if (route_local) {
     return route_local->engine(mode);


### PR DESCRIPTION
Commit Message: http: consider per-virtualhost typed filter config instead of per-route only
Additional Description:
Envoy supported per-virtualhost typed filter config and pre-route typed filter config.  The
`Http::Utility::resolveMostSpecificPerFilterConfig` is a helper method to filter to traverse all
the per-filter typed config and choice the correct one. But there are some filters uses
`RouteEntry::mostSpecificPerFilterConfigTyped` method, it only get the pre-route typed filter
config. It leads to some filter loses the support of per-virtualhost typed config.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: bug fix
Fixes #14894

