### PR TITLE
[1.18] apple dns: fix crash on invalid dns name (#16028)

### DIFF
--- a/source/common/network/apple_dns_impl.cc
+++ b/source/common/network/apple_dns_impl.cc
@@ -302,8 +302,6 @@ void AppleDnsResolverImpl::PendingResolution::onDNSServiceGetAddrInfoReply(
             "error_code={}, hostname={}",
             dns_name_, flags, flags & kDNSServiceFlagsMoreComing ? "yes" : "no",
             flags & kDNSServiceFlagsAdd ? "yes" : "no", interface_index, error_code, hostname);
-  RELEASE_ASSERT(interface_index == 0,
-                 fmt::format("unexpected interface_index={}", interface_index));
 
   if (!pending_cb_) {
     pending_cb_ = {ResolutionStatus::Success, {}};


### PR DESCRIPTION
This is a cherry-pick of https://github.com/envoyproxy/envoy/pull/16028