### PR TITLE
docs: Update title for CDS in docs

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cds.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cds.rst
@@ -1,7 +1,7 @@
 .. _config_cluster_manager_cds:
 
-Cluster discovery service
-=========================
+Cluster discovery service (CDS)
+===============================
 
 The cluster discovery service (CDS) is an optional API that Envoy will call to dynamically fetch
 cluster manager members. Envoy will reconcile the API response and add, modify, or remove known


### PR DESCRIPTION
Commit Message: Update title for CDS in docs
Additional Description: Appends " (CDS)" to the title of the Cluster Discovery Service doc, to provide consistency with other xDS like [LDS](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/lds.html) or [ADS](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/discovery/v3/ads.proto.html). This is especially important for the improvement of docs search discovery when searching for the service by it's acronym.
Risk Level:
Testing:
Docs Changes: Updated
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
