### PR TITLE
ci: Dont clone filter example where not necessary

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -6,8 +6,9 @@ set -e
 
 
 build_setup_args=""
-if [[ "$1" == "format_pre" || "$1" == "fix_format" || "$1" == "check_format" || \
-          "$1" == "bazel.clang_tidy" || "$1" == "tooling" || "$1" == "deps" ]]; then
+if [[ "$1" == "format_pre" || "$1" == "fix_format" || "$1" == "check_format" || "$1" == "docs" ||  \
+          "$1" == "bazel.clang_tidy" || "$1" == "tooling" || "$1" == "deps" || "$1" == "verify_examples" || \
+          "$1" == "verify_build_examples" ]]; then
     build_setup_args="-nofetch"
 fi
 


### PR DESCRIPTION
Commit Message: ci: Dont clone filter example where not necessary
Additional Description:

not sure if this catches all - not entirely clear to me what in the ci uses the filter-example

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
