### PR TITLE
remove support for v2 UNSUPPORTED_REST_LEGACY

### DIFF
--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -44,9 +44,8 @@ void Utility::translateApiConfigSource(
     envoy::config::core::v3::GrpcService* grpc_service = api_config_source.add_grpc_services();
     grpc_service->mutable_envoy_grpc()->set_cluster_name(cluster);
   } else {
-    if (api_type == ApiType::get().Rest) {
-      api_config_source.set_api_type(envoy::config::core::v3::ApiConfigSource::REST);
-    }
+    ASSERT(api_type == ApiType::get().Rest);
+    api_config_source.set_api_type(envoy::config::core::v3::ApiConfigSource::REST);
     api_config_source.add_cluster_names(cluster);
   }
 

--- a/source/common/config/utility.cc
+++ b/source/common/config/utility.cc
@@ -44,10 +44,7 @@ void Utility::translateApiConfigSource(
     envoy::config::core::v3::GrpcService* grpc_service = api_config_source.add_grpc_services();
     grpc_service->mutable_envoy_grpc()->set_cluster_name(cluster);
   } else {
-    if (api_type == ApiType::get().UnsupportedRestLegacy) {
-      api_config_source.set_api_type(envoy::config::core::v3::ApiConfigSource::
-                                         hidden_envoy_deprecated_UNSUPPORTED_REST_LEGACY);
-    } else if (api_type == ApiType::get().Rest) {
+    if (api_type == ApiType::get().Rest) {
       api_config_source.set_api_type(envoy::config::core::v3::ApiConfigSource::REST);
     }
     api_config_source.add_cluster_names(cluster);

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -220,16 +220,11 @@ TEST_F(SubscriptionFactoryTest, FilesystemCollectionSubscription) {
   collectionSubscriptionFromUrl(fmt::format("file:///{}", file_path), {})->start({});
 }
 
-TEST_F(SubscriptionFactoryTest, LegacySubscription) {
-  envoy::config::core::v3::ConfigSource config;
-  auto* api_config_source = config.mutable_api_config_source();
-  api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
-  api_config_source->add_cluster_names("static_cluster");
-  Upstream::ClusterManager::ClusterSet primary_clusters;
-  primary_clusters.insert("static_cluster");
-  EXPECT_CALL(cm_, primaryClusters()).WillOnce(ReturnRef(primary_clusters));
-  EXPECT_THROW_WITH_REGEX(subscriptionFromConfigSource(config)->start({"static_cluster"}),
-                          EnvoyException, "REST_LEGACY no longer a supported ApiConfigSource.*");
+TEST_F(SubscriptionFactoryTest, FilesystemCollectionSubscriptionNonExistentFile) {
+  EXPECT_THROW_WITH_MESSAGE(collectionSubscriptionFromUrl("file:///blahblah", {})->start({}),
+                            EnvoyException,
+                            "envoy::api::v2::Path must refer to an existing path in the system: "
+                            "'/blahblah' does not exist");
 }
 
 TEST_F(SubscriptionFactoryTest, HttpSubscriptionCustomRequestTimeout) {

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -220,13 +220,6 @@ TEST_F(SubscriptionFactoryTest, FilesystemCollectionSubscription) {
   collectionSubscriptionFromUrl(fmt::format("file:///{}", file_path), {})->start({});
 }
 
-TEST_F(SubscriptionFactoryTest, FilesystemCollectionSubscriptionNonExistentFile) {
-  EXPECT_THROW_WITH_MESSAGE(collectionSubscriptionFromUrl("file:///blahblah", {})->start({}),
-                            EnvoyException,
-                            "envoy::api::v2::Path must refer to an existing path in the system: "
-                            "'/blahblah' does not exist");
-}
-
 TEST_F(SubscriptionFactoryTest, LegacySubscription) {
   envoy::config::core::v3::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();

--- a/test/common/config/subscription_factory_impl_test.cc
+++ b/test/common/config/subscription_factory_impl_test.cc
@@ -230,8 +230,6 @@ TEST_F(SubscriptionFactoryTest, FilesystemCollectionSubscriptionNonExistentFile)
 TEST_F(SubscriptionFactoryTest, LegacySubscription) {
   envoy::config::core::v3::ConfigSource config;
   auto* api_config_source = config.mutable_api_config_source();
-  api_config_source->set_api_type(
-      envoy::config::core::v3::ApiConfigSource::hidden_envoy_deprecated_UNSUPPORTED_REST_LEGACY);
   api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
   api_config_source->add_cluster_names("static_cluster");
   Upstream::ClusterManager::ClusterSet primary_clusters;

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -74,9 +74,6 @@ TEST(UtilityTest, TranslateApiConfigSource) {
   Utility::translateApiConfigSource("test_rest_legacy_cluster", 10000,
                                     ApiType::get().UnsupportedRestLegacy,
                                     api_config_source_rest_legacy);
-  EXPECT_EQ(
-      envoy::config::core::v3::ApiConfigSource::hidden_envoy_deprecated_UNSUPPORTED_REST_LEGACY,
-      api_config_source_rest_legacy.api_type());
   EXPECT_EQ(10000,
             DurationUtil::durationToMilliseconds(api_config_source_rest_legacy.refresh_delay()));
   EXPECT_EQ("test_rest_legacy_cluster", api_config_source_rest_legacy.cluster_names(0));

--- a/test/common/config/utility_test.cc
+++ b/test/common/config/utility_test.cc
@@ -71,9 +71,10 @@ TEST(UtilityTest, ConfigSourceInitFetchTimeout) {
 
 TEST(UtilityTest, TranslateApiConfigSource) {
   envoy::config::core::v3::ApiConfigSource api_config_source_rest_legacy;
-  Utility::translateApiConfigSource("test_rest_legacy_cluster", 10000,
-                                    ApiType::get().UnsupportedRestLegacy,
+  Utility::translateApiConfigSource("test_rest_legacy_cluster", 10000, ApiType::get().Rest,
                                     api_config_source_rest_legacy);
+  EXPECT_EQ(envoy::config::core::v3::ApiConfigSource::REST,
+            api_config_source_rest_legacy.api_type());
   EXPECT_EQ(10000,
             DurationUtil::durationToMilliseconds(api_config_source_rest_legacy.refresh_delay()));
   EXPECT_EQ("test_rest_legacy_cluster", api_config_source_rest_legacy.cluster_names(0));


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: remove support for v2 UNSUPPORTED_REST_LEGACY
Additional Description: Another PR of type remove_v2_support. first PR is https://github.com/envoyproxy/envoy/pull/16274
Risk Level: LOW
Testing: Yes
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
