### PR TITLE
compdb: Use vscode argument in shell script

### DIFF
--- a/tools/vscode/refresh_compdb.sh
+++ b/tools/vscode/refresh_compdb.sh
@@ -3,7 +3,7 @@
 [[ -z "${SKIP_PROTO_FORMAT}" ]] && tools/proto_format/proto_format.sh fix
 
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py
+TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-compdb tools/gen_compilation_database.py --vscode
 
 # Kill clangd to reload the compilation database
-pkill clangd
+pkill clangd || :


### PR DESCRIPTION
And append `|| :` to the pkill command so that the
script doesn't exit with code 1 when clangd is not running.

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>