### PR TITLE
wasm: fix remote code without specified runtime

### DIFF
--- a/source/extensions/common/wasm/plugin.h
+++ b/source/extensions/common/wasm/plugin.h
@@ -27,7 +27,7 @@ public:
   EnvironmentVariableMap& environmentVariables() { return envs_; }
 
 private:
-  const envoy::extensions::wasm::v3::PluginConfig& config_;
+  const envoy::extensions::wasm::v3::PluginConfig config_;
   proxy_wasm::AllowedCapabilitiesMap allowed_capabilities_{};
   EnvironmentVariableMap envs_;
 };

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -702,8 +702,6 @@ TEST_P(WasmCommonTest, VmCache) {
       absl::StrCat("envoy.wasm.runtime.", GetParam());
   plugin_config.mutable_vm_config()->mutable_configuration()->set_value(vm_configuration);
   plugin_config.mutable_configuration()->set_value(plugin_configuration);
-  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
-      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
 
   ServerLifecycleNotifier::StageCallbackWithCompletion lifecycle_callback;
   EXPECT_CALL(lifecycle_notifier, registerCallback2(_, _))
@@ -733,6 +731,9 @@ TEST_P(WasmCommonTest, VmCache) {
   }
   EXPECT_FALSE(code.empty());
   vm_config->mutable_code()->mutable_local()->set_inline_bytes(code);
+  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
+      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
+
   WasmHandleSharedPtr wasm_handle;
   createWasm(plugin, scope, cluster_manager, init_manager, *dispatcher, *api, lifecycle_notifier,
              remote_data_provider,
@@ -811,8 +812,6 @@ TEST_P(WasmCommonTest, RemoteCode) {
       absl::StrCat("envoy.wasm.runtime.", GetParam());
   plugin_config.mutable_vm_config()->mutable_configuration()->set_value(vm_configuration);
   plugin_config.mutable_configuration()->set_value(plugin_configuration);
-  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
-      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
 
   std::string code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       absl::StrCat("{{ test_rundir }}/test/extensions/common/wasm/test_data/test_cpp.wasm")));
@@ -831,6 +830,9 @@ TEST_P(WasmCommonTest, RemoteCode) {
   vm_config->mutable_code()->mutable_remote()->mutable_http_uri()->set_cluster("example_com");
   vm_config->mutable_code()->mutable_remote()->mutable_http_uri()->mutable_timeout()->set_seconds(
       5);
+  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
+      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
+
   WasmHandleSharedPtr wasm_handle;
   NiceMock<Http::MockAsyncClient> client;
   NiceMock<Http::MockAsyncClientRequest> request(&client);
@@ -924,8 +926,6 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
       absl::StrCat("envoy.wasm.runtime.", GetParam());
   plugin_config.mutable_vm_config()->mutable_configuration()->set_value(vm_configuration);
   plugin_config.mutable_configuration()->set_value(plugin_configuration);
-  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
-      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
 
   std::string code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       absl::StrCat("{{ test_rundir }}/test/extensions/common/wasm/test_data/test_cpp.wasm")));
@@ -950,6 +950,9 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
       ->mutable_retry_policy()
       ->mutable_num_retries()
       ->set_value(num_retries);
+  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
+      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info, nullptr);
+
   WasmHandleSharedPtr wasm_handle;
   NiceMock<Http::MockAsyncClient> client;
   NiceMock<Http::MockAsyncClientRequest> request(&client);

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -807,9 +807,10 @@ TEST_P(WasmCommonTest, RemoteCode) {
   auto vm_configuration = "vm_cache";
   auto plugin_configuration = "done";
 
-  Extensions::Common::Wasm::PluginSharedPtr plugin;
   std::string code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       absl::StrCat("{{ test_rundir }}/test/extensions/common/wasm/test_data/test_cpp.wasm")));
+
+  Extensions::Common::Wasm::PluginSharedPtr plugin;
   {
     // plugin_config is only valid in this scope.
     // test that the proto_config parameter is released after the factory is created


### PR DESCRIPTION
Signed-off-by: Yiheng Li <lyhutopi@gmail.com>

Commit Message: fix remote code without specified runtime
Additional Description:
When I use the remote code of the wasm plugin threre is a warning log tells:
`2021-06-11 10:14:41.794][184533][warning][wasm] [source/extensions/common/wasm/wasm_vm.cc:79] Failed to create Wasm VM with unspecified runtime`
Plugin does not start correctly.
I found that the plugin only saves references to ProtoConfig. The ProtoConfig may have been released when the asynchronous download of the remote code is complete.
So copy ProtoConfig to fix this problem

Risk Level: Low, no behavior change
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
