### PR TITLE
router: fix suppress_grpc_request_failure_code_stats bug

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -55,7 +55,6 @@ Bug Fixes
 * http: port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
 * http: raise max configurable max_request_headers_kb limit to 8192 KiB (8MiB) from 96 KiB in http connection manager.
 * listener: fix the crash which could happen when the ongoing filter chain only listener update is followed by the listener removal or full listener update.
-* router: fix bug when using boolean :ref:`suppress_grpc_request_failure_code_stats <envoy_v3_api_field_extensions.filters.http.router.v3.Router.suppress_grpc_request_failure_code_stats>` to avoid suppressing upstream_rq_completed stats.
 * udp: limit each UDP listener to read maxmium 6000 packets per event loop. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.udp_per_event_loop_read_limit`` to false.
 * validation: fix an issue that causes TAP sockets to panic during config validation mode.
 * xray: fix the default sampling 'rate' for AWS X-Ray tracer extension to be 5% as opposed to 50%.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -55,7 +55,7 @@ Bug Fixes
 * http: port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
 * http: raise max configurable max_request_headers_kb limit to 8192 KiB (8MiB) from 96 KiB in http connection manager.
 * listener: fix the crash which could happen when the ongoing filter chain only listener update is followed by the listener removal or full listener update.
-* router: fix bug when using boolean :ref:`suppress_grpc_request_failure_code_stats <envoy_v3_api_field_extensions.filters.http.router.v3.Router.suppress_grpc_request_failure_code_stats> to avoid suppressing upstream_rq_completed stats.
+* router: fix bug when using boolean :ref:`suppress_grpc_request_failure_code_stats <envoy_v3_api_field_extensions.filters.http.router.v3.Router.suppress_grpc_request_failure_code_stats>` to avoid suppressing upstream_rq_completed stats.
 * udp: limit each UDP listener to read maxmium 6000 packets per event loop. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.udp_per_event_loop_read_limit`` to false.
 * validation: fix an issue that causes TAP sockets to panic during config validation mode.
 * xray: fix the default sampling 'rate' for AWS X-Ray tracer extension to be 5% as opposed to 50%.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -55,6 +55,7 @@ Bug Fixes
 * http: port stripping now works for CONNECT requests, though the port will be restored if the CONNECT request is sent upstream. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.strip_port_from_connect`` to false.
 * http: raise max configurable max_request_headers_kb limit to 8192 KiB (8MiB) from 96 KiB in http connection manager.
 * listener: fix the crash which could happen when the ongoing filter chain only listener update is followed by the listener removal or full listener update.
+* router: fix bug when using boolean :ref:`suppress_grpc_request_failure_code_stats <envoy_v3_api_field_extensions.filters.http.router.v3.Router.suppress_grpc_request_failure_code_stats> to avoid suppressing upstream_rq_completed stats.
 * udp: limit each UDP listener to read maxmium 6000 packets per event loop. This behavior can be temporarily reverted by setting ``envoy.reloadable_features.udp_per_event_loop_read_limit`` to false.
 * validation: fix an issue that causes TAP sockets to panic during config validation mode.
 * xray: fix the default sampling 'rate' for AWS X-Ray tracer extension to be 5% as opposed to 50%.

--- a/envoy/http/codes.h
+++ b/envoy/http/codes.h
@@ -94,7 +94,7 @@ public:
    * Charge a simple response stat to an upstream.
    */
   virtual void chargeBasicResponseStat(Stats::Scope& scope, Stats::StatName prefix,
-                                       Code response_code) const PURE;
+                                       Code response_code, bool exclude_http_code_stats) const PURE;
 
   /**
    * Charge a response stat to both agg counters (*xx) as well as code specific counters. This

--- a/envoy/http/codes.h
+++ b/envoy/http/codes.h
@@ -91,7 +91,8 @@ public:
   struct ResponseTimingInfo;
 
   /**
-   * Charge a simple response stat to an upstream.
+   * Charge a simple response stat to an upstream. exclude_http_code_stats will skip charging
+   * HTTP group/individual status code stats if set to True.
    */
   virtual void chargeBasicResponseStat(Stats::Scope& scope, Stats::StatName prefix,
                                        Code response_code, bool exclude_http_code_stats) const PURE;

--- a/source/common/http/codes.h
+++ b/source/common/http/codes.h
@@ -45,8 +45,8 @@ public:
   explicit CodeStatsImpl(Stats::SymbolTable& symbol_table);
 
   // CodeStats
-  void chargeBasicResponseStat(Stats::Scope& scope, Stats::StatName prefix,
-                               Code response_code) const override;
+  void chargeBasicResponseStat(Stats::Scope& scope, Stats::StatName prefix, Code response_code,
+                               bool exclude_http_code_stats) const override;
   void chargeResponseStat(const ResponseStatInfo& info,
                           bool exclude_http_code_stats) const override;
   void chargeResponseTiming(const ResponseTimingInfo& info) const override;

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1271,11 +1271,11 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
         pending_retries_++;
         upstream_request.upstreamHost()->stats().rq_error_.inc();
         Http::CodeStats& code_stats = httpContext().codeStats();
-        const bool exclude_http_code_stats = grpc_request_ && config_.suppress_grpc_request_failure_code_stats_;
-        code_stats.chargeBasicResponseStat(cluster_->statsScope(),
-                                           config_.stats_.stat_names_.retry_,
-                                           static_cast<Http::Code>(response_code), 
-                                           exclude_http_code_stats);
+        const bool exclude_http_code_stats =
+            grpc_request_ && config_.suppress_grpc_request_failure_code_stats_;
+        code_stats.chargeBasicResponseStat(
+            cluster_->statsScope(), config_.stats_.stat_names_.retry_,
+            static_cast<Http::Code>(response_code), exclude_http_code_stats);
 
         if (!end_stream || !upstream_request.encodeComplete()) {
           upstream_request.resetStream();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1271,9 +1271,11 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
         pending_retries_++;
         upstream_request.upstreamHost()->stats().rq_error_.inc();
         Http::CodeStats& code_stats = httpContext().codeStats();
+        const bool exclude_http_code_stats = grpc_request_ && config_.suppress_grpc_request_failure_code_stats_;
         code_stats.chargeBasicResponseStat(cluster_->statsScope(),
                                            config_.stats_.stat_names_.retry_,
-                                           static_cast<Http::Code>(response_code), false);
+                                           static_cast<Http::Code>(response_code), 
+                                           exclude_http_code_stats);
 
         if (!end_stream || !upstream_request.encodeComplete()) {
           upstream_request.resetStream();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -297,8 +297,6 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
     const bool is_canary = (upstream_canary_header && upstream_canary_header->value() == "true") ||
                            (upstream_host ? upstream_host->canary() : false);
     const bool internal_request = Http::HeaderUtility::isEnvoyInternalRequest(*downstream_headers_);
-    const bool exclude_http_code_stats =
-        grpc_request_ && config_.suppress_grpc_request_failure_code_stats_;
 
     Stats::StatName upstream_zone = upstreamZone(upstream_host);
     Http::CodeStats::ResponseStatInfo info{config_.scope_,
@@ -314,7 +312,7 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
                                            is_canary};
 
     Http::CodeStats& code_stats = httpContext().codeStats();
-    code_stats.chargeResponseStat(info, exclude_http_code_stats);
+    code_stats.chargeResponseStat(info, exclude_http_code_stats_);
 
     if (alt_stat_prefix_ != nullptr) {
       Http::CodeStats::ResponseStatInfo alt_info{config_.scope_,
@@ -327,7 +325,7 @@ void Filter::chargeUpstreamCode(uint64_t response_status_code,
                                                  config_.zone_name_,
                                                  upstream_zone,
                                                  is_canary};
-      code_stats.chargeResponseStat(alt_info, exclude_http_code_stats);
+      code_stats.chargeResponseStat(alt_info, exclude_http_code_stats_);
     }
 
     if (dropped) {
@@ -362,6 +360,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
   // TODO: Maybe add a filter API for this.
   grpc_request_ = Grpc::Common::isGrpcRequestHeaders(headers);
+  exclude_http_code_stats_ = grpc_request_ && config_.suppress_grpc_request_failure_code_stats_;
 
   // Only increment rq total stat if we actually decode headers here. This does not count requests
   // that get handled by earlier filters.
@@ -1271,11 +1270,9 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
         pending_retries_++;
         upstream_request.upstreamHost()->stats().rq_error_.inc();
         Http::CodeStats& code_stats = httpContext().codeStats();
-        const bool exclude_http_code_stats =
-            grpc_request_ && config_.suppress_grpc_request_failure_code_stats_;
         code_stats.chargeBasicResponseStat(
             cluster_->statsScope(), config_.stats_.stat_names_.retry_,
-            static_cast<Http::Code>(response_code), exclude_http_code_stats);
+            static_cast<Http::Code>(response_code), exclude_http_code_stats_);
 
         if (!end_stream || !upstream_request.encodeComplete()) {
           upstream_request.resetStream();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1273,7 +1273,7 @@ void Filter::onUpstreamHeaders(uint64_t response_code, Http::ResponseHeaderMapPt
         Http::CodeStats& code_stats = httpContext().codeStats();
         code_stats.chargeBasicResponseStat(cluster_->statsScope(),
                                            config_.stats_.stat_names_.retry_,
-                                           static_cast<Http::Code>(response_code));
+                                           static_cast<Http::Code>(response_code), false);
 
         if (!end_stream || !upstream_request.encodeComplete()) {
           upstream_request.resetStream();

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -527,6 +527,7 @@ private:
   // response forwarded downstream
   UpstreamRequest* final_upstream_request_;
   bool grpc_request_{};
+  bool exclude_http_code_stats_ = false;
   Http::RequestHeaderMap* downstream_headers_{};
   Http::RequestTrailerMap* downstream_trailers_{};
   MonotonicTime downstream_request_complete_time_;

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -764,7 +764,9 @@ TEST_F(RouterTestSupressGRPCStatsEnabled, ExcludeTimeoutHttpStats) {
   EXPECT_EQ(1UL, cm_.thread_local_cluster_.conn_pool_.host_->stats().rq_timeout_.value());
   EXPECT_EQ(1U,
             callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_timeout_.value());
-
+  EXPECT_EQ(1U,
+            cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_completed")
+                .value());
   EXPECT_EQ(
       0U,
       cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_504").value());
@@ -834,6 +836,9 @@ TEST_F(RouterTestSupressGRPCStatsDisabled, IncludeHttpTimeoutStats) {
   EXPECT_EQ(
       1U,
       cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_5xx").value());
+  EXPECT_EQ(1U,
+            cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_completed")
+                .value());
 }
 
 } // namespace Router


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Fixes bug that disables `upstream_rq_completed` stats when setting `suppress_grpc_request_failure_code_stats` to `True` on the router filter.
Additional Description: See original issue that created this configuration for more details on [goal](https://github.com/envoyproxy/envoy/issues/16667). We wanted to disable HTTP status code stats, but maintain all other stats within the `upstream_rq_*` namespace. This is a new behavior, so I don't expect it has been adopted by many users.
Risk Level: Low
Testing: Unit
Docs Changes: Added note to bug fixes for version history
Release Notes: n/a
Platform Specific Features: n/a
Fixes: https://github.com/envoyproxy/envoy/issues/17203
