### PR TITLE
docs: Use bazel build for generating external deps rst

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -78,7 +78,7 @@ BAZEL_BUILD_OPTIONS+=(
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/docs:extensions_security_rst
 
 # Generate RST for external dependency docs in intro/arch_overview/security.
-bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/dependency:generate_external_dep_rst
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/docs:external_deps_rst
 
 function generate_api_rst() {
   local proto_target
@@ -145,8 +145,9 @@ rsync -av \
       "${SCRIPT_DIR}"/_ext \
       "${GENERATED_RST_DIR}"
 
-# TODO(phlax): once all of above jobs are moved to bazel build genrules this can be done as part of the sphinx build
-tar -xf bazel-out/k8-fastbuild/bin/tools/docs/extensions_security_rst.tar -C "${GENERATED_RST_DIR}"
+# TODO(phlax): once all of above jobs are moved to bazel build genrules these can be done as part of the sphinx build
+tar -xf bazel-bin/tools/docs/extensions_security_rst.tar -C "${GENERATED_RST_DIR}"
+tar -xf bazel-bin/tools/docs/external_deps_rst.tar -C "${GENERATED_RST_DIR}"
 
 # Merge generated redirects
 jq -r 'with_entries(.key |= sub("^envoy/";"api-v3/")) | with_entries(.value |= sub("^envoy/";"api-v2/")) | to_entries[] | "\(.value)\t\t\(.key)"' docs/v2_mapping.json >> "${GENERATED_RST_DIR}"/redirects.txt

--- a/tools/dependency/BUILD
+++ b/tools/dependency/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@deps_pip3//:requirements.bzl", "requirement")
 load("//bazel:envoy_build_system.bzl", "envoy_package")
 load("//tools/base:envoy_python.bzl", "envoy_py_binary")
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-py_binary(
+py_library(
     name = "exports",
     srcs = ["exports.py"],
     data = [
@@ -17,15 +17,10 @@ py_binary(
     ],
 )
 
-py_binary(
-    name = "generate_external_dep_rst",
-    srcs = [
-        "generate_external_dep_rst.py",
-        "utils.py",
-    ],
-    data = [
-        ":exports",
-    ],
+py_library(
+    name = "utils",
+    srcs = ["utils.py"],
+    deps = [":exports"],
 )
 
 py_binary(

--- a/tools/dependency/utils.py
+++ b/tools/dependency/utils.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 
-from exports import (
+from tools.dependency.exports import (
     api_repository_locations, envoy_repository_locations, repository_locations_utils)
 
 

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -24,3 +24,28 @@ genrule(
     ),
     tools = [":generate_extensions_security_rst"],
 )
+
+py_binary(
+    name = "generate_external_deps_rst",
+    srcs = [
+        "generate_external_deps_rst.py",
+    ],
+    deps = [
+        "//tools/dependency:exports",
+        "//tools/dependency:utils",
+    ],
+)
+
+genrule(
+    name = "external_deps_rst",
+    srcs = [
+        "//bazel:repository_locations.bzl",
+        "@envoy_api_canonical//bazel:repository_locations.bzl",
+        "@envoy_api_canonical//bazel:repository_locations_utils.bzl",
+    ],
+    outs = ["external_deps_rst.tar"],
+    cmd = (
+        "$(location generate_external_deps_rst) $@"
+    ),
+    tools = [":generate_external_deps_rst"],
+)


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Use bazel build for generating external deps rst
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
