### PR TITLE
docs: Use bazel to build redirects.txt

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])  # Apache 2
 exports_files([
     "protodoc_manifest.yaml",
     "v2_mapping.json",
+    "redirects.txt",
 ])
 
 envoy_package()
@@ -43,4 +44,21 @@ filegroup(
             "root/**/*.pb",
         ],
     ),
+)
+
+genrule(
+    name = "v2_redirects",
+    outs = ["v2_redirects.txt"],
+    cmd = "jq -r 'with_entries(.key |= sub(\"^envoy/\";\"api-v3/\")) | with_entries(.value |= sub(\"^envoy/\";\"api-v2/\")) | to_entries[] | \"\\(.value)\t\t\\(.key)\"' docs/v2_mapping.json > $@",
+    tools = ["//docs:v2_mapping.json"],
+)
+
+genrule(
+    name = "redirects",
+    outs = ["envoy-redirects.txt"],
+    cmd = "cat $(location //docs:redirects.txt) > $@ && cat $(location :v2_redirects) >> $@",
+    tools = [
+        ":redirects.txt",
+        ":v2_redirects",
+    ],
 )

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -145,12 +145,12 @@ rsync -av \
       "${SCRIPT_DIR}"/_ext \
       "${GENERATED_RST_DIR}"
 
+bazel build "${BAZEL_BUILD_OPTIONS[@]}" //docs:redirects
+
 # TODO(phlax): once all of above jobs are moved to bazel build genrules these can be done as part of the sphinx build
 tar -xf bazel-bin/tools/docs/extensions_security_rst.tar -C "${GENERATED_RST_DIR}"
 tar -xf bazel-bin/tools/docs/external_deps_rst.tar -C "${GENERATED_RST_DIR}"
-
-# Merge generated redirects
-jq -r 'with_entries(.key |= sub("^envoy/";"api-v3/")) | with_entries(.value |= sub("^envoy/";"api-v2/")) | to_entries[] | "\(.value)\t\t\(.key)"' docs/v2_mapping.json >> "${GENERATED_RST_DIR}"/redirects.txt
+cp -a bazel-bin/docs/envoy-redirects.txt "${GENERATED_RST_DIR}"
 
 # To speed up validate_fragment invocations in validating_code_block
 bazel build "${BAZEL_BUILD_OPTIONS[@]}" //tools/config_validation:validate_fragment

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -288,7 +288,7 @@ htmlhelp_basename = 'envoydoc'
 # TODO(phlax): add redirect diff (`rediraffe_branch` setting)
 #  - not sure how diffing will work with main merging in PRs - might need
 #    to be injected dynamically, somehow
-rediraffe_redirects = "redirects.txt"
+rediraffe_redirects = "envoy-redirects.txt"
 
 intersphinx_mapping = {
     'v1.5.0': ('https://www.envoyproxy.io/docs/envoy/v1.5.0', None),


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Use bazel to build redirects.txt
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
