### PR TITLE
ci: Only run flaky test when there is flaky data

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -143,8 +143,12 @@ function bazel_binary_build() {
 }
 
 function run_process_test_result() {
-  echo "running flaky test reporting script"
-  "${ENVOY_SRCDIR}"/ci/flaky_test/run_process_xml.sh "$CI_TARGET"
+  if [[ $(find "$TEST_TMPDIR" -name "*_attempt.xml" 2> /dev/null) ]]; then
+      echo "running flaky test reporting script"
+      "${ENVOY_SRCDIR}"/ci/flaky_test/run_process_xml.sh "$CI_TARGET"
+  else
+      echo "no flaky test results found"
+  fi
 }
 
 function run_ci_verify () {


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Only run flaky test when there is flaky data
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
