### PR TITLE
socket: move connection id interface to SocketAddressProvider

### DIFF
--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -81,6 +81,11 @@ public:
   virtual absl::string_view requestedServerName() const PURE;
 
   /**
+   * @return Connection ID of the downstream connection, or unset if not available.
+   **/
+  virtual absl::optional<uint64_t> connectionID() const PURE;
+
+  /**
    * Dumps the state of the SocketAddressProvider to the given ostream.
    *
    * @param os the std::ostream to dump to.
@@ -121,6 +126,11 @@ public:
    * @param SNI value requested.
    */
   virtual void setRequestedServerName(const absl::string_view requested_server_name) PURE;
+
+  /**
+   * @param id Connection ID of the downstream connection.
+   **/
+  virtual void setConnectionID(uint64_t id) PURE;
 };
 
 using SocketAddressSetterSharedPtr = std::shared_ptr<SocketAddressSetter>;

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -590,11 +590,6 @@ public:
   virtual absl::optional<uint64_t> connectionID() const PURE;
 
   /**
-   * @param id Connection ID of the downstream connection.
-   **/
-  virtual void setConnectionID(uint64_t id) PURE;
-
-  /**
    * @param filter_chain_name Network filter chain name of the downstream connection.
    */
   virtual void setFilterChainName(absl::string_view filter_chain_name) PURE;

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -585,11 +585,6 @@ public:
   virtual Tracing::Reason traceReason() const PURE;
 
   /**
-   * @return Connection ID of the downstream connection, or unset if not available.
-   **/
-  virtual absl::optional<uint64_t> connectionID() const PURE;
-
-  /**
    * @param filter_chain_name Network filter chain name of the downstream connection.
    */
   virtual void setFilterChainName(absl::string_view filter_chain_name) PURE;

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -814,7 +814,7 @@ StreamInfoFormatter::StreamInfoFormatter(const std::string& field_name) {
   } else if (field_name == "CONNECTION_ID") {
     field_extractor_ = std::make_unique<StreamInfoUInt64FieldExtractor>(
         [](const StreamInfo::StreamInfo& stream_info) {
-          return stream_info.connectionID().value_or(0);
+          return stream_info.downstreamAddressProvider().connectionID().value_or(0);
         });
   } else if (field_name == "REQUESTED_SERVER_NAME") {
     field_extractor_ = std::make_unique<StreamInfoStringFieldExtractor>(

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -651,9 +651,6 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
   filter_manager_.streamInfo().setDownstreamSslConnection(
       connection_manager_.read_callbacks_->connection().ssl());
 
-  filter_manager_.streamInfo().setConnectionID(
-      connection_manager_.read_callbacks_->connection().id());
-
   if (connection_manager_.config_.streamIdleTimeout().count()) {
     idle_timeout_ms_ = connection_manager_.config_.streamIdleTimeout();
     stream_idle_timer_ =

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -621,6 +621,9 @@ public:
   absl::string_view requestedServerName() const override {
     return StreamInfoImpl::downstreamAddressProvider().requestedServerName();
   }
+  absl::optional<uint64_t> connectionID() const override {
+    return StreamInfoImpl::downstreamAddressProvider().connectionID();
+  }
   void dumpState(std::ostream& os, int indent_level) const override {
     StreamInfoImpl::dumpState(os, indent_level);
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -95,6 +95,8 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
       Event::FileReadyType::Read | Event::FileReadyType::Write);
 
   transport_socket_->setTransportSocketCallbacks(*this);
+
+  socket_->addressProvider().setConnectionID(id());
 }
 
 ConnectionImpl::~ConnectionImpl() {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -96,6 +96,8 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
 
   transport_socket_->setTransportSocketCallbacks(*this);
 
+  // TODO(soulxu): generate the connection id inside the addressProvider directly,
+  // then we don't need a setter or any of the optional stuff.
   socket_->addressProvider().setConnectionID(id());
 }
 

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -49,13 +49,19 @@ public:
   void setRequestedServerName(const absl::string_view requested_server_name) override {
     server_name_ = std::string(requested_server_name);
   }
-
+  absl::optional<uint64_t> connectionID() const override {
+    return connection_id_;
+  }
+  void setConnectionID(uint64_t id) {
+    connection_id_ = id;
+  }
 private:
   Address::InstanceConstSharedPtr local_address_;
   bool local_address_restored_{false};
   Address::InstanceConstSharedPtr remote_address_;
   Address::InstanceConstSharedPtr direct_remote_address_;
   std::string server_name_;
+  absl::optional<uint64_t> connection_id_;
 };
 
 class SocketImpl : public virtual Socket {

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -49,12 +49,9 @@ public:
   void setRequestedServerName(const absl::string_view requested_server_name) override {
     server_name_ = std::string(requested_server_name);
   }
-  absl::optional<uint64_t> connectionID() const override {
-    return connection_id_;
-  }
-  void setConnectionID(uint64_t id) override {
-    connection_id_ = id;
-  }
+  absl::optional<uint64_t> connectionID() const override { return connection_id_; }
+  void setConnectionID(uint64_t id) override { connection_id_ = id; }
+
 private:
   Address::InstanceConstSharedPtr local_address_;
   bool local_address_restored_{false};

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -52,7 +52,7 @@ public:
   absl::optional<uint64_t> connectionID() const override {
     return connection_id_;
   }
-  void setConnectionID(uint64_t id) {
+  void setConnectionID(uint64_t id) override {
     connection_id_ = id;
   }
 private:

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -274,10 +274,6 @@ struct StreamInfoImpl : public StreamInfo {
     return upstream_cluster_info_;
   }
 
-  void setConnectionID(uint64_t id) override { connection_id_ = id; }
-
-  absl::optional<uint64_t> connectionID() const override { return connection_id_; }
-
   void setFilterChainName(absl::string_view filter_chain_name) override {
     filter_chain_name_ = std::string(filter_chain_name);
   }

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -332,7 +332,6 @@ private:
   UpstreamTiming upstream_timing_;
   std::string upstream_transport_failure_reason_;
   absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_;
-  absl::optional<uint64_t> connection_id_;
   std::string filter_chain_name_;
   Tracing::Reason trace_reason_;
 };

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -186,7 +186,7 @@ absl::optional<CelValue> ConnectionWrapper::operator[](CelValue key) const {
   } else if (value == RequestedServerName) {
     return CelValue::CreateStringView(info_.downstreamAddressProvider().requestedServerName());
   } else if (value == ID) {
-    auto id = info_.connectionID();
+    auto id = info_.downstreamAddressProvider().connectionID();
     if (id.has_value()) {
       return CelValue::CreateUint64(id.value());
     }

--- a/source/server/active_tcp_listener.cc
+++ b/source/server/active_tcp_listener.cc
@@ -409,7 +409,6 @@ ActiveTcpConnection::ActiveTcpConnection(ActiveConnections& active_connections,
   listener.stats_.downstream_cx_active_.inc();
   listener.per_worker_stats_.downstream_cx_total_.inc();
   listener.per_worker_stats_.downstream_cx_active_.inc();
-  stream_info_->setConnectionID(connection_->id());
 
   // Active connections on the handler (not listener). The per listener connections have already
   // been incremented at this point either via the connection balancer or in the socket accept

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -663,7 +663,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
   {
     StreamInfoFormatter upstream_format("CONNECTION_ID");
     uint64_t id = 123;
-    EXPECT_CALL(stream_info, connectionID()).WillRepeatedly(Return(id));
+    stream_info.downstream_address_provider_->setConnectionID(id);
     EXPECT_EQ("123", upstream_format.format(request_headers, response_headers, response_trailers,
                                             stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -302,7 +302,7 @@ TEST_F(HttpConnectionManagerImplTest, PopulateStreamInfo) {
 
   EXPECT_EQ(requestIDExtension().get(), decoder_->streamInfo().getRequestIDProvider());
   EXPECT_EQ(ssl_connection_, decoder_->streamInfo().downstreamSslConnection());
-  EXPECT_EQ(filter_callbacks_.connection_.id_, decoder_->streamInfo().connectionID());
+  EXPECT_EQ(filter_callbacks_.connection_.id_, decoder_->streamInfo().downstreamAddressProvider().connectionID());
   EXPECT_EQ(server_name_, decoder_->streamInfo().downstreamAddressProvider().requestedServerName());
 
   // Clean up.

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -302,7 +302,8 @@ TEST_F(HttpConnectionManagerImplTest, PopulateStreamInfo) {
 
   EXPECT_EQ(requestIDExtension().get(), decoder_->streamInfo().getRequestIDProvider());
   EXPECT_EQ(ssl_connection_, decoder_->streamInfo().downstreamSslConnection());
-  EXPECT_EQ(filter_callbacks_.connection_.id_, decoder_->streamInfo().downstreamAddressProvider().connectionID());
+  EXPECT_EQ(filter_callbacks_.connection_.id_,
+            decoder_->streamInfo().downstreamAddressProvider().connectionID());
   EXPECT_EQ(server_name_, decoder_->streamInfo().downstreamAddressProvider().requestedServerName());
 
   // Clean up.

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -293,7 +293,6 @@ TEST_F(HttpConnectionManagerImplTest, 100ContinueResponseWithDecoderPause) {
 // When create new stream, the stream info will be populated from the connection.
 TEST_F(HttpConnectionManagerImplTest, PopulateStreamInfo) {
   setup(true, "", false);
-  EXPECT_CALL(filter_callbacks_.connection_, id()).WillRepeatedly(Return(1234));
 
   // Set up the codec.
   Buffer::OwnedImpl fake_input("input");
@@ -303,7 +302,7 @@ TEST_F(HttpConnectionManagerImplTest, PopulateStreamInfo) {
 
   EXPECT_EQ(requestIDExtension().get(), decoder_->streamInfo().getRequestIDProvider());
   EXPECT_EQ(ssl_connection_, decoder_->streamInfo().downstreamSslConnection());
-  EXPECT_EQ(1234U, decoder_->streamInfo().connectionID());
+  EXPECT_EQ(filter_callbacks_.connection_.id_, decoder_->streamInfo().connectionID());
   EXPECT_EQ(server_name_, decoder_->streamInfo().downstreamAddressProvider().requestedServerName());
 
   // Clean up.

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -252,14 +252,6 @@ TEST_F(StreamInfoImplTest, DefaultRequestIDExtensionTest) {
   EXPECT_EQ(nullptr, stream_info.getRequestIDProvider());
 }
 
-TEST_F(StreamInfoImplTest, ConnectionID) {
-  StreamInfoImpl stream_info(test_time_.timeSystem(), nullptr);
-  EXPECT_FALSE(stream_info.connectionID().has_value());
-  uint64_t id = 123;
-  stream_info.setConnectionID(id);
-  EXPECT_EQ(id, stream_info.connectionID());
-}
-
 TEST_F(StreamInfoImplTest, Details) {
   StreamInfoImpl stream_info(test_time_.timeSystem(), nullptr);
   EXPECT_FALSE(stream_info.responseCodeDetails().has_value());

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -213,8 +213,6 @@ public:
     return upstream_cluster_info_;
   }
 
-  absl::optional<uint64_t> connectionID() const override { return connection_id_; }
-
   void setFilterChainName(absl::string_view filter_chain_name) override {
     filter_chain_name_ = std::string(filter_chain_name);
   }

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -213,8 +213,6 @@ public:
     return upstream_cluster_info_;
   }
 
-  void setConnectionID(uint64_t id) override { connection_id_ = id; }
-
   absl::optional<uint64_t> connectionID() const override { return connection_id_; }
 
   void setFilterChainName(absl::string_view filter_chain_name) override {

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -449,6 +449,7 @@ TEST(Context, ConnectionAttributes) {
   EXPECT_CALL(info, upstreamTransportFailureReason())
       .WillRepeatedly(ReturnRef(upstream_transport_failure_reason));
   EXPECT_CALL(info, connectionID()).WillRepeatedly(Return(123));
+  info.downstream_address_provider_->setConnectionID(123);
   const absl::optional<std::string> connection_termination_details = "unauthorized";
   EXPECT_CALL(info, connectionTerminationDetails())
       .WillRepeatedly(ReturnRef(connection_termination_details));

--- a/test/mocks/network/connection.cc
+++ b/test/mocks/network/connection.cc
@@ -81,6 +81,7 @@ template <class T> static void initializeMockConnection(T& connection) {
     connection.raiseEvent(Network::ConnectionEvent::LocalClose);
   }));
   ON_CALL(connection, id()).WillByDefault(Return(connection.next_id_));
+  connection.stream_info_.downstream_address_provider_->setConnectionID(connection.id_);
   ON_CALL(connection, state()).WillByDefault(ReturnPointee(&connection.state_));
 
   // The real implementation will move the buffer data into the socket.

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -118,7 +118,6 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, getRouteName()).WillByDefault(ReturnRef(route_name_));
   ON_CALL(*this, upstreamTransportFailureReason())
       .WillByDefault(ReturnRef(upstream_transport_failure_reason_));
-  ON_CALL(*this, connectionID()).WillByDefault(Return(connection_id_));
   ON_CALL(*this, setConnectionID(_)).WillByDefault(Invoke([this](uint64_t id) {
     connection_id_ = id;
   }));


### PR DESCRIPTION
Commit Message: socket: move connection id interface to SocketAddressProvider
Additional Description:
Avoid populating the connection id into streamInfo by multiple places, moving connection
id into SocketAddressProvider.
Risk Level: low
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Part of #17168

Signed-off-by: He Jie Xu hejie.xu@intel.com