### PR TITLE
Renamed TransportSocketOptionsSharedPtr to TransportSocketOptionsConstSharedPtr

### DIFF
--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -218,8 +218,7 @@ public:
                        const Network::TransportSocketFactory& factory) const PURE;
 };
 
-// TODO(mattklein123): Rename to TransportSocketOptionsConstSharedPtr in a dedicated follow up.
-using TransportSocketOptionsSharedPtr = std::shared_ptr<const TransportSocketOptions>;
+using TransportSocketOptionsConstSharedPtr = std::shared_ptr<const TransportSocketOptions>;
 
 /**
  * A factory for creating transport socket. It will be associated to filter chains and clusters.
@@ -238,7 +237,7 @@ public:
    * @return Network::TransportSocketPtr a transport socket to be passed to connection.
    */
   virtual TransportSocketPtr
-  createTransportSocket(TransportSocketOptionsSharedPtr options) const PURE;
+  createTransportSocket(TransportSocketOptionsConstSharedPtr options) const PURE;
 
   /**
    * @return bool whether the transport socket will use proxy protocol options.

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -363,7 +363,7 @@ public:
                    const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
                        alternate_protocol_options,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                   const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                    TimeSource& time_source, ClusterConnectivityState& state) PURE;
 
   /**
@@ -374,7 +374,7 @@ public:
   allocateTcpConnPool(Event::Dispatcher& dispatcher, HostConstSharedPtr host,
                       ResourcePriority priority,
                       const Network::ConnectionSocket::OptionsSharedPtr& options,
-                      Network::TransportSocketOptionsSharedPtr transport_socket_options,
+                      Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                       ClusterConnectivityState& state) PURE;
 
   /**

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -82,7 +82,7 @@ public:
   /**
    * Returns the transport socket options which should be applied on upstream connections
    */
-  virtual Network::TransportSocketOptionsSharedPtr upstreamTransportSocketOptions() const PURE;
+  virtual Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const PURE;
 };
 
 /**

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -92,10 +92,9 @@ public:
    *         will be returned along with the connection vs. the host the method was called on.
    *         If it matters, callers should not assume that the returned host will be the same.
    */
-  virtual CreateConnectionData
-  createConnection(Event::Dispatcher& dispatcher,
-                   const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   Network::TransportSocketOptionsSharedPtr transport_socket_options) const PURE;
+  virtual CreateConnectionData createConnection(
+      Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const PURE;
 
   /**
    * Create a health check connection for this host.
@@ -104,10 +103,10 @@ public:
    * connection.
    * @return the connection data.
    */
-  virtual CreateConnectionData
-  createHealthCheckConnection(Event::Dispatcher& dispatcher,
-                              Network::TransportSocketOptionsSharedPtr transport_socket_options,
-                              const envoy::config::core::v3::Metadata* metadata) const PURE;
+  virtual CreateConnectionData createHealthCheckConnection(
+      Event::Dispatcher& dispatcher,
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
+      const envoy::config::core::v3::Metadata* metadata) const PURE;
 
   /**
    * @return host specific gauges.

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -21,7 +21,7 @@ namespace {
 ConnPoolImplBase::ConnPoolImplBase(
     Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
     Upstream::ClusterConnectivityState& state)
     : state_(state), host_(host), priority_(priority), dispatcher_(dispatcher),
       socket_options_(options), transport_socket_options_(transport_socket_options),

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -140,7 +140,7 @@ public:
   ConnPoolImplBase(Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                    Event::Dispatcher& dispatcher,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                   const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                    Upstream::ClusterConnectivityState& state);
   virtual ~ConnPoolImplBase();
 
@@ -216,7 +216,7 @@ public:
   Event::Dispatcher& dispatcher() { return dispatcher_; }
   Upstream::ResourcePriority priority() const { return priority_; }
   const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() { return socket_options_; }
-  const Network::TransportSocketOptionsSharedPtr& transportSocketOptions() {
+  const Network::TransportSocketOptionsConstSharedPtr& transportSocketOptions() {
     return transport_socket_options_;
   }
   bool hasPendingStreams() const { return !pending_streams_.empty(); }
@@ -297,7 +297,7 @@ protected:
 
   Event::Dispatcher& dispatcher_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
-  const Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
 
   std::list<Instance::DrainedCb> drained_callbacks_;
 

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -10,8 +10,8 @@
 namespace Envoy {
 namespace Http {
 
-Network::TransportSocketOptionsSharedPtr
-wrapTransportSocketOptions(Network::TransportSocketOptionsSharedPtr transport_socket_options,
+Network::TransportSocketOptionsConstSharedPtr
+wrapTransportSocketOptions(Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                            std::vector<Protocol> protocols) {
   std::vector<std::string> fallbacks;
   for (auto protocol : protocols) {
@@ -44,7 +44,7 @@ wrapTransportSocketOptions(Network::TransportSocketOptionsSharedPtr transport_so
 HttpConnPoolImplBase::HttpConnPoolImplBase(
     Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
     Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
     std::vector<Http::Protocol> protocols)
     : Envoy::ConnectionPool::ConnPoolImplBase(

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -47,13 +47,12 @@ class ActiveClient;
 class HttpConnPoolImplBase : public Envoy::ConnectionPool::ConnPoolImplBase,
                              public Http::ConnectionPool::Instance {
 public:
-  HttpConnPoolImplBase(Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-                       Event::Dispatcher& dispatcher,
-                       const Network::ConnectionSocket::OptionsSharedPtr& options,
-                       const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
-                       Random::RandomGenerator& random_generator,
-                       Upstream::ClusterConnectivityState& state,
-                       std::vector<Http::Protocol> protocols);
+  HttpConnPoolImplBase(
+      Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
+      Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
+      const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
+      Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
+      std::vector<Http::Protocol> protocols);
   ~HttpConnPoolImplBase() override;
 
   // ConnectionPool::Instance
@@ -143,13 +142,12 @@ public:
   using CreateCodecFn = std::function<CodecClientPtr(Upstream::Host::CreateConnectionData& data,
                                                      HttpConnPoolImplBase* pool)>;
 
-  FixedHttpConnPoolImpl(Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-                        Event::Dispatcher& dispatcher,
-                        const Network::ConnectionSocket::OptionsSharedPtr& options,
-                        const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
-                        Random::RandomGenerator& random_generator,
-                        Upstream::ClusterConnectivityState& state, CreateClientFn client_fn,
-                        CreateCodecFn codec_fn, std::vector<Http::Protocol> protocols)
+  FixedHttpConnPoolImpl(
+      Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
+      Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
+      const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
+      Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
+      CreateClientFn client_fn, CreateCodecFn codec_fn, std::vector<Http::Protocol> protocols)
       : HttpConnPoolImplBase(host, priority, dispatcher, options, transport_socket_options,
                              random_generator, state, protocols),
         codec_fn_(codec_fn), client_fn_(client_fn), protocol_(protocols[0]) {

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -190,7 +190,7 @@ ConnectivityGrid::ConnectivityGrid(
     Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
     Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
     const Network::ConnectionSocket::OptionsSharedPtr& options,
-    const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
     Upstream::ClusterConnectivityState& state, TimeSource& time_source,
     AlternateProtocolsCacheSharedPtr alternate_protocols,
     std::chrono::milliseconds next_attempt_duration, ConnectivityOptions connectivity_options)

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -130,7 +130,7 @@ public:
   ConnectivityGrid(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                    Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                   const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                    Upstream::ClusterConnectivityState& state, TimeSource& time_source,
                    AlternateProtocolsCacheSharedPtr alternate_protocols,
                    std::chrono::milliseconds next_attempt_duration,
@@ -186,7 +186,7 @@ private:
   Upstream::HostConstSharedPtr host_;
   Upstream::ResourcePriority priority_;
   const Network::ConnectionSocket::OptionsSharedPtr options_;
-  const Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   Upstream::ClusterConnectivityState& state_;
   std::chrono::milliseconds next_attempt_duration_;
   TimeSource& time_source_;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -103,7 +103,7 @@ ConnectionPool::InstancePtr
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
-                 const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                 const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state) {
   return std::make_unique<FixedHttpConnPoolImpl>(
       std::move(host), std::move(priority), dispatcher, options, transport_socket_options,

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -73,7 +73,7 @@ ConnectionPool::InstancePtr
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
-                 const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                 const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state);
 
 } // namespace Http1

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -27,7 +27,7 @@ ConnectionPool::InstancePtr
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
-                 const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                 const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state) {
   return std::make_unique<FixedHttpConnPoolImpl>(
       host, priority, dispatcher, options, transport_socket_options, random_generator, state,

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -26,7 +26,7 @@ ConnectionPool::InstancePtr
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
-                 const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                 const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state);
 
 } // namespace Http2

--- a/source/common/http/http3/conn_pool.cc
+++ b/source/common/http/http3/conn_pool.cc
@@ -32,7 +32,7 @@ void Http3ConnPoolImpl::setQuicConfigFromClusterConfig(const Upstream::ClusterIn
 Http3ConnPoolImpl::Http3ConnPoolImpl(
     Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
     Random::RandomGenerator& random_generator, Upstream::ClusterConnectivityState& state,
     CreateClientFn client_fn, CreateCodecFn codec_fn, std::vector<Http::Protocol> protocol,
     TimeSource& time_source)
@@ -58,7 +58,7 @@ ConnectionPool::InstancePtr
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
-                 const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                 const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state, TimeSource& time_source) {
   return std::make_unique<Http3ConnPoolImpl>(
       host, priority, dispatcher, options, transport_socket_options, random_generator, state,

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -40,7 +40,7 @@ public:
   Http3ConnPoolImpl(Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                     Event::Dispatcher& dispatcher,
                     const Network::ConnectionSocket::OptionsSharedPtr& options,
-                    const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                     Random::RandomGenerator& random_generator,
                     Upstream::ClusterConnectivityState& state, CreateClientFn client_fn,
                     CreateCodecFn codec_fn, std::vector<Http::Protocol> protocol,
@@ -65,7 +65,7 @@ ConnectionPool::InstancePtr
 allocateConnPool(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                  Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                  const Network::ConnectionSocket::OptionsSharedPtr& options,
-                 const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                 const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                  Upstream::ClusterConnectivityState& state, TimeSource& time_source);
 
 } // namespace Http3

--- a/source/common/http/mixed_conn_pool.h
+++ b/source/common/http/mixed_conn_pool.h
@@ -8,11 +8,12 @@ namespace Http {
 // An HTTP connection pool which supports both HTTP/1 and HTTP/2 based on ALPN
 class HttpConnPoolImplMixed : public HttpConnPoolImplBase {
 public:
-  HttpConnPoolImplMixed(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
-                        Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
-                        const Network::ConnectionSocket::OptionsSharedPtr& options,
-                        const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
-                        Upstream::ClusterConnectivityState& state)
+  HttpConnPoolImplMixed(
+      Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
+      Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
+      const Network::ConnectionSocket::OptionsSharedPtr& options,
+      const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
+      Upstream::ClusterConnectivityState& state)
       : HttpConnPoolImplBase(std::move(host), std::move(priority), dispatcher, options,
                              transport_socket_options, random_generator, state,
                              {Protocol::Http2, Protocol::Http11}) {}

--- a/source/common/network/raw_buffer_socket.cc
+++ b/source/common/network/raw_buffer_socket.cc
@@ -87,7 +87,7 @@ absl::string_view RawBufferSocket::failureReason() const { return EMPTY_STRING; 
 void RawBufferSocket::onConnected() { callbacks_->raiseEvent(ConnectionEvent::Connected); }
 
 TransportSocketPtr
-RawBufferSocketFactory::createTransportSocket(TransportSocketOptionsSharedPtr) const {
+RawBufferSocketFactory::createTransportSocket(TransportSocketOptionsConstSharedPtr) const {
   return std::make_unique<RawBufferSocket>();
 }
 

--- a/source/common/network/raw_buffer_socket.h
+++ b/source/common/network/raw_buffer_socket.h
@@ -31,7 +31,8 @@ private:
 class RawBufferSocketFactory : public TransportSocketFactory {
 public:
   // Network::TransportSocketFactory
-  TransportSocketPtr createTransportSocket(TransportSocketOptionsSharedPtr options) const override;
+  TransportSocketPtr
+  createTransportSocket(TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return false; }
 };

--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -58,7 +58,7 @@ void TransportSocketOptionsImpl::hashKey(std::vector<uint8_t>& key,
   commonHashKey(*this, key, factory);
 }
 
-TransportSocketOptionsSharedPtr
+TransportSocketOptionsConstSharedPtr
 TransportSocketOptionsUtility::fromFilterState(const StreamInfo::FilterState& filter_state) {
   absl::string_view server_name;
   std::vector<std::string> application_protocols;

--- a/source/common/network/transport_socket_options_impl.h
+++ b/source/common/network/transport_socket_options_impl.h
@@ -11,7 +11,7 @@ namespace Network {
 class AlpnDecoratingTransportSocketOptions : public TransportSocketOptions {
 public:
   AlpnDecoratingTransportSocketOptions(std::vector<std::string>&& alpn,
-                                       TransportSocketOptionsSharedPtr inner_options)
+                                       TransportSocketOptionsConstSharedPtr inner_options)
       : alpn_fallback_(std::move(alpn)), inner_options_(std::move(inner_options)) {}
   // Network::TransportSocketOptions
   const absl::optional<std::string>& serverNameOverride() const override {
@@ -34,7 +34,7 @@ public:
 
 private:
   const std::vector<std::string> alpn_fallback_;
-  const TransportSocketOptionsSharedPtr inner_options_;
+  const TransportSocketOptionsConstSharedPtr inner_options_;
 };
 
 class TransportSocketOptionsImpl : public TransportSocketOptions {
@@ -83,10 +83,10 @@ public:
   /**
    * Construct TransportSocketOptions from StreamInfo::FilterState, using UpstreamServerName
    * and ApplicationProtocols key in the filter state.
-   * @returns TransportSocketOptionsSharedPtr a shared pointer to the transport socket options,
+   * @returns TransportSocketOptionsConstSharedPtr a shared pointer to the transport socket options,
    * nullptr if nothing is in the filter state.
    */
-  static TransportSocketOptionsSharedPtr
+  static TransportSocketOptionsConstSharedPtr
   fromFilterState(const StreamInfo::FilterState& stream_info);
 };
 

--- a/source/common/quic/quic_transport_socket_factory.h
+++ b/source/common/quic/quic_transport_socket_factory.h
@@ -45,7 +45,7 @@ public:
 
   // Network::TransportSocketFactory
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr /*options*/) const override {
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr /*options*/) const override {
     NOT_REACHED_GCOVR_EXCL_LINE;
   }
   bool implementsSecureTransport() const override { return true; }
@@ -104,7 +104,7 @@ public:
   // is needed. In this case the QuicClientTransportSocketFactory falls over to
   // using the fallback factory.
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override {
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override {
     return fallback_factory_->createTransportSocket(options);
   }
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -388,7 +388,7 @@ public:
                                           : callbacks_->getUpstreamSocketOptions();
   }
 
-  Network::TransportSocketOptionsSharedPtr upstreamTransportSocketOptions() const override {
+  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
     return transport_socket_options_;
   }
 
@@ -549,7 +549,7 @@ private:
   uint32_t attempt_count_{1};
   uint32_t pending_retries_{0};
 
-  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   Network::Socket::OptionsSharedPtr upstream_options_;
 };
 

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -139,7 +139,7 @@ public:
   ConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                Upstream::ResourcePriority priority,
                const Network::ConnectionSocket::OptionsSharedPtr& options,
-               Network::TransportSocketOptionsSharedPtr transport_socket_options,
+               Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                Upstream::ClusterConnectivityState& state)
       : Envoy::ConnectionPool::ConnPoolImplBase(host, priority, dispatcher, options,
                                                 transport_socket_options, state) {}

--- a/source/common/tcp/original_conn_pool.cc
+++ b/source/common/tcp/original_conn_pool.cc
@@ -15,7 +15,7 @@ namespace Tcp {
 OriginalConnPoolImpl::OriginalConnPoolImpl(
     Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
     Upstream::ResourcePriority priority, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Network::TransportSocketOptionsSharedPtr transport_socket_options)
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options)
     : dispatcher_(dispatcher), host_(host), priority_(priority), socket_options_(options),
       transport_socket_options_(transport_socket_options),
       upstream_ready_cb_(dispatcher_.createSchedulableCallback([this]() { onUpstreamReady(); })) {}

--- a/source/common/tcp/original_conn_pool.h
+++ b/source/common/tcp/original_conn_pool.h
@@ -24,7 +24,7 @@ public:
   OriginalConnPoolImpl(Event::Dispatcher& dispatcher, Upstream::HostConstSharedPtr host,
                        Upstream::ResourcePriority priority,
                        const Network::ConnectionSocket::OptionsSharedPtr& options,
-                       Network::TransportSocketOptionsSharedPtr transport_socket_options);
+                       Network::TransportSocketOptionsConstSharedPtr transport_socket_options);
 
   ~OriginalConnPoolImpl() override;
 
@@ -154,7 +154,7 @@ protected:
   Upstream::HostConstSharedPtr host_;
   Upstream::ResourcePriority priority_;
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
-  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
 
   std::list<ActiveConnPtr> pending_conns_; // conns awaiting connected event
   std::list<ActiveConnPtr> ready_conns_;   // conns ready for assignment

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -278,7 +278,7 @@ public:
     return &read_callbacks_->connection();
   }
 
-  Network::TransportSocketOptionsSharedPtr upstreamTransportSocketOptions() const override {
+  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
     return transport_socket_options_;
   }
 
@@ -380,7 +380,7 @@ protected:
   std::unique_ptr<GenericConnPool> generic_conn_pool_;
   RouteConstSharedPtr route_;
   Router::MetadataMatchCriteriaConstPtr metadata_match_criteria_;
-  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   Network::Socket::OptionsSharedPtr upstream_options_;
   uint32_t connect_attempts_{};
   bool connecting_{};

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1525,8 +1525,8 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
     const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
         alternate_protocol_options,
     const Network::ConnectionSocket::OptionsSharedPtr& options,
-    const Network::TransportSocketOptionsSharedPtr& transport_socket_options, TimeSource& source,
-    ClusterConnectivityState& state) {
+    const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
+    TimeSource& source, ClusterConnectivityState& state) {
   if (protocols.size() == 3 && runtime_.snapshot().featureEnabled("upstream.use_http3", 100)) {
     ASSERT(contains(protocols,
                     {Http::Protocol::Http11, Http::Protocol::Http2, Http::Protocol::Http3}));
@@ -1576,7 +1576,7 @@ Http::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateConnPool(
 Tcp::ConnectionPool::InstancePtr ProdClusterManagerFactory::allocateTcpConnPool(
     Event::Dispatcher& dispatcher, HostConstSharedPtr host, ResourcePriority priority,
     const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Network::TransportSocketOptionsSharedPtr transport_socket_options,
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
     ClusterConnectivityState& state) {
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.new_tcp_connection_pool")) {
     return std::make_unique<Tcp::ConnPoolImpl>(dispatcher, host, priority, options,

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -74,13 +74,13 @@ public:
                    const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
                        alternate_protocol_options,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                   const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                    TimeSource& time_source, ClusterConnectivityState& state) override;
   Tcp::ConnectionPool::InstancePtr
   allocateTcpConnPool(Event::Dispatcher& dispatcher, HostConstSharedPtr host,
                       ResourcePriority priority,
                       const Network::ConnectionSocket::OptionsSharedPtr& options,
-                      Network::TransportSocketOptionsSharedPtr transport_socket_options,
+                      Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                       ClusterConnectivityState& state) override;
   std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr>
   clusterFromProto(const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cm,

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -185,7 +185,7 @@ public:
 
   Network::Socket::OptionsSharedPtr upstreamSocketOptions() const override { return nullptr; }
 
-  Network::TransportSocketOptionsSharedPtr upstreamTransportSocketOptions() const override {
+  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
     return nullptr;
   }
 };

--- a/source/common/upstream/logical_host.cc
+++ b/source/common/upstream/logical_host.cc
@@ -5,7 +5,7 @@ namespace Upstream {
 
 Upstream::Host::CreateConnectionData LogicalHost::createConnection(
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Network::TransportSocketOptionsSharedPtr transport_socket_options) const {
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const {
   const auto current_address = address();
   return {HostImpl::createConnection(
               dispatcher, cluster(), current_address, transportSocketFactory(), options,

--- a/source/common/upstream/logical_host.h
+++ b/source/common/upstream/logical_host.h
@@ -15,12 +15,13 @@ namespace Upstream {
  */
 class LogicalHost : public HostImpl {
 public:
-  LogicalHost(const ClusterInfoConstSharedPtr& cluster, const std::string& hostname,
-              const Network::Address::InstanceConstSharedPtr& address,
-              const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
-              const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint,
-              const Network::TransportSocketOptionsSharedPtr& override_transport_socket_options,
-              TimeSource& time_source)
+  LogicalHost(
+      const ClusterInfoConstSharedPtr& cluster, const std::string& hostname,
+      const Network::Address::InstanceConstSharedPtr& address,
+      const envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint,
+      const envoy::config::endpoint::v3::LbEndpoint& lb_endpoint,
+      const Network::TransportSocketOptionsConstSharedPtr& override_transport_socket_options,
+      TimeSource& time_source)
       : HostImpl(cluster, hostname, address,
                  // TODO(zyfjeff): Created through metadata shared pool
                  std::make_shared<const envoy::config::core::v3::Metadata>(lb_endpoint.metadata()),
@@ -47,7 +48,7 @@ public:
   // Upstream::Host
   CreateConnectionData createConnection(
       Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-      Network::TransportSocketOptionsSharedPtr transport_socket_options) const override;
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const override;
 
   // Upstream::HostDescription
   Network::Address::InstanceConstSharedPtr address() const override {
@@ -60,7 +61,7 @@ public:
   }
 
 private:
-  const Network::TransportSocketOptionsSharedPtr override_transport_socket_options_;
+  const Network::TransportSocketOptionsConstSharedPtr override_transport_socket_options_;
   mutable absl::Mutex address_lock_;
 };
 

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -158,7 +158,7 @@ private:
     Network::Socket::OptionsSharedPtr upstreamSocketOptions() const override {
       return wrapped_->upstreamSocketOptions();
     }
-    Network::TransportSocketOptionsSharedPtr upstreamTransportSocketOptions() const override {
+    Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
       return wrapped_->upstreamTransportSocketOptions();
     }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -280,7 +280,7 @@ Network::TransportSocketFactory& HostDescriptionImpl::resolveTransportSocketFact
 
 Host::CreateConnectionData HostImpl::createConnection(
     Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-    Network::TransportSocketOptionsSharedPtr transport_socket_options) const {
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const {
   return {createConnection(dispatcher, cluster(), address(), transportSocketFactory(), options,
                            transport_socket_options),
           shared_from_this()};
@@ -306,7 +306,7 @@ void HostImpl::setEdsHealthFlag(envoy::config::core::v3::HealthStatus health_sta
 
 Host::CreateConnectionData HostImpl::createHealthCheckConnection(
     Event::Dispatcher& dispatcher,
-    Network::TransportSocketOptionsSharedPtr transport_socket_options,
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
     const envoy::config::core::v3::Metadata* metadata) const {
 
   Network::TransportSocketFactory& factory =
@@ -322,7 +322,7 @@ HostImpl::createConnection(Event::Dispatcher& dispatcher, const ClusterInfo& clu
                            const Network::Address::InstanceConstSharedPtr& address,
                            Network::TransportSocketFactory& socket_factory,
                            const Network::ConnectionSocket::OptionsSharedPtr& options,
-                           Network::TransportSocketOptionsSharedPtr transport_socket_options) {
+                           Network::TransportSocketOptionsConstSharedPtr transport_socket_options) {
   Network::ConnectionSocket::OptionsSharedPtr connection_options;
   if (cluster.clusterSocketOptions() != nullptr) {
     if (options) {

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -209,11 +209,11 @@ public:
   }
   CreateConnectionData createConnection(
       Event::Dispatcher& dispatcher, const Network::ConnectionSocket::OptionsSharedPtr& options,
-      Network::TransportSocketOptionsSharedPtr transport_socket_options) const override;
-  CreateConnectionData
-  createHealthCheckConnection(Event::Dispatcher& dispatcher,
-                              Network::TransportSocketOptionsSharedPtr transport_socket_options,
-                              const envoy::config::core::v3::Metadata* metadata) const override;
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const override;
+  CreateConnectionData createHealthCheckConnection(
+      Event::Dispatcher& dispatcher,
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
+      const envoy::config::core::v3::Metadata* metadata) const override;
 
   std::vector<std::pair<absl::string_view, Stats::PrimitiveGaugeReference>>
   gauges() const override {
@@ -260,7 +260,7 @@ protected:
                    const Network::Address::InstanceConstSharedPtr& address,
                    Network::TransportSocketFactory& socket_factory,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   Network::TransportSocketOptionsSharedPtr transport_socket_options);
+                   Network::TransportSocketOptionsConstSharedPtr transport_socket_options);
 
 private:
   void setEdsHealthFlag(envoy::config::core::v3::HealthStatus health_status);

--- a/source/extensions/clusters/aggregate/lb_context.h
+++ b/source/extensions/clusters/aggregate/lb_context.h
@@ -62,7 +62,7 @@ public:
   Network::Socket::OptionsSharedPtr upstreamSocketOptions() const override {
     return context_->upstreamSocketOptions();
   }
-  Network::TransportSocketOptionsSharedPtr upstreamTransportSocketOptions() const override {
+  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
     return context_->upstreamTransportSocketOptions();
   }
 

--- a/source/extensions/transport_sockets/alts/tsi_socket.cc
+++ b/source/extensions/transport_sockets/alts/tsi_socket.cc
@@ -372,7 +372,7 @@ TsiSocketFactory::TsiSocketFactory(HandshakerFactory handshaker_factory,
 bool TsiSocketFactory::implementsSecureTransport() const { return true; }
 
 Network::TransportSocketPtr
-TsiSocketFactory::createTransportSocket(Network::TransportSocketOptionsSharedPtr) const {
+TsiSocketFactory::createTransportSocket(Network::TransportSocketOptionsConstSharedPtr) const {
   return std::make_unique<TsiSocket>(handshaker_factory_, handshake_validator_);
 }
 

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -130,7 +130,7 @@ public:
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return false; }
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
 
 private:
   HandshakerFactory handshaker_factory_;

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -19,7 +19,7 @@ namespace ProxyProtocol {
 
 UpstreamProxyProtocolSocket::UpstreamProxyProtocolSocket(
     Network::TransportSocketPtr&& transport_socket,
-    Network::TransportSocketOptionsSharedPtr options, ProxyProtocolConfig_Version version)
+    Network::TransportSocketOptionsConstSharedPtr options, ProxyProtocolConfig_Version version)
     : PassthroughSocket(std::move(transport_socket)), options_(options), version_(version) {}
 
 void UpstreamProxyProtocolSocket::setTransportSocketCallbacks(
@@ -110,7 +110,7 @@ UpstreamProxyProtocolSocketFactory::UpstreamProxyProtocolSocketFactory(
     : transport_socket_factory_(std::move(transport_socket_factory)), config_(config) {}
 
 Network::TransportSocketPtr UpstreamProxyProtocolSocketFactory::createTransportSocket(
-    Network::TransportSocketOptionsSharedPtr options) const {
+    Network::TransportSocketOptionsConstSharedPtr options) const {
   auto inner_socket = transport_socket_factory_->createTransportSocket(options);
   if (inner_socket == nullptr) {
     return nullptr;

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
@@ -20,7 +20,7 @@ class UpstreamProxyProtocolSocket : public TransportSockets::PassthroughSocket,
                                     public Logger::Loggable<Logger::Id::connection> {
 public:
   UpstreamProxyProtocolSocket(Network::TransportSocketPtr&& transport_socket,
-                              Network::TransportSocketOptionsSharedPtr options,
+                              Network::TransportSocketOptionsConstSharedPtr options,
                               ProxyProtocolConfig_Version version);
 
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
@@ -33,7 +33,7 @@ private:
   void generateHeaderV2();
   Network::IoResult writeHeader();
 
-  Network::TransportSocketOptionsSharedPtr options_;
+  Network::TransportSocketOptionsConstSharedPtr options_;
   Network::TransportSocketCallbacks* callbacks_{};
   Buffer::OwnedImpl header_buffer_{};
   ProxyProtocolConfig_Version version_{ProxyProtocolConfig_Version::ProxyProtocolConfig_Version_V1};
@@ -46,7 +46,7 @@ public:
 
   // Network::TransportSocketFactory
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return true; }
 

--- a/source/extensions/transport_sockets/starttls/starttls_socket.cc
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.cc
@@ -23,7 +23,7 @@ bool StartTlsSocket::startSecureTransport() {
 }
 
 Network::TransportSocketPtr StartTlsSocketFactory::createTransportSocket(
-    Network::TransportSocketOptionsSharedPtr transport_socket_options) const {
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const {
   return std::make_unique<StartTlsSocket>(
       raw_socket_factory_->createTransportSocket(transport_socket_options),
       tls_socket_factory_->createTransportSocket(transport_socket_options),

--- a/source/extensions/transport_sockets/starttls/starttls_socket.h
+++ b/source/extensions/transport_sockets/starttls/starttls_socket.h
@@ -18,7 +18,7 @@ class StartTlsSocket : public Network::TransportSocket, Logger::Loggable<Logger:
 public:
   StartTlsSocket(Network::TransportSocketPtr raw_socket, // RawBufferSocket
                  Network::TransportSocketPtr tls_socket, // TlsSocket
-                 const Network::TransportSocketOptionsSharedPtr&)
+                 const Network::TransportSocketOptionsConstSharedPtr&)
       : active_socket_(std::move(raw_socket)), tls_socket_(std::move(tls_socket)) {}
 
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override {
@@ -74,7 +74,7 @@ public:
         tls_socket_factory_(std::move(tls_socket_factory)) {}
 
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override { return false; }
   bool usesProxyProtocolOptions() const override { return false; }
 

--- a/source/extensions/transport_sockets/tap/tap.cc
+++ b/source/extensions/transport_sockets/tap/tap.cc
@@ -56,8 +56,8 @@ TapSocketFactory::TapSocketFactory(
                           singleton_manager, tls, main_thread_dispatcher),
       transport_socket_factory_(std::move(transport_socket_factory)) {}
 
-Network::TransportSocketPtr
-TapSocketFactory::createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const {
+Network::TransportSocketPtr TapSocketFactory::createTransportSocket(
+    Network::TransportSocketOptionsConstSharedPtr options) const {
   return std::make_unique<TapSocket>(currentConfigHelper<SocketTapConfig>(),
                                      transport_socket_factory_->createTransportSocket(options));
 }

--- a/source/extensions/transport_sockets/tap/tap.h
+++ b/source/extensions/transport_sockets/tap/tap.h
@@ -39,7 +39,7 @@ public:
 
   // Network::TransportSocketFactory
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override;
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -46,7 +46,7 @@ public:
 } // namespace
 
 SslSocket::SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
-                     const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                     const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                      Ssl::HandshakerFactoryCb handshaker_factory_cb)
     : transport_socket_options_(transport_socket_options),
       ctx_(std::dynamic_pointer_cast<ContextImpl>(ctx)),
@@ -356,7 +356,7 @@ ClientSslSocketFactory::ClientSslSocketFactory(Envoy::Ssl::ClientContextConfigPt
 }
 
 Network::TransportSocketPtr ClientSslSocketFactory::createTransportSocket(
-    Network::TransportSocketOptionsSharedPtr transport_socket_options) const {
+    Network::TransportSocketOptionsConstSharedPtr transport_socket_options) const {
   // onAddOrUpdateSecret() could be invoked in the middle of checking the existence of ssl_ctx and
   // creating SslSocket using ssl_ctx. Capture ssl_ctx_ into a local variable so that we check and
   // use the same ssl_ctx to create SslSocket.
@@ -402,7 +402,7 @@ Envoy::Ssl::ClientContextSharedPtr ClientSslSocketFactory::sslCtx() {
 }
 
 Network::TransportSocketPtr
-ServerSslSocketFactory::createTransportSocket(Network::TransportSocketOptionsSharedPtr) const {
+ServerSslSocketFactory::createTransportSocket(Network::TransportSocketOptionsConstSharedPtr) const {
   // onAddOrUpdateSecret() could be invoked in the middle of checking the existence of ssl_ctx and
   // creating SslSocket using ssl_ctx. Capture ssl_ctx_ into a local variable so that we check and
   // use the same ssl_ctx to create SslSocket.

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -48,7 +48,7 @@ class SslSocket : public Network::TransportSocket,
                   protected Logger::Loggable<Logger::Id::connection> {
 public:
   SslSocket(Envoy::Ssl::ContextSharedPtr ctx, InitialState state,
-            const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+            const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
             Ssl::HandshakerFactoryCb handshaker_factory_cb);
 
   // Network::TransportSocket
@@ -90,7 +90,7 @@ private:
     return callbacks_ != nullptr && callbacks_->connection().dispatcher().isThreadSafe();
   }
 
-  const Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   Network::TransportSocketCallbacks* callbacks_{};
   ContextImplSharedPtr ctx_;
   uint64_t bytes_to_retry_{};
@@ -107,7 +107,7 @@ public:
                          Envoy::Ssl::ContextManager& manager, Stats::Scope& stats_scope);
 
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return false; }
   bool supportsAlpn() const override { return true; }
@@ -137,7 +137,7 @@ public:
                          const std::vector<std::string>& server_names);
 
   Network::TransportSocketPtr
-  createTransportSocket(Network::TransportSocketOptionsSharedPtr options) const override;
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options) const override;
   bool implementsSecureTransport() const override;
   bool usesProxyProtocolOptions() const override { return false; }
 

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -127,7 +127,7 @@ public:
   }
 
   const Network::ConnectionSocket::OptionsSharedPtr socket_options_;
-  const Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   ConnectivityGrid::ConnectivityOptions options_;
   Upstream::ClusterConnectivityState state_;
   NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -300,7 +300,7 @@ TEST_F(Http1ConnPoolImplTest, VerifyAlpnFallback) {
   auto factory = std::make_unique<Network::MockTransportSocketFactory>();
   EXPECT_CALL(*factory, createTransportSocket(_))
       .WillOnce(Invoke(
-          [](Network::TransportSocketOptionsSharedPtr options) -> Network::TransportSocketPtr {
+          [](Network::TransportSocketOptionsConstSharedPtr options) -> Network::TransportSocketPtr {
             EXPECT_TRUE(options != nullptr);
             EXPECT_EQ(options->applicationProtocolFallback()[0],
                       Http::Utility::AlpnNames::get().Http11);

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -41,7 +41,7 @@ public:
   TestConnPoolImpl(Event::Dispatcher& dispatcher, Random::RandomGenerator& random_generator,
                    Upstream::HostConstSharedPtr host, Upstream::ResourcePriority priority,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                   const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                    Envoy::Upstream::ClusterConnectivityState& state)
       : FixedHttpConnPoolImpl(
             std::move(host), std::move(priority), dispatcher, options, transport_socket_options,
@@ -347,7 +347,7 @@ TEST_F(Http2ConnPoolImplTest, VerifyAlpnFallback) {
   createTestClients(1);
   EXPECT_CALL(*factory_ptr, createTransportSocket(_))
       .WillOnce(Invoke(
-          [](Network::TransportSocketOptionsSharedPtr options) -> Network::TransportSocketPtr {
+          [](Network::TransportSocketOptionsConstSharedPtr options) -> Network::TransportSocketPtr {
             EXPECT_TRUE(options != nullptr);
             EXPECT_EQ(options->applicationProtocolFallback()[0],
                       Http::Utility::AlpnNames::get().Http2);

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -44,7 +44,7 @@ public:
     EXPECT_CALL(mockHost(), transportSocketFactory()).WillRepeatedly(testing::ReturnRef(factory_));
     new Event::MockSchedulableCallback(&dispatcher_);
     Network::ConnectionSocket::OptionsSharedPtr options;
-    Network::TransportSocketOptionsSharedPtr transport_options;
+    Network::TransportSocketOptionsConstSharedPtr transport_options;
     pool_ = allocateConnPool(dispatcher_, random_, host_, Upstream::ResourcePriority::Default,
                              options, transport_options, state_, simTime());
   }

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -5863,7 +5863,7 @@ TEST_F(RouterTest, ApplicationProtocols) {
   EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _))
       .WillOnce(Invoke([&](Upstream::ResourcePriority, absl::optional<Http::Protocol>,
                            Upstream::LoadBalancerContext* context) {
-        Network::TransportSocketOptionsSharedPtr transport_socket_options =
+        Network::TransportSocketOptionsConstSharedPtr transport_socket_options =
             context->upstreamTransportSocketOptions();
         EXPECT_NE(transport_socket_options, nullptr);
         EXPECT_FALSE(transport_socket_options->applicationProtocolListOverride().empty());

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -99,7 +99,7 @@ public:
   ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
                NiceMock<Event::MockSchedulableCallback>* upstream_ready_cb,
                Network::ConnectionSocket::OptionsSharedPtr options,
-               Network::TransportSocketOptionsSharedPtr transport_socket_options,
+               Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                bool test_new_connection_pool);
 
   void addDrainedCallback(DrainedCb cb) override { conn_pool_->addDrainedCallback(cb); }
@@ -155,14 +155,14 @@ public:
   Network::ConnectionCallbacks* callbacks_ = nullptr;
   bool test_new_connection_pool_;
   Network::ConnectionSocket::OptionsSharedPtr options_;
-  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
 
 protected:
   class ConnPoolImplForTest : public ConnPoolImpl {
   public:
     ConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
                         Network::ConnectionSocket::OptionsSharedPtr options,
-                        Network::TransportSocketOptionsSharedPtr transport_socket_options,
+                        Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                         ConnPoolBase& parent)
         : ConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, options,
                        transport_socket_options, state_),
@@ -187,10 +187,11 @@ protected:
 
   class OriginalConnPoolImplForTest : public OriginalConnPoolImpl {
   public:
-    OriginalConnPoolImplForTest(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
-                                Network::ConnectionSocket::OptionsSharedPtr options,
-                                Network::TransportSocketOptionsSharedPtr transport_socket_options,
-                                ConnPoolBase& parent)
+    OriginalConnPoolImplForTest(
+        Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
+        Network::ConnectionSocket::OptionsSharedPtr options,
+        Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
+        ConnPoolBase& parent)
         : OriginalConnPoolImpl(dispatcher, host, Upstream::ResourcePriority::Default, options,
                                transport_socket_options),
           parent_(parent) {}
@@ -229,7 +230,7 @@ protected:
 ConnPoolBase::ConnPoolBase(Event::MockDispatcher& dispatcher, Upstream::HostSharedPtr host,
                            NiceMock<Event::MockSchedulableCallback>* upstream_ready_cb,
                            Network::ConnectionSocket::OptionsSharedPtr options,
-                           Network::TransportSocketOptionsSharedPtr transport_socket_options,
+                           Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
                            bool test_new_connection_pool)
     : mock_dispatcher_(dispatcher), mock_upstream_ready_cb_(upstream_ready_cb),
       test_new_connection_pool_(test_new_connection_pool), options_(options),
@@ -285,7 +286,7 @@ public:
   NiceMock<Event::MockSchedulableCallback>* upstream_ready_cb_;
   Upstream::HostSharedPtr host_;
   Network::ConnectionSocket::OptionsSharedPtr options_;
-  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   std::unique_ptr<ConnPoolBase> conn_pool_;
   NiceMock<Runtime::MockLoader> runtime_;
 };

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -911,7 +911,7 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(UpstreamServerName)) {
   // override-server-name
   EXPECT_CALL(factory_context_.cluster_manager_.thread_local_cluster_, tcpConnPool(_, _))
       .WillOnce(Invoke([](Upstream::ResourcePriority, Upstream::LoadBalancerContext* context) {
-        Network::TransportSocketOptionsSharedPtr transport_socket_options =
+        Network::TransportSocketOptionsConstSharedPtr transport_socket_options =
             context->upstreamTransportSocketOptions();
         EXPECT_NE(transport_socket_options, nullptr);
         EXPECT_TRUE(transport_socket_options->serverNameOverride().has_value());
@@ -941,7 +941,7 @@ TEST_F(TcpProxyRoutingTest, DEPRECATED_FEATURE_TEST(ApplicationProtocols)) {
   // override-application-protocol
   EXPECT_CALL(factory_context_.cluster_manager_.thread_local_cluster_, tcpConnPool(_, _))
       .WillOnce(Invoke([](Upstream::ResourcePriority, Upstream::LoadBalancerContext* context) {
-        Network::TransportSocketOptionsSharedPtr transport_socket_options =
+        Network::TransportSocketOptionsConstSharedPtr transport_socket_options =
             context->upstreamTransportSocketOptions();
         EXPECT_NE(transport_socket_options, nullptr);
         EXPECT_FALSE(transport_socket_options->applicationProtocolListOverride().empty());

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -1074,7 +1074,7 @@ TEST_F(HttpHealthCheckerImplTest, ZeroRetryInterval) {
 }
 
 MATCHER_P(ApplicationProtocolListEq, expected, "") {
-  const Network::TransportSocketOptionsSharedPtr& options = arg;
+  const Network::TransportSocketOptionsConstSharedPtr& options = arg;
   EXPECT_EQ(options->applicationProtocolListOverride(), std::vector<std::string>{expected});
   return true;
 }

--- a/test/common/upstream/test_cluster_manager.h
+++ b/test/common/upstream/test_cluster_manager.h
@@ -82,7 +82,7 @@ public:
                    const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
                        alternate_protocol_options,
                    const Network::ConnectionSocket::OptionsSharedPtr& options,
-                   const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+                   const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                    TimeSource&, ClusterConnectivityState& state) override {
     return Http::ConnectionPool::InstancePtr{allocateConnPool_(
         host, alternate_protocol_options, options, transport_socket_options, state)};
@@ -91,7 +91,7 @@ public:
   Tcp::ConnectionPool::InstancePtr
   allocateTcpConnPool(Event::Dispatcher&, HostConstSharedPtr host, ResourcePriority,
                       const Network::ConnectionSocket::OptionsSharedPtr&,
-                      Network::TransportSocketOptionsSharedPtr,
+                      Network::TransportSocketOptionsConstSharedPtr,
                       Upstream::ClusterConnectivityState&) override {
     return Tcp::ConnectionPool::InstancePtr{allocateTcpConnPool_(host)};
   }
@@ -123,7 +123,7 @@ public:
                const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
                    alternate_protocol_options,
                Network::ConnectionSocket::OptionsSharedPtr,
-               Network::TransportSocketOptionsSharedPtr, ClusterConnectivityState&));
+               Network::TransportSocketOptionsConstSharedPtr, ClusterConnectivityState&));
   MOCK_METHOD(Tcp::ConnectionPool::Instance*, allocateTcpConnPool_, (HostConstSharedPtr host));
   MOCK_METHOD((std::pair<ClusterSharedPtr, ThreadAwareLoadBalancer*>), clusterFromProto_,
               (const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cm,

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -32,7 +32,7 @@ public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
-              (Network::TransportSocketOptionsSharedPtr), (const));
+              (Network::TransportSocketOptionsConstSharedPtr), (const));
   FakeTransportSocketFactory(std::string id) : id_(std::move(id)) {}
   std::string id() const { return id_; }
 
@@ -48,7 +48,7 @@ public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketPtr, createTransportSocket,
-              (Network::TransportSocketOptionsSharedPtr), (const));
+              (Network::TransportSocketOptionsConstSharedPtr), (const));
 
   Network::TransportSocketFactoryPtr
   createTransportSocketFactory(const Protobuf::Message& proto,

--- a/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/transport_sockets/proxy_protocol/proxy_protocol_test.cc
@@ -35,7 +35,7 @@ namespace {
 class ProxyProtocolTest : public testing::Test {
 public:
   void initialize(ProxyProtocolConfig_Version version,
-                  Network::TransportSocketOptionsSharedPtr socket_options) {
+                  Network::TransportSocketOptionsConstSharedPtr socket_options) {
     auto inner_socket = std::make_unique<NiceMock<Network::MockTransportSocket>>();
     inner_socket_ = inner_socket.get();
     ON_CALL(transport_callbacks_, ioHandle()).WillByDefault(ReturnRef(io_handle_));
@@ -253,7 +253,7 @@ TEST_F(ProxyProtocolTest, V1IPV4DownstreamAddresses) {
       new Network::Address::Ipv4Instance("202.168.0.13", 52000));
   auto dst_addr = Network::Address::InstanceConstSharedPtr(
       new Network::Address::Ipv4Instance("174.2.2.222", 80));
-  Network::TransportSocketOptionsSharedPtr socket_options =
+  Network::TransportSocketOptionsConstSharedPtr socket_options =
       std::make_shared<Network::TransportSocketOptionsImpl>(
           "", std::vector<std::string>{}, std::vector<std::string>{}, std::vector<std::string>{},
           absl::optional<Network::ProxyProtocolData>(
@@ -285,7 +285,7 @@ TEST_F(ProxyProtocolTest, V1IPV6DownstreamAddresses) {
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv6Instance("1::2:3", 52000));
   auto dst_addr =
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv6Instance("a:b:c:d::", 80));
-  Network::TransportSocketOptionsSharedPtr socket_options =
+  Network::TransportSocketOptionsConstSharedPtr socket_options =
       std::make_shared<Network::TransportSocketOptionsImpl>(
           "", std::vector<std::string>{}, std::vector<std::string>{}, std::vector<std::string>{},
           absl::optional<Network::ProxyProtocolData>(
@@ -362,7 +362,7 @@ TEST_F(ProxyProtocolTest, V2IPV4DownstreamAddresses) {
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("1.2.3.4", 773));
   auto dst_addr =
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv4Instance("0.1.1.2", 513));
-  Network::TransportSocketOptionsSharedPtr socket_options =
+  Network::TransportSocketOptionsConstSharedPtr socket_options =
       std::make_shared<Network::TransportSocketOptionsImpl>(
           "", std::vector<std::string>{}, std::vector<std::string>{}, std::vector<std::string>{},
           absl::optional<Network::ProxyProtocolData>(
@@ -394,7 +394,7 @@ TEST_F(ProxyProtocolTest, V2IPV6DownstreamAddresses) {
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv6Instance("1:2:3::4", 8));
   auto dst_addr = Network::Address::InstanceConstSharedPtr(
       new Network::Address::Ipv6Instance("1:100:200:3::", 2));
-  Network::TransportSocketOptionsSharedPtr socket_options =
+  Network::TransportSocketOptionsConstSharedPtr socket_options =
       std::make_shared<Network::TransportSocketOptionsImpl>(
           "", std::vector<std::string>{}, std::vector<std::string>{}, std::vector<std::string>{},
           absl::optional<Network::ProxyProtocolData>(
@@ -426,7 +426,7 @@ TEST_F(ProxyProtocolTest, OnConnectedCallsInnerOnConnected) {
       Network::Address::InstanceConstSharedPtr(new Network::Address::Ipv6Instance("1:2:3::4", 8));
   auto dst_addr = Network::Address::InstanceConstSharedPtr(
       new Network::Address::Ipv6Instance("1:100:200:3::", 2));
-  Network::TransportSocketOptionsSharedPtr socket_options =
+  Network::TransportSocketOptionsConstSharedPtr socket_options =
       std::make_shared<Network::TransportSocketOptionsImpl>(
           "", std::vector<std::string>{}, std::vector<std::string>{}, std::vector<std::string>{},
           absl::optional<Network::ProxyProtocolData>(

--- a/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_socket_test.cc
@@ -25,7 +25,7 @@ public:
 };
 
 TEST(StartTlsTest, BasicSwitch) {
-  Network::TransportSocketOptionsSharedPtr options =
+  Network::TransportSocketOptionsConstSharedPtr options =
       std::make_shared<Network::TransportSocketOptionsImpl>();
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
   NiceMock<StartTlsTransportSocketMock>* raw_socket = new NiceMock<StartTlsTransportSocketMock>;

--- a/test/extensions/transport_sockets/tls/ssl_socket_test.cc
+++ b/test/extensions/transport_sockets/tls/ssl_socket_test.cc
@@ -567,13 +567,13 @@ public:
 
   const std::string& expectedALPNProtocol() const { return expected_alpn_protocol_; }
 
-  TestUtilOptionsV2&
-  setTransportSocketOptions(Network::TransportSocketOptionsSharedPtr transport_socket_options) {
+  TestUtilOptionsV2& setTransportSocketOptions(
+      Network::TransportSocketOptionsConstSharedPtr transport_socket_options) {
     transport_socket_options_ = transport_socket_options;
     return *this;
   }
 
-  Network::TransportSocketOptionsSharedPtr transportSocketOptions() const {
+  Network::TransportSocketOptionsConstSharedPtr transportSocketOptions() const {
     return transport_socket_options_;
   }
 
@@ -598,7 +598,7 @@ private:
   std::string expected_server_cert_digest_;
   std::string expected_requested_server_name_;
   std::string expected_alpn_protocol_;
-  Network::TransportSocketOptionsSharedPtr transport_socket_options_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
   std::string expected_transport_failure_reason_contains_;
 };
 
@@ -4589,7 +4589,7 @@ TEST_P(SslSocketTest, OverrideRequestedServerName) {
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client;
   client.set_sni("lyft.com");
 
-  Network::TransportSocketOptionsSharedPtr transport_socket_options(
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options(
       new Network::TransportSocketOptionsImpl("example.com"));
 
   TestUtilOptionsV2 test_options(listener, client, true, GetParam());
@@ -4611,7 +4611,7 @@ TEST_P(SslSocketTest, OverrideRequestedServerNameWithoutSniInUpstreamTlsContext)
 
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client;
 
-  Network::TransportSocketOptionsSharedPtr transport_socket_options(
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options(
       new Network::TransportSocketOptionsImpl("example.com"));
   TestUtilOptionsV2 test_options(listener, client, true, GetParam());
   testUtilV2(test_options.setExpectedRequestedServerName("example.com")

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -39,7 +39,7 @@ public:
   MOCK_METHOD(bool, implementsSecureTransport, (), (const));
   MOCK_METHOD(bool, usesProxyProtocolOptions, (), (const));
   MOCK_METHOD(bool, supportsAlpn, (), (const));
-  MOCK_METHOD(TransportSocketPtr, createTransportSocket, (TransportSocketOptionsSharedPtr),
+  MOCK_METHOD(TransportSocketPtr, createTransportSocket, (TransportSocketOptionsConstSharedPtr),
               (const));
 };
 

--- a/test/mocks/upstream/cluster_manager_factory.h
+++ b/test/mocks/upstream/cluster_manager_factory.h
@@ -26,13 +26,13 @@ public:
                const absl::optional<envoy::config::core::v3::AlternateProtocolsCacheOptions>&
                    alternate_protocol_options,
                const Network::ConnectionSocket::OptionsSharedPtr& options,
-               const Network::TransportSocketOptionsSharedPtr& transport_socket_options,
+               const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                TimeSource& source, ClusterConnectivityState& state));
 
   MOCK_METHOD(Tcp::ConnectionPool::InstancePtr, allocateTcpConnPool,
               (Event::Dispatcher & dispatcher, HostConstSharedPtr host, ResourcePriority priority,
                const Network::ConnectionSocket::OptionsSharedPtr& options,
-               Network::TransportSocketOptionsSharedPtr, ClusterConnectivityState& state));
+               Network::TransportSocketOptionsConstSharedPtr, ClusterConnectivityState& state));
 
   MOCK_METHOD((std::pair<ClusterSharedPtr, ThreadAwareLoadBalancerPtr>), clusterFromProto,
               (const envoy::config::cluster::v3::Cluster& cluster, ClusterManager& cm,

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -130,16 +130,17 @@ public:
   MockHost();
   ~MockHost() override;
 
-  CreateConnectionData createConnection(Event::Dispatcher& dispatcher,
-                                        const Network::ConnectionSocket::OptionsSharedPtr& options,
-                                        Network::TransportSocketOptionsSharedPtr) const override {
+  CreateConnectionData
+  createConnection(Event::Dispatcher& dispatcher,
+                   const Network::ConnectionSocket::OptionsSharedPtr& options,
+                   Network::TransportSocketOptionsConstSharedPtr) const override {
     MockCreateConnectionData data = createConnection_(dispatcher, options);
     return {Network::ClientConnectionPtr{data.connection_}, data.host_description_};
   }
 
   CreateConnectionData
   createHealthCheckConnection(Event::Dispatcher& dispatcher,
-                              Network::TransportSocketOptionsSharedPtr,
+                              Network::TransportSocketOptionsConstSharedPtr,
                               const envoy::config::core::v3::Metadata*) const override {
     MockCreateConnectionData data = createConnection_(dispatcher, nullptr);
     return {Network::ClientConnectionPtr{data.connection_}, data.host_description_};

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -21,7 +21,7 @@ public:
   MOCK_METHOD(bool, shouldSelectAnotherHost, (const Host&));
   MOCK_METHOD(uint32_t, hostSelectionRetryCount, (), (const));
   MOCK_METHOD(Network::Socket::OptionsSharedPtr, upstreamSocketOptions, (), (const));
-  MOCK_METHOD(Network::TransportSocketOptionsSharedPtr, upstreamTransportSocketOptions, (),
+  MOCK_METHOD(Network::TransportSocketOptionsConstSharedPtr, upstreamTransportSocketOptions, (),
               (const));
 
 private:


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manish.kumar1@india.nec.com>
 
Renamed TransportSocketOptionsSharedPtr to TransportSocketOptionsConstSharedPtr.