### PR TITLE
protobuf: allow relaxed opaque message with no properties

### DIFF
--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -774,9 +774,9 @@ bool redactOpaque(Protobuf::Message* message, bool ancestor_is_sensitive,
   const auto* reflection = message->GetReflection();
   const auto* type_url_field_descriptor = opaque_descriptor->FindFieldByName("type_url");
   const auto* value_field_descriptor = opaque_descriptor->FindFieldByName("value");
-  ASSERT(type_url_field_descriptor != nullptr && value_field_descriptor != nullptr &&
-         reflection->HasField(*message, type_url_field_descriptor));
-  if (!reflection->HasField(*message, value_field_descriptor)) {
+  ASSERT(type_url_field_descriptor != nullptr && value_field_descriptor != nullptr);
+  if (!reflection->HasField(*message, type_url_field_descriptor) ||
+      !reflection->HasField(*message, value_field_descriptor)) {
     return true;
   }
 

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -775,9 +775,13 @@ bool redactOpaque(Protobuf::Message* message, bool ancestor_is_sensitive,
   const auto* type_url_field_descriptor = opaque_descriptor->FindFieldByName("type_url");
   const auto* value_field_descriptor = opaque_descriptor->FindFieldByName("value");
   ASSERT(type_url_field_descriptor != nullptr && value_field_descriptor != nullptr);
-  if (!reflection->HasField(*message, type_url_field_descriptor) ||
+  if (!reflection->HasField(*message, type_url_field_descriptor) &&
       !reflection->HasField(*message, value_field_descriptor)) {
     return true;
+  }
+  if (!reflection->HasField(*message, type_url_field_descriptor) ||
+      !reflection->HasField(*message, value_field_descriptor)) {
+    return false;
   }
 
   // Try to find a descriptor for `type_url` in the pool and instantiate a new message of the

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -986,6 +986,19 @@ type_url: type.googleapis.com/envoy.test.Sensitive
   EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
 }
 
+TEST_F(ProtobufUtilityTest, RedactTypedStructWithNoTypeUrl) {
+  udpa::type::v1::TypedStruct actual;
+  TestUtility::loadFromYaml(R"EOF(
+value:
+  sensitive_string: This field is sensitive, but we have no way of knowing.
+)EOF",
+                            actual);
+
+  udpa::type::v1::TypedStruct expected = actual;
+  MessageUtil::redact(actual);
+  EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
+}
+
 // Messages packed into `TypedStruct` with unknown type URLs are skipped.
 TEST_F(ProtobufUtilityTest, RedactTypedStructWithUnknownTypeUrl) {
   udpa::type::v1::TypedStruct actual;

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1003,8 +1003,8 @@ value:
 
 TEST_F(ProtobufUtilityTest, RedactEmptyTypeUrlTypedStruct) {
   udpa::type::v1::TypedStruct actual;
-  MessageUtil::redact(actual);
   udpa::type::v1::TypedStruct expected = actual;
+  MessageUtil::redact(actual);
   EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
 }
 

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1001,6 +1001,20 @@ value:
   EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
 }
 
+TEST_F(ProtobufUtilityTest, RedactEmptyTypeUrlTypedStruct) {
+  udpa::type::v1::TypedStruct actual;
+  MessageUtil::redact(actual);
+  udpa::type::v1::TypedStruct expected = actual;
+  EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
+}
+
+TEST_F(ProtobufUtilityTest, RedactEmptyTypeUrlAny) {
+  ProtobufWkt::Any actual;
+  MessageUtil::redact(actual);
+  ProtobufWkt::Any expected = actual;
+  EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
+}
+
 // Deeply-nested opaque protos (`Any` and `TypedStruct`), which are reified using the
 // `DynamicMessageFactory`, should be redacted correctly.
 TEST_F(ProtobufUtilityTest, RedactDeeplyNestedOpaqueProtos) {


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: I faced a crash while opening config_dump. 

```
[2021-06-24 14:48:48.771][934895][critical][assert] [source/common/protobuf/utility.cc:778] assert failure: type_url_field_descriptor != nullptr && value_field_descriptor != nullptr && reflection->HasField(*message, type_url_field_descriptor).
```

It is because we passed opaque message without any properties as follows.

```
- name: envoy.filters.http.router
  typed_config: {}
```

We can avoid this crash with providing as follows

```
- name: envoy.filters.http.router
  typed_config:
    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
```

But, initial way should be accepted even if config_dump because Envoy accepts it while bootstrap.
This PR fixes to accept relaxed opaque type and avoid crash with it.

Additional Description:
Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
