### PR TITLE
doc: fix misplaced #[extension-category] for Wasm runtimes

### DIFF
--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -86,7 +86,6 @@ message VmConfig {
   // (proxy_on_start). `google.protobuf.Struct` is serialized as JSON before
   // passing it to the plugin. `google.protobuf.BytesValue` and
   // `google.protobuf.StringValue` are passed directly without the wrapper.
-  // [#extension-category: envoy.wasm.runtime]
   google.protobuf.Any configuration = 4;
 
   // Allow the wasm file to include pre-compiled code on VMs which support it.

--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -52,7 +52,6 @@ message VmConfig {
   // The Wasm runtime type.
   // Available Wasm runtime types are registered as extensions. The following runtimes are included
   // in Envoy code base:
-  // [#extension-category: envoy.wasm.runtime]
   //
   // .. _extension_envoy.wasm.runtime.null:
   //
@@ -78,6 +77,7 @@ message VmConfig {
   // **envoy.wasm.runtime.wasmtime**: `Wasmtime <https://wasmtime.dev/>`_-based WebAssembly runtime.
   // This runtime is not enabled in the official build.
   //
+  // [#extension-category: envoy.wasm.runtime]
   string runtime = 2 [(validate.rules).string = {min_len: 1}];
 
   // The Wasm code that Envoy will execute.

--- a/api/envoy/extensions/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/wasm/v3/wasm.proto
@@ -52,6 +52,7 @@ message VmConfig {
   // The Wasm runtime type.
   // Available Wasm runtime types are registered as extensions. The following runtimes are included
   // in Envoy code base:
+  // [#extension-category: envoy.wasm.runtime]
   //
   // .. _extension_envoy.wasm.runtime.null:
   //

--- a/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
@@ -86,7 +86,6 @@ message VmConfig {
   // (proxy_on_start). `google.protobuf.Struct` is serialized as JSON before
   // passing it to the plugin. `google.protobuf.BytesValue` and
   // `google.protobuf.StringValue` are passed directly without the wrapper.
-  // [#extension-category: envoy.wasm.runtime]
   google.protobuf.Any configuration = 4;
 
   // Allow the wasm file to include pre-compiled code on VMs which support it.

--- a/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
@@ -52,7 +52,6 @@ message VmConfig {
   // The Wasm runtime type.
   // Available Wasm runtime types are registered as extensions. The following runtimes are included
   // in Envoy code base:
-  // [#extension-category: envoy.wasm.runtime]
   //
   // .. _extension_envoy.wasm.runtime.null:
   //
@@ -78,6 +77,7 @@ message VmConfig {
   // **envoy.wasm.runtime.wasmtime**: `Wasmtime <https://wasmtime.dev/>`_-based WebAssembly runtime.
   // This runtime is not enabled in the official build.
   //
+  // [#extension-category: envoy.wasm.runtime]
   string runtime = 2 [(validate.rules).string = {min_len: 1}];
 
   // The Wasm code that Envoy will execute.

--- a/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/wasm/v3/wasm.proto
@@ -52,6 +52,7 @@ message VmConfig {
   // The Wasm runtime type.
   // Available Wasm runtime types are registered as extensions. The following runtimes are included
   // in Envoy code base:
+  // [#extension-category: envoy.wasm.runtime]
   //
   // .. _extension_envoy.wasm.runtime.null:
   //


### PR DESCRIPTION
`[#extension-category: envoy.wasm.runtime]` was misplaced on `configuration` field, so this PR puts in the right place (`runtime` field).

![スクリーンショット 2021-06-22 22 18 26](https://user-images.githubusercontent.com/13513977/122931363-c8651900-d3a7-11eb-9f6a-fa9cdc93e646.png)
