### PR TITLE
thrift proxy: support outlier

### DIFF
--- a/docs/root/intro/arch_overview/upstream/outlier.rst
+++ b/docs/root/intro/arch_overview/upstream/outlier.rst
@@ -13,7 +13,8 @@ independently, and form the basis for an overall upstream health checking soluti
 Outlier detection is part of the :ref:`cluster configuration <envoy_v3_api_msg_config.cluster.v3.OutlierDetection>`
 and it needs filters to report errors, timeouts, and resets. Currently, the following filters support
 outlier detection: :ref:`http router <config_http_filters_router>`,
-:ref:`tcp proxy <config_network_filters_tcp_proxy>`  and :ref:`redis proxy <config_network_filters_redis_proxy>`.
+:ref:`tcp proxy <config_network_filters_tcp_proxy>`,
+:ref:`redis proxy <config_network_filters_redis_proxy>` and :ref:`thrift proxy <config_network_filters_thrift_proxy>`.
 
 Detected errors fall into two categories: externally and locally originated errors. Externally generated errors
 are transaction specific and occur on the upstream server in response to the received request. For example, an HTTP server returning error code 500 or a redis server returning a payload which cannot be decoded. Those errors are generated on the upstream host after Envoy has connected to it successfully.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -105,6 +105,7 @@ New Features
 * router: added flag ``suppress_grpc_request_failure_code_stats`` to :ref:`key <envoy_v3_api_msg_extensions.filters.http.router.v3.Router>` to allow users to exclude incrementing HTTP status code stats on gRPC requests.
 * tcp: added support for :ref:`preconnecting <v1.18.0:envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic.
 * thrift_proxy: added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request and response size histograms.
+* thrift_proxy: added :ref:`outlier <arch_overview_outlier_detection>` to support.
 * tls: allow dual ECDSA/RSA certs via SDS. Previously, SDS only supported a single certificate per context, and dual cert was only supported via non-SDS.
 * udp_proxy: added :ref:`key <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.HashPolicy>` as another hash policy to support hash based routing on any given key.
 * windows container image: added user, EnvoyUser which is part of the Network Configuration Operators group to the container image.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -105,7 +105,7 @@ New Features
 * router: added flag ``suppress_grpc_request_failure_code_stats`` to :ref:`key <envoy_v3_api_msg_extensions.filters.http.router.v3.Router>` to allow users to exclude incrementing HTTP status code stats on gRPC requests.
 * tcp: added support for :ref:`preconnecting <v1.18.0:envoy_v3_api_msg_config.cluster.v3.Cluster.PreconnectPolicy>`. Preconnecting is off by default, but recommended for clusters serving latency-sensitive traffic.
 * thrift_proxy: added per upstream metrics within the :ref:`thrift router <envoy_v3_api_msg_extensions.filters.network.thrift_proxy.router.v3.Router>` for request and response size histograms.
-* thrift_proxy: added :ref:`outlier <arch_overview_outlier_detection>` to support.
+* thrift_proxy: added support for :ref:`outlier detection <arch_overview_outlier_detection>`.
 * tls: allow dual ECDSA/RSA certs via SDS. Previously, SDS only supported a single certificate per context, and dual cert was only supported via non-SDS.
 * udp_proxy: added :ref:`key <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.HashPolicy>` as another hash policy to support hash based routing on any given key.
 * windows container image: added user, EnvoyUser which is part of the Network Configuration Operators group to the container image.

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -362,13 +362,19 @@ void Router::onUpstreamData(Buffer::Instance& data, bool end_stream) {
       case MessageType::Reply:
         incClusterScopeCounter({upstream_resp_reply_});
         if (callbacks_->responseSuccess()) {
+          upstream_request_->upstream_host_->outlierDetector().putResult(
+              Upstream::Outlier::Result::ExtOriginRequestSuccess);
           incClusterScopeCounter({upstream_resp_reply_success_});
         } else {
+          upstream_request_->upstream_host_->outlierDetector().putResult(
+              Upstream::Outlier::Result::ExtOriginRequestFailed);
           incClusterScopeCounter({upstream_resp_reply_error_});
         }
         break;
 
       case MessageType::Exception:
+        upstream_request_->upstream_host_->outlierDetector().putResult(
+            Upstream::Outlier::Result::ExtOriginRequestFailed);
         incClusterScopeCounter({upstream_resp_exception_});
         break;
 
@@ -497,6 +503,8 @@ void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr
   bool continue_decoding = conn_pool_handle_ != nullptr;
 
   onUpstreamHostSelected(host);
+  host->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess);
+
   conn_data_ = std::move(conn_data);
   conn_data_->addUpstreamCallbacks(parent_);
   conn_pool_handle_ = nullptr;
@@ -566,12 +574,21 @@ void Router::UpstreamRequest::onResetStream(ConnectionPool::PoolFailureReason re
         true);
     break;
   case ConnectionPool::PoolFailureReason::LocalConnectionFailure:
+    upstream_host_->outlierDetector().putResult(
+        Upstream::Outlier::Result::LocalOriginConnectFailed);
     // Should only happen if we closed the connection, due to an error condition, in which case
     // we've already handled any possible downstream response.
     parent_.callbacks_->resetDownstreamConnection();
     break;
   case ConnectionPool::PoolFailureReason::RemoteConnectionFailure:
   case ConnectionPool::PoolFailureReason::Timeout:
+    if (reason == ConnectionPool::PoolFailureReason::Timeout) {
+      upstream_host_->outlierDetector().putResult(Upstream::Outlier::Result::LocalOriginTimeout);
+    } else if (reason == ConnectionPool::PoolFailureReason::RemoteConnectionFailure) {
+      upstream_host_->outlierDetector().putResult(
+          Upstream::Outlier::Result::LocalOriginConnectFailed);
+    }
+
     // TODO(zuercher): distinguish between these cases where appropriate (particularly timeout)
     if (!response_started_) {
       parent_.callbacks_->sendLocalReply(

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.cc
@@ -388,6 +388,8 @@ void Router::onUpstreamData(Buffer::Instance& data, bool end_stream) {
     } else if (status == ThriftFilters::ResponseStatus::Reset) {
       // Note: invalid responses are not accounted in the response size histogram.
       ENVOY_STREAM_LOG(debug, "upstream reset", *callbacks_);
+      upstream_request_->upstream_host_->outlierDetector().putResult(
+          Upstream::Outlier::Result::ExtOriginRequestFailed);
       upstream_request_->resetStream();
       return;
     }


### PR DESCRIPTION
Signed-off-by: Yiheng Li <lyhutopi@gmail.com>
Commit Message: thrift proxy support outlier
Additional Description: Put upstream result to outlier monitor in thrift route filter.
Risk Level: Low, no behavior change
Testing: UTs
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a