### PR TITLE
[1.18] Windows ci add bazel args (#16643)

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -23,9 +23,6 @@ powershell Invoke-WebRequest https://github.com/bazelbuild/bazelisk/releases/lat
 set PATH=%PATH%;%USERPROFILE%\bazel
 ```
 
-If you're building from an revision of Envoy prior to August 2019, which doesn't contains a `.bazelversion` file, run `ci/run_envoy_docker.sh "bazel version"`
-to find the right version of Bazel and set the version to `USE_BAZEL_VERSION` environment variable to build.
-
 ## Production environments
 
 To build Envoy with Bazel in a production environment, where the [Envoy
@@ -156,9 +153,9 @@ for how to update or override dependencies.
     and Bazel rules which follow POSIX python conventions. Add `pip.exe` to the PATH and install the `wheel`
     package.
     ```cmd
-    mklink %USERPROFILE%\Python38\python3.exe %USERPROFILE%\Python38\python.exe
-    set PATH=%PATH%;%USERPROFILE%\Python38
-    set PATH=%PATH%;%USERPROFILE%\Python38\Scripts
+    mklink %USERPROFILE%\Python39\python3.exe %USERPROFILE%\Python39\python.exe
+    set PATH=%PATH%;%USERPROFILE%\Python39
+    set PATH=%PATH%;%USERPROFILE%\Python39\Scripts
     pip install wheel
     ```
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -34,7 +34,7 @@ Currently there are three build images for Linux and one for Windows:
 * `envoyproxy/envoy-build` &mdash; alias to `envoyproxy/envoy-build-ubuntu`.
 * `envoyproxy/envoy-build-ubuntu` &mdash; based on Ubuntu 18.04 (Bionic) with GCC 9 and Clang 10 compiler.
 * `envoyproxy/envoy-build-centos` &mdash; based on CentOS 7 with GCC 9 and Clang 10 compiler, this image is experimental and not well tested.
-* `envoyproxy/envoy-build-windows2019` &mdash; based on Windows 2019 LTS with VS 2019 Build Tools.
+* `envoyproxy/envoy-build-windows2019` &mdash; based on Windows ltsc2019 with VS 2019 Build Tools, as well as LLVM.
 
 The source for these images is located in the [envoyproxy/envoy-build-tools](https://github.com/envoyproxy/envoy-build-tools)
 repository.
@@ -148,15 +148,15 @@ An example basic invocation to build the Envoy static binary and run tests is:
 ./ci/run_envoy_docker.sh './ci/windows_ci_steps.sh'
 ```
 
-You can modify `./ci/windows_ci_steps.sh` to modify `bazel` arguments, tests to run, etc. as well
+You can pass additional command line arguments to `./ci/windows_ci_steps.sh` to list specific `bazel` arguments and build/test targets.
 as set environment variables to adjust your container build environment as described above.
 
-The Envoy binary can be found in `C:\Windows\Temp\envoy-docker-build\envoy\source\exe` on the Docker host. You
+The Envoy binary can be found in `${TEMP}\envoy-docker-build\envoy\source\exe` on the Docker host. You
 can control this by setting `ENVOY_DOCKER_BUILD_DIR` in the environment, e.g. to
 generate the binary in `C:\Users\foo\build\envoy\source\exe` you can run:
 
 ```bash
-ENVOY_DOCKER_BUILD_DIR="C:\Users\foo\build" ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.dev'
+ENVOY_DOCKER_BUILD_DIR="C:\Users\foo\build" ./ci/run_envoy_docker.sh './ci/windows_ci_steps.sh'
 ```
 
 Note the quotations around the `ENVOY_DOCKER_BUILD_DIR` value to preserve the backslashes in the
@@ -168,7 +168,9 @@ If you would like to run an interactive session to keep the build container runn
 ./ci/run_envoy_docker.sh 'bash'
 ```
 
-From an interactive session, you can invoke `bazel` manually or use the `./ci/windows_ci_steps.sh` script to build and run tests.
+From an interactive session, you can invoke `bazel` directly, or use the `./ci/windows_ci_steps.sh` script to build and run tests.
+Bazel will look for .bazelrc in the `${HOME}` path, which is mapped to the persistent path `${TEMP}\envoy-docker-build\` on the
+Docker host.
 
 # Testing changes to the build image as a developer
 

--- a/test/extensions/http/header_formatters/preserve_case/BUILD
+++ b/test/extensions/http/header_formatters/preserve_case/BUILD
@@ -28,6 +28,8 @@ envoy_extension_cc_test(
         "preserve_case_formatter_integration_test.cc",
     ],
     extension_name = "envoy.http.stateful_header_formatters.preserve_case",
+    # Broken until bazel 5.0.0 fix to shorten resulting paths for SymInitialize() failure
+    tags = ["skip_on_windows"],
     deps = [
         "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
         "//test/integration:http_integration_lib",

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/BUILD
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/BUILD
@@ -42,6 +42,8 @@ envoy_extension_cc_test(
         "//test/extensions/transport_sockets/tls/test_data:certs",
     ],
     extension_name = "envoy.tls.cert_validator.spiffe",
+    # Broken until bazel 5.0.0 fix to shorten resulting paths for SymInitialize() failure
+    tags = ["skip_on_windows"],
     deps = [
         "//source/extensions/transport_sockets/tls/cert_validator/spiffe:config",
         "//test/integration:http_integration_lib",


### PR DESCRIPTION
This is a port of https://github.com/envoyproxy/envoy/pull/16643

* Windows: Expand functionality of ci/windows_ci_steps.sh

- Watch for //source/exe:envoy-static or empty args to trigger the build
- Treat arbitrary args as bazel test directives

This allows forms such as;

  ci/windows_ci_steps.sh //source/exe:envoy-static   - build the binary, nothing else
  ci/windows_ci_steps.sh //test/...                  - test everything with exceptions and flake processing

The default (no args) does both of the above, and checks unused deps under bazel/... that are not skip_on_windows

  ci/windows_ci_steps.sh //test/common/...           - test everything with no exceptions below common
  ci/windows_ci_steps.sh //test/common/... --test_tag_filters=-skip_on_windows
- same as above, avoiding broken components under common

* Update bazel/README.md

- If building an 18 month old envoy, an 18 month old copy of this document
  is present in that source tarball
- Offer a more recognizable symlink/path advisory based on current Python release

* Clarify windows_build_steps.sh and windows docker invocation

* Skip three longest windows test names for the month

- Bazel before 5.0.0 fails to shorten executable path names of a specific length.
- SymInitialize() fails to load the executable paths of a specific length
- abesil tries to prepare for crash analysis and silently continue on failure
- grps tries and abruptly aborts the program if symbols cannot be loaded

Fix is in for the next bazel rolling release of the 5.0.0 series

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>
Signed-off-by: Dmitri Dolguikh <ddolguik@redhat.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
