### PR TITLE
admin: Fix crashes on invalid FieldMasks

### DIFF
--- a/source/server/admin/config_dump_handler.cc
+++ b/source/server/admin/config_dump_handler.cc
@@ -143,6 +143,8 @@ Http::Code ConfigDumpHandler::handlerConfigDump(absl::string_view url,
   if (resource.has_value()) {
     auto err = addResourceToDump(dump, mask, resource.value(), include_eds);
     if (err.has_value()) {
+      response_headers.addReference(Http::Headers::get().XContentTypeOptions,
+                                    Http::Headers::get().XContentTypeOptionValues.Nosniff);
       response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Text);
       response.add(err.value().second);
       return err.value().first;
@@ -150,6 +152,8 @@ Http::Code ConfigDumpHandler::handlerConfigDump(absl::string_view url,
   } else {
     auto err = addAllConfigToDump(dump, mask, include_eds);
     if (err.has_value()) {
+      response_headers.addReference(Http::Headers::get().XContentTypeOptions,
+                                    Http::Headers::get().XContentTypeOptionValues.Nosniff);
       response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Text);
       response.add(err.value().second);
       return err.value().first;

--- a/source/server/admin/config_dump_handler.h
+++ b/source/server/admin/config_dump_handler.h
@@ -27,8 +27,9 @@ public:
                                Buffer::Instance& response, AdminStream&) const;
 
 private:
-  void addAllConfigToDump(envoy::admin::v3::ConfigDump& dump,
-                          const absl::optional<std::string>& mask, bool include_eds) const;
+  absl::optional<std::pair<Http::Code, std::string>>
+  addAllConfigToDump(envoy::admin::v3::ConfigDump& dump, const absl::optional<std::string>& mask,
+                     bool include_eds) const;
   /**
    * Add the config matching the passed resource to the passed config dump.
    * @return absl::nullopt on success, else the Http::Code and an error message that should be added

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -630,7 +630,10 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
   EXPECT_EQ("FieldMask paths: \"cluster.transport_socket_matches.name\"\n could not be "
             "successfully used.",
             response.toString());
-  EXPECT_EQ(header_map.ContentType()->value().getStringView(), "text/plain");
+  EXPECT_EQ(header_map.ContentType()->value().getStringView(),
+            Http::Headers::get().ContentTypeValues.Text);
+  EXPECT_EQ(header_map.get(Http::Headers::get().XContentTypeOptions)[0]->value(),
+            Http::Headers::get().XContentTypeOptionValues.Nosniff);
 }
 
 TEST_P(AdminInstanceTest, InvalidFieldMaskWithoutResourceDoesNotCrash) {
@@ -648,7 +651,10 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithoutResourceDoesNotCrash) {
   EXPECT_EQ("FieldMask paths: \"bootstrap.node.extensions.name\"\n could not be "
             "successfully used.",
             response.toString());
-  EXPECT_EQ(header_map.ContentType()->value().getStringView(), "text/plain");
+  EXPECT_EQ(header_map.ContentType()->value().getStringView(),
+            Http::Headers::get().ContentTypeValues.Text);
+  EXPECT_EQ(header_map.get(Http::Headers::get().XContentTypeOptions)[0]->value(),
+            Http::Headers::get().XContentTypeOptionValues.Nosniff);
 }
 
 } // namespace Server

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -611,5 +611,43 @@ TEST_P(AdminInstanceTest, ConfigDumpResourceNotRepeated) {
             getCallback("/config_dump?resource=version_info", header_map, response));
 }
 
+TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
+  Buffer::OwnedImpl response;
+  Http::TestResponseHeaderMapImpl header_map;
+  auto clusters = admin_.getConfigTracker().add("clusters", [] {
+    auto msg = std::make_unique<envoy::admin::v3::ClustersConfigDump>();
+    auto* static_cluster = msg->add_static_clusters();
+    envoy::config::cluster::v3::Cluster inner_cluster;
+    inner_cluster.add_transport_socket_matches()->set_name("match1");
+    inner_cluster.add_transport_socket_matches()->set_name("match2");
+    static_cluster->mutable_cluster()->PackFrom(inner_cluster);
+    return msg;
+  });
+  EXPECT_EQ(Http::Code::BadRequest,
+            getCallback(
+                "/config_dump?resource=static_clusters&mask=cluster.transport_socket_matches.name",
+                header_map, response));
+  EXPECT_EQ("FieldMask paths: \"cluster.transport_socket_matches.name\"\n could not be "
+            "successfully used.",
+            response.toString());
+}
+
+TEST_P(AdminInstanceTest, InvalidFieldMaskWithoutResourceDoesNotCrash) {
+  Buffer::OwnedImpl response;
+  Http::TestResponseHeaderMapImpl header_map;
+  auto bootstrap = admin_.getConfigTracker().add("bootstrap", [] {
+    auto msg = std::make_unique<envoy::admin::v3::BootstrapConfigDump>();
+    auto* bootstrap = msg->mutable_bootstrap();
+    bootstrap->mutable_node()->add_extensions()->set_name("ext1");
+    bootstrap->mutable_node()->add_extensions()->set_name("ext2");
+    return msg;
+  });
+  EXPECT_EQ(Http::Code::BadRequest,
+            getCallback("/config_dump?mask=bootstrap.node.extensions.name", header_map, response));
+  EXPECT_EQ("FieldMask paths: \"bootstrap.node.extensions.name\"\n could not be "
+            "successfully used.",
+            response.toString());
+}
+
 } // namespace Server
 } // namespace Envoy

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -578,10 +578,10 @@ TEST_P(AdminInstanceTest, ConfigDumpNonExistentMask) {
  ]
 }
 )EOF";
-  EXPECT_EQ(Http::Code::OK,
+  EXPECT_EQ(Http::Code::BadRequest,
             getCallback("/config_dump?resource=static_clusters&mask=bad", header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, testing::HasSubstr("could not be successfully used"));
 }
 
 // Test that a 404 Not found is returned if a non-existent resource is passed in as the

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -630,6 +630,7 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
   EXPECT_EQ("FieldMask paths: \"cluster.transport_socket_matches.name\"\n could not be "
             "successfully used.",
             response.toString());
+  EXPECT_EQ(header_map.ContentType()->value().getStringView(), "text/plain");
 }
 
 TEST_P(AdminInstanceTest, InvalidFieldMaskWithoutResourceDoesNotCrash) {
@@ -647,6 +648,7 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithoutResourceDoesNotCrash) {
   EXPECT_EQ("FieldMask paths: \"bootstrap.node.extensions.name\"\n could not be "
             "successfully used.",
             response.toString());
+  EXPECT_EQ(header_map.ContentType()->value().getStringView(), "text/plain");
 }
 
 } // namespace Server


### PR DESCRIPTION
Signed-off-by: Paul Gallagher <pgal@google.com>

Note: Though this is an unexpected crash, this change does not require the security process, as the admin interface already has documented methods of triggering a crash (`/quitquitquit`), and should always be protected anyway.

Commit Message: admin: Fix crashes on invalid FieldMasks
Additional Description: When a field mask is invalid, TrimMessage will LOG(FATAL). Since explicitly checking validity of a field mask via FieldMaskUtil::IsValidFieldMask for a message requires compile-time knowledge of the message type, the best we can do is catch the exception thrown by TrimMessage and return an error.
Risk Level: Low
Testing: Unit tests.
Docs Changes: None, this aligns actual behavior with documented behavior.
