### PR TITLE
ci: Fix wasm verify example

### DIFF
--- a/ci/verify_examples.sh
+++ b/ci/verify_examples.sh
@@ -30,7 +30,10 @@ run_examples () {
     local examples example
     cd "${SRCDIR}/examples" || exit 1
 
-    examples=$(find . -mindepth 1 -maxdepth 1 -type d -name "$TESTFILTER" ! -iname "_*" | grep -Ev "$TESTEXCLUDES" | sort)
+    examples=$(find . -mindepth 1 -maxdepth 1 -type d -name "$TESTFILTER" ! -iname "_*" | sort)
+    if [[ -n "$TESTEXCLUDES" ]]; then
+        examples=$(echo "$examples" | grep -Ev "$TESTEXCLUDES")
+    fi
     for example in $examples; do
         pushd "$example" > /dev/null || return 1
         ./verify.sh


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Fix wasm verify example
Additional Description:

the wasm verify_example was broken in a previous iteration that changed the filters in `verify_examples.sh` - this fixes it

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
