### PR TITLE
ci: Add azp cache for missing precheck jobs

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -18,6 +18,12 @@ stages:
     pool:
       vmImage: "ubuntu-18.04"
     steps:
+    - task: Cache@2
+      inputs:
+        key: "format_pre | ./WORKSPACE | **/*.bzl"
+        path: $(Build.StagingDirectory)/repository_cache
+      continueOnError: true
+
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh format_pre'
       workingDirectory: $(Build.SourcesDirectory)
       env:
@@ -38,6 +44,12 @@ stages:
     pool:
       vmImage: "ubuntu-18.04"
     steps:
+    - task: Cache@2
+      inputs:
+        key: "tooling | ./WORKSPACE | **/*.bzl"
+        path: $(Build.StagingDirectory)/repository_cache
+      continueOnError: true
+
     - script: ci/run_envoy_docker.sh 'ci/do_ci.sh tooling'
       workingDirectory: $(Build.SourcesDirectory)
       env:


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: ci: Remove azp cache for precheck jobs
Additional Description:

most of the precheck jobs dont use the cache, and im not sure what purpose it serves here

for the most part its quick, if unnecessary, but sometimes there can be contention on the cache and it can take a long time

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
