### PR TITLE
extend load balancer context interface to provide primary host

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -83,6 +83,16 @@ public:
    * Returns the transport socket options which should be applied on upstream connections
    */
   virtual Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const PURE;
+
+  using ExpectedHostStatus = uint32_t;
+  using ExpectedHost = std::pair<std::string, ExpectedHostStatus>;
+
+  /**
+   * Returns the primary host the load balancer shouled slected.If the expected host exists and the
+   * health status of the host matches the expectation, the load balancer can bypass the load
+   * balancing algorithm and return the corresponding host directly.
+   */
+  virtual absl::optional<ExpectedHost> primaryHostShouldSelected() const PURE;
 };
 
 /**
@@ -119,9 +129,12 @@ public:
   virtual ~LoadBalancerFactory() = default;
 
   /**
+   * Create a new worker local load balancer.
+   *
+   * @param thread_local_priority_set supplies worker local PrioritySet for host selection.
    * @return LoadBalancerPtr a new load balancer.
    */
-  virtual LoadBalancerPtr create() PURE;
+  virtual LoadBalancerPtr create(const PrioritySet& thread_local_priority_set) PURE;
 };
 
 using LoadBalancerFactorySharedPtr = std::shared_ptr<LoadBalancerFactory>;

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -197,6 +197,8 @@ using HealthyHostVector = Phantom<HostVector, Healthy>;
 using DegradedHostVector = Phantom<HostVector, Degraded>;
 using ExcludedHostVector = Phantom<HostVector, Excluded>;
 using HostMap = absl::flat_hash_map<std::string, Upstream::HostSharedPtr>;
+using HostMapSharedPtr = std::shared_ptr<HostMap>;
+using HostMapConstSharedPtr = std::shared_ptr<const HostMap>;
 using HostVectorSharedPtr = std::shared_ptr<HostVector>;
 using HostVectorConstSharedPtr = std::shared_ptr<const HostVector>;
 
@@ -497,6 +499,13 @@ public:
    * @param callback callback to use to add hosts.
    */
   virtual void batchHostUpdate(BatchUpdateCb& callback) PURE;
+
+  /**
+   * @return const HostMapConstSharedPtr& host map that will be used to search host by address
+   * string. If the PrioritySet does not provide the fast searching of host, this method returns
+   * nullptr.
+   */
+  virtual const HostMapConstSharedPtr& readOnlyHostMap() const PURE;
 };
 
 /**

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -478,7 +478,7 @@ void ClusterManagerImpl::onClusterInit(ClusterManagerCluster& cm_cluster) {
 
   // Now setup for cross-thread updates.
   cluster_data->second->member_update_cb_ = cluster.prioritySet().addMemberUpdateCb(
-      [&cluster, this](const HostVector&, const HostVector& hosts_removed) -> void {
+      [&cm_cluster, &cluster, this](const HostVector&, const HostVector& hosts_removed) -> void {
         if (cluster.info()->lbConfig().close_connections_on_host_set_change()) {
           for (const auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
             // This will drain all tcp and http connection pools.
@@ -495,6 +495,14 @@ void ClusterManagerImpl::onClusterInit(ClusterManagerCluster& cm_cluster) {
             postThreadLocalDrainConnections(cluster, hosts_removed);
           }
         }
+
+        // A read only HostMap is used to provide fast host search for the corresponding
+        // PrioritySet. In order to reduce the memory overhead, the HostMap is shared by the
+        // PrioritySet in all threads. When any member of the current cluster changes, the HostMap
+        // in the PrioritySet of main thread needs to be synchronized to each worker thread.
+        //
+        // NOTE: Currently only the PrioritySet of the EDS cluster has a valid read only HostMap.
+        postThreadLocalHostMapUpdate(cm_cluster);
       });
 
   cluster_data->second->priority_update_cb_ = cluster.prioritySet().addPriorityUpdateCb(
@@ -1006,6 +1014,46 @@ void ClusterManagerImpl::postThreadLocalClusterUpdate(ClusterManagerCluster& cm_
       });
 }
 
+void ClusterManagerImpl::postThreadLocalHostMapUpdate(ClusterManagerCluster& cm_cluster) {
+  bool add_or_update_cluster = false;
+  if (!cm_cluster.addedOrUpdated()) {
+    add_or_update_cluster = true;
+    cm_cluster.setAddedOrUpdated();
+  }
+  LoadBalancerFactorySharedPtr load_balancer_factory;
+  if (add_or_update_cluster) {
+    load_balancer_factory = cm_cluster.loadBalancerFactory();
+  }
+
+  tls_.runOnAllThreads([info = cm_cluster.cluster().info(), add_or_update_cluster,
+                        load_balancer_factory,
+                        host_map = cm_cluster.cluster().prioritySet().readOnlyHostMap()](
+                           OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+    ThreadLocalClusterManagerImpl::ClusterEntry* cluster_entry = nullptr;
+    if (add_or_update_cluster) {
+      if (cluster_manager->thread_local_clusters_.count(info->name()) > 0) {
+        ENVOY_LOG(debug, "updating TLS cluster {}", info->name());
+      } else {
+        ENVOY_LOG(debug, "adding TLS cluster {}", info->name());
+      }
+      cluster_entry = new ThreadLocalClusterManagerImpl::ClusterEntry(*cluster_manager, info,
+                                                                      load_balancer_factory);
+      cluster_manager->thread_local_clusters_[info->name()].reset(cluster_entry);
+
+      for (auto& cb : cluster_manager->update_callbacks_) {
+        cb->onClusterAddOrUpdate(*cluster_entry);
+      }
+    } else {
+      ASSERT(cluster_manager->thread_local_clusters_.find(info->name()) !=
+             cluster_manager->thread_local_clusters_.end());
+      cluster_entry = cluster_manager->thread_local_clusters_[info->name()].get();
+    }
+
+    ASSERT(cluster_entry != nullptr);
+    cluster_entry->priority_set_.setReadOnlyHostMap(host_map);
+  });
+}
+
 void ClusterManagerImpl::postThreadLocalHealthFailure(const HostSharedPtr& host) {
   tls_.runOnAllThreads([host](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
     cluster_manager->onHostHealthFailure(host);
@@ -1245,7 +1293,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
   // If an LB is thread aware, create a new worker local LB on membership changes.
   if (cluster_entry->lb_factory_ != nullptr) {
     ENVOY_LOG(debug, "re-creating local LB for TLS cluster {}", name);
-    cluster_entry->lb_ = cluster_entry->lb_factory_->create();
+    cluster_entry->lb_ = cluster_entry->lb_factory_->create(cluster_entry->priority_set_);
   }
 }
 
@@ -1371,7 +1419,7 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
     case LoadBalancerType::Maglev:
     case LoadBalancerType::OriginalDst: {
       ASSERT(lb_factory_ != nullptr);
-      lb_ = lb_factory_->create();
+      lb_ = lb_factory_->create(priority_set_);
       break;
     }
     }

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -319,6 +319,8 @@ protected:
   virtual void postThreadLocalDrainConnections(const Cluster& cluster,
                                                const HostVector& hosts_removed);
 
+  virtual void postThreadLocalHostMapUpdate(ClusterManagerCluster& cm_cluster);
+
   // Parameters for calling postThreadLocalClusterUpdate()
   struct ThreadLocalClusterUpdateParams {
     struct PerPriority {

--- a/source/common/upstream/eds.h
+++ b/source/common/upstream/eds.h
@@ -78,7 +78,9 @@ private:
   const LocalInfo::LocalInfo& local_info_;
   const std::string cluster_name_;
   std::vector<LocalityWeightsMap> locality_weights_map_;
-  HostMap all_hosts_;
+
+  HostMapSharedPtr all_host_map_;
+
   Event::TimerPtr assignment_timeout_;
   InitializePhase initialize_phase_;
 };

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -42,6 +42,9 @@ public:
 
   HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
 
+  static HostConstSharedPtr selectPrimaryHost(const PrioritySet& priority_set,
+                                              LoadBalancerContext* context);
+
 protected:
   /**
    * By implementing this method instead of chooseHost, host selection will
@@ -165,6 +168,10 @@ private:
 
 class LoadBalancerContextBase : public LoadBalancerContext {
 public:
+  static ExpectedHostStatus createExpectedHostStatus(
+      const Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus>& statuses);
+  static bool validateExpectedHostStatus(Host::Health health, ExpectedHostStatus status);
+
   absl::optional<uint64_t> computeHashKey() override { return {}; }
 
   const Network::Connection* downstreamConnection() const override { return nullptr; }
@@ -188,6 +195,8 @@ public:
   Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
     return nullptr;
   }
+
+  absl::optional<ExpectedHost> primaryHostShouldSelected() const override { return {}; }
 };
 
 /**

--- a/source/common/upstream/original_dst_cluster.h
+++ b/source/common/upstream/original_dst_cluster.h
@@ -69,7 +69,9 @@ private:
     LoadBalancerFactory(const std::shared_ptr<OriginalDstCluster>& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancerFactory
-    Upstream::LoadBalancerPtr create() override { return std::make_unique<LoadBalancer>(cluster_); }
+    Upstream::LoadBalancerPtr create(const PrioritySet&) override {
+      return std::make_unique<LoadBalancer>(cluster_);
+    }
 
     const std::shared_ptr<OriginalDstCluster> cluster_;
   };

--- a/source/common/upstream/subset_lb.h
+++ b/source/common/upstream/subset_lb.h
@@ -162,6 +162,10 @@ private:
       return wrapped_->upstreamTransportSocketOptions();
     }
 
+    absl::optional<ExpectedHost> primaryHostShouldSelected() const override {
+      return wrapped_->primaryHostShouldSelected();
+    }
+
   private:
     LoadBalancerContext* wrapped_;
     Router::MetadataMatchCriteriaConstPtr metadata_match_;

--- a/source/common/upstream/thread_aware_lb_impl.h
+++ b/source/common/upstream/thread_aware_lb_impl.h
@@ -110,8 +110,9 @@ private:
   using PerPriorityStatePtr = std::unique_ptr<PerPriorityState>;
 
   struct LoadBalancerImpl : public LoadBalancer {
-    LoadBalancerImpl(ClusterStats& stats, Random::RandomGenerator& random)
-        : stats_(stats), random_(random) {}
+    LoadBalancerImpl(ClusterStats& stats, Random::RandomGenerator& random,
+                     const PrioritySet& thread_local_priority_set)
+        : stats_(stats), random_(random), priority_set_(thread_local_priority_set) {}
 
     // Upstream::LoadBalancer
     HostConstSharedPtr chooseHost(LoadBalancerContext* context) override;
@@ -123,6 +124,9 @@ private:
     std::shared_ptr<std::vector<PerPriorityStatePtr>> per_priority_state_;
     std::shared_ptr<HealthyLoad> healthy_per_priority_load_;
     std::shared_ptr<DegradedLoad> degraded_per_priority_load_;
+
+    // PrioritySet for current ThreadLocalCluster.
+    const PrioritySet& priority_set_;
   };
 
   struct LoadBalancerFactoryImpl : public LoadBalancerFactory {
@@ -130,7 +134,7 @@ private:
         : stats_(stats), random_(random) {}
 
     // Upstream::LoadBalancerFactory
-    LoadBalancerPtr create() override;
+    LoadBalancerPtr create(const PrioritySet& thread_local_priority_set) override;
 
     ClusterStats& stats_;
     Random::RandomGenerator& random_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -477,6 +477,12 @@ public:
 
   void batchHostUpdate(BatchUpdateCb& callback) override;
 
+  const HostMapConstSharedPtr& readOnlyHostMap() const override { return read_only_host_map_; }
+
+  virtual void setReadOnlyHostMap(HostMapConstSharedPtr host_map) {
+    read_only_host_map_ = std::move(host_map);
+  }
+
 protected:
   // Allows subclasses of PrioritySetImpl to create their own type of HostSetImpl.
   virtual HostSetImplPtr createHostSet(uint32_t priority,
@@ -506,6 +512,8 @@ private:
   mutable Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;
   bool batch_update_ : 1;
+
+  HostMapConstSharedPtr read_only_host_map_{};
 
   // Helper class to maintain state as we perform multiple host updates. Keeps track of all hosts
   // that have been added/removed throughout the batch update, and ensures that we properly manage

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -135,7 +135,7 @@ private:
 struct AggregateLoadBalancerFactory : public Upstream::LoadBalancerFactory {
   AggregateLoadBalancerFactory(const Cluster& cluster) : cluster_(cluster) {}
   // Upstream::LoadBalancerFactory
-  Upstream::LoadBalancerPtr create() override {
+  Upstream::LoadBalancerPtr create(const Upstream::PrioritySet&) override {
     return std::make_unique<AggregateClusterLoadBalancer>(
         cluster_.info(), cluster_.cluster_manager_, cluster_.runtime_, cluster_.random_,
         cluster_.clusters_);

--- a/source/extensions/clusters/aggregate/lb_context.h
+++ b/source/extensions/clusters/aggregate/lb_context.h
@@ -10,7 +10,7 @@ namespace Aggregate {
 
 // AggregateLoadBalancerContext wraps the load balancer context to re-assign priority load
 // according the to host priority selected by the aggregate load balancer.
-class AggregateLoadBalancerContext : public Upstream::LoadBalancerContext {
+class AggregateLoadBalancerContext : public Upstream::LoadBalancerContextBase {
 public:
   AggregateLoadBalancerContext(Upstream::LoadBalancerContext* context,
                                Upstream::LoadBalancerBase::HostAvailability host_availability,

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -68,7 +68,9 @@ private:
     LoadBalancerFactory(Cluster& cluster) : cluster_(cluster) {}
 
     // Upstream::LoadBalancerFactory
-    Upstream::LoadBalancerPtr create() override { return std::make_unique<LoadBalancer>(cluster_); }
+    Upstream::LoadBalancerPtr create(const Upstream::PrioritySet&) override {
+      return std::make_unique<LoadBalancer>(cluster_);
+    }
 
     Cluster& cluster_;
   };

--- a/source/extensions/clusters/redis/redis_cluster_lb.cc
+++ b/source/extensions/clusters/redis/redis_cluster_lb.cc
@@ -99,7 +99,7 @@ void RedisClusterLoadBalancerFactory::onHostHealthUpdate() {
   }
 }
 
-Upstream::LoadBalancerPtr RedisClusterLoadBalancerFactory::create() {
+Upstream::LoadBalancerPtr RedisClusterLoadBalancerFactory::create(const Upstream::PrioritySet&) {
   absl::ReaderMutexLock lock(&mutex_);
   return std::make_unique<RedisClusterLoadBalancer>(slot_array_, shard_vector_, random_);
 }

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -134,7 +134,7 @@ public:
   void onHostHealthUpdate() override;
 
   // Upstream::LoadBalancerFactory
-  Upstream::LoadBalancerPtr create() override;
+  Upstream::LoadBalancerPtr create(const Upstream::PrioritySet& thread_local_priority_set) override;
 
 private:
   class RedisShard {

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -240,6 +240,7 @@ envoy_cc_test(
         "//test/mocks:common_lib",
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
+        "//test/mocks/upstream:host_mocks",
         "//test/mocks/upstream:host_set_mocks",
         "//test/mocks/upstream:load_balancer_context_mock",
         "//test/mocks/upstream:priority_set_mocks",

--- a/test/common/upstream/eds_test.cc
+++ b/test/common/upstream/eds_test.cc
@@ -672,7 +672,7 @@ TEST_F(EdsTest, ReadOnlyMapUpdateOfPrioritySet) {
   EXPECT_NE(test_host_map.get(), cluster_->prioritySet().readOnlyHostMap().get());
   test_host_map = cluster_->prioritySet().readOnlyHostMap();
 
-  for (auto host : cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()) {
+  for (const auto& host : cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()) {
     // Remove the pending HC flag. This is normally done by the health checker.
     host->healthFlagClear(Host::HealthFlag::PENDING_ACTIVE_HC);
     // Mark the hosts as healthy

--- a/test/common/upstream/load_balancer_benchmark.cc
+++ b/test/common/upstream/load_balancer_benchmark.cc
@@ -308,7 +308,7 @@ void benchmarkRingHashLoadBalancerChooseHost(::benchmark::State& state) {
     const uint64_t keys_to_simulate = state.range(2);
     RingHashTester tester(num_hosts, min_ring_size);
     tester.ring_hash_lb_->initialize();
-    LoadBalancerPtr lb = tester.ring_hash_lb_->factory()->create();
+    LoadBalancerPtr lb = tester.ring_hash_lb_->factory()->create(tester.priority_set_);
     absl::node_hash_map<std::string, uint64_t> hit_counter;
     TestLoadBalancerContext context;
     state.ResumeTiming();
@@ -346,7 +346,7 @@ void benchmarkMaglevLoadBalancerChooseHost(::benchmark::State& state) {
     const uint64_t keys_to_simulate = state.range(1);
     MaglevTester tester(num_hosts);
     tester.maglev_lb_->initialize();
-    LoadBalancerPtr lb = tester.maglev_lb_->factory()->create();
+    LoadBalancerPtr lb = tester.maglev_lb_->factory()->create(tester.priority_set_);
     absl::node_hash_map<std::string, uint64_t> hit_counter;
     TestLoadBalancerContext context;
     state.ResumeTiming();
@@ -385,7 +385,7 @@ void benchmarkRingHashLoadBalancerHostLoss(::benchmark::State& state) {
   for (auto _ : state) { // NOLINT: Silences warning about dead store
     RingHashTester tester(num_hosts, min_ring_size);
     tester.ring_hash_lb_->initialize();
-    LoadBalancerPtr lb = tester.ring_hash_lb_->factory()->create();
+    LoadBalancerPtr lb = tester.ring_hash_lb_->factory()->create(tester.priority_set_);
     std::vector<HostConstSharedPtr> hosts;
     TestLoadBalancerContext context;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
@@ -395,7 +395,7 @@ void benchmarkRingHashLoadBalancerHostLoss(::benchmark::State& state) {
 
     RingHashTester tester2(num_hosts - hosts_to_lose, min_ring_size);
     tester2.ring_hash_lb_->initialize();
-    lb = tester2.ring_hash_lb_->factory()->create();
+    lb = tester2.ring_hash_lb_->factory()->create(tester2.priority_set_);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
@@ -433,7 +433,7 @@ void benchmarkMaglevLoadBalancerHostLoss(::benchmark::State& state) {
 
     MaglevTester tester(num_hosts);
     tester.maglev_lb_->initialize();
-    LoadBalancerPtr lb = tester.maglev_lb_->factory()->create();
+    LoadBalancerPtr lb = tester.maglev_lb_->factory()->create(tester.priority_set_);
     std::vector<HostConstSharedPtr> hosts;
     TestLoadBalancerContext context;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
@@ -443,7 +443,7 @@ void benchmarkMaglevLoadBalancerHostLoss(::benchmark::State& state) {
 
     MaglevTester tester2(num_hosts - hosts_to_lose);
     tester2.maglev_lb_->initialize();
-    lb = tester2.maglev_lb_->factory()->create();
+    lb = tester2.maglev_lb_->factory()->create(tester2.priority_set_);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);
@@ -480,7 +480,7 @@ void benchmarkMaglevLoadBalancerWeighted(::benchmark::State& state) {
 
     MaglevTester tester(num_hosts, weighted_subset_percent, before_weight);
     tester.maglev_lb_->initialize();
-    LoadBalancerPtr lb = tester.maglev_lb_->factory()->create();
+    LoadBalancerPtr lb = tester.maglev_lb_->factory()->create(tester.priority_set_);
     std::vector<HostConstSharedPtr> hosts;
     TestLoadBalancerContext context;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
@@ -490,7 +490,7 @@ void benchmarkMaglevLoadBalancerWeighted(::benchmark::State& state) {
 
     MaglevTester tester2(num_hosts, weighted_subset_percent, after_weight);
     tester2.maglev_lb_->initialize();
-    lb = tester2.maglev_lb_->factory()->create();
+    lb = tester2.maglev_lb_->factory()->create(tester2.priority_set_);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
       context.hash_key_ = hashInt(i);

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -1993,6 +1993,28 @@ TEST(LoadBalancerSubsetInfoImplTest, KeysSubsetEqualKeysInvalid) {
 
 TEST(LoadBalancerContextBaseTest, LoadBalancerContextBaseTest) {
   {
+    auto context = LoadBalancerContextBase();
+    MockPrioritySet mock_priority_set;
+    HealthyAndDegradedLoad priority_load{Upstream::HealthyLoad({100, 0, 0}),
+                                         Upstream::DegradedLoad({0, 0, 0})};
+    RetryPriority::PriorityMappingFunc empty_func =
+        [](const Upstream::HostDescription&) -> absl::optional<uint32_t> { return absl::nullopt; };
+    MockHost mock_host;
+
+    EXPECT_EQ(absl::nullopt, context.computeHashKey());
+    EXPECT_EQ(nullptr, context.downstreamConnection());
+    EXPECT_EQ(nullptr, context.metadataMatchCriteria());
+    EXPECT_EQ(nullptr, context.downstreamHeaders());
+
+    EXPECT_EQ(&priority_load,
+              &(context.determinePriorityLoad(mock_priority_set, priority_load, empty_func)));
+    EXPECT_EQ(false, context.shouldSelectAnotherHost(mock_host));
+    EXPECT_EQ(1, context.hostSelectionRetryCount());
+    EXPECT_EQ(nullptr, context.upstreamSocketOptions());
+    EXPECT_EQ(nullptr, context.upstreamTransportSocketOptions());
+    EXPECT_EQ(absl::nullopt, context.primaryHostShouldSelected());
+  }
+  {
     Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
     statuses.Add(envoy::config::core::v3::HealthStatus::UNKNOWN);
     statuses.Add(envoy::config::core::v3::HealthStatus::HEALTHY);

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -14,6 +14,7 @@
 #include "test/mocks/common.h"
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
+#include "test/mocks/upstream/host.h"
 #include "test/mocks/upstream/host_set.h"
 #include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/priority_set.h"
@@ -32,6 +33,10 @@ using testing::ReturnRef;
 namespace Envoy {
 namespace Upstream {
 namespace {
+
+static constexpr uint32_t UnhealthyStatus = 0b001u;
+static constexpr uint32_t DegradedStatus = 0b010u;
+static constexpr uint32_t HealthyStatus = 0b100u;
 
 class LoadBalancerTestBase : public Event::TestUsingSimulatedTime,
                              public testing::TestWithParam<bool> {
@@ -537,6 +542,88 @@ TEST_P(LoadBalancerBaseTest, BoundaryConditions) {
     uint32_t healthy_hosts = std::min<uint32_t>(num_hosts, rand.random() % 100);
     // Make sure random health situations don't trigger the assert in recalculatePerPriorityState
     updateHostSet(*priority_set_.getMockHostSet(i), num_hosts, healthy_hosts);
+  }
+}
+
+TEST_P(LoadBalancerBaseTest, SelectPrimaryHostTestInLb) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+
+  auto mock_host = std::make_shared<NiceMock<MockHost>>();
+  EXPECT_CALL(*mock_host, health()).WillOnce(Return(Host::Health::Degraded));
+
+  LoadBalancerContext::ExpectedHost expected_host{"1.2.3.4", HealthyStatus | DegradedStatus};
+  EXPECT_CALL(context, primaryHostShouldSelected())
+      .WillOnce(Return(absl::make_optional(expected_host)));
+
+  auto host_map = std::make_shared<HostMap>();
+  host_map->insert({"1.2.3.4", mock_host});
+  priority_set_.read_only_host_map_ = host_map;
+  EXPECT_EQ(mock_host, lb_.chooseHost(&context));
+}
+
+TEST(LoadBalancerBaseTest, SelectPrimaryHostTest) {
+  NiceMock<MockPrioritySet> priority_set;
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+
+  {
+    // No valid host map.
+    priority_set.read_only_host_map_ = nullptr;
+    EXPECT_EQ(nullptr, LoadBalancerBase::selectPrimaryHost(priority_set, &context));
+  }
+  {
+    // No valid load balancer context.
+    priority_set.read_only_host_map_ = std::make_shared<HostMap>();
+    EXPECT_EQ(nullptr, LoadBalancerBase::selectPrimaryHost(priority_set, nullptr));
+  }
+  {
+    // No valid expected host.
+    EXPECT_CALL(context, primaryHostShouldSelected()).WillOnce(Return(absl::nullopt));
+    priority_set.read_only_host_map_ = std::make_shared<HostMap>();
+    EXPECT_EQ(nullptr, LoadBalancerBase::selectPrimaryHost(priority_set, &context));
+  }
+  {
+    // The host map does not contain the expected host.
+    LoadBalancerContext::ExpectedHost expected_host{"1.2.3.4", HealthyStatus};
+    EXPECT_CALL(context, primaryHostShouldSelected())
+        .WillOnce(Return(absl::make_optional(expected_host)));
+    priority_set.read_only_host_map_ = std::make_shared<HostMap>();
+    EXPECT_EQ(nullptr, LoadBalancerBase::selectPrimaryHost(priority_set, &context));
+  }
+  {
+    // The host map does not contain the expected host.
+    LoadBalancerContext::ExpectedHost expected_host{"1.2.3.4", HealthyStatus};
+    EXPECT_CALL(context, primaryHostShouldSelected())
+        .WillOnce(Return(absl::make_optional(expected_host)));
+    priority_set.read_only_host_map_ = std::make_shared<HostMap>();
+    EXPECT_EQ(nullptr, LoadBalancerBase::selectPrimaryHost(priority_set, &context));
+  }
+  {
+    // The status of host is not as expected.
+    auto mock_host = std::make_shared<NiceMock<MockHost>>();
+    EXPECT_CALL(*mock_host, health()).WillOnce(Return(Host::Health::Unhealthy));
+
+    LoadBalancerContext::ExpectedHost expected_host{"1.2.3.4", HealthyStatus};
+    EXPECT_CALL(context, primaryHostShouldSelected())
+        .WillOnce(Return(absl::make_optional(expected_host)));
+
+    auto host_map = std::make_shared<HostMap>();
+    host_map->insert({"1.2.3.4", mock_host});
+    priority_set.read_only_host_map_ = host_map;
+    EXPECT_EQ(nullptr, LoadBalancerBase::selectPrimaryHost(priority_set, &context));
+  }
+  {
+    // Get expected host.
+    auto mock_host = std::make_shared<NiceMock<MockHost>>();
+    EXPECT_CALL(*mock_host, health()).WillOnce(Return(Host::Health::Degraded));
+
+    LoadBalancerContext::ExpectedHost expected_host{"1.2.3.4", HealthyStatus | DegradedStatus};
+    EXPECT_CALL(context, primaryHostShouldSelected())
+        .WillOnce(Return(absl::make_optional(expected_host)));
+
+    auto host_map = std::make_shared<HostMap>();
+    host_map->insert({"1.2.3.4", mock_host});
+    priority_set.read_only_host_map_ = host_map;
+    EXPECT_EQ(mock_host, LoadBalancerBase::selectPrimaryHost(priority_set, &context));
   }
 }
 
@@ -1902,6 +1989,59 @@ TEST(LoadBalancerSubsetInfoImplTest, KeysSubsetEqualKeysInvalid) {
 
   EXPECT_THROW_WITH_MESSAGE(LoadBalancerSubsetInfoImpl{subset_config}, EnvoyException,
                             "fallback_keys_subset cannot be equal to keys");
+}
+
+TEST(LoadBalancerContextBaseTest, LoadBalancerContextBaseTest) {
+  {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
+    statuses.Add(envoy::config::core::v3::HealthStatus::UNKNOWN);
+    statuses.Add(envoy::config::core::v3::HealthStatus::HEALTHY);
+    EXPECT_EQ(LoadBalancerContextBase::createExpectedHostStatus(statuses), HealthyStatus);
+  }
+  {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
+    statuses.Add(envoy::config::core::v3::HealthStatus::UNHEALTHY);
+    statuses.Add(envoy::config::core::v3::HealthStatus::DRAINING);
+    statuses.Add(envoy::config::core::v3::HealthStatus::TIMEOUT);
+
+    EXPECT_EQ(LoadBalancerContextBase::createExpectedHostStatus(statuses), UnhealthyStatus);
+  }
+  {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
+    statuses.Add(envoy::config::core::v3::HealthStatus::DEGRADED);
+    EXPECT_EQ(LoadBalancerContextBase::createExpectedHostStatus(statuses), DegradedStatus);
+  }
+  {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
+    EXPECT_EQ(LoadBalancerContextBase::createExpectedHostStatus(statuses), 0);
+  }
+  {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
+    statuses.Add(envoy::config::core::v3::HealthStatus::UNHEALTHY);
+    statuses.Add(envoy::config::core::v3::HealthStatus::DRAINING);
+    statuses.Add(envoy::config::core::v3::HealthStatus::TIMEOUT);
+    statuses.Add(envoy::config::core::v3::HealthStatus::UNKNOWN);
+    statuses.Add(envoy::config::core::v3::HealthStatus::HEALTHY);
+    EXPECT_EQ(LoadBalancerContextBase::createExpectedHostStatus(statuses), 0b101u);
+  }
+
+  {
+    Protobuf::RepeatedPtrField<envoy::config::core::v3::HealthStatus> statuses;
+    statuses.Add(envoy::config::core::v3::HealthStatus::UNHEALTHY);
+    statuses.Add(envoy::config::core::v3::HealthStatus::DRAINING);
+    statuses.Add(envoy::config::core::v3::HealthStatus::TIMEOUT);
+    statuses.Add(envoy::config::core::v3::HealthStatus::UNKNOWN);
+    statuses.Add(envoy::config::core::v3::HealthStatus::HEALTHY);
+    statuses.Add(envoy::config::core::v3::HealthStatus::DEGRADED);
+    EXPECT_EQ(LoadBalancerContextBase::createExpectedHostStatus(statuses), 0b111u);
+  }
+
+  EXPECT_TRUE(LoadBalancerContextBase::validateExpectedHostStatus(Host::Health::Unhealthy,
+                                                                  UnhealthyStatus));
+  EXPECT_TRUE(
+      LoadBalancerContextBase::validateExpectedHostStatus(Host::Health::Healthy, HealthyStatus));
+  EXPECT_FALSE(
+      LoadBalancerContextBase::validateExpectedHostStatus(Host::Health::Healthy, UnhealthyStatus));
 }
 
 } // namespace

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2195,6 +2195,10 @@ TEST(PrioritySet, Extend) {
   // We expect to see two priority changes, but only one membership change.
   EXPECT_EQ(3, priority_changes);
   EXPECT_EQ(2, membership_changes);
+
+  HostMapSharedPtr test_host_map = std::make_shared<HostMap>();
+  priority_set.setReadOnlyHostMap(test_host_map);
+  EXPECT_EQ(test_host_map.get(), priority_set.readOnlyHostMap().get());
 }
 
 class ClusterInfoImplTest : public testing::Test {

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -90,6 +90,16 @@ public:
     setupSecondary(1, 1, 1, 1);
   }
 
+  Upstream::LoadBalancerPtr createThreadLocalLoadBalancer() {
+    // When creating a thread local load balancer for aggregate cluster, the
+    // thread_local_priority_set parameter will be ignored. Aggregate cluster does not rely on
+    // thread_local_priority_set to select a suitable upstream host, so an empty PrioritySet can be
+    // used to assist the test.
+    const Upstream::PrioritySetImpl empty_priority_set;
+
+    return lb_factory_->create(empty_priority_set);
+  }
+
   void initialize(const std::string& yaml_config) {
     envoy::config::cluster::v3::Cluster cluster_config =
         Upstream::parseClusterFromV3Yaml(yaml_config);
@@ -121,7 +131,7 @@ public:
 
     thread_aware_lb_ = std::make_unique<AggregateThreadAwareLoadBalancer>(*cluster_);
     lb_factory_ = thread_aware_lb_->factory();
-    lb_ = lb_factory_->create();
+    lb_ = createThreadLocalLoadBalancer();
   }
 
   Stats::TestUtil::TestStore stats_store_;

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -101,7 +101,15 @@ public:
     host_map_[host]->address_ = Network::Utility::parseInternetAddress(address);
   }
 
-  void refreshLb() { lb_ = lb_factory_->create(); }
+  void refreshLb() {
+    // When creating a thread local load balancer for dynamic forward proxy cluster, the
+    // thread_local_priority_set parameter will be ignored. dynamic forward proxy cluster does not
+    // rely on thread_local_priority_set to select a suitable upstream host, so an empty PrioritySet
+    // can be used to assist the test.
+    const Upstream::PrioritySetImpl empty_priority_set;
+
+    lb_ = lb_factory_->create(empty_priority_set);
+  }
 
   Upstream::MockLoadBalancerContext* setHostAndReturnContext(const std::string& host) {
     downstream_headers_.remove(":authority");

--- a/test/integration/clusters/custom_static_cluster.h
+++ b/test/integration/clusters/custom_static_cluster.h
@@ -51,7 +51,9 @@ private:
   struct LbFactory : public Upstream::LoadBalancerFactory {
     LbFactory(const Upstream::HostSharedPtr& host) : host_(host) {}
 
-    Upstream::LoadBalancerPtr create() override { return std::make_unique<LbImpl>(host_); }
+    Upstream::LoadBalancerPtr create(const Upstream::PrioritySet&) override {
+      return std::make_unique<LbImpl>(host_);
+    }
 
     const Upstream::HostSharedPtr host_;
   };

--- a/test/mocks/upstream/load_balancer_context.h
+++ b/test/mocks/upstream/load_balancer_context.h
@@ -23,6 +23,7 @@ public:
   MOCK_METHOD(Network::Socket::OptionsSharedPtr, upstreamSocketOptions, (), (const));
   MOCK_METHOD(Network::TransportSocketOptionsConstSharedPtr, upstreamTransportSocketOptions, (),
               (const));
+  MOCK_METHOD(absl::optional<ExpectedHost>, primaryHostShouldSelected, (), (const));
 
 private:
   HealthyAndDegradedLoad priority_load_;

--- a/test/mocks/upstream/priority_set.cc
+++ b/test/mocks/upstream/priority_set.cc
@@ -25,6 +25,7 @@ MockPrioritySet::MockPrioritySet() {
       .WillByDefault(Invoke([this](PrioritySet::PriorityUpdateCb cb) -> Common::CallbackHandlePtr {
         return priority_update_cb_helper_.add(cb);
       }));
+  ON_CALL(*this, readOnlyHostMap()).WillByDefault(ReturnRef(read_only_host_map_));
 }
 
 MockPrioritySet::~MockPrioritySet() = default;

--- a/test/mocks/upstream/priority_set.h
+++ b/test/mocks/upstream/priority_set.h
@@ -27,6 +27,7 @@ public:
                LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
                const HostVector& hosts_removed, absl::optional<uint32_t> overprovisioning_factor));
   MOCK_METHOD(void, batchHostUpdate, (BatchUpdateCb&));
+  MOCK_METHOD(const HostMapConstSharedPtr&, readOnlyHostMap, (), (const));
 
   MockHostSet* getMockHostSet(uint32_t priority) {
     getHostSet(priority); // Ensure the host set exists.
@@ -38,6 +39,8 @@ public:
   Common::CallbackManager<const HostVector&, const HostVector&> member_update_cb_helper_;
   Common::CallbackManager<uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;
+
+  HostMapConstSharedPtr read_only_host_map_{};
 };
 } // namespace Upstream
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: extend load balancer context interface to provide primary host

Additional Description:

Extend load balancer context interface to provide primary host and allow the load balancer to skip the load balancing calculation and directly select the eligible primary host.

This is one of the most critical tasks related to #16698. After completing the work, we can complete #16698 by extending the specific implementation of LocalBalancerContext. 

Risk Level: Medium.
Testing: Added.
Docs Changes: N/A.
Release Notes: N/A.
