### PR TITLE
upstream: fixing deletion order bug

### DIFF
--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -561,13 +561,13 @@ ActiveClient::ActiveClient(ConnPoolImplBase& parent, uint32_t lifetime_stream_li
   parent_.host()->cluster().resourceManager(parent_.priority()).connections().inc();
 }
 
-ActiveClient::~ActiveClient() { releaseResources(); }
+ActiveClient::~ActiveClient() { releaseResourcesBase(); }
 
 void ActiveClient::onEvent(Network::ConnectionEvent event) {
   parent_.onConnectionEvent(*this, "", event);
 }
 
-void ActiveClient::releaseResources() {
+void ActiveClient::releaseResourcesBase() {
   if (!resources_released_) {
     resources_released_ = true;
 

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -34,7 +34,8 @@ public:
                uint32_t concurrent_stream_limit);
   ~ActiveClient() override;
 
-  void releaseResources();
+  virtual void releaseResources() { releaseResourcesBase(); }
+  void releaseResourcesBase();
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -87,6 +87,8 @@ ActiveClient::ActiveClient(HttpConnPoolImplBase& parent, Upstream::Host::CreateC
   parent.host()->cluster().stats().upstream_cx_http1_total_.inc();
 }
 
+ActiveClient::~ActiveClient() { ASSERT(!stream_wrapper_.get()); }
+
 bool ActiveClient::closingWithIncompleteStream() const {
   return (stream_wrapper_ != nullptr) && (!stream_wrapper_->decode_complete_);
 }

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -18,6 +18,7 @@ class ActiveClient : public Envoy::Http::ActiveClient {
 public:
   ActiveClient(HttpConnPoolImplBase& parent);
   ActiveClient(HttpConnPoolImplBase& parent, Upstream::Host::CreateConnectionData& data);
+  ~ActiveClient() override;
 
   // ConnPoolImplBase::ActiveClient
   bool closingWithIncompleteStream() const override;
@@ -30,11 +31,17 @@ public:
     // capacity and assign a new stream before decode is complete.
     return stream_wrapper_.get() ? 1 : 0;
   }
+  void releaseResources() override {
+    parent_.dispatcher().deferredDelete(std::move(stream_wrapper_));
+    Envoy::Http::ActiveClient::releaseResources();
+  }
 
   struct StreamWrapper : public RequestEncoderWrapper,
                          public ResponseDecoderWrapper,
                          public StreamCallbacks,
+                         public Event::DeferredDeletable,
                          protected Logger::Loggable<Logger::Id::pool> {
+  public:
     StreamWrapper(ResponseDecoder& response_decoder, ActiveClient& parent);
     ~StreamWrapper() override;
 
@@ -50,8 +57,6 @@ public:
     void onResetStream(StreamResetReason, absl::string_view) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
-
-    void onStreamDestroy();
 
     ActiveClient& parent_;
     bool stream_incomplete_{};


### PR DESCRIPTION
The ActiveClient is often getting deleted while the StreamWrapper is non-null.
StreamWrapper calls onStreamClosed on the pool, which accesses member variables of the ActiveClient.
This adds an assert that the wrapper is deleted before the client, to avoid accessing member variables in a destructor.

Risk Level: Medium (data plane change)
Testing: new assert passes all integration tests
Docs Changes: n/a
Release Notes: n/a