### PR TITLE
listener: remove well_known_names

### DIFF
--- a/source/extensions/filters/listener/BUILD
+++ b/source/extensions/filters/listener/BUILD
@@ -1,19 +1,8 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_library",
     "envoy_extension_package",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_extension_package()
-
-envoy_cc_library(
-    name = "well_known_names",
-    hdrs = ["well_known_names.h"],
-    # Well known names are public.
-    visibility = ["//visibility:public"],
-    deps = [
-        "//source/common/singleton:const_singleton",
-    ],
-)

--- a/source/extensions/filters/listener/http_inspector/BUILD
+++ b/source/extensions/filters/listener/http_inspector/BUILD
@@ -35,7 +35,6 @@ envoy_cc_extension(
         ":http_inspector_lib",
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
-        "//source/extensions/filters/listener:well_known_names",
         "@envoy_api//envoy/extensions/filters/listener/http_inspector/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/listener/http_inspector/config.cc
+++ b/source/extensions/filters/listener/http_inspector/config.cc
@@ -4,7 +4,6 @@
 #include "envoy/server/filter_config.h"
 
 #include "source/extensions/filters/listener/http_inspector/http_inspector.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -33,7 +32,7 @@ public:
         envoy::extensions::filters::listener::http_inspector::v3::HttpInspector>();
   }
 
-  std::string name() const override { return ListenerFilterNames::get().HttpInspector; }
+  std::string name() const override { return "envoy.filters.listener.http_inspector"; }
 };
 
 /**

--- a/source/extensions/filters/listener/original_dst/BUILD
+++ b/source/extensions/filters/listener/original_dst/BUILD
@@ -37,7 +37,6 @@ envoy_cc_extension(
         ":original_dst_lib",
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
-        "//source/extensions/filters/listener:well_known_names",
         "@envoy_api//envoy/extensions/filters/listener/original_dst/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/listener/original_dst/config.cc
+++ b/source/extensions/filters/listener/original_dst/config.cc
@@ -6,7 +6,6 @@
 #include "envoy/server/filter_config.h"
 
 #include "source/extensions/filters/listener/original_dst/original_dst.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -51,7 +50,7 @@ public:
     return std::make_unique<envoy::extensions::filters::listener::original_dst::v3::OriginalDst>();
   }
 
-  std::string name() const override { return ListenerFilterNames::get().OriginalDst; }
+  std::string name() const override { return "envoy.filters.listener.original_dst"; }
 };
 
 /**

--- a/source/extensions/filters/listener/original_src/BUILD
+++ b/source/extensions/filters/listener/original_src/BUILD
@@ -43,7 +43,6 @@ envoy_cc_extension(
         ":original_src_lib",
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
-        "//source/extensions/filters/listener:well_known_names",
         "@envoy_api//envoy/extensions/filters/listener/original_src/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/listener/original_src/original_src_config_factory.cc
+++ b/source/extensions/filters/listener/original_src/original_src_config_factory.cc
@@ -6,7 +6,6 @@
 
 #include "source/extensions/filters/listener/original_src/config.h"
 #include "source/extensions/filters/listener/original_src/original_src.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/listener/original_src/original_src_config_factory.h
+++ b/source/extensions/filters/listener/original_src/original_src_config_factory.h
@@ -3,8 +3,6 @@
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
 
-#include "source/extensions/filters/listener/well_known_names.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace ListenerFilters {
@@ -22,7 +20,7 @@ public:
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 
-  std::string name() const override { return ListenerFilterNames::get().OriginalSrc; }
+  std::string name() const override { return "envoy.filters.listener.original_src"; }
 };
 
 } // namespace OriginalSrc

--- a/source/extensions/filters/listener/proxy_protocol/BUILD
+++ b/source/extensions/filters/listener/proxy_protocol/BUILD
@@ -32,7 +32,6 @@ envoy_cc_library(
         "//source/common/network:address_lib",
         "//source/common/network:utility_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",
-        "//source/extensions/filters/listener:well_known_names",
         "@envoy_api//envoy/extensions/filters/listener/proxy_protocol/v3:pkg_cc_proto",
     ],
 )
@@ -47,7 +46,6 @@ envoy_cc_extension(
     deps = [
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
-        "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/listener/proxy_protocol:proxy_protocol_lib",
         "@envoy_api//envoy/extensions/filters/listener/proxy_protocol/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/listener/proxy_protocol/config.cc
+++ b/source/extensions/filters/listener/proxy_protocol/config.cc
@@ -6,7 +6,6 @@
 #include "envoy/server/filter_config.h"
 
 #include "source/extensions/filters/listener/proxy_protocol/proxy_protocol.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -41,7 +40,7 @@ public:
         envoy::extensions::filters::listener::proxy_protocol::v3::ProxyProtocol>();
   }
 
-  std::string name() const override { return ListenerFilterNames::get().ProxyProtocol; }
+  std::string name() const override { return "envoy.filters.listener.proxy_protocol"; }
 };
 
 /**

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -22,7 +22,6 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/utility.h"
 #include "source/extensions/common/proxy_protocol/proxy_protocol_header.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 using Envoy::Extensions::Common::ProxyProtocol::PROXY_PROTO_V1_SIGNATURE;
 using Envoy::Extensions::Common::ProxyProtocol::PROXY_PROTO_V1_SIGNATURE_LEN;
@@ -372,7 +371,7 @@ bool Filter::parseTlvs(const std::vector<uint8_t>& tlvs) {
                                       tlv_value_length);
 
       std::string metadata_key = key_value_pair->metadata_namespace().empty()
-                                     ? ListenerFilterNames::get().ProxyProtocol
+                                     ? "envoy.filters.listener.proxy_protocol"
                                      : key_value_pair->metadata_namespace();
 
       ProtobufWkt::Struct metadata(

--- a/source/extensions/filters/listener/tls_inspector/BUILD
+++ b/source/extensions/filters/listener/tls_inspector/BUILD
@@ -42,7 +42,6 @@ envoy_cc_extension(
     deps = [
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
-        "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
         "@envoy_api//envoy/extensions/filters/listener/tls_inspector/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/listener/tls_inspector/config.cc
+++ b/source/extensions/filters/listener/tls_inspector/config.cc
@@ -6,7 +6,6 @@
 #include "envoy/server/filter_config.h"
 
 #include "source/extensions/filters/listener/tls_inspector/tls_inspector.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -35,7 +34,7 @@ public:
         envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector>();
   }
 
-  std::string name() const override { return ListenerFilterNames::get().TlsInspector; }
+  std::string name() const override { return "envoy.filters.listener.tls_inspector"; }
 };
 
 /**

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -409,7 +409,6 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/stream_info:stream_info_lib",
-        "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/upstreams/http/generic:config",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -40,7 +40,7 @@ namespace Server {
 
 namespace {
 
-const std::string TlsInspector = ""envoy.listener.tls_inspector"";
+const std::string TlsInspector = "envoy.filters.listener.tls_inspector";
 
 bool anyFilterChain(
     const envoy::config::listener::v3::Listener& config,
@@ -63,7 +63,7 @@ bool needTlsInspector(const envoy::config::listener::v3::Listener& config) {
                         }) &&
          !std::any_of(config.listener_filters().begin(), config.listener_filters().end(),
                       [](const auto& filter) {
-                        return filter.name() == "envoy.filters.listener.tls_inspector" ||
+                        return filter.name() == "envoy.listener.tls_inspector" ||
                                filter.name() == TlsInspector;
                       });
 }

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -23,7 +23,6 @@
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/runtime/runtime_features.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 #include "source/server/active_raw_udp_listener_config.h"
 #include "source/server/configuration_impl.h"
 #include "source/server/drain_manager_impl.h"
@@ -59,13 +58,11 @@ bool needTlsInspector(const envoy::config::listener::v3::Listener& config) {
                                   (!matcher.server_names().empty() ||
                                    !matcher.application_protocols().empty()));
                         }) &&
-         !std::any_of(
-             config.listener_filters().begin(), config.listener_filters().end(),
-             [](const auto& filter) {
-               return filter.name() ==
-                          Extensions::ListenerFilters::ListenerFilterNames::get().TlsInspector ||
-                      filter.name() == "envoy.listener.tls_inspector";
-             });
+         !std::any_of(config.listener_filters().begin(), config.listener_filters().end(),
+                      [](const auto& filter) {
+                        return filter.name() == "envoy.filters.listener.tls_inspector" ||
+                               filter.name() == "envoy.listener.tls_inspector";
+                      });
 }
 
 bool usesProxyProto(const envoy::config::listener::v3::Listener& config) {
@@ -552,7 +549,7 @@ void ListenerImpl::buildOriginalDstListenerFilter() {
   if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config_, use_original_dst, false)) {
     auto& factory =
         Config::Utility::getAndCheckFactoryByName<Configuration::NamedListenerFilterConfigFactory>(
-            Extensions::ListenerFilters::ListenerFilterNames::get().OriginalDst);
+            "envoy.filters.listener.original_dst");
 
     listener_filter_factories_.push_back(factory.createListenerFilterFactoryFromProto(
         Envoy::ProtobufWkt::Empty(),
@@ -568,7 +565,7 @@ void ListenerImpl::buildProxyProtocolListenerFilter() {
   if (usesProxyProto(config_)) {
     auto& factory =
         Config::Utility::getAndCheckFactoryByName<Configuration::NamedListenerFilterConfigFactory>(
-            Extensions::ListenerFilters::ListenerFilterNames::get().ProxyProtocol);
+            "envoy.filters.listener.proxy_protocol");
     listener_filter_factories_.push_back(factory.createListenerFilterFactoryFromProto(
         envoy::extensions::filters::listener::proxy_protocol::v3::ProxyProtocol(),
         /*listener_filter_matcher=*/nullptr, *listener_factory_context_));
@@ -589,7 +586,7 @@ void ListenerImpl::buildTlsInspectorListenerFilter() {
 
     auto& factory =
         Config::Utility::getAndCheckFactoryByName<Configuration::NamedListenerFilterConfigFactory>(
-            Extensions::ListenerFilters::ListenerFilterNames::get().TlsInspector);
+            "envoy.filters.listener.tls_inspector");
     listener_filter_factories_.push_back(factory.createListenerFilterFactoryFromProto(
         Envoy::ProtobufWkt::Empty(),
         /*listener_filter_matcher=*/nullptr, *listener_factory_context_));

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -40,7 +40,7 @@ namespace Server {
 
 namespace {
 
-const std::string TlsInspector = "envoy.filters.listener.tls_inspector";
+const std::string TlsInspector = ""envoy.listener.tls_inspector"";
 
 bool anyFilterChain(
     const envoy::config::listener::v3::Listener& config,

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -39,6 +39,9 @@ namespace Envoy {
 namespace Server {
 
 namespace {
+
+const std::string TlsInspector = "envoy.filters.listener.tls_inspector";
+
 bool anyFilterChain(
     const envoy::config::listener::v3::Listener& config,
     std::function<bool(const envoy::config::listener::v3::FilterChain&)> predicate) {
@@ -61,7 +64,7 @@ bool needTlsInspector(const envoy::config::listener::v3::Listener& config) {
          !std::any_of(config.listener_filters().begin(), config.listener_filters().end(),
                       [](const auto& filter) {
                         return filter.name() == "envoy.filters.listener.tls_inspector" ||
-                               filter.name() == "envoy.listener.tls_inspector";
+                               filter.name() == TlsInspector;
                       });
 }
 
@@ -586,7 +589,7 @@ void ListenerImpl::buildTlsInspectorListenerFilter() {
 
     auto& factory =
         Config::Utility::getAndCheckFactoryByName<Configuration::NamedListenerFilterConfigFactory>(
-            "envoy.filters.listener.tls_inspector");
+            TlsInspector);
     listener_filter_factories_.push_back(factory.createListenerFilterFactoryFromProto(
         Envoy::ProtobufWkt::Empty(),
         /*listener_filter_matcher=*/nullptr, *listener_factory_context_));

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -34,8 +34,6 @@
 #include "source/server/filter_chain_manager_impl.h"
 #include "source/server/transport_socket_config_impl.h"
 
-#include "source/extensions/filters/listener/well_known_names.h"
-
 namespace Envoy {
 namespace Server {
 namespace {

--- a/test/extensions/filters/listener/http_inspector/BUILD
+++ b/test/extensions/filters/listener/http_inspector/BUILD
@@ -36,7 +36,6 @@ envoy_extension_cc_test(
     srcs = ["http_inspector_config_test.cc"],
     extension_name = "envoy.filters.listener.http_inspector",
     deps = [
-        "//source/extensions/filters/listener:well_known_names",
         "//source/extensions/filters/listener/http_inspector:config",
         "//source/extensions/filters/listener/http_inspector:http_inspector_lib",
         "//test/mocks/api:api_mocks",

--- a/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
@@ -1,5 +1,4 @@
 #include "source/extensions/filters/listener/http_inspector/http_inspector.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 
 #include "test/mocks/server/listener_factory_context.h"
 
@@ -17,9 +16,9 @@ namespace {
 TEST(HttpInspectorConfigFactoryTest, TestCreateFactory) {
   Server::Configuration::NamedListenerFilterConfigFactory* factory =
       Registry::FactoryRegistry<Server::Configuration::NamedListenerFilterConfigFactory>::
-          getFactory(ListenerFilters::ListenerFilterNames::get().HttpInspector);
+          getFactory("envoy.filters.listener.http_inspector");
 
-  EXPECT_EQ(factory->name(), ListenerFilters::ListenerFilterNames::get().HttpInspector);
+  EXPECT_EQ(factory->name(), "envoy.filters.listener.http_inspector");
 
   const std::string yaml = R"EOF(
       {}

--- a/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
+++ b/test/extensions/filters/listener/http_inspector/http_inspector_config_test.cc
@@ -14,11 +14,11 @@ namespace HttpInspector {
 namespace {
 
 TEST(HttpInspectorConfigFactoryTest, TestCreateFactory) {
-  Server::Configuration::NamedListenerFilterConfigFactory* factory =
-      Registry::FactoryRegistry<Server::Configuration::NamedListenerFilterConfigFactory>::
-          getFactory("envoy.filters.listener.http_inspector");
+  const std::string HttpInspector = "envoy.filters.listener.http_inspector";
+  Server::Configuration::NamedListenerFilterConfigFactory* factory = Registry::FactoryRegistry<
+      Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(HttpInspector);
 
-  EXPECT_EQ(factory->name(), "envoy.filters.listener.http_inspector");
+  EXPECT_EQ(factory->name(), HttpInspector);
 
   const std::string yaml = R"EOF(
       {}

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -923,6 +923,8 @@ TEST_P(ProxyProtocolTest, V2PartialRead) {
   disconnect();
 }
 
+const std::string ProxyProtocol = "envoy.filters.listener.proxy_protocol";
+
 TEST_P(ProxyProtocolTest, V2ExtractTlvOfInterest) {
   // A well-formed ipv4/tcp with a pair of TLV extensions is accepted
   constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
@@ -951,9 +953,9 @@ TEST_P(ProxyProtocolTest, V2ExtractTlvOfInterest) {
 
   auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
   EXPECT_EQ(1, metadata.size());
-  EXPECT_EQ(1, metadata.count("envoy.filters.listener.proxy_protocol"));
+  EXPECT_EQ(1, metadata.count(ProxyProtocol));
 
-  auto fields = metadata.at("envoy.filters.listener.proxy_protocol").fields();
+  auto fields = metadata.at(ProxyProtocol).fields();
   EXPECT_EQ(1, fields.size());
   EXPECT_EQ(1, fields.count("PP2 type authority"));
 
@@ -1044,9 +1046,9 @@ TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterest) {
 
   auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
   EXPECT_EQ(1, metadata.size());
-  EXPECT_EQ(1, metadata.count("envoy.filters.listener.proxy_protocol"));
+  EXPECT_EQ(1, metadata.count(ProxyProtocol));
 
-  auto fields = metadata.at("envoy.filters.listener.proxy_protocol").fields();
+  auto fields = metadata.at(ProxyProtocol).fields();
   EXPECT_EQ(2, fields.size());
   EXPECT_EQ(1, fields.count("PP2 type authority"));
   EXPECT_EQ(1, fields.count("PP2 vpc id"));
@@ -1098,9 +1100,9 @@ TEST_P(ProxyProtocolTest, V2WillNotOverwriteTLV) {
 
   auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
   EXPECT_EQ(1, metadata.size());
-  EXPECT_EQ(1, metadata.count("envoy.filters.listener.proxy_protocol"));
+  EXPECT_EQ(1, metadata.count(ProxyProtocol));
 
-  auto fields = metadata.at("envoy.filters.listener.proxy_protocol").fields();
+  auto fields = metadata.at(ProxyProtocol).fields();
   EXPECT_EQ(1, fields.size());
   EXPECT_EQ(1, fields.count("PP2 type authority"));
 
@@ -1436,11 +1438,10 @@ TEST_P(WildcardProxyProtocolTest, BasicV6) {
 }
 
 TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
-  Server::Configuration::NamedListenerFilterConfigFactory* factory =
-      Registry::FactoryRegistry<Server::Configuration::NamedListenerFilterConfigFactory>::
-          getFactory("envoy.filters.listener.proxy_protocol");
+  Server::Configuration::NamedListenerFilterConfigFactory* factory = Registry::FactoryRegistry<
+      Server::Configuration::NamedListenerFilterConfigFactory>::getFactory(ProxyProtocol);
 
-  EXPECT_EQ(factory->name(), "envoy.filters.listener.proxy_protocol");
+  EXPECT_EQ(factory->name(), ProxyProtocol);
 
   const std::string yaml = R"EOF(
       rules:

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -15,7 +15,6 @@
 #include "source/common/network/tcp_listener_impl.h"
 #include "source/common/network/utility.h"
 #include "source/extensions/filters/listener/proxy_protocol/proxy_protocol.h"
-#include "source/extensions/filters/listener/well_known_names.h"
 #include "source/server/connection_handler_impl.h"
 
 #include "test/mocks/api/mocks.h"
@@ -952,9 +951,9 @@ TEST_P(ProxyProtocolTest, V2ExtractTlvOfInterest) {
 
   auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
   EXPECT_EQ(1, metadata.size());
-  EXPECT_EQ(1, metadata.count(ListenerFilters::ListenerFilterNames::get().ProxyProtocol));
+  EXPECT_EQ(1, metadata.count("envoy.filters.listener.proxy_protocol"));
 
-  auto fields = metadata.at(ListenerFilters::ListenerFilterNames::get().ProxyProtocol).fields();
+  auto fields = metadata.at("envoy.filters.listener.proxy_protocol").fields();
   EXPECT_EQ(1, fields.size());
   EXPECT_EQ(1, fields.count("PP2 type authority"));
 
@@ -1045,9 +1044,9 @@ TEST_P(ProxyProtocolTest, V2ExtractMultipleTlvsOfInterest) {
 
   auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
   EXPECT_EQ(1, metadata.size());
-  EXPECT_EQ(1, metadata.count(ListenerFilters::ListenerFilterNames::get().ProxyProtocol));
+  EXPECT_EQ(1, metadata.count("envoy.filters.listener.proxy_protocol"));
 
-  auto fields = metadata.at(ListenerFilters::ListenerFilterNames::get().ProxyProtocol).fields();
+  auto fields = metadata.at("envoy.filters.listener.proxy_protocol").fields();
   EXPECT_EQ(2, fields.size());
   EXPECT_EQ(1, fields.count("PP2 type authority"));
   EXPECT_EQ(1, fields.count("PP2 vpc id"));
@@ -1099,9 +1098,9 @@ TEST_P(ProxyProtocolTest, V2WillNotOverwriteTLV) {
 
   auto metadata = server_connection_->streamInfo().dynamicMetadata().filter_metadata();
   EXPECT_EQ(1, metadata.size());
-  EXPECT_EQ(1, metadata.count(ListenerFilters::ListenerFilterNames::get().ProxyProtocol));
+  EXPECT_EQ(1, metadata.count("envoy.filters.listener.proxy_protocol"));
 
-  auto fields = metadata.at(ListenerFilters::ListenerFilterNames::get().ProxyProtocol).fields();
+  auto fields = metadata.at("envoy.filters.listener.proxy_protocol").fields();
   EXPECT_EQ(1, fields.size());
   EXPECT_EQ(1, fields.count("PP2 type authority"));
 
@@ -1439,9 +1438,9 @@ TEST_P(WildcardProxyProtocolTest, BasicV6) {
 TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
   Server::Configuration::NamedListenerFilterConfigFactory* factory =
       Registry::FactoryRegistry<Server::Configuration::NamedListenerFilterConfigFactory>::
-          getFactory(ListenerFilters::ListenerFilterNames::get().ProxyProtocol);
+          getFactory("envoy.filters.listener.proxy_protocol");
 
-  EXPECT_EQ(factory->name(), ListenerFilters::ListenerFilterNames::get().ProxyProtocol);
+  EXPECT_EQ(factory->name(), "envoy.filters.listener.proxy_protocol");
 
   const std::string yaml = R"EOF(
       rules:


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Remove well_known_names in listener field, part of #7238

Additional Description:
Risk Level: Low
Testing: functional, integration
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
