### PR TITLE
replace RequestHeaderMap in tracers with general TraceContext

### DIFF
--- a/envoy/tracing/BUILD
+++ b/envoy/tracing/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
     name = "trace_driver_interface",
     hdrs = ["trace_driver.h"],
     deps = [
+        ":trace_context_interface",
         ":trace_reason_interface",
         "//envoy/stream_info:stream_info_interface",
     ],

--- a/envoy/tracing/trace_context.h
+++ b/envoy/tracing/trace_context.h
@@ -14,6 +14,10 @@ namespace Tracing {
  * Protocol-independent abstraction for traceable stream. It hides the differences between different
  * protocol and provides tracer driver with common methods for obtaining and setting the tracing
  * context.
+ *
+ * TODO(wbpcode): A new interface should be added to obtain general traceable stream information,
+ * such as host, RPC method, protocol identification, etc. At the same time, a new interface needs
+ * to be added to support traversal of all trace contexts.
  */
 class TraceContext {
 public:

--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -6,6 +6,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/stream_info/stream_info.h"
+#include "envoy/tracing/trace_context.h"
 #include "envoy/tracing/trace_reason.h"
 
 namespace Envoy {
@@ -22,7 +23,7 @@ enum class OperationName { Ingress, Egress };
  * The context for the custom tag to obtain the tag value.
  */
 struct CustomTagContext {
-  const Http::RequestHeaderMap* request_headers;
+  const TraceContext* trace_context;
   const StreamInfo::StreamInfo& stream_info;
 };
 
@@ -117,7 +118,7 @@ public:
    * (implementation-specific) trace.
    * @param request_headers the headers to which propagation context will be added
    */
-  virtual void injectContext(Http::RequestHeaderMap& request_headers) PURE;
+  virtual void injectContext(TraceContext& trace_conext) PURE;
 
   /**
    * Create and start a child Span, with this Span as its parent in the trace.
@@ -171,7 +172,7 @@ public:
   /**
    * Start driver specific span.
    */
-  virtual SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  virtual SpanPtr startSpan(const Config& config, TraceContext& trace_conext,
                             const std::string& operation_name, SystemTime start_time,
                             const Tracing::Decision tracing_decision) PURE;
 };

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -322,7 +322,7 @@ absl::string_view RequestHeaderCustomTag::value(const CustomTagContext& ctx) con
   }
   // TODO(https://github.com/envoyproxy/envoy/issues/13454): Potentially populate all header values.
   const auto entry = ctx.trace_context->getTraceContext(name_);
-  return entry.has_value() ? entry.value() : default_value_;
+  return entry.value_or(default_value_);
 }
 
 MetadataCustomTag::MetadataCustomTag(const std::string& tag,

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -317,12 +317,12 @@ RequestHeaderCustomTag::RequestHeaderCustomTag(
       default_value_(request_header.default_value()) {}
 
 absl::string_view RequestHeaderCustomTag::value(const CustomTagContext& ctx) const {
-  if (!ctx.request_headers) {
+  if (ctx.trace_context == nullptr) {
     return default_value_;
   }
   // TODO(https://github.com/envoyproxy/envoy/issues/13454): Potentially populate all header values.
-  const auto entry = ctx.request_headers->get(name_);
-  return !entry.empty() ? entry[0]->value().getStringView() : default_value_;
+  const auto entry = ctx.trace_context->getTraceContext(name_);
+  return entry.has_value() ? entry.value() : default_value_;
 }
 
 MetadataCustomTag::MetadataCustomTag(const std::string& tag,

--- a/source/common/tracing/null_span_impl.h
+++ b/source/common/tracing/null_span_impl.h
@@ -22,7 +22,7 @@ public:
   void setTag(absl::string_view, absl::string_view) override {}
   void log(SystemTime, const std::string&) override {}
   void finishSpan() override {}
-  void injectContext(Http::RequestHeaderMap&) override {}
+  void injectContext(Tracing::TraceContext&) override {}
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -21,28 +21,27 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Request
     ot_span_context_handle(Http::CustomHeaders::get().OtSpanContext);
 
 namespace {
-class OpenTracingHTTPHeadersWriter : public opentracing::HTTPHeadersWriter {
+class OpenTracingHeadersWriter : public opentracing::HTTPHeadersWriter {
 public:
-  explicit OpenTracingHTTPHeadersWriter(Http::HeaderMap& request_headers)
-      : request_headers_(request_headers) {}
+  explicit OpenTracingHeadersWriter(Tracing::TraceContext& trace_context)
+      : trace_context_(trace_context) {}
 
   // opentracing::HTTPHeadersWriter
   opentracing::expected<void> Set(opentracing::string_view key,
                                   opentracing::string_view value) const override {
     Http::LowerCaseString lowercase_key{{key.data(), key.size()}};
-    request_headers_.remove(lowercase_key);
-    request_headers_.addCopy(std::move(lowercase_key), {value.data(), value.size()});
+    trace_context_.setTraceContext(lowercase_key, {value.data(), value.size()});
     return {};
   }
 
 private:
-  Http::HeaderMap& request_headers_;
+  Tracing::TraceContext& trace_context_;
 };
 
-class OpenTracingHTTPHeadersReader : public opentracing::HTTPHeadersReader {
+class OpenTracingHeadersReader : public opentracing::HTTPHeadersReader {
 public:
-  explicit OpenTracingHTTPHeadersReader(const Http::RequestHeaderMap& request_headers)
-      : request_headers_(request_headers) {}
+  explicit OpenTracingHeadersReader(const Tracing::TraceContext& trace_context)
+      : trace_context_(trace_context) {}
 
   using OpenTracingCb = std::function<opentracing::expected<void>(opentracing::string_view,
                                                                   opentracing::string_view)>;
@@ -50,23 +49,29 @@ public:
   // opentracing::HTTPHeadersReader
   opentracing::expected<opentracing::string_view>
   LookupKey(opentracing::string_view key) const override {
-    const auto entry = request_headers_.get(Http::LowerCaseString{{key.data(), key.size()}});
-    if (!entry.empty()) {
-      // This is an implicitly untrusted header, so only the first value is used.
-      return opentracing::string_view{entry[0]->value().getStringView().data(),
-                                      entry[0]->value().getStringView().length()};
+    Http::LowerCaseString lowercase_key{{key.data(), key.size()}};
+    const auto entry = trace_context_.getTraceContext(lowercase_key);
+    if (entry.has_value()) {
+      return opentracing::string_view{entry.value().data(), entry.value().length()};
     } else {
       return opentracing::make_unexpected(opentracing::key_not_found_error);
     }
   }
 
   opentracing::expected<void> ForeachKey(OpenTracingCb f) const override {
-    request_headers_.iterate(headerMapCallback(f));
+    // TODO(wbpcode): TraceContext currently does not provide an API to traverse all entries. So
+    // dynamic_cast has to be used here. This is a temporary compromise to ensure that the existing
+    // functions are correct. After TraceContext provides the iterative API, this part of the code
+    // needs to be rewritten.
+    const auto headers = dynamic_cast<const Http::RequestHeaderMap*>(&trace_context_);
+    if (headers != nullptr) {
+      headers->iterate(headerMapCallback(f));
+    }
     return {};
   }
 
 private:
-  const Http::RequestHeaderMap& request_headers_;
+  const Tracing::TraceContext& trace_context_;
 
   static Http::HeaderMap::ConstIterateCb headerMapCallback(OpenTracingCb callback) {
     return [callback =
@@ -113,7 +118,7 @@ std::string OpenTracingSpan::getBaggage(absl::string_view key) {
   return span_->BaggageItem({key.data(), key.length()});
 }
 
-void OpenTracingSpan::injectContext(Http::RequestHeaderMap& request_headers) {
+void OpenTracingSpan::injectContext(Tracing::TraceContext& trace_context) {
   if (driver_.propagationMode() == OpenTracingDriver::PropagationMode::SingleHeader) {
     // Inject the span context using Envoy's single-header format.
     std::ostringstream oss;
@@ -125,12 +130,12 @@ void OpenTracingSpan::injectContext(Http::RequestHeaderMap& request_headers) {
       return;
     }
     const std::string current_span_context = oss.str();
-    request_headers.setInline(
-        ot_span_context_handle.handle(),
+    trace_context.setTraceContextReferenceKey(
+        Http::CustomHeaders::get().OtSpanContext,
         Base64::encode(current_span_context.c_str(), current_span_context.length()));
   } else {
-    // Inject the context using the tracer's standard HTTP header format.
-    const OpenTracingHTTPHeadersWriter writer{request_headers};
+    // Inject the context using the tracer's standard header format.
+    const OpenTracingHeadersWriter writer{trace_context};
     const opentracing::expected<void> was_successful =
         span_->tracer().Inject(span_->context(), writer);
     if (!was_successful) {
@@ -157,7 +162,7 @@ OpenTracingDriver::OpenTracingDriver(Stats::Scope& scope)
     : tracer_stats_{OPENTRACING_TRACER_STATS(POOL_COUNTER_PREFIX(scope, "tracing.opentracing."))} {}
 
 Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
-                                              Http::RequestHeaderMap& request_headers,
+                                              Tracing::TraceContext& trace_context,
                                               const std::string& operation_name,
                                               SystemTime start_time,
                                               const Tracing::Decision tracing_decision) {
@@ -165,11 +170,11 @@ Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
   const opentracing::Tracer& tracer = this->tracer();
   std::unique_ptr<opentracing::Span> active_span;
   std::unique_ptr<opentracing::SpanContext> parent_span_ctx;
-  if (propagation_mode == PropagationMode::SingleHeader &&
-      request_headers.getInline(ot_span_context_handle.handle())) {
+
+  const auto entry = trace_context.getTraceContext(Http::CustomHeaders::get().OtSpanContext);
+  if (propagation_mode == PropagationMode::SingleHeader && entry.has_value()) {
     opentracing::expected<std::unique_ptr<opentracing::SpanContext>> parent_span_ctx_maybe;
-    std::string parent_context = Base64::decode(
-        std::string(request_headers.getInlineValue(ot_span_context_handle.handle())));
+    std::string parent_context = Base64::decode(std::string(entry.value()));
 
     if (!parent_context.empty()) {
       InputConstMemoryStream istream{parent_context.data(), parent_context.size()};
@@ -187,7 +192,7 @@ Tracing::SpanPtr OpenTracingDriver::startSpan(const Tracing::Config& config,
       tracerStats().span_context_extraction_error_.inc();
     }
   } else if (propagation_mode == PropagationMode::TracerNative) {
-    const OpenTracingHTTPHeadersReader reader{request_headers};
+    const OpenTracingHeadersReader reader{trace_context};
     opentracing::expected<std::unique_ptr<opentracing::SpanContext>> parent_span_ctx_maybe =
         tracer.Extract(reader);
     if (parent_span_ctx_maybe) {

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.cc
@@ -21,6 +21,10 @@ Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::Request
     ot_span_context_handle(Http::CustomHeaders::get().OtSpanContext);
 
 namespace {
+
+/**
+ * TODO(wbpcode): Use opentracing::TextMapWriter to replace opentracing::HTTPHeadersWriter.
+ */
 class OpenTracingHeadersWriter : public opentracing::HTTPHeadersWriter {
 public:
   explicit OpenTracingHeadersWriter(Tracing::TraceContext& trace_context)
@@ -38,6 +42,9 @@ private:
   Tracing::TraceContext& trace_context_;
 };
 
+/**
+ * TODO(wbpcode): Use opentracing::TextMapReader to replace opentracing::HTTPHeadersReader.
+ */
 class OpenTracingHeadersReader : public opentracing::HTTPHeadersReader {
 public:
   explicit OpenTracingHeadersReader(const Tracing::TraceContext& trace_context)

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -37,7 +37,7 @@ public:
   void setOperation(absl::string_view operation) override;
   void setTag(absl::string_view name, const absl::string_view) override;
   void log(SystemTime timestamp, const std::string& event) override;
-  void injectContext(Http::RequestHeaderMap& request_headers) override;
+  void injectContext(Tracing::TraceContext& trace_context) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
                               SystemTime start_time) override;
   void setSampled(bool) override;
@@ -64,7 +64,7 @@ public:
   explicit OpenTracingDriver(Stats::Scope& scope);
 
   // Tracer::TracingDriver
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
                              const std::string& operation_name, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -58,7 +58,7 @@ using Constants = ConstSingleton<ConstantValues>;
 class Span : public Tracing::Span {
 public:
   Span(const Tracing::Config& config, const envoy::config::trace::v3::OpenCensusConfig& oc_config,
-       Http::RequestHeaderMap& request_headers, const std::string& operation_name,
+       Tracing::TraceContext& trace_context, const std::string& operation_name,
        SystemTime start_time, const Tracing::Decision tracing_decision);
 
   // Used by spawnChild().
@@ -69,7 +69,7 @@ public:
   void setTag(absl::string_view name, absl::string_view value) override;
   void log(SystemTime timestamp, const std::string& event) override;
   void finishSpan() override;
-  void injectContext(Http::RequestHeaderMap& request_headers) override;
+  void injectContext(Tracing::TraceContext& trace_context) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
                               SystemTime start_time) override;
   void setSampled(bool sampled) override;
@@ -86,7 +86,7 @@ private:
 };
 
 ::opencensus::trace::Span
-startSpanHelper(const std::string& name, bool traced, const Http::RequestHeaderMap& request_headers,
+startSpanHelper(const std::string& name, bool traced, const Tracing::TraceContext& trace_context,
                 const envoy::config::trace::v3::OpenCensusConfig& oc_config) {
   // Determine if there is a parent context.
   using OpenCensusConfig = envoy::config::trace::v3::OpenCensusConfig;
@@ -95,34 +95,32 @@ startSpanHelper(const std::string& name, bool traced, const Http::RequestHeaderM
     bool found = false;
     switch (incoming) {
     case OpenCensusConfig::TRACE_CONTEXT: {
-      const auto header = request_headers.get(Constants::get().TRACEPARENT);
-      if (!header.empty()) {
+      const auto entry = trace_context.getTraceContext(Constants::get().TRACEPARENT);
+      if (entry.has_value()) {
         found = true;
         // This is an implicitly untrusted header, so only the first value is used.
-        parent_ctx = ::opencensus::trace::propagation::FromTraceParentHeader(
-            header[0]->value().getStringView());
+        parent_ctx = ::opencensus::trace::propagation::FromTraceParentHeader(entry.value());
       }
       break;
     }
 
     case OpenCensusConfig::GRPC_TRACE_BIN: {
-      const auto header = request_headers.get(Constants::get().GRPC_TRACE_BIN);
-      if (!header.empty()) {
+      const auto entry = trace_context.getTraceContext(Constants::get().GRPC_TRACE_BIN);
+      if (entry.has_value()) {
         found = true;
         // This is an implicitly untrusted header, so only the first value is used.
         parent_ctx = ::opencensus::trace::propagation::FromGrpcTraceBinHeader(
-            Base64::decodeWithoutPadding(header[0]->value().getStringView()));
+            Base64::decodeWithoutPadding(entry.value()));
       }
       break;
     }
 
     case OpenCensusConfig::CLOUD_TRACE_CONTEXT: {
-      const auto header = request_headers.get(Constants::get().X_CLOUD_TRACE_CONTEXT);
-      if (!header.empty()) {
+      const auto entry = trace_context.getTraceContext(Constants::get().X_CLOUD_TRACE_CONTEXT);
+      if (entry.has_value()) {
         found = true;
         // This is an implicitly untrusted header, so only the first value is used.
-        parent_ctx = ::opencensus::trace::propagation::FromCloudTraceContextHeader(
-            header[0]->value().getStringView());
+        parent_ctx = ::opencensus::trace::propagation::FromCloudTraceContextHeader(entry.value());
       }
       break;
     }
@@ -132,27 +130,23 @@ startSpanHelper(const std::string& name, bool traced, const Http::RequestHeaderM
       absl::string_view b3_span_id;
       absl::string_view b3_sampled;
       absl::string_view b3_flags;
-      const auto h_b3_trace_id = request_headers.get(Constants::get().X_B3_TRACEID);
-      if (!h_b3_trace_id.empty()) {
-        // This is an implicitly untrusted header, so only the first value is used.
-        b3_trace_id = h_b3_trace_id[0]->value().getStringView();
+      const auto h_b3_trace_id = trace_context.getTraceContext(Constants::get().X_B3_TRACEID);
+      if (h_b3_trace_id.has_value()) {
+        b3_trace_id = h_b3_trace_id.value();
       }
-      const auto h_b3_span_id = request_headers.get(Constants::get().X_B3_SPANID);
-      if (!h_b3_span_id.empty()) {
-        // This is an implicitly untrusted header, so only the first value is used.
-        b3_span_id = h_b3_span_id[0]->value().getStringView();
+      const auto h_b3_span_id = trace_context.getTraceContext(Constants::get().X_B3_SPANID);
+      if (h_b3_span_id.has_value()) {
+        b3_span_id = h_b3_span_id.value();
       }
-      const auto h_b3_sampled = request_headers.get(Constants::get().X_B3_SAMPLED);
-      if (!h_b3_sampled.empty()) {
-        // This is an implicitly untrusted header, so only the first value is used.
-        b3_sampled = h_b3_sampled[0]->value().getStringView();
+      const auto h_b3_sampled = trace_context.getTraceContext(Constants::get().X_B3_SAMPLED);
+      if (h_b3_sampled.has_value()) {
+        b3_sampled = h_b3_sampled.value();
       }
-      const auto h_b3_flags = request_headers.get(Constants::get().X_B3_FLAGS);
-      if (!h_b3_flags.empty()) {
-        // This is an implicitly untrusted header, so only the first value is used.
-        b3_flags = h_b3_flags[0]->value().getStringView();
+      const auto h_b3_flags = trace_context.getTraceContext(Constants::get().X_B3_FLAGS);
+      if (h_b3_flags.has_value()) {
+        b3_flags = h_b3_flags.value();
       }
-      if (!h_b3_trace_id.empty() && !h_b3_span_id.empty()) {
+      if (h_b3_trace_id.has_value() && h_b3_span_id.has_value()) {
         found = true;
         parent_ctx = ::opencensus::trace::propagation::FromB3Headers(b3_trace_id, b3_span_id,
                                                                      b3_sampled, b3_flags);
@@ -183,9 +177,9 @@ startSpanHelper(const std::string& name, bool traced, const Http::RequestHeaderM
 
 Span::Span(const Tracing::Config& config,
            const envoy::config::trace::v3::OpenCensusConfig& oc_config,
-           Http::RequestHeaderMap& request_headers, const std::string& operation_name,
+           Tracing::TraceContext& trace_context, const std::string& operation_name,
            SystemTime /*start_time*/, const Tracing::Decision tracing_decision)
-    : span_(startSpanHelper(operation_name, tracing_decision.traced, request_headers, oc_config)),
+    : span_(startSpanHelper(operation_name, tracing_decision.traced, trace_context, oc_config)),
       oc_config_(oc_config) {
   span_.AddAttribute("OperationName", config.operationName() == Tracing::OperationName::Ingress
                                           ? "Ingress"
@@ -209,36 +203,36 @@ void Span::log(SystemTime /*timestamp*/, const std::string& event) {
 
 void Span::finishSpan() { span_.End(); }
 
-void Span::injectContext(Http::RequestHeaderMap& request_headers) {
+void Span::injectContext(Tracing::TraceContext& trace_context) {
   using OpenCensusConfig = envoy::config::trace::v3::OpenCensusConfig;
   const auto& ctx = span_.context();
   for (const auto& outgoing : oc_config_.outgoing_trace_context()) {
     switch (outgoing) {
     case OpenCensusConfig::TRACE_CONTEXT:
-      request_headers.setReferenceKey(Constants::get().TRACEPARENT,
-                                      ::opencensus::trace::propagation::ToTraceParentHeader(ctx));
+      trace_context.setTraceContextReferenceKey(
+          Constants::get().TRACEPARENT, ::opencensus::trace::propagation::ToTraceParentHeader(ctx));
       break;
 
     case OpenCensusConfig::GRPC_TRACE_BIN: {
       std::string val = ::opencensus::trace::propagation::ToGrpcTraceBinHeader(ctx);
       val = Base64::encode(val.data(), val.size(), /*add_padding=*/false);
-      request_headers.setReferenceKey(Constants::get().GRPC_TRACE_BIN, val);
+      trace_context.setTraceContextReferenceKey(Constants::get().GRPC_TRACE_BIN, val);
       break;
     }
 
     case OpenCensusConfig::CLOUD_TRACE_CONTEXT:
-      request_headers.setReferenceKey(
+      trace_context.setTraceContextReferenceKey(
           Constants::get().X_CLOUD_TRACE_CONTEXT,
           ::opencensus::trace::propagation::ToCloudTraceContextHeader(ctx));
       break;
 
     case OpenCensusConfig::B3:
-      request_headers.setReferenceKey(Constants::get().X_B3_TRACEID,
-                                      ::opencensus::trace::propagation::ToB3TraceIdHeader(ctx));
-      request_headers.setReferenceKey(Constants::get().X_B3_SPANID,
-                                      ::opencensus::trace::propagation::ToB3SpanIdHeader(ctx));
-      request_headers.setReferenceKey(Constants::get().X_B3_SAMPLED,
-                                      ::opencensus::trace::propagation::ToB3SampledHeader(ctx));
+      trace_context.setTraceContextReferenceKey(
+          Constants::get().X_B3_TRACEID, ::opencensus::trace::propagation::ToB3TraceIdHeader(ctx));
+      trace_context.setTraceContextReferenceKey(
+          Constants::get().X_B3_SPANID, ::opencensus::trace::propagation::ToB3SpanIdHeader(ctx));
+      trace_context.setTraceContextReferenceKey(
+          Constants::get().X_B3_SAMPLED, ::opencensus::trace::propagation::ToB3SampledHeader(ctx));
       // OpenCensus's trace context propagation doesn't produce the
       // "X-B3-Flags:" header.
       break;
@@ -384,10 +378,10 @@ void Driver::applyTraceConfig(const opencensus::proto::trace::v1::TraceConfig& c
 }
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
-                                   Http::RequestHeaderMap& request_headers,
+                                   Tracing::TraceContext& trace_context,
                                    const std::string& operation_name, SystemTime start_time,
                                    const Tracing::Decision tracing_decision) {
-  return std::make_unique<Span>(config, oc_config_, request_headers, operation_name, start_time,
+  return std::make_unique<Span>(config, oc_config_, trace_context, operation_name, start_time,
                                 tracing_decision);
 }
 

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.h
@@ -23,7 +23,7 @@ public:
   /**
    * Implements the abstract Driver's startSpan operation.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
                              const std::string& operation_name, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.cc
@@ -45,14 +45,14 @@ Driver::Driver(const envoy::config::trace::v3::SkyWalkingConfig& proto_config,
 }
 
 Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
-                                   Http::RequestHeaderMap& request_headers,
+                                   Tracing::TraceContext& trace_context,
                                    const std::string& operation_name, Envoy::SystemTime start_time,
                                    const Tracing::Decision decision) {
   auto& tracer = tls_slot_ptr_->getTyped<Driver::TlsTracer>().tracer();
   TracingContextPtr tracing_context;
   // TODO(shikugawa): support extension span header.
-  auto propagation_header = request_headers.get(skywalkingPropagationHeaderKey());
-  if (propagation_header.empty()) {
+  auto propagation_header = trace_context.getTraceContext(skywalkingPropagationHeaderKey());
+  if (!propagation_header.has_value()) {
     tracing_context = tracing_context_factory_->create();
     // Sampling status is always true on SkyWalking. But with disabling skip_analysis,
     // this span can't be analyzed.
@@ -60,7 +60,7 @@ Tracing::SpanPtr Driver::startSpan(const Tracing::Config& config,
       tracing_context->setSkipAnalysis();
     }
   } else {
-    auto header_value_string = propagation_header[0]->value().getStringView();
+    auto header_value_string = propagation_header.value();
     try {
       SpanContextPtr span_context =
           createSpanContext(toStdStringView(header_value_string)); // NOLINT(std::string_view)

--- a/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
+++ b/source/extensions/tracers/skywalking/skywalking_tracer_impl.h
@@ -24,7 +24,7 @@ public:
   explicit Driver(const envoy::config::trace::v3::SkyWalkingConfig& config,
                   Server::Configuration::TracerFactoryContext& context);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
                              const std::string& operation, Envoy::SystemTime start_time,
                              const Tracing::Decision decision) override;
 

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -44,11 +44,11 @@ void Span::finishSpan() {
   parent_tracer_.sendSegment(tracing_context_);
 }
 
-void Span::injectContext(Http::RequestHeaderMap& request_headers) {
-  auto sw8_header =
-      tracing_context_->createSW8HeaderValue(std::string(request_headers.getHostValue()));
+void Span::injectContext(Tracing::TraceContext& trace_context) {
+  const auto host = trace_context.getTraceContext(Http::Headers::get().HostLegacy).value_or("");
+  auto sw8_header = tracing_context_->createSW8HeaderValue({host.data(), host.size()});
   if (sw8_header.has_value()) {
-    request_headers.setReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
+    trace_context.setTraceContextReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
   }
 }
 

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -49,7 +49,7 @@ void Span::injectContext(Tracing::TraceContext& trace_context) {
 
   // TODO(wbpcode): Due to https://github.com/SkyAPM/cpp2sky/issues/83 in cpp2sky, it is necessary
   // to ensure that there is '\0' at the end of the string_view parameter to ensure that the
-  // corresponding sw8 header is generated correctly. For this reason, we cannot directly use host
+  // corresponding trace header is generated correctly. For this reason, we cannot directly use host
   // as argument. We need create a copy of std::string based on host and std::string will
   // automatically add '\0' to the end of the string content.
   auto sw8_header = tracing_context_->createSW8HeaderValue(std::string(host));

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -46,7 +46,13 @@ void Span::finishSpan() {
 
 void Span::injectContext(Tracing::TraceContext& trace_context) {
   const auto host = trace_context.getTraceContext(Http::Headers::get().HostLegacy).value_or("");
-  auto sw8_header = tracing_context_->createSW8HeaderValue({host.data(), host.size()});
+
+  // TODO(wbpcode): Due to https://github.com/SkyAPM/cpp2sky/issues/83 in cpp2sky, it is necessary
+  // to ensure that there is '\0' at the end of the string_view parameter to ensure that the
+  // corresponding sw8 header is generated correctly. For this reason, we cannot directly use host
+  // as argument. We need create a copy of std::string based on host and std::string will
+  // automatically add '\0' to the end of the string content.
+  auto sw8_header = tracing_context_->createSW8HeaderValue(std::string(host));
   if (sw8_header.has_value()) {
     trace_context.setTraceContextReferenceKey(skywalkingPropagationHeaderKey(), sw8_header.value());
   }

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -66,7 +66,7 @@ public:
   void setTag(absl::string_view name, absl::string_view value) override;
   void log(SystemTime timestamp, const std::string& event) override;
   void finishSpan() override;
-  void injectContext(Http::RequestHeaderMap& request_headers) override;
+  void injectContext(Tracing::TraceContext& trace_context) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config& config, const std::string& name,
                               SystemTime start_time) override;
   void setSampled(bool do_sample) override;

--- a/source/extensions/tracers/xray/BUILD
+++ b/source/extensions/tracers/xray/BUILD
@@ -46,6 +46,7 @@ envoy_cc_library(
         "//source/common/common:macros",
         "//source/common/common:random_generator_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/http:headers_lib",
         "//source/common/json:json_loader_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_lib",

--- a/source/extensions/tracers/xray/sampling_strategy.h
+++ b/source/extensions/tracers/xray/sampling_strategy.h
@@ -15,9 +15,9 @@ namespace Tracers {
 namespace XRay {
 
 struct SamplingRequest {
-  std::string host_;
-  std::string http_method_;
-  std::string http_url_;
+  absl::string_view host_;
+  absl::string_view http_method_;
+  absl::string_view http_url_;
 };
 
 /**

--- a/source/extensions/tracers/xray/tracer.cc
+++ b/source/extensions/tracers/xray/tracer.cc
@@ -97,10 +97,10 @@ void Span::finishSpan() {
   broker_.send(json);
 } // namespace XRay
 
-void Span::injectContext(Http::RequestHeaderMap& request_headers) {
+void Span::injectContext(Tracing::TraceContext& trace_context) {
   const std::string xray_header_value =
       fmt::format("Root={};Parent={};Sampled={}", traceId(), id(), sampled() ? "1" : "0");
-  request_headers.setCopy(Http::LowerCaseString(XRayTraceHeader), xray_header_value);
+  trace_context.setTraceContextReferenceKey(XRayTraceHeader, xray_header_value);
 }
 
 Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& operation_name,

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -123,7 +123,7 @@ public:
   /**
    * Adds X-Ray trace header to the set of outgoing headers.
    */
-  void injectContext(Http::RequestHeaderMap& request_headers) override;
+  void injectContext(Tracing::TraceContext& trace_context) override;
 
   /**
    * Gets the start time of this Span.

--- a/source/extensions/tracers/xray/xray_tracer_impl.h
+++ b/source/extensions/tracers/xray/xray_tracer_impl.h
@@ -17,7 +17,7 @@ public:
   Driver(const XRay::XRayConfiguration& config,
          Server::Configuration::TracerFactoryContext& context);
 
-  Tracing::SpanPtr startSpan(const Tracing::Config& config, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
                              const std::string& operation_name, Envoy::SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -28,17 +28,17 @@ bool getSamplingFlags(char c, const Tracing::Decision tracing_decision) {
 
 } // namespace
 
-SpanContextExtractor::SpanContextExtractor(Http::RequestHeaderMap& request_headers)
-    : request_headers_(request_headers) {}
+SpanContextExtractor::SpanContextExtractor(Tracing::TraceContext& trace_context)
+    : trace_context_(trace_context) {}
 
 SpanContextExtractor::~SpanContextExtractor() = default;
 
 bool SpanContextExtractor::extractSampled(const Tracing::Decision tracing_decision) {
   bool sampled(false);
-  auto b3_header_entry = request_headers_.get(ZipkinCoreConstants::get().B3);
-  if (!b3_header_entry.empty()) {
+  auto b3_header_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().B3);
+  if (b3_header_entry.has_value()) {
     // This is an implicitly untrusted header, so only the first value is used.
-    absl::string_view b3 = b3_header_entry[0]->value().getStringView();
+    absl::string_view b3 = b3_header_entry.value();
     int sampled_pos = 0;
     switch (b3.length()) {
     case 1:
@@ -61,20 +61,20 @@ bool SpanContextExtractor::extractSampled(const Tracing::Decision tracing_decisi
     return getSamplingFlags(b3[sampled_pos], tracing_decision);
   }
 
-  auto x_b3_sampled_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_SAMPLED);
-  if (x_b3_sampled_entry.empty()) {
+  auto x_b3_sampled_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_SAMPLED);
+  if (!x_b3_sampled_entry.has_value()) {
     return tracing_decision.traced;
   }
   // Checking if sampled flag has been specified. Also checking for 'true' value, as some old
   // zipkin tracers may still use that value, although should be 0 or 1.
   // This is an implicitly untrusted header, so only the first value is used.
-  absl::string_view xb3_sampled = x_b3_sampled_entry[0]->value().getStringView();
+  absl::string_view xb3_sampled = x_b3_sampled_entry.value();
   sampled = xb3_sampled == SAMPLED || xb3_sampled == "true";
   return sampled;
 }
 
 std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sampled) {
-  if (!request_headers_.get(ZipkinCoreConstants::get().B3).empty()) {
+  if (trace_context_.getTraceContext(ZipkinCoreConstants::get().B3).has_value()) {
     return extractSpanContextFromB3SingleFormat(is_sampled);
   }
   uint64_t trace_id(0);
@@ -82,14 +82,14 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
   uint64_t span_id(0);
   uint64_t parent_id(0);
 
-  auto b3_trace_id_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_TRACE_ID);
-  auto b3_span_id_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_SPAN_ID);
-  if (!b3_span_id_entry.empty() && !b3_trace_id_entry.empty()) {
+  auto b3_trace_id_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_TRACE_ID);
+  auto b3_span_id_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_SPAN_ID);
+  if (b3_span_id_entry.has_value() && b3_trace_id_entry.has_value()) {
     // Extract trace id - which can either be 128 or 64 bit. For 128 bit,
     // it needs to be divided into two 64 bit numbers (high and low).
     // This is an implicitly untrusted header, so only the first value is used.
-    const std::string tid(b3_trace_id_entry[0]->value().getStringView());
-    if (b3_trace_id_entry[0]->value().size() == 32) {
+    const std::string tid(b3_trace_id_entry.value());
+    if (b3_trace_id_entry.value().size() == 32) {
       const std::string high_tid = tid.substr(0, 16);
       const std::string low_tid = tid.substr(16, 16);
       if (!StringUtil::atoull(high_tid.c_str(), trace_id_high, 16) ||
@@ -102,15 +102,16 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
     }
 
     // This is an implicitly untrusted header, so only the first value is used.
-    const std::string spid(b3_span_id_entry[0]->value().getStringView());
+    const std::string spid(b3_span_id_entry.value());
     if (!StringUtil::atoull(spid.c_str(), span_id, 16)) {
       throw ExtractorException(absl::StrCat("Invalid span id ", spid.c_str()));
     }
 
-    auto b3_parent_id_entry = request_headers_.get(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
-    if (!b3_parent_id_entry.empty() && !b3_parent_id_entry[0]->value().empty()) {
+    auto b3_parent_id_entry =
+        trace_context_.getTraceContext(ZipkinCoreConstants::get().X_B3_PARENT_SPAN_ID);
+    if (b3_parent_id_entry.has_value() && !b3_parent_id_entry.value().empty()) {
       // This is an implicitly untrusted header, so only the first value is used.
-      const std::string pspid(b3_parent_id_entry[0]->value().getStringView());
+      const std::string pspid(b3_parent_id_entry.value());
       if (!StringUtil::atoull(pspid.c_str(), parent_id, 16)) {
         throw ExtractorException(absl::StrCat("Invalid parent span id ", pspid.c_str()));
       }
@@ -124,10 +125,10 @@ std::pair<SpanContext, bool> SpanContextExtractor::extractSpanContext(bool is_sa
 
 std::pair<SpanContext, bool>
 SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
-  auto b3_head_entry = request_headers_.get(ZipkinCoreConstants::get().B3);
-  ASSERT(!b3_head_entry.empty());
+  auto b3_head_entry = trace_context_.getTraceContext(ZipkinCoreConstants::get().B3);
+  ASSERT(b3_head_entry.has_value());
   // This is an implicitly untrusted header, so only the first value is used.
-  const std::string b3(b3_head_entry[0]->value().getStringView());
+  const std::string b3(b3_head_entry.value());
   if (!b3.length()) {
     throw ExtractorException("Invalid input: empty");
   }

--- a/source/extensions/tracers/zipkin/span_context_extractor.h
+++ b/source/extensions/tracers/zipkin/span_context_extractor.h
@@ -21,7 +21,7 @@ struct ExtractorException : public EnvoyException {
  */
 class SpanContextExtractor {
 public:
-  SpanContextExtractor(Http::RequestHeaderMap& request_headers);
+  SpanContextExtractor(Tracing::TraceContext& trace_context);
   ~SpanContextExtractor();
   bool extractSampled(const Tracing::Decision tracing_decision);
   std::pair<SpanContext, bool> extractSpanContext(bool is_sampled);
@@ -34,7 +34,7 @@ private:
    */
   std::pair<SpanContext, bool> extractSpanContextFromB3SingleFormat(bool is_sampled);
   bool tryExtractSampledFromB3SingleFormat();
-  const Http::RequestHeaderMap& request_headers_;
+  const Tracing::TraceContext& trace_context_;
 };
 
 } // namespace Zipkin

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -72,7 +72,7 @@ public:
 
   void log(SystemTime timestamp, const std::string& event) override;
 
-  void injectContext(Http::RequestHeaderMap& request_headers) override;
+  void injectContext(Tracing::TraceContext& trace_context) override;
   Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& name,
                               SystemTime start_time) override;
 
@@ -122,7 +122,7 @@ public:
    * Thus, this implementation of the virtual function startSpan() ignores the operation name
    * ("ingress" or "egress") passed by the caller.
    */
-  Tracing::SpanPtr startSpan(const Tracing::Config&, Http::RequestHeaderMap& request_headers,
+  Tracing::SpanPtr startSpan(const Tracing::Config&, Tracing::TraceContext& trace_context,
                              const std::string&, SystemTime start_time,
                              const Tracing::Decision tracing_decision) override;
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1289,8 +1289,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlow) {
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -1447,8 +1447,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -1513,8 +1513,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -1580,8 +1580,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Ingress, config.operationName());
 
             return span;
@@ -1661,8 +1661,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
             return span;
@@ -1743,8 +1743,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
             return span;
@@ -1827,8 +1827,8 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
   auto* span = new NiceMock<Tracing::MockSpan>();
   EXPECT_CALL(*tracer_, startSpan_(_, _, _, _))
       .WillOnce(
-          Invoke([&](const Tracing::Config& config, const HeaderMap&, const StreamInfo::StreamInfo&,
-                     const Tracing::Decision) -> Tracing::Span* {
+          Invoke([&](const Tracing::Config& config, const RequestHeaderMap&,
+                     const StreamInfo::StreamInfo&, const Tracing::Decision) -> Tracing::Span* {
             EXPECT_EQ(Tracing::OperationName::Egress, config.operationName());
 
             return span;

--- a/test/common/tracing/http_tracer_manager_impl_test.cc
+++ b/test/common/tracing/http_tracer_manager_impl_test.cc
@@ -22,7 +22,7 @@ namespace {
 
 class SampleDriver : public Driver {
 public:
-  SpanPtr startSpan(const Config&, Http::RequestHeaderMap&, const std::string&, SystemTime,
+  SpanPtr startSpan(const Config&, Tracing::TraceContext&, const std::string&, SystemTime,
                     const Tracing::Decision) override {
     return nullptr;
   }

--- a/test/extensions/tracers/opencensus/config_test.cc
+++ b/test/extensions/tracers/opencensus/config_test.cc
@@ -376,6 +376,27 @@ TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerStackdriverGrpc) {
 #endif
 }
 
+TEST(OpenCensusTracerConfigTest, OpenCensusHttpTracerStackdriverAddress) {
+  NiceMock<Server::Configuration::MockTracerFactoryContext> context;
+  const std::string yaml_string = R"EOF(
+  http:
+    name: opencensus
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig
+      stackdriver_exporter_enabled: true
+      stackdriver_address: 127.0.0.1:55678
+  )EOF";
+
+  envoy::config::trace::v3::Tracing configuration;
+  TestUtility::loadFromYaml(yaml_string, configuration);
+
+  OpenCensusTracerFactory factory;
+  auto message = Config::Utility::translateToFactoryConfig(
+      configuration.http(), ProtobufMessage::getStrictValidationVisitor(), factory);
+  auto tracer = factory.createTracerDriver(*message, context);
+  EXPECT_NE(nullptr, tracer);
+}
+
 } // namespace OpenCensus
 } // namespace Tracers
 } // namespace Extensions

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -5,6 +5,7 @@
 
 #include "envoy/tracing/http_tracer.h"
 #include "envoy/tracing/http_tracer_manager.h"
+#include "envoy/tracing/trace_driver.h"
 
 #include "gmock/gmock.h"
 
@@ -35,7 +36,7 @@ public:
   MOCK_METHOD(void, setTag, (absl::string_view name, absl::string_view value));
   MOCK_METHOD(void, log, (SystemTime timestamp, const std::string& event));
   MOCK_METHOD(void, finishSpan, ());
-  MOCK_METHOD(void, injectContext, (Http::RequestHeaderMap & request_headers));
+  MOCK_METHOD(void, injectContext, (Tracing::TraceContext & request_headers));
   MOCK_METHOD(void, setSampled, (const bool sampled));
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
@@ -62,7 +63,7 @@ public:
   }
 
   MOCK_METHOD(Span*, startSpan_,
-              (const Config& config, Http::HeaderMap& request_headers,
+              (const Config& config, Http::RequestHeaderMap& request_headers,
                const StreamInfo::StreamInfo& stream_info,
                const Tracing::Decision tracing_decision));
 };
@@ -72,17 +73,15 @@ public:
   MockDriver();
   ~MockDriver() override;
 
-  SpanPtr startSpan(const Config& config, Http::RequestHeaderMap& request_headers,
+  SpanPtr startSpan(const Config& config, TraceContext& trace_context,
                     const std::string& operation_name, SystemTime start_time,
                     const Tracing::Decision tracing_decision) override {
-    return SpanPtr{
-        startSpan_(config, request_headers, operation_name, start_time, tracing_decision)};
+    return SpanPtr{startSpan_(config, trace_context, operation_name, start_time, tracing_decision)};
   }
 
   MOCK_METHOD(Span*, startSpan_,
-              (const Config& config, Http::HeaderMap& request_headers,
-               const std::string& operation_name, SystemTime start_time,
-               const Tracing::Decision tracing_decision));
+              (const Config& config, TraceContext& trace_context, const std::string& operation_name,
+               SystemTime start_time, const Tracing::Decision tracing_decision));
 };
 
 class MockHttpTracerManager : public HttpTracerManager {


### PR DESCRIPTION

Sub-PR of #16049. Check #16049 get more background information.

This PR is last sub-PR of #16049. It simply replaces `Http::RequestHeaderMap` with general `Tracing::TraceContext` in all tracer drivers implementations.

Check #16793 get more info about `Tracing::TraceContext`.

After this PR, the main body of the entire general tracing system is completed. Next, we can try to use the new general tracing system in dubbo and thrift.

Commit Message: replace RequestHeaderMap in tracers with general TraceContext
Risk Level: Low.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
