### PR TITLE
api listener: add dump state to synthetic connection

### DIFF
--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -146,7 +146,7 @@ protected:
       bool startSecureTransport() override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
       absl::optional<std::chrono::milliseconds> lastRoundTripTime() const override { return {}; };
       // ScopeTrackedObject
-      void dumpState(std::ostream&, int) const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+      void dumpState(std::ostream& os, int) const override { os << "SyntheticConnection"; }
 
       SyntheticReadCallbacks& parent_;
       Network::SocketAddressSetterSharedPtr address_provider_;


### PR DESCRIPTION
Commit Message: api listener - add dump state to synthetic connection
Additional Description: there is only one api_listener and thus one synthetic connection. No other state is relevant.
Risk Level: low
Testing: tested enabling signal handling on an envoy instance using an Api Listener.

Signed-off-by: Jose Nino <jnino@lyft.com>
