### PR TITLE
docs: add seealso section to gzip sandbox

### DIFF
--- a/docs/root/start/sandboxes/gzip.rst
+++ b/docs/root/start/sandboxes/gzip.rst
@@ -85,8 +85,10 @@ Now, use ``curl`` to make a request for the compressed statistics:
     content-encoding: gzip
 
 .. seealso::
+   :ref:`Gzip Api <envoy_v3_api_field_extensions.filters.http.gzip.v3.Gzip.compressor>`
+      Learn more abort Envoy’s gzip Apis.
 
-   :ref:`gzip filter <config_http_filters_gzip>`.
+   :ref:`Gzip configuration <config_http_filters_gzip>`.
       Learn more about configuring Envoy's gzip filter.
 
    :ref:`Envoy admin quick start guide <start_quick_start_admin>`

--- a/docs/root/start/sandboxes/gzip.rst
+++ b/docs/root/start/sandboxes/gzip.rst
@@ -86,10 +86,10 @@ Now, use ``curl`` to make a request for the compressed statistics:
 
 .. seealso::
    :ref:`Gzip Api <envoy_v3_api_field_extensions.filters.http.gzip.v3.Gzip.compressor>`
-      Learn more abort Envoy’s gzip Apis.
+      API and configuration reference for Envoy's gzip compression.
 
    :ref:`Gzip configuration <config_http_filters_gzip>`.
-      Learn more about configuring Envoy's gzip filter.
+      Reference documentation for Envoy's gzip compression.
 
    :ref:`Envoy admin quick start guide <start_quick_start_admin>`
       Quick start guide to the Envoy admin interface.

--- a/docs/root/start/sandboxes/gzip.rst
+++ b/docs/root/start/sandboxes/gzip.rst
@@ -83,3 +83,11 @@ Now, use ``curl`` to make a request for the compressed statistics:
 
     $ curl -si -H "Accept-Encoding: gzip" localhost:9902/stats/prometheus | grep "content-encoding"
     content-encoding: gzip
+
+.. seealso::
+
+   :ref:`gzip filter <config_http_filters_gzip>`.
+      Learn more about configuring Envoy's gzip filter.
+
+   :ref:`Envoy admin quick start guide <start_quick_start_admin>`
+      Quick start guide to the Envoy admin interface.

--- a/docs/root/start/sandboxes/gzip.rst
+++ b/docs/root/start/sandboxes/gzip.rst
@@ -85,10 +85,10 @@ Now, use ``curl`` to make a request for the compressed statistics:
     content-encoding: gzip
 
 .. seealso::
-   :ref:`Gzip Api <envoy_v3_api_field_extensions.filters.http.gzip.v3.Gzip.compressor>`
+   :ref:`Gzip Api <envoy_v3_api_msg_extensions.compression.gzip.compressor.v3.Gzip>`
       API and configuration reference for Envoy's gzip compression.
 
-   :ref:`Gzip configuration <config_http_filters_gzip>`.
+   :ref:`Gzip configuration <config_http_filters_compressor>`.
       Reference documentation for Envoy's gzip compression.
 
    :ref:`Envoy admin quick start guide <start_quick_start_admin>`

--- a/docs/root/start/sandboxes/gzip.rst
+++ b/docs/root/start/sandboxes/gzip.rst
@@ -85,11 +85,11 @@ Now, use ``curl`` to make a request for the compressed statistics:
     content-encoding: gzip
 
 .. seealso::
-   :ref:`Gzip Api <envoy_v3_api_msg_extensions.compression.gzip.compressor.v3.Gzip>`
+   :ref:`Gzip API <envoy_v3_api_msg_extensions.compression.gzip.compressor.v3.Gzip>`
       API and configuration reference for Envoy's gzip compression.
 
-   :ref:`Gzip configuration <config_http_filters_compressor>`.
-      Reference documentation for Envoy's gzip compression.
+   :ref:`Compression configuration <config_http_filters_compressor>`
+      Reference documentation for Envoy's compressor filter.
 
    :ref:`Envoy admin quick start guide <start_quick_start_admin>`
       Quick start guide to the Envoy admin interface.


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Add seealso section to gzip sandbox

Additional Description:
Risk Level: LOW
Testing:
Docs Changes: add seealso section.
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue] Fix #16748
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
