### PR TITLE
docs: format code which can not pass clang_format check

### DIFF
--- a/source/common/common/interval_value.h
+++ b/source/common/common/interval_value.h
@@ -25,10 +25,11 @@ public:
   // Returns a value that is as far from max as the original value is from min.
   // This guarantees that max().invert() == min() and min().invert() == max().
   ClosedIntervalValue invert() const {
-    return ClosedIntervalValue(value_ == Interval::max_value ? Interval::min_value
-                               : value_ == Interval::min_value
-                                   ? Interval::max_value
-                                   : Interval::max_value - (value_ - Interval::min_value));
+    return ClosedIntervalValue(value_ == Interval::max_value
+                                   ? Interval::min_value
+                                   : value_ == Interval::min_value
+                                         ? Interval::max_value
+                                         : Interval::max_value - (value_ - Interval::min_value));
   }
 
   // Comparisons are performed using the same operators on the underlying value

--- a/source/common/local_reply/local_reply.cc
+++ b/source/common/local_reply/local_reply.cc
@@ -25,11 +25,12 @@ public:
   BodyFormatter(const envoy::config::core::v3::SubstitutionFormatString& config, Api::Api& api)
       : formatter_(Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, api)),
         content_type_(
-            !config.content_type().empty() ? config.content_type()
-            : config.format_case() ==
-                    envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat
-                ? Http::Headers::get().ContentTypeValues.Json
-                : Http::Headers::get().ContentTypeValues.Text) {}
+            !config.content_type().empty()
+                ? config.content_type()
+                : config.format_case() ==
+                          envoy::config::core::v3::SubstitutionFormatString::FormatCase::kJsonFormat
+                      ? Http::Headers::get().ContentTypeValues.Json
+                      : Http::Headers::get().ContentTypeValues.Text) {}
 
   void format(const Http::RequestHeaderMap& request_headers,
               const Http::ResponseHeaderMap& response_headers,

--- a/test/common/network/apple_dns_impl_test.cc
+++ b/test/common/network/apple_dns_impl_test.cc
@@ -369,12 +369,12 @@ TEST_F(AppleDnsImplFakeApiTest, SynchronousErrorInGetAddrInfo) {
   // The Query's sd ref will be deallocated.
   EXPECT_CALL(dns_service_, dnsServiceRefDeallocate(_));
 
-  EXPECT_EQ(nullptr,
-            resolver_->resolve("foo.com", Network::DnsLookupFamily::Auto,
-                               [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void {
-                                 // This callback should never be executed.
-                                 FAIL();
-                               }));
+  EXPECT_EQ(nullptr, resolver_->resolve(
+                         "foo.com", Network::DnsLookupFamily::Auto,
+                         [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void {
+                           // This callback should never be executed.
+                           FAIL();
+                         }));
 }
 
 TEST_F(AppleDnsImplFakeApiTest, QuerySynchronousCompletion) {
@@ -773,7 +773,7 @@ TEST_F(AppleDnsImplFakeApiTest, ResultWithNullAddress) {
 
   auto query = resolver_->resolve(
       hostname, Network::DnsLookupFamily::Auto,
-      [](DnsResolver::ResolutionStatus, std::list<DnsResponse>&&) -> void { FAIL(); });
+      [](DnsResolver::ResolutionStatus, std::list<DnsResponse> &&) -> void { FAIL(); });
   ASSERT_NE(nullptr, query);
 
   EXPECT_DEATH(reply_callback(nullptr, kDNSServiceFlagsAdd, 0, kDNSServiceErr_NoError,

--- a/test/test_common/environment.cc
+++ b/test/test_common/environment.cc
@@ -370,9 +370,9 @@ std::string TestEnvironment::temporaryFileSubstitute(const std::string& path,
   out_json_string = substitute(out_json_string, version);
 
   auto name = Filesystem::fileSystemForTest().splitPathFromFilename(path).file_;
-  const std::string extension = absl::EndsWith(name, ".yaml")      ? ".yaml"
-                                : absl::EndsWith(name, ".pb_text") ? ".pb_text"
-                                                                   : ".json";
+  const std::string extension = absl::EndsWith(name, ".yaml")
+                                    ? ".yaml"
+                                    : absl::EndsWith(name, ".pb_text") ? ".pb_text" : ".json";
   const std::string out_json_path =
       TestEnvironment::temporaryPath(name) + ".with.ports" + extension;
   {


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
These codes can not pass the `clang_format` check which will run at /support/hooks/pre-push before pushing.

Commit Message: format code which can not pass clang_format check
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
