### PR TITLE
bazel/README.md: add aspell comment

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -874,7 +874,7 @@ to run clang-format scripts on your workstation directly:
 
 To run the tools directly, you must install the correct version of clang. This
 may change over time, check the version of clang in the docker image. You must
-also have 'buildifier' installed from the bazel distribution.
+also have 'buildifier' installed from the bazel distribution and `aspell`.
 
 Edit the paths shown here to reflect the installation locations on your system:
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -863,7 +863,7 @@ TEST_TMPDIR=/tmp tools/gen_compilation_database.py
 ```
 
 
-# Running format without docker
+# Running format linting without docker
 
 The easiest way to run the clang-format check/fix commands is to run them via
 docker, which helps ensure the right toolchain is set up. However you may prefer
@@ -876,7 +876,7 @@ To run the tools directly, you must install the correct version of clang. This
 may change over time, check the version of clang in the docker image. You must
 also have 'buildifier' installed from the bazel distribution.
 
-Note that if you run `check_spelling.py` script, it requires `aspell` command.
+Note that if you run the `check_spelling.py` script you will need to have `aspell` installed.
 
 Edit the paths shown here to reflect the installation locations on your system:
 

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -863,7 +863,7 @@ TEST_TMPDIR=/tmp tools/gen_compilation_database.py
 ```
 
 
-# Running clang-format without docker
+# Running format without docker
 
 The easiest way to run the clang-format check/fix commands is to run them via
 docker, which helps ensure the right toolchain is set up. However you may prefer
@@ -874,7 +874,9 @@ to run clang-format scripts on your workstation directly:
 
 To run the tools directly, you must install the correct version of clang. This
 may change over time, check the version of clang in the docker image. You must
-also have 'buildifier' installed from the bazel distribution and `aspell`.
+also have 'buildifier' installed from the bazel distribution.
+
+Note that if you run `check_spelling.py` script, it requires `aspell` command.
 
 Edit the paths shown here to reflect the installation locations on your system:
 


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

Add `aspell` comment.

To fix below error:
```
root:[envoy]$ ./tools/spelling/check_spelling_pedantic.py fix
Traceback (most recent call last):
  File "./tools/spelling/check_spelling_pedantic.py", line 835, in <module>
    rv = execute(target_paths, args.dictionary, args.operation_type == 'fix')
  File "./tools/spelling/check_spelling_pedantic.py", line 735, in execute
    checker.start()
  File "./tools/spelling/check_spelling_pedantic.py", line 184, in start
    universal_newlines=True)
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'aspell': 'aspell'
```

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
