### PR TITLE
mocks: fix spelling of MockScopeTrackedObject

### DIFF
--- a/test/common/common/scope_tracker_test.cc
+++ b/test/common/common/scope_tracker_test.cc
@@ -18,7 +18,7 @@ using testing::_;
 TEST(ScopeTrackerScopeStateTest, ShouldManageTrackedObjectOnDispatcherStack) {
   Api::ApiPtr api(Api::createApiForTest());
   Event::DispatcherPtr dispatcher(api->allocateDispatcher("test_thread"));
-  MockScopedTrackedObject tracked_object;
+  MockScopeTrackedObject tracked_object;
   {
     ScopeTrackerScopeState scope(&tracked_object, *dispatcher);
     // Check that the tracked_object is on the tracked object stack

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -593,7 +593,7 @@ TEST_F(DispatcherImplTest, Timer) {
 
 TEST_F(DispatcherImplTest, TimerWithScope) {
   TimerPtr timer;
-  MockScopedTrackedObject scope;
+  MockScopeTrackedObject scope;
   dispatcher_->post([this, &timer, &scope]() {
     {
       // Expect a call to dumpState. The timer will call onFatalError during

--- a/test/common/event/scaled_range_timer_manager_impl_test.cc
+++ b/test/common/event/scaled_range_timer_manager_impl_test.cc
@@ -299,7 +299,7 @@ class ScaledRangeTimerManagerTestWithScope : public ScaledRangeTimerManagerTest,
                                              public testing::WithParamInterface<bool> {
 public:
   ScopeTrackedObject* getScope() { return GetParam() ? &scope_ : nullptr; }
-  MockScopedTrackedObject scope_;
+  MockScopeTrackedObject scope_;
 };
 
 TEST_P(ScaledRangeTimerManagerTestWithScope, ReRegisterOnCallback) {

--- a/test/mocks/common.h
+++ b/test/mocks/common.h
@@ -88,7 +88,7 @@ inline bool operator==(const StringViewSaver& saver, const char* str) {
   return saver.value() == str;
 }
 
-class MockScopedTrackedObject : public ScopeTrackedObject {
+class MockScopeTrackedObject : public ScopeTrackedObject {
 public:
   MOCK_METHOD(void, dumpState, (std::ostream&, int), (const));
 };

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -275,7 +275,7 @@ public:
   std::list<DownstreamWatermarkCallbacks*> callbacks_{};
   testing::NiceMock<Tracing::MockSpan> active_span_;
   testing::NiceMock<Tracing::MockConfig> tracing_config_;
-  testing::NiceMock<MockScopedTrackedObject> scope_;
+  testing::NiceMock<MockScopeTrackedObject> scope_;
   bool is_grpc_request_{};
   bool is_head_request_{false};
   bool stream_destroyed_{};
@@ -327,7 +327,7 @@ public:
   Buffer::InstancePtr buffer_;
   testing::NiceMock<Tracing::MockSpan> active_span_;
   testing::NiceMock<Tracing::MockConfig> tracing_config_;
-  testing::NiceMock<MockScopedTrackedObject> scope_;
+  testing::NiceMock<MockScopeTrackedObject> scope_;
 };
 
 class MockStreamDecoderFilter : public StreamDecoderFilter {


### PR DESCRIPTION
Commit Message: mocks - fix spelling of MockScopeTrackedObject
Risk Level: low
Testing: existing

Signed-off-by: Jose Nino <jnino@lyft.com>
