### PR TITLE
Updates docs temporarily to cloudsmith until packages complete

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -13,47 +13,50 @@ getting your Envoy proxy up and running.
 Install Envoy on Debian GNU/Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can `install Envoy on Debian <https://www.getenvoy.io/install/envoy/debian/>`_
-using `Get Envoy <https://www.getenvoy.io/>`__ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
+You can `install Envoy on Debian using packages created by Tetrate <https://cloudsmith.io/~tetrate/repos/getenvoy-deb-stable/setup/#formats-deb>`_
+until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
 
 .. code-block:: console
 
    $ sudo apt update
-   $ sudo apt install apt-transport-https ca-certificates curl gnupg2 software-properties-common
-   $ curl -sL 'https://getenvoy.io/gpg' | sudo gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
+   $ sudo apt install debian-keyring debian-archive-keyring apt-transport-https curl lsb-release
+   $ curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | sudo gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
    # Verify the keyring - this should yield "OK"
-   $ echo 1a2f6152efc6cc39e384fb869cdf3cc3e4e1ac68f4ad8f8f114a7c58bb0bea01 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check
-   $ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://dl.bintray.com/tetrate/getenvoy-deb $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/getenvoy.list
+   $ echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check
+   $ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/debian $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/getenvoy.list
    $ sudo apt update
    $ sudo apt install getenvoy-envoy
 
 Install Envoy on Ubuntu Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can `install Envoy on Ubuntu <https://www.getenvoy.io/install/envoy/ubuntu/>`_
-using `Get Envoy <https://www.getenvoy.io/>`__ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
+You can `install Envoy on Ubuntu using packages created by Tetrate <https://cloudsmith.io/~tetrate/repos/getenvoy-deb-stable/setup/#formats-deb>`_
+until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
 
 .. code-block:: console
 
    $ sudo apt update
-   $ sudo apt install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-   $ curl -sL 'https://getenvoy.io/gpg' | sudo gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
+   $ sudo apt install apt-transport-https gnupg2 curl lsb-release
+   $ curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | sudo gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
    # Verify the keyring - this should yield "OK"
-   $ echo 1a2f6152efc6cc39e384fb869cdf3cc3e4e1ac68f4ad8f8f114a7c58bb0bea01 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check
-   $ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://dl.bintray.com/tetrate/getenvoy-deb $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/getenvoy.list
+   $ echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check
+   $ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/getenvoy.list
    $ sudo apt update
    $ sudo apt install -y getenvoy-envoy
 
 Install Envoy on RPM-based distros
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can `install Envoy on Centos/Redhat Enterprise Linux (RHEL) <https://www.getenvoy.io/install/envoy/rpm/>`_
-using `Get Envoy <https://www.getenvoy.io/>`__ until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
+You can install Envoy on Centos/Redhat Enterprise Linux (RHEL) using `packages created by Tetrate <https://cloudsmith.io/~tetrate/repos/getenvoy-rpm-stable/setup/#formats-rpm>`_
+until `official packages exist <https://github.com/envoyproxy/envoy/issues/16867>`_.
 
 .. code-block:: console
 
    $ sudo yum install yum-utils
-   $ sudo yum-config-manager --add-repo https://getenvoy.io/linux/rpm/tetrate-getenvoy.repo
+   $ sudo rpm --import 'https://rpm.dl.getenvoy.io/public/gpg.CF716AF503183491.key'
+   $ curl -sL 'https://rpm.dl.getenvoy.io/public/config.rpm.txt?distro=el&codename=7' > /tmp/tetrate-getenvoy-rpm-stable.repo
+   $ sudo yum-config-manager --add-repo '/tmp/tetrate-getenvoy-rpm-stable.repo'
+   $ sudo yum makecache --disablerepo='*' --enablerepo='tetrate-getenvoy-rpm-stable'
    $ sudo yum install getenvoy-envoy
 
 .. _start_install_macosx:


### PR DESCRIPTION
A month ago, we changed the install page to say official packages are
on the way. #16867 hasn't landed, yet and now problems are surfacing
like #17236, but also spread out over the ecosystem also.

Specifically the "Get Envoy" instructions no longer work because
Bintray no longer works at all and #16867 isn't finished. This fixes the
instructions until packages are available, after which the "Get Envoy"
parts should be deleted as "Get Envoy" is a canceled project due to
trademark issues with the Linux Foundation.

Thanks very much to @carlossg for finding these instructions and
@arkodg for verifying them.

---

These instructions are hand-crafted due to requests from the Envoy
project team. End users can also look at instructions maintained by
Cloudsmith here as they are more likely to remain up-to-date.

Ex. https://cloudsmith.io/~tetrate/repos/getenvoy-deb-stable/setup/#formats-deb

Also note, @phlax insisted these instructions use sudo which is intentionally not installed in docker-based distributions. Those using this with docker will want to install sudo manually or change the instructions accordingly. In any case, the instructions are more manual than necessary to match prior conventions.