### PR TITLE
upstream: Add an addressList() method to Upstream::HostDescription

### DIFF
--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -123,7 +123,7 @@ public:
   /**
    * @return the address used to connect to the host.
    */
-  virtual const std::vector<Network::Address::InstanceConstSharedPtr> addressList() const PURE;
+  virtual const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const PURE;
 
   /**
    * @return host specific stats.

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -121,7 +121,8 @@ public:
   virtual Network::Address::InstanceConstSharedPtr address() const PURE;
 
   /**
-   * @return a optional list of addresses which the host resolved to.
+   * @return a optional list of additional addresses which the host resolved to. These addresses
+   *         may be used to create upstream connections if the primary address is unreachable.
    */
   virtual const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const PURE;
 

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -121,7 +121,7 @@ public:
   virtual Network::Address::InstanceConstSharedPtr address() const PURE;
 
   /**
-   * @return the address used to connect to the host.
+   * @return a optional list of addresses which the host resolved to.
    */
   virtual const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const PURE;
 

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "envoy/common/time.h"
 #include "envoy/config/core/v3/base.pb.h"
@@ -118,6 +119,11 @@ public:
    * @return the address used to connect to the host.
    */
   virtual Network::Address::InstanceConstSharedPtr address() const PURE;
+
+  /**
+   * @return the address used to connect to the host.
+   */
+  virtual const std::vector<Network::Address::InstanceConstSharedPtr> addressList() const PURE;
 
   /**
    * @return host specific stats.

--- a/source/common/upstream/logical_host.h
+++ b/source/common/upstream/logical_host.h
@@ -95,6 +95,9 @@ public:
   }
   const std::string& hostname() const override { return logical_host_->hostname(); }
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
+  const std::vector<Network::Address::InstanceConstSharedPtr> addressList() const override {
+    return logical_host_->addressList();
+  }
   const envoy::config::core::v3::Locality& locality() const override {
     return logical_host_->locality();
   }

--- a/source/common/upstream/logical_host.h
+++ b/source/common/upstream/logical_host.h
@@ -95,7 +95,7 @@ public:
   }
   const std::string& hostname() const override { return logical_host_->hostname(); }
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-  const std::vector<Network::Address::InstanceConstSharedPtr> addressList() const override {
+  const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const override {
     return logical_host_->addressList();
   }
   const envoy::config::core::v3::Locality& locality() const override {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -130,6 +130,9 @@ public:
   const std::string& hostnameForHealthChecks() const override { return health_checks_hostname_; }
   const std::string& hostname() const override { return hostname_; }
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
+  const std::vector<Network::Address::InstanceConstSharedPtr> addressList() const override {
+    return address_list_;
+  }
   Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {
     return health_check_address_;
   }
@@ -164,6 +167,7 @@ private:
   const std::string hostname_;
   const std::string health_checks_hostname_;
   Network::Address::InstanceConstSharedPtr address_;
+  std::vector<Network::Address::InstanceConstSharedPtr> address_list_;
   Network::Address::InstanceConstSharedPtr health_check_address_;
   std::atomic<bool> canary_;
   mutable absl::Mutex metadata_mutex_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -130,7 +130,7 @@ public:
   const std::string& hostnameForHealthChecks() const override { return health_checks_hostname_; }
   const std::string& hostname() const override { return hostname_; }
   Network::Address::InstanceConstSharedPtr address() const override { return address_; }
-  const std::vector<Network::Address::InstanceConstSharedPtr> addressList() const override {
+  const std::vector<Network::Address::InstanceConstSharedPtr>& addressList() const override {
     return address_list_;
   }
   Network::Address::InstanceConstSharedPtr healthCheckAddress() const override {

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1299,6 +1299,13 @@ TEST_F(HostImplTest, HealthPipeAddress) {
       EnvoyException, "Invalid host configuration: non-zero port for non-IP address");
 }
 
+TEST_F(HostImplTest, HostAddressList) {
+  MockClusterMockPrioritySet cluster;
+  HostSharedPtr host = makeTestHost(cluster.info_, "tcp://10.0.0.1:1234", simTime(), 1);
+  const std::vector<Network::Address::InstanceConstSharedPtr> address_list = {};
+  EXPECT_EQ(address_list, host->addressList());
+}
+
 // Test that hostname flag from the health check config propagates.
 TEST_F(HostImplTest, HealthcheckHostname) {
   std::shared_ptr<MockClusterInfo> info{new NiceMock<MockClusterInfo>()};

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -83,7 +83,8 @@ public:
   ~MockHostDescription() override;
 
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
-  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (), (const));
+  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (),
+              (const));
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, healthCheckAddress, (), (const));
   MOCK_METHOD(bool, canary, (), (const));
   MOCK_METHOD(void, canary, (bool new_canary));
@@ -159,7 +160,8 @@ public:
   }
 
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
-  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (), (const));
+  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (),
+              (const));
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, healthCheckAddress, (), (const));
   MOCK_METHOD(bool, canary, (), (const));
   MOCK_METHOD(void, canary, (bool new_canary));

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -83,6 +83,7 @@ public:
   ~MockHostDescription() override;
 
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
+  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (), (const));
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, healthCheckAddress, (), (const));
   MOCK_METHOD(bool, canary, (), (const));
   MOCK_METHOD(void, canary, (bool new_canary));
@@ -158,6 +159,7 @@ public:
   }
 
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, address, (), (const));
+  MOCK_METHOD(const std::vector<Network::Address::InstanceConstSharedPtr>&, addressList, (), (const));
   MOCK_METHOD(Network::Address::InstanceConstSharedPtr, healthCheckAddress, (), (const));
   MOCK_METHOD(bool, canary, (), (const));
   MOCK_METHOD(void, canary, (bool new_canary));


### PR DESCRIPTION
upstream: Add an addressList() method to Upstream::HostDescription so that connection pools (or the Grid) can implement HappyEyeballs.

Future PRs worked on independently will
* Populate this list based on host resolution
* Consume this list in the connection pools

Risk Level: Low
Testing: N/A - Unused currently
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A