### PR TITLE
Use partial error match to accommodate upcoming changes to absl::Status::operator<<

### DIFF
--- a/test/common/http/match_wrapper/config_test.cc
+++ b/test/common/http/match_wrapper/config_test.cc
@@ -164,7 +164,7 @@ matcher:
 )EOF");
 
   MatchWrapperConfig match_wrapper_config;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THROW_WITH_REGEX(
       match_wrapper_config.createFilterFactoryFromProto(config, "", factory_context),
       EnvoyException,
       "requirement violation while creating match tree: INVALID_ARGUMENT: data input typeUrl "


### PR DESCRIPTION
Risk Level: Low, test only
Testing: Unit test

Signed-off-by: Yan Avlasov <yavlasov@google.com>
