### PR TITLE
dubbo proxy: support outlier

### DIFF
--- a/source/extensions/filters/network/dubbo_proxy/router/config.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/config.cc
@@ -16,7 +16,7 @@ DubboFilters::FilterFactoryCb RouterFilterConfig::createFilterFactoryFromProtoTy
     const envoy::extensions::filters::network::dubbo_proxy::router::v3::Router&, const std::string&,
     Server::Configuration::FactoryContext& context) {
   return [&context](DubboFilters::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addDecoderFilter(std::make_shared<Router>(context.clusterManager()));
+    callbacks.addFilter(std::make_shared<Router>(context.clusterManager()));
   };
 }
 

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
@@ -117,6 +117,43 @@ FilterStatus Router::onMessageDecoded(MessageMetadataSharedPtr metadata, Context
   return upstream_request_->start();
 }
 
+void Router::setEncoderFilterCallbacks(DubboFilters::EncoderFilterCallbacks& callbacks) {
+  encoder_callbacks_ = &callbacks;
+}
+
+FilterStatus Router::onMessageEncoded(MessageMetadataSharedPtr metadata, ContextSharedPtr) {
+  if (metadata->hasResponseStatus() && upstream_request_ != nullptr) {
+    ENVOY_STREAM_LOG(trace, "dubbo router: response status: {}", *encoder_callbacks_,
+                     metadata->responseStatus());
+
+    switch (metadata->responseStatus()) {
+    case ResponseStatus::Ok:
+      if (metadata->messageType() == MessageType::Exception) {
+        upstream_request_->upstream_host_->outlierDetector().putResult(
+            Upstream::Outlier::Result::ExtOriginRequestFailed);
+      } else {
+        upstream_request_->upstream_host_->outlierDetector().putResult(
+            Upstream::Outlier::Result::ExtOriginRequestSuccess);
+      }
+      break;
+    case ResponseStatus::ServerTimeout:
+      upstream_request_->upstream_host_->outlierDetector().putResult(
+          Upstream::Outlier::Result::LocalOriginTimeout);
+      break;
+    case ResponseStatus::ServiceError:
+    case ResponseStatus::ServerError:
+    case ResponseStatus::ServerThreadpoolExhaustedError:
+      upstream_request_->upstream_host_->outlierDetector().putResult(
+          Upstream::Outlier::Result::ExtOriginRequestFailed);
+      break;
+    default:
+      break;
+    }
+  }
+
+  return FilterStatus::Continue;
+}
+
 void Router::onUpstreamData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!upstream_request_->response_complete_);
 
@@ -168,6 +205,8 @@ void Router::onEvent(Network::ConnectionEvent event) {
   switch (event) {
   case Network::ConnectionEvent::RemoteClose:
     upstream_request_->onResetStream(ConnectionPool::PoolFailureReason::RemoteConnectionFailure);
+    upstream_request_->upstream_host_->outlierDetector().putResult(
+        Upstream::Outlier::Result::LocalOriginConnectFailed);
     break;
   case Network::ConnectionEvent::LocalClose:
     upstream_request_->onResetStream(ConnectionPool::PoolFailureReason::LocalConnectionFailure);
@@ -254,6 +293,11 @@ void Router::UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason re
   if (reason == ConnectionPool::PoolFailureReason::Timeout ||
       reason == ConnectionPool::PoolFailureReason::LocalConnectionFailure ||
       reason == ConnectionPool::PoolFailureReason::RemoteConnectionFailure) {
+    if (reason == ConnectionPool::PoolFailureReason::Timeout) {
+      host->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginTimeout);
+    } else if (reason == ConnectionPool::PoolFailureReason::RemoteConnectionFailure) {
+      host->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginConnectFailed);
+    }
     parent_.callbacks_->continueDecoding();
   }
 }
@@ -266,6 +310,8 @@ void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr
   bool continue_decoding = conn_pool_handle_ != nullptr;
 
   onUpstreamHostSelected(host);
+  host->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess);
+
   conn_data_ = std::move(conn_data);
   conn_data_->addUpstreamCallbacks(parent_);
   conn_pool_handle_ = nullptr;

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
@@ -20,7 +20,7 @@ namespace Router {
 
 class Router : public Tcp::ConnectionPool::UpstreamCallbacks,
                public Upstream::LoadBalancerContextBase,
-               public DubboFilters::DecoderFilter,
+               public DubboFilters::CodecFilter,
                Logger::Loggable<Logger::Id::dubbo> {
 public:
   Router(Upstream::ClusterManager& cluster_manager) : cluster_manager_(cluster_manager) {}
@@ -31,6 +31,11 @@ public:
   void setDecoderFilterCallbacks(DubboFilters::DecoderFilterCallbacks& callbacks) override;
 
   FilterStatus onMessageDecoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) override;
+
+  // DubboFilter::EncoderFilter
+  void setEncoderFilterCallbacks(DubboFilters::EncoderFilterCallbacks& callbacks) override;
+
+  FilterStatus onMessageEncoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) override;
 
   // Upstream::LoadBalancerContextBase
   const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() override { return nullptr; }
@@ -89,6 +94,7 @@ private:
   Upstream::ClusterManager& cluster_manager_;
 
   DubboFilters::DecoderFilterCallbacks* callbacks_{};
+  DubboFilters::EncoderFilterCallbacks* encoder_callbacks_{};
   RouteConstSharedPtr route_{};
   const RouteEntry* route_entry_{};
   Upstream::ClusterInfoConstSharedPtr cluster_;

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
@@ -34,7 +34,6 @@ public:
 
   // DubboFilter::EncoderFilter
   void setEncoderFilterCallbacks(DubboFilters::EncoderFilterCallbacks& callbacks) override;
-
   FilterStatus onMessageEncoded(MessageMetadataSharedPtr metadata, ContextSharedPtr ctx) override;
 
   // Upstream::LoadBalancerContextBase

--- a/test/extensions/filters/network/dubbo_proxy/config_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/config_test.cc
@@ -161,7 +161,8 @@ TEST_F(DubboFilterConfigTest, CreateFilterChain) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   DubboFilters::MockFilterChainFactoryCallbacks callbacks;
   ConfigImpl config(dubbo_config, context);
-  EXPECT_CALL(callbacks, addDecoderFilter(_)).Times(2);
+  EXPECT_CALL(callbacks, addDecoderFilter(_));
+  EXPECT_CALL(callbacks, addFilter(_));
   config.createFilterChain(callbacks);
 }
 

--- a/test/extensions/filters/network/dubbo_proxy/router_filter_config_test.cc
+++ b/test/extensions/filters/network/dubbo_proxy/router_filter_config_test.cc
@@ -25,7 +25,7 @@ TEST(DubboProxyRouterFilterConfigTest, RouterV2Alpha1Filter) {
   DubboFilters::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(router_config, "stats", context);
   DubboFilters::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addDecoderFilter(_));
+  EXPECT_CALL(filter_callback, addFilter(_));
   cb(filter_callback);
 }
 
@@ -35,7 +35,7 @@ TEST(DubboProxyRouterFilterConfigTest, RouterFilterWithEmptyProtoConfig) {
   DubboFilters::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*factory.createEmptyConfigProto(), "stats", context);
   DubboFilters::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addDecoderFilter(_));
+  EXPECT_CALL(filter_callback, addFilter(_));
   cb(filter_callback);
 }
 


### PR DESCRIPTION
Put upstream result to outlier monitor in dubbo route filter.

Risk Level: Low, no behavior change
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a