### PR TITLE
Patch flaky VeryLargeRequestHeadersRejected test

### DIFF
--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -1150,7 +1150,7 @@ void HttpIntegrationTest::testLargeRequestUrl(uint32_t url_size, uint32_t max_he
 
     if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
       ASSERT_TRUE(codec_client_->waitForDisconnect());
-      EXPECT_TRUE(response->complete());
+      ASSERT_TRUE(response->complete());
       EXPECT_EQ("431", response->headers().Status()->value().getStringView());
     } else {
       ASSERT_TRUE(response->waitForReset());
@@ -1199,7 +1199,7 @@ void HttpIntegrationTest::testLargeRequestHeaders(uint32_t size, uint32_t count,
 
     if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
       ASSERT_TRUE(codec_client_->waitForDisconnect());
-      EXPECT_TRUE(response->complete());
+      ASSERT_TRUE(response->complete());
       EXPECT_EQ("431", response->headers().getStatusValue());
     } else {
       ASSERT_TRUE(response->waitForReset());

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1571,7 +1571,8 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
 TEST_P(DownstreamProtocolIntegrationTest, VeryLargeRequestHeadersRejected) {
   // Send one very large 600 kB header with limit 500 kB and 100 headers.
   // The limit and the header size are set in such a way to accommodate for flow control limits.
-  // If the headers are too large and the flow control blocks the response is truncated and the test flakes.
+  // If the headers are too large and the flow control blocks the response is truncated and the test
+  // flakes.
   testLargeRequestHeaders(600, 1, 500, 100);
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -1569,8 +1569,10 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, VeryLargeRequestHeadersRejected) {
-  // Send one very large 2048 kB (2 MB) header with limit 1024 kB (1 MB) and 100 headers.
-  testLargeRequestHeaders(2048, 1, 1024, 100);
+  // Send one very large 600 kB header with limit 500 kB and 100 headers.
+  // The limit and the header size are set in such a way to accommodate for flow control limits.
+  // If the headers are too large and the flow control blocks the response is truncated and the test flakes.
+  testLargeRequestHeaders(600, 1, 500, 100);
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersAccepted) {


### PR DESCRIPTION
Commit Message:

As discussed in #16214 there is a case when flow control blocks and
as a result the reponse gets truncated.

To deflake the test we reduce the size of the headers and the limit.

Validated with no flakes in 10k test runs.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>