### PR TITLE
server: directly inspect the BoringSSL FIPS mode

### DIFF
--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -60,11 +60,12 @@ envoy_cc_library(
     srcs = ["version.cc"],
     copts = envoy_select_boringssl(
         [
-            "-DENVOY_SSL_VERSION=\\\"BoringSSL-FIPS\\\"",
+            "-DENVOY_SSL_VERSION=\\\"BoringSSL\\\"",
             "-DENVOY_SSL_FIPS",
         ],
         ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     ),
+    external_deps = ["ssl"],
     deps = [
         ":version_includes",
         "//source/common/common:macros",

--- a/test/common/common/version_test.cc
+++ b/test/common/common/version_test.cc
@@ -17,6 +17,16 @@ public:
   }
 };
 
+TEST(VersionTest, FipsCompliance) {
+#ifdef ENVOY_SSL_FIPS
+  EXPECT_TRUE(VersionInfoTestPeer::sslFipsCompliant());
+  EXPECT_THAT(VersionInfoTestPeer::sslVersion(), testing::EndsWith("-FIPS"));
+#else
+  EXPECT_FALSE(VersionInfoTestPeer::sslFipsCompliant());
+  EXPECT_THAT(VersionInfoTestPeer::sslVersion(), testing::Not(testing::EndsWith("-FIPS")));
+#endif
+}
+
 TEST(VersionTest, BuildVersion) {
   auto build_version = VersionInfo::buildVersion();
   std::string version_string =
@@ -35,11 +45,6 @@ TEST(VersionTest, BuildVersion) {
             fields.at(BuildVersionMetadataKeys::get().RevisionStatus).string_value());
   EXPECT_EQ(VersionInfoTestPeer::buildType(),
             fields.at(BuildVersionMetadataKeys::get().BuildType).string_value());
-#ifdef ENVOY_SSL_FIPS
-  EXPECT_TRUE(VersionInfoTestPeer::sslFipsCompliant());
-#else
-  EXPECT_FALSE(VersionInfoTestPeer::sslFipsCompliant());
-#endif
   EXPECT_EQ(VersionInfoTestPeer::sslVersion(),
             fields.at(BuildVersionMetadataKeys::get().SslVersion).string_value());
 }
@@ -51,11 +56,6 @@ TEST(VersionTest, MakeBuildVersionWithLabel) {
   EXPECT_EQ(3, build_version.version().patch());
   const auto& fields = build_version.metadata().fields();
   EXPECT_GE(fields.size(), 1);
-#ifdef ENVOY_SSL_FIPS
-  EXPECT_TRUE(VersionInfoTestPeer::sslFipsCompliant());
-#else
-  EXPECT_FALSE(VersionInfoTestPeer::sslFipsCompliant());
-#endif
   EXPECT_EQ("foo-bar", fields.at(BuildVersionMetadataKeys::get().BuildLabel).string_value());
 }
 


### PR DESCRIPTION
Commit Message:

Rather than depending on the preprocessor macro, directly inspect the
BoringSSL FIPS mode API to determine whether FIPS mode is enabled. This
binds Envoy's notion of FIPS mode directly to BoringSSL's notion of
FIPS mode, reducing the liklihood of build misconfigurations not being
detected.

Additional Description: N/A
Risk Level: Low
Testing: Unit tests in FIPS and non-FIPS mode
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
