### PR TITLE
Refactor WatermarkFactory::create to WatermarkFactory::createBuffer.

### DIFF
--- a/envoy/buffer/buffer.h
+++ b/envoy/buffer/buffer.h
@@ -480,6 +480,7 @@ private:
 using InstancePtr = std::unique_ptr<Instance>;
 
 /**
+ * A factory for creating buffers which call callbacks when reaching high and low watermarks.
  */
 class WatermarkFactory {
 public:

--- a/envoy/buffer/buffer.h
+++ b/envoy/buffer/buffer.h
@@ -480,7 +480,6 @@ private:
 using InstancePtr = std::unique_ptr<Instance>;
 
 /**
- * A factory for creating buffers which call callbacks when reaching high and low watermarks.
  */
 class WatermarkFactory {
 public:
@@ -494,9 +493,9 @@ public:
    *   high watermark.
    * @return a newly created InstancePtr.
    */
-  virtual InstancePtr create(std::function<void()> below_low_watermark,
-                             std::function<void()> above_high_watermark,
-                             std::function<void()> above_overflow_watermark) PURE;
+  virtual InstancePtr createBuffer(std::function<void()> below_low_watermark,
+                                   std::function<void()> above_high_watermark,
+                                   std::function<void()> above_overflow_watermark) PURE;
 };
 
 using WatermarkFactoryPtr = std::unique_ptr<WatermarkFactory>;

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -75,9 +75,9 @@ using WatermarkBufferPtr = std::unique_ptr<WatermarkBuffer>;
 class WatermarkBufferFactory : public WatermarkFactory {
 public:
   // Buffer::WatermarkFactory
-  InstancePtr create(std::function<void()> below_low_watermark,
-                     std::function<void()> above_high_watermark,
-                     std::function<void()> above_overflow_watermark) override {
+  InstancePtr createBuffer(std::function<void()> below_low_watermark,
+                           std::function<void()> above_high_watermark,
+                           std::function<void()> above_overflow_watermark) override {
     return std::make_unique<WatermarkBuffer>(below_low_watermark, above_high_watermark,
                                              above_overflow_watermark);
   }

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -298,7 +298,7 @@ bool ActiveStreamDecoderFilter::canContinue() {
 }
 
 Buffer::InstancePtr ActiveStreamDecoderFilter::createBuffer() {
-  auto buffer = dispatcher().getWatermarkFactory().create(
+  auto buffer = dispatcher().getWatermarkFactory().createBuffer(
       [this]() -> void { this->requestDataDrained(); },
       [this]() -> void { this->requestDataTooLarge(); },
       []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });
@@ -1459,7 +1459,7 @@ absl::optional<Router::ConfigConstSharedPtr> ActiveStreamDecoderFilter::routeCon
 }
 
 Buffer::InstancePtr ActiveStreamEncoderFilter::createBuffer() {
-  auto buffer = dispatcher().getWatermarkFactory().create(
+  auto buffer = dispatcher().getWatermarkFactory().createBuffer(
       [this]() -> void { this->responseDataDrained(); },
       [this]() -> void { this->responseDataTooLarge(); },
       []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -469,7 +469,7 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
           "envoy.reloadable_features.send_strict_1xx_and_204_response_headers")),
       dispatching_(false), no_chunked_encoding_header_for_304_(Runtime::runtimeFeatureEnabled(
                                "envoy.reloadable_features.no_chunked_encoding_header_for_304")),
-      output_buffer_(connection.dispatcher().getWatermarkFactory().create(
+      output_buffer_(connection.dispatcher().getWatermarkFactory().createBuffer(
           [&]() -> void { this->onBelowLowWatermark(); },
           [&]() -> void { this->onAboveHighWatermark(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -131,11 +131,11 @@ template <typename T> static T* removeConst(const void* object) {
 
 ConnectionImpl::StreamImpl::StreamImpl(ConnectionImpl& parent, uint32_t buffer_limit)
     : parent_(parent),
-      pending_recv_data_(parent_.connection_.dispatcher().getWatermarkFactory().create(
+      pending_recv_data_(parent_.connection_.dispatcher().getWatermarkFactory().createBuffer(
           [this]() -> void { this->pendingRecvBufferLowWatermark(); },
           [this]() -> void { this->pendingRecvBufferHighWatermark(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),
-      pending_send_data_(parent_.connection_.dispatcher().getWatermarkFactory().create(
+      pending_send_data_(parent_.connection_.dispatcher().getWatermarkFactory().createBuffer(
           [this]() -> void { this->pendingSendBufferLowWatermark(); },
           [this]() -> void { this->pendingSendBufferHighWatermark(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -69,11 +69,11 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
     : ConnectionImplBase(dispatcher, next_global_id_++),
       transport_socket_(std::move(transport_socket)), socket_(std::move(socket)),
       stream_info_(stream_info), filter_manager_(*this, *socket_),
-      write_buffer_(dispatcher.getWatermarkFactory().create(
+      write_buffer_(dispatcher.getWatermarkFactory().createBuffer(
           [this]() -> void { this->onWriteBufferLowWatermark(); },
           [this]() -> void { this->onWriteBufferHighWatermark(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),
-      read_buffer_(dispatcher.getWatermarkFactory().create(
+      read_buffer_(dispatcher.getWatermarkFactory().createBuffer(
           [this]() -> void { this->onReadBufferLowWatermark(); },
           [this]() -> void { this->onReadBufferHighWatermark(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -234,7 +234,7 @@ void UpstreamRequest::encodeData(Buffer::Instance& data, bool end_stream) {
   if (!upstream_ || paused_for_connect_) {
     ENVOY_STREAM_LOG(trace, "buffering {} bytes", *parent_.callbacks(), data.length());
     if (!buffered_request_body_) {
-      buffered_request_body_ = parent_.callbacks()->dispatcher().getWatermarkFactory().create(
+      buffered_request_body_ = parent_.callbacks()->dispatcher().getWatermarkFactory().createBuffer(
           [this]() -> void { this->enableDataFromDownstreamForFlowControl(); },
           [this]() -> void { this->disableDataFromDownstreamForFlowControl(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -200,7 +200,7 @@ protected:
     dispatcher_ = api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{factory});
     // The first call to create a client session will get a MockBuffer.
     // Other calls for server sessions will by default get a normal OwnedImpl.
-    EXPECT_CALL(*factory, create_(_, _, _))
+    EXPECT_CALL(*factory, createBuffer_(_, _, _))
         .Times(AnyNumber())
         .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
                              std::function<void()> above_overflow) -> Buffer::Instance* {
@@ -224,11 +224,11 @@ protected:
 
   ConnectionMocks createConnectionMocks(bool create_timer = true) {
     auto dispatcher = std::make_unique<NiceMock<Event::MockDispatcher>>();
-    EXPECT_CALL(dispatcher->buffer_factory_, create_(_, _, _))
+    EXPECT_CALL(dispatcher->buffer_factory_, createBuffer_(_, _, _))
         .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                   std::function<void()> above_overflow) -> Buffer::Instance* {
-          // ConnectionImpl calls Envoy::MockBufferFactory::create(), which calls create_() and
-          // wraps the returned raw pointer below with a unique_ptr.
+          // ConnectionImpl calls Envoy::MockBufferFactory::create(), which calls createBuffer_()
+          // and wraps the returned raw pointer below with a unique_ptr.
           return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
         }));
 
@@ -1621,7 +1621,7 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayConfigDisabledTest) {
 
   NiceMock<MockConnectionCallbacks> callbacks;
   NiceMock<Event::MockDispatcher> dispatcher;
-  EXPECT_CALL(dispatcher.buffer_factory_, create_(_, _, _))
+  EXPECT_CALL(dispatcher.buffer_factory_, createBuffer_(_, _, _))
       .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                 std::function<void()> above_overflow) -> Buffer::Instance* {
         return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
@@ -1984,7 +1984,7 @@ class MockTransportConnectionImplTest : public testing::Test {
 public:
   MockTransportConnectionImplTest() : stream_info_(dispatcher_.timeSource(), nullptr) {
     EXPECT_CALL(dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
-    EXPECT_CALL(dispatcher_.buffer_factory_, create_(_, _, _))
+    EXPECT_CALL(dispatcher_.buffer_factory_, createBuffer_(_, _, _))
         .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                   std::function<void()> above_overflow) -> Buffer::Instance* {
           return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);

--- a/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
@@ -176,7 +176,7 @@ public:
 };
 
 void StartTlsIntegrationTest::initialize() {
-  EXPECT_CALL(*mock_buffer_factory_, create_(_, _, _))
+  EXPECT_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
       // Connection constructor will first create write buffer.
       // Test tracks how many bytes are sent.
       .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -4879,7 +4879,7 @@ protected:
     dispatcher_ = api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{factory});
 
     // By default, expect 4 buffers to be created - the client and server read and write buffers.
-    EXPECT_CALL(*factory, create_(_, _, _))
+    EXPECT_CALL(*factory, createBuffer_(_, _, _))
         .Times(4)
         .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
                              std::function<void()> above_overflow) -> Buffer::Instance* {

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -60,7 +60,7 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
   // complex test hooks to the server and/or spin waiting on stats, neither of which I think are
   // necessary right now.
   timeSystem().realSleepDoNotUseWithoutScrutiny(std::chrono::milliseconds(10));
-  ON_CALL(*mock_buffer_factory_, create_(_, _, _))
+  ON_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
       .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                std::function<void()> above_overflow) -> Buffer::Instance* {
         return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);

--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -41,7 +41,7 @@ IntegrationTcpClient::IntegrationTcpClient(
     Network::Address::InstanceConstSharedPtr source_address)
     : payload_reader_(new WaitForPayloadReader(dispatcher)),
       callbacks_(new ConnectionCallbacks(*this)) {
-  EXPECT_CALL(factory, create_(_, _, _))
+  EXPECT_CALL(factory, createBuffer_(_, _, _))
       .Times(AtLeast(1))
       .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
                            std::function<void()> above_overflow) -> Buffer::Instance* {

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1180,7 +1180,7 @@ void TcpProxySslIntegrationTest::setupConnections() {
   // Set up the mock buffer factory so the newly created SSL client will have a mock write
   // buffer. This allows us to track the bytes actually written to the socket.
 
-  EXPECT_CALL(*mock_buffer_factory_, create_(_, _, _))
+  EXPECT_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
       .Times(AtLeast(1))
       .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
                            std::function<void()> above_overflow) -> Buffer::Instance* {

--- a/test/integration/tracked_watermark_buffer.cc
+++ b/test/integration/tracked_watermark_buffer.cc
@@ -14,9 +14,9 @@ TrackedWatermarkBufferFactory::~TrackedWatermarkBufferFactory() {
 }
 
 Buffer::InstancePtr
-TrackedWatermarkBufferFactory::create(std::function<void()> below_low_watermark,
-                                      std::function<void()> above_high_watermark,
-                                      std::function<void()> above_overflow_watermark) {
+TrackedWatermarkBufferFactory::createBuffer(std::function<void()> below_low_watermark,
+                                            std::function<void()> above_high_watermark,
+                                            std::function<void()> above_overflow_watermark) {
   absl::MutexLock lock(&mutex_);
   uint64_t idx = next_idx_++;
   ++active_buffer_count_;

--- a/test/integration/tracked_watermark_buffer.h
+++ b/test/integration/tracked_watermark_buffer.h
@@ -64,9 +64,9 @@ public:
   TrackedWatermarkBufferFactory() = default;
   ~TrackedWatermarkBufferFactory() override;
   // Buffer::WatermarkFactory
-  Buffer::InstancePtr create(std::function<void()> below_low_watermark,
-                             std::function<void()> above_high_watermark,
-                             std::function<void()> above_overflow_watermark) override;
+  Buffer::InstancePtr createBuffer(std::function<void()> below_low_watermark,
+                                   std::function<void()> above_high_watermark,
+                                   std::function<void()> above_overflow_watermark) override;
 
   // Number of buffers created.
   uint64_t numBuffersCreated() const;

--- a/test/integration/tracked_watermark_buffer_test.cc
+++ b/test/integration/tracked_watermark_buffer_test.cc
@@ -35,15 +35,16 @@ TEST_F(TrackedWatermarkBufferTest, WatermarkFunctions) {
   ReadyWatcher overflow_watermark;
   ReadyWatcher now;
 
-  auto buffer = factory_.create([&]() { low_watermark.ready(); }, [&]() { high_watermark.ready(); },
-                                [&]() { overflow_watermark.ready(); });
+  auto buffer =
+      factory_.createBuffer([&]() { low_watermark.ready(); }, [&]() { high_watermark.ready(); },
+                            [&]() { overflow_watermark.ready(); });
   // Test highWatermarkRange
   EXPECT_THAT(factory_.highWatermarkRange(), Pair(0, 0));
 
   buffer->setWatermarks(100);
   EXPECT_THAT(factory_.highWatermarkRange(), Pair(100, 100));
 
-  auto buffer2 = factory_.create([]() {}, []() {}, []() {});
+  auto buffer2 = factory_.createBuffer([]() {}, []() {}, []() {});
   EXPECT_THAT(factory_.highWatermarkRange(), Pair(100, 0));
 
   buffer2->setWatermarks(200);
@@ -64,9 +65,9 @@ TEST_F(TrackedWatermarkBufferTest, WatermarkFunctions) {
 }
 
 TEST_F(TrackedWatermarkBufferTest, BufferSizes) {
-  auto buffer = factory_.create([]() {}, []() {}, []() {});
+  auto buffer = factory_.createBuffer([]() {}, []() {}, []() {});
   buffer->setWatermarks(100);
-  auto buffer2 = factory_.create([]() {}, []() {}, []() {});
+  auto buffer2 = factory_.createBuffer([]() {}, []() {}, []() {});
   EXPECT_EQ(2, factory_.numBuffersCreated());
   EXPECT_EQ(2, factory_.numBuffersActive());
   // Add some bytes to the buffers, and verify max and sum(max).
@@ -109,9 +110,9 @@ TEST_F(TrackedWatermarkBufferTest, BufferSizes) {
 }
 
 TEST_F(TrackedWatermarkBufferTest, WaitUntilTotalBufferedExceeds) {
-  auto buffer1 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer2 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer3 = factory_.create([]() {}, []() {}, []() {});
+  auto buffer1 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer2 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer3 = factory_.createBuffer([]() {}, []() {}, []() {});
 
   auto thread1 = Thread::threadFactoryForTest().createThread([&]() { buffer1->add("a"); });
   auto thread2 = Thread::threadFactoryForTest().createThread([&]() { buffer2->add("b"); });
@@ -127,9 +128,9 @@ TEST_F(TrackedWatermarkBufferTest, WaitUntilTotalBufferedExceeds) {
 }
 
 TEST_F(TrackedWatermarkBufferTest, TracksNumberOfBuffersActivelyBound) {
-  auto buffer1 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer2 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer3 = factory_.create([]() {}, []() {}, []() {});
+  auto buffer1 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer2 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer3 = factory_.createBuffer([]() {}, []() {}, []() {});
   BufferMemoryAccountSharedPtr account = std::make_shared<BufferMemoryAccountImpl>();
   ASSERT_TRUE(factory_.waitUntilExpectedNumberOfAccountsAndBoundBuffers(0, 0));
 
@@ -152,9 +153,9 @@ TEST_F(TrackedWatermarkBufferTest, TracksNumberOfBuffersActivelyBound) {
 }
 
 TEST_F(TrackedWatermarkBufferTest, TracksNumberOfAccountsActive) {
-  auto buffer1 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer2 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer3 = factory_.create([]() {}, []() {}, []() {});
+  auto buffer1 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer2 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer3 = factory_.createBuffer([]() {}, []() {}, []() {});
   BufferMemoryAccountSharedPtr account1 = std::make_shared<BufferMemoryAccountImpl>();
   ASSERT_TRUE(factory_.waitUntilExpectedNumberOfAccountsAndBoundBuffers(0, 0));
 
@@ -179,8 +180,8 @@ TEST_F(TrackedWatermarkBufferTest, TracksNumberOfAccountsActive) {
 }
 
 TEST_F(TrackedWatermarkBufferTest, WaitForExpectedAccountBalanceShouldReturnTrueWhenConditionsMet) {
-  auto buffer1 = factory_.create([]() {}, []() {}, []() {});
-  auto buffer2 = factory_.create([]() {}, []() {}, []() {});
+  auto buffer1 = factory_.createBuffer([]() {}, []() {}, []() {});
+  auto buffer2 = factory_.createBuffer([]() {}, []() {}, []() {});
   BufferMemoryAccountSharedPtr account1 = std::make_shared<BufferMemoryAccountImpl>();
   BufferMemoryAccountSharedPtr account2 = std::make_shared<BufferMemoryAccountImpl>();
   buffer1->bindAccount(account1);

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "envoy/buffer/buffer.h"
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/buffer/watermark_buffer.h"
 #include "source/common/network/io_socket_error_impl.h"
@@ -74,14 +76,15 @@ public:
   MockBufferFactory();
   ~MockBufferFactory() override;
 
-  Buffer::InstancePtr create(std::function<void()> below_low, std::function<void()> above_high,
-                             std::function<void()> above_overflow) override {
-    auto buffer = Buffer::InstancePtr{create_(below_low, above_high, above_overflow)};
+  Buffer::InstancePtr createBuffer(std::function<void()> below_low,
+                                   std::function<void()> above_high,
+                                   std::function<void()> above_overflow) override {
+    auto buffer = Buffer::InstancePtr{createBuffer_(below_low, above_high, above_overflow)};
     ASSERT(buffer != nullptr);
     return buffer;
   }
 
-  MOCK_METHOD(Buffer::Instance*, create_,
+  MOCK_METHOD(Buffer::Instance*, createBuffer_,
               (std::function<void()> below_low, std::function<void()> above_high,
                std::function<void()> above_overflow));
 };

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -29,7 +29,7 @@ MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
       .WillByDefault(ReturnNew<NiceMock<Event::MockTimer>>());
   ON_CALL(*this, post(_)).WillByDefault(Invoke([](PostCb cb) -> void { cb(); }));
 
-  ON_CALL(buffer_factory_, create_(_, _, _))
+  ON_CALL(buffer_factory_, createBuffer_(_, _, _))
       .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
                                std::function<void()> above_overflow) -> Buffer::Instance* {
         return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);


### PR DESCRIPTION
Refactor WatermarkFactory::create to WatermarkFactory::createBuffer. we'll be creating BufferMemoryAccounts from the factories as well.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Refactor WatermarkFactory::create to WatermarkFactory::createBuffer.
Additional Description: See https://github.com/envoyproxy/envoy/pull/17093#discussion_r656632550
Risk Level: low 
Testing: Ran tests
Docs Changes: NA
Release Notes: NA
Platform Specific Features: NA
Related Issue #15791