### PR TITLE
feat: Make the initial delay and max initial delay configurable

### DIFF
--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
+import "envoy/config/core/v3/backoff.proto;
 import "envoy/config/core/v3/grpc_service.proto";
 
 import "google/protobuf/duration.proto";
@@ -140,6 +141,9 @@ message RateLimitSettings {
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
+
+  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff
+  BackoffStrategy backoff_strategy = 3;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -142,7 +142,7 @@ message RateLimitSettings {
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 
-  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff
+  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff.
   BackoffStrategy backoff_strategy = 3;
 }
 

--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
-import "envoy/config/core/v3/backoff.proto;
+import "envoy/config/core/v3/backoff.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 
 import "google/protobuf/duration.proto";

--- a/api/envoy/config/core/v3/config_source.proto
+++ b/api/envoy/config/core/v3/config_source.proto
@@ -142,7 +142,7 @@ message RateLimitSettings {
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 
-  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff.
+  // Configurable initial delay and maximum delay. Default value please see backoff_strategy.
   BackoffStrategy backoff_strategy = 3;
 }
 

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -146,7 +146,7 @@ message RateLimitSettings {
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 
-  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff
+  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff.
   BackoffStrategy backoff_strategy = 3;
 }
 

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v4alpha;
 
+import "envoy/config/core/v4alpha/backoff.proto;
 import "envoy/config/core/v4alpha/grpc_service.proto";
 
 import "google/protobuf/duration.proto";
@@ -145,13 +146,8 @@ message RateLimitSettings {
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 
-  // Initial retry delay in Milli Second. If not set, a
-  // default value of 500 will be used.
-  google.protobuf.UInt32Value retry_initial_delay_ms = 3;
-
-  // Maximum retry delay in Milli Second. If not set, a
-  // default value of 30000 will be used.
-  google.protobuf.UInt32Value retry_max_delay_ms = 4;
+  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff
+  BackoffStrategy backoff_strategy = 3;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -144,6 +144,14 @@ message RateLimitSettings {
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
+
+  // Initial retry delay in Milli Second. If not set, a
+  // default value of 500 will be used.
+  google.protobuf.UInt32Value retry_initial_delay_ms = 3;
+
+  // Maximum retry delay in Milli Second. If not set, a
+  // default value of 30000 will be used.
+  google.protobuf.UInt32Value retry_max_delay_ms = 4;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -146,7 +146,7 @@ message RateLimitSettings {
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
 
-  // Backoff strategy will give the ability to initialize initial delay and max delay for backoff.
+  // Configurable initial delay and maximum delay. Default value please see backoff_strategy.
   BackoffStrategy backoff_strategy = 3;
 }
 

--- a/api/envoy/config/core/v4alpha/config_source.proto
+++ b/api/envoy/config/core/v4alpha/config_source.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v4alpha;
 
-import "envoy/config/core/v4alpha/backoff.proto;
+import "envoy/config/core/v4alpha/backoff.proto";
 import "envoy/config/core/v4alpha/grpc_service.proto";
 
 import "google/protobuf/duration.proto";

--- a/generated_api_shadow/envoy/config/core/v3/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v3/config_source.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v3;
 
+import "envoy/config/core/v3/backoff.proto";
 import "envoy/config/core/v3/grpc_service.proto";
 
 import "google/protobuf/duration.proto";
@@ -143,6 +144,9 @@ message RateLimitSettings {
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
+
+  // Configurable initial delay and maximum delay. Default value please see backoff_strategy.
+  BackoffStrategy backoff_strategy = 3;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
@@ -147,6 +147,14 @@ message RateLimitSettings {
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
+
+  // Initial retry delay in Milli Second. If not set, a
+  // default value of 500 will be used.
+  google.protobuf.UInt32Value retry_initial_delay_ms = 3;
+
+  // Maximum retry delay in Milli Second. If not set, a
+  // default value of 30000 will be used.
+  google.protobuf.UInt32Value retry_max_delay_ms = 4;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
@@ -147,14 +147,6 @@ message RateLimitSettings {
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
-
-  // Initial retry delay in Milli Second. If not set, a
-  // default value of 500 will be used.
-  google.protobuf.UInt32Value retry_initial_delay_ms = 3;
-
-  // Maximum retry delay in Milli Second. If not set, a
-  // default value of 30000 will be used.
-  google.protobuf.UInt32Value retry_max_delay_ms = 4;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/config_source.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.config.core.v4alpha;
 
+import "envoy/config/core/v4alpha/backoff.proto";
 import "envoy/config/core/v4alpha/grpc_service.proto";
 
 import "google/protobuf/duration.proto";
@@ -147,6 +148,9 @@ message RateLimitSettings {
   // Rate at which tokens will be filled per second. If not set, a default fill rate of 10 tokens
   // per second will be used.
   google.protobuf.DoubleValue fill_rate = 2 [(validate.rules).double = {gt: 0.0}];
+
+  // Configurable initial delay and maximum delay. Default value please see backoff_strategy.
+  BackoffStrategy backoff_strategy = 3;
 }
 
 // Configuration for :ref:`listeners <config_listeners>`, :ref:`clusters

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -217,6 +217,14 @@ Utility::parseRateLimitSettings(const envoy::config::core::v3::ApiConfigSource& 
     rate_limit_settings.fill_rate_ =
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), fill_rate,
                                         Envoy::Config::RateLimitSettings::DefaultFillRate);
+
+    rate_limit_settings.retry_initial_delay_ms =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), retry_initial_delay_ms,
+                                        Envoy::Config::RateLimitSettings::DefaultRetryInitialDelayMs);
+    
+    rate_limit_settings.retry_max_delay_ms =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), retry_max_delay_ms,
+                                        Envoy::Config::RateLimitSettings::DefaultRetryMaxDelayMs);
   }
   return rate_limit_settings;
 }

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -218,12 +218,12 @@ Utility::parseRateLimitSettings(const envoy::config::core::v3::ApiConfigSource& 
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), fill_rate,
                                         Envoy::Config::RateLimitSettings::DefaultFillRate);
 
-    rate_limit_settings.retry_initial_delay_ms =
-        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), retry_initial_delay_ms,
+    rate_limit_settings.backoff_strategy.base_interval =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), backoff_strategy.base_interval,
                                         Envoy::Config::RateLimitSettings::DefaultRetryInitialDelayMs);
     
-    rate_limit_settings.retry_max_delay_ms =
-        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), retry_max_delay_ms,
+    rate_limit_settings.backoff_strategy.max_interval =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), backoff_strategy.max_interval,
                                         Envoy::Config::RateLimitSettings::DefaultRetryMaxDelayMs);
   }
   return rate_limit_settings;

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -218,13 +218,15 @@ Utility::parseRateLimitSettings(const envoy::config::core::v3::ApiConfigSource& 
         PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), fill_rate,
                                         Envoy::Config::RateLimitSettings::DefaultFillRate);
 
-    rate_limit_settings.backoff_strategy.base_interval =
-        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), backoff_strategy.base_interval,
-                                        Envoy::Config::RateLimitSettings::DefaultRetryInitialDelayMs);
-    
-    rate_limit_settings.backoff_strategy.max_interval =
-        PROTOBUF_GET_WRAPPED_OR_DEFAULT(api_config_source.rate_limit_settings(), backoff_strategy.max_interval,
-                                        Envoy::Config::RateLimitSettings::DefaultRetryMaxDelayMs);
+    if (api_config_source.rate_limit_settings().has_backoff_strategy()) {
+      rate_limit_settings.backoff_strategy_.base_interval = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          api_config_source.rate_limit_settings().backoff_strategy(), base_interval,
+          Envoy::Config::RateLimitSettings::DefaultRetryInitialDelayMs);
+
+      rate_limit_settings.backoff_strategy_.max_interval = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          api_config_source.rate_limit_settings().backoff_strategy(), max_interval,
+          Envoy::Config::RateLimitSettings::DefaultRetryMaxDelayMs);
+    }
   }
   return rate_limit_settings;
 }

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -60,7 +60,8 @@ struct RateLimitSettings {
   uint32_t max_tokens_{DefaultMaxTokens};
   double fill_rate_{DefaultFillRate};
   bool enabled_{false};
-  BackOffStrategy backoff_strategy_{DefaultRetryInitialDelayMs, DefaultRetryMaxDelayMs};
+  envoy::config::core::v3::BackOffStrategy backoff_strategy_{DefaultRetryInitialDelayMs,
+                                                             DefaultRetryMaxDelayMs};
 };
 
 using ApiType = ConstSingleton<ApiTypeValues>;

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -53,10 +53,15 @@ struct RateLimitSettings {
   static const uint32_t DefaultMaxTokens = 100;
   // Default Fill Rate.
   static constexpr double DefaultFillRate = 10;
-
+  // Default Retry Initial Delay.
+  static constexpr uint32_t DefaultRetryInitialDelayMs = 500;
+  // Default Retry Max Delay. Do not cross more than 30s.
+  static constexpr uint32_t DefaultRetryMaxDelayMs = 30000;
   uint32_t max_tokens_{DefaultMaxTokens};
   double fill_rate_{DefaultFillRate};
   bool enabled_{false};
+  uint32_t retry_initial_delay_ms_{DefaultRetryInitialDelayMs};
+  uint32_t retry_max_delay_ms_{DefaultRetryMaxDelayMs};
 };
 
 using ApiType = ConstSingleton<ApiTypeValues>;

--- a/source/common/config/utility.h
+++ b/source/common/config/utility.h
@@ -60,8 +60,7 @@ struct RateLimitSettings {
   uint32_t max_tokens_{DefaultMaxTokens};
   double fill_rate_{DefaultFillRate};
   bool enabled_{false};
-  uint32_t retry_initial_delay_ms_{DefaultRetryInitialDelayMs};
-  uint32_t retry_max_delay_ms_{DefaultRetryMaxDelayMs};
+  BackOffStrategy backoff_strategy_{DefaultRetryInitialDelayMs, DefaultRetryMaxDelayMs};
 };
 
 using ApiType = ConstSingleton<ApiTypeValues>;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
In current configuration, we're unable to override the value for initial delay
as well as the maximum retry delay. This limitation also mentioned on
[this part)[https://github.com/envoyproxy/envoy/blob/main/source/common/config/grpc_stream.h#L48].

Added:
- Configurable field for the initial retry delay as well as the maximum delay, both of which
is in the Milli Second time unit.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
