### PR TITLE
docs: Fix broken URL links in HTTP upgrades doc

### DIFF
--- a/docs/root/intro/arch_overview/http/upgrades.rst
+++ b/docs/root/intro/arch_overview/http/upgrades.rst
@@ -96,7 +96,7 @@ will synthesize 200 response headers, and then forward the TCP data as the HTTP 
   will be forwarded *unsanitized* headers if they are in the body payload. Please use with caution
 
 For an example of proxying connect, please see :repo:`configs/proxy_connect.yaml <configs/proxy_connect.yaml>`
-For an example of terminating connect, please see :repo:`configs/terminate_connect.yaml <configs/terminate_connect.yaml>`
+For an example of terminating connect, please see :repo:`configs/terminate_http1_connect.yaml <configs/terminate_http1_connect.yaml>` and :repo:`configs/terminate_http2_connect.yaml <configs/terminate_connect.yaml>`
 
 Note that for CONNECT-over-tls, Envoy can not currently be configured to do the CONNECT request in the clear
 and encrypt previously unencrypted payload in one hop. To send CONNECT in plaintext and encrypt the payload,

--- a/docs/root/intro/arch_overview/http/upgrades.rst
+++ b/docs/root/intro/arch_overview/http/upgrades.rst
@@ -96,7 +96,7 @@ will synthesize 200 response headers, and then forward the TCP data as the HTTP 
   will be forwarded *unsanitized* headers if they are in the body payload. Please use with caution
 
 For an example of proxying connect, please see :repo:`configs/proxy_connect.yaml <configs/proxy_connect.yaml>`
-For an example of terminating connect, please see :repo:`configs/terminate_http1_connect.yaml <configs/terminate_http1_connect.yaml>` and :repo:`configs/terminate_http2_connect.yaml <configs/terminate_connect.yaml>`
+For an example of terminating connect, please see :repo:`configs/terminate_http1_connect.yaml <configs/terminate_http1_connect.yaml>` and :repo:`configs/terminate_http2_connect.yaml <configs/terminate_http2_connect.yaml>`
 
 Note that for CONNECT-over-tls, Envoy can not currently be configured to do the CONNECT request in the clear
 and encrypt previously unencrypted payload in one hop. To send CONNECT in plaintext and encrypt the payload,

--- a/docs/root/intro/arch_overview/listeners/network_filter_chain.rst
+++ b/docs/root/intro/arch_overview/listeners/network_filter_chain.rst
@@ -16,7 +16,7 @@ chosen to serve the request. If the default filter chain is not supplied, the co
 Filter chain only update
 ------------------------
 
-:ref:`Filter chains <envoy_v3_api_msg_config.listener.v3.FilterChain>` can be updated indepedently. Upon listener config
+:ref:`Filter chains <envoy_v3_api_msg_config.listener.v3.FilterChain>` can be updated independently. Upon listener config
 update, if the listener manager determines that the listener update is a filter chain only update, the listener update
 will be executed by adding, updating and removing filter chains. The connections owned by these destroying filter chains will
 be drained as described in listener drain.


### PR DESCRIPTION
Signed-off-by: Dean Liu <dliu@lyft.com>

Commit Message: Fixing broken links in the HTTP upgrades doc.  The sample CONNECT configs point to nothing.
Additional Description:
Risk Level: None
Testing: None
Docs Changes:  No changes to code.  Just doc changes.
