### PR TITLE
Removes most references to getenvoy

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -5,9 +5,6 @@ Installing Envoy
 
 The Envoy project :ref:`provides a number of pre-built Docker images <install_binaries>` for both ``amd64`` and ``arm64`` architectures.
 
-The `Get Envoy <https://www.getenvoy.io/>`__ project also maintains a number of binaries
-and repositories to accommodate many popular distributions.
-
 If you are :ref:`installing on Mac OSX <start_install_macosx>`, you can install natively with ``brew``.
 
 Once you have installed Envoy, check out the :ref:`quick start <start_quick_start>` guide for more information on
@@ -17,7 +14,7 @@ Install Envoy on Debian GNU/Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can `install Envoy on Debian <https://www.getenvoy.io/install/envoy/debian/>`_
-using `Get Envoy <https://www.getenvoy.io/>`__.
+using `Get Envoy <https://www.getenvoy.io/>`__ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
 
 .. code-block:: console
 
@@ -30,16 +27,11 @@ using `Get Envoy <https://www.getenvoy.io/>`__.
    $ sudo apt update
    $ sudo apt install getenvoy-envoy
 
-.. tip::
-
-   To add the nightly repository instead, replace the word ``stable`` with ``nightly``,
-   when adding the ``apt`` repository.
-
 Install Envoy on Ubuntu Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can `install Envoy on Ubuntu <https://www.getenvoy.io/install/envoy/ubuntu/>`_
-using `Get Envoy <https://www.getenvoy.io/>`__.
+using `Get Envoy <https://www.getenvoy.io/>`__ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
 
 .. code-block:: console
 
@@ -52,16 +44,11 @@ using `Get Envoy <https://www.getenvoy.io/>`__.
    $ sudo apt update
    $ sudo apt install -y getenvoy-envoy
 
-.. tip::
-
-   To add the nightly repository instead, replace the word ``stable`` with ``nightly``,
-   when adding the ``apt`` repository.
-
 Install Envoy on RPM-based distros
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can `install Envoy on Centos/Redhat Enterprise Linux (RHEL) <https://www.getenvoy.io/install/envoy/rpm/>`_
-using `Get Envoy <https://www.getenvoy.io/>`__.
+using `Get Envoy <https://www.getenvoy.io/>`__ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
 
 .. code-block:: console
 
@@ -69,22 +56,12 @@ using `Get Envoy <https://www.getenvoy.io/>`__.
    $ sudo yum-config-manager --add-repo https://getenvoy.io/linux/rpm/tetrate-getenvoy.repo
    $ sudo yum install getenvoy-envoy
 
-.. tip::
-
-   You can enable/disable ``nightly`` using ``yum-config-manager``:
-
-   .. code-block:: console
-
-      $ sudo yum-config-manager --enable tetrate-getenvoy-nightly
-      $ sudo yum-config-manager --disable tetrate-getenvoy-nightly
-
 .. _start_install_macosx:
 
 Install Envoy on Mac OSX
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can install Envoy on Mac OSX using the official brew repositories, or from
-`Get Envoy <https://www.getenvoy.io/install/envoy/macos>`__.
+You can install Envoy on Mac OSX using the official brew repositories.
 
 .. tabs::
 
@@ -92,19 +69,6 @@ You can install Envoy on Mac OSX using the official brew repositories, or from
 
       $ brew update
       $ brew install envoy
-
-   .. tab:: Get Envoy
-
-      .. code-block:: console
-
-         $ brew tap tetratelabs/getenvoy
-         $ brew install envoy
-
-      .. tip::
-
-         You can install the ``nightly`` version from
-         `Get Envoy <https://www.getenvoy.io/>`__ by adding the ``--HEAD`` flag to
-         the install command.
 
 .. _start_install_windows:
 
@@ -123,8 +87,7 @@ You can run Envoy using the official Windows Docker image.
 Install Envoy using Docker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can run Envoy using the official Docker images, or by
-using images provided by `Get Envoy <https://www.getenvoy.io/install/envoy/docker/>`__.
+You can run Envoy using the official Docker images.
 
 The following commands will pull and show the Envoy version of current images.
 
@@ -143,18 +106,6 @@ The following commands will pull and show the Envoy version of current images.
 
          $ docker pull envoyproxy/|envoy_distroless_docker_image|
          $ docker run --rm envoyproxy/|envoy_distroless_docker_image| --version
-
-   .. tab:: Get Envoy
-
-      .. code-block:: console
-
-         $ docker pull getenvoy/envoy:stable
-         $ docker run --rm getenvoy/envoy:stable --version
-
-      .. tip::
-
-         To use the ``nightly`` version from `Get Envoy <https://www.getenvoy.io/>`__
-         replace the word ``stable`` with ``nightly`` in the above commands.
 
 .. _install_binaries:
 


### PR DESCRIPTION
Commit Message: Removes most references to getenvoy

Additional Description:
This removes the website links of getenvoy for everything except system
packages which #16867 will solve.

It also removes the section about nightlies as I don't think they are being
maintained and certainly won't be moving forward.

Risk Level: Low
Testing: None
Docs Changes: Only Docs
Release Notes: No
Platform Specific Features: No
