### PR TITLE
examples: update Zipkin port environment variable name in docker-compose files

### DIFF
--- a/examples/jaeger-native-tracing/docker-compose.yaml
+++ b/examples/jaeger-native-tracing/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     environment:
-    - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+    - COLLECTOR_ZIPKIN_HOST_PORT=9411
     networks:
     - envoymesh
     ports:

--- a/examples/jaeger-tracing/docker-compose.yaml
+++ b/examples/jaeger-tracing/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one
     environment:
-    - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+    - COLLECTOR_ZIPKIN_HOST_PORT=9411
     networks:
     - envoymesh
     ports:


### PR DESCRIPTION
Signed-off-by: David Goffredo <dmgoffredo@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
examples: update Zipkin port environment variable name in docker-compose files

Additional Description:
I wasn't seeing any traces in the Jaeger UI after following the instructions for the "jaeger-tracing" example.

The issue was that Envoy was unable to connect to the Jaeger collector process.  The socket error code was 111 (connection refused).  Eventually I found the issue by cloning Jaeger, and finding that `git grep -i zipkin` included:
```
CHANGELOG.md:  * `collector.zipkin.http-port` is superseded by `collector.zipkin.host-port`
```
After changing `COLLECTOR_ZIPKIN_HTTP_PORT` to `COLLECTOR_ZIPKIN_HOST_PORT` and re-running the example, I began to see the expected traces in the Jaeger UI as mentioned in [documentation](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/jaeger_tracing).

I also changed the same environment variable where is appears in another example, "jaeger-native-tracing".

This problem could be prevented by pinning the version of `jaegertracing/all-in-one` used in the examples, but then of course somebody would have to periodically update the version and test that it still works.

Risk Level:
Testing:
I manually tested this change for the "jaeger-tracing" example by following the instructions in [the docs](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/jaeger_tracing) and verifying that traces were visible in the Jaeger UI after hitting one of the example service endpoints with `curl`.

Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
