### PR TITLE
xds: Clarify that RouteMatch.case_sensitive field does not apply to safe_regex

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -473,7 +473,7 @@ message RouteMatch {
   }
 
   // Indicates that prefix/path matching should be case sensitive. The default
-  // is true.
+  // is true. Ignored for safe_regex matching.
   google.protobuf.BoolValue case_sensitive = 4;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route

--- a/api/envoy/config/route/v4alpha/route_components.proto
+++ b/api/envoy/config/route/v4alpha/route_components.proto
@@ -474,7 +474,7 @@ message RouteMatch {
   }
 
   // Indicates that prefix/path matching should be case sensitive. The default
-  // is true.
+  // is true. Ignored for safe_regex matching.
   google.protobuf.BoolValue case_sensitive = 4;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route

--- a/generated_api_shadow/envoy/config/route/v3/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v3/route_components.proto
@@ -482,7 +482,7 @@ message RouteMatch {
   }
 
   // Indicates that prefix/path matching should be case sensitive. The default
-  // is true.
+  // is true. Ignored for safe_regex matching.
   google.protobuf.BoolValue case_sensitive = 4;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route

--- a/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
+++ b/generated_api_shadow/envoy/config/route/v4alpha/route_components.proto
@@ -475,7 +475,7 @@ message RouteMatch {
   }
 
   // Indicates that prefix/path matching should be case sensitive. The default
-  // is true.
+  // is true. Ignored for safe_regex matching.
   google.protobuf.BoolValue case_sensitive = 4;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: xds: Clarify that RouteMatch.case_sensitive field does not apply to safe_regex
Additional Description: N/A
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: