### PR TITLE
tools: support running generate_go_protobuf.py for other repos

### DIFF
--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -47,9 +47,9 @@ def generate_protobufs(targets, output, api_repo):
         #
         # Example output directory:
         # go_out/envoy/config/bootstrap/v2
-        _, stripped_path = rule.decode().rsplit('//', 1) # envoy/config/bootstrap/v3:pkg_go_proto
+        _, stripped_path = rule.decode().rsplit('//', 1)  # envoy/config/bootstrap/v3:pkg_go_proto
         rule_dir, proto = stripped_path.rsplit(':', 1)
-    
+
         if len(api_repo) == 0:
             prefix = ''
         else:

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -22,12 +22,12 @@ USER_NAME = 'go-control-plane(Azure Pipelines)'
 USER_EMAIL = 'go-control-plane@users.noreply.github.com'
 
 
-def generate_protobufs(output):
+def generate_protobufs(targets, output, api_repo):
     bazel_bin = check_output(['bazel', 'info', 'bazel-bin']).decode().strip()
     go_protos = check_output([
         'bazel',
         'query',
-        'kind("go_proto_library", %s)' % TARGETS,
+        'kind("go_proto_library", %s)' % targets,
     ]).split()
 
     # Each rule has the form @envoy_api//foo/bar:baz_go_proto.
@@ -47,9 +47,15 @@ def generate_protobufs(output):
         #
         # Example output directory:
         # go_out/envoy/config/bootstrap/v2
-        rule_dir, proto = rule.decode()[len('@envoy_api//'):].rsplit(':', 1)
+        stripped_path = rule.decode().rsplit('//', 1) # envoy/config/bootstrap/v3:pkg_go_proto
+        rule_dir, proto = strippped_path.rsplit(':', 1)
+    
+        if len(api_repo) == 0:
+            prefix = ''
+        else:
+            prefix = os.path.join('external', api_repo)
         input_dir = os.path.join(
-            bazel_bin, 'external', 'envoy_api', rule_dir, proto + '_', IMPORT_BASE, rule_dir)
+            bazel_bin, prefix, rule_dir, proto + '_', IMPORT_BASE, rule_dir)
         input_files = glob.glob(os.path.join(input_dir, '*.go'))
         output_dir = os.path.join(output, rule_dir)
 
@@ -126,11 +132,13 @@ if __name__ == "__main__":
         description='Generate Go protobuf files and sync with go-control-plane')
     parser.add_argument('--sync', action='store_true')
     parser.add_argument('--output_base', default='build_go')
+    parser.add_argument('--targets', default=TARGETS)
+    parser.add_argument('--api_repo', default="envoy_api")
     args = parser.parse_args()
 
     workspace = check_output(['bazel', 'info', 'workspace']).decode().strip()
     output = os.path.join(workspace, args.output_base)
-    generate_protobufs(output)
+    generate_protobufs(args.targets, output, parser.api_repo)
     if not args.sync:
         print('Skipping sync with go-control-plane')
         sys.exit()

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -47,13 +47,9 @@ def generate_protobufs(targets, output, api_repo):
         #
         # Example output directory:
         # go_out/envoy/config/bootstrap/v2
-        _, stripped_path = rule.decode().rsplit('//', 1)  # envoy/config/bootstrap/v3:pkg_go_proto
-        rule_dir, proto = stripped_path.rsplit(':', 1)
+        rule_dir, proto = rule.decode().rsplit('//', 1)[1].rsplit(':', 1)
 
-        if len(api_repo) == 0:
-            prefix = ''
-        else:
-            prefix = os.path.join('external', api_repo)
+        prefix = '' if not api_repo else os.path.join('external', api_repo)
         input_dir = os.path.join(bazel_bin, prefix, rule_dir, proto + '_', IMPORT_BASE, rule_dir)
         input_files = glob.glob(os.path.join(input_dir, '*.go'))
         output_dir = os.path.join(output, rule_dir)

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -54,8 +54,7 @@ def generate_protobufs(targets, output, api_repo):
             prefix = ''
         else:
             prefix = os.path.join('external', api_repo)
-        input_dir = os.path.join(
-            bazel_bin, prefix, rule_dir, proto + '_', IMPORT_BASE, rule_dir)
+        input_dir = os.path.join(bazel_bin, prefix, rule_dir, proto + '_', IMPORT_BASE, rule_dir)
         input_files = glob.glob(os.path.join(input_dir, '*.go'))
         output_dir = os.path.join(output, rule_dir)
 

--- a/tools/api/generate_go_protobuf.py
+++ b/tools/api/generate_go_protobuf.py
@@ -47,8 +47,8 @@ def generate_protobufs(targets, output, api_repo):
         #
         # Example output directory:
         # go_out/envoy/config/bootstrap/v2
-        stripped_path = rule.decode().rsplit('//', 1) # envoy/config/bootstrap/v3:pkg_go_proto
-        rule_dir, proto = strippped_path.rsplit(':', 1)
+        _, stripped_path = rule.decode().rsplit('//', 1) # envoy/config/bootstrap/v3:pkg_go_proto
+        rule_dir, proto = stripped_path.rsplit(':', 1)
     
         if len(api_repo) == 0:
             prefix = ''
@@ -138,7 +138,7 @@ if __name__ == "__main__":
 
     workspace = check_output(['bazel', 'info', 'workspace']).decode().strip()
     output = os.path.join(workspace, args.output_base)
-    generate_protobufs(args.targets, output, parser.api_repo)
+    generate_protobufs(args.targets, output, args.api_repo)
     if not args.sync:
         print('Skipping sync with go-control-plane')
         sys.exit()


### PR DESCRIPTION
Makes some minor modifications to the generate_go_protobuf.py script that allows overriding the targets
and API repo. This allows projects that may want to define protos that depend on Envoy protos to use this
script to generate Go files for the added protobuf files. 

Risk Level: Medium
Testing: Sanity checked that the Envoy protobuf files are still generated as before.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
