### PR TITLE
quiche: do not call reset callback once end stream is decoded and encoded.

### DIFF
--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -265,7 +265,7 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicRstStreamErrorCode error) {
   bool ret = quic::QuicSpdyServerStreamBase::OnStopSending(error);
   ASSERT(write_side_closed());
   if (read_side_closed() && !end_stream_encoded) {
-    // If both directions are closed but end stream hasn't be encoded yet, notify reset callbacks.
+    // If both directions are closed but end stream hasn't been encoded yet, notify reset callbacks.
     // Treat this as a remote reset, since the stream will be closed in both directions.
     runResetCallbacks(quicRstErrorToEnvoyRemoteResetReason(error));
   }

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -263,6 +263,7 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicRstStreamErrorCode error) {
   bool end_stream_encoded = local_end_stream_;
   // This call will close write.
   bool ret = quic::QuicSpdyServerStreamBase::OnStopSending(error);
+  ASSERT(write_side_closed());
   if (read_side_closed() && !end_stream_encoded) {
     // If both directions are closed but end stream hasn't be encoded yet, notify reset callbacks.
     // Treat this as a remote reset, since the stream will be closed in both directions.
@@ -278,6 +279,7 @@ void EnvoyQuicServerStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
   // This closes read side in both Google Quic and IETF Quic, but doesn't close write side in IETF
   // Quic.
   quic::QuicSpdyServerStreamBase::OnStreamReset(frame);
+  ASSERT(read_side_closed());
   if (write_side_closed() && !end_stream_decoded_and_encoded) {
     // If both directions are closed but upstream hasn't received or sent end stream, run reset
     // stream callback.

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -260,8 +260,9 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicRstStreamErrorCode error) {
   // Only called in IETF Quic to close write side.
   ENVOY_STREAM_LOG(debug, "received STOP_SENDING with reset code={}", *this, error);
   stats_.rx_reset_.inc();
+  bool end_stream_decoded_and_encoded = read_side_closed() && local_end_stream_;
   bool ret = quic::QuicSpdyServerStreamBase::OnStopSending(error);
-  if (read_side_closed() && !local_end_stream_) {
+  if (read_side_closed() && !end_stream_decoded_and_encoded) {
     // Treat this as a remote reset, since the stream will be closed in both directions.
     runResetCallbacks(quicRstErrorToEnvoyRemoteResetReason(error));
   }
@@ -269,14 +270,15 @@ bool EnvoyQuicServerStream::OnStopSending(quic::QuicRstStreamErrorCode error) {
 }
 
 void EnvoyQuicServerStream::OnStreamReset(const quic::QuicRstStreamFrame& frame) {
-  ENVOY_STREAM_LOG(debug, "received RST_STREAM with reset code={}", *this, frame.error_code);
+  ENVOY_STREAM_LOG(debug, "received RESET_STREAM with reset code={}", *this, frame.error_code);
   stats_.rx_reset_.inc();
+  bool end_stream_decoded_and_encoded = read_side_closed() && local_end_stream_;
   // This closes read side in both Google Quic and IETF Quic, but doesn't close write side in IETF
   // Quic.
   quic::QuicSpdyServerStreamBase::OnStreamReset(frame);
-  if (write_side_closed() && !local_end_stream_) {
-    // If the stream is closed in both directions and upstream hasn't ended the stream, run reset
-    // stream callback.
+  if (write_side_closed() && !end_stream_decoded_and_encoded) {
+    // If the stream is closed in both directions and upstream hasn't received or sent end stream,
+    // run reset stream callback.
     runResetCallbacks(quicRstErrorToEnvoyRemoteResetReason(frame.error_code));
   }
 }

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -367,22 +367,23 @@ TEST_P(EnvoyQuicServerSessionTest, NoNewStreamForInvalidIncomingStream) {
   EXPECT_EQ(nullptr, envoy_quic_session_.GetOrCreateStream(stream_id));
 }
 
-TEST_P(EnvoyQuicServerSessionTest, OnResetFrame) {
+TEST_P(EnvoyQuicServerSessionTest, OnResetFrameGoogleQuic) {
   installReadFilter();
+  if (quic::VersionUsesHttp3(quic_version_[0].transport_version)) {
+    return;
+  }
   Http::MockRequestDecoder request_decoder;
   Http::MockStreamCallbacks stream_callbacks;
   quic::QuicStream* stream1 = createNewStream(request_decoder, stream_callbacks);
   quic::QuicRstStreamFrame rst1(/*control_frame_id=*/1u, stream1->id(),
                                 quic::QUIC_ERROR_PROCESSING_STREAM, /*bytes_written=*/0u);
   EXPECT_CALL(stream_callbacks, onResetStream(Http::StreamResetReason::RemoteReset, _));
-  if (!quic::VersionUsesHttp3(quic_version_[0].transport_version)) {
-    EXPECT_CALL(*quic_connection_, SendControlFrame(_))
-        .WillOnce(Invoke([stream_id = stream1->id()](const quic::QuicFrame& frame) {
-          EXPECT_EQ(stream_id, frame.rst_stream_frame->stream_id);
-          EXPECT_EQ(quic::QUIC_RST_ACKNOWLEDGEMENT, frame.rst_stream_frame->error_code);
-          return false;
-        }));
-  }
+  EXPECT_CALL(*quic_connection_, SendControlFrame(_))
+      .WillOnce(Invoke([stream_id = stream1->id()](const quic::QuicFrame& frame) {
+        EXPECT_EQ(stream_id, frame.rst_stream_frame->stream_id);
+        EXPECT_EQ(quic::QUIC_RST_ACKNOWLEDGEMENT, frame.rst_stream_frame->error_code);
+        return false;
+      }));
   envoy_quic_session_.OnRstStream(rst1);
 
   EXPECT_CALL(http_connection_callbacks_, newStream(_, false))
@@ -396,6 +397,7 @@ TEST_P(EnvoyQuicServerSessionTest, OnResetFrame) {
                                 /*bytes_written=*/0u);
   EXPECT_CALL(stream_callbacks,
               onResetStream(Http::StreamResetReason::RemoteRefusedStreamReset, _));
+
   envoy_quic_session_.OnRstStream(rst2);
 
   EXPECT_EQ(1U, TestUtility::findCounter(
@@ -405,6 +407,55 @@ TEST_P(EnvoyQuicServerSessionTest, OnResetFrame) {
   EXPECT_EQ(1U, TestUtility::findCounter(
                     static_cast<Stats::IsolatedStoreImpl&>(listener_config_.listenerScope()),
                     "http3.downstream.rx.quic_reset_stream_error_code_QUIC_ERROR_PROCESSING_STREAM")
+                    ->value());
+}
+
+TEST_P(EnvoyQuicServerSessionTest, OnResetFrameIetfQuic) {
+  installReadFilter();
+  if (!quic::VersionUsesHttp3(quic_version_[0].transport_version)) {
+    return;
+  }
+  Http::MockRequestDecoder request_decoder;
+  Http::MockStreamCallbacks stream_callbacks;
+  auto stream1 =
+      dynamic_cast<EnvoyQuicServerStream*>(createNewStream(request_decoder, stream_callbacks));
+  // Receiving RESET_STREAM alone should only close read side.
+  quic::QuicRstStreamFrame rst1(/*control_frame_id=*/1u, stream1->id(),
+                                quic::QUIC_ERROR_PROCESSING_STREAM, /*bytes_written=*/0u);
+  envoy_quic_session_.OnRstStream(rst1);
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  stream1->encodeHeaders(response_headers, true);
+
+  EXPECT_EQ(1U, TestUtility::findCounter(
+                    static_cast<Stats::IsolatedStoreImpl&>(listener_config_.listenerScope()),
+                    "http3.downstream.rx.quic_reset_stream_error_code_QUIC_ERROR_PROCESSING_STREAM")
+                    ->value());
+
+  EXPECT_CALL(http_connection_callbacks_, newStream(_, false))
+      .WillOnce(Invoke([&request_decoder, &stream_callbacks](Http::ResponseEncoder& encoder,
+                                                             bool) -> Http::RequestDecoder& {
+        encoder.getStream().addCallbacks(stream_callbacks);
+        return request_decoder;
+      }));
+  quic::QuicStream* stream2 = envoy_quic_session_.GetOrCreateStream(stream1->id() + 4u);
+  quic::QuicRstStreamFrame rst2(/*control_frame_id=*/1u, stream2->id(), quic::QUIC_REFUSED_STREAM,
+                                /*bytes_written=*/0u);
+  quic::QuicStopSendingFrame stop_sending(/*control_frame_id=*/1u, stream2->id(),
+                                          quic::QUIC_REFUSED_STREAM);
+  // Receiving both STOP_SENDING and RESET_STREAM should close the stream.
+  EXPECT_CALL(stream_callbacks,
+              onResetStream(Http::StreamResetReason::RemoteRefusedStreamReset, _));
+  EXPECT_CALL(*quic_connection_, SendControlFrame(_))
+      .WillOnce(Invoke([stream_id = stream2->id()](const quic::QuicFrame& frame) {
+        EXPECT_EQ(stream_id, frame.rst_stream_frame->stream_id);
+        EXPECT_EQ(quic::QUIC_REFUSED_STREAM, frame.rst_stream_frame->error_code);
+        return false;
+      }));
+  envoy_quic_session_.OnStopSendingFrame(stop_sending);
+  envoy_quic_session_.OnRstStream(rst2);
+  EXPECT_EQ(1U, TestUtility::findCounter(
+                    static_cast<Stats::IsolatedStoreImpl&>(listener_config_.listenerScope()),
+                    "http3.downstream.rx.quic_reset_stream_error_code_QUIC_REFUSED_STREAM")
                     ->value());
 }
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2688,6 +2688,9 @@ TEST_P(ProtocolIntegrationTest, ReqRespSizeStats) {
 }
 
 TEST_P(ProtocolIntegrationTest, ResetLargeResponseUponReceivingHeaders) {
+  if (downstreamProtocol() == Http::CodecType::HTTP1) {
+    return;
+  }
   autonomous_upstream_ = true;
   autonomous_allow_incomplete_streams_ = true;
   initialize();
@@ -2717,6 +2720,7 @@ TEST_P(ProtocolIntegrationTest, ResetLargeResponseUponReceivingHeaders) {
   response->waitForHeaders();
   // Reset stream while the quic server stream might have FIN buffered in its send buffer.
   codec_client_->sendReset(encoder);
+  codec_client_->close();
 }
 
 } // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2687,4 +2687,36 @@ TEST_P(ProtocolIntegrationTest, ReqRespSizeStats) {
   test_server_->waitUntilHistogramHasSamples("cluster.cluster_0.upstream_rs_headers_size");
 }
 
+TEST_P(ProtocolIntegrationTest, ResetLargeResponseUponReceivingHeaders) {
+  autonomous_upstream_ = true;
+  autonomous_allow_incomplete_streams_ = true;
+  initialize();
+
+  envoy::config::core::v3::Http2ProtocolOptions http2_options =
+      ::Envoy::Http2::Utility::initializeAndValidateOptions(
+          envoy::config::core::v3::Http2ProtocolOptions());
+  http2_options.mutable_initial_stream_window_size()->set_value(65535);
+  http2_options.mutable_initial_connection_window_size()->set_value(65535);
+  codec_client_ = makeRawHttpConnection(makeClientConnection(lookupPort("http")), http2_options);
+
+  // The response is larger than the stream flow control window. So the reset of it will
+  // likely be buffered QUIC stream send buffer.
+  constexpr uint64_t response_size = 100 * 1024;
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-length", "10"},
+                                     {"response_size_bytes", absl::StrCat(response_size)}});
+  auto& encoder = encoder_decoder.first;
+  std::string data(10, 'a');
+  codec_client_->sendData(encoder, data, true);
+
+  auto response = std::move(encoder_decoder.second);
+  response->waitForHeaders();
+  // Reset stream while the quic server stream might have FIN buffered in its send buffer.
+  codec_client_->sendReset(encoder);
+}
+
 } // namespace Envoy

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -417,5 +417,37 @@ TEST_P(QuicHttpIntegrationTest, ResetRequestWithoutAuthorityHeader) {
   EXPECT_EQ("400", response->headers().getStatusValue());
 }
 
+TEST_P(QuicHttpIntegrationTest, ResetLargeResponseUponReceivingHeaders) {
+  autonomous_upstream_ = true;
+  autonomous_allow_incomplete_streams_ = true;
+  initialize();
+
+  envoy::config::core::v3::Http2ProtocolOptions http2_options =
+      ::Envoy::Http2::Utility::initializeAndValidateOptions(
+          envoy::config::core::v3::Http2ProtocolOptions());
+  http2_options.mutable_initial_stream_window_size()->set_value(65535);
+  http2_options.mutable_initial_connection_window_size()->set_value(65535);
+  codec_client_ = makeRawHttpConnection(makeClientConnection(lookupPort("http")), http2_options);
+
+  // The response is larger than the stream flow control window. So the reset of it will
+  // likely be buffered QUIC stream send buffer.
+  constexpr uint64_t response_size = 100 * 1024;
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-length", "10"},
+                                     {"response_size_bytes", absl::StrCat(response_size)}});
+  auto& encoder = encoder_decoder.first;
+  std::string data(10, 'a');
+  codec_client_->sendData(encoder, data, true);
+
+  auto response = std::move(encoder_decoder.second);
+  response->waitForHeaders();
+  // Reset stream while the quic server stream might have FIN bufferred in its send buffer.
+  codec_client_->sendReset(encoder);
+}
+
 } // namespace Quic
 } // namespace Envoy

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -445,7 +445,7 @@ TEST_P(QuicHttpIntegrationTest, ResetLargeResponseUponReceivingHeaders) {
 
   auto response = std::move(encoder_decoder.second);
   response->waitForHeaders();
-  // Reset stream while the quic server stream might have FIN bufferred in its send buffer.
+  // Reset stream while the quic server stream might have FIN buffered in its send buffer.
   codec_client_->sendReset(encoder);
 }
 


### PR DESCRIPTION
Signed-off-by: Dan Zhang <danzh@google.com>

Commit Message: EnvoyQuicServerStream::OnStopSending() and OnStopSending() shouldn't call reset callbacks if it already encoded and decoded end_stream.

Testing: added an integration test ResetLargeResponseUponReceivingHeaders for both Google Quic and IETF Quic.