### PR TITLE
xds: restructure CertificateProvider fields

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/BUILD
+++ b/api/envoy/extensions/transport_sockets/tls/v3/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/api/v2/auth:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/type/matcher/v3:pkg",

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -233,35 +233,13 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// Config for Certificate provider to get certificates. This provider should allow certificates to be
-// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-// [#not-implemented-hide:]
-message CertificateProviderPlugin {
-  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
-
-  // Provider specific config.
-  // Note: an implementation is expected to dedup multiple instances of the same config
-  // to maintain a single certificate-provider instance. The sharing can happen, for
-  // example, among multiple clusters or between the tls_certificate and validation_context
-  // certificate providers of a cluster.
-  // This config could be supplied inline or (in future) a named xDS resource.
-  oneof config {
-    option (validate.required) = true;
-
-    config.core.v3.TypedExtensionConfig typed_config = 2;
-  }
-}
-
-// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
-// the client side instead of being sent from the control plane.
+// Indicates a certificate to be obtained from a named CertificateProvider plugin instance.
+// The plugin instances are defined in the client's bootstrap file.
+// The plugin allows certificates to be fetched/refreshed over the network asynchronously with
+// respect to the TLS handshake.
 // [#not-implemented-hide:]
 message CertificateProviderPluginInstance {
-  // Provider instance name. This name must be defined in the client's configuration (e.g., a
-  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
-  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
-  // control plane). If not present, defaults to "default".
+  // Provider instance name. If not present, defaults to "default".
   //
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
@@ -275,7 +253,7 @@ message CertificateProviderPluginInstance {
   string certificate_name = 2;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 14]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -331,20 +309,12 @@ message CertificateValidationContext {
   config.core.v3.DataSource trusted_ca = 1
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
-  // Certificate provider for fetching TLS certificates.
-  //
-  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-  // may be specified.
-  // [#not-implemented-hide:]
-  CertificateProviderPlugin ca_certificate_provider = 13
-      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
-
   // Certificate provider instance for fetching TLS certificates.
   //
   // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
   // may be specified.
   // [#not-implemented-hide:]
-  CertificateProviderPluginInstance ca_certificate_provider_instance = 14
+  CertificateProviderPluginInstance ca_certificate_provider_instance = 13
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -301,8 +301,7 @@ message CertificateValidationContext {
   // applies to dynamic secrets, when the *CertificateValidationContext* is
   // delivered via SDS.
   //
-  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-  // may be specified.
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
   //
   // [#next-major-version: This field and watched_directory below should ideally be moved into a
   // separate sub-message, since there's no point in specifying the latter field without this one.]
@@ -311,8 +310,7 @@ message CertificateValidationContext {
 
   // Certificate provider instance for fetching TLS certificates.
   //
-  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-  // may be specified.
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
   // [#not-implemented-hide:]
   CertificateProviderPluginInstance ca_certificate_provider_instance = 13
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -9,6 +9,7 @@ import "envoy/type/matcher/v3/string.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/wrappers.proto";
 
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -232,7 +233,49 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// [#next-free-field: 13]
+// Config for Certificate provider to get certificates. This provider should allow certificates to be
+// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+// [#not-implemented-hide:]
+message CertificateProviderPlugin {
+  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Provider specific config.
+  // Note: an implementation is expected to dedup multiple instances of the same config
+  // to maintain a single certificate-provider instance. The sharing can happen, for
+  // example, among multiple clusters or between the tls_certificate and validation_context
+  // certificate providers of a cluster.
+  // This config could be supplied inline or (in future) a named xDS resource.
+  oneof config {
+    option (validate.required) = true;
+
+    config.core.v3.TypedExtensionConfig typed_config = 2;
+  }
+}
+
+// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
+// the client side instead of being sent from the control plane.
+// [#not-implemented-hide:]
+message CertificateProviderPluginInstance {
+  // Provider instance name. This name must be defined in the client's configuration (e.g., a
+  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
+  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
+  // control plane). If not present, defaults to "default".
+  //
+  // Instance names should generally be defined not in terms of the underlying provider
+  // implementation (e.g., "file_watcher") but rather in terms of the function of the
+  // certificates (e.g., "foo_deployment_identity").
+  string instance_name = 1;
+
+  // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "example.com" to specify a certificate for a
+  // particular domain. Not all provider instances will actually use this field, so the value
+  // defaults to the empty string.
+  string certificate_name = 2;
+}
+
+// [#next-free-field: 15]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -279,7 +322,30 @@ message CertificateValidationContext {
   // directory for any file moves to support rotation. This currently only
   // applies to dynamic secrets, when the *CertificateValidationContext* is
   // delivered via SDS.
-  config.core.v3.DataSource trusted_ca = 1;
+  //
+  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+  // may be specified.
+  //
+  // [#next-major-version: This field and watched_directory below should ideally be moved into a
+  // separate sub-message, since there's no point in specifying the latter field without this one.]
+  config.core.v3.DataSource trusted_ca = 1
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
+
+  // Certificate provider for fetching TLS certificates.
+  //
+  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+  // may be specified.
+  // [#not-implemented-hide:]
+  CertificateProviderPlugin ca_certificate_provider = 13
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
+
+  // Certificate provider instance for fetching TLS certificates.
+  //
+  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+  // may be specified.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance ca_certificate_provider_instance = 14
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered
   // by this watch. This allows explicit control over the path watched, by

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -9,7 +9,7 @@ import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -125,7 +125,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 14]
+// [#next-free-field: 16]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -179,29 +179,23 @@ message CommonTlsContext {
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
-    SdsSecretConfig validation_context_sds_secret_config = 2 [
-      (validate.rules).message = {required: true},
-      (udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"
-    ];
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message = {required: true}];
 
-    // Certificate provider for fetching validation context.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
+    // Certificate provider for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
-        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-    // Certificate provider instance for fetching validation context.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
+    // Certificate provider instance for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
     // [#not-implemented-hide:]
     CertificateProviderInstance validation_context_certificate_provider_instance = 4
-        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
-  reserved 5;
+  reserved 5, 10, 12;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -249,15 +243,19 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
-
-    // Certificate provider for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProvider validation_context_certificate_provider = 10;
-
-    // Certificate provider instance for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
+
+  // Certificate provider for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProvider validation_context_certificate_provider = 14;
+
+  // Certificate provider instance for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -131,6 +131,11 @@ message CommonTlsContext {
 
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProvider {
     // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
     // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
@@ -151,6 +156,11 @@ message CommonTlsContext {
 
   // Similar to CertificateProvider above, but allows the provider instances to be configured on
   // the client side instead of being sent from the control plane.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProviderInstance {
     // Provider instance name. This name must be defined in the client's configuration (e.g., a
     // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
@@ -206,6 +216,12 @@ message CommonTlsContext {
   // Only a single TLS certificate is supported in client contexts. In server contexts, the first
   // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
   // used for clients that support ECDSA.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
   // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
@@ -214,18 +230,37 @@ message CommonTlsContext {
   // The same number and types of certificates as :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
   // are valid in the the certificates fetched through this setting.
   //
-  // If :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
-  // is non-empty, this field is ignored.
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
+  // Certificate provider for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPlugin tls_certificate_provider = 14;
+
+  // Certificate provider instance for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProvider tls_certificate_certificate_provider = 9;
+  CertificateProvider tls_certificate_certificate_provider = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Certificate provider instance for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   oneof validation_context_type {
     // How to validate peer certificates.
@@ -254,18 +289,6 @@ message CommonTlsContext {
     CertificateProviderInstance validation_context_certificate_provider_instance = 12
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
-
-  // Certificate provider for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProvider ca_certificate_provider = 14;
-
-  // Certificate provider instance for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -220,7 +220,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
@@ -233,7 +233,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -195,7 +195,7 @@ message CommonTlsContext {
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
-  reserved 5, 10, 12;
+  reserved 5;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -243,19 +243,29 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
+
+    // Certificate provider for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProvider validation_context_certificate_provider = 10
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   // Certificate provider for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProvider validation_context_certificate_provider = 14;
+  CertificateProvider ca_certificate_provider = 14;
 
   // Certificate provider instance for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
+  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -132,8 +132,9 @@ message CommonTlsContext {
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
   //
-  // DEPRECATED: This message was moved outside of CommonTlsContext
-  // and now lives in common.proto.
+  // DEPRECATED: This message is not currently used, but if we ever do need it, we will want to
+  // move it out of CommonTlsContext and into common.proto, similar to the existing
+  // CertificateProviderPluginInstance message.
   //
   // [#not-implemented-hide:]
   message CertificateProvider {

--- a/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -125,7 +125,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 16]
+// [#next-free-field: 15]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -218,7 +218,7 @@ message CommonTlsContext {
   // used for clients that support ECDSA.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
@@ -231,26 +231,19 @@ message CommonTlsContext {
   // are valid in the the certificates fetched through this setting.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
-  // Certificate provider for fetching TLS certs.
-  //
-  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
-  // [#not-implemented-hide:]
-  CertificateProviderPlugin tls_certificate_provider = 14;
-
   // Certificate provider instance for fetching TLS certs.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#not-implemented-hide:]
-  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
 
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -234,7 +234,55 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// [#next-free-field: 13]
+// Config for Certificate provider to get certificates. This provider should allow certificates to be
+// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+// [#not-implemented-hide:]
+message CertificateProviderPlugin {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPlugin";
+
+  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Provider specific config.
+  // Note: an implementation is expected to dedup multiple instances of the same config
+  // to maintain a single certificate-provider instance. The sharing can happen, for
+  // example, among multiple clusters or between the tls_certificate and validation_context
+  // certificate providers of a cluster.
+  // This config could be supplied inline or (in future) a named xDS resource.
+  oneof config {
+    option (validate.required) = true;
+
+    config.core.v4alpha.TypedExtensionConfig typed_config = 2;
+  }
+}
+
+// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
+// the client side instead of being sent from the control plane.
+// [#not-implemented-hide:]
+message CertificateProviderPluginInstance {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance";
+
+  // Provider instance name. This name must be defined in the client's configuration (e.g., a
+  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
+  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
+  // control plane). If not present, defaults to "default".
+  //
+  // Instance names should generally be defined not in terms of the underlying provider
+  // implementation (e.g., "file_watcher") but rather in terms of the function of the
+  // certificates (e.g., "foo_deployment_identity").
+  string instance_name = 1;
+
+  // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "example.com" to specify a certificate for a
+  // particular domain. Not all provider instances will actually use this field, so the value
+  // defaults to the empty string.
+  string certificate_name = 2;
+}
+
+// [#next-free-field: 15]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext";
@@ -254,34 +302,56 @@ message CertificateValidationContext {
 
   reserved "verify_subject_alt_name";
 
-  // TLS certificate data containing certificate authority certificates to use in verifying
-  // a presented peer certificate (e.g. server certificate for clusters or client certificate
-  // for listeners). If not specified and a peer certificate is presented it will not be
-  // verified. By default, a client certificate is optional, unless one of the additional
-  // options (:ref:`require_client_certificate
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.require_client_certificate>`,
-  // :ref:`verify_certificate_spki
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_spki>`,
-  // :ref:`verify_certificate_hash
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_hash>`, or
-  // :ref:`match_subject_alt_names
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`) is also
-  // specified.
-  //
-  // It can optionally contain certificate revocation lists, in which case Envoy will verify
-  // that the presented peer certificate has not been revoked by one of the included CRLs. Note
-  // that if a CRL is provided for any certificate authority in a trust chain, a CRL must be
-  // provided for all certificate authorities in that chain. Failure to do so will result in
-  // verification failure for both revoked and unrevoked certificates from that chain.
-  //
-  // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
-  // system CA locations.
-  //
-  // If *trusted_ca* is a filesystem path, a watch will be added to the parent
-  // directory for any file moves to support rotation. This currently only
-  // applies to dynamic secrets, when the *CertificateValidationContext* is
-  // delivered via SDS.
-  config.core.v4alpha.DataSource trusted_ca = 1;
+  oneof ca_cert_source {
+    // TLS certificate data containing certificate authority certificates to use in verifying
+    // a presented peer certificate (e.g. server certificate for clusters or client certificate
+    // for listeners). If not specified and a peer certificate is presented it will not be
+    // verified. By default, a client certificate is optional, unless one of the additional
+    // options (:ref:`require_client_certificate
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.require_client_certificate>`,
+    // :ref:`verify_certificate_spki
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_spki>`,
+    // :ref:`verify_certificate_hash
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_hash>`, or
+    // :ref:`match_subject_alt_names
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`) is also
+    // specified.
+    //
+    // It can optionally contain certificate revocation lists, in which case Envoy will verify
+    // that the presented peer certificate has not been revoked by one of the included CRLs. Note
+    // that if a CRL is provided for any certificate authority in a trust chain, a CRL must be
+    // provided for all certificate authorities in that chain. Failure to do so will result in
+    // verification failure for both revoked and unrevoked certificates from that chain.
+    //
+    // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
+    // system CA locations.
+    //
+    // If *trusted_ca* is a filesystem path, a watch will be added to the parent
+    // directory for any file moves to support rotation. This currently only
+    // applies to dynamic secrets, when the *CertificateValidationContext* is
+    // delivered via SDS.
+    //
+    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+    // may be specified.
+    //
+    // [#next-major-version: This field and watched_directory below should ideally be moved into a
+    // separate sub-message, since there's no point in specifying the latter field without this one.]
+    config.core.v4alpha.DataSource trusted_ca = 1;
+
+    // Certificate provider for fetching TLS certificates.
+    //
+    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+    // may be specified.
+    // [#not-implemented-hide:]
+    CertificateProviderPlugin ca_certificate_provider = 13;
+
+    // Certificate provider instance for fetching TLS certificates.
+    //
+    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+    // may be specified.
+    // [#not-implemented-hide:]
+    CertificateProviderPluginInstance ca_certificate_provider_instance = 14;
+  }
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered
   // by this watch. This allows explicit control over the path watched, by

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -306,8 +306,7 @@ message CertificateValidationContext {
     // applies to dynamic secrets, when the *CertificateValidationContext* is
     // delivered via SDS.
     //
-    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-    // may be specified.
+    // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
     //
     // [#next-major-version: This field and watched_directory below should ideally be moved into a
     // separate sub-message, since there's no point in specifying the latter field without this one.]
@@ -315,8 +314,7 @@ message CertificateValidationContext {
 
     // Certificate provider instance for fetching TLS certificates.
     //
-    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-    // may be specified.
+    // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
     // [#not-implemented-hide:]
     CertificateProviderPluginInstance ca_certificate_provider_instance = 13;
   }

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -234,41 +234,16 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// Config for Certificate provider to get certificates. This provider should allow certificates to be
-// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-// [#not-implemented-hide:]
-message CertificateProviderPlugin {
-  option (udpa.annotations.versioning).previous_message_type =
-      "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPlugin";
-
-  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
-
-  // Provider specific config.
-  // Note: an implementation is expected to dedup multiple instances of the same config
-  // to maintain a single certificate-provider instance. The sharing can happen, for
-  // example, among multiple clusters or between the tls_certificate and validation_context
-  // certificate providers of a cluster.
-  // This config could be supplied inline or (in future) a named xDS resource.
-  oneof config {
-    option (validate.required) = true;
-
-    config.core.v4alpha.TypedExtensionConfig typed_config = 2;
-  }
-}
-
-// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
-// the client side instead of being sent from the control plane.
+// Indicates a certificate to be obtained from a named CertificateProvider plugin instance.
+// The plugin instances are defined in the client's bootstrap file.
+// The plugin allows certificates to be fetched/refreshed over the network asynchronously with
+// respect to the TLS handshake.
 // [#not-implemented-hide:]
 message CertificateProviderPluginInstance {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance";
 
-  // Provider instance name. This name must be defined in the client's configuration (e.g., a
-  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
-  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
-  // control plane). If not present, defaults to "default".
+  // Provider instance name. If not present, defaults to "default".
   //
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
@@ -282,7 +257,7 @@ message CertificateProviderPluginInstance {
   string certificate_name = 2;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 14]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext";
@@ -338,19 +313,12 @@ message CertificateValidationContext {
     // separate sub-message, since there's no point in specifying the latter field without this one.]
     config.core.v4alpha.DataSource trusted_ca = 1;
 
-    // Certificate provider for fetching TLS certificates.
-    //
-    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-    // may be specified.
-    // [#not-implemented-hide:]
-    CertificateProviderPlugin ca_certificate_provider = 13;
-
     // Certificate provider instance for fetching TLS certificates.
     //
     // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
     // may be specified.
     // [#not-implemented-hide:]
-    CertificateProviderPluginInstance ca_certificate_provider_instance = 14;
+    CertificateProviderPluginInstance ca_certificate_provider_instance = 13;
   }
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -124,7 +124,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 14]
+// [#next-free-field: 16]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext";
@@ -180,33 +180,22 @@ message CommonTlsContext {
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext."
         "CombinedCertificateValidationContext";
 
+    reserved 3, 4;
+
+    reserved "validation_context_certificate_provider",
+        "validation_context_certificate_provider_instance";
+
     // How to validate peer certificates.
     CertificateValidationContext default_validation_context = 1
         [(validate.rules).message = {required: true}];
 
-    oneof dynamic_validation_context {
-      // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
-      // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-      // or validation_context_certificate_provider_instance may be used.
-      SdsSecretConfig validation_context_sds_secret_config = 2
-          [(validate.rules).message = {required: true}];
-
-      // Certificate provider for fetching validation context.
-      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-      // or validation_context_certificate_provider_instance may be used.
-      // [#not-implemented-hide:]
-      CertificateProvider validation_context_certificate_provider = 3;
-
-      // Certificate provider instance for fetching validation context.
-      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-      // or validation_context_certificate_provider_instance may be used.
-      // [#not-implemented-hide:]
-      CertificateProviderInstance validation_context_certificate_provider_instance = 4;
-    }
+    // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
+    // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message = {required: true}];
   }
 
-  reserved 5;
+  reserved 5, 10, 12;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -254,15 +243,19 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
-
-    // Certificate provider for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProvider validation_context_certificate_provider = 10;
-
-    // Certificate provider instance for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
+
+  // Certificate provider for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProvider validation_context_certificate_provider = 14;
+
+  // Certificate provider instance for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -223,7 +223,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
@@ -236,7 +236,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -131,6 +131,11 @@ message CommonTlsContext {
 
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProvider {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProvider";
@@ -154,6 +159,11 @@ message CommonTlsContext {
 
   // Similar to CertificateProvider above, but allows the provider instances to be configured on
   // the client side instead of being sent from the control plane.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProviderInstance {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance";
@@ -195,10 +205,10 @@ message CommonTlsContext {
         [(validate.rules).message = {required: true}];
   }
 
-  reserved 5, 10, 12;
+  reserved 5, 9, 11, 10, 12;
 
-  reserved "validation_context_certificate_provider",
-      "validation_context_certificate_provider_instance";
+  reserved "tls_certificate_certificate_provider", "tls_certificate_certificate_provider_instance",
+      "validation_context_certificate_provider", "validation_context_certificate_provider_instance";
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -209,6 +219,12 @@ message CommonTlsContext {
   // Only a single TLS certificate is supported in client contexts. In server contexts, the first
   // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
   // used for clients that support ECDSA.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
   // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
@@ -217,18 +233,27 @@ message CommonTlsContext {
   // The same number and types of certificates as :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
   // are valid in the the certificates fetched through this setting.
   //
-  // If :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
-  // is non-empty, this field is ignored.
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
-  // Certificate provider for fetching TLS certificates.
+  // Certificate provider for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#not-implemented-hide:]
-  CertificateProvider tls_certificate_certificate_provider = 9;
+  CertificateProviderPlugin tls_certificate_provider = 14;
 
-  // Certificate provider instance for fetching TLS certificates.
+  // Certificate provider instance for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#not-implemented-hide:]
-  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
 
   oneof validation_context_type {
     // How to validate peer certificates.
@@ -247,18 +272,6 @@ message CommonTlsContext {
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
   }
-
-  // Certificate provider for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProvider ca_certificate_provider = 14;
-
-  // Certificate provider instance for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -197,6 +197,9 @@ message CommonTlsContext {
 
   reserved 5, 10, 12;
 
+  reserved "validation_context_certificate_provider",
+      "validation_context_certificate_provider_instance";
+
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
 
@@ -249,13 +252,13 @@ message CommonTlsContext {
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProvider validation_context_certificate_provider = 14;
+  CertificateProvider ca_certificate_provider = 14;
 
   // Certificate provider instance for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
+  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -124,7 +124,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 16]
+// [#next-free-field: 15]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext";
@@ -221,7 +221,7 @@ message CommonTlsContext {
   // used for clients that support ECDSA.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
@@ -234,26 +234,19 @@ message CommonTlsContext {
   // are valid in the the certificates fetched through this setting.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
-  // Certificate provider for fetching TLS certs.
-  //
-  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
-  // [#not-implemented-hide:]
-  CertificateProviderPlugin tls_certificate_provider = 14;
-
   // Certificate provider instance for fetching TLS certs.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#not-implemented-hide:]
-  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
 
   oneof validation_context_type {
     // How to validate peer certificates.

--- a/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -132,8 +132,9 @@ message CommonTlsContext {
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
   //
-  // DEPRECATED: This message was moved outside of CommonTlsContext
-  // and now lives in common.proto.
+  // DEPRECATED: This message is not currently used, but if we ever do need it, we will want to
+  // move it out of CommonTlsContext and into common.proto, similar to the existing
+  // CertificateProviderPluginInstance message.
   //
   // [#not-implemented-hide:]
   message CertificateProvider {

--- a/docs/root/extending/extending.rst
+++ b/docs/root/extending/extending.rst
@@ -19,6 +19,7 @@ types including:
 * :ref:`Stat sinks <arch_overview_statistics>`
 * :ref:`Tracers <arch_overview_tracing>`
 * :ref:`Request ID <arch_overview_tracing>`
+* Transport sockets
 * BoringSSL private key methods
 * :ref:`Watchdog action <envoy_v3_api_msg_config.bootstrap.v3.Watchdog.WatchdogAction>`
 * :ref:`Internal redirect policy <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`

--- a/docs/root/extending/extending.rst
+++ b/docs/root/extending/extending.rst
@@ -19,7 +19,6 @@ types including:
 * :ref:`Stat sinks <arch_overview_statistics>`
 * :ref:`Tracers <arch_overview_tracing>`
 * :ref:`Request ID <arch_overview_tracing>`
-* :ref:`Transport sockets <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateProviderPlugin.typed_config>`
 * BoringSSL private key methods
 * :ref:`Watchdog action <envoy_v3_api_msg_config.bootstrap.v3.Watchdog.WatchdogAction>`
 * :ref:`Internal redirect policy <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`

--- a/docs/root/extending/extending.rst
+++ b/docs/root/extending/extending.rst
@@ -19,7 +19,7 @@ types including:
 * :ref:`Stat sinks <arch_overview_statistics>`
 * :ref:`Tracers <arch_overview_tracing>`
 * :ref:`Request ID <arch_overview_tracing>`
-* :ref:`Transport sockets <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProvider.typed_config>`
+* :ref:`Transport sockets <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateProviderPlugin.typed_config>`
 * BoringSSL private key methods
 * :ref:`Watchdog action <envoy_v3_api_msg_config.bootstrap.v3.Watchdog.WatchdogAction>`
 * :ref:`Internal redirect policy <envoy_v3_api_field_config.route.v3.InternalRedirectPolicy.predicates>`

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -11,6 +11,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";
+import "udpa/annotations/migrate.proto";
 import "udpa/annotations/sensitive.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
@@ -236,7 +237,49 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// [#next-free-field: 13]
+// Config for Certificate provider to get certificates. This provider should allow certificates to be
+// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+// [#not-implemented-hide:]
+message CertificateProviderPlugin {
+  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Provider specific config.
+  // Note: an implementation is expected to dedup multiple instances of the same config
+  // to maintain a single certificate-provider instance. The sharing can happen, for
+  // example, among multiple clusters or between the tls_certificate and validation_context
+  // certificate providers of a cluster.
+  // This config could be supplied inline or (in future) a named xDS resource.
+  oneof config {
+    option (validate.required) = true;
+
+    config.core.v3.TypedExtensionConfig typed_config = 2;
+  }
+}
+
+// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
+// the client side instead of being sent from the control plane.
+// [#not-implemented-hide:]
+message CertificateProviderPluginInstance {
+  // Provider instance name. This name must be defined in the client's configuration (e.g., a
+  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
+  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
+  // control plane). If not present, defaults to "default".
+  //
+  // Instance names should generally be defined not in terms of the underlying provider
+  // implementation (e.g., "file_watcher") but rather in terms of the function of the
+  // certificates (e.g., "foo_deployment_identity").
+  string instance_name = 1;
+
+  // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "example.com" to specify a certificate for a
+  // particular domain. Not all provider instances will actually use this field, so the value
+  // defaults to the empty string.
+  string certificate_name = 2;
+}
+
+// [#next-free-field: 15]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -281,7 +324,30 @@ message CertificateValidationContext {
   // directory for any file moves to support rotation. This currently only
   // applies to dynamic secrets, when the *CertificateValidationContext* is
   // delivered via SDS.
-  config.core.v3.DataSource trusted_ca = 1;
+  //
+  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+  // may be specified.
+  //
+  // [#next-major-version: This field and watched_directory below should ideally be moved into a
+  // separate sub-message, since there's no point in specifying the latter field without this one.]
+  config.core.v3.DataSource trusted_ca = 1
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
+
+  // Certificate provider for fetching TLS certificates.
+  //
+  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+  // may be specified.
+  // [#not-implemented-hide:]
+  CertificateProviderPlugin ca_certificate_provider = 13
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
+
+  // Certificate provider instance for fetching TLS certificates.
+  //
+  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+  // may be specified.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance ca_certificate_provider_instance = 14
+      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered
   // by this watch. This allows explicit control over the path watched, by

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -237,35 +237,13 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// Config for Certificate provider to get certificates. This provider should allow certificates to be
-// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-// [#not-implemented-hide:]
-message CertificateProviderPlugin {
-  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
-
-  // Provider specific config.
-  // Note: an implementation is expected to dedup multiple instances of the same config
-  // to maintain a single certificate-provider instance. The sharing can happen, for
-  // example, among multiple clusters or between the tls_certificate and validation_context
-  // certificate providers of a cluster.
-  // This config could be supplied inline or (in future) a named xDS resource.
-  oneof config {
-    option (validate.required) = true;
-
-    config.core.v3.TypedExtensionConfig typed_config = 2;
-  }
-}
-
-// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
-// the client side instead of being sent from the control plane.
+// Indicates a certificate to be obtained from a named CertificateProvider plugin instance.
+// The plugin instances are defined in the client's bootstrap file.
+// The plugin allows certificates to be fetched/refreshed over the network asynchronously with
+// respect to the TLS handshake.
 // [#not-implemented-hide:]
 message CertificateProviderPluginInstance {
-  // Provider instance name. This name must be defined in the client's configuration (e.g., a
-  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
-  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
-  // control plane). If not present, defaults to "default".
+  // Provider instance name. If not present, defaults to "default".
   //
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
@@ -279,7 +257,7 @@ message CertificateProviderPluginInstance {
   string certificate_name = 2;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 14]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -333,20 +311,12 @@ message CertificateValidationContext {
   config.core.v3.DataSource trusted_ca = 1
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
-  // Certificate provider for fetching TLS certificates.
-  //
-  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-  // may be specified.
-  // [#not-implemented-hide:]
-  CertificateProviderPlugin ca_certificate_provider = 13
-      [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
-
   // Certificate provider instance for fetching TLS certificates.
   //
   // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
   // may be specified.
   // [#not-implemented-hide:]
-  CertificateProviderPluginInstance ca_certificate_provider_instance = 14
+  CertificateProviderPluginInstance ca_certificate_provider_instance = 13
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -303,8 +303,7 @@ message CertificateValidationContext {
   // applies to dynamic secrets, when the *CertificateValidationContext* is
   // delivered via SDS.
   //
-  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-  // may be specified.
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
   //
   // [#next-major-version: This field and watched_directory below should ideally be moved into a
   // separate sub-message, since there's no point in specifying the latter field without this one.]
@@ -313,8 +312,7 @@ message CertificateValidationContext {
 
   // Certificate provider instance for fetching TLS certificates.
   //
-  // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-  // may be specified.
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
   // [#not-implemented-hide:]
   CertificateProviderPluginInstance ca_certificate_provider_instance = 13
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -9,7 +9,7 @@ import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-import "udpa/annotations/migrate.proto";
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -125,7 +125,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 14]
+// [#next-free-field: 16]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -179,29 +179,23 @@ message CommonTlsContext {
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
-    SdsSecretConfig validation_context_sds_secret_config = 2 [
-      (validate.rules).message = {required: true},
-      (udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"
-    ];
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message = {required: true}];
 
-    // Certificate provider for fetching validation context.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
+    // Certificate provider for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
     // [#not-implemented-hide:]
     CertificateProvider validation_context_certificate_provider = 3
-        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-    // Certificate provider instance for fetching validation context.
-    // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-    // or validation_context_certificate_provider_instance may be used.
+    // Certificate provider instance for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
     // [#not-implemented-hide:]
     CertificateProviderInstance validation_context_certificate_provider_instance = 4
-        [(udpa.annotations.field_migrate).oneof_promotion = "dynamic_validation_context"];
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
-  reserved 5;
+  reserved 5, 10, 12;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -249,15 +243,19 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
-
-    // Certificate provider for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProvider validation_context_certificate_provider = 10;
-
-    // Certificate provider instance for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
+
+  // Certificate provider for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProvider validation_context_certificate_provider = 14;
+
+  // Certificate provider instance for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -131,6 +131,11 @@ message CommonTlsContext {
 
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProvider {
     // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
     // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
@@ -151,6 +156,11 @@ message CommonTlsContext {
 
   // Similar to CertificateProvider above, but allows the provider instances to be configured on
   // the client side instead of being sent from the control plane.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProviderInstance {
     // Provider instance name. This name must be defined in the client's configuration (e.g., a
     // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
@@ -206,6 +216,12 @@ message CommonTlsContext {
   // Only a single TLS certificate is supported in client contexts. In server contexts, the first
   // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
   // used for clients that support ECDSA.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
   // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
@@ -214,18 +230,37 @@ message CommonTlsContext {
   // The same number and types of certificates as :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
   // are valid in the the certificates fetched through this setting.
   //
-  // If :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
-  // is non-empty, this field is ignored.
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
+  // Certificate provider for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPlugin tls_certificate_provider = 14;
+
+  // Certificate provider instance for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProvider tls_certificate_certificate_provider = 9;
+  CertificateProvider tls_certificate_certificate_provider = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Certificate provider instance for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   oneof validation_context_type {
     // How to validate peer certificates.
@@ -254,18 +289,6 @@ message CommonTlsContext {
     CertificateProviderInstance validation_context_certificate_provider_instance = 12
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
-
-  // Certificate provider for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProvider ca_certificate_provider = 14;
-
-  // Certificate provider instance for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -220,7 +220,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
@@ -233,7 +233,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -195,7 +195,7 @@ message CommonTlsContext {
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
-  reserved 5, 10, 12;
+  reserved 5;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -243,19 +243,29 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
+
+    // Certificate provider for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProvider validation_context_certificate_provider = 10
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance validation_context_certificate_provider_instance = 12
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   // Certificate provider for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProvider validation_context_certificate_provider = 14;
+  CertificateProvider ca_certificate_provider = 14;
 
   // Certificate provider instance for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
+  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -132,8 +132,9 @@ message CommonTlsContext {
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
   //
-  // DEPRECATED: This message was moved outside of CommonTlsContext
-  // and now lives in common.proto.
+  // DEPRECATED: This message is not currently used, but if we ever do need it, we will want to
+  // move it out of CommonTlsContext and into common.proto, similar to the existing
+  // CertificateProviderPluginInstance message.
   //
   // [#not-implemented-hide:]
   message CertificateProvider {

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -125,7 +125,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 16]
+// [#next-free-field: 15]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.CommonTlsContext";
 
@@ -218,7 +218,7 @@ message CommonTlsContext {
   // used for clients that support ECDSA.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
@@ -231,26 +231,19 @@ message CommonTlsContext {
   // are valid in the the certificates fetched through this setting.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
-  // Certificate provider for fetching TLS certs.
-  //
-  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
-  // [#not-implemented-hide:]
-  CertificateProviderPlugin tls_certificate_provider = 14;
-
   // Certificate provider instance for fetching TLS certs.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#not-implemented-hide:]
-  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
 
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/BUILD
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/BUILD
@@ -6,6 +6,7 @@ licenses(["notice"])  # Apache 2
 
 api_proto_package(
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v4alpha:pkg",
         "//envoy/extensions/transport_sockets/tls/v3:pkg",
         "//envoy/type/matcher/v4alpha:pkg",

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -234,7 +234,55 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// [#next-free-field: 13]
+// Config for Certificate provider to get certificates. This provider should allow certificates to be
+// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+// [#not-implemented-hide:]
+message CertificateProviderPlugin {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPlugin";
+
+  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // Provider specific config.
+  // Note: an implementation is expected to dedup multiple instances of the same config
+  // to maintain a single certificate-provider instance. The sharing can happen, for
+  // example, among multiple clusters or between the tls_certificate and validation_context
+  // certificate providers of a cluster.
+  // This config could be supplied inline or (in future) a named xDS resource.
+  oneof config {
+    option (validate.required) = true;
+
+    config.core.v4alpha.TypedExtensionConfig typed_config = 2;
+  }
+}
+
+// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
+// the client side instead of being sent from the control plane.
+// [#not-implemented-hide:]
+message CertificateProviderPluginInstance {
+  option (udpa.annotations.versioning).previous_message_type =
+      "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance";
+
+  // Provider instance name. This name must be defined in the client's configuration (e.g., a
+  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
+  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
+  // control plane). If not present, defaults to "default".
+  //
+  // Instance names should generally be defined not in terms of the underlying provider
+  // implementation (e.g., "file_watcher") but rather in terms of the function of the
+  // certificates (e.g., "foo_deployment_identity").
+  string instance_name = 1;
+
+  // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "example.com" to specify a certificate for a
+  // particular domain. Not all provider instances will actually use this field, so the value
+  // defaults to the empty string.
+  string certificate_name = 2;
+}
+
+// [#next-free-field: 15]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext";
@@ -254,34 +302,56 @@ message CertificateValidationContext {
 
   reserved "verify_subject_alt_name";
 
-  // TLS certificate data containing certificate authority certificates to use in verifying
-  // a presented peer certificate (e.g. server certificate for clusters or client certificate
-  // for listeners). If not specified and a peer certificate is presented it will not be
-  // verified. By default, a client certificate is optional, unless one of the additional
-  // options (:ref:`require_client_certificate
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.require_client_certificate>`,
-  // :ref:`verify_certificate_spki
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_spki>`,
-  // :ref:`verify_certificate_hash
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_hash>`, or
-  // :ref:`match_subject_alt_names
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`) is also
-  // specified.
-  //
-  // It can optionally contain certificate revocation lists, in which case Envoy will verify
-  // that the presented peer certificate has not been revoked by one of the included CRLs. Note
-  // that if a CRL is provided for any certificate authority in a trust chain, a CRL must be
-  // provided for all certificate authorities in that chain. Failure to do so will result in
-  // verification failure for both revoked and unrevoked certificates from that chain.
-  //
-  // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
-  // system CA locations.
-  //
-  // If *trusted_ca* is a filesystem path, a watch will be added to the parent
-  // directory for any file moves to support rotation. This currently only
-  // applies to dynamic secrets, when the *CertificateValidationContext* is
-  // delivered via SDS.
-  config.core.v4alpha.DataSource trusted_ca = 1;
+  oneof ca_cert_source {
+    // TLS certificate data containing certificate authority certificates to use in verifying
+    // a presented peer certificate (e.g. server certificate for clusters or client certificate
+    // for listeners). If not specified and a peer certificate is presented it will not be
+    // verified. By default, a client certificate is optional, unless one of the additional
+    // options (:ref:`require_client_certificate
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.DownstreamTlsContext.require_client_certificate>`,
+    // :ref:`verify_certificate_spki
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_spki>`,
+    // :ref:`verify_certificate_hash
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_hash>`, or
+    // :ref:`match_subject_alt_names
+    // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names>`) is also
+    // specified.
+    //
+    // It can optionally contain certificate revocation lists, in which case Envoy will verify
+    // that the presented peer certificate has not been revoked by one of the included CRLs. Note
+    // that if a CRL is provided for any certificate authority in a trust chain, a CRL must be
+    // provided for all certificate authorities in that chain. Failure to do so will result in
+    // verification failure for both revoked and unrevoked certificates from that chain.
+    //
+    // See :ref:`the TLS overview <arch_overview_ssl_enabling_verification>` for a list of common
+    // system CA locations.
+    //
+    // If *trusted_ca* is a filesystem path, a watch will be added to the parent
+    // directory for any file moves to support rotation. This currently only
+    // applies to dynamic secrets, when the *CertificateValidationContext* is
+    // delivered via SDS.
+    //
+    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+    // may be specified.
+    //
+    // [#next-major-version: This field and watched_directory below should ideally be moved into a
+    // separate sub-message, since there's no point in specifying the latter field without this one.]
+    config.core.v4alpha.DataSource trusted_ca = 1;
+
+    // Certificate provider for fetching TLS certificates.
+    //
+    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+    // may be specified.
+    // [#not-implemented-hide:]
+    CertificateProviderPlugin ca_certificate_provider = 13;
+
+    // Certificate provider instance for fetching TLS certificates.
+    //
+    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
+    // may be specified.
+    // [#not-implemented-hide:]
+    CertificateProviderPluginInstance ca_certificate_provider_instance = 14;
+  }
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered
   // by this watch. This allows explicit control over the path watched, by

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -306,8 +306,7 @@ message CertificateValidationContext {
     // applies to dynamic secrets, when the *CertificateValidationContext* is
     // delivered via SDS.
     //
-    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-    // may be specified.
+    // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
     //
     // [#next-major-version: This field and watched_directory below should ideally be moved into a
     // separate sub-message, since there's no point in specifying the latter field without this one.]
@@ -315,8 +314,7 @@ message CertificateValidationContext {
 
     // Certificate provider instance for fetching TLS certificates.
     //
-    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-    // may be specified.
+    // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
     // [#not-implemented-hide:]
     CertificateProviderPluginInstance ca_certificate_provider_instance = 13;
   }

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/common.proto
@@ -234,41 +234,16 @@ message TlsSessionTicketKeys {
       [(validate.rules).repeated = {min_items: 1}, (udpa.annotations.sensitive) = true];
 }
 
-// Config for Certificate provider to get certificates. This provider should allow certificates to be
-// fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-// [#not-implemented-hide:]
-message CertificateProviderPlugin {
-  option (udpa.annotations.versioning).previous_message_type =
-      "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPlugin";
-
-  // opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
-  // a root-certificate (validation context) or "TLS" to specify a new tls-certificate.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
-
-  // Provider specific config.
-  // Note: an implementation is expected to dedup multiple instances of the same config
-  // to maintain a single certificate-provider instance. The sharing can happen, for
-  // example, among multiple clusters or between the tls_certificate and validation_context
-  // certificate providers of a cluster.
-  // This config could be supplied inline or (in future) a named xDS resource.
-  oneof config {
-    option (validate.required) = true;
-
-    config.core.v4alpha.TypedExtensionConfig typed_config = 2;
-  }
-}
-
-// Similar to CertificateProviderPlugin above, but allows the provider instances to be configured on
-// the client side instead of being sent from the control plane.
+// Indicates a certificate to be obtained from a named CertificateProvider plugin instance.
+// The plugin instances are defined in the client's bootstrap file.
+// The plugin allows certificates to be fetched/refreshed over the network asynchronously with
+// respect to the TLS handshake.
 // [#not-implemented-hide:]
 message CertificateProviderPluginInstance {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance";
 
-  // Provider instance name. This name must be defined in the client's configuration (e.g., a
-  // bootstrap file) to correspond to a provider instance (i.e., the same data in the typed_config
-  // field that would be sent in the CertificateProviderPlugin message if the config was sent by the
-  // control plane). If not present, defaults to "default".
+  // Provider instance name. If not present, defaults to "default".
   //
   // Instance names should generally be defined not in terms of the underlying provider
   // implementation (e.g., "file_watcher") but rather in terms of the function of the
@@ -282,7 +257,7 @@ message CertificateProviderPluginInstance {
   string certificate_name = 2;
 }
 
-// [#next-free-field: 15]
+// [#next-free-field: 14]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext";
@@ -338,19 +313,12 @@ message CertificateValidationContext {
     // separate sub-message, since there's no point in specifying the latter field without this one.]
     config.core.v4alpha.DataSource trusted_ca = 1;
 
-    // Certificate provider for fetching TLS certificates.
-    //
-    // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
-    // may be specified.
-    // [#not-implemented-hide:]
-    CertificateProviderPlugin ca_certificate_provider = 13;
-
     // Certificate provider instance for fetching TLS certificates.
     //
     // Only one of *trusted_ca*, *ca_certificate_provider*, and *ca_certificate_provider_instance*
     // may be specified.
     // [#not-implemented-hide:]
-    CertificateProviderPluginInstance ca_certificate_provider_instance = 14;
+    CertificateProviderPluginInstance ca_certificate_provider_instance = 13;
   }
 
   // If specified, updates of a file-based *trusted_ca* source will be triggered

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -204,7 +204,7 @@ message CommonTlsContext {
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
-  reserved 5, 10, 12;
+  reserved 5;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -252,19 +252,30 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
+
+    // Certificate provider for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProvider hidden_envoy_deprecated_validation_context_certificate_provider = 10
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
+
+    // Certificate provider instance for fetching validation context.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance
+        hidden_envoy_deprecated_validation_context_certificate_provider_instance = 12
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
   // Certificate provider for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProvider validation_context_certificate_provider = 14;
+  CertificateProvider ca_certificate_provider = 14;
 
   // Certificate provider instance for fetching CA certs. This will populate the
   // :ref:`CertificateValidationContext.trusted_ca field
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
   // [#not-implemented-hide:]
-  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
+  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -9,6 +9,7 @@ import "envoy/extensions/transport_sockets/tls/v4alpha/secret.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
+import "envoy/annotations/deprecation.proto";
 import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
@@ -124,7 +125,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 14]
+// [#next-free-field: 16]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext";
@@ -184,29 +185,26 @@ message CommonTlsContext {
     CertificateValidationContext default_validation_context = 1
         [(validate.rules).message = {required: true}];
 
-    oneof dynamic_validation_context {
-      // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
-      // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-      // or validation_context_certificate_provider_instance may be used.
-      SdsSecretConfig validation_context_sds_secret_config = 2
-          [(validate.rules).message = {required: true}];
+    // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
+    // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+    SdsSecretConfig validation_context_sds_secret_config = 2
+        [(validate.rules).message = {required: true}];
 
-      // Certificate provider for fetching validation context.
-      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-      // or validation_context_certificate_provider_instance may be used.
-      // [#not-implemented-hide:]
-      CertificateProvider validation_context_certificate_provider = 3;
+    // Certificate provider for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
+    // [#not-implemented-hide:]
+    CertificateProvider hidden_envoy_deprecated_validation_context_certificate_provider = 3
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
-      // Certificate provider instance for fetching validation context.
-      // Only one of validation_context_sds_secret_config, validation_context_certificate_provider,
-      // or validation_context_certificate_provider_instance may be used.
-      // [#not-implemented-hide:]
-      CertificateProviderInstance validation_context_certificate_provider_instance = 4;
-    }
+    // Certificate provider instance for fetching CA certs. This will populate the
+    // *default_validation_context.trusted_ca* field.
+    // [#not-implemented-hide:]
+    CertificateProviderInstance
+        hidden_envoy_deprecated_validation_context_certificate_provider_instance = 4
+        [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
 
-  reserved 5;
+  reserved 5, 10, 12;
 
   // TLS protocol versions, cipher suites etc.
   TlsParameters tls_params = 1;
@@ -254,15 +252,19 @@ message CommonTlsContext {
     // CertificateValidationContext, and concatenates repeated fields to default
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
-
-    // Certificate provider for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProvider validation_context_certificate_provider = 10;
-
-    // Certificate provider instance for fetching validation context.
-    // [#not-implemented-hide:]
-    CertificateProviderInstance validation_context_certificate_provider_instance = 12;
   }
+
+  // Certificate provider for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProvider validation_context_certificate_provider = 14;
+
+  // Certificate provider instance for fetching CA certs. This will populate the
+  // :ref:`CertificateValidationContext.trusted_ca field
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
+  // [#not-implemented-hide:]
+  CertificateProviderInstance validation_context_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -133,8 +133,9 @@ message CommonTlsContext {
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
   //
-  // DEPRECATED: This message was moved outside of CommonTlsContext
-  // and now lives in common.proto.
+  // DEPRECATED: This message is not currently used, but if we ever do need it, we will want to
+  // move it out of CommonTlsContext and into common.proto, similar to the existing
+  // CertificateProviderPluginInstance message.
   //
   // [#not-implemented-hide:]
   message CertificateProvider {

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -132,6 +132,11 @@ message CommonTlsContext {
 
   // Config for Certificate provider to get certificates. This provider should allow certificates to be
   // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProvider {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProvider";
@@ -155,6 +160,11 @@ message CommonTlsContext {
 
   // Similar to CertificateProvider above, but allows the provider instances to be configured on
   // the client side instead of being sent from the control plane.
+  //
+  // DEPRECATED: This message was moved outside of CommonTlsContext
+  // and now lives in common.proto.
+  //
+  // [#not-implemented-hide:]
   message CertificateProviderInstance {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance";
@@ -215,6 +225,12 @@ message CommonTlsContext {
   // Only a single TLS certificate is supported in client contexts. In server contexts, the first
   // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
   // used for clients that support ECDSA.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
   // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
@@ -223,18 +239,38 @@ message CommonTlsContext {
   // The same number and types of certificates as :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
   // are valid in the the certificates fetched through this setting.
   //
-  // If :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
-  // is non-empty, this field is ignored.
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
+  // Certificate provider for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPlugin tls_certificate_provider = 14;
+
+  // Certificate provider instance for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProvider tls_certificate_certificate_provider = 9;
+  CertificateProvider hidden_envoy_deprecated_tls_certificate_certificate_provider = 9
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // Certificate provider instance for fetching TLS certificates.
   // [#not-implemented-hide:]
-  CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
+  CertificateProviderInstance
+      hidden_envoy_deprecated_tls_certificate_certificate_provider_instance = 11
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   oneof validation_context_type {
     // How to validate peer certificates.
@@ -264,18 +300,6 @@ message CommonTlsContext {
         hidden_envoy_deprecated_validation_context_certificate_provider_instance = 12
         [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
   }
-
-  // Certificate provider for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProvider ca_certificate_provider = 14;
-
-  // Certificate provider instance for fetching CA certs. This will populate the
-  // :ref:`CertificateValidationContext.trusted_ca field
-  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  // [#not-implemented-hide:]
-  CertificateProviderInstance ca_certificate_provider_instance = 15;
 
   // Supplies the list of ALPN protocols that the listener should expose. In
   // practice this is likely to be set to one of two values (see the

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -125,7 +125,7 @@ message DownstreamTlsContext {
 }
 
 // TLS context shared by both client and server TLS contexts.
-// [#next-free-field: 16]
+// [#next-free-field: 15]
 message CommonTlsContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.extensions.transport_sockets.tls.v3.CommonTlsContext";
@@ -227,7 +227,7 @@ message CommonTlsContext {
   // used for clients that support ECDSA.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
@@ -240,26 +240,19 @@ message CommonTlsContext {
   // are valid in the the certificates fetched through this setting.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
   // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];
 
-  // Certificate provider for fetching TLS certs.
-  //
-  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
-  // [#not-implemented-hide:]
-  CertificateProviderPlugin tls_certificate_provider = 14;
-
   // Certificate provider instance for fetching TLS certs.
   //
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
-  // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
+  // and *tls_certificate_provider_instance* may be used.
   // [#not-implemented-hide:]
-  CertificateProviderPluginInstance tls_certificate_provider_instance = 15;
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
 
   // Certificate provider for fetching TLS certificates.
   // [#not-implemented-hide:]

--- a/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
+++ b/generated_api_shadow/envoy/extensions/transport_sockets/tls/v4alpha/tls.proto
@@ -229,7 +229,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated TlsCertificate tls_certificates = 2;
 
@@ -242,7 +242,7 @@ message CommonTlsContext {
   // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
   // *tls_certificate_provider*, and *tls_certificate_provider_instance* may be used.
   // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
-  // not legal to put a repeated field in a oneof. In the next majory version, we should rework
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
   // this to avoid this problem.]
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6
       [(validate.rules).repeated = {max_items: 2}];


### PR DESCRIPTION
Signed-off-by: Mark D. Roth <roth@google.com>

Commit Message: xds: restructure CertificateProvider fields
Additional Description: When these fields were originally added, we didn't fully understand how the `CertificateValidationContext` configuration worked.  A `CertificateProvider` cannot provide a full `CertificateValidationContext` proto; it provides only the CA certs (i.e., the `trusted_ca` field within the `CertificateValidationContext` proto).  So this PR makes the following changes:
- Duplicates the `CertificateProvider` and `CertificateProviderInstance` messages from `CommonTlsContext` as `CertificateProviderPlugin` and `CertificateProviderPluginInstance` outside of `CommonTlsContext` (in common.proto instead of tls.proto).  (Note that this also paves the way for reusing these messages for SPIFFE validation in the future.)
- Adds new `CertificateProviderPlugin` and `CertificateProviderPluginInstance` fields to `CertificateValidationContext`, as an alternative to the existing `trusted_ca` field.  (Added annotations to make this a `oneof` in the future.)
- In `CommonTlsContext`, I have deprecated the `validation_context_certificate_provider` and `validation_context_certificate_provider_instance` fields both in the `validation_context_type` oneof and in `CombinedValidationContext`.
- In `CommonTlsContext`, I have replaced the `tls_certificate_certificate_provider` and `tls_certificate_certificate_provider_instance` fields with new fields that use the new messages outside of `CommonTlsContext`.

Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @sanjaypujare @ejona86 @dfawley @yashykt @easwars @jaychenatr 