### PR TITLE
runtime: scope rtds stats to layer name

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -34,6 +34,7 @@ Minor Behavior Changes
   <envoy_v3_api_field_config.route.v3.HeaderMatcher.present_match>`.
 * listener: respect the :ref:`connection balance config <envoy_v3_api_field_config.listener.v3.Listener.connection_balance_config>`
   defined within the listener where the sockets are redirected to. Clear that field to restore the previous behavior.
+* runtime: rtds stats will now include the layer name, making it possible to differentiate RTDS stats for each layer.
 * tcp: switched to the new connection pool by default. Any unexpected behavioral changes can be reverted by setting runtime guard ``envoy.reloadable_features.new_tcp_connection_pool`` to false.
 
 Bug Fixes

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -456,7 +456,8 @@ RtdsSubscription::RtdsSubscription(
     : Envoy::Config::SubscriptionBase<envoy::service::runtime::v3::Runtime>(
           rtds_layer.rtds_config().resource_api_version(), validation_visitor, "name"),
       parent_(parent), config_source_(rtds_layer.rtds_config()), store_(store),
-      stats_scope_(store_.createScope("runtime")), resource_name_(rtds_layer.name()),
+      stats_scope_(store_.createScope("runtime." + rtds_layer.name())),
+      resource_name_(rtds_layer.name()),
       init_target_("RTDS " + resource_name_, [this]() { start(); }) {}
 
 void RtdsSubscription::createSubscription() {

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -866,11 +866,16 @@ public:
       rtds_layer->mutable_rtds_config();
     }
     EXPECT_CALL(cm_, subscriptionFactory()).Times(layers_.size());
+    size_t layer_index = 0;
     ON_CALL(cm_.subscription_factory_, subscriptionFromConfigSource(_, _, _, _, _, _))
-        .WillByDefault(testing::Invoke(
-            [this](const envoy::config::core::v3::ConfigSource&, absl::string_view, Stats::Scope&,
-                   Config::SubscriptionCallbacks& callbacks, Config::OpaqueResourceDecoder&,
-                   const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
+        .WillByDefault(
+            testing::Invoke([&](const envoy::config::core::v3::ConfigSource&, absl::string_view,
+                                Stats::Scope& scope, Config::SubscriptionCallbacks& callbacks,
+                                Config::OpaqueResourceDecoder&,
+                                const Config::SubscriptionOptions&) -> Config::SubscriptionPtr {
+              // Verify that we pass the correct scope to the subscription factory.
+              EXPECT_EQ(scope.counterFromString("foo").name(),
+                        fmt::format("runtime.{}.foo", layers_[layer_index++]));
               auto ret = std::make_unique<testing::NiceMock<Config::MockSubscription>>();
               rtds_subscriptions_.push_back(ret.get());
               rtds_callbacks_.push_back(&callbacks);

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -177,9 +177,9 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
   EXPECT_EQ("saz", getRuntimeKey("baz"));
 
   EXPECT_EQ(0, test_server_->counter("runtime.load_error")->value());
-  EXPECT_EQ(0, test_server_->counter("runtime.update_failure")->value());
+  EXPECT_EQ(0, test_server_->counter("runtime.some_rtds_layer.update_failure")->value());
   EXPECT_EQ(initial_load_success_ + 2, test_server_->counter("runtime.load_success")->value());
-  EXPECT_EQ(2, test_server_->counter("runtime.update_success")->value());
+  EXPECT_EQ(2, test_server_->counter("runtime.some_rtds_layer.update_success")->value());
   EXPECT_EQ(initial_keys_ + 1, test_server_->gauge("runtime.num_keys")->value());
   EXPECT_EQ(3, test_server_->gauge("runtime.num_layers")->value());
 }


### PR DESCRIPTION
This changes the name of the scope given to rtds resource subscriptions to include the layer name. Currently if multiple RTDS
layers are used, they will share the same scope, making it impossible to tease apart the stats per layer.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium, changes a stat name
Testing: UT
Docs Changes: n/a
Release Notes: n/a
