### PR TITLE
Explicit use of absl::string_view

### DIFF
--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -49,7 +49,7 @@ void MockClusterManager::initializeThreadLocalClusters(
   // TODO(mattklein123): This should create a dedicated and new mock for each initialized cluster,
   // but this has larger test implications. I will fix this in a follow up.
   for (const auto& cluster_name : cluster_names) {
-    ON_CALL(*this, getThreadLocalCluster(cluster_name))
+    ON_CALL(*this, getThreadLocalCluster(absl::string_view(cluster_name)))
         .WillByDefault(Return(&thread_local_cluster_));
   }
 }


### PR DESCRIPTION
After #16029, our build breaks without this.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
