### PR TITLE
upstream: Allow users of HttpPoolData to access the underlying pool.

### DIFF
--- a/envoy/upstream/thread_local_cluster.h
+++ b/envoy/upstream/thread_local_cluster.h
@@ -26,6 +26,8 @@ public:
 
   Upstream::HostDescriptionConstSharedPtr host() const { return pool_->host(); }
 
+  Http::ConnectionPool::Instance* pool() const { return pool_; }
+
 private:
   friend class HttpPoolDataPeer;
 


### PR DESCRIPTION
A recent change (#16544) moved the `Http::ConnectionPool::Instance*` returned from `ThreadLocalCluster::httpConnPool()` behind a new class `HttpPoolData` which no longer exposes the pool instance.

[Nighthawk](https://github.com/envoyproxy/nighthawk) depends on the pool when terminating a benchmark [here](https://github.com/envoyproxy/nighthawk/blob/8534dbddb6adc6aaf6f0bcafbe6b969ae062e720/source/client/benchmark_client_impl.cc#L109-L129).

This PR proposes a `HttpPoolData::pool()` method which exposes the pool to Nighthawk in order to retain the original functionality. Happy to discuss alternatives if this isn't acceptable. Note - this breakage in Nighthawk will prevent an Envoy import into Google until / unless we find a workaround.

Risk Level: low, existing functionality isn't affected.
Testing: n/a, only accessor method added.
Docs Changes: n/a.
Release Notes: n/a.

Signed-off-by: Jakub Sobon <mumak@google.com>