### PR TITLE
ci: Separate docs version history check

### DIFF
--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -61,6 +61,10 @@ bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/extensions:extensions_check
 CURRENT=spelling
 "${ENVOY_SRCDIR}"/tools/spelling/check_spelling_pedantic.py --mark check
 
+CURRENT=rst
+# TODO(phlax): Move this to general docs checking of all rst files
+bazel run "${BAZEL_BUILD_OPTIONS[@]}" //tools/docs:rst_check
+
 if [[ "${#FAILED[@]}" -ne "0" ]]; then
     echo "${BASH_ERR_PREFIX}TESTS FAILED:" >&2
     for failed in "${FAILED[@]}"; do

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -36,9 +36,7 @@ EXCLUDED_PREFIXES = (
     "./source/extensions/common/wasm/ext",
     "./examples/wasm-cc",
 )
-SUFFIXES = (
-    "BUILD", "WORKSPACE", ".bzl", ".cc", ".h", ".java", ".m", ".md", ".mm", ".proto", ".rst")
-DOCS_SUFFIX = (".md", ".rst")
+SUFFIXES = ("BUILD", "WORKSPACE", ".bzl", ".cc", ".h", ".java", ".m", ".mm", ".proto")
 PROTO_SUFFIX = (".proto")
 
 # Files in these paths can make reference to protobuf stuff directly
@@ -180,16 +178,11 @@ EXTENSIONS_CODEOWNERS_REGEX = re.compile(r'.*(extensions[^@]*\s+)(@.*)')
 COMMENT_REGEX = re.compile(r"//|\*")
 DURATION_VALUE_REGEX = re.compile(r'\b[Dd]uration\(([0-9.]+)')
 PROTO_VALIDATION_STRING = re.compile(r'\bmin_bytes\b')
-VERSION_HISTORY_NEW_LINE_REGEX = re.compile("\* ([a-z \-_]+): ([a-z:`]+)")
-VERSION_HISTORY_SECTION_NAME = re.compile("^[A-Z][A-Za-z ]*$")
-RELOADABLE_FLAG_REGEX = re.compile(".*(...)(envoy.reloadable_features.[^ ]*)\s.*")
-INVALID_REFLINK = re.compile(".* ref:.*")
 OLD_MOCK_METHOD_REGEX = re.compile("MOCK_METHOD\d")
 # C++17 feature, lacks sufficient support across various libraries / compilers.
 FOR_EACH_N_REGEX = re.compile("for_each_n\(")
 # Check for punctuation in a terminal ref clause, e.g.
 # :ref:`panic mode. <arch_overview_load_balancing_panic_threshold>`
-REF_WITH_PUNCTUATION_REGEX = re.compile(".*\. <[^<]*>`\s*")
 DOT_MULTI_SPACE_REGEX = re.compile("\\. +")
 FLAG_REGEX = re.compile("    \"(.*)\",")
 
@@ -453,7 +446,7 @@ class FormatChecker:
         return any(file_path.startswith(prefix) for prefix in REGISTER_FACTORY_TEST_ALLOWLIST)
 
     def allow_listed_for_serialize_as_string(self, file_path):
-        return file_path in SERIALIZE_AS_STRING_ALLOWLIST or file_path.endswith(DOCS_SUFFIX)
+        return file_path in SERIALIZE_AS_STRING_ALLOWLIST
 
     def allow_listed_for_std_string_view(self, file_path):
         return file_path in STD_STRING_VIEW_ALLOWLIST
@@ -465,8 +458,7 @@ class FormatChecker:
         return name in HISTOGRAM_WITH_SI_SUFFIX_ALLOWLIST
 
     def allow_listed_for_std_regex(self, file_path):
-        return file_path.startswith(
-            "./test") or file_path in STD_REGEX_ALLOWLIST or file_path.endswith(DOCS_SUFFIX)
+        return file_path.startswith("./test") or file_path in STD_REGEX_ALLOWLIST
 
     def allow_listed_for_grpc_init(self, file_path):
         return file_path in GRPC_INIT_ALLOWLIST
@@ -483,8 +475,6 @@ class FormatChecker:
     def deny_listed_for_exceptions(self, file_path):
         # Returns true when it is a non test header file or the file_path is in DENYLIST or
         # it is under tools/testdata subdirectory.
-        if file_path.endswith(DOCS_SUFFIX):
-            return False
 
         return (file_path.endswith('.h') and not file_path.startswith("./test/") and not file_path in EXCEPTION_ALLOWLIST) or file_path in EXCEPTION_DENYLIST \
             or self.is_in_subdir(file_path, 'tools/testdata')
@@ -552,92 +542,8 @@ class FormatChecker:
                     error_messages.append("%s and %s are out of order\n" % (line, previous_flag))
             previous_flag = line
 
-    def check_current_release_notes(self, file_path, error_messages):
-        first_word_of_prior_line = ''
-        next_word_to_check = ''  # first word after :
-        prior_line = ''
-
-        def ends_with_period(prior_line):
-            if not prior_line:
-                return True  # Don't punctuation-check empty lines.
-            if prior_line.endswith('.'):
-                return True  # Actually ends with .
-            if prior_line.endswith('`') and REF_WITH_PUNCTUATION_REGEX.match(prior_line):
-                return True  # The text in the :ref ends with a .
-            return False
-
-        for line_number, line in enumerate(self.read_lines(file_path)):
-
-            def report_error(message):
-                error_messages.append("%s:%d: %s" % (file_path, line_number + 1, message))
-
-            if VERSION_HISTORY_SECTION_NAME.match(line):
-                if line == "Deprecated":
-                    # The deprecations section is last, and does not have enforced formatting.
-                    break
-
-                # Reset all parsing at the start of a section.
-                first_word_of_prior_line = ''
-                next_word_to_check = ''  # first word after :
-                prior_line = ''
-
-            invalid_reflink_match = INVALID_REFLINK.match(line)
-            if invalid_reflink_match:
-                report_error("Found text \" ref:\". This should probably be \" :ref:\"\n%s" % line)
-
-            # make sure flags are surrounded by ``s (ie "inline literal")
-            flag_match = RELOADABLE_FLAG_REGEX.match(line)
-            if flag_match:
-                if not flag_match.groups()[0].startswith(' ``'):
-                    report_error(
-                        "Flag %s should be enclosed in double back ticks" % flag_match.groups()[1])
-
-            if line.startswith("* "):
-                if not ends_with_period(prior_line):
-                    report_error(
-                        "The following release note does not end with a '.'\n %s" % prior_line)
-
-                match = VERSION_HISTORY_NEW_LINE_REGEX.match(line)
-                if not match:
-                    report_error(
-                        "Version history line malformed. "
-                        "Does not match VERSION_HISTORY_NEW_LINE_REGEX in check_format.py\n %s\n"
-                        "Please use messages in the form 'category: feature explanation.', "
-                        "starting with a lower-cased letter and ending with a period." % line)
-                else:
-                    first_word = match.groups()[0]
-                    next_word = match.groups()[1]
-                    # Do basic alphabetization checks of the first word on the line and the
-                    # first word after the :
-                    if first_word_of_prior_line and first_word_of_prior_line > first_word:
-                        report_error(
-                            "Version history not in alphabetical order (%s vs %s): please check placement of line\n %s. "
-                            % (first_word_of_prior_line, first_word, line))
-                    if first_word_of_prior_line == first_word and next_word_to_check and next_word_to_check > next_word:
-                        report_error(
-                            "Version history not in alphabetical order (%s vs %s): please check placement of line\n %s. "
-                            % (next_word_to_check, next_word, line))
-                    first_word_of_prior_line = first_word
-                    next_word_to_check = next_word
-
-                    prior_line = line
-            elif not line:
-                # If we hit the end of this release note block block, check the prior line.
-                if not ends_with_period(prior_line):
-                    report_error(
-                        "The following release note does not end with a '.'\n %s" % prior_line)
-                prior_line = ''
-            elif prior_line:
-                prior_line += line
-
     def check_file_contents(self, file_path, checker):
         error_messages = []
-
-        if file_path.endswith("version_history/current.rst"):
-            # Version file checking has enough special cased logic to merit its own checks.
-            # This only validates entries for the current release as very old release
-            # notes have a different format.
-            self.check_current_release_notes(file_path, error_messages)
         if file_path.endswith("source/common/runtime/runtime_features.cc"):
             # Do runtime alphabetical order checks.
             self.check_runtime_flags(file_path, error_messages)
@@ -1037,10 +943,9 @@ class FormatChecker:
 
         error_messages = []
 
-        if not file_path.endswith(DOCS_SUFFIX):
-            if not file_path.endswith(PROTO_SUFFIX):
-                error_messages += self.fix_header_order(file_path)
-            error_messages += self.clang_format(file_path)
+        if not file_path.endswith(PROTO_SUFFIX):
+            error_messages += self.fix_header_order(file_path)
+        error_messages += self.clang_format(file_path)
         if file_path.endswith(PROTO_SUFFIX) and self.is_api_file(file_path):
             package_name, error_message = self.package_name_for_proto(file_path)
             if package_name is None:
@@ -1050,16 +955,15 @@ class FormatChecker:
     def check_source_path(self, file_path):
         error_messages = self.check_file_contents(file_path, self.check_source_line)
 
-        if not file_path.endswith(DOCS_SUFFIX):
-            if not file_path.endswith(PROTO_SUFFIX):
-                error_messages += self.check_namespace(file_path)
-                command = (
-                    "%s --include_dir_order %s --path %s | diff %s -" %
-                    (HEADER_ORDER_PATH, self.include_dir_order, file_path, file_path))
-                error_messages += self.execute_command(
-                    command, "header_order.py check failed", file_path)
-            command = ("%s %s | diff %s -" % (CLANG_FORMAT_PATH, file_path, file_path))
-            error_messages += self.execute_command(command, "clang-format check failed", file_path)
+        if not file_path.endswith(PROTO_SUFFIX):
+            error_messages += self.check_namespace(file_path)
+            command = (
+                "%s --include_dir_order %s --path %s | diff %s -" %
+                (HEADER_ORDER_PATH, self.include_dir_order, file_path, file_path))
+            error_messages += self.execute_command(
+                command, "header_order.py check failed", file_path)
+        command = ("%s %s | diff %s -" % (CLANG_FORMAT_PATH, file_path, file_path))
+        error_messages += self.execute_command(command, "clang-format check failed", file_path)
 
         if file_path.endswith(PROTO_SUFFIX) and self.is_api_file(file_path):
             package_name, error_message = self.package_name_for_proto(file_path)
@@ -1106,12 +1010,6 @@ class FormatChecker:
         return []
 
     def check_format(self, file_path):
-        if file_path.startswith(EXCLUDED_PREFIXES):
-            return []
-
-        if not file_path.endswith(SUFFIXES):
-            return []
-
         error_messages = []
         # Apply fixes first, if asked, and then run checks. If we wind up attempting to fix
         # an issue, but there's still an error, that's a problem.
@@ -1333,9 +1231,18 @@ if __name__ == "__main__":
             # For each file in target_path, start a new task in the pool and collect the
             # results (results is passed by reference, and is used as an output).
             for root, _, files in os.walk(args.target_path):
+                _files = []
+                for filename in files:
+                    file_path = os.path.join(root, filename)
+                    check_file = (
+                        path_predicate(filename) and not file_path.startswith(EXCLUDED_PREFIXES)
+                        and file_path.endswith(SUFFIXES))
+                    if check_file:
+                        _files.append(filename)
+                if not _files:
+                    continue
                 format_checker.check_format_visitor(
-                    (pool, results, owned_directories, error_messages), root,
-                    [f for f in files if path_predicate(f)])
+                    (pool, results, owned_directories, error_messages), root, _files)
 
             # Close the pool to new tasks, wait for all of the running tasks to finish,
             # then collect the error messages.

--- a/tools/code_format/check_format_test_helper.py
+++ b/tools/code_format/check_format_test_helper.py
@@ -195,17 +195,6 @@ def run_checks():
         "serialize_as_string.cc",
         "Don't use MessageLite::SerializeAsString for generating deterministic serialization")
     errors += check_unfixable_error(
-        "version_history/current.rst",
-        "Version history not in alphabetical order (zzzzz vs aaaaa): please check placement of line"
-    )
-    errors += check_unfixable_error(
-        "version_history/current.rst",
-        "Version history not in alphabetical order (this vs aaaa): please check placement of line")
-    errors += check_unfixable_error(
-        "version_history/current.rst",
-        "Version history line malformed. Does not match VERSION_HISTORY_NEW_LINE_REGEX in "
-        "check_format.py")
-    errors += check_unfixable_error(
         "counter_from_string.cc",
         "Don't lookup stats by name at runtime; use StatName saved during construction")
     errors += check_unfixable_error(

--- a/tools/docs/BUILD
+++ b/tools/docs/BUILD
@@ -75,3 +75,9 @@ envoy_py_binary(
         requirement("urllib3"),
     ],
 )
+
+envoy_py_binary(
+    name = "tools.docs.rst_check",
+    data = ["//docs:root/version_history/current.rst"],
+    deps = ["//tools/base:checker"],
+)

--- a/tools/docs/rst_check.py
+++ b/tools/docs/rst_check.py
@@ -1,0 +1,128 @@
+import re
+import sys
+from typing import Iterator
+
+from tools.base import checker
+
+INVALID_REFLINK = re.compile(r".* ref:.*")
+REF_WITH_PUNCTUATION_REGEX = re.compile(r".*\. <[^<]*>`\s*")
+RELOADABLE_FLAG_REGEX = re.compile(r".*(...)(envoy.reloadable_features.[^ ]*)\s.*")
+VERSION_HISTORY_NEW_LINE_REGEX = re.compile(r"\* ([a-z \-_]+): ([a-z:`]+)")
+VERSION_HISTORY_SECTION_NAME = re.compile(r"^[A-Z][A-Za-z ]*$")
+
+
+class CurrentVersionFile(object):
+
+    def __init__(self, path):
+        self._path = path
+
+    @property
+    def lines(self) -> Iterator[str]:
+        with open(self.path) as f:
+            for line in f.readlines():
+                yield line.strip()
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @property
+    def prior_endswith_period(self) -> bool:
+        return bool(
+            self.prior_line.endswith(".")
+            # Don't punctuation-check empty lines.
+            or not self.prior_line
+            # The text in the :ref ends with a .
+            or
+            (self.prior_line.endswith('`') and REF_WITH_PUNCTUATION_REGEX.match(self.prior_line)))
+
+    def check_flags(self, line: str) -> list:
+        # TODO(phlax): improve checking of inline literals
+        # make sure flags are surrounded by ``s (ie "inline literal")
+        flag_match = RELOADABLE_FLAG_REGEX.match(line)
+        return ([f"Flag {flag_match.groups()[1]} should be enclosed in double back ticks"]
+                if flag_match and not flag_match.groups()[0].startswith(' ``') else [])
+
+    def check_line(self, line: str) -> list:
+        errors = self.check_reflink(line) + self.check_flags(line)
+        if line.startswith("* "):
+            errors += self.check_list_item(line)
+        elif not line:
+            # If we hit the end of this release note block block, check the prior line.
+            errors += self.check_previous_period()
+            self.prior_line = ''
+        elif self.prior_line:
+            self.prior_line += line
+        return errors
+
+    def check_list_item(self, line: str) -> list:
+        errors = []
+        if not self.prior_endswith_period:
+            errors.append(f"The following release note does not end with a '.'\n {self.prior_line}")
+
+        match = VERSION_HISTORY_NEW_LINE_REGEX.match(line)
+        if not match:
+            return errors + [
+                "Version history line malformed. "
+                f"Does not match VERSION_HISTORY_NEW_LINE_REGEX in docs_check.py\n {line}\n"
+                "Please use messages in the form 'category: feature explanation.', "
+                "starting with a lower-cased letter and ending with a period."
+            ]
+        first_word = match.groups()[0]
+        next_word = match.groups()[1]
+
+        # Do basic alphabetization checks of the first word on the line and the
+        # first word after the :
+        if self.first_word_of_prior_line and self.first_word_of_prior_line > first_word:
+            errors.append(
+                f"Version history not in alphabetical order "
+                f"({self.first_word_of_prior_line} vs {first_word}): "
+                f"please check placement of line\n {line}. ")
+        if self.first_word_of_prior_line == first_word and self.next_word_to_check and self.next_word_to_check > next_word:
+            errors.append(
+                f"Version history not in alphabetical order "
+                f"({self.next_word_to_check} vs {next_word}): "
+                f"please check placement of line\n {line}. ")
+        self.set_tokens(line, first_word, next_word)
+        return errors
+
+    def check_previous_period(self) -> list:
+        return ([f"The following release note does not end with a '.'\n {self.prior_line}"]
+                if not self.prior_endswith_period else [])
+
+    def check_reflink(self, line: str) -> list:
+        # TODO(phlax): Check reflinks for all rst files
+        return ([f"Found text \" ref:\". This should probably be \" :ref:\"\n{line}"]
+                if INVALID_REFLINK.match(line) else [])
+
+    def run_checks(self) -> Iterator[str]:
+        self.set_tokens()
+        for line_number, line in enumerate(self.lines):
+            if VERSION_HISTORY_SECTION_NAME.match(line):
+                if line == "Deprecated":
+                    break
+                self.set_tokens()
+            for error in self.check_line(line):
+                yield f"({self.path}:{line_number + 1}) {error}"
+
+    def set_tokens(self, line: str = "", first_word: str = "", next_word: str = "") -> None:
+        self.prior_line = line
+        self.first_word_of_prior_line = first_word
+        self.next_word_to_check = next_word
+
+
+class RSTChecker(checker.Checker):
+    checks = ("current_version",)
+
+    def check_current_version(self):
+        errors = list(CurrentVersionFile("docs/root/version_history/current.rst").run_checks())
+        if errors:
+            self.error("current_version", errors)
+
+
+def main(*args) -> int:
+    return RSTChecker(*args).run()
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/tools/docs/tests/test_rst_check.py
+++ b/tools/docs/tests/test_rst_check.py
@@ -1,0 +1,373 @@
+
+import types
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from tools.docs import rst_check
+
+
+def test_rst_check_current_version_constructor():
+    version_file = rst_check.CurrentVersionFile("PATH")
+    assert version_file._path == "PATH"
+    assert version_file.path == "PATH"
+
+
+def test_rst_check_current_version_lines(patches):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        "open",
+        ("CurrentVersionFile.path", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.rst_check")
+
+    expected = [MagicMock(), MagicMock()]
+    with patched as (m_open, m_path):
+        m_open.return_value.__enter__.return_value.readlines.return_value = expected
+        _lines = version_file.lines
+        assert isinstance(_lines, types.GeneratorType)
+        lines = list(_lines)
+
+    assert (
+        list(m_open.call_args)
+        == [(m_path.return_value,), {}])
+    assert lines == [expected[0].strip.return_value, expected[1].strip.return_value]
+
+
+@pytest.mark.parametrize(
+    "prior", [
+        [".", True],
+        ["asdf .", True],
+        ["asdf.", True],
+        ["asdf", False],
+        ["asdf,", False],
+        ["", True],
+        ["foo. <asdf>`", True],
+        ["foo. <asdf>` xxx", False],
+        ["foo <asdf>`", False]])
+def test_rst_check_current_version_prior_ends_with_period(prior):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    version_file.prior_line, expected = prior
+    assert version_file.prior_endswith_period == expected
+
+
+@pytest.mark.parametrize("matches", [True, False, "partial"])
+def test_rst_check_current_version_check_flags(patches, matches):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        "RELOADABLE_FLAG_REGEX",
+        prefix="tools.docs.rst_check")
+
+    with patched as (m_flag, ):
+        if matches == "partial":
+            m_flag.match.return_value.groups.return_value.__getitem__.return_value.startswith.return_value = False
+        elif not matches:
+            m_flag.match.return_value = False
+        result = version_file.check_flags("LINE")
+
+    assert (
+        list(m_flag.match.call_args)
+        == [('LINE',), {}])
+
+    if matches:
+        assert (
+            list(m_flag.match.return_value.groups.call_args)
+            == [(), {}])
+        assert (
+            list(m_flag.match.return_value.groups.return_value.__getitem__.return_value.startswith.call_args)
+            == [(' ``',), {}])
+        if matches == "partial":
+            assert (
+                result
+                == [f"Flag {m_flag.match.return_value.groups.return_value.__getitem__.return_value} should be enclosed in double back ticks"])
+            assert (
+                list(list(c) for c in m_flag.match.return_value.groups.return_value.__getitem__.call_args_list)
+                == [[(0,), {}], [(1,), {}]])
+        else:
+            assert (
+                list(list(c) for c in m_flag.match.return_value.groups.return_value.__getitem__.call_args_list)
+                == [[(0,), {}]])
+            assert result == []
+    else:
+        assert result == []
+
+
+@pytest.mark.parametrize("line", ["", " ", "* ", "*asdf"])
+@pytest.mark.parametrize("prior_period", [True, False])
+@pytest.mark.parametrize("prior_line", ["", "line_content"])
+def test_rst_check_current_version_check_line(patches, line, prior_period, prior_line):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        "CurrentVersionFile.check_reflink",
+        "CurrentVersionFile.check_flags",
+        "CurrentVersionFile.check_list_item",
+        "CurrentVersionFile.check_previous_period",
+        prefix="tools.docs.rst_check")
+    version_file.prior_line = prior_line
+
+    with patched as (m_ref, m_flags, m_item, m_period):
+        result = version_file.check_line(line)
+
+    expected = m_ref.return_value.__add__.return_value
+    assert (
+        list(m_ref.call_args)
+        == [(line,), {}])
+    assert (
+        list(m_flags.call_args)
+        == [(line,), {}])
+    assert (
+        list(m_ref.return_value.__add__.call_args)
+        == [(m_flags.return_value,), {}])
+
+    if line.startswith("* "):
+        assert (
+            list(expected.__iadd__.call_args)
+            == [(m_item.return_value,), {}])
+        assert (
+            list(m_item.call_args)
+            == [(line,), {}])
+        assert not m_period.called
+        assert result == expected.__iadd__.return_value
+        assert version_file.prior_line == prior_line
+    elif not line:
+        assert (
+            list(expected.__iadd__.call_args)
+            == [(m_period.return_value,), {}])
+        assert (
+            list(m_period.call_args)
+            == [(), {}])
+        assert result == expected.__iadd__.return_value
+        assert not m_item.called
+        assert version_file.prior_line == ""
+    elif prior_line:
+        assert not m_period.called
+        assert not m_item.called
+        assert version_file.prior_line == prior_line + line
+        assert result == expected
+    else:
+        assert not m_period.called
+        assert not m_item.called
+        assert version_file.prior_line == prior_line
+        assert result == expected
+
+
+@pytest.mark.parametrize("prior", [True, False])
+@pytest.mark.parametrize("matches", [True, False])
+@pytest.mark.parametrize("prior_first", ["", "AAA", "BBB", "CCC"])
+@pytest.mark.parametrize("prior_next", ["", "AAA", "BBB", "CCC"])
+@pytest.mark.parametrize("first_word", ["AAA", "BBB", "CCC"])
+@pytest.mark.parametrize("next_word", ["AAA", "BBB", "CCC"])
+def test_rst_check_current_version_check_list_item(patches, matches, prior, prior_first, prior_next, first_word, next_word):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        "VERSION_HISTORY_NEW_LINE_REGEX",
+        "CurrentVersionFile.set_tokens",
+        ("CurrentVersionFile.prior_endswith_period", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.rst_check")
+    version_file.prior_line = "PRIOR LINE"
+    version_file.first_word_of_prior_line = prior_first
+    version_file.next_word_to_check = prior_next
+
+    def _get_item(item):
+        if item == 0:
+            return first_word
+        return next_word
+
+    with patched as (m_regex, m_tokens, m_prior):
+        if not matches:
+            m_regex.match.return_value = False
+        else:
+            m_regex.match.return_value.groups.return_value.__getitem__.side_effect = _get_item
+        m_prior.return_value = prior
+        result = version_file.check_list_item("LINE")
+
+    expected = []
+    if not prior:
+        expected += ["The following release note does not end with a '.'\n PRIOR LINE"]
+
+    assert (
+        list(m_regex.match.call_args)
+        == [('LINE',), {}])
+
+    if not matches:
+        expected += [
+            f"Version history line malformed. "
+            f"Does not match VERSION_HISTORY_NEW_LINE_REGEX in docs_check.py\n LINE\n"
+            "Please use messages in the form 'category: feature explanation.', "
+            "starting with a lower-cased letter and ending with a period."]
+        assert result == expected
+        assert not m_tokens.called
+        return
+
+    assert (
+        list(list(c) for c in m_regex.match.return_value.groups.call_args_list)
+        == [[(), {}], [(), {}]])
+
+    if prior_first and prior_first > first_word:
+        expected += [f'Version history not in alphabetical order ({prior_first} vs {first_word}): please check placement of line\n LINE. ']
+
+    if prior_first == first_word and prior_next > next_word:
+        expected += [f'Version history not in alphabetical order ({prior_next} vs {next_word}): please check placement of line\n LINE. ']
+
+    assert result == expected
+    assert (
+        list(m_tokens.call_args)
+        == [('LINE', first_word, next_word), {}])
+
+
+@pytest.mark.parametrize("prior", [True, False])
+def test_rst_check_current_version_check_previous_period(patches, prior):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        ("CurrentVersionFile.prior_endswith_period", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.rst_check")
+
+    version_file.prior_line = "PRIOR"
+
+    with patched as (m_period, ):
+        m_period.return_value = prior
+        result = version_file.check_previous_period()
+    if prior:
+        assert result == []
+    else:
+        assert result == ["The following release note does not end with a '.'\n PRIOR"]
+
+
+@pytest.mark.parametrize("matches", [True, False])
+def test_rst_check_current_version_check_reflink(patches, matches):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        "INVALID_REFLINK",
+        prefix="tools.docs.rst_check")
+
+    with patched as (m_reflink, ):
+        m_reflink.match.return_value = matches
+        result = version_file.check_reflink("LINE")
+
+    assert (
+        list(m_reflink.match.call_args)
+        == [('LINE',), {}])
+
+    if matches:
+        assert (
+            result
+            == ['Found text " ref:". This should probably be " :ref:"\nLINE'])
+    else:
+        assert result == []
+
+
+@pytest.mark.parametrize(
+    "lines",
+    [[],
+     [[0, "AAA"], [1, "BBB"]],
+     [[0, "AAA"], [1, "BBB"], [2, "CCC"]],
+     [[0, "AAA"], [1, "Deprecated"], [2, "BBB"], [3, "CCC"]]])
+@pytest.mark.parametrize("errors", [[], ["err1", "err2"]])
+@pytest.mark.parametrize("matches", [True, False])
+def test_rst_check_current_version_run_checks(patches, lines, errors, matches):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    patched = patches(
+        "enumerate",
+        "VERSION_HISTORY_SECTION_NAME",
+        "CurrentVersionFile.set_tokens",
+        "CurrentVersionFile.check_line",
+        ("CurrentVersionFile.lines", dict(new_callable=PropertyMock)),
+        prefix="tools.docs.rst_check")
+
+    with patched as (m_enum, m_section, m_tokens, m_check, m_lines):
+        m_enum.return_value = lines
+        m_check.return_value = errors
+        m_section.match.return_value = matches
+        _result = version_file.run_checks()
+        assert isinstance(_result, types.GeneratorType)
+        result = list(_result)
+
+    assert (
+        list(m_enum.call_args)
+        == [(m_lines.return_value,), {}])
+
+    if not lines:
+        assert result == []
+        assert not m_section.match.called
+        assert not m_check.called
+        assert (
+            list(list(c) for c in m_tokens.call_args_list)
+            == [[(), {}]])
+        return
+
+    _match = []
+    _tokens = 1
+    _checks = []
+    _errors = []
+
+    for line_number, line in lines:
+        _match.append(line)
+        if matches:
+            if line == "Deprecated":
+                break
+            _tokens += 1
+        _checks.append(line)
+        for error in errors:
+            _errors.append((line_number, error))
+    assert (
+        list(list(c) for c in m_section.match.call_args_list)
+        == [[(line,), {}] for line in _match])
+    assert (
+        list(list(c) for c in m_tokens.call_args_list)
+        == [[(), {}]] * _tokens)
+    assert (
+        list(list(c) for c in m_check.call_args_list)
+        == [[(line,), {}] for line in _checks])
+    assert (
+        result
+        == [f"(PATH:{line_number + 1}) {error}"
+            for line_number, error in _errors])
+
+
+@pytest.mark.parametrize("line", [None, "", "foo"])
+@pytest.mark.parametrize("first_word", [None, "", "foo"])
+@pytest.mark.parametrize("next_word", [None, "", "foo"])
+def test_rst_check_current_version_set_tokens(patches, line, first_word, next_word):
+    version_file = rst_check.CurrentVersionFile("PATH")
+    version_file.set_tokens(line, first_word, next_word)
+    assert version_file.first_word_of_prior_line == first_word
+    assert version_file.next_word_to_check == next_word
+
+
+def test_rst_checker_constructor():
+    checker = rst_check.RSTChecker("path1", "path2", "path3")
+    assert checker.checks == ("current_version", )
+    assert checker.args.paths == ['path1', 'path2', 'path3']
+
+
+@pytest.mark.parametrize("errors", [[], ["err1", "err2"]])
+def test_rst_checker_check_current_version(patches, errors):
+    checker = rst_check.RSTChecker("path1", "path2", "path3")
+
+    patched = patches(
+        "CurrentVersionFile",
+        "RSTChecker.error",
+        prefix="tools.docs.rst_check")
+
+    with patched as (m_version, m_error):
+        m_version.return_value.run_checks.return_value = errors
+        checker.check_current_version()
+
+    assert (
+        list(m_version.call_args)
+        == [('docs/root/version_history/current.rst',), {}])
+    assert (
+        list(m_version.return_value.run_checks.call_args)
+        == [(), {}])
+
+    if not errors:
+        assert not m_error.called
+    else:
+        assert (
+            list(m_error.call_args)
+            == [('current_version', ['err1', 'err2']), {}])
+
+
+def test_rst_checker_main(command_main):
+    command_main(
+        rst_check.main,
+        "tools.docs.rst_check.RSTChecker")


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Separate docs version history check
Additional Description:

Currently the code_format checker is run against lots of rst and markdown files but doesnt afaict do anything with them - with the exception of the current version_history file

this pr separates out the checks for the current version history file and adds some small optimization to file path filtering in the code_format tool

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
