### PR TITLE
ext_authz, docs: Authorization is automatically included in allowed_headers

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -215,18 +215,21 @@ message AuthorizationRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.AuthorizationRequest";
 
-  // Authorization request will include the client request headers that have a correspondent match
-  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. Note that in addition to the
-  // user's supplied matchers:
+  // Authorization request includes the client request headers that have a correspondent match
+  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`.
   //
-  // 1. *Host*, *Method*, *Path* and *Content-Length* are automatically included to the list.
+  // .. note::
   //
-  // 2. *Content-Length* will be set to 0 and the request to the authorization service will not have
-  // a message body. However, the authorization request can include the buffered client request body
-  // (controlled by :ref:`with_request_body
-  // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
-  // consequently the value of *Content-Length* of the authorization request reflects the size of
-  // its payload size.
+  //   In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //
+  // .. note::
+  //
+  //   By default, ``Content-Length`` header is set to ``0`` and the request to the authorization
+  //   service has no message body. However, the authorization request *may* include the buffered
+  //   client request body (controlled by :ref:`with_request_body
+  //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
+  //   setting) hence the value of its ``Content-Length`` reflects the size of its payload size.
   //
   type.matcher.v3.ListStringMatcher allowed_headers = 1;
 

--- a/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -215,18 +215,21 @@ message AuthorizationRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.ext_authz.v3.AuthorizationRequest";
 
-  // Authorization request will include the client request headers that have a correspondent match
-  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. Note that in addition to the
-  // user's supplied matchers:
+  // Authorization request includes the client request headers that have a correspondent match
+  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`.
   //
-  // 1. *Host*, *Method*, *Path* and *Content-Length* are automatically included to the list.
+  // .. note::
   //
-  // 2. *Content-Length* will be set to 0 and the request to the authorization service will not have
-  // a message body. However, the authorization request can include the buffered client request body
-  // (controlled by :ref:`with_request_body
-  // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
-  // consequently the value of *Content-Length* of the authorization request reflects the size of
-  // its payload size.
+  //   In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //
+  // .. note::
+  //
+  //   By default, ``Content-Length`` header is set to ``0`` and the request to the authorization
+  //   service has no message body. However, the authorization request *may* include the buffered
+  //   client request body (controlled by :ref:`with_request_body
+  //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
+  //   setting) hence the value of its ``Content-Length`` reflects the size of its payload size.
   //
   type.matcher.v4alpha.ListStringMatcher allowed_headers = 1;
 

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -218,18 +218,21 @@ message AuthorizationRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.AuthorizationRequest";
 
-  // Authorization request will include the client request headers that have a correspondent match
-  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. Note that in addition to the
-  // user's supplied matchers:
+  // Authorization request includes the client request headers that have a correspondent match
+  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`.
   //
-  // 1. *Host*, *Method*, *Path* and *Content-Length* are automatically included to the list.
+  // .. note::
   //
-  // 2. *Content-Length* will be set to 0 and the request to the authorization service will not have
-  // a message body. However, the authorization request can include the buffered client request body
-  // (controlled by :ref:`with_request_body
-  // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
-  // consequently the value of *Content-Length* of the authorization request reflects the size of
-  // its payload size.
+  //   In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //
+  // .. note::
+  //
+  //   By default, ``Content-Length`` header is set to ``0`` and the request to the authorization
+  //   service has no message body. However, the authorization request *may* include the buffered
+  //   client request body (controlled by :ref:`with_request_body
+  //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
+  //   setting) hence the value of its ``Content-Length`` reflects the size of its payload size.
   //
   type.matcher.v3.ListStringMatcher allowed_headers = 1;
 

--- a/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/ext_authz/v4alpha/ext_authz.proto
@@ -215,18 +215,21 @@ message AuthorizationRequest {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.filters.http.ext_authz.v3.AuthorizationRequest";
 
-  // Authorization request will include the client request headers that have a correspondent match
-  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`. Note that in addition to the
-  // user's supplied matchers:
+  // Authorization request includes the client request headers that have a correspondent match
+  // in the :ref:`list <envoy_v3_api_msg_type.matcher.v3.ListStringMatcher>`.
   //
-  // 1. *Host*, *Method*, *Path* and *Content-Length* are automatically included to the list.
+  // .. note::
   //
-  // 2. *Content-Length* will be set to 0 and the request to the authorization service will not have
-  // a message body. However, the authorization request can include the buffered client request body
-  // (controlled by :ref:`with_request_body
-  // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>` setting),
-  // consequently the value of *Content-Length* of the authorization request reflects the size of
-  // its payload size.
+  //   In addition to the the user's supplied matchers, ``Host``, ``Method``, ``Path``,
+  //   ``Content-Length``, and ``Authorization`` are **automatically included** to the list.
+  //
+  // .. note::
+  //
+  //   By default, ``Content-Length`` header is set to ``0`` and the request to the authorization
+  //   service has no message body. However, the authorization request *may* include the buffered
+  //   client request body (controlled by :ref:`with_request_body
+  //   <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.with_request_body>`
+  //   setting) hence the value of its ``Content-Length`` reflects the size of its payload size.
   //
   type.matcher.v4alpha.ListStringMatcher allowed_headers = 1;
 


### PR DESCRIPTION
Commit Message:

From https://github.com/envoyproxy/envoy/blob/0a55eb90060664ffa01229a8cd7c1fedcbc0599d/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc#L132-L133
Authorization header from client request is automatically included (in addition to `Host`, `Path`, `Method`, and `Content-Length`) in the request to the authorization service.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>

Additional Description: While not sure, I also re-phrased the current description into:

![image](https://user-images.githubusercontent.com/73152/122638311-a6586600-d11d-11eb-875c-2b43fbcd5be7.png)

the current docs of alowed_headers (https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html#envoy-v3-api-field-extensions-filters-http-ext-authz-v3-authorizationrequest-allowed-headers):

![image](https://user-images.githubusercontent.com/73152/122638342-c4be6180-d11d-11eb-8d4d-e36ddd8c7b6b.png)

Risk Level: Low, docs only
Testing: None
Docs Changes: Yes
Release Notes: N/A
Platform-Specific Features: N/A
