### PR TITLE
thrift_proxy: remove well_known_names

### DIFF
--- a/source/extensions/filters/network/thrift_proxy/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/BUILD
@@ -54,7 +54,6 @@ envoy_cc_extension(
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
         "//source/extensions/filters/network/thrift_proxy/filters:filter_config_interface",
-        "//source/extensions/filters/network/thrift_proxy/filters:well_known_names",
         "//source/extensions/filters/network/thrift_proxy/router:router_lib",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/network/thrift_proxy/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/config.cc
@@ -15,7 +15,6 @@
 #include "source/extensions/filters/network/thrift_proxy/compact_protocol_impl.h"
 #include "source/extensions/filters/network/thrift_proxy/decoder.h"
 #include "source/extensions/filters/network/thrift_proxy/filters/filter_config.h"
-#include "source/extensions/filters/network/thrift_proxy/filters/well_known_names.h"
 #include "source/extensions/filters/network/thrift_proxy/framed_transport_impl.h"
 #include "source/extensions/filters/network/thrift_proxy/stats.h"
 #include "source/extensions/filters/network/thrift_proxy/unframed_transport_impl.h"
@@ -128,7 +127,7 @@ ConfigImpl::ConfigImpl(
     ENVOY_LOG(debug, "using default router filter");
 
     envoy::extensions::filters::network::thrift_proxy::v3::ThriftFilter router;
-    router.set_name(ThriftFilters::ThriftFilterNames::get().ROUTER);
+    router.set_name("envoy.filters.thrift.router");
     processFilter(router);
   } else {
     for (const auto& filter : config.thrift_filters()) {

--- a/source/extensions/filters/network/thrift_proxy/filters/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/filters/BUILD
@@ -39,16 +39,7 @@ envoy_cc_library(
         "//source/extensions/filters/network/thrift_proxy:decoder_events_lib",
         "//source/extensions/filters/network/thrift_proxy:protocol_interface",
         "//source/extensions/filters/network/thrift_proxy:thrift_lib",
-        "//source/extensions/filters/network/thrift_proxy/filters:well_known_names",
         "//source/extensions/filters/network/thrift_proxy/router:router_interface",
-    ],
-)
-
-envoy_cc_library(
-    name = "well_known_names",
-    hdrs = ["well_known_names.h"],
-    deps = [
-        "//source/common/singleton:const_singleton",
     ],
 )
 

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/BUILD
@@ -22,7 +22,6 @@ envoy_cc_library(
         "//source/extensions/filters/common/ratelimit:stat_names_lib",
         "//source/extensions/filters/network/thrift_proxy:app_exception_lib",
         "//source/extensions/filters/network/thrift_proxy/filters:pass_through_filter_lib",
-        "//source/extensions/filters/network/thrift_proxy/filters:well_known_names",
         "//source/extensions/filters/network/thrift_proxy/router:router_ratelimit_interface",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/filters/ratelimit/v3:pkg_cc_proto",
     ],
@@ -40,7 +39,6 @@ envoy_cc_extension(
         "//source/extensions/filters/common/ratelimit:ratelimit_client_interface",
         "//source/extensions/filters/common/ratelimit:ratelimit_lib",
         "//source/extensions/filters/network/thrift_proxy/filters:factory_base_lib",
-        "//source/extensions/filters/network/thrift_proxy/filters:well_known_names",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/filters/ratelimit/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/config.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/config.h
@@ -5,7 +5,6 @@
 
 #include "source/extensions/filters/common/ratelimit/ratelimit.h"
 #include "source/extensions/filters/network/thrift_proxy/filters/factory_base.h"
-#include "source/extensions/filters/network/thrift_proxy/filters/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -21,8 +20,7 @@ class RateLimitFilterConfig
     : public ThriftProxy::ThriftFilters::FactoryBase<
           envoy::extensions::filters::network::thrift_proxy::filters::ratelimit::v3::RateLimit> {
 public:
-  RateLimitFilterConfig()
-      : FactoryBase(ThriftProxy::ThriftFilters::ThriftFilterNames::get().RATE_LIMIT) {}
+  RateLimitFilterConfig() : FactoryBase("envoy.filters.thrift.rate_limit") {}
 
 private:
   ThriftProxy::ThriftFilters::FilterFactoryCb createFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.cc
@@ -2,7 +2,6 @@
 
 #include "source/common/tracing/http_tracer_impl.h"
 #include "source/extensions/filters/network/thrift_proxy/app_exception_impl.h"
-#include "source/extensions/filters/network/thrift_proxy/filters/well_known_names.h"
 #include "source/extensions/filters/network/thrift_proxy/router/router.h"
 #include "source/extensions/filters/network/thrift_proxy/router/router_ratelimit.h"
 
@@ -72,8 +71,8 @@ void Filter::complete(Filters::Common::RateLimit::LimitStatus status,
   UNREFERENCED_PARAMETER(request_headers_to_add);
 
   if (dynamic_metadata != nullptr && !dynamic_metadata->fields().empty()) {
-    decoder_callbacks_->streamInfo().setDynamicMetadata(
-        ThriftProxy::ThriftFilters::ThriftFilterNames::get().RATE_LIMIT, *dynamic_metadata);
+    decoder_callbacks_->streamInfo().setDynamicMetadata("envoy.filters.thrift.rate_limit",
+                                                        *dynamic_metadata);
   }
 
   state_ = State::Complete;

--- a/source/extensions/filters/network/thrift_proxy/router/BUILD
+++ b/source/extensions/filters/network/thrift_proxy/router/BUILD
@@ -18,7 +18,6 @@ envoy_cc_extension(
         "//envoy/registry",
         "//source/extensions/filters/network/thrift_proxy/filters:factory_base_lib",
         "//source/extensions/filters/network/thrift_proxy/filters:filter_config_interface",
-        "//source/extensions/filters/network/thrift_proxy/filters:well_known_names",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/router/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/network/thrift_proxy/router/config.h
+++ b/source/extensions/filters/network/thrift_proxy/router/config.h
@@ -4,7 +4,6 @@
 #include "envoy/extensions/filters/network/thrift_proxy/router/v3/router.pb.validate.h"
 
 #include "source/extensions/filters/network/thrift_proxy/filters/factory_base.h"
-#include "source/extensions/filters/network/thrift_proxy/filters/well_known_names.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -16,7 +15,7 @@ class RouterFilterConfig
     : public ThriftFilters::FactoryBase<
           envoy::extensions::filters::network::thrift_proxy::router::v3::Router> {
 public:
-  RouterFilterConfig() : FactoryBase(ThriftFilters::ThriftFilterNames::get().ROUTER) {}
+  RouterFilterConfig() : FactoryBase("envoy.filters.thrift.router") {}
 
 private:
   ThriftFilters::FilterFactoryCb createFilterFactoryFromProtoTyped(

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/BUILD
@@ -19,7 +19,6 @@ envoy_extension_cc_test(
         "//source/common/buffer:buffer_lib",
         "//source/common/common:empty_string",
         "//source/common/http:headers_lib",
-        "//source/extensions/filters/network/thrift_proxy/filters:well_known_names",
         "//source/extensions/filters/network/thrift_proxy/filters/ratelimit:ratelimit_lib",
         "//test/extensions/filters/common/ratelimit:ratelimit_mocks",
         "//test/extensions/filters/network/thrift_proxy:mocks",

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -338,7 +338,7 @@ TEST_F(ThriftRateLimitFilterTest, ErrorResponseWithDynamicMetadata) {
   EXPECT_CALL(filter_callbacks_.stream_info_, setDynamicMetadata(_, _))
       .WillOnce(Invoke([&dynamic_metadata](const std::string& ns,
                                            const ProtobufWkt::Struct& returned_dynamic_metadata) {
-        EXPECT_EQ(ns, ThriftProxy::ThriftFilters::ThriftFilterNames::get().RATE_LIMIT);
+        EXPECT_EQ(ns, "envoy.filters.thrift.rate_limit");
         EXPECT_TRUE(TestUtility::protoEqual(returned_dynamic_metadata, *dynamic_metadata));
       }));
 

--- a/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit_test.cc
@@ -9,7 +9,6 @@
 #include "source/common/http/headers.h"
 #include "source/extensions/filters/network/thrift_proxy/app_exception_impl.h"
 #include "source/extensions/filters/network/thrift_proxy/filters/ratelimit/ratelimit.h"
-#include "source/extensions/filters/network/thrift_proxy/filters/well_known_names.h"
 
 #include "test/extensions/filters/common/ratelimit/mocks.h"
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: 

Remove well_known_names in thrift_proxy field, part of #7238

Additional Description:
Risk Level: Low
Testing: functional
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
