### PR TITLE
quic: remove preprocessor guard on QuicStatNames.

### DIFF
--- a/source/common/quic/quic_stat_names.cc
+++ b/source/common/quic/quic_stat_names.cc
@@ -79,7 +79,7 @@ Stats::StatName QuicStatNames::resetStreamErrorStatName(quic::QuicRstStreamError
 }
 
 #else
-QuicStatNames::QuicStatNames(Stats::SymbolTable& symbol_table) {}
+QuicStatNames::QuicStatNames(Stats::SymbolTable& /*symbol_table*/) {}
 
 #endif
 

--- a/source/common/quic/quic_stat_names.cc
+++ b/source/common/quic/quic_stat_names.cc
@@ -3,6 +3,8 @@
 namespace Envoy {
 namespace Quic {
 
+#ifdef ENVOY_ENABLE_QUIC
+
 // TODO(renjietang): Currently these stats are only available in downstream. Wire it up to upstream
 // QUIC also.
 QuicStatNames::QuicStatNames(Stats::SymbolTable& symbol_table)
@@ -75,6 +77,11 @@ Stats::StatName QuicStatNames::resetStreamErrorStatName(quic::QuicRstStreamError
             "quic_reset_stream_error_code_", QuicRstStreamErrorCodeToString(error_code)));
       }));
 }
+
+#else
+QuicStatNames::QuicStatNames(Stats::SymbolTable& symbol_table) {}
+
+#endif
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/quic_stat_names.h
+++ b/source/common/quic/quic_stat_names.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef ENVOY_ENABLE_QUIC
+
 #include "envoy/stats/scope.h"
 
 #include "source/common/common/thread.h"
@@ -45,6 +47,19 @@ private:
                          Thread::AtomicPtrAllocMode::DoNotDelete>
       reset_stream_error_stat_names_;
 };
+
+#else
+
+#include "source/common/stats/symbol_table_impl.h"
+namespace Envoy {
+namespace Quic {
+
+class QuicStatNames {
+public:
+  explicit QuicStatNames(Stats::SymbolTable& symbol_table);
+};
+
+#endif
 
 } // namespace Quic
 } // namespace Envoy

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -410,6 +410,7 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/extensions/filters/network/http_connection_manager:config",
+        "//source/common/quic:quic_stat_names_lib",
         "//source/extensions/upstreams/http/generic:config",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
@@ -421,7 +422,6 @@ envoy_cc_library(
         "//source/common/quic:quic_factory_lib",
         "//source/common/quic:quic_transport_socket_factory_lib",
         "//source/common/quic:udp_gso_batch_writer_lib",
-        "//source/common/quic:quic_stat_names_lib",
     ]),
 )
 

--- a/source/server/listener_impl.cc
+++ b/source/server/listener_impl.cc
@@ -296,12 +296,8 @@ ListenerImpl::ListenerImpl(const envoy::config::listener::v3::Listener& config,
                               // ready.
                               listener_init_target_.ready();
                             }
-                          })
-#ifdef ENVOY_ENABLE_QUIC
-      ,
-      quic_stat_names_(parent_.quicStatNames())
-#endif
-{
+                          }),
+      quic_stat_names_(parent_.quicStatNames()) {
 
   const absl::optional<std::string> runtime_val =
       listener_factory_context_->runtime().snapshot().get(cx_limit_runtime_key_);
@@ -368,12 +364,8 @@ ListenerImpl::ListenerImpl(ListenerImpl& origin,
                           [this] {
                             ASSERT(workers_started_);
                             parent_.inPlaceFilterChainUpdate(*this);
-                          })
-#ifdef ENVOY_ENABLE_QUIC
-      ,
-      quic_stat_names_(parent_.quicStatNames())
-#endif
-{
+                          }),
+      quic_stat_names_(parent_.quicStatNames()) {
   buildAccessLog();
   auto socket_type = Network::Utility::protobufAddressSocketType(config.address());
   buildListenSocketOptions(socket_type);

--- a/source/server/listener_impl.h
+++ b/source/server/listener_impl.h
@@ -17,13 +17,10 @@
 #include "source/common/common/logger.h"
 #include "source/common/init/manager_impl.h"
 #include "source/common/init/target_impl.h"
+#include "source/common/quic/quic_stat_names.h"
 #include "source/server/filter_chain_manager_impl.h"
 
 #include "absl/base/call_once.h"
-
-#ifdef ENVOY_ENABLE_QUIC
-#include "source/common/quic/quic_stat_names.h"
-#endif
 
 namespace Envoy {
 namespace Server {
@@ -427,9 +424,7 @@ private:
   // callback during the destroy of ListenerImpl.
   Init::WatcherImpl local_init_watcher_;
 
-#ifdef ENVOY_ENABLE_QUIC
   Quic::QuicStatNames& quic_stat_names_;
-#endif
 
   // to access ListenerManagerImpl::factory_.
   friend class ListenerFilterChainFactoryBuilder;

--- a/source/server/listener_manager_impl.cc
+++ b/source/server/listener_manager_impl.cc
@@ -256,7 +256,8 @@ ListenerManagerImpl::ListenerManagerImpl(Instance& server,
       scope_(server.stats().createScope("listener_manager.")), stats_(generateStats(*scope_)),
       config_tracker_entry_(server.admin().getConfigTracker().add(
           "listeners", [this] { return dumpListenerConfigs(); })),
-      enable_dispatcher_stats_(enable_dispatcher_stats) {
+      enable_dispatcher_stats_(enable_dispatcher_stats),
+      quic_stat_names_(server_.stats().symbolTable()) {
   for (uint32_t i = 0; i < server.options().concurrency(); i++) {
     workers_.emplace_back(
         worker_factory.createWorker(i, server.overloadManager(), absl::StrCat("worker_", i)));

--- a/source/server/listener_manager_impl.h
+++ b/source/server/listener_manager_impl.h
@@ -18,14 +18,11 @@
 #include "envoy/server/worker.h"
 #include "envoy/stats/scope.h"
 
+#include "source/common/quic/quic_stat_names.h"
 #include "source/server/filter_chain_factory_context_callback.h"
 #include "source/server/filter_chain_manager_impl.h"
 #include "source/server/lds_api.h"
 #include "source/server/listener_impl.h"
-
-#ifdef ENVOY_ENABLE_QUIC
-#include "source/common/quic/quic_stat_names.h"
-#endif
 
 namespace Envoy {
 namespace Server {
@@ -206,9 +203,7 @@ public:
   Http::Context& httpContext() { return server_.httpContext(); }
   ApiListenerOptRef apiListener() override;
 
-#ifdef ENVOY_ENABLE_QUIC
   Quic::QuicStatNames& quicStatNames() { return quic_stat_names_; }
-#endif
 
   Instance& server_;
   ListenerComponentFactory& factory_;
@@ -324,9 +319,7 @@ private:
   using UpdateFailureState = envoy::admin::v3::UpdateFailureState;
   absl::flat_hash_map<std::string, std::unique_ptr<UpdateFailureState>> error_state_tracker_;
   FailureStates overall_error_state_;
-#ifdef ENVOY_ENABLE_QUIC
-  Quic::QuicStatNames quic_stat_names_ = Quic::QuicStatNames(server_.stats().symbolTable());
-#endif
+  Quic::QuicStatNames quic_stat_names_;
 };
 
 class ListenerFilterChainFactoryBuilder : public FilterChainFactoryBuilder {


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@google.com>

Commit Message: Move QuicStatNames' preprocessor guard into the class itself.
Additional Description: This mitigates pollution by ENVOY_ENABLE_QUIC preprocessor across the codebase. More such preprocessors may be moved in followup PRs.
Risk Level: Low
Testing: Refactor only
Docs Changes: NA

