### PR TITLE
examples: fix Wasm example.

### DIFF
--- a/examples/wasm-cc/envoy_filter_http_wasm_example.cc
+++ b/examples/wasm-cc/envoy_filter_http_wasm_example.cc
@@ -78,9 +78,9 @@ FilterDataStatus ExampleContext::onRequestBody(size_t body_buffer_length,
   return FilterDataStatus::Continue;
 }
 
-FilterDataStatus ExampleContext::onResponseBody(size_t /* body_buffer_length */,
+FilterDataStatus ExampleContext::onResponseBody(size_t body_buffer_length,
                                                 bool /* end_of_stream */) {
-  setBuffer(WasmBufferType::HttpResponseBody, 0, 12, "Hello, world");
+  setBuffer(WasmBufferType::HttpResponseBody, 0, body_buffer_length, "Hello, world\n");
   return FilterDataStatus::Continue;
 }
 


### PR DESCRIPTION
Previously, the setBuffer API was misused and the size of a new data
was passed instead of the size of data to replace.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>