### PR TITLE
remove support of hidden_deprecated_use_alpha

### DIFF
--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -43,12 +43,6 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
   } else if (proto_config.grpc_service().has_google_grpc()) {
     // Google gRPC client.
 
-    // The use_alpha field was there select the v2alpha api version, which is
-    // long deprecated and should not be used anymore.
-    if (proto_config.hidden_envoy_deprecated_use_alpha()) {
-      throw EnvoyException("The use_alpha field is deprecated and is no longer supported.");
-    }
-
     const uint32_t timeout_ms =
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
 
@@ -64,14 +58,6 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
   } else {
     // Envoy gRPC client.
 
-    // The use_alpha field was there select the v2alpha api version, which is
-    // long deprecated and should not be used anymore.
-    if (proto_config.hidden_envoy_deprecated_use_alpha()) {
-      throw EnvoyException("The use_alpha field is deprecated and is no longer supported.");
-    }
-    Grpc::RawAsyncClientSharedPtr raw_client =
-        context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
-            proto_config.grpc_service(), context.scope(), true, Grpc::CacheOption::AlwaysCache);
     const uint32_t timeout_ms =
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
     callback = [raw_client, filter_config, timeout_ms,

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -58,6 +58,9 @@ Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoTyped(
   } else {
     // Envoy gRPC client.
 
+    Grpc::RawAsyncClientSharedPtr raw_client =
+        context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClient(
+            proto_config.grpc_service(), context.scope(), true, Grpc::CacheOption::AlwaysCache);
     const uint32_t timeout_ms =
         PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, DefaultTimeout);
     callback = [raw_client, filter_config, timeout_ms,

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -131,56 +131,6 @@ TEST(HttpExtAuthzConfigTest, CorrectProtoHttp) {
   cb(filter_callback);
 }
 
-// Test that setting the use_alpha proto field throws.
-TEST(HttpExtAuthzConfigTest, DEPRECATED_FEATURE_TEST(UseAlphaFieldIsNoLongerSupported)) {
-  TestScopedRuntime scoped_runtime;
-  Runtime::LoaderSingleton::getExisting()->mergeValues(
-      {{"envoy.deprecated_features:envoy.extensions.filters.http.ext_authz.v3.ExtAuthz.hidden_"
-        "envoy_deprecated_use_alpha",
-        "true"}});
-
-  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config;
-  proto_config.set_hidden_envoy_deprecated_use_alpha(true);
-
-  // Trigger the throw in the Envoy gRPC branch.
-  {
-    testing::StrictMock<Server::Configuration::MockFactoryContext> context;
-    testing::StrictMock<Server::Configuration::MockServerFactoryContext> server_context;
-    EXPECT_CALL(context, getServerFactoryContext())
-        .WillRepeatedly(testing::ReturnRef(server_context));
-    EXPECT_CALL(context, messageValidationVisitor());
-    EXPECT_CALL(context, runtime());
-    EXPECT_CALL(context, scope());
-
-    ExtAuthzFilterConfig factory;
-    EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context),
-                              EnvoyException,
-                              "The use_alpha field is deprecated and is no longer supported.")
-  }
-
-  // Trigger the throw in the Google gRPC branch.
-  {
-    auto google_grpc = new envoy::config::core::v3::GrpcService_GoogleGrpc();
-    google_grpc->set_stat_prefix("grpc");
-    google_grpc->set_target_uri("http://example.com");
-    proto_config.set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
-    proto_config.mutable_grpc_service()->set_allocated_google_grpc(google_grpc);
-
-    testing::StrictMock<Server::Configuration::MockFactoryContext> context;
-    testing::StrictMock<Server::Configuration::MockServerFactoryContext> server_context;
-    EXPECT_CALL(context, getServerFactoryContext())
-        .WillRepeatedly(testing::ReturnRef(server_context));
-    EXPECT_CALL(context, messageValidationVisitor());
-    EXPECT_CALL(context, runtime());
-    EXPECT_CALL(context, scope());
-
-    ExtAuthzFilterConfig factory;
-    EXPECT_THROW_WITH_MESSAGE(factory.createFilterFactoryFromProto(proto_config, "stats", context),
-                              EnvoyException,
-                              "The use_alpha field is deprecated and is no longer supported.")
-  }
-}
-
 // Test that the deprecated extension name still functions.
 TEST(HttpExtAuthzConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
   const std::string deprecated_name = "envoy.ext_authz";

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -280,7 +280,7 @@ transport_socket_matches:
       EXPECT_EQ("POST", hds_stream_->headers().getMethodValue());
       EXPECT_EQ(TestUtility::getVersionedMethodPath("envoy.service.{1}.{0}.HealthDiscoveryService",
                                                     "StreamHealthCheck", apiVersion(),
-                                                    /*use_alpha=*/false, serviceNamespace()),
+                                                    serviceNamespace()),
                 hds_stream_->headers().getPathValue());
       EXPECT_EQ("application/grpc", hds_stream_->headers().getContentTypeValue());
     }
@@ -335,7 +335,7 @@ transport_socket_matches:
       EXPECT_EQ("POST", hds_stream_->headers().getMethodValue());
       EXPECT_EQ(TestUtility::getVersionedMethodPath("envoy.service.{1}.{0}.HealthDiscoveryService",
                                                     "StreamHealthCheck", apiVersion(),
-                                                    /*use_alpha=*/false, serviceNamespace()),
+                                                    serviceNamespace()),
                 hds_stream_->headers().getPathValue());
       EXPECT_EQ("application/grpc", hds_stream_->headers().getContentTypeValue());
     }

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -793,9 +793,8 @@ public:
     case envoy::config::core::v3::ApiVersion::AUTO:
       FALLTHRU;
     case envoy::config::core::v3::ApiVersion::V2:
-      return fmt::format(service_full_name_template, "v2",
-                         service_namespace);  
-    
+      return fmt::format(service_full_name_template, "v2", service_namespace);
+
     case envoy::config::core::v3::ApiVersion::V3:
       return fmt::format(service_full_name_template, "v3", service_namespace);
     default:
@@ -816,10 +815,10 @@ public:
                                             absl::string_view method_name,
                                             envoy::config::core::v3::ApiVersion api_version,
                                             const std::string& service_namespace = EMPTY_STRING) {
-    return absl::StrCat("/",
-                        getVersionedServiceFullName(service_full_name_template, api_version,
-                                                    service_namespace),
-                        "/", method_name);
+    return absl::StrCat(
+        "/",
+        getVersionedServiceFullName(service_full_name_template, api_version, service_namespace),
+        "/", method_name);
   }
 };
 

--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -782,22 +782,20 @@ public:
    *
    * @param service_full_name_template the service fully-qualified name template.
    * @param api_version version of a service.
-   * @param use_alpha if the alpha version is preferred.
    * @param service_namespace to override the service namespace.
    * @return std::string full path of a service method.
    */
   static std::string
   getVersionedServiceFullName(const std::string& service_full_name_template,
                               envoy::config::core::v3::ApiVersion api_version,
-                              bool use_alpha = false,
                               const std::string& service_namespace = EMPTY_STRING) {
     switch (api_version) {
     case envoy::config::core::v3::ApiVersion::AUTO:
       FALLTHRU;
     case envoy::config::core::v3::ApiVersion::V2:
-      return fmt::format(service_full_name_template, use_alpha ? "v2alpha" : "v2",
-                         service_namespace);
-
+      return fmt::format(service_full_name_template, "v2",
+                         service_namespace);  
+    
     case envoy::config::core::v3::ApiVersion::V3:
       return fmt::format(service_full_name_template, "v3", service_namespace);
     default:
@@ -811,18 +809,16 @@ public:
    * @param service_full_name_template the service fully-qualified name template.
    * @param method_name the method name.
    * @param api_version version of a service method.
-   * @param use_alpha if the alpha version is preferred.
    * @param service_namespace to override the service namespace.
    * @return std::string full path of a service method.
    */
   static std::string getVersionedMethodPath(const std::string& service_full_name_template,
                                             absl::string_view method_name,
                                             envoy::config::core::v3::ApiVersion api_version,
-                                            bool use_alpha = false,
                                             const std::string& service_namespace = EMPTY_STRING) {
     return absl::StrCat("/",
                         getVersionedServiceFullName(service_full_name_template, api_version,
-                                                    use_alpha, service_namespace),
+                                                    service_namespace),
                         "/", method_name);
   }
 };


### PR DESCRIPTION
Signed-off-by: Abhay Narayan Katare <abhay.katare@india.nec.com>

Commit Message: Another PR of type remove_v2_support. first PR is #16274
Additional Description: Removing support of hidden_deprecated_use_alpha
Risk Level: LOW
Testing: unit (i.e. bazel test under bazel test test/extensions/filters/http/ext_authz/... )
Docs Changes: NA
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
