### PR TITLE
Added option to configure max_header_value_len.

### DIFF
--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -130,6 +130,7 @@ message Config {
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
 
-  // Configure max_header_value_len.
+  // Configures maximum length for :ref:`header value <envoy_v3_api_field_extensions.filters.http.header_to_metadata.v3.Config.KeyValuePair.value>`
+  // to be added in the metadata. If this value exceeds, no metadata will be added. If not specified, the default is 8KiB.
   uint32 max_header_value_len = 3;
 }

--- a/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -129,4 +129,7 @@ message Config {
 
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
+
+  // Configure max_header_value_len.
+  uint32 max_header_value_len = 3;
 }

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -127,4 +127,7 @@ message Config {
 
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
+
+  // Configure max_header_value_len.
+  uint32 max_header_value_len = 3;
 }

--- a/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/api/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -128,6 +128,7 @@ message Config {
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
 
-  // Configure max_header_value_len.
+  // Configures maximum length for :ref:`header value <envoy_v3_api_field_extensions.filters.http.header_to_metadata.v3.Config.KeyValuePair.value>`
+  // to be added in the metadata. If this value exceeds, no metadata will be added. If not specified, the default is 8KiB.
   uint32 max_header_value_len = 3;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -130,6 +130,7 @@ message Config {
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
 
-  // Configure max_header_value_len.
+  // Configures maximum length for :ref:`header value <envoy_v3_api_field_extensions.filters.http.header_to_metadata.v3.Config.KeyValuePair.value>`
+  // to be added in the metadata. If this value exceeds, no metadata will be added. If not specified, the default is 8KiB.
   uint32 max_header_value_len = 3;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v3/header_to_metadata.proto
@@ -129,4 +129,7 @@ message Config {
 
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
+
+  // Configure max_header_value_len.
+  uint32 max_header_value_len = 3;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -127,4 +127,7 @@ message Config {
 
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
+
+  // Configure max_header_value_len.
+  uint32 max_header_value_len = 3;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/header_to_metadata/v4alpha/header_to_metadata.proto
@@ -128,6 +128,7 @@ message Config {
   // The list of rules to apply to responses.
   repeated Rule response_rules = 2;
 
-  // Configure max_header_value_len.
+  // Configures maximum length for :ref:`header value <envoy_v3_api_field_extensions.filters.http.header_to_metadata.v3.Config.KeyValuePair.value>`
+  // to be added in the metadata. If this value exceeds, no metadata will be added. If not specified, the default is 8KiB.
   uint32 max_header_value_len = 3;
 }

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -101,6 +101,10 @@ Config::Config(const envoy::extensions::filters::http::header_to_metadata::v3::C
     throw EnvoyException("header_to_metadata_filter: Per filter configs must at least specify "
                          "either request or response rules");
   }
+
+  if (config.max_header_value_len()) {
+    max_header_value_len_ = config.max_header_value_len();
+  }
 }
 
 bool Config::configToVector(const ProtobufRepeatedRule& proto_rules,
@@ -157,7 +161,7 @@ bool HeaderToMetadataFilter::addMetadata(StructMap& map, const std::string& meta
 
   ASSERT(!value.empty());
 
-  if (value.size() >= MAX_HEADER_VALUE_LEN) {
+  if (value.size() >= config_->getMaxHeaderValueLen()) {
     // Too long, go away.
     ENVOY_LOG(debug, "metadata value is too long");
     return false;

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -84,8 +84,8 @@ private:
 
 using HeaderToMetadataRules = std::vector<Rule>;
 
-// TODO(yangminzhu): Make MAX_HEADER_VALUE_LEN configurable.
-const uint32_t MAX_HEADER_VALUE_LEN = 8 * 1024;
+// The default value of max_header_value_len.
+const uint32_t DEFAULT_MAX_HEADER_VALUE_LEN = 8 * 1024;
 
 /**
  *  Encapsulates the filter configuration with STL containers and provides an area for any custom
@@ -101,6 +101,7 @@ public:
   const HeaderToMetadataRules& responseRules() const { return response_rules_; }
   bool doResponse() const { return response_set_; }
   bool doRequest() const { return request_set_; }
+  uint32_t getMaxHeaderValueLen() const { return max_header_value_len_; };
 
 private:
   using ProtobufRepeatedRule = Protobuf::RepeatedPtrField<ProtoRule>;
@@ -123,6 +124,7 @@ private:
   HeaderToMetadataRules response_rules_;
   bool response_set_;
   bool request_set_;
+  uint32_t max_header_value_len_{DEFAULT_MAX_HEADER_VALUE_LEN};
 };
 
 using ConfigSharedPtr = std::shared_ptr<Config>;

--- a/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/header_to_metadata_filter_test.cc
@@ -408,7 +408,8 @@ TEST_F(HeaderToMetadataTest, EmptyHeaderValue) {
  */
 TEST_F(HeaderToMetadataTest, HeaderValueTooLong) {
   initializeFilter(request_config_yaml);
-  auto length = Envoy::Extensions::HttpFilters::HeaderToMetadataFilter::MAX_HEADER_VALUE_LEN + 1;
+  auto length =
+      Envoy::Extensions::HttpFilters::HeaderToMetadataFilter::DEFAULT_MAX_HEADER_VALUE_LEN + 1;
   Http::TestRequestHeaderMapImpl incoming_headers{{"X-VERSION", std::string(length, 'x')}};
 
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(req_info_));


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>

 
Commit Message: Added option to configure max_header_value_len. 
Additional Description: MAX_HEADER_VALUE_LEN is hardcoded, this PR will make it configurable.
Risk Level:
Testing:
Docs Changes: API
Release Notes: n/a