### PR TITLE
rocketmq_proxy: fix wrong value set

### DIFF
--- a/source/extensions/filters/network/rocketmq_proxy/active_message.cc
+++ b/source/extensions/filters/network/rocketmq_proxy/active_message.cc
@@ -175,7 +175,7 @@ void ActiveMessage::onQueryTopicRoute() {
         int32_t read_queue_num = 0;
         if (metadata_fields.contains(RocketmqConstants::get().ReadQueueNum)) {
           read_queue_num = static_cast<int32_t>(
-              metadata_fields.at(RocketmqConstants::get().WriteQueueNum).number_value());
+              metadata_fields.at(RocketmqConstants::get().ReadQueueNum).number_value());
         }
         int32_t write_queue_num = 0;
         if (metadata_fields.contains(RocketmqConstants::get().WriteQueueNum)) {


### PR DESCRIPTION
Signed-off-by: Long Dai <long0dai@foxmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:

It should use ReadQueueNum value.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
