### PR TITLE
mysql proxy: mysql password hash function

### DIFF
--- a/source/extensions/filters/network/mysql_proxy/BUILD
+++ b/source/extensions/filters/network/mysql_proxy/BUILD
@@ -78,6 +78,9 @@ envoy_cc_library(
     name = "util_lib",
     srcs = ["mysql_utils.cc"],
     hdrs = ["mysql_utils.h"],
+    external_deps = [
+        "ssl",
+    ],
     deps = [
         ":codec_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/extensions/filters/network/mysql_proxy/mysql_utils.cc
+++ b/source/extensions/filters/network/mysql_proxy/mysql_utils.cc
@@ -1,5 +1,9 @@
 #include "source/extensions/filters/network/mysql_proxy/mysql_utils.h"
 
+#include <openssl/digest.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+
 #include "envoy/common/exception.h"
 
 #include "source/common/buffer/buffer_impl.h"
@@ -136,10 +140,10 @@ DecodeStatus BufferHelper::readLengthEncodedInteger(Buffer::Instance& buffer, ui
 DecodeStatus BufferHelper::skipBytes(Buffer::Instance& buffer, size_t skip_bytes) {
   if (buffer.length() < skip_bytes) {
     return DecodeStatus::Failure;
-  }
+  } // namespace MySQLProxy
   buffer.drain(skip_bytes);
   return DecodeStatus::Success;
-}
+} // namespace NetworkFilters
 
 DecodeStatus BufferHelper::readString(Buffer::Instance& buffer, std::string& str) {
   char end = MYSQL_STR_END;
@@ -214,6 +218,147 @@ DecodeStatus BufferHelper::peekHdr(Buffer::Instance& buffer, uint32_t& len, uint
   len = val & MYSQL_HDR_PKT_SIZE_MASK;
   ENVOY_LOG(trace, "mysql_proxy: MYSQL-hdrseq {}, len {}", seq, len);
   return DecodeStatus::Success;
+}
+
+AuthMethod AuthHelper::authMethod(uint32_t cap, const std::string& auth_plugin_name) {
+  if (auth_plugin_name.empty()) {
+    /*
+     * https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase.html
+     */
+    bool v41 = cap & CLIENT_PROTOCOL_41;
+    bool sconn = cap & CLIENT_SECURE_CONNECTION;
+    if (!v41 || !sconn) {
+      return AuthMethod::OldPassword;
+    }
+    return AuthMethod::NativePassword;
+  }
+
+  if (auth_plugin_name == "mysql_old_password") {
+    return AuthMethod::OldPassword;
+  }
+  if (auth_plugin_name == "mysql_native_password") {
+    return AuthMethod::NativePassword;
+  }
+  if (auth_plugin_name == "sha256_password") {
+    return AuthMethod::Sha256Password;
+  }
+  if (auth_plugin_name == "caching_sha2_password") {
+    return AuthMethod::CacheSha2Password;
+  }
+  if (auth_plugin_name == "mysql_clear_password") {
+    return AuthMethod::ClearPassword;
+  }
+  return AuthMethod::Unknown;
+}
+
+std::string AuthHelper::authPluginName(AuthMethod method) {
+  switch (method) {
+  case AuthMethod::OldPassword:
+    return "mysql_old_password";
+  case AuthMethod::NativePassword:
+    return "mysql_native_password";
+  case AuthMethod::Sha256Password:
+    return "sha256_password";
+  case AuthMethod::CacheSha2Password:
+    return "caching_sha2_password";
+  case AuthMethod::ClearPassword:
+    return "mysql_clear_password";
+  case AuthMethod::Unknown:
+  default:
+    return "unknown auth plugin";
+  }
+}
+
+// https://github.com/mysql/mysql-server/blob/5.5/sql/password.c#L186
+std::vector<uint8_t> OldPassword::signature(const std::string& password,
+                                            const std::vector<uint8_t>& seed) {
+  std::vector<uint8_t> to;
+  if (password.empty()) {
+    return to;
+  }
+  to.resize(SEED_LENGTH);
+  auto hash_pass = hash(password);
+  auto hash_seed = hash(seed);
+  RandStruct rand_st(hash_pass[0] ^ hash_seed[0], hash_pass[1] ^ hash_seed[1]);
+  for (int i = 0; i < SEED_LENGTH; i++) {
+    to[i] = static_cast<char>((floor(rand_st.myRnd() * 31) + 64));
+  }
+  char extra = static_cast<char>(floor(rand_st.myRnd() * 31));
+  for (int i = 0; i < SEED_LENGTH; i++) {
+    to[i] ^= extra;
+  }
+  return to;
+}
+
+std::vector<uint8_t> NativePassword::generateSeed() {
+  std::vector<uint8_t> res(SEED_LENGTH);
+  RAND_bytes(res.data(), SEED_LENGTH);
+  return res;
+}
+
+std::vector<uint8_t> NativePassword::signature(const std::string& password,
+                                               const std::vector<uint8_t>& seed) {
+  auto hashstage1 = hash(password);
+  auto hashstage2 = hash(hashstage1);
+
+  auto text = seed;
+  text.insert(text.end(), hashstage2.begin(), hashstage2.end());
+  auto to_be_xor = hash(text);
+
+  for (int i = 0; i < SHA_DIGEST_LENGTH; i++) {
+    to_be_xor[i] = to_be_xor[i] ^ hashstage1[i];
+  }
+  return to_be_xor;
+}
+
+std::vector<uint8_t> NativePassword::hash(const char* text, int size) {
+  bssl::ScopedEVP_MD_CTX ctx;
+  std::vector<uint8_t> result(SHA_DIGEST_LENGTH);
+  auto rc = EVP_DigestInit(ctx.get(), EVP_sha1());
+  RELEASE_ASSERT(rc == 1, "Failed to init digest context");
+  rc = EVP_DigestUpdate(ctx.get(), text, size);
+  RELEASE_ASSERT(rc == 1, "Failed to update digest");
+  rc = EVP_DigestFinal(ctx.get(), result.data(), nullptr);
+  RELEASE_ASSERT(rc == 1, "Failed to finalize digest");
+  return result;
+}
+
+std::vector<uint8_t> OldPassword::generateSeed() {
+  std::vector<uint8_t> res(SEED_LENGTH);
+  RAND_bytes(res.data(), SEED_LENGTH);
+  return res;
+}
+
+std::vector<uint32_t> OldPassword::hash(const char* text, int size) {
+  uint32_t nr = 1345345333L, add = 7, nr2 = 0x12345671L;
+  uint32_t tmp;
+  std::vector<uint32_t> result(2);
+  for (int i = 0; i < size; i++) {
+    if (text[i] == ' ' || text[i] == '\t') {
+      continue;
+    }
+    tmp = static_cast<uint32_t>(text[i]);
+    nr ^= (((nr & 63) + add) * tmp) + (nr << 8);
+    nr2 += (nr2 << 8) ^ nr;
+    add += tmp;
+  }
+
+  result[0] = nr & ((static_cast<uint32_t>(1L) << 31) - 1L); /* Don't use sign bit (str2int) */
+  result[1] = nr2 & ((static_cast<uint32_t>(1L) << 31) - 1L);
+  return result;
+}
+
+OldPassword::RandStruct::RandStruct(uint32_t seed1, uint32_t seed2) {
+  max_value_ = 0x3FFFFFFFL;
+  max_value_dbl_ = static_cast<double>(max_value_);
+  seed1_ = seed1 % max_value_;
+  seed2_ = seed2 % max_value_;
+}
+
+double OldPassword::RandStruct::myRnd() {
+  seed1_ = (seed1_ * 3 + seed2_) % max_value_;
+  seed2_ = (seed1_ + seed2_ + 33) % max_value_;
+  return ((static_cast<double>(seed1_)) / max_value_dbl_);
 }
 
 } // namespace MySQLProxy

--- a/source/extensions/filters/network/mysql_proxy/mysql_utils.h
+++ b/source/extensions/filters/network/mysql_proxy/mysql_utils.h
@@ -51,6 +51,71 @@ public:
   static DecodeStatus peekHdr(Buffer::Instance& buffer, uint32_t& len, uint8_t& seq);
 };
 
+/**
+ * MySQL auth method.
+ */
+enum class AuthMethod : uint8_t {
+  Unknown,
+  OldPassword,
+  NativePassword,
+  Sha256Password,
+  CacheSha2Password,
+  ClearPassword
+};
+
+// Helper function collection of old_password
+struct OldPassword {
+public:
+  static std::vector<uint8_t> generateSeed();
+  static std::vector<uint8_t> signature(const std::string& password,
+                                        const std::vector<uint8_t>& seed);
+  static std::vector<uint32_t> hash(const std::string& text) {
+    return hash(text.data(), text.size());
+  }
+  static std::vector<uint32_t> hash(const std::vector<uint8_t>& text) {
+    return hash(reinterpret_cast<const char*>(text.data()), text.size());
+  }
+  /*
+   * Generate binary hash from raw text string
+   * Used for Pre-4.1 password handling
+   */
+  static std::vector<uint32_t> hash(const char* text, int size);
+  static constexpr int SEED_LENGTH = 8;
+
+private:
+  struct RandStruct {
+    RandStruct(uint32_t seed1, uint32_t seed2);
+    double myRnd();
+    uint32_t seed1_, seed2_, max_value_;
+    double max_value_dbl_;
+  };
+};
+
+// Helper function collection of native_password
+struct NativePassword {
+  static std::vector<uint8_t> generateSeed();
+  static std::vector<uint8_t> signature(const std::string& password,
+                                        const std::vector<uint8_t>& seed);
+
+  static std::vector<uint8_t> hash(const std::string& text) {
+    return hash(text.data(), text.size());
+  }
+  static std::vector<uint8_t> hash(const std::vector<uint8_t>& text) {
+    return hash(reinterpret_cast<const char*>(text.data()), text.size());
+  }
+  static std::vector<uint8_t> hash(const char* data, int len);
+  static constexpr int SEED_LENGTH = 20;
+};
+
+/**
+ * Auth helpers for auth MySQL client and server.
+ */
+class AuthHelper {
+public:
+  static AuthMethod authMethod(uint32_t cap, const std::string& auth_plugin_name);
+  static std::string authPluginName(AuthMethod method);
+};
+
 } // namespace MySQLProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/mysql_proxy/BUILD
+++ b/test/extensions/filters/network/mysql_proxy/BUILD
@@ -23,6 +23,17 @@ envoy_extension_cc_test_library(
 )
 
 envoy_extension_cc_test(
+    name = "mysql_auth_plugin_tests",
+    srcs = [
+        "mysql_auth_plugin_test.cc",
+    ],
+    extension_name = "envoy.filters.network.mysql_proxy",
+    deps = [
+        ":mysql_test_utils_lib",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "mysql_codec_tests",
     srcs = [
         "mysql_codec_test.cc",

--- a/test/extensions/filters/network/mysql_proxy/mysql_auth_plugin_test.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_auth_plugin_test.cc
@@ -1,0 +1,137 @@
+#include <map>
+#include <vector>
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/hex.h"
+#include "source/extensions/filters/network/mysql_proxy/mysql_utils.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mysql_test_utils.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace MySQLProxy {
+
+/* the api of mysql old password function is */
+TEST(AuthHelperTest, OldPassWordHash) {
+  /*
+   * OldPasswordCases generated from MySQL Server by "set old_passwords=1; SELECT PASSWORD(text);"
+   */
+  std::map<std::string, std::string> oldPassWordCases = {{
+      {"lspbmbnl", "04634f346a43ff51"}, {"sxvpxvng", "0edb7f6258b0580a"},
+      {"npzsltxt", "4dd0c97d07484d41"}, {"izosmxhr", "33fe1bd20270bc72"},
+      {"mtemsuyl", "17614bd602386385"}, {"kcjypgul", "57257c4b0e224152"},
+      {"herxsyge", "201bb5bd30541f27"}, {"ftlpfzvm", "3a4f942d449b9061"},
+      {"jywqqfrh", "5960d6ce7f814ccc"}, {"omosqeyy", "4f5a09846cdd86ef"},
+      {"ncjjzjhh", "379f21fb7511644f"}, {"zzsmxelk", "7cd63d5e534ca948"},
+      {"lwqwfpve", "6e083fea5fe9717f"}, {"jdubrwik", "0fe9dc444a4259f3"},
+      {"cogoctit", "1974fdc23962d219"}, {"namdszhy", "76e89bdc5148efe0"},
+      {"zlkxtjuh", "2bb60d22103409ad"}, {"flhmfvwt", "7f5cd79c0a58d21f"},
+      {"ogwcccqb", "45890ffb79c2f03c"}, {"ynrwbuqm", "4b4e61473903c4d2"},
+      {"ipqwmcgj", "3698a07c25dc1a97"}, {"nljxsrqy", "3921fd114429a6e6"},
+      {"vzzlcyvm", "386bc3b7782c0379"}, {"vcjpgsfn", "19d31ddb4aa048be"},
+      {"ddvtbfhi", "0a426efb0ae239a3"}, {"ehdosgsu", "0512db8036b9d3de"},
+      {"exekfjbz", "41e0df8705cab80e"}, {"xialkbfn", "7b5f19d161bbbaef"},
+      {"jcpghhfo", "5aca66af047a78b5"}, {"qixefqlq", "574ec4711241808b"},
+      {"unlyxufj", "60f9761b33fb784f"}, {"difewfvw", "0500eb5443cdf0b5"},
+      {"viemvtrd", "39a422f716fa7d76"}, {"spgulhxe", "4f1bfbee7c7c43fd"},
+      {"pkealafr", "410bb4906c6ee405"}, {"uhwesfin", "4b211eeb0102007a"},
+      {"fdzgongj", "118415ab577e08e7"}, {"shjgdjul", "6a7ff4c95e7aeba4"},
+      {"spisholn", "00c6d81259d142d5"}, {"vojzqdew", "061f0c1c11d00b82"},
+      {"jpwivnyw", "114cea307c297a4d"}, {"kzdntqjb", "07ee40ca5724732e"},
+      {"yznplsgh", "153e4895794f87f0"}, {"wvzbfusy", "5b9b138e364a3cf3"},
+      {"cgaxolxb", "6e2d938a0806323e"}, {"tlpsvudx", "2b10508001af7188"},
+      {"ptmscvsq", "35c03bcb493e24ef"}, {"imyjbide", "7f5335df7d9116a2"},
+      {"qmwrjnpk", "3dda289c041bc6d7"}, {"lmbnatik", "4b4eec946b3e3050"},
+  }};
+
+  for (const auto& old_password_case : oldPassWordCases) {
+    auto old_hash = OldPassword::hash(old_password_case.first);
+    EXPECT_EQ(old_password_case.second,
+              MySQLTestUtils::encodeUint32Hex(old_hash.data(), old_hash.size()));
+  }
+  EXPECT_EQ(OldPassword::hash("lmbnatik"), OldPassword::hash("lm bna  tik"));
+}
+
+TEST(AuthHelperTest, NativePassWordHash) {
+  /*
+   * NativePasswordCases generated from MySQL Server by "set old_passwords=0; SELECT
+   * PASSWORD(text);" "PASSWORD(text) = SHA1(SHA1(text))"
+   */
+  std::map<std::string, std::string> nativePassWordCases = {{
+      {"lspbmbnl", "448ecbe03d36ae7ae9fa0168e6a01a92abd8f7d6"},
+      {"sxvpxvng", "d4228938a4553d9af357c9c807da8bba04a52513"},
+      {"npzsltxt", "a1cd14776d4f52c1d3e93febabc3a9357603a0e2"},
+      {"izosmxhr", "6e3a92c68473f9d1060ad7d6ae5f78cc5e84c01e"},
+      {"mtemsuyl", "59ec607666e2638f6b572aeeb29a09c8912ec7b5"},
+      {"kcjypgul", "0f081da5cf58d3d83b968807503de69d87aab0a7"},
+      {"herxsyge", "b4784aad9265c0ed90b1e10353c46435ca901269"},
+      {"ftlpfzvm", "abdb23d36503f2d434987ab68fe98c1484e89f41"},
+      {"jywqqfrh", "599baffb9094455e66c855ab348eb5d319b57e90"},
+      {"omosqeyy", "c519aa6344a47a7f8b36c21d70c7da3ac39c93f4"},
+      {"ncjjzjhh", "7cd7f5f45db0f8b4164bc44feb3f7c41280a6dd8"},
+      {"zzsmxelk", "b10c76dcf2c42c1fed2872509b57011b49e32991"},
+      {"lwqwfpve", "221dd48d592f0efd5a78748bca920704cfaecafd"},
+      {"jdubrwik", "2c6280d2b7e878dc894ea836ef042175cc84995a"},
+      {"cogoctit", "15d8dc7a2720352a6aec67ac5eff3f701cdfcec1"},
+      {"namdszhy", "d057f0d66f441be52d1b7f1e4dc624c106592928"},
+      {"zlkxtjuh", "f42cf7310a1c7661e5a6a469f602304aa7aba0a3"},
+      {"flhmfvwt", "65850a28dc5059ade5d093c14393cafc75c2e51e"},
+      {"ogwcccqb", "f2ab16cc3f72de4b1c3c2de76f6d91e4669b6e70"},
+      {"ynrwbuqm", "1a95a1dfdd56f8a4fc481236ff3f825e378a5563"},
+      {"ipqwmcgj", "6916b39eb7c7cbc9551fc9d444a33605eeb48ea3"},
+      {"nljxsrqy", "ae2da3ecd402a1aca1fb9e3845b0e5918064e7bb"},
+      {"vzzlcyvm", "1bd1cf9f711e53dc2c42bc8cdae44cc54e0ce5d0"},
+      {"vcjpgsfn", "a22d405cfd135ce02e1eb113dcad6b778f05d019"},
+      {"ddvtbfhi", "f3f0b21605aed1e5734f8ea3cdd3b6bde2dc81d1"},
+      {"ehdosgsu", "fd9d99f4849abba5bd0c46745464af228ae9f547"},
+      {"exekfjbz", "9d34353c739925ee98cc9819859a8893e44dcec4"},
+      {"xialkbfn", "981bc1edd3beb8ed85cf415408e37687ebb5720d"},
+      {"jcpghhfo", "c5ba17d664814e9dcffd63e0492b6728f011d306"},
+      {"qixefqlq", "788ad6e588d094f1d80118f4929cdfb7a11fa7e2"},
+      {"unlyxufj", "b69424caa75118b457412d31bcf1776862c4867b"},
+      {"difewfvw", "8808d829ddba130f13d553b57fe5b938b5fc0b89"},
+      {"viemvtrd", "4e09524074d479fa3accc085b148ee780a8319be"},
+      {"spgulhxe", "7446286e0148a9304158ec7c0659cc61649e612e"},
+      {"pkealafr", "32047f137c2fcae896223dd1b2d8a5b33183b3c7"},
+      {"uhwesfin", "d3dac8608d97958ebbd73f56faa8ead7eb9f4765"},
+      {"fdzgongj", "5d5b09eef92aee133a920471551200fda80daefa"},
+      {"shjgdjul", "eb9d2c8bd7c3f298e5fa2106bf1a355bc274f500"},
+      {"spisholn", "ef415c589308274f9cff39fd53c716badf32b726"},
+      {"vojzqdew", "45ef7fa3d3e980bdef16246c1f32c99585b3cfc1"},
+      {"jpwivnyw", "66a092aadbfc43f1dc0ac4dc3af18c6b4c727726"},
+      {"kzdntqjb", "5e09d42667f75c1795507575a5d069afb4b83a19"},
+      {"yznplsgh", "3a4732c9e449e3b2e2fceff073b0ef8e6d8ec5fe"},
+      {"wvzbfusy", "7f874f2aec995979dd5c05e238e230fa79d051d8"},
+      {"cgaxolxb", "df126f29dfe72708e804bbae7101b7afd069bd13"},
+      {"tlpsvudx", "563af94b8daf99bd9af725f6441b3dfb4a835ccc"},
+      {"ptmscvsq", "d04bd9f7660b52b61b20cca5f6190cac20ca8a38"},
+      {"imyjbide", "63523a15d3bd04c05c7d2a6645f59b9fffa5f541"},
+      {"qmwrjnpk", "f048ba144e9bc7a6dcf9bee489de9b559124ca43"},
+      {"lmbnatik", "73d2c956a3abbe49dd706bbd09b19a44c05016af"},
+  }};
+  for (const auto& native_password_case : nativePassWordCases) {
+    auto actual = NativePassword::hash(native_password_case.first);
+    actual = NativePassword::hash(actual);
+    EXPECT_EQ(Hex::encode(reinterpret_cast<uint8_t*>(actual.data()), actual.size()),
+              native_password_case.second);
+  }
+}
+
+TEST(AuthHelperTest, AuthMethod) {
+  uint32_t cap = CLIENT_PROTOCOL_41;
+  EXPECT_EQ(AuthHelper::authMethod(cap, "sha256_password"), AuthMethod::Sha256Password);
+  EXPECT_EQ(AuthHelper::authMethod(cap, "caching_sha2_password"), AuthMethod::CacheSha2Password);
+  EXPECT_EQ(AuthHelper::authMethod(cap, "mysql_clear_password"), AuthMethod::ClearPassword);
+  EXPECT_EQ(AuthHelper::authMethod(cap, "mysql_unknown_password"), AuthMethod::Unknown);
+  EXPECT_EQ(AuthHelper::authMethod(0, ""), AuthMethod::OldPassword);
+  cap = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | MYSQL_EXT_CL_PLUGIN_AUTH;
+  EXPECT_EQ(AuthHelper::authMethod(cap, ""), AuthMethod::NativePassword);
+}
+
+} // namespace MySQLProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.cc
@@ -134,6 +134,27 @@ int MySQLTestUtils::sizeOfLengthEncodeInteger(uint64_t val) {
   }
 }
 
+std::string MySQLTestUtils::encodeUint32Hex(const uint32_t* data, size_t len) {
+  static const char* const digits = "0123456789abcdef";
+
+  std::string ret;
+  ret.reserve(len * sizeof(uint32_t) * 2);
+
+  for (size_t i = 0; i < len; i++) {
+    uint32_t d = data[i];
+    ret.push_back(digits[(d >> (8 * 3 + 4)) & 0xf]);
+    ret.push_back(digits[(d >> (8 * 3)) & 0xf]);
+    ret.push_back(digits[(d >> (8 * 2 + 4)) & 0xf]);
+    ret.push_back(digits[(d >> (8 * 2)) & 0xf]);
+    ret.push_back(digits[(d >> (8 * 1 + 4)) & 0xf]);
+    ret.push_back(digits[(d >> (8 * 1)) & 0xf]);
+    ret.push_back(digits[(d >> 4) & 0xf]);
+    ret.push_back(digits[d & 0xf]);
+  }
+
+  return ret;
+}
+
 } // namespace MySQLProxy
 } // namespace NetworkFilters
 } // namespace Extensions

--- a/test/extensions/filters/network/mysql_proxy/mysql_test_utils.h
+++ b/test/extensions/filters/network/mysql_proxy/mysql_test_utils.h
@@ -45,6 +45,8 @@ public:
   std::string encodeAuthSwitchResp();
 
   std::string encodeMessage(uint32_t packet_len, uint8_t it = 0, uint8_t seq_force = 0);
+
+  static std::string encodeUint32Hex(const uint32_t* data, size_t len);
 };
 } // namespace MySQLProxy
 } // namespace NetworkFilters


### PR DESCRIPTION
Signed-off-by: qinggniq <livewithblank@gmail.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Hash helper function of `mysql_old_passoword` and `mysql_native_password` to construct auth response.

Commit Message: add mysql password hash functions
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
