### PR TITLE
regex: remove parseStdRegexAsCompiledMatcher

### DIFF
--- a/source/common/common/regex.cc
+++ b/source/common/common/regex.cc
@@ -127,11 +127,6 @@ CompiledMatcherPtr Utility::parseRegex(const envoy::type::matcher::v3::RegexMatc
   return std::make_unique<CompiledGoogleReMatcher>(matcher);
 }
 
-CompiledMatcherPtr Utility::parseStdRegexAsCompiledMatcher(const std::string& regex,
-                                                           std::regex::flag_type flags) {
-  return std::make_unique<CompiledStdMatcher>(parseStdRegex(regex, flags));
-}
-
 std::regex Utility::parseStdRegex(const std::string& regex, std::regex::flag_type flags) {
   // TODO(zuercher): In the future, PGV (https://github.com/envoyproxy/protoc-gen-validate)
   // annotations may allow us to remove this in favor of direct validation of regular

--- a/source/common/common/regex.h
+++ b/source/common/common/regex.h
@@ -27,16 +27,6 @@ public:
                                   std::regex::flag_type flags = std::regex::optimize);
 
   /**
-   * Construct an std::regex compiled regex matcher.
-   *
-   * TODO(mattklein123): In general this is only currently used in deprecated code paths and can be
-   * removed once all of those code paths are removed.
-   */
-  static CompiledMatcherPtr
-  parseStdRegexAsCompiledMatcher(const std::string& regex,
-                                 std::regex::flag_type flags = std::regex::optimize);
-
-  /**
    * Construct a compiled regex matcher from a match config.
    */
   static CompiledMatcherPtr parseRegex(const envoy::type::matcher::v3::RegexMatcher& matcher);

--- a/test/common/common/regex_test.cc
+++ b/test/common/common/regex_test.cc
@@ -17,9 +17,6 @@ TEST(Utility, ParseStdRegex) {
   EXPECT_THROW_WITH_REGEX(Utility::parseStdRegex("(+invalid)"), EnvoyException,
                           "Invalid regex '\\(\\+invalid\\)': .+");
 
-  EXPECT_THROW_WITH_REGEX(Utility::parseStdRegexAsCompiledMatcher("(+invalid)"), EnvoyException,
-                          "Invalid regex '\\(\\+invalid\\)': .+");
-
   {
     std::regex regex = Utility::parseStdRegex("x*");
     EXPECT_NE(0, regex.flags() & std::regex::optimize);
@@ -29,15 +26,6 @@ TEST(Utility, ParseStdRegex) {
     std::regex regex = Utility::parseStdRegex("x*", std::regex::icase);
     EXPECT_NE(0, regex.flags() & std::regex::icase);
     EXPECT_EQ(0, regex.flags() & std::regex::optimize);
-  }
-
-  {
-    // Regression test to cover high-complexity regular expressions that throw on std::regex_match.
-    // Note that not all std::regex_match implementations will throw when matching against the
-    // expression below, but at least clang 9.0.0 under linux does.
-    auto matcher = Utility::parseStdRegexAsCompiledMatcher(
-        "|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||");
-    EXPECT_FALSE(matcher->match("0"));
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Remove useless func, now it is only used in test:
```
root:[envoy]$ git grep parseStdRegexAsCompiledMatcher
source/common/common/regex.cc:130:CompiledMatcherPtr Utility::parseStdRegexAsCompiledMatcher(const std::string& regex,
source/common/common/regex.h:36:  parseStdRegexAsCompiledMatcher(const std::string& regex,
test/common/common/regex_test.cc:20:  EXPECT_THROW_WITH_REGEX(Utility::parseStdRegexAsCompiledMatcher("(+invalid)"), EnvoyException,
test/common/common/regex_test.cc:38:    auto matcher = Utility::parseStdRegexAsCompiledMatcher(
```

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
