### PR TITLE
http3: forcing config for upstream quic in tests

### DIFF
--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -44,10 +44,11 @@ Http3ConnPoolImpl::Http3ConnPoolImpl(
     source_address = Network::Utility::getLocalAddress(host_address->ip()->version());
   }
   Network::TransportSocketFactory& transport_socket_factory = host->transportSocketFactory();
+  quic::QuicConfig quic_config;
+  setQuicConfigFromClusterConfig(host_->cluster(), quic_config);
   quic_info_ = std::make_unique<Quic::PersistentQuicInfoImpl>(
-      dispatcher, transport_socket_factory, time_source, source_address,
+      dispatcher, transport_socket_factory, time_source, source_address, quic_config,
       host->cluster().perConnectionBufferLimitBytes());
-  setQuicConfigFromClusterConfig(host_->cluster(), quic_info_->quic_config_);
 }
 
 // Make sure all connections are torn down before quic_info_ is deleted.

--- a/source/common/quic/client_connection_factory_impl.cc
+++ b/source/common/quic/client_connection_factory_impl.cc
@@ -43,12 +43,12 @@ std::shared_ptr<quic::QuicCryptoClientConfig> PersistentQuicInfoImpl::cryptoConf
 PersistentQuicInfoImpl::PersistentQuicInfoImpl(
     Event::Dispatcher& dispatcher, Network::TransportSocketFactory& transport_socket_factory,
     TimeSource& time_source, Network::Address::InstanceConstSharedPtr server_addr,
-    uint32_t buffer_limit)
+    const quic::QuicConfig& quic_config, uint32_t buffer_limit)
     : conn_helper_(dispatcher), alarm_factory_(dispatcher, *conn_helper_.GetClock()),
       server_id_{getConfig(transport_socket_factory).serverNameIndication(),
                  static_cast<uint16_t>(server_addr->ip()->port()), false},
       transport_socket_factory_(transport_socket_factory), time_source_(time_source),
-      buffer_limit_(buffer_limit) {
+      quic_config_(quic_config), buffer_limit_(buffer_limit) {
   quiche::FlagRegistry::getInstance();
 }
 

--- a/source/common/quic/client_connection_factory_impl.h
+++ b/source/common/quic/client_connection_factory_impl.h
@@ -20,7 +20,7 @@ struct PersistentQuicInfoImpl : public Http::PersistentQuicInfo {
                          Network::TransportSocketFactory& transport_socket_factory,
                          TimeSource& time_source,
                          Network::Address::InstanceConstSharedPtr server_addr,
-                         uint32_t buffer_limit);
+                         const quic::QuicConfig& quic_config, uint32_t buffer_limit);
 
   // Returns the most recent crypto config from transport_socket_factory_;
   std::shared_ptr<quic::QuicCryptoClientConfig> cryptoConfig();
@@ -40,7 +40,6 @@ struct PersistentQuicInfoImpl : public Http::PersistentQuicInfo {
   // If client context changes, client config will be updated as well.
   std::shared_ptr<quic::QuicCryptoClientConfig> client_config_;
   const quic::ParsedQuicVersionVector supported_versions_{quic::CurrentSupportedVersions()};
-  // TODO(alyssawilk) actually set this up properly.
   quic::QuicConfig quic_config_;
   // The cluster buffer limits.
   const uint32_t buffer_limit_;

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -50,7 +50,8 @@ protected:
 TEST_F(QuicNetworkConnectionTest, BufferLimits) {
   initialize();
 
-  PersistentQuicInfoImpl info{dispatcher_, *factory_, simTime(), test_address_, 45};
+  quic::QuicConfig config;
+  PersistentQuicInfoImpl info{dispatcher_, *factory_, simTime(), test_address_, config, 45};
 
   std::unique_ptr<Network::ClientConnection> client_connection =
       createQuicNetworkConnection(info, dispatcher_, test_address_, test_address_);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -338,8 +338,9 @@ void HttpIntegrationTest::initialize() {
   Network::Address::InstanceConstSharedPtr server_addr = Network::Utility::resolveUrl(fmt::format(
       "udp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), lookupPort("http")));
   // Needs to outlive all QUIC connections.
+  quic::QuicConfig config;
   auto quic_connection_persistent_info = std::make_unique<Quic::PersistentQuicInfoImpl>(
-      *dispatcher_, *quic_transport_socket_factory_, timeSystem(), server_addr, 0);
+      *dispatcher_, *quic_transport_socket_factory_, timeSystem(), server_addr, config, 0);
   // Config IETF QUIC flow control window.
   quic_connection_persistent_info->quic_config_
       .SetInitialMaxStreamDataBytesIncomingBidirectionalToSend(

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -209,9 +209,10 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
   Network::TransportSocketFactoryPtr transport_socket_factory =
       createQuicUpstreamTransportSocketFactory(api, mock_stats_store, manager,
                                                "spiffe://lyft.com/backend-team");
+  quic::QuicConfig config;
   std::unique_ptr<Http::PersistentQuicInfo> persistent_info;
   persistent_info = std::make_unique<Quic::PersistentQuicInfoImpl>(
-      *dispatcher, *transport_socket_factory, time_system, addr, 0);
+      *dispatcher, *transport_socket_factory, time_system, addr, config, 0);
 
   Network::Address::InstanceConstSharedPtr local_address;
   if (addr->ip()->version() == Network::Address::IpVersion::v4) {


### PR DESCRIPTION
Addressing a TODO.

the quic config was set in all production use (H3 connection pool) but this forces all users of PersistentQuicInfoImpl to set it so it can't be overlooked in future.

Risk Level: Low (H3 refactor)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a