### PR TITLE
bazel: Fix pch timestamp issues

### DIFF
--- a/bazel/pch.bzl
+++ b/bazel/pch.bzl
@@ -33,8 +33,7 @@ def _pch(ctx):
         "\n".join(["#include \"{}\"".format(include) for include in ctx.attr.includes]) + "\n",
     )
 
-    # TODO: -fno-pch-timestamp / invalidation in that case doesn't work
-    pch_flags = ["-x", "c++-header"]
+    pch_flags = ["-x", "c++-header", "-Xclang", "-fno-pch-timestamp"]
     pch_file = ctx.actions.declare_file(ctx.label.name + ".pch")
 
     deps_ctx = deps_cc_info.compilation_context


### PR DESCRIPTION
Previously I thought it wasn't safe to pass this because it wasn't in a
shipped version of clang yet but it turns out I wasn't using `-Xclang`.
This solves an issue where if you build a pch, then `touch` a header
file that's included in it without actually changing contents, including
the pch would fail. Now we let bazel handle that and since it doesn't
use timestamps it's a bit smarter about it.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>