### PR TITLE
mysql proxy: connection attributes parsing 

### DIFF
--- a/source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.h"
 
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/logger.h"
 #include "source/extensions/filters/network/mysql_proxy/mysql_codec.h"
 #include "source/extensions/filters/network/mysql_proxy/mysql_utils.h"
 
@@ -55,6 +57,10 @@ bool ClientLogin::isClientSecureConnection() const {
   return client_cap_ & CLIENT_SECURE_CONNECTION;
 }
 
+void ClientLogin::addConnectionAttribute(const std::pair<std::string, std::string>& attr) {
+  conn_attr_.emplace_back(attr);
+}
+
 DecodeStatus ClientLogin::parseMessage(Buffer::Instance& buffer, uint32_t len) {
   /* 4.0 uses 2 bytes, 4.1+ uses 4 bytes, but the proto-flag is in the lower 2
    * bytes */
@@ -96,6 +102,7 @@ DecodeStatus ClientLogin::parseResponseSsl(Buffer::Instance& buffer) {
 }
 
 DecodeStatus ClientLogin::parseResponse41(Buffer::Instance& buffer) {
+  int total = buffer.length();
   uint16_t ext_cap;
   if (BufferHelper::readUint16(buffer, ext_cap) != DecodeStatus::Success) {
     ENVOY_LOG(debug, "error when parsing client cap flag of client login message");
@@ -155,6 +162,49 @@ DecodeStatus ClientLogin::parseResponse41(Buffer::Instance& buffer) {
     ENVOY_LOG(debug, "error when parsing auth plugin name of client login message");
     return DecodeStatus::Failure;
   }
+  if (client_cap_ & CLIENT_CONNECT_ATTRS) {
+    // length of all key value pairs
+    uint64_t kvs_len;
+    if (BufferHelper::readLengthEncodedInteger(buffer, kvs_len) != DecodeStatus::Success) {
+      ENVOY_LOG(debug, "error when parsing length of all key-values in connection attributes of "
+                       "client login message");
+      return DecodeStatus::Failure;
+    }
+    while (kvs_len > 0) {
+      uint64_t str_len;
+      uint64_t prev_len = buffer.length();
+      if (BufferHelper::readLengthEncodedInteger(buffer, str_len) != DecodeStatus::Success) {
+        ENVOY_LOG(
+            debug,
+            "error when parsing length of connection attribute key in connection attributes of "
+            "client login message");
+        return DecodeStatus::Failure;
+      }
+      std::string key;
+      if (BufferHelper::readStringBySize(buffer, str_len, key) != DecodeStatus::Success) {
+        ENVOY_LOG(debug, "error when parsing connection attribute key in connection attributes of "
+                         "client login message");
+        return DecodeStatus::Failure;
+      }
+      if (BufferHelper::readLengthEncodedInteger(buffer, str_len) != DecodeStatus::Success) {
+        ENVOY_LOG(
+            debug,
+            "error when parsing length of connection attribute value in connection attributes of "
+            "client login message");
+        return DecodeStatus::Failure;
+      }
+      std::string val;
+      if (BufferHelper::readStringBySize(buffer, str_len, val) != DecodeStatus::Success) {
+        ENVOY_LOG(debug, "error when parsing connection attribute val in connection attributes of "
+                         "client login message");
+        return DecodeStatus::Failure;
+      }
+      conn_attr_.emplace_back(std::make_pair(std::move(key), std::move(val)));
+      kvs_len -= prev_len - buffer.length();
+    }
+  }
+  ENVOY_LOG(debug, "parse client login protocol 41, consumed len {}, remain {}",
+            total - buffer.length(), buffer.length());
   return DecodeStatus::Success;
 }
 
@@ -237,6 +287,17 @@ void ClientLogin::encodeResponse41(Buffer::Instance& out) const {
   if (client_cap_ & CLIENT_PLUGIN_AUTH) {
     BufferHelper::addString(out, auth_plugin_name_);
     BufferHelper::addUint8(out, enc_end_string);
+  }
+  if (client_cap_ & CLIENT_CONNECT_ATTRS) {
+    Buffer::OwnedImpl conn_attr;
+    for (const auto& kv : conn_attr_) {
+      BufferHelper::addLengthEncodedInteger(conn_attr, kv.first.length());
+      BufferHelper::addString(conn_attr, kv.first);
+      BufferHelper::addLengthEncodedInteger(conn_attr, kv.second.length());
+      BufferHelper::addString(conn_attr, kv.second);
+    }
+    BufferHelper::addLengthEncodedInteger(out, conn_attr.length());
+    out.move(conn_attr);
   }
 }
 

--- a/source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.cc
@@ -174,10 +174,9 @@ DecodeStatus ClientLogin::parseResponse41(Buffer::Instance& buffer) {
       uint64_t str_len;
       uint64_t prev_len = buffer.length();
       if (BufferHelper::readLengthEncodedInteger(buffer, str_len) != DecodeStatus::Success) {
-        ENVOY_LOG(
-            debug,
-            "error when parsing length of connection attribute key in connection attributes of "
-            "client login message");
+        ENVOY_LOG(debug, "error when parsing total length of connection attribute key in "
+                         "connection attributes of "
+                         "client login message");
         return DecodeStatus::Failure;
       }
       std::string key;
@@ -203,7 +202,7 @@ DecodeStatus ClientLogin::parseResponse41(Buffer::Instance& buffer) {
       kvs_len -= prev_len - buffer.length();
     }
   }
-  ENVOY_LOG(debug, "parse client login protocol 41, consumed len {}, remain {}",
+  ENVOY_LOG(debug, "parsed client login protocol 41, consumed len {}, remain len {}",
             total - buffer.length(), buffer.length());
   return DecodeStatus::Success;
 }

--- a/source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.h
+++ b/source/extensions/filters/network/mysql_proxy/mysql_codec_clogin.h
@@ -25,6 +25,9 @@ public:
   const std::vector<uint8_t>& getAuthResp() const { return auth_resp_; }
   const std::string& getDb() const { return db_; }
   const std::string& getAuthPluginName() const { return auth_plugin_name_; }
+  const std::vector<std::pair<std::string, std::string>>& getConnectionAttribute() const {
+    return conn_attr_;
+  }
   bool isResponse41() const;
   bool isResponse320() const;
   bool isSSLRequest() const;
@@ -40,6 +43,7 @@ public:
   void setAuthResp(const std::vector<uint8_t>& auth_resp);
   void setDb(const std::string& db);
   void setAuthPluginName(const std::string& auth_plugin_name);
+  void addConnectionAttribute(const std::pair<std::string, std::string>&);
 
 private:
   DecodeStatus parseResponseSsl(Buffer::Instance& buffer);
@@ -56,6 +60,7 @@ private:
   std::vector<uint8_t> auth_resp_;
   std::string db_;
   std::string auth_plugin_name_;
+  std::vector<std::pair<std::string, std::string>> conn_attr_;
 };
 
 } // namespace MySQLProxy

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
@@ -123,7 +123,7 @@ std::string MySQLTestUtils::encodeMessage(uint32_t packet_len, uint8_t it, uint8
 }
 
 int MySQLTestUtils::bytesOfConnAtrributeLength(
-    const std::vector<std::pair<std::string, std::string>> conn_attrs) {
+    const std::vector<std::pair<std::string, std::string>>& conn_attrs) {
   int64_t total_len = 0;
   for (const auto& kv : conn_attrs) {
     total_len += sizeOfLengthEncodeInteger(kv.first.length());

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
@@ -122,6 +122,18 @@ std::string MySQLTestUtils::encodeMessage(uint32_t packet_len, uint8_t it, uint8
   return buffer.toString();
 }
 
+int MySQLTestUtils::bytesOfConnAtrributeLength(
+    const std::vector<std::pair<std::string, std::string>> conn_attrs) {
+  int64_t allLen = 0;
+  for (const auto& kv : conn_attrs) {
+    allLen += sizeOfLengthEncodeInteger(kv.first.length());
+    allLen += kv.first.length();
+    allLen += sizeOfLengthEncodeInteger(kv.second.length());
+    allLen += kv.second.length();
+  }
+  return sizeOfLengthEncodeInteger(allLen);
+}
+
 int MySQLTestUtils::sizeOfLengthEncodeInteger(uint64_t val) {
   if (val < 251) {
     return sizeof(uint8_t);

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
@@ -124,14 +124,14 @@ std::string MySQLTestUtils::encodeMessage(uint32_t packet_len, uint8_t it, uint8
 
 int MySQLTestUtils::bytesOfConnAtrributeLength(
     const std::vector<std::pair<std::string, std::string>> conn_attrs) {
-  int64_t allLen = 0;
+  int64_t total_len = 0;
   for (const auto& kv : conn_attrs) {
-    allLen += sizeOfLengthEncodeInteger(kv.first.length());
-    allLen += kv.first.length();
-    allLen += sizeOfLengthEncodeInteger(kv.second.length());
-    allLen += kv.second.length();
+    total_len += sizeOfLengthEncodeInteger(kv.first.length());
+    total_len += kv.first.length();
+    total_len += sizeOfLengthEncodeInteger(kv.second.length());
+    total_len += kv.second.length();
   }
-  return sizeOfLengthEncodeInteger(allLen);
+  return sizeOfLengthEncodeInteger(total_len);
 }
 
 int MySQLTestUtils::sizeOfLengthEncodeInteger(uint64_t val) {

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.h
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.h
@@ -37,6 +37,8 @@ public:
   static std::string getDb() { return "mysql.db"; }
   static std::string getCommandResponse() { return "command response"; }
   static std::string getInfo() { return "info"; }
+  static int
+  bytesOfConnAtrributeLength(const std::vector<std::pair<std::string, std::string>> conn);
   static int sizeOfLengthEncodeInteger(uint64_t val);
 
   std::string encodeServerGreeting(int protocol);

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.h
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.h
@@ -38,7 +38,7 @@ public:
   static std::string getCommandResponse() { return "command response"; }
   static std::string getInfo() { return "info"; }
   static int
-  bytesOfConnAtrributeLength(const std::vector<std::pair<std::string, std::string>> conn);
+  bytesOfConnAtrributeLength(const std::vector<std::pair<std::string, std::string>>& conn);
   static int sizeOfLengthEncodeInteger(uint64_t val);
 
   std::string encodeServerGreeting(int protocol);


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Parse connection attributes when CLIENT_CONNECT_ATTRS is set at the client capability.

[Some connector](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html) will set connection attributes when connecting. If CLIENT_CONNECT_ATTRS is set but the related field is empty, the server will return bad handshake error. 

Commit Message: MySQL proxy codec parsing of connection attributes 
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
