### PR TITLE
upstream: Add HttpPoolData methods required by Nighthawk.

### DIFF
--- a/envoy/upstream/thread_local_cluster.h
+++ b/envoy/upstream/thread_local_cluster.h
@@ -17,12 +17,23 @@ public:
   HttpPoolData(OnNewStreamFn on_new_stream, Http::ConnectionPool::Instance* pool)
       : on_new_stream_(on_new_stream), pool_(pool) {}
 
+  /**
+   * See documentation of Http::ConnectionPool::Instance.
+   */
   Envoy::Http::ConnectionPool::Cancellable*
   newStream(Http::ResponseDecoder& response_decoder,
             Envoy::Http::ConnectionPool::Callbacks& callbacks) {
     on_new_stream_();
     return pool_->newStream(response_decoder, callbacks);
   }
+  bool hasActiveConnections() const { return pool_->hasActiveConnections(); };
+
+  /**
+   * See documentation of Envoy::ConnectionPool::Instance.
+   */
+  void addDrainedCallback(ConnectionPool::Instance::DrainedCb cb) {
+    pool_->addDrainedCallback(cb);
+  };
 
   Upstream::HostDescriptionConstSharedPtr host() const { return pool_->host(); }
 


### PR DESCRIPTION
A recent change (#16544) moved the `Http::ConnectionPool::Instance*` returned from `ThreadLocalCluster::httpConnPool()` behind a new class `HttpPoolData` which no longer exposes the pool instance.

A temporary workaround was added to [Nighthawk's](https://github.com/envoyproxy/nighthawk) code [here](https://github.com/envoyproxy/nighthawk/blob/fffa66ba50e93273369f428a9796e7b83d2890fa/source/client/benchmark_client_impl.h#L28-L41) to support the [this code](https://github.com/envoyproxy/nighthawk/blob/fffa66ba50e93273369f428a9796e7b83d2890fa/source/client/benchmark_client_impl.cc#L109-L133).

This PR adds two new methods on `HttpPoolData` to allow the removal of said workaround - `hasActiveConnections` and `addDrainedCallback`. Both just forward the call to the underlying pool.

Risk Level: low, existing functionality isn't affected.
Testing: n/a, only accessor method added.
Docs Changes: n/a.
Release Notes: n/a.

Signed-off-by: Jakub Sobon <mumak@google.com>