### PR TITLE
Fix pointer-bool-comparison warning.

### DIFF
--- a/source/common/common/dump_state_utils.h
+++ b/source/common/common/dump_state_utils.h
@@ -25,7 +25,7 @@ namespace Envoy {
 #define DUMP_DETAILS(member)                                                                       \
   do {                                                                                             \
     os << spaces << #member ": ";                                                                  \
-    if (member) {                                                                                  \
+    if ((member) != nullptr) {                                                                     \
       os << "\n";                                                                                  \
       (member)->dumpState(os, indent_level + 1);                                                   \
     } else {                                                                                       \


### PR DESCRIPTION
Commit Message:

Fix pointer-bool-comparison warning.

Additional Description:

I haven't seen this problem compiling locally, but on experimenting with different toolchains, I got this error from clang:

```
In file included from external/envoy/source/extensions/access_loggers/grpc/tcp_config.cc:10:
In file included from external/envoy/source/common/grpc/async_client_impl.h:12:
external/envoy/source/common/http/async_client_impl.h:444:53: error: address of 'this->stream_info_' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
    do { os << spaces << "&stream_info_" ": "; if (&stream_info_) { os << "\n"; (&stream_info_)->dumpState(os, indent_level + 1); } else { os << spaces << "null\n"; } } while (false);
                                               ~~   ^~~~~~~~~~~~
```

The warning looks reasonable to me, but I don't know how to explain why it's not normally seen. Maybe the macro makes the compiler hide it for some reason?

Risk Level: Low. Could be a build error if this macro is intended to take non-pointer values, but I don't think it is.
Testing: Unit tests.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.