### PR TITLE
dns cache: time to resolution histogram

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -239,7 +239,7 @@ void DnsCacheImpl::startResolve(const std::string& host, PrimaryHostInfo& host_i
 
   stats_.dns_query_attempt_.inc();
   host_info.resolution_timespan_ = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
-      stats_.time_to_resolution_ms_, main_thread_dispatcher_.timeSource());
+      stats_.time_to_resolution_, main_thread_dispatcher_.timeSource());
 
   host_info.active_query_ =
       resolver_->resolve(host_info.host_info_->resolvedHost(), dns_lookup_family_,

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h
@@ -31,7 +31,7 @@ namespace DynamicForwardProxy {
   COUNTER(host_removed)                                                                            \
   COUNTER(dns_rq_pending_overflow)                                                                 \
   GAUGE(num_hosts, NeverImport)                                                                    \
-  HISTOGRAM(time_to_resolution_ms, Milliseconds)
+  HISTOGRAM(time_to_resolution, Milliseconds)
 
 /**
  * Struct definition for all DNS cache stats. @see stats_macros.h


### PR DESCRIPTION
Commit Message: add time to resolution histogram to get information about dns cache behavior.
Additional Description:
Risk Level: low. New metric on already existing functionality.
Testing: pending
Docs Changes: pending
Release Notes: pending
