### PR TITLE
bazel: Use color by default for build and run commands

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,7 @@
 # Startup options cannot be selected via config.
 startup --host_jvm_args=-Xmx2g
 
+build --color=yes
 build --workspace_status_command="bash bazel/get_workspace_status"
 build --experimental_strict_action_env=true
 build --host_force_python=PY3

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,8 @@
 # Startup options cannot be selected via config.
 startup --host_jvm_args=-Xmx2g
 
+run --color=yes
+
 build --color=yes
 build --workspace_status_command="bash bazel/get_workspace_status"
 build --experimental_strict_action_env=true

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -29,7 +29,6 @@ fi
 # This is for local RBE setup, should be no-op for builds without RBE setting in bazelrc files.
 IFS=" " read -ra BAZEL_BUILD_OPTIONS <<< "${BAZEL_BUILD_OPTIONS:-}"
 BAZEL_BUILD_OPTIONS+=(
-    "--color=yes"
     "--remote_download_outputs=all"
     "--strategy=protodoc=sandboxed,local"
     "--action_env=DOCS_TAG"


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: bazel: Use color by default for build commands
Additional Description:

this can really improve ux for grokking logs

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
