### PR TITLE
tracing: route config precedes runtime

### DIFF
--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1011,19 +1011,19 @@ public:
    * This method returns the client sampling percentage.
    * @return the client sampling percentage
    */
-  virtual const envoy::type::v3::FractionalPercent& getClientSampling() const PURE;
+  virtual const envoy::config::core::v3::RuntimeFractionalPercent& getClientSampling() const PURE;
 
   /**
    * This method returns the random sampling percentage.
    * @return the random sampling percentage
    */
-  virtual const envoy::type::v3::FractionalPercent& getRandomSampling() const PURE;
+  virtual const envoy::config::core::v3::RuntimeFractionalPercent& getRandomSampling() const PURE;
 
   /**
    * This method returns the overall sampling percentage.
    * @return the overall sampling percentage
    */
-  virtual const envoy::type::v3::FractionalPercent& getOverallSampling() const PURE;
+  virtual const envoy::config::core::v3::RuntimeFractionalPercent& getOverallSampling() const PURE;
 
   /**
    * This method returns the route level tracing custom tags.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -127,9 +127,9 @@ struct ConnectionManagerTracingStats {
 struct TracingConnectionManagerConfig {
   Tracing::OperationName operation_name_;
   Tracing::CustomTagMap custom_tags_;
-  envoy::type::v3::FractionalPercent client_sampling_;
-  envoy::type::v3::FractionalPercent random_sampling_;
-  envoy::type::v3::FractionalPercent overall_sampling_;
+  envoy::config::core::v3::RuntimeFractionalPercent client_sampling_;
+  envoy::config::core::v3::RuntimeFractionalPercent random_sampling_;
+  envoy::config::core::v3::RuntimeFractionalPercent overall_sampling_;
   bool verbose_;
   uint32_t max_path_tag_length_;
 };

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -259,38 +259,46 @@ const std::string& DecoratorImpl::getOperation() const { return operation_; }
 bool DecoratorImpl::propagate() const { return propagate_; }
 
 RouteTracingImpl::RouteTracingImpl(const envoy::config::route::v3::Tracing& tracing) {
+  // TODO(ikonst): add runtime_key to envoy.config.route.v3.Tracing
+  //  to allow per-route runtime tracing overrides
   if (!tracing.has_client_sampling()) {
-    client_sampling_.set_numerator(100);
-    client_sampling_.set_denominator(envoy::type::v3::FractionalPercent::HUNDRED);
+    client_sampling_.mutable_default_value().set_numerator(100);
+    client_sampling_.mutable_default_value().set_denominator(
+        envoy::type::v3::FractionalPercent::HUNDRED);
   } else {
-    client_sampling_ = tracing.client_sampling();
+    client_sampling_.set_default_value(tracing.client_sampling());
   }
   if (!tracing.has_random_sampling()) {
-    random_sampling_.set_numerator(100);
-    random_sampling_.set_denominator(envoy::type::v3::FractionalPercent::HUNDRED);
+    random_sampling_.mutable_default_value().set_numerator(100);
+    random_sampling_.mutable_default_value().set_denominator(
+        envoy::type::v3::FractionalPercent::HUNDRED);
   } else {
-    random_sampling_ = tracing.random_sampling();
+    random_sampling_.set_default_value(tracing.random_sampling());
   }
   if (!tracing.has_overall_sampling()) {
-    overall_sampling_.set_numerator(100);
-    overall_sampling_.set_denominator(envoy::type::v3::FractionalPercent::HUNDRED);
+    overall_sampling_.mutable_default_value().set_numerator(100);
+    overall_sampling_.mutable_default_value().set_denominator(
+        envoy::type::v3::FractionalPercent::HUNDRED);
   } else {
-    overall_sampling_ = tracing.overall_sampling();
+    overall_sampling_.set_default_value(tracing.overall_sampling());
   }
   for (const auto& tag : tracing.custom_tags()) {
     custom_tags_.emplace(tag.tag(), Tracing::HttpTracerUtility::createCustomTag(tag));
   }
 }
 
-const envoy::type::v3::FractionalPercent& RouteTracingImpl::getClientSampling() const {
+const envoy::config::core::v3::RuntimeFractionalPercent&
+RouteTracingImpl::getClientSampling() const {
   return client_sampling_;
 }
 
-const envoy::type::v3::FractionalPercent& RouteTracingImpl::getRandomSampling() const {
+const envoy::config::core::v3::RuntimeFractionalPercent&
+RouteTracingImpl::getRandomSampling() const {
   return random_sampling_;
 }
 
-const envoy::type::v3::FractionalPercent& RouteTracingImpl::getOverallSampling() const {
+const envoy::config::core::v3::RuntimeFractionalPercent&
+RouteTracingImpl::getOverallSampling() const {
   return overall_sampling_;
 }
 const Tracing::CustomTagMap& RouteTracingImpl::getCustomTags() const { return custom_tags_; }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -411,20 +411,20 @@ public:
   explicit RouteTracingImpl(const envoy::config::route::v3::Tracing& tracing);
 
   // Tracing::getClientSampling
-  const envoy::type::v3::FractionalPercent& getClientSampling() const override;
+  const envoy::config::core::v3::RuntimeFractionalPercent& getClientSampling() const override;
 
   // Tracing::getRandomSampling
-  const envoy::type::v3::FractionalPercent& getRandomSampling() const override;
+  const envoy::config::core::v3::RuntimeFractionalPercent& getRandomSampling() const override;
 
   // Tracing::getOverallSampling
-  const envoy::type::v3::FractionalPercent& getOverallSampling() const override;
+  const envoy::config::core::v3::RuntimeFractionalPercent& getOverallSampling() const override;
 
   const Tracing::CustomTagMap& getCustomTags() const override;
 
 private:
-  envoy::type::v3::FractionalPercent client_sampling_;
-  envoy::type::v3::FractionalPercent random_sampling_;
-  envoy::type::v3::FractionalPercent overall_sampling_;
+  envoy::config::core::v3::RuntimeFractionalPercent client_sampling_;
+  envoy::config::core::v3::RuntimeFractionalPercent random_sampling_;
+  envoy::config::core::v3::RuntimeFractionalPercent overall_sampling_;
   Tracing::CustomTagMap custom_tags_;
 };
 


### PR DESCRIPTION
Per-route tracing configuration should take precedence over non-specific runtime-derived configuration, i.e.
1. Per-route configuration
2. Runtime
3. Per-connection manager configuration

The motivation is to allow per-route overrides while using runtime flags to control tracing configuration for most routes. (I do think it makes sense to allow controlling per-route tracing through runtime as well -- I suppose we'll need to make changes to `envoy.config.route.v3.Tracing` for that.)

The implementation replaces internally the `FractionalPercent` with a `RuntimeFractionalPercent` so that the configuration values are self-contained along with their runtime flag.

**Risk Level:**
Medium

**Testing:**
TBD

**Docs Changes:**
TBD

**Release Notes:**
TBD