### PR TITLE
test: Fix admission control integration test flakiness

### DIFF
--- a/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
@@ -30,7 +30,7 @@ typed_config:
   max_rejection_probability:
     default_value:
       value: 100.0
-      runtime_key: "foo.mrp"
+    runtime_key: "foo.mrp"
   enabled:
     default_value: true
     runtime_key: "foo.enabled"

--- a/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
@@ -124,7 +124,7 @@ TEST_P(AdmissionControlIntegrationTest, HttpTest) {
     ++request_count;
   }
 
-  // Given the current throttling rate formula with an aggression of 1.0, it should result in a ~98%
+  // Given the current throttling rate formula with an aggression of 2.0, it should result in a ~98%
   // throttling rate.
   EXPECT_NEAR(throttle_count / request_count, 0.98, ALLOWED_ERROR);
 
@@ -164,7 +164,7 @@ TEST_P(AdmissionControlIntegrationTest, GrpcTest) {
     ++request_count;
   }
 
-  // Given the current throttling rate formula with an aggression of 1.0, it should result in a ~98%
+  // Given the current throttling rate formula with an aggression of 2.0, it should result in a ~98%
   // throttling rate.
   EXPECT_NEAR(throttle_count / request_count, 0.98, ALLOWED_ERROR);
 

--- a/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
+++ b/test/extensions/filters/http/admission_control/admission_control_integration_test.cc
@@ -8,6 +8,9 @@
 namespace Envoy {
 namespace {
 
+// For how this value was chosen, see https://github.com/envoyproxy/envoy/issues/17067.
+constexpr double ALLOWED_ERROR = 0.10;
+
 const std::string ADMISSION_CONTROL_CONFIG =
     R"EOF(
 name: envoy.filters.http.admission_control
@@ -24,6 +27,10 @@ typed_config:
     default_value:
       value: 100.0
     runtime_key: "foo.sr_threshold"
+  max_rejection_probability:
+    default_value:
+      value: 100.0
+      runtime_key: "foo.mrp"
   enabled:
     default_value: true
     runtime_key: "foo.enabled"
@@ -117,9 +124,9 @@ TEST_P(AdmissionControlIntegrationTest, HttpTest) {
     ++request_count;
   }
 
-  // Given the current throttling rate formula with an aggression of 1, it should result in a ~80%
-  // throttling rate (default max_rejection_probability). Allowing an error of 10%.
-  EXPECT_NEAR(throttle_count / request_count, 0.80, 0.10);
+  // Given the current throttling rate formula with an aggression of 1.0, it should result in a ~98%
+  // throttling rate.
+  EXPECT_NEAR(throttle_count / request_count, 0.98, ALLOWED_ERROR);
 
   // We now wait for the history to become stale.
   timeSystem().advanceTimeWait(std::chrono::seconds(120));
@@ -157,9 +164,9 @@ TEST_P(AdmissionControlIntegrationTest, GrpcTest) {
     ++request_count;
   }
 
-  // Given the current throttling rate formula with an aggression of 1, it should result in a ~80%
-  // throttling rate (default max_rejection_probability). Allowing an error of 10%.
-  EXPECT_NEAR(throttle_count / request_count, 0.80, 0.10);
+  // Given the current throttling rate formula with an aggression of 1.0, it should result in a ~98%
+  // throttling rate.
+  EXPECT_NEAR(throttle_count / request_count, 0.98, ALLOWED_ERROR);
 
   // We now wait for the history to become stale.
   timeSystem().advanceTimeWait(std::chrono::seconds(120));


### PR DESCRIPTION
## Fix admission control integration test flakiness
Merging #16742 added the default upper-bound of 80% on rejection probability, which results in a slower convergence of the observed rejection rate to what we expect. I hacked up a script to see the variability of the error for 300 requests across 1000 tests:
![image](https://user-images.githubusercontent.com/1109246/123178323-d06e9880-d43b-11eb-9812-a3f90a67923b.png)

As the upper-bound drops, the variance in observed errors increases. I expect there to have been around ~20% flakiness in those tests since the patch was merged. Increasing the allowed error to 10% as you did in #17084 would still probably yield some flakiness...

I think the best option here is to just increase the rejection upper-bound to 100% in the test and leave the allowed absolute error at 10% to put this thing to rest.

_This is a test-only change, so foregoing most of the template._
Fixes #17067