### PR TITLE
metrics service: make metric predicate overridable

### DIFF
--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.cc
@@ -59,19 +59,19 @@ MetricsPtr MetricsFlusher::flush(Stats::MetricSnapshot& snapshot) const {
                                  snapshot.snapshotTime().time_since_epoch())
                                  .count();
   for (const auto& counter : snapshot.counters()) {
-    if (counter.counter_.get().used()) {
+    if (predicate_(counter.counter_.get())) {
       flushCounter(*metrics->Add(), counter, snapshot_time_ms);
     }
   }
 
   for (const auto& gauge : snapshot.gauges()) {
-    if (gauge.get().used()) {
+    if (predicate_(gauge)) {
       flushGauge(*metrics->Add(), gauge.get(), snapshot_time_ms);
     }
   }
 
   for (const auto& histogram : snapshot.histograms()) {
-    if (histogram.get().used()) {
+    if (predicate_(histogram.get())) {
       flushHistogram(*metrics->Add(), *metrics->Add(), histogram.get(), snapshot_time_ms);
     }
   }

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -86,7 +86,8 @@ public:
       bool report_counters_as_deltas, bool emit_labels,
       std::function<bool(const Stats::Metric&)> predicate =
           [](const auto& metric) { return metric.used(); })
-      : report_counters_as_deltas_(report_counters_as_deltas), emit_labels_(emit_labels), predicate_(predicate) {}
+      : report_counters_as_deltas_(report_counters_as_deltas), emit_labels_(emit_labels),
+        predicate_(predicate) {}
 
   MetricsPtr flush(Stats::MetricSnapshot& snapshot) const;
 

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -82,8 +82,11 @@ using GrpcMetricsStreamerImplPtr = std::unique_ptr<GrpcMetricsStreamerImpl>;
 
 class MetricsFlusher {
 public:
-  MetricsFlusher(bool report_counters_as_deltas, bool emit_labels)
-      : report_counters_as_deltas_(report_counters_as_deltas), emit_labels_(emit_labels) {}
+  MetricsFlusher(
+      bool report_counters_as_deltas, bool emit_labels,
+      std::function<bool(const Stats::Metric&)> predicate =
+          [](const auto& metric) { return metric.used(); })
+      : report_counters_as_deltas_(report_counters_as_deltas), emit_labels_(emit_labels), predicate_(predicate) {}
 
   MetricsPtr flush(Stats::MetricSnapshot& snapshot) const;
 
@@ -105,6 +108,7 @@ private:
 
   const bool report_counters_as_deltas_;
   const bool emit_labels_;
+  const std::function<bool(const Stats::Metric&)> predicate_;
 };
 
 /**

--- a/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/grpc_metrics_service_impl_test.cc
@@ -286,7 +286,7 @@ TEST_F(MetricsServiceSinkTest, FlushPredicate) {
     EXPECT_EQ(2, metrics->size());
   }
 
-  // Using a predicate that rejects all metrcis, we'd flush no metrics.
+  // Using a predicate that rejects all metrics, we'd flush no metrics.
   MetricsFlusher flusher(true, true, [](const auto&) { return false; });
   auto metrics = flusher.flush(snapshot_);
   EXPECT_EQ(0, metrics->size());


### PR DESCRIPTION
Adds the predicate to use to determine whether to include a metric when flushing as a ctor parameter to MetrcsFlusher. 
This allows custom sinks that reuse the metrics service components to override the predicate, allowing for modifcations
of which subset of metrics are flushed without having do tamper with the incoming snapshot.

Risk Level: Low, no behavior change
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
