### PR TITLE
Disable fuzz coverage test on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,14 +24,15 @@ tasks:
     test_flags:
     - "--config=coverage"
     - "--config=clang"
-  fuzz_coverage:
-    name: "Fuzz-Coverage"
-    platform: ubuntu1804
-    shell_commands:
-    - "bazel/setup_clang.sh /usr/lib/llvm-10"
-    test_targets:
-    - "//test/server:server_fuzz_test"
-    test_flags:
-    - "--config=fuzz-coverage"
-    - "--config=coverage"
-    - "--config=clang"
+# Re-enable after fixing https://github.com/envoyproxy/envoy/issues/16542
+#   fuzz_coverage:
+#     name: "Fuzz-Coverage"
+#     platform: ubuntu1804
+#     shell_commands:
+#     - "bazel/setup_clang.sh /usr/lib/llvm-10"
+#     test_targets:
+#     - "//test/server:server_fuzz_test"
+#     test_flags:
+#     - "--config=fuzz-coverage"
+#     - "--config=coverage"
+#     - "--config=clang"


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/issues/16542 has been keep Envoy red on Bazel CI for a long time, it doesn't make sense to keep a failing test if it's not going to be fixed.

