### PR TITLE
TSAN: fix data race when reading a histogram's sample count

### DIFF
--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -469,8 +469,8 @@ public:
   void waitUntilHistogramHasSamples(
       const std::string& name,
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero()) override {
-    ASSERT_TRUE(
-        TestUtility::waitUntilHistogramHasSamples(statStore(), name, time_system_, timeout));
+    ASSERT_TRUE(TestUtility::waitUntilHistogramHasSamples(statStore(), name, time_system_,
+                                                          server().dispatcher(), timeout));
   }
 
   Stats::CounterSharedPtr counter(const std::string& name) override {

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -293,6 +293,15 @@ public:
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
 
   /**
+   * Read a histogram's sample count from the main thread.
+   * @param store supplies the stats store.
+   * @param name histogram name.
+   * @return uint64_t the sample count.
+   */
+  static uint64_t readSampleCount(Event::Dispatcher& main_dispatcher,
+                                  const Stats::ParentHistogram& histogram);
+
+  /**
    * Find a readout in a stats store.
    * @param store supplies the stats store.
    * @param name supplies the name to search for.

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -289,6 +289,7 @@ public:
    */
   static AssertionResult waitUntilHistogramHasSamples(
       Stats::Store& store, const std::string& name, Event::TestTimeSystem& time_system,
+      Event::Dispatcher& main_dispatcher,
       std::chrono::milliseconds timeout = std::chrono::milliseconds::zero());
 
   /**


### PR DESCRIPTION
Commit Message: Fix TSAN issue caused from tests when reading histograms.

Additional Description:
This was introduced by #15908. We need to read a histogram's from
the main thread to avoid data races between writes (from the main
thread) and reads (from a worker thread).

Risk Level: Low.
Testing: Unit tests + TSAN should pass.
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>
