### PR TITLE
docs: update local rate limit with descriptors example

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/local-rate-limit-with-descriptors.yaml
+++ b/docs/root/configuration/http/http_filters/_include/local-rate-limit-with-descriptors.yaml
@@ -1,97 +1,96 @@
 static_resources:
   listeners:
-    - address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 8000
-      listener_filters:
-      filter_chains:
-        - filters:
-            - name: envoy.filters.network.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                stat_prefix: ingress_http
-                http_filters:
-                  - name: envoy.filters.http.router
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                  - name: local_service
-                    domains: ["*"]
-                    routes:
-                    - match: { prefix: "/foo" }
-                      route:
-                        cluster: service_protected_by_rate_limit
-                        rate_limits:
-                        - actions: # any actions in here
-                          - request_headers:
-                              header_name: x-envoy-downstream-service-cluster
-                              descriptor_key: client_cluster
-                          - request_headers:
-                              header_name: ":path"
-                              descriptor_key: path
-                      typed_per_filter_config:
-                        envoy.filters.http.local_ratelimit:
-                          "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-                          stat_prefix: test
-                          token_bucket:
-                            max_tokens: 1000
-                            tokens_per_fill: 1000
-                            fill_interval: 60s
-                          filter_enabled:
-                            runtime_key: test_enabled
-                            default_value:
-                              numerator: 100
-                              denominator: HUNDRED
-                          filter_enforced:
-                            runtime_key: test_enforced
-                            default_value:
-                              numerator: 100
-                              denominator: HUNDRED
-                          response_headers_to_add:
-                            - append: false
-                              header:
-                                key: x-test-rate-limit
-                                value: 'true'
-                          descriptors:
-                          - entries:
-                            - key: client_cluster
-                              value: foo
-                            - key: path
-                              value: /foo/bar
-                            token_bucket:
-                              max_tokens: 10
-                              tokens_per_fill: 10
-                              fill_interval: 60s
-                          - entries:
-                            - key: client_cluster
-                              value: foo
-                            - key: path
-                              value: /foo/bar2
-                            token_bucket:
-                              max_tokens: 100
-                              tokens_per_fill: 100
-                              fill_interval: 60s
-                    - match: { prefix: "/" }
-                      route: { cluster: default_service }
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/foo" }
+                route:
+                  cluster: service_protected_by_rate_limit
+                  rate_limits:
+                  - actions: # any actions in here
+                    - request_headers:
+                        header_name: x-envoy-downstream-service-cluster
+                        descriptor_key: client_cluster
+                    - request_headers:
+                        header_name: ":path"
+                        descriptor_key: path
+                typed_per_filter_config:
+                  envoy.filters.http.local_ratelimit:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                    stat_prefix: test
+                    token_bucket:
+                      max_tokens: 1000
+                      tokens_per_fill: 1000
+                      fill_interval: 60s
+                    filter_enabled:
+                      runtime_key: test_enabled
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    filter_enforced:
+                      runtime_key: test_enforced
+                      default_value:
+                        numerator: 100
+                        denominator: HUNDRED
+                    response_headers_to_add:
+                    - append: false
+                      header:
+                        key: x-test-rate-limit
+                        value: 'true'
+                    descriptors:
+                    - entries:
+                      - key: client_cluster
+                        value: foo
+                      - key: path
+                        value: /foo/bar
+                      token_bucket:
+                        max_tokens: 10
+                        tokens_per_fill: 10
+                        fill_interval: 60s
+                    - entries:
+                      - key: client_cluster
+                        value: foo
+                      - key: path
+                        value: /foo/bar2
+                      token_bucket:
+                        max_tokens: 100
+                        tokens_per_fill: 100
+                        fill_interval: 60s
+              - match: { prefix: "/" }
+                route: { cluster: default_service }
   clusters:
-    - name: default_service
-      load_assignment:
-        cluster_name: default_service
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: 127.0.0.1
-                      port_value: 8080
-    - name: service_protected_by_rate_limit
-      load_assignment:
-        cluster_name: service_protected_by_rate_limit
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: 127.0.0.1
-                      port_value: 8081
+  - name: default_service
+    load_assignment:
+      cluster_name: default_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8080
+  - name: service_protected_by_rate_limit
+    load_assignment:
+      cluster_name: service_protected_by_rate_limit
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8081

--- a/docs/root/configuration/http/http_filters/_include/local-rate-limit-with-descriptors.yaml
+++ b/docs/root/configuration/http/http_filters/_include/local-rate-limit-with-descriptors.yaml
@@ -1,0 +1,99 @@
+static_resources:
+  listeners:
+    - address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8000
+      listener_filters:
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                http_filters:
+                  - name: envoy.filters.http.router
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                  - name: local_service
+                    domains: ["*"]
+                    routes:
+                    - match: { prefix: "/foo" }
+                      route:
+                        cluster: service_protected_by_rate_limit
+                        rate_limits:
+                        - actions: # any actions in here
+                          - request_headers:
+                              header_name: x-envoy-downstream-service-cluster
+                              descriptor_key: client_cluster
+                          - request_headers:
+                              header_name: ":path"
+                              descriptor_key: path
+                      typed_per_filter_config:
+                        envoy.filters.http.local_ratelimit:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+                          stat_prefix: test
+                          token_bucket:
+                            max_tokens: 1000
+                            tokens_per_fill: 1000
+                            fill_interval: 60s
+                          filter_enabled:
+                            runtime_key: test_enabled
+                            default_value:
+                              numerator: 100
+                              denominator: HUNDRED
+                          filter_enforced:
+                            runtime_key: test_enforced
+                            default_value:
+                              numerator: 100
+                              denominator: HUNDRED
+                          response_headers_to_add:
+                            - append: false
+                              header:
+                                key: x-test-rate-limit
+                                value: 'true'
+                          descriptors:
+                          - entries:
+                            - key: client_cluster
+                              value: foo
+                            - key: path
+                              value: /foo/bar
+                            token_bucket:
+                              max_tokens: 10
+                              tokens_per_fill: 10
+                              fill_interval: 60s
+                          - entries:
+                            - key: client_cluster
+                              value: foo
+                            - key: path
+                              value: /foo/bar2
+                            token_bucket:
+                              max_tokens: 100
+                              tokens_per_fill: 100
+                              fill_interval: 60s
+                    - match: { prefix: "/" }
+                      route: { cluster: default_service }
+  clusters:
+    - name: default_service
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: default_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8080
+    - name: service_protected_by_rate_limit
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: service_protected_by_rate_limit
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8081

--- a/docs/root/configuration/http/http_filters/_include/local-rate-limit-with-descriptors.yaml
+++ b/docs/root/configuration/http/http_filters/_include/local-rate-limit-with-descriptors.yaml
@@ -76,7 +76,6 @@ static_resources:
                       route: { cluster: default_service }
   clusters:
     - name: default_service
-      connect_timeout: 1s
       load_assignment:
         cluster_name: default_service
         endpoints:
@@ -87,7 +86,6 @@ static_resources:
                       address: 127.0.0.1
                       port_value: 8080
     - name: service_protected_by_rate_limit
-      connect_timeout: 1s
       load_assignment:
         cluster_name: service_protected_by_rate_limit
         endpoints:

--- a/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
@@ -127,70 +127,9 @@ the default token bucket is used.
 
 Example filter configuration using descriptors:
 
-.. validated-code-block:: yaml
-  :type-name:  envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-
-  route_config:
-    name: local_route
-    virtual_hosts:
-    - name: local_service
-      domains: ["*"]
-      routes:
-      - match: { prefix: "/foo" }
-        route:
-          cluster: service_protected_by_rate_limit
-          rate_limits:
-          - actions: # any actions in here
-            - request_headers:
-                header_name: x-envoy-downstream-service-cluster
-                descriptor_key: client_cluster
-            - request_headers:
-                header_name: ":path"
-                descriptor_key: path
-        typed_per_filter_config:
-          envoy.filters.http.local_ratelimit:
-            "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-            stat_prefix: test
-            token_bucket:
-              max_tokens: 1000
-              tokens_per_fill: 1000
-              fill_interval: 60s
-            filter_enabled:
-              runtime_key: test_enabled
-              default_value:
-                numerator: 100
-                denominator: HUNDRED
-            filter_enforced:
-              runtime_key: test_enforced
-              default_value:
-                numerator: 100
-                denominator: HUNDRED
-            response_headers_to_add:
-              - append: false
-                header:
-                  key: x-test-rate-limit
-                  value: 'true'
-            descriptors:
-            - entries:
-              - key: client_cluster
-                value: foo
-              - key: path
-                value: /foo/bar
-              token_bucket:
-                max_tokens: 10
-                tokens_per_fill: 10
-                fill_interval: 60s
-            - entries:
-              - key: client_cluster
-                value: foo
-              - key: path
-                value: /foo/bar2
-              token_bucket:
-                max_tokens: 100
-                tokens_per_fill: 100
-                fill_interval: 60s
-      - match: { prefix: "/" }
-        route: { cluster: default_service }
+.. literalinclude:: _include/local-rate-limit-with-descriptors.yaml
+   :language: yaml
+   :lines: 16-76
 
 In this example, requests are rate-limited for routes prefixed with "/foo" as
 follow. If requests come from a downstream service cluster "foo" for "/foo/bar"

--- a/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
@@ -129,7 +129,8 @@ Example filter configuration using descriptors:
 
 .. literalinclude:: _include/local-rate-limit-with-descriptors.yaml
    :language: yaml
-   :lines: 16-76
+   :lines: 15-75
+   :caption: :download:`local-rate-limit-with-descriptors.yaml < _include/local-rate-limit-with-descriptors.yaml>`
 
 In this example, requests are rate-limited for routes prefixed with "/foo" as
 follow. If requests come from a downstream service cluster "foo" for "/foo/bar"

--- a/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
@@ -130,7 +130,7 @@ Example filter configuration using descriptors:
 .. literalinclude:: _include/local-rate-limit-with-descriptors.yaml
    :language: yaml
    :lines: 15-75
-   :caption: :download:`local-rate-limit-with-descriptors.yaml < _include/local-rate-limit-with-descriptors.yaml>`
+   :caption: :download:`local-rate-limit-with-descriptors.yaml <_include/local-rate-limit-with-descriptors.yaml>`
 
 In this example, requests are rate-limited for routes prefixed with "/foo" as
 follow. If requests come from a downstream service cluster "foo" for "/foo/bar"

--- a/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
+++ b/docs/root/configuration/http/http_filters/local_rate_limit_filter.rst
@@ -137,7 +137,16 @@ Example filter configuration using descriptors:
       domains: ["*"]
       routes:
       - match: { prefix: "/foo" }
-        route: { cluster: service_protected_by_rate_limit }
+        route:
+          cluster: service_protected_by_rate_limit
+          rate_limits:
+          - actions: # any actions in here
+            - request_headers:
+                header_name: x-envoy-downstream-service-cluster
+                descriptor_key: client_cluster
+            - request_headers:
+                header_name: ":path"
+                descriptor_key: path
         typed_per_filter_config:
           envoy.filters.http.local_ratelimit:
             "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
@@ -182,14 +191,6 @@ Example filter configuration using descriptors:
                 fill_interval: 60s
       - match: { prefix: "/" }
         route: { cluster: default_service }
-      rate_limits:
-      - actions: # any actions in here
-        - request_headers:
-            header_name: x-envoy-downstream-service-cluster
-            descriptor_key: client_cluster
-        - request_headers:
-            header_name: ":path"
-            descriptor_key: path
 
 In this example, requests are rate-limited for routes prefixed with "/foo" as
 follow. If requests come from a downstream service cluster "foo" for "/foo/bar"


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Commit Message: The example is incorrect since local rate limit does not implement virtual host fallback
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
Issue: https://github.com/envoyproxy/envoy/issues/14851