### PR TITLE
AlternateProtocolsCache: Add Mocks

### DIFF
--- a/test/mocks/http/BUILD
+++ b/test/mocks/http/BUILD
@@ -10,6 +10,15 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_mock(
+    name = "alternate_protocols_cache_mocks",
+    srcs = ["alternate_protocols_cache.cc"],
+    hdrs = ["alternate_protocols_cache.h"],
+    deps = [
+        "//include/envoy/http:alternate_protocols_cache_interface",
+    ],
+)
+
+envoy_cc_mock(
     name = "api_listener_mocks",
     srcs = ["api_listener.cc"],
     hdrs = ["api_listener.h"],

--- a/test/mocks/http/alternate_protocols_cache.cc
+++ b/test/mocks/http/alternate_protocols_cache.cc
@@ -1,0 +1,13 @@
+#include "test/mocks/http/alternate_protocols_cache.h"
+
+namespace Envoy {
+namespace Http {
+
+MockAlternateProtocolsCache::~MockAlternateProtocolsCache() = default;
+
+MockAlternateProtocolsCacheManager::~MockAlternateProtocolsCacheManager() = default;
+
+MockAlternateProtocolsCacheManagerFactory::~MockAlternateProtocolsCacheManagerFactory() = default;
+
+} // namespace Http
+} // namespace Envoy

--- a/test/mocks/http/alternate_protocols_cache.h
+++ b/test/mocks/http/alternate_protocols_cache.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "envoy/http/alternate_protocols_cache.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Http {
+
+class MockAlternateProtocolsCache : public AlternateProtocolsCache {
+public:
+  ~MockAlternateProtocolsCache() override;
+
+  MOCK_METHOD(void, setAlternatives,
+              (const Origin& origin, const std::vector<AlternateProtocol>& protocols));
+  MOCK_METHOD(OptRef<const std::vector<AlternateProtocol>>, findAlternatives,
+              (const Origin& origin));
+  MOCK_METHOD(size_t, size, (), (const));
+};
+
+class MockAlternateProtocolsCacheManager : public AlternateProtocolsCacheManager {
+public:
+  ~MockAlternateProtocolsCacheManager() override;
+
+  MOCK_METHOD(AlternateProtocolsCacheSharedPtr, getCache,
+              (const envoy::config::core::v3::AlternateProtocolsCacheOptions& config));
+};
+
+class MockAlternateProtocolsCacheManagerFactory : public AlternateProtocolsCacheManagerFactory {
+public:
+  ~MockAlternateProtocolsCacheManagerFactory() override;
+
+  MOCK_METHOD(AlternateProtocolsCacheManagerSharedPtr, get, ());
+};
+
+} // namespace Http
+} // namespace Envoy


### PR DESCRIPTION
Add mocks of the various AlternateProtocolsCache classes.

Risk Level: Low
Testing: Test-only code
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A