### PR TITLE
conn_pool: enable http3 in conn_pool_grid_test for real

### DIFF
--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -436,6 +436,7 @@ envoy_cc_test(
         "//test/mocks/router:router_mocks",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/mocks/server:transport_socket_factory_context_mocks",
         "//source/common/quic:quic_factory_lib",
         "//source/common/quic:quic_transport_socket_factory_lib",
         "//source/common/quic:client_connection_factory_lib",


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: Http3 tests have always  been disabled by wrong preprocessor. Enable them for real.

