### PR TITLE
protos: Remove squash from api:v2_protos

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -54,7 +54,6 @@ proto_library(
         "//envoy/config/filter/http/rate_limit/v2:pkg",
         "//envoy/config/filter/http/rbac/v2:pkg",
         "//envoy/config/filter/http/router/v2:pkg",
-        "//envoy/config/filter/http/squash/v2:pkg",
         "//envoy/config/filter/http/tap/v2alpha:pkg",
         "//envoy/config/filter/http/transcoder/v2:pkg",
         "//envoy/config/filter/listener/http_inspector/v2:pkg",

--- a/generated_api_shadow/BUILD
+++ b/generated_api_shadow/BUILD
@@ -54,7 +54,6 @@ proto_library(
         "//envoy/config/filter/http/rate_limit/v2:pkg",
         "//envoy/config/filter/http/rbac/v2:pkg",
         "//envoy/config/filter/http/router/v2:pkg",
-        "//envoy/config/filter/http/squash/v2:pkg",
         "//envoy/config/filter/http/tap/v2alpha:pkg",
         "//envoy/config/filter/http/transcoder/v2:pkg",
         "//envoy/config/filter/listener/http_inspector/v2:pkg",


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: protos: Remove squash from api:v2_protos
Additional Description:

this is a follow up to #16336 as in a subsequent PR `proto_format` was trying to remove this

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
