### PR TITLE
Adding note section in Original Source HTTP Filter in docs

### DIFF
--- a/docs/root/intro/arch_overview/other_features/ip_transparency.rst
+++ b/docs/root/intro/arch_overview/other_features/ip_transparency.rst
@@ -116,3 +116,7 @@ Some drawbacks to the Original Source filter:
   :ref:`x-forwarded-for <config_http_conn_man_headers_x-forwarded-for>` header.
 * Its configuration is relatively complex.
 * It may introduce a slight performance hit due to restrictions on connection pooling.
+
+.. note::
+
+ This feature is not supported on Windows.


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: this PR adding **Note** section missing in docs for Original Source HTTP Filter
Additional Description: As per https://www.envoyproxy.io/docs/envoy/latest/faq/windows/win_not_supported_features
following features are not supported in Windows OS
- Watchdog
- Tracers
- Original Src HTTP Filter.
- Hot restart
However **Note** section is missing for the same in https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#original-source-http-filter

Risk Level: LOW
Testing: 
Docs Changes: Yes
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
