### PR TITLE
vscode: preserve arguments field of launch.json

### DIFF
--- a/tools/vscode/generate_debug_config.py
+++ b/tools/vscode/generate_debug_config.py
@@ -97,7 +97,9 @@ def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_
         always_overwritten_fields = ["program", "sourceMap", "cwd", "type", "request"]
         new_config = lldb_config(target, binary, workspace, execroot, arguments)
     else:
-        always_overwritten_fields = ["request", "type", "target", "debugger_args", "cwd", "valuesFormatting"]
+        always_overwritten_fields = [
+            "request", "type", "target", "debugger_args", "cwd", "valuesFormatting"
+        ]
         new_config = gdb_config(target, binary, workspace, execroot, arguments)
 
     configurations = launch.get("configurations", [])
@@ -109,7 +111,9 @@ def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_
             else:
                 for k in always_overwritten_fields:
                     config[k] = new_config[k]
-                print(f"old config exists, only {always_overwritten_fields} will be updated, use --overwirte to recreate config")
+                print(
+                    f"old config exists, only {always_overwritten_fields} will be updated, use --overwirte to recreate config"
+                )
             break
     else:
         configurations.append(new_config)
@@ -122,7 +126,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Build and generate launch config for VSCode')
     parser.add_argument('--debugger', default="gdb", help="debugger type, one of [gdb, lldb]")
     parser.add_argument('--args', default='', help="command line arguments if target binary")
-    parser.add_argument('--overwrite', action="store_true", help="recreate config in launch config rather than preserve old config")
+    parser.add_argument(
+        '--overwrite',
+        action="store_true",
+        help="recreate config in launch config rather than preserve old config")
     parser.add_argument('target', help="target binary which you want to build")
     args = parser.parse_args()
 
@@ -130,4 +137,5 @@ if __name__ == "__main__":
     execution_root = get_execution_root(workspace)
     debug_binary = build_binary_with_debug_info(args.target)
     add_to_launch_json(
-        args.target, debug_binary, workspace, execution_root, args.args, args.debugger, args.overwrite)
+        args.target, debug_binary, workspace, execution_root, args.args, args.debugger,
+        args.overwrite)

--- a/tools/vscode/generate_debug_config.py
+++ b/tools/vscode/generate_debug_config.py
@@ -88,6 +88,17 @@ def lldb_config(target, binary, workspace, execroot, arguments):
         "request": "launch"
     }
 
+def args_of_config(debugger_type, config):
+    if debugger_type == "lldb":
+        return config.get("args", "")
+    else:
+        return config.get("arguments", "")
+
+def set_args(debugger_type, config, args):
+   if debugger_type == "lldb":
+        config["args"] = args
+   else:
+        config["arguments"] = args
 
 def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_type):
     launch = get_launch_json(workspace)
@@ -100,7 +111,11 @@ def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_
     configurations = launch.get("configurations", [])
     for config in configurations:
         if config.get("name", None) == new_config["name"]:
+            old_args = args_of_config(debugger_type, config)
             config.clear()
+	    # preserve old args only when no arguments set at commmand line, and old args is not empty
+            if len(old_args) != 0 and len(arguments) == 0:
+                set_args(debugger_type, new_config, old_args)
             config.update(new_config)
             break
     else:

--- a/tools/vscode/generate_debug_config.py
+++ b/tools/vscode/generate_debug_config.py
@@ -112,7 +112,7 @@ def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_
                 for k in always_overwritten_fields:
                     config[k] = new_config[k]
                 print(
-                    f"old config exists, only {always_overwritten_fields} will be updated, use --overwirte to recreate config"
+                    f"old config exists, only {always_overwritten_fields} will be updated, use --overwrite to recreate config"
                 )
             break
     else:
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '--overwrite',
         action="store_true",
-        help="recreate config in launch config rather than preserve old config")
+        help="recreate config without preserving any existing config")
     parser.add_argument('target', help="target binary which you want to build")
     args = parser.parse_args()
 

--- a/tools/vscode/generate_debug_config.py
+++ b/tools/vscode/generate_debug_config.py
@@ -88,17 +88,20 @@ def lldb_config(target, binary, workspace, execroot, arguments):
         "request": "launch"
     }
 
+
 def args_of_config(debugger_type, config):
     if debugger_type == "lldb":
         return config.get("args", "")
     else:
         return config.get("arguments", "")
 
+
 def set_args(debugger_type, config, args):
-   if debugger_type == "lldb":
+    if debugger_type == "lldb":
         config["args"] = args
-   else:
+    else:
         config["arguments"] = args
+
 
 def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_type):
     launch = get_launch_json(workspace)
@@ -113,7 +116,7 @@ def add_to_launch_json(target, binary, workspace, execroot, arguments, debugger_
         if config.get("name", None) == new_config["name"]:
             old_args = args_of_config(debugger_type, config)
             config.clear()
-	    # preserve old args only when no arguments set at commmand line, and old args is not empty
+            # preserve old argument only when no argument is set at the command line, and the old argument is not empty
             if len(old_args) != 0 and len(arguments) == 0:
                 set_args(debugger_type, new_config, old_args)
             config.update(new_config)


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->
`./tools/vscode/generate_debug_config.py` always replaces arguments of the previous config, preserve the arguments field will make it more convenient when we want to debug. 

It will preserve old argument only when no argument is set at the command line, and the old argument is not empty

Commit Message: preserve arguments field of config in launch.json
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
