### PR TITLE
configs: Add descriptor path arg for config validation

### DIFF
--- a/tools/config_validation/validate_fragment.py
+++ b/tools/config_validation/validate_fragment.py
@@ -46,13 +46,13 @@ class IgnoredKey(yaml.YAMLObject):
         return dumper.represent_scalar(cls.yaml_tag, data.strval)
 
 
-def validate_yaml(type_name, content):
+def validate_yaml(type_name, content, descriptor_path=None):
     yaml.SafeLoader.add_constructor('!ignore', IgnoredKey.from_yaml)
     yaml.SafeDumper.add_multi_representer(IgnoredKey, IgnoredKey.to_yaml)
-    validate_fragment(type_name, yaml.safe_load(content))
+    validate_fragment(type_name, yaml.safe_load(content), descriptor_path)
 
 
-def validate_fragment(type_name, fragment):
+def validate_fragment(type_name, fragment, descriptor_path=None):
     """Validate a dictionary representing a JSON/YAML fragment against an Envoy API proto3 type.
 
     Throws Protobuf errors on parsing exceptions, successful validations produce
@@ -66,14 +66,14 @@ def validate_fragment(type_name, fragment):
     """
     json_fragment = json.dumps(fragment, skipkeys=True)
 
-    r = runfiles.Create()
-    all_protos_pb_text_path = r.Rlocation(
-        'envoy/tools/type_whisperer/all_protos_with_ext_pb_text.pb_text')
+    if not descriptor_path:
+        r = runfiles.Create()
+        descriptor_path = r.Rlocation(
+            'envoy/tools/type_whisperer/all_protos_with_ext_pb_text.pb_text')
+
     file_desc_set = descriptor_pb2.FileDescriptorSet()
     text_format.Parse(
-        pathlib.Path(all_protos_pb_text_path).read_text(),
-        file_desc_set,
-        allow_unknown_extension=True)
+        pathlib.Path(descriptor_path).read_text(), file_desc_set, allow_unknown_extension=True)
 
     pool = descriptor_pool.DescriptorPool()
     for f in file_desc_set.file:
@@ -91,7 +91,7 @@ def parse_args():
         help='a string providing the type name, e.g. envoy.config.bootstrap.v3.Bootstrap.')
     parser.add_argument('fragment_path', nargs='?', help='Path to a YAML configuration fragment.')
     parser.add_argument('-s', required=False, help='YAML configuration fragment.')
-
+    parser.add_argument('--descriptor_path', nargs='?', help='Path to a protobuf descriptor file.')
     return parser.parse_args()
 
 
@@ -100,4 +100,4 @@ if __name__ == '__main__':
     message_type = parsed_args.message_type
     content = parsed_args.s if (parsed_args.fragment_path is None) else pathlib.Path(
         parsed_args.fragment_path).read_text()
-    validate_yaml(message_type, content)
+    validate_yaml(message_type, content, descriptor_path=parsed_args.descriptor_path)


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: configs: Allow descriptor path in config validation
Additional Description:

Another breakout from #15229 

This makes the path to the pb descriptor file configurable - which allows the config validation to work in a build context where the currently hardcoded path does not work. 

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
