### PR TITLE
Increase common/common coverage

### DIFF
--- a/source/common/common/regex.cc
+++ b/source/common/common/regex.cc
@@ -15,32 +15,6 @@ namespace Envoy {
 namespace Regex {
 namespace {
 
-class CompiledStdMatcher : public CompiledMatcher {
-public:
-  CompiledStdMatcher(std::regex&& regex) : regex_(std::move(regex)) {}
-
-  // CompiledMatcher
-  bool match(absl::string_view value) const override {
-    try {
-      return std::regex_match(value.begin(), value.end(), regex_);
-    } catch (const std::regex_error& e) {
-      return false;
-    }
-  }
-
-  // CompiledMatcher
-  std::string replaceAll(absl::string_view value, absl::string_view substitution) const override {
-    try {
-      return std::regex_replace(std::string(value), regex_, std::string(substitution));
-    } catch (const std::regex_error& e) {
-      return std::string(value);
-    }
-  }
-
-private:
-  const std::regex regex_;
-};
-
 class CompiledGoogleReMatcher : public CompiledMatcher {
 public:
   CompiledGoogleReMatcher(const envoy::type::matcher::v3::RegexMatcher& config)

--- a/test/common/common/stl_helpers_test.cc
+++ b/test/common/common/stl_helpers_test.cc
@@ -22,4 +22,12 @@ TEST(StlHelpersTest, AccumulateToString) {
                                           [](const int& i) { return std::to_string(i); }));
 }
 
+TEST(StlHelpersTest, ContainsReferenceTest) {
+  std::string str1{"1"};
+  std::vector<std::reference_wrapper<std::string>> numbers{str1};
+  EXPECT_TRUE(containsReference(numbers, str1));
+  std::string str2{"2"};
+  EXPECT_FALSE(containsReference(numbers, str2));
+}
+
 } // namespace Envoy

--- a/test/per_file_coverage.sh
+++ b/test/per_file_coverage.sh
@@ -6,7 +6,7 @@ declare -a KNOWN_LOW_COVERAGE=(
 "source/common:96.3" # Raise when QUIC coverage goes up
 "source/common/api:75.3"
 "source/common/api/posix:73.9"
-"source/common/common:96.2"
+"source/common/common:96.3"
 "source/common/common/posix:94.1"
 "source/common/crypto:0.0"
 "source/common/event:94.2" # Emulated edge events guards don't report LCOV


### PR DESCRIPTION
Increase common/common coverage by:

1. Removing `CompiledStdMatcher` partially cleaned by #17061
2. Add test for ContainsReference in `stl_helpers`

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>