### PR TITLE
quiche: remove post callback in stream OnClose()

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -286,7 +286,6 @@ void EnvoyQuicClientStream::OnClose() {
     // This is called in the scope of a watermark buffer updater. Clear the
     // buffer accounting afterwards so that the updater doesn't override the
     // result.
-    connection()->dispatcher().post([this] { clearWatermarkBuffer(); });
     return;
   }
   clearWatermarkBuffer();

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -295,7 +295,6 @@ void EnvoyQuicServerStream::OnConnectionClosed(quic::QuicErrorCode error,
 void EnvoyQuicServerStream::OnClose() {
   quic::QuicSpdyServerStreamBase::OnClose();
   if (isDoingWatermarkAccounting()) {
-    connection()->dispatcher().post([this] { clearWatermarkBuffer(); });
     return;
   }
   clearWatermarkBuffer();

--- a/source/common/quic/send_buffer_monitor.cc
+++ b/source/common/quic/send_buffer_monitor.cc
@@ -21,7 +21,7 @@ SendBufferMonitor::ScopedWatermarkBufferUpdater::~ScopedWatermarkBufferUpdater()
     ASSERT(static_cast<void*>(quic_stream_) != static_cast<void*>(send_buffer_monitor_));
     return;
   }
-  // If quic_stream_ is done writting, regards all buffered bytes, if there is any, as drained.
+  // If quic_stream_ is done writing, regards all buffered bytes, if there is any, as drained.
   uint64_t new_buffered_bytes =
       quic_stream_->write_side_closed() ? 0u : quic_stream_->BufferedDataBytes();
   send_buffer_monitor_->is_doing_watermark_accounting_ = false;

--- a/source/common/quic/send_buffer_monitor.cc
+++ b/source/common/quic/send_buffer_monitor.cc
@@ -21,7 +21,9 @@ SendBufferMonitor::ScopedWatermarkBufferUpdater::~ScopedWatermarkBufferUpdater()
     ASSERT(static_cast<void*>(quic_stream_) != static_cast<void*>(send_buffer_monitor_));
     return;
   }
-  uint64_t new_buffered_bytes = quic_stream_->BufferedDataBytes();
+  // If quic_stream_ is done writting, regards all buffered bytes, if there is any, as drained.
+  uint64_t new_buffered_bytes =
+      quic_stream_->write_side_closed() ? 0u : quic_stream_->BufferedDataBytes();
   send_buffer_monitor_->is_doing_watermark_accounting_ = false;
   send_buffer_monitor_->updateBytesBuffered(old_buffered_bytes_, new_buffered_bytes);
 }

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -703,9 +703,6 @@ TEST_P(EnvoyQuicServerStreamTest, ConnectionCloseDuringEncoding) {
   // Though the stream send buffer is above high watermark, onAboveWriteBufferHighWatermark())
   // shouldn't be called because the connection is closed.
   quic_stream_->encodeData(buffer, false);
-  EXPECT_GT(quic_session_.bytesToSend(), 0u);
-  // Clearing watermark buffer accounting takes effect is the next event loop.
-  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   EXPECT_EQ(quic_session_.bytesToSend(), 0u);
 }
 


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: the post callback to clear watermark buffer bytes accounting is not necessary given that ScopedWatermarkBufferUpdater can do that at the end of its life time.

Fixes #16907
