### PR TITLE
backport: v1.16 - ci: Publish artefacts for the exactly required docker images (#17080)

### DIFF
--- a/ci/docker_ci.sh
+++ b/ci/docker_ci.sh
@@ -71,7 +71,6 @@ build_images() {
       IMAGE_TAG="${BUILD_TAG}-${ARCH/linux\//}"
     fi
     docker buildx build --platform "${ARCH}" "${args[@]}" -t "${IMAGE_TAG}" . --load
-    IMAGES_TO_SAVE+=("${IMAGE_TAG}")
   done
 }
 
@@ -118,13 +117,23 @@ VRP_BASE_IMAGE="${DOCKER_IMAGE_PREFIX}${IMAGE_POSTFIX}:${IMAGE_NAME}"
 # Test the docker build in all cases, but use a local tag that we will overwrite before push in the
 # cases where we do push.
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
-  build_images "${BUILD_TYPE}" "${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"
+    image_tag="${DOCKER_IMAGE_PREFIX}${BUILD_TYPE}${IMAGE_POSTFIX}:${IMAGE_NAME}"
+    build_images "${BUILD_TYPE}" "$image_tag"
+
+    if [[ "$BUILD_TYPE" == "" || "$BUILD_TYPE" == "-alpine" ]]; then
+        # verify_examples expects the base and alpine images, and for them to be named `-dev`
+        dev_image="envoyproxy/envoy${BUILD_TYPE}-dev:latest"
+        docker tag "$image_tag" "$dev_image"
+        IMAGES_TO_SAVE+=("$dev_image")
+    fi
 done
 
 mkdir -p "${ENVOY_DOCKER_IMAGE_DIRECTORY}"
-ENVOY_DOCKER_TAR="${ENVOY_DOCKER_IMAGE_DIRECTORY}/envoy-docker-images.tar.xz"
-echo "Saving built images to ${ENVOY_DOCKER_TAR}."
-docker save "${IMAGES_TO_SAVE[@]}" | xz -T0 -2 >"${ENVOY_DOCKER_TAR}"
+if [[ ${#IMAGES_TO_SAVE[@]} -ne 0 ]]; then
+    ENVOY_DOCKER_TAR="${ENVOY_DOCKER_IMAGE_DIRECTORY}/envoy-docker-images.tar.xz"
+    echo "Saving built images to ${ENVOY_DOCKER_TAR}: ${IMAGES_TO_SAVE[*]}"
+    docker save "${IMAGES_TO_SAVE[@]}" | xz -T0 -2 >"${ENVOY_DOCKER_TAR}"
+fi
 
 # Only push images for main builds, release branch builds, and tag builds.
 if [[ "${AZP_BRANCH}" != "${MAIN_BRANCH}" ]] &&


### PR DESCRIPTION

Commit Message: backport: v1.16 - ci: Publish artefacts for the exactly required docker images (#17080)
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
