### PR TITLE
remove the wrong comment on test

### DIFF
--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -574,7 +574,7 @@ public:
   std::shared_ptr<LoadBalancer> lb_;
   HostsPerLocalityConstSharedPtr empty_locality_;
   HostVector empty_host_vector_;
-}; // namespace
+};
 
 // For the tests which mutate primary and failover host sets explicitly, only
 // run once.


### PR DESCRIPTION

It's just a comment error discovered by accident. 

Risk Level: Low.
Testing: N/A.
Docs Changes: N/A.
Release Notes: N/A.
