### PR TITLE
Revert "alpha matching: support generic action factory context (#17025)"

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -76,12 +76,11 @@ public:
 using ActionPtr = std::unique_ptr<Action>;
 using ActionFactoryCb = std::function<ActionPtr()>;
 
-template <class ActionFactoryContext> class ActionFactory : public Config::TypedFactory {
+class ActionFactory : public Config::TypedFactory {
 public:
   virtual ActionFactoryCb
-  createActionFactoryCb(const Protobuf::Message& config,
-                        ActionFactoryContext& action_factory_context,
-                        ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+  createActionFactoryCb(const Protobuf::Message& config, const std::string& stats_prefix,
+                        Server::Configuration::FactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.matching.action"; }
 };
@@ -156,7 +155,7 @@ class InputMatcherFactory : public Config::TypedFactory {
 public:
   virtual InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+                              Server::Configuration::FactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.input_matchers"; }
 };
@@ -227,7 +226,7 @@ public:
    */
   virtual DataInputFactoryCb<DataType>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+                           Server::Configuration::FactoryContext& factory_context) PURE;
 
   /**
    * The category of this factory depends on the DataType, so we require a name() function to exist
@@ -263,7 +262,7 @@ public:
    */
   virtual CommonProtocolInputFactoryCb
   createCommonProtocolInputFactoryCb(const Protobuf::Message& config,
-                                     ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+                                     Server::Configuration::FactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.common_inputs"; }
 };

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -13,13 +13,11 @@
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
 
-#include "matching/data_impl.h"
-
 namespace Envoy {
 namespace Http {
 
 namespace {
-REGISTER_FACTORY(SkipActionFactory, Matcher::ActionFactory<Matching::HttpFilterActionContext>);
+REGISTER_FACTORY(SkipActionFactory, Matcher::ActionFactory);
 
 template <class T> using FilterList = std::list<std::unique_ptr<T>>;
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -68,12 +68,11 @@ private:
 
 using FilterMatchStateSharedPtr = std::shared_ptr<FilterMatchState>;
 
-class SkipActionFactory : public Matcher::ActionFactory<Matching::HttpFilterActionContext> {
+class SkipActionFactory : public Matcher::ActionFactory {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&,
-                                                 Matching::HttpFilterActionContext&,
-                                                 ProtobufMessage::ValidationVisitor&) override {
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&, const std::string&,
+                                                 Server::Configuration::FactoryContext&) override {
     return []() { return std::make_unique<SkipAction>(); };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/common/http/match_wrapper/BUILD
+++ b/source/common/http/match_wrapper/BUILD
@@ -15,7 +15,6 @@ envoy_cc_library(
     deps = [
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
-        "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@envoy_api//envoy/extensions/common/matching/v3:pkg_cc_proto",

--- a/source/common/http/match_wrapper/config.cc
+++ b/source/common/http/match_wrapper/config.cc
@@ -5,7 +5,6 @@
 #include "envoy/registry/registry.h"
 
 #include "source/common/config/utility.h"
-#include "source/common/http/matching/data_impl.h"
 #include "source/common/matcher/matcher.h"
 
 #include "absl/status/status.h"
@@ -104,11 +103,9 @@ Envoy::Http::FilterFactoryCb MatchWrapperConfig::createFilterFactoryFromProtoTyp
 
   MatchTreeValidationVisitor validation_visitor(*factory.matchingRequirements());
 
-  Envoy::Http::Matching::HttpFilterActionContext action_context{prefix, context};
-  auto match_tree = Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData,
-                                              Envoy::Http::Matching::HttpFilterActionContext>(
-                        action_context, context.messageValidationVisitor(), validation_visitor)
-                        .create(proto_config.matcher());
+  auto match_tree =
+      Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData>(prefix, context, validation_visitor)
+          .create(proto_config.matcher());
 
   if (!validation_visitor.errors().empty()) {
     // TODO(snowp): Output all violations.

--- a/source/common/http/matching/data_impl.h
+++ b/source/common/http/matching/data_impl.h
@@ -55,10 +55,6 @@ private:
 
 using HttpMatchingDataImplSharedPtr = std::shared_ptr<HttpMatchingDataImpl>;
 
-struct HttpFilterActionContext {
-  const std::string& stat_prefix_;
-  Server::Configuration::FactoryContext& factory_context_;
-};
 } // namespace Matching
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/matching/inputs.h
+++ b/source/common/http/matching/inputs.h
@@ -55,9 +55,9 @@ public:
 
   Matcher::DataInputFactoryCb<HttpMatchingData>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           ProtobufMessage::ValidationVisitor& validation_visitor) override {
-    const auto& typed_config =
-        MessageUtil::downcastAndValidate<const ProtoType&>(config, validation_visitor);
+                           Server::Configuration::FactoryContext& factory_context) override {
+    const auto& typed_config = MessageUtil::downcastAndValidate<const ProtoType&>(
+        config, factory_context.messageValidationVisitor());
 
     return [header_name = typed_config.header_name()] {
       return std::make_unique<DataInputType>(header_name);

--- a/source/extensions/filters/http/composite/BUILD
+++ b/source/extensions/filters/http/composite/BUILD
@@ -16,7 +16,6 @@ envoy_cc_library(
     srcs = ["action.cc"],
     hdrs = ["action.h"],
     deps = [
-        "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",
         "@envoy_api//envoy/extensions/filters/http/composite/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -7,8 +7,7 @@ namespace Composite {
 void ExecuteFilterAction::createFilters(Http::FilterChainFactoryCallbacks& callbacks) const {
   cb_(callbacks);
 }
-REGISTER_FACTORY(ExecuteFilterActionFactory,
-                 Matcher::ActionFactory<Http::Matching::HttpFilterActionContext>);
+REGISTER_FACTORY(ExecuteFilterActionFactory, Matcher::ActionFactory);
 } // namespace Composite
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/matching/common_inputs/environment_variable/config.cc
+++ b/source/extensions/matching/common_inputs/environment_variable/config.cc
@@ -12,10 +12,10 @@ namespace EnvironmentVariable {
 
 Envoy::Matcher::CommonProtocolInputFactoryCb
 Config::createCommonProtocolInputFactoryCb(const Protobuf::Message& config,
-                                           ProtobufMessage::ValidationVisitor& validation_visitor) {
+                                           Server::Configuration::FactoryContext& factory_context) {
   const auto& environment_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::matching::common_inputs::environment_variable::v3::Config&>(
-      config, validation_visitor);
+      config, factory_context.messageValidationVisitor());
 
   // We read the env variable at construction time to avoid repeat lookups.
   // This assumes that the environment remains stable during the process lifetime.

--- a/source/extensions/matching/common_inputs/environment_variable/config.h
+++ b/source/extensions/matching/common_inputs/environment_variable/config.h
@@ -18,7 +18,7 @@ class Config : public Envoy::Matcher::CommonProtocolInputFactory {
 public:
   Envoy::Matcher::CommonProtocolInputFactoryCb createCommonProtocolInputFactoryCb(
       const Protobuf::Message& config,
-      ProtobufMessage::ValidationVisitor& validation_visitor) override;
+      Server::Configuration::FactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.common_inputs.environment_variable"; }
 

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.cc
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.cc
@@ -7,11 +7,11 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 Envoy::Matcher::InputMatcherFactoryCb ConsistentHashingConfig::createInputMatcherFactoryCb(
-    const Protobuf::Message& config, ProtobufMessage::ValidationVisitor& validation_visitor) {
+    const Protobuf::Message& config, Server::Configuration::FactoryContext& factory_context) {
   const auto& consistent_hashing_config =
       MessageUtil::downcastAndValidate<const envoy::extensions::matching::input_matchers::
                                            consistent_hashing::v3::ConsistentHashing&>(
-          config, validation_visitor);
+          config, factory_context.messageValidationVisitor());
 
   if (consistent_hashing_config.threshold() > consistent_hashing_config.modulo()) {
     throw EnvoyException(fmt::format("threshold cannot be greater than modulo: {} > {}",

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.h
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.h
@@ -18,7 +18,7 @@ class ConsistentHashingConfig : public Envoy::Matcher::InputMatcherFactory {
 public:
   Envoy::Matcher::InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              ProtobufMessage::ValidationVisitor& validation_visitor) override;
+                              Server::Configuration::FactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.consistent_hashing"; }
 

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -22,16 +22,12 @@ namespace Envoy {
 namespace Matcher {
 class MatcherTest : public ::testing::Test {
 public:
-  MatcherTest()
-      : inject_action_(action_factory_),
-        factory_(context_, ProtobufMessage::getStrictValidationVisitor(), validation_visitor_) {}
+  MatcherTest() : inject_action_(action_factory_) {}
 
   StringActionFactory action_factory_;
-  Registry::InjectFactory<ActionFactory<absl::string_view>> inject_action_;
+  Registry::InjectFactory<ActionFactory> inject_action_;
+  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   MockMatchTreeValidationVisitor<TestData> validation_visitor_;
-
-  absl::string_view context_ = "";
-  MatchTreeFactory<TestData, absl::string_view> factory_;
 };
 
 TEST_F(MatcherTest, TestMatcher) {
@@ -68,13 +64,15 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(2);
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -106,9 +104,10 @@ matcher_list:
   MessageUtil::loadFromYaml(yaml, matcher, ProtobufMessage::getStrictValidationVisitor());
 
   TestUtility::validate(matcher);
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
 
   auto common_input_factory = TestCommonProtocolInputFactory("generic", "foo");
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -142,12 +141,14 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
   NeverMatchFactory match_factory;
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"));
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -197,13 +198,15 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(3);
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -254,13 +257,15 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(3);
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -294,12 +299,14 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
   NeverMatchFactory match_factory;
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"));
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -343,13 +350,15 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
+  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
+
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(2);
-  auto match_tree = factory_.create(matcher);
+  auto match_tree = factory.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -30,7 +30,7 @@ public:
 
   CommonProtocolInputFactoryCb
   createCommonProtocolInputFactoryCb(const Protobuf::Message&,
-                                     ProtobufMessage::ValidationVisitor&) override {
+                                     Server::Configuration::FactoryContext&) override {
     return [&]() { return std::make_unique<CommonProtocolTestInput>(value_); };
   }
 
@@ -60,7 +60,8 @@ public:
       : factory_name_(std::string(factory_name)), value_(std::string(data)), injection_(*this) {}
 
   DataInputFactoryCb<TestData>
-  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
+  createDataInputFactoryCb(const Protobuf::Message&,
+                           Server::Configuration::FactoryContext&) override {
     return [&]() {
       return std::make_unique<TestInput>(
           DataInputGetResult{DataInputGetResult::DataAvailability::AllDataAvailable, value_});
@@ -107,10 +108,10 @@ struct StringAction : public ActionBase<ProtobufWkt::StringValue> {
 };
 
 // Factory for StringAction.
-class StringActionFactory : public ActionFactory<absl::string_view> {
+class StringActionFactory : public ActionFactory {
 public:
-  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config, absl::string_view&,
-                                        ProtobufMessage::ValidationVisitor&) override {
+  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config, const std::string&,
+                                        Server::Configuration::FactoryContext&) override {
     const auto& string = dynamic_cast<const ProtobufWkt::StringValue&>(config);
     return [string]() { return std::make_unique<StringAction>(string.value()); };
   }
@@ -134,8 +135,9 @@ class NeverMatchFactory : public InputMatcherFactory {
 public:
   NeverMatchFactory() : inject_factory_(*this) {}
 
-  InputMatcherFactoryCb createInputMatcherFactoryCb(const Protobuf::Message&,
-                                                    ProtobufMessage::ValidationVisitor&) override {
+  InputMatcherFactoryCb
+  createInputMatcherFactoryCb(const Protobuf::Message&,
+                              Server::Configuration::FactoryContext&) override {
     return []() { return std::make_unique<NeverMatch>(); };
   }
 

--- a/test/extensions/matching/common_inputs/environment_variable/config_test.cc
+++ b/test/extensions/matching/common_inputs/environment_variable/config_test.cc
@@ -13,6 +13,8 @@ namespace CommonInputs {
 namespace EnvironmentVariable {
 
 TEST(ConfigTest, TestConfig) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -28,16 +30,14 @@ TEST(ConfigTest, TestConfig) {
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
 
   {
-    auto input_factory = factory.createCommonProtocolInputFactoryCb(
-        *message, ProtobufMessage::getStrictValidationVisitor());
+    auto input_factory = factory.createCommonProtocolInputFactoryCb(*message, context);
     EXPECT_NE(nullptr, input_factory);
     EXPECT_EQ(input_factory()->get(), absl::nullopt);
   }
 
   TestEnvironment::setEnvVar("foo", "bar", 1);
   {
-    auto input_factory = factory.createCommonProtocolInputFactoryCb(
-        *message, ProtobufMessage::getStrictValidationVisitor());
+    auto input_factory = factory.createCommonProtocolInputFactoryCb(*message, context);
     EXPECT_NE(nullptr, input_factory);
     EXPECT_EQ(input_factory()->get(), absl::make_optional("bar"));
   }

--- a/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
+++ b/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
@@ -11,6 +11,8 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 TEST(ConfigTest, TestConfig) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -25,13 +27,14 @@ TEST(ConfigTest, TestConfig) {
   ConsistentHashingConfig factory;
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  auto matcher =
-      factory.createInputMatcherFactoryCb(*message, ProtobufMessage::getStrictValidationVisitor());
+  auto matcher = factory.createInputMatcherFactoryCb(*message, context);
   ASSERT_NE(nullptr, matcher);
   matcher();
 }
 
 TEST(ConfigTest, InvalidConfig) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -46,9 +49,8 @@ TEST(ConfigTest, InvalidConfig) {
   ConsistentHashingConfig factory;
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createInputMatcherFactoryCb(*message, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "threshold cannot be greater than modulo: 200 > 100");
+  EXPECT_THROW_WITH_MESSAGE(factory.createInputMatcherFactoryCb(*message, context), EnvoyException,
+                            "threshold cannot be greater than modulo: 200 > 100");
 }
 } // namespace ConsistentHashing
 } // namespace InputMatchers


### PR DESCRIPTION
This reverts commit be1cd7b7aac719ddea6223672d2a56921d5d05f2.

Conflicts with https://github.com/envoyproxy/envoy/pull/16592