### PR TITLE
tests: fixing parameter type passed to is_optional

### DIFF
--- a/test/integration/http_typed_per_filter_config_test.cc
+++ b/test/integration/http_typed_per_filter_config_test.cc
@@ -58,7 +58,7 @@ TEST_F(HTTPTypedPerFilterConfigTest, IgnoreUnknownOptionalHttpFilterInTypedPerFi
 
         auto* filter = hcm.mutable_http_filters()->Add();
         filter->set_name("filter.unknown");
-        filter->set_is_optional("true");
+        filter->set_is_optional(true);
         // keep router the last
         auto size = hcm.http_filters_size();
         hcm.mutable_http_filters()->SwapElements(size - 2, size - 1);

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -552,7 +552,7 @@ key:
              http_connection_manager) {
         auto* filter = http_connection_manager.mutable_http_filters()->Add();
         filter->set_name("filter.unknown");
-        filter->set_is_optional("true");
+        filter->set_is_optional(true);
         // keep router the last
         auto size = http_connection_manager.http_filters_size();
         http_connection_manager.mutable_http_filters()->SwapElements(size - 2, size - 1);


### PR DESCRIPTION

Commit Message: fixing parameter type passed to is_optional
Additional Description:
A couple of tests passed a string `"true"` to a boolean protobuf field.
This PR changes the passed parameter to boolean.

Risk Level: Low - tests code only.
Testing: Updating tests.
Docs Changes: N/A.
Release Notes: N/A.
Platform Specific Features: N/A.

Signed-off-by: Adi Suissa-Peleg <adip@google.com>
