### PR TITLE
docs: Add minimal requirements check in build.sh

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -7,6 +7,17 @@
 
 set -e
 
+if [[ ! $(command -v bazel) ]]; then
+    # shellcheck disable=SC2016
+    echo 'ERROR: bazel must be installed and available in "$PATH" to build docs' >&2
+    exit 1
+fi
+if [[ ! $(command -v jq) ]]; then
+    # shellcheck disable=SC2016
+    echo 'ERROR: jq must be installed and available in "$PATH" to build docs' >&2
+    exit 1
+fi
+
 RELEASE_TAG_REGEX="^refs/tags/v.*"
 
 if [[ "${AZP_BRANCH}" =~ ${RELEASE_TAG_REGEX} ]]; then


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: docs: Add minimal requirements check in build.sh
Additional Description:

if either bazel or jq are not available then the script will not succeed so bail early and notify user

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
