### PR TITLE
fix proto_sync.py to ensure that the expected diff content is output

### DIFF
--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -9,7 +9,6 @@
 
 import argparse
 from collections import defaultdict
-from genericpath import exists
 import multiprocessing as mp
 import os
 import pathlib

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -481,6 +481,10 @@ def sync(api_root, mode, is_ci, labels, shadow):
             copy_dst_dir.mkdir(exist_ok=True)
             shutil.copy(str(pathlib.Path(api_root, f)), str(copy_dst_dir))
 
+        for proto in IGNORED_V2_PROTOS:
+            print("remove: " + str(dst_dir.joinpath("envoy", proto[6:])))
+            shutil.rmtree(str(dst_dir.joinpath("envoy", proto[6:])))
+
         diff = subprocess.run(['diff', '-Npur', "a", "b"], cwd=tmp, stdout=subprocess.PIPE).stdout
 
         if diff.strip():

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -9,6 +9,7 @@
 
 import argparse
 from collections import defaultdict
+from genericpath import exists
 import multiprocessing as mp
 import os
 import pathlib
@@ -482,7 +483,9 @@ def sync(api_root, mode, is_ci, labels, shadow):
             shutil.copy(str(pathlib.Path(api_root, f)), str(copy_dst_dir))
 
         for proto in IGNORED_V2_PROTOS:
-            shutil.rmtree(str(dst_dir.joinpath("envoy", proto[6:])))
+            ignored_v2_proto_path = str(dst_dir.joinpath("envoy", proto[6:]))
+            if(os.path.exists(ignored_v2_proto_path)):
+                shutil.rmtree(str(dst_dir.joinpath("envoy", proto[6:])))
 
         diff = subprocess.run(['diff', '-Npur', "a", "b"], cwd=tmp, stdout=subprocess.PIPE).stdout
 

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -483,7 +483,7 @@ def sync(api_root, mode, is_ci, labels, shadow):
 
         for proto in IGNORED_V2_PROTOS:
             ignored_v2_proto_path = str(dst_dir.joinpath("envoy", proto[6:]))
-            if(os.path.exists(ignored_v2_proto_path)):
+            if (os.path.exists(ignored_v2_proto_path)):
                 shutil.rmtree(ignored_v2_proto_path)
 
         diff = subprocess.run(['diff', '-Npur', "a", "b"], cwd=tmp, stdout=subprocess.PIPE).stdout

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -482,7 +482,6 @@ def sync(api_root, mode, is_ci, labels, shadow):
             shutil.copy(str(pathlib.Path(api_root, f)), str(copy_dst_dir))
 
         for proto in IGNORED_V2_PROTOS:
-            print("remove: " + str(dst_dir.joinpath("envoy", proto[6:])))
             shutil.rmtree(str(dst_dir.joinpath("envoy", proto[6:])))
 
         diff = subprocess.run(['diff', '-Npur', "a", "b"], cwd=tmp, stdout=subprocess.PIPE).stdout

--- a/tools/proto_format/proto_sync.py
+++ b/tools/proto_format/proto_sync.py
@@ -484,7 +484,7 @@ def sync(api_root, mode, is_ci, labels, shadow):
         for proto in IGNORED_V2_PROTOS:
             ignored_v2_proto_path = str(dst_dir.joinpath("envoy", proto[6:]))
             if(os.path.exists(ignored_v2_proto_path)):
-                shutil.rmtree(str(dst_dir.joinpath("envoy", proto[6:])))
+                shutil.rmtree(ignored_v2_proto_path)
 
         diff = subprocess.run(['diff', '-Npur', "a", "b"], cwd=tmp, stdout=subprocess.PIPE).stdout
 


### PR DESCRIPTION
When we use `proto_format.sh` to generate new `generated_api_shadow`, a lot of meaningless diff content will be generated.

The reason is that when the current API is copied to tmp dir for diff, part of the v2 API will be removed. But the destination API did not remove the corresponding v2 API. 

Risk Level: Low.
