### PR TITLE
mysql proxy: special handle of decoder at command phase

### DIFF
--- a/docs/root/start/sandboxes/mysql.rst
+++ b/docs/root/start/sandboxes/mysql.rst
@@ -96,11 +96,12 @@ Terminal 1
   mysql.egress_mysql.decoder_errors: 0
   mysql.egress_mysql.login_attempts: 1
   mysql.egress_mysql.login_failures: 0
-  mysql.egress_mysql.protocol_errors: 21
+  mysql.egress_mysql.protocol_errors: 0
   mysql.egress_mysql.queries_parse_error: 2
   mysql.egress_mysql.queries_parsed: 7
-  mysql.egress_mysql.sessions: 1
+  mysql.egress_mysql.sessions: 6
   mysql.egress_mysql.upgraded_to_ssl: 0
+
 
 
 Step 4: Check TCP stats

--- a/source/extensions/filters/network/mysql_proxy/mysql_filter.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_filter.cc
@@ -113,8 +113,8 @@ void MySQLFilter::onCommand(Command& command) {
   auto result = Common::SQLUtils::SQLUtils::setMetadata(command.getData(),
                                                         decoder_->getAttributes(), metadata);
 
-  ENVOY_CONN_LOG(trace, "mysql_proxy: query processed {}", read_callbacks_->connection(),
-                 command.getData());
+  ENVOY_CONN_LOG(trace, "mysql_proxy: query processed {}, result {}, cmd type {}",
+                 read_callbacks_->connection(), command.getData(), result, command.getCmd());
 
   if (!result) {
     config_->stats_.queries_parse_error_.inc();

--- a/test/extensions/common/sqlutils/sqlutils_test.cc
+++ b/test/extensions/common/sqlutils/sqlutils_test.cc
@@ -181,9 +181,12 @@ INSTANTIATE_TEST_SUITE_P(
         // Schema. Should be parsed fine, but should not produce any metadata
         TEST_VALUE("SHOW databases;", true, {}, {}), TEST_VALUE("SHOW tables;", true, {}, {}),
         TEST_VALUE("SELECT * FROM;", false, {}, {}),
-        TEST_VALUE("SELECT 1 FROM tabletest1;", true, {{"tabletest1", {"select"}}}, {})
+        TEST_VALUE("SELECT 1 FROM tabletest1;", true, {{"tabletest1", {"select"}}}, {}),
 
-            ));
+        // SQL parser now can not recognize use keywords as identifier.
+        TEST_VALUE("CREATE TABLE test ( text VARCHAR(255) );", false, {}, {}),
+        // Keyword as function.
+        TEST_VALUE("SHOW DATABASE();", false, {}, {})));
 
 } // namespace SQLUtils
 } // namespace Common

--- a/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_filter_test.cc
@@ -996,7 +996,7 @@ TEST_F(MySQLFilterTest, MySqlLoginAndQueryTest) {
   srv_resp_data = encodeClientLoginResp(MYSQL_RESP_OK, 0, 1);
   Buffer::InstancePtr request_resp_data(new Buffer::OwnedImpl(srv_resp_data));
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(*request_resp_data, false));
-  EXPECT_EQ(MySQLSession::State::Req, filter_->getSession().getState());
+  EXPECT_EQ(MySQLSession::State::ReqResp, filter_->getSession().getState());
 
   mysql_cmd_encode.setCmd(Command::Cmd::Query);
   query = "show databases";
@@ -1012,7 +1012,7 @@ TEST_F(MySQLFilterTest, MySqlLoginAndQueryTest) {
   srv_resp_data = encodeClientLoginResp(MYSQL_RESP_OK, 0, 1);
   Buffer::InstancePtr show_resp_data(new Buffer::OwnedImpl(srv_resp_data));
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(*show_resp_data, false));
-  EXPECT_EQ(MySQLSession::State::Req, filter_->getSession().getState());
+  EXPECT_EQ(MySQLSession::State::ReqResp, filter_->getSession().getState());
 
   mysql_cmd_encode.setCmd(Command::Cmd::Query);
   query = "CREATE TABLE students (name TEXT, student_number INTEGER, city TEXT)";
@@ -1029,7 +1029,7 @@ TEST_F(MySQLFilterTest, MySqlLoginAndQueryTest) {
   srv_resp_data = encodeClientLoginResp(MYSQL_RESP_OK, 0, 1);
   Buffer::InstancePtr create_resp_data(new Buffer::OwnedImpl(srv_resp_data));
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(*create_resp_data, false));
-  EXPECT_EQ(MySQLSession::State::Req, filter_->getSession().getState());
+  EXPECT_EQ(MySQLSession::State::ReqResp, filter_->getSession().getState());
 
   mysql_cmd_encode.setCmd(Command::Cmd::Query);
   query = "CREATE index index1";
@@ -1047,7 +1047,7 @@ TEST_F(MySQLFilterTest, MySqlLoginAndQueryTest) {
   Buffer::InstancePtr create_index_resp_data(new Buffer::OwnedImpl(srv_resp_data));
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue,
             filter_->onData(*create_index_resp_data, false));
-  EXPECT_EQ(MySQLSession::State::Req, filter_->getSession().getState());
+  EXPECT_EQ(MySQLSession::State::ReqResp, filter_->getSession().getState());
 
   mysql_cmd_encode.setCmd(Command::Cmd::FieldList);
   query = "";
@@ -1064,7 +1064,7 @@ TEST_F(MySQLFilterTest, MySqlLoginAndQueryTest) {
   srv_resp_data = encodeClientLoginResp(MYSQL_RESP_OK, 0, 1);
   Buffer::InstancePtr field_list_resp_data(new Buffer::OwnedImpl(srv_resp_data));
   EXPECT_EQ(Envoy::Network::FilterStatus::Continue, filter_->onData(*field_list_resp_data, false));
-  EXPECT_EQ(MySQLSession::State::Req, filter_->getSession().getState());
+  EXPECT_EQ(MySQLSession::State::ReqResp, filter_->getSession().getState());
 }
 
 } // namespace MySQLProxy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

MySQL command response contains more than one packet, do special handle when server response over and client send the request.

2 parse errors occur in `mysql.rst` is due to SQL parser can not parse:
1. `CREATE TABLE test ( text VARCHAR(255) );`
2. `SHOW DATABASE();`

Commit Message: special handle of decoder at command phase
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
