### PR TITLE
kafka: new deserializers

### DIFF
--- a/source/extensions/filters/network/kafka/serialization.h
+++ b/source/extensions/filters/network/kafka/serialization.h
@@ -224,6 +224,72 @@ private:
   bool ready_ = false;
 };
 
+class VarInt32Deserializer : public Deserializer<int32_t> {
+public:
+  VarInt32Deserializer() = default;
+
+  uint32_t feed(absl::string_view& data) override { return varuint32_deserializer_.feed(data); }
+
+  bool ready() const override { return varuint32_deserializer_.ready(); }
+
+  int32_t get() const override {
+    const uint32_t res = varuint32_deserializer_.get();
+    return (res >> 1) ^ -(res & 1);
+  }
+
+private:
+  VarUInt32Deserializer varuint32_deserializer_;
+};
+
+class VarInt64Deserializer : public Deserializer<int64_t> {
+public:
+  VarInt64Deserializer() = default;
+
+  uint32_t feed(absl::string_view& data) override {
+    uint32_t processed = 0;
+    while (!ready_ && !data.empty()) {
+
+      // Read next byte from input.
+      uint8_t el;
+      safeMemcpy(&el, data.data());
+      data = {data.data() + 1, data.size() - 1};
+      processed++;
+
+      // Put the 7 bits where they should have been.
+      // Impl note: the cast is done to avoid undefined behaviour when offset_ >= 63 and some bits
+      // at positions 2-7 are set (we would have left shift of signed value that does not fit in
+      // data type).
+      bytes_ |= ((static_cast<uint64_t>(el) & 0x7f) << offset_);
+      if ((el & 0x80) == 0) {
+        // If this was the last byte to process (what is marked by unset highest bit), we are done.
+        ready_ = true;
+        break;
+      } else {
+        // Otherwise, we need to read next byte.
+        offset_ += 7;
+        // Valid input can have at most 5 bytes.
+        if (offset_ >= 10 * 7) {
+          ExceptionUtil::throwEnvoyException(
+              "VarInt64 is too long (10th byte has highest bit set)");
+        }
+      }
+    }
+    return processed;
+  }
+
+  bool ready() const override { return ready_; }
+
+  int64_t get() const override {
+    // Do the final conversion, this is a zig-zag encoded signed value.
+    return (bytes_ >> 1) ^ -(bytes_ & 1);
+  }
+
+private:
+  uint64_t bytes_ = 0;
+  uint32_t offset_ = 0;
+  bool ready_ = false;
+};
+
 /**
  * Deserializer of string value.
  * First reads length (INT16) and then allocates the buffer of given length.
@@ -373,10 +439,10 @@ private:
 
 /**
  * Deserializer of compact bytes value.
- * First reads length (UNSIGNED_VARINT) and then allocates the buffer of given length.
+ * First reads length (UNSIGNED_VARINT32) and then allocates the buffer of given length.
  *
  * From Kafka documentation:
- * First the length N+1 is given as an UNSIGNED_VARINT. Then N bytes follow.
+ * First the length N+1 is given as an UNSIGNED_VARINT32. Then N bytes follow.
  */
 class CompactBytesDeserializer : public Deserializer<Bytes> {
 public:

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/network/kafka/tagged_fields.h"
 
 #include "test/extensions/filters/network/kafka/serialization_utilities.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -27,6 +28,8 @@ TEST_EmptyDeserializerShouldNotBeReady(UInt32Deserializer);
 TEST_EmptyDeserializerShouldNotBeReady(Int64Deserializer);
 TEST_EmptyDeserializerShouldNotBeReady(BooleanDeserializer);
 TEST_EmptyDeserializerShouldNotBeReady(VarUInt32Deserializer);
+TEST_EmptyDeserializerShouldNotBeReady(VarInt32Deserializer);
+TEST_EmptyDeserializerShouldNotBeReady(VarInt64Deserializer);
 
 TEST_EmptyDeserializerShouldNotBeReady(StringDeserializer);
 TEST_EmptyDeserializerShouldNotBeReady(CompactStringDeserializer);
@@ -151,7 +154,76 @@ TEST(VarUInt32Deserializer, ShouldThrowIfNoEndWith5Bytes) {
 
   // when
   // then
-  EXPECT_THROW(testee.feed(data), EnvoyException);
+  EXPECT_THROW_WITH_REGEX(testee.feed(data), EnvoyException, "is too long");
+}
+
+// Missing tests (chunks).
+
+TEST(VarInt32Deserializer, ShouldDeserialize) {
+  Buffer::OwnedImpl buffer;
+  const char input[1] = {0};
+  buffer.add(absl::string_view(input, sizeof(input)));
+  const int32_t expected_value = 0;
+  deserializeCompactAndCheckEqualityInOneGo<VarInt32Deserializer>(buffer, expected_value);
+}
+
+TEST(VarInt32Deserializer, ShouldDeserializeMinInt32) {
+  Buffer::OwnedImpl buffer;
+  const uint8_t input[5] = {0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
+  buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
+  const int32_t expected_value = std::numeric_limits<int32_t>::min();
+  deserializeCompactAndCheckEqualityInOneGo<VarInt32Deserializer>(buffer, expected_value);
+}
+
+TEST(VarInt32Deserializer, ShouldDeserializeMaxInt32) {
+  Buffer::OwnedImpl buffer;
+  const uint8_t input[5] = {0xFE, 0xFF, 0xFF, 0xFF, 0x0F};
+  buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
+  const int32_t expected_value = std::numeric_limits<int32_t>::max();
+  deserializeCompactAndCheckEqualityInOneGo<VarInt32Deserializer>(buffer, expected_value);
+}
+
+TEST(VarInt64Deserializer, ShouldDeserialize) {
+  Buffer::OwnedImpl buffer;
+  const char input[1] = {0};
+  buffer.add(absl::string_view(input, sizeof(input)));
+  const int64_t expected_value = 0;
+  deserializeCompactAndCheckEqualityInOneGo<VarInt64Deserializer>(buffer, expected_value);
+}
+
+TEST(VarInt64Deserializer, ShouldDeserializeMinInt64) {
+  Buffer::OwnedImpl buffer;
+  const uint8_t input[10] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
+  buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
+  const int64_t expected_value = std::numeric_limits<int64_t>::min();
+  deserializeCompactAndCheckEqualityInOneGo<VarInt64Deserializer>(buffer, expected_value);
+}
+
+TEST(VarInt64Deserializer, ShouldDeserializeMaxInt64) {
+  Buffer::OwnedImpl buffer;
+  const uint8_t input[10] = {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
+  buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
+  const int64_t expected_value = std::numeric_limits<int64_t>::max();
+  deserializeCompactAndCheckEqualityInOneGo<VarInt64Deserializer>(buffer, expected_value);
+}
+
+TEST(VarInt64Deserializer, ShouldThrowIfNoEndWith10Bytes) {
+  // given
+  VarInt64Deserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  // The buffer makes no sense, it's 10 times 0xFF, while varint encoding ensures that in the worst
+  // case 10th byte has the highest bit clear.
+  for (int i = 0; i < 10; ++i) {
+    const uint8_t all_bits_set = 0xFF;
+    buffer.add(&all_bits_set, sizeof(all_bits_set));
+  }
+
+  absl::string_view data = {getRawData(buffer), 1024};
+
+  // when
+  // then
+  EXPECT_THROW_WITH_REGEX(testee.feed(data), EnvoyException, "is too long");
 }
 
 // String tests.

--- a/test/extensions/filters/network/kafka/serialization_test.cc
+++ b/test/extensions/filters/network/kafka/serialization_test.cc
@@ -157,14 +157,14 @@ TEST(VarUInt32Deserializer, ShouldThrowIfNoEndWith5Bytes) {
   EXPECT_THROW_WITH_REGEX(testee.feed(data), EnvoyException, "is too long");
 }
 
-// Missing tests (chunks).
+// Variable-length int32_t tests.
 
 TEST(VarInt32Deserializer, ShouldDeserialize) {
   Buffer::OwnedImpl buffer;
   const char input[1] = {0};
   buffer.add(absl::string_view(input, sizeof(input)));
   const int32_t expected_value = 0;
-  deserializeCompactAndCheckEqualityInOneGo<VarInt32Deserializer>(buffer, expected_value);
+  deserializeCompactAndCheckEquality<VarInt32Deserializer>(buffer, expected_value);
 }
 
 TEST(VarInt32Deserializer, ShouldDeserializeMinInt32) {
@@ -172,7 +172,7 @@ TEST(VarInt32Deserializer, ShouldDeserializeMinInt32) {
   const uint8_t input[5] = {0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
   buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
   const int32_t expected_value = std::numeric_limits<int32_t>::min();
-  deserializeCompactAndCheckEqualityInOneGo<VarInt32Deserializer>(buffer, expected_value);
+  deserializeCompactAndCheckEquality<VarInt32Deserializer>(buffer, expected_value);
 }
 
 TEST(VarInt32Deserializer, ShouldDeserializeMaxInt32) {
@@ -180,15 +180,17 @@ TEST(VarInt32Deserializer, ShouldDeserializeMaxInt32) {
   const uint8_t input[5] = {0xFE, 0xFF, 0xFF, 0xFF, 0x0F};
   buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
   const int32_t expected_value = std::numeric_limits<int32_t>::max();
-  deserializeCompactAndCheckEqualityInOneGo<VarInt32Deserializer>(buffer, expected_value);
+  deserializeCompactAndCheckEquality<VarInt32Deserializer>(buffer, expected_value);
 }
+
+// Variable-length int64_t tests.
 
 TEST(VarInt64Deserializer, ShouldDeserialize) {
   Buffer::OwnedImpl buffer;
   const char input[1] = {0};
   buffer.add(absl::string_view(input, sizeof(input)));
   const int64_t expected_value = 0;
-  deserializeCompactAndCheckEqualityInOneGo<VarInt64Deserializer>(buffer, expected_value);
+  deserializeCompactAndCheckEquality<VarInt64Deserializer>(buffer, expected_value);
 }
 
 TEST(VarInt64Deserializer, ShouldDeserializeMinInt64) {
@@ -196,7 +198,7 @@ TEST(VarInt64Deserializer, ShouldDeserializeMinInt64) {
   const uint8_t input[10] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
   buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
   const int64_t expected_value = std::numeric_limits<int64_t>::min();
-  deserializeCompactAndCheckEqualityInOneGo<VarInt64Deserializer>(buffer, expected_value);
+  deserializeCompactAndCheckEquality<VarInt64Deserializer>(buffer, expected_value);
 }
 
 TEST(VarInt64Deserializer, ShouldDeserializeMaxInt64) {
@@ -204,7 +206,7 @@ TEST(VarInt64Deserializer, ShouldDeserializeMaxInt64) {
   const uint8_t input[10] = {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
   buffer.add(absl::string_view(reinterpret_cast<const char*>(input), sizeof(input)));
   const int64_t expected_value = std::numeric_limits<int64_t>::max();
-  deserializeCompactAndCheckEqualityInOneGo<VarInt64Deserializer>(buffer, expected_value);
+  deserializeCompactAndCheckEquality<VarInt64Deserializer>(buffer, expected_value);
 }
 
 TEST(VarInt64Deserializer, ShouldThrowIfNoEndWith10Bytes) {

--- a/test/extensions/filters/network/kafka/serialization_utilities.cc
+++ b/test/extensions/filters/network/kafka/serialization_utilities.cc
@@ -12,7 +12,7 @@ void assertStringViewIncrement(const absl::string_view incremented,
   ASSERT_EQ(incremented.size(), original.size() - difference);
 }
 
-const char* getRawData(const Buffer::OwnedImpl& buffer) {
+const char* getRawData(const Buffer::Instance& buffer) {
   Buffer::RawSliceVector slices = buffer.getRawSlices(1);
   ASSERT(slices.size() == 1);
   return reinterpret_cast<const char*>((slices[0]).mem_);

--- a/test/extensions/filters/network/kafka/serialization_utilities.h
+++ b/test/extensions/filters/network/kafka/serialization_utilities.h
@@ -33,8 +33,8 @@ const char* getRawData(const Buffer::Instance& buffer);
 // 4. verify that data pointer moved correct amount,
 // 5. feed testee more data,
 // 6. verify that nothing more was consumed (because the testee has been ready since step 3).
-template <typename BT, typename AT>
-void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
+template <typename BT>
+void serializeThenDeserializeAndCheckEqualityInOneGo(const typename BT::result_type expected) {
   // given
   BT testee{};
 
@@ -68,8 +68,8 @@ void serializeThenDeserializeAndCheckEqualityInOneGo(AT expected) {
 // Does the same thing as the above test, but instead of providing whole data at one, it provides
 // it in N one-byte chunks.
 // This verifies if deserializer keeps state properly (no overwrites etc.).
-template <typename BT, typename AT>
-void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
+template <typename BT>
+void serializeThenDeserializeAndCheckEqualityWithChunks(const typename BT::result_type expected) {
   // given
   BT testee{};
 
@@ -109,9 +109,11 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
   ASSERT_EQ(more_data.size(), garbage_size);
 }
 
-// Deserialization of compact type only (for data types where we do not implement serializiation).
-template <typename BT, typename AT>
-void deserializeCompactAndCheckEqualityInOneGo(Buffer::Instance& buffer, const AT expected) {
+// Deserialization (only) of compact-encoded data (for data types where we do not need serializer
+// code).
+template <typename BT>
+void deserializeCompactAndCheckEqualityInOneGo(Buffer::Instance& buffer,
+                                               const typename BT::result_type expected) {
   // given
   BT testee{};
 
@@ -145,8 +147,9 @@ void deserializeCompactAndCheckEqualityInOneGo(Buffer::Instance& buffer, const A
 // Does the same thing as the above test, but instead of providing whole data at one, it provides
 // it in N one-byte chunks.
 // This verifies if deserializer keeps state properly (no overwrites etc.).
-template <typename BT, typename AT>
-void deserializeCompactAndCheckEqualityWithChunks(Buffer::Instance& buffer, AT expected) {
+template <typename BT>
+void deserializeCompactAndCheckEqualityWithChunks(Buffer::Instance& buffer,
+                                                  const typename BT::result_type expected) {
   // given
   BT testee{};
 
@@ -189,8 +192,9 @@ void deserializeCompactAndCheckEqualityWithChunks(Buffer::Instance& buffer, AT e
 }
 
 // Same thing as 'serializeThenDeserializeAndCheckEqualityInOneGo', just uses compact encoding.
-template <typename BT, typename AT>
-void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
+template <typename BT>
+void serializeCompactThenDeserializeAndCheckEqualityInOneGo(
+    const typename BT::result_type expected) {
   Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
   const uint32_t expected_written_size = encoder.computeCompactSize(expected);
@@ -200,8 +204,9 @@ void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
 }
 
 // Same thing as 'serializeThenDeserializeAndCheckEqualityWithChunks', just uses compact encoding.
-template <typename BT, typename AT>
-void serializeCompactThenDeserializeAndCheckEqualityWithChunks(AT expected) {
+template <typename BT>
+void serializeCompactThenDeserializeAndCheckEqualityWithChunks(
+    const typename BT::result_type expected) {
   // given
   BT testee{};
 
@@ -247,14 +252,15 @@ void serializeCompactThenDeserializeAndCheckEqualityWithChunks(AT expected) {
 }
 
 // Wrapper to run both tests for normal serialization.
-template <typename BT, typename AT> void serializeThenDeserializeAndCheckEquality(AT expected) {
+template <typename BT>
+void serializeThenDeserializeAndCheckEquality(const typename BT::result_type expected) {
   serializeThenDeserializeAndCheckEqualityInOneGo<BT>(expected);
   serializeThenDeserializeAndCheckEqualityWithChunks<BT>(expected);
 }
 
 // Wrapper to run both tests for compact serialization.
-template <typename BT, typename AT>
-void serializeCompactThenDeserializeAndCheckEquality(AT expected) {
+template <typename BT>
+void serializeCompactThenDeserializeAndCheckEquality(const typename BT::result_type expected) {
   serializeCompactThenDeserializeAndCheckEqualityInOneGo<BT>(expected);
   serializeCompactThenDeserializeAndCheckEqualityWithChunks<BT>(expected);
 }
@@ -262,7 +268,7 @@ void serializeCompactThenDeserializeAndCheckEquality(AT expected) {
 // Wrapper to run both tests for compact deserialization (for non-serializable types).
 template <typename BT>
 void deserializeCompactAndCheckEquality(Buffer::Instance& buffer,
-                                        typename BT::result_type expected) {
+                                        const typename BT::result_type expected) {
   Buffer::OwnedImpl
       copy_for_chunking_test; // Tests modify input buffers, so let's just make a copy.
   copy_for_chunking_test.add(getRawData(buffer), buffer.length());

--- a/test/extensions/filters/network/kafka/serialization_utilities.h
+++ b/test/extensions/filters/network/kafka/serialization_utilities.h
@@ -20,7 +20,7 @@ void assertStringViewIncrement(absl::string_view incremented, absl::string_view 
                                size_t difference);
 
 // Helper function converting buffer to raw bytes.
-const char* getRawData(const Buffer::OwnedImpl& buffer);
+const char* getRawData(const Buffer::Instance& buffer);
 
 // Exactly what is says on the tin:
 // 1. serialize expected using Encoder,
@@ -105,20 +105,15 @@ void serializeThenDeserializeAndCheckEqualityWithChunks(AT expected) {
   ASSERT_EQ(more_data.size(), garbage_size);
 }
 
-// Same thing as 'serializeThenDeserializeAndCheckEqualityInOneGo', just uses compact encoding.
 template <typename BT, typename AT>
-void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
+void deserializeCompactAndCheckEqualityInOneGo(Buffer::Instance& buffer, const AT expected) {
   // given
   BT testee{};
 
-  Buffer::OwnedImpl buffer;
   EncodingContext encoder{-1};
-  const uint32_t expected_written_size = encoder.computeCompactSize(expected);
-  const uint32_t written = encoder.encodeCompact(expected, buffer);
-  ASSERT_EQ(written, expected_written_size);
+  const uint32_t written = buffer.length();
   // Insert garbage after serialized payload.
   const uint32_t garbage_size = encoder.encode(Bytes(10000), buffer);
-
   const char* raw_buffer_ptr =
       reinterpret_cast<const char*>(buffer.linearize(written + garbage_size));
   // Tell parser that there is more data, it should never consume more than written.
@@ -140,6 +135,17 @@ void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
   // then - 2 (nothing changes)
   ASSERT_EQ(consumed2, 0);
   assertStringViewIncrement(data, orig_data, consumed);
+}
+
+// Same thing as 'serializeThenDeserializeAndCheckEqualityInOneGo', just uses compact encoding.
+template <typename BT, typename AT>
+void serializeCompactThenDeserializeAndCheckEqualityInOneGo(AT expected) {
+  Buffer::OwnedImpl buffer;
+  EncodingContext encoder{-1};
+  const uint32_t expected_written_size = encoder.computeCompactSize(expected);
+  const uint32_t written = encoder.encodeCompact(expected, buffer);
+  ASSERT_EQ(written, expected_written_size);
+  deserializeCompactAndCheckEqualityInOneGo<BT>(buffer, expected);
 }
 
 // Same thing as 'serializeThenDeserializeAndCheckEqualityWithChunks', just uses compact encoding.


### PR DESCRIPTION
Commit Message: kafka: new deserializers
Additional Description: new deserializers for kafka variable-length encoded int32 & int64 (called [varint, varlong](https://kafka.apache.org/protocol.html#protocol_types) there). These deserializers will be used in kafka-mesh-filter to decode internals of received kafka produce request objects so we can get the real messages out of the envelope [(like here)](https://github.com/envoyproxy/envoy/pull/11936/files#diff-a5b85c101e48a968f816536f17e9e7ab84db7abf19e468826f30085260ad2421R199), and forward them to kafka producers.
Risk Level: Low
Testing: unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
