### PR TITLE
Revert "Revert "alpha matching: support generic action factory contex…

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -76,11 +76,12 @@ public:
 using ActionPtr = std::unique_ptr<Action>;
 using ActionFactoryCb = std::function<ActionPtr()>;
 
-class ActionFactory : public Config::TypedFactory {
+template <class ActionFactoryContext> class ActionFactory : public Config::TypedFactory {
 public:
   virtual ActionFactoryCb
-  createActionFactoryCb(const Protobuf::Message& config, const std::string& stats_prefix,
-                        Server::Configuration::FactoryContext& context) PURE;
+  createActionFactoryCb(const Protobuf::Message& config,
+                        ActionFactoryContext& action_factory_context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
 
   std::string category() const override { return "envoy.matching.action"; }
 };
@@ -155,7 +156,7 @@ class InputMatcherFactory : public Config::TypedFactory {
 public:
   virtual InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              Server::Configuration::FactoryContext& factory_context) PURE;
+                              ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
 
   std::string category() const override { return "envoy.matching.input_matchers"; }
 };
@@ -226,7 +227,7 @@ public:
    */
   virtual DataInputFactoryCb<DataType>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           Server::Configuration::FactoryContext& factory_context) PURE;
+                           ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
 
   /**
    * The category of this factory depends on the DataType, so we require a name() function to exist
@@ -262,7 +263,7 @@ public:
    */
   virtual CommonProtocolInputFactoryCb
   createCommonProtocolInputFactoryCb(const Protobuf::Message& config,
-                                     Server::Configuration::FactoryContext& factory_context) PURE;
+                                     ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
 
   std::string category() const override { return "envoy.matching.common_inputs"; }
 };

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -156,7 +156,7 @@ class InputMatcherFactory : public Config::TypedFactory {
 public:
   virtual InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-  Server::Configuration::ServerFactoryContext& factory_context) PURE;
+                              Server::Configuration::ServerFactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.input_matchers"; }
 };

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -16,7 +16,7 @@ namespace Envoy {
 
 namespace Server {
 namespace Configuration {
-class FactoryContext;
+class ServerFactoryContext;
 }
 } // namespace Server
 
@@ -156,7 +156,7 @@ class InputMatcherFactory : public Config::TypedFactory {
 public:
   virtual InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
+  Server::Configuration::ServerFactoryContext& factory_context) PURE;
 
   std::string category() const override { return "envoy.matching.input_matchers"; }
 };

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -13,11 +13,13 @@
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
 
+#include "matching/data_impl.h"
+
 namespace Envoy {
 namespace Http {
 
 namespace {
-REGISTER_FACTORY(SkipActionFactory, Matcher::ActionFactory);
+REGISTER_FACTORY(SkipActionFactory, Matcher::ActionFactory<Matching::HttpFilterActionContext>);
 
 template <class T> using FilterList = std::list<std::unique_ptr<T>>;
 

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -68,11 +68,12 @@ private:
 
 using FilterMatchStateSharedPtr = std::shared_ptr<FilterMatchState>;
 
-class SkipActionFactory : public Matcher::ActionFactory {
+class SkipActionFactory : public Matcher::ActionFactory<Matching::HttpFilterActionContext> {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&, const std::string&,
-                                                 Server::Configuration::FactoryContext&) override {
+  Matcher::ActionFactoryCb createActionFactoryCb(const Protobuf::Message&,
+                                                 Matching::HttpFilterActionContext&,
+                                                 ProtobufMessage::ValidationVisitor&) override {
     return []() { return std::make_unique<SkipAction>(); };
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/common/http/match_wrapper/BUILD
+++ b/source/common/http/match_wrapper/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     deps = [
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
+        "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@envoy_api//envoy/extensions/common/matching/v3:pkg_cc_proto",

--- a/source/common/http/match_wrapper/config.cc
+++ b/source/common/http/match_wrapper/config.cc
@@ -5,6 +5,7 @@
 #include "envoy/registry/registry.h"
 
 #include "source/common/config/utility.h"
+#include "source/common/http/matching/data_impl.h"
 #include "source/common/matcher/matcher.h"
 
 #include "absl/status/status.h"
@@ -103,9 +104,11 @@ Envoy::Http::FilterFactoryCb MatchWrapperConfig::createFilterFactoryFromProtoTyp
 
   MatchTreeValidationVisitor validation_visitor(*factory.matchingRequirements());
 
-  auto match_tree =
-      Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData>(prefix, context, validation_visitor)
-          .create(proto_config.matcher());
+  Envoy::Http::Matching::HttpFilterActionContext action_context{prefix, context};
+  auto match_tree = Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData,
+                                              Envoy::Http::Matching::HttpFilterActionContext>(
+                        action_context, context.messageValidationVisitor(), validation_visitor)
+                        .create(proto_config.matcher());
 
   if (!validation_visitor.errors().empty()) {
     // TODO(snowp): Output all violations.

--- a/source/common/http/match_wrapper/config.cc
+++ b/source/common/http/match_wrapper/config.cc
@@ -107,7 +107,7 @@ Envoy::Http::FilterFactoryCb MatchWrapperConfig::createFilterFactoryFromProtoTyp
   Envoy::Http::Matching::HttpFilterActionContext action_context{prefix, context};
   auto match_tree = Matcher::MatchTreeFactory<Envoy::Http::HttpMatchingData,
                                               Envoy::Http::Matching::HttpFilterActionContext>(
-                        action_context, context.messageValidationVisitor(), validation_visitor)
+                        action_context, context.getServerFactoryContext(), validation_visitor)
                         .create(proto_config.matcher());
 
   if (!validation_visitor.errors().empty()) {

--- a/source/common/http/matching/data_impl.h
+++ b/source/common/http/matching/data_impl.h
@@ -55,6 +55,10 @@ private:
 
 using HttpMatchingDataImplSharedPtr = std::shared_ptr<HttpMatchingDataImpl>;
 
+struct HttpFilterActionContext {
+  const std::string& stat_prefix_;
+  Server::Configuration::FactoryContext& factory_context_;
+};
 } // namespace Matching
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/matching/data_impl.h
+++ b/source/common/http/matching/data_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/http/filter.h"
+#include "envoy/server/factory_context.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/common/http/matching/inputs.h
+++ b/source/common/http/matching/inputs.h
@@ -55,9 +55,9 @@ public:
 
   Matcher::DataInputFactoryCb<HttpMatchingData>
   createDataInputFactoryCb(const Protobuf::Message& config,
-                           Server::Configuration::FactoryContext& factory_context) override {
-    const auto& typed_config = MessageUtil::downcastAndValidate<const ProtoType&>(
-        config, factory_context.messageValidationVisitor());
+                           ProtobufMessage::ValidationVisitor& validation_visitor) override {
+    const auto& typed_config =
+        MessageUtil::downcastAndValidate<const ProtoType&>(config, validation_visitor);
 
     return [header_name = typed_config.header_name()] {
       return std::make_unique<DataInputType>(header_name);

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -66,13 +66,15 @@ template <class DataType> using DataInputFactoryCb = std::function<DataInputPtr<
 
 /**
  * Recursively constructs a MatchTree from a protobuf configuration.
+ * @param DataType the type used as a source for DataInputs
+ * @param ActionFactoryContext the context provided to Action factories
  */
-template <class DataType> class MatchTreeFactory {
+template <class DataType, class ActionFactoryContext> class MatchTreeFactory {
 public:
-  MatchTreeFactory(const std::string& stats_prefix,
-                   Server::Configuration::FactoryContext& factory_context,
+  MatchTreeFactory(ActionFactoryContext& context,
+                   ProtobufMessage::ValidationVisitor& proto_validation_visitor,
                    MatchTreeValidationVisitor<DataType>& validation_visitor)
-      : stats_prefix_(stats_prefix), factory_context_(factory_context),
+      : action_factory_context_(context), proto_validation_visitor_(proto_validation_visitor),
         validation_visitor_(validation_visitor) {}
 
   MatchTreeFactoryCb<DataType> create(const envoy::config::common::matcher::v3::Matcher& config) {
@@ -200,12 +202,13 @@ private:
         return OnMatch<DataType>{{}, matcher_factory()};
       };
     } else if (on_match.has_action()) {
-      auto& factory = Config::Utility::getAndCheckFactory<ActionFactory>(on_match.action());
+      auto& factory = Config::Utility::getAndCheckFactory<ActionFactory<ActionFactoryContext>>(
+          on_match.action());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          on_match.action().typed_config(), factory_context_.messageValidationVisitor(), factory);
+          on_match.action().typed_config(), proto_validation_visitor_, factory);
 
-      auto action_factory =
-          factory.createActionFactoryCb(*message, stats_prefix_, factory_context_);
+      auto action_factory = factory.createActionFactoryCb(*message, action_factory_context_,
+                                                          proto_validation_visitor_);
       return [action_factory] { return OnMatch<DataType>{action_factory, {}}; };
     }
 
@@ -234,8 +237,8 @@ private:
       validation_visitor_.validateDataInput(*factory, config.typed_config().type_url());
 
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          config.typed_config(), factory_context_.messageValidationVisitor(), *factory);
-      auto data_input = factory->createDataInputFactoryCb(*message, factory_context_);
+          config.typed_config(), proto_validation_visitor_, *factory);
+      auto data_input = factory->createDataInputFactoryCb(*message, proto_validation_visitor_);
       return data_input;
     }
 
@@ -244,9 +247,9 @@ private:
     auto& common_input_factory =
         Config::Utility::getAndCheckFactory<CommonProtocolInputFactory>(config);
     ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-        config.typed_config(), factory_context_.messageValidationVisitor(), common_input_factory);
-    auto common_input =
-        common_input_factory.createCommonProtocolInputFactoryCb(*message, factory_context_);
+        config.typed_config(), proto_validation_visitor_, common_input_factory);
+    auto common_input = common_input_factory.createCommonProtocolInputFactoryCb(
+        *message, proto_validation_visitor_);
     return
         [common_input]() { return std::make_unique<CommonProtocolInputWrapper>(common_input()); };
   }
@@ -265,9 +268,8 @@ private:
       auto& factory =
           Config::Utility::getAndCheckFactory<InputMatcherFactory>(predicate.custom_match());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          predicate.custom_match().typed_config(), factory_context_.messageValidationVisitor(),
-          factory);
-      return factory.createInputMatcherFactoryCb(*message, factory_context_);
+          predicate.custom_match().typed_config(), proto_validation_visitor_, factory);
+      return factory.createInputMatcherFactoryCb(*message, proto_validation_visitor_);
     }
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;
@@ -275,7 +277,8 @@ private:
   }
 
   const std::string stats_prefix_;
-  Server::Configuration::FactoryContext& factory_context_;
+  ActionFactoryContext& action_factory_context_;
+  ProtobufMessage::ValidationVisitor& proto_validation_visitor_;
   MatchTreeValidationVisitor<DataType>& validation_visitor_;
 };
 } // namespace Matcher

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -72,9 +72,9 @@ template <class DataType> using DataInputFactoryCb = std::function<DataInputPtr<
 template <class DataType, class ActionFactoryContext> class MatchTreeFactory {
 public:
   MatchTreeFactory(ActionFactoryContext& context,
-                   ProtobufMessage::ValidationVisitor& proto_validation_visitor,
+                   Server::Configuration::ServerFactoryContext& server_factory_context,
                    MatchTreeValidationVisitor<DataType>& validation_visitor)
-      : action_factory_context_(context), proto_validation_visitor_(proto_validation_visitor),
+      : action_factory_context_(context), server_factory_context_(server_factory_context),
         validation_visitor_(validation_visitor) {}
 
   MatchTreeFactoryCb<DataType> create(const envoy::config::common::matcher::v3::Matcher& config) {
@@ -205,10 +205,11 @@ private:
       auto& factory = Config::Utility::getAndCheckFactory<ActionFactory<ActionFactoryContext>>(
           on_match.action());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          on_match.action().typed_config(), proto_validation_visitor_, factory);
+          on_match.action().typed_config(), server_factory_context_.messageValidationVisitor(),
+          factory);
 
-      auto action_factory = factory.createActionFactoryCb(*message, action_factory_context_,
-                                                          proto_validation_visitor_);
+      auto action_factory = factory.createActionFactoryCb(
+          *message, action_factory_context_, server_factory_context_.messageValidationVisitor());
       return [action_factory] { return OnMatch<DataType>{action_factory, {}}; };
     }
 
@@ -237,8 +238,9 @@ private:
       validation_visitor_.validateDataInput(*factory, config.typed_config().type_url());
 
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          config.typed_config(), proto_validation_visitor_, *factory);
-      auto data_input = factory->createDataInputFactoryCb(*message, proto_validation_visitor_);
+          config.typed_config(), server_factory_context_.messageValidationVisitor(), *factory);
+      auto data_input = factory->createDataInputFactoryCb(
+          *message, server_factory_context_.messageValidationVisitor());
       return data_input;
     }
 
@@ -247,9 +249,10 @@ private:
     auto& common_input_factory =
         Config::Utility::getAndCheckFactory<CommonProtocolInputFactory>(config);
     ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-        config.typed_config(), proto_validation_visitor_, common_input_factory);
+        config.typed_config(), server_factory_context_.messageValidationVisitor(),
+        common_input_factory);
     auto common_input = common_input_factory.createCommonProtocolInputFactoryCb(
-        *message, proto_validation_visitor_);
+        *message, server_factory_context_.messageValidationVisitor());
     return
         [common_input]() { return std::make_unique<CommonProtocolInputWrapper>(common_input()); };
   }
@@ -268,8 +271,9 @@ private:
       auto& factory =
           Config::Utility::getAndCheckFactory<InputMatcherFactory>(predicate.custom_match());
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-          predicate.custom_match().typed_config(), proto_validation_visitor_, factory);
-      return factory.createInputMatcherFactoryCb(*message, proto_validation_visitor_);
+          predicate.custom_match().typed_config(),
+          server_factory_context_.messageValidationVisitor(), factory);
+      return factory.createInputMatcherFactoryCb(*message, server_factory_context_);
     }
     default:
       NOT_REACHED_GCOVR_EXCL_LINE;
@@ -278,7 +282,7 @@ private:
 
   const std::string stats_prefix_;
   ActionFactoryContext& action_factory_context_;
-  ProtobufMessage::ValidationVisitor& proto_validation_visitor_;
+  Server::Configuration::ServerFactoryContext& server_factory_context_;
   MatchTreeValidationVisitor<DataType>& validation_visitor_;
 };
 } // namespace Matcher

--- a/source/extensions/filters/http/composite/BUILD
+++ b/source/extensions/filters/http/composite/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     srcs = ["action.cc"],
     hdrs = ["action.h"],
     deps = [
+        "//source/common/http/matching:data_impl_lib",
         "//source/common/matcher:matcher_lib",
         "@envoy_api//envoy/extensions/filters/http/composite/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -7,7 +7,8 @@ namespace Composite {
 void ExecuteFilterAction::createFilters(Http::FilterChainFactoryCallbacks& callbacks) const {
   cb_(callbacks);
 }
-REGISTER_FACTORY(ExecuteFilterActionFactory, Matcher::ActionFactory);
+REGISTER_FACTORY(ExecuteFilterActionFactory,
+                 Matcher::ActionFactory<Http::Matching::HttpFilterActionContext>);
 } // namespace Composite
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -2,6 +2,7 @@
 
 #include "envoy/extensions/filters/http/composite/v3/composite.pb.validate.h"
 
+#include "source/common/http/matching/data_impl.h"
 #include "source/common/matcher/matcher.h"
 
 namespace Envoy {
@@ -21,23 +22,25 @@ private:
   Http::FilterFactoryCb cb_;
 };
 
-class ExecuteFilterActionFactory : public Matcher::ActionFactory {
+class ExecuteFilterActionFactory
+    : public Matcher::ActionFactory<Http::Matching::HttpFilterActionContext> {
 public:
   std::string name() const override { return "composite-action"; }
   Matcher::ActionFactoryCb
-  createActionFactoryCb(const Protobuf::Message& config, const std::string& stat_prefix,
-                        Server::Configuration::FactoryContext& factory_context) override {
+  createActionFactoryCb(const Protobuf::Message& config,
+                        Http::Matching::HttpFilterActionContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override {
     const auto& composite_action = MessageUtil::downcastAndValidate<
         const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction&>(
-        config, factory_context.messageValidationVisitor());
+        config, validation_visitor);
 
     auto& factory =
         Config::Utility::getAndCheckFactory<Server::Configuration::NamedHttpFilterConfigFactory>(
             composite_action.typed_config());
     ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-        composite_action.typed_config().typed_config(), factory_context.messageValidationVisitor(),
-        factory);
-    auto callback = factory.createFilterFactoryFromProto(*message, stat_prefix, factory_context);
+        composite_action.typed_config().typed_config(), validation_visitor, factory);
+    auto callback = factory.createFilterFactoryFromProto(*message, context.stat_prefix_,
+                                                         context.factory_context_);
     return [cb = std::move(callback)]() -> Matcher::ActionPtr {
       return std::make_unique<ExecuteFilterAction>(cb);
     };

--- a/source/extensions/matching/common_inputs/environment_variable/config.cc
+++ b/source/extensions/matching/common_inputs/environment_variable/config.cc
@@ -12,10 +12,10 @@ namespace EnvironmentVariable {
 
 Envoy::Matcher::CommonProtocolInputFactoryCb
 Config::createCommonProtocolInputFactoryCb(const Protobuf::Message& config,
-                                           Server::Configuration::FactoryContext& factory_context) {
+                                           ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& environment_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::matching::common_inputs::environment_variable::v3::Config&>(
-      config, factory_context.messageValidationVisitor());
+      config, validation_visitor);
 
   // We read the env variable at construction time to avoid repeat lookups.
   // This assumes that the environment remains stable during the process lifetime.

--- a/source/extensions/matching/common_inputs/environment_variable/config.h
+++ b/source/extensions/matching/common_inputs/environment_variable/config.h
@@ -18,7 +18,7 @@ class Config : public Envoy::Matcher::CommonProtocolInputFactory {
 public:
   Envoy::Matcher::CommonProtocolInputFactoryCb createCommonProtocolInputFactoryCb(
       const Protobuf::Message& config,
-      Server::Configuration::FactoryContext& factory_context) override;
+      ProtobufMessage::ValidationVisitor& validation_visitor) override;
 
   std::string name() const override { return "envoy.matching.common_inputs.environment_variable"; }
 

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.cc
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.cc
@@ -7,11 +7,11 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 Envoy::Matcher::InputMatcherFactoryCb ConsistentHashingConfig::createInputMatcherFactoryCb(
-    const Protobuf::Message& config, Server::Configuration::FactoryContext& factory_context) {
+    const Protobuf::Message& config, ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& consistent_hashing_config =
       MessageUtil::downcastAndValidate<const envoy::extensions::matching::input_matchers::
                                            consistent_hashing::v3::ConsistentHashing&>(
-          config, factory_context.messageValidationVisitor());
+          config, validation_visitor);
 
   if (consistent_hashing_config.threshold() > consistent_hashing_config.modulo()) {
     throw EnvoyException(fmt::format("threshold cannot be greater than modulo: {} > {}",

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.cc
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.cc
@@ -7,11 +7,11 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 Envoy::Matcher::InputMatcherFactoryCb ConsistentHashingConfig::createInputMatcherFactoryCb(
-    const Protobuf::Message& config, ProtobufMessage::ValidationVisitor& validation_visitor) {
+    const Protobuf::Message& config, Server::Configuration::ServerFactoryContext& factory_context) {
   const auto& consistent_hashing_config =
       MessageUtil::downcastAndValidate<const envoy::extensions::matching::input_matchers::
                                            consistent_hashing::v3::ConsistentHashing&>(
-          config, validation_visitor);
+          config, factory_context.messageValidationVisitor());
 
   if (consistent_hashing_config.threshold() > consistent_hashing_config.modulo()) {
     throw EnvoyException(fmt::format("threshold cannot be greater than modulo: {} > {}",

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.h
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.h
@@ -18,7 +18,7 @@ class ConsistentHashingConfig : public Envoy::Matcher::InputMatcherFactory {
 public:
   Envoy::Matcher::InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              Server::Configuration::FactoryContext& factory_context) override;
+                              ProtobufMessage::ValidationVisitor& validation_visitor) override;
 
   std::string name() const override { return "envoy.matching.matchers.consistent_hashing"; }
 

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.h
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.h
@@ -18,7 +18,7 @@ class ConsistentHashingConfig : public Envoy::Matcher::InputMatcherFactory {
 public:
   Envoy::Matcher::InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  Server::Configuration::ServerFactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.consistent_hashing"; }
 

--- a/source/extensions/matching/input_matchers/consistent_hashing/config.h
+++ b/source/extensions/matching/input_matchers/consistent_hashing/config.h
@@ -16,9 +16,9 @@ namespace ConsistentHashing {
 
 class ConsistentHashingConfig : public Envoy::Matcher::InputMatcherFactory {
 public:
-  Envoy::Matcher::InputMatcherFactoryCb
-  createInputMatcherFactoryCb(const Protobuf::Message& config,
-  Server::Configuration::ServerFactoryContext& factory_context) override;
+  Envoy::Matcher::InputMatcherFactoryCb createInputMatcherFactoryCb(
+      const Protobuf::Message& config,
+      Server::Configuration::ServerFactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.consistent_hashing"; }
 

--- a/source/extensions/matching/input_matchers/ip/config.cc
+++ b/source/extensions/matching/input_matchers/ip/config.cc
@@ -8,10 +8,10 @@ namespace IP {
 
 Envoy::Matcher::InputMatcherFactoryCb
 Config::createInputMatcherFactoryCb(const Protobuf::Message& config,
-                                    Server::Configuration::FactoryContext& context) {
+                                   Server::Configuration::ServerFactoryContext& factory_context) {
   const auto& ip_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::matching::input_matchers::ip::v3::Ip&>(
-      config, context.messageValidationVisitor());
+      config, factory_context.messageValidationVisitor());
 
   const auto& cidr_ranges = ip_config.cidr_ranges();
   std::vector<Network::Address::CidrRange> ranges;
@@ -30,7 +30,7 @@ Config::createInputMatcherFactoryCb(const Protobuf::Message& config,
   }
 
   const std::string& stat_prefix = ip_config.stat_prefix();
-  Stats::Scope& scope = context.scope();
+  Stats::Scope& scope = factory_context.scope();
   return [ranges, stat_prefix, &scope]() {
     return std::make_unique<Matcher>(ranges, stat_prefix, scope);
   };

--- a/source/extensions/matching/input_matchers/ip/config.cc
+++ b/source/extensions/matching/input_matchers/ip/config.cc
@@ -8,7 +8,7 @@ namespace IP {
 
 Envoy::Matcher::InputMatcherFactoryCb
 Config::createInputMatcherFactoryCb(const Protobuf::Message& config,
-                                   Server::Configuration::ServerFactoryContext& factory_context) {
+                                    Server::Configuration::ServerFactoryContext& factory_context) {
   const auto& ip_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::matching::input_matchers::ip::v3::Ip&>(
       config, factory_context.messageValidationVisitor());

--- a/source/extensions/matching/input_matchers/ip/config.h
+++ b/source/extensions/matching/input_matchers/ip/config.h
@@ -18,7 +18,7 @@ class Config : public Envoy::Matcher::InputMatcherFactory {
 public:
   Envoy::Matcher::InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              Server::Configuration::FactoryContext& factory_context) override;
+                              Server::Configuration::ServerFactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.ip"; }
 

--- a/source/extensions/matching/input_matchers/ip/config.h
+++ b/source/extensions/matching/input_matchers/ip/config.h
@@ -16,9 +16,9 @@ namespace IP {
 
 class Config : public Envoy::Matcher::InputMatcherFactory {
 public:
-  Envoy::Matcher::InputMatcherFactoryCb
-  createInputMatcherFactoryCb(const Protobuf::Message& config,
-                              Server::Configuration::ServerFactoryContext& factory_context) override;
+  Envoy::Matcher::InputMatcherFactoryCb createInputMatcherFactoryCb(
+      const Protobuf::Message& config,
+      Server::Configuration::ServerFactoryContext& factory_context) override;
 
   std::string name() const override { return "envoy.matching.matchers.ip"; }
 

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -22,12 +22,16 @@ namespace Envoy {
 namespace Matcher {
 class MatcherTest : public ::testing::Test {
 public:
-  MatcherTest() : inject_action_(action_factory_) {}
+  MatcherTest()
+      : inject_action_(action_factory_),
+        factory_(context_, ProtobufMessage::getStrictValidationVisitor(), validation_visitor_) {}
 
   StringActionFactory action_factory_;
-  Registry::InjectFactory<ActionFactory> inject_action_;
-  NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
+  Registry::InjectFactory<ActionFactory<absl::string_view>> inject_action_;
   MockMatchTreeValidationVisitor<TestData> validation_visitor_;
+
+  absl::string_view context_ = "";
+  MatchTreeFactory<TestData, absl::string_view> factory_;
 };
 
 TEST_F(MatcherTest, TestMatcher) {
@@ -64,15 +68,13 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
-
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(2);
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -104,10 +106,9 @@ matcher_list:
   MessageUtil::loadFromYaml(yaml, matcher, ProtobufMessage::getStrictValidationVisitor());
 
   TestUtility::validate(matcher);
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
 
   auto common_input_factory = TestCommonProtocolInputFactory("generic", "foo");
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -141,14 +142,12 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
-
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
   NeverMatchFactory match_factory;
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"));
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -198,15 +197,13 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
-
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(3);
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -257,15 +254,13 @@ matcher_tree:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
-
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(3);
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -299,14 +294,12 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
-
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
   NeverMatchFactory match_factory;
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"));
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
@@ -350,15 +343,13 @@ matcher_list:
 
   TestUtility::validate(matcher);
 
-  MatchTreeFactory<TestData> factory("", factory_context_, validation_visitor_);
-
   auto outer_factory = TestDataInputFactory("outer_input", "value");
   auto inner_factory = TestDataInputFactory("inner_input", "foo");
 
   EXPECT_CALL(validation_visitor_,
               performDataInputValidation(_, "type.googleapis.com/google.protobuf.StringValue"))
       .Times(2);
-  auto match_tree = factory.create(matcher);
+  auto match_tree = factory_.create(matcher);
 
   const auto result = match_tree()->match(TestData());
   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);

--- a/test/common/matcher/matcher_test.cc
+++ b/test/common/matcher/matcher_test.cc
@@ -23,14 +23,15 @@ namespace Matcher {
 class MatcherTest : public ::testing::Test {
 public:
   MatcherTest()
-      : inject_action_(action_factory_),
-        factory_(context_, ProtobufMessage::getStrictValidationVisitor(), validation_visitor_) {}
+      : inject_action_(action_factory_), factory_(context_, factory_context_, validation_visitor_) {
+  }
 
   StringActionFactory action_factory_;
   Registry::InjectFactory<ActionFactory<absl::string_view>> inject_action_;
   MockMatchTreeValidationVisitor<TestData> validation_visitor_;
 
   absl::string_view context_ = "";
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   MatchTreeFactory<TestData, absl::string_view> factory_;
 };
 

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -30,7 +30,7 @@ public:
 
   CommonProtocolInputFactoryCb
   createCommonProtocolInputFactoryCb(const Protobuf::Message&,
-                                     Server::Configuration::FactoryContext&) override {
+                                     ProtobufMessage::ValidationVisitor&) override {
     return [&]() { return std::make_unique<CommonProtocolTestInput>(value_); };
   }
 
@@ -60,8 +60,7 @@ public:
       : factory_name_(std::string(factory_name)), value_(std::string(data)), injection_(*this) {}
 
   DataInputFactoryCb<TestData>
-  createDataInputFactoryCb(const Protobuf::Message&,
-                           Server::Configuration::FactoryContext&) override {
+  createDataInputFactoryCb(const Protobuf::Message&, ProtobufMessage::ValidationVisitor&) override {
     return [&]() {
       return std::make_unique<TestInput>(
           DataInputGetResult{DataInputGetResult::DataAvailability::AllDataAvailable, value_});
@@ -108,10 +107,10 @@ struct StringAction : public ActionBase<ProtobufWkt::StringValue> {
 };
 
 // Factory for StringAction.
-class StringActionFactory : public ActionFactory {
+class StringActionFactory : public ActionFactory<absl::string_view> {
 public:
-  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config, const std::string&,
-                                        Server::Configuration::FactoryContext&) override {
+  ActionFactoryCb createActionFactoryCb(const Protobuf::Message& config, absl::string_view&,
+                                        ProtobufMessage::ValidationVisitor&) override {
     const auto& string = dynamic_cast<const ProtobufWkt::StringValue&>(config);
     return [string]() { return std::make_unique<StringAction>(string.value()); };
   }
@@ -135,9 +134,8 @@ class NeverMatchFactory : public InputMatcherFactory {
 public:
   NeverMatchFactory() : inject_factory_(*this) {}
 
-  InputMatcherFactoryCb
-  createInputMatcherFactoryCb(const Protobuf::Message&,
-                              Server::Configuration::FactoryContext&) override {
+  InputMatcherFactoryCb createInputMatcherFactoryCb(const Protobuf::Message&,
+                                                    ProtobufMessage::ValidationVisitor&) override {
     return []() { return std::make_unique<NeverMatch>(); };
   }
 

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -134,8 +134,9 @@ class NeverMatchFactory : public InputMatcherFactory {
 public:
   NeverMatchFactory() : inject_factory_(*this) {}
 
-  InputMatcherFactoryCb createInputMatcherFactoryCb(const Protobuf::Message&,
-                                                    ProtobufMessage::ValidationVisitor&) override {
+  InputMatcherFactoryCb
+  createInputMatcherFactoryCb(const Protobuf::Message&,
+                              Server::Configuration::ServerFactoryContext&) override {
     return []() { return std::make_unique<NeverMatch>(); };
   }
 

--- a/test/extensions/matching/common_inputs/environment_variable/config_test.cc
+++ b/test/extensions/matching/common_inputs/environment_variable/config_test.cc
@@ -13,8 +13,6 @@ namespace CommonInputs {
 namespace EnvironmentVariable {
 
 TEST(ConfigTest, TestConfig) {
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -30,14 +28,16 @@ TEST(ConfigTest, TestConfig) {
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
 
   {
-    auto input_factory = factory.createCommonProtocolInputFactoryCb(*message, context);
+    auto input_factory = factory.createCommonProtocolInputFactoryCb(
+        *message, ProtobufMessage::getStrictValidationVisitor());
     EXPECT_NE(nullptr, input_factory);
     EXPECT_EQ(input_factory()->get(), absl::nullopt);
   }
 
   TestEnvironment::setEnvVar("foo", "bar", 1);
   {
-    auto input_factory = factory.createCommonProtocolInputFactoryCb(*message, context);
+    auto input_factory = factory.createCommonProtocolInputFactoryCb(
+        *message, ProtobufMessage::getStrictValidationVisitor());
     EXPECT_NE(nullptr, input_factory);
     EXPECT_EQ(input_factory()->get(), absl::make_optional("bar"));
   }

--- a/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
+++ b/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
@@ -11,8 +11,6 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 TEST(ConfigTest, TestConfig) {
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -27,14 +25,13 @@ TEST(ConfigTest, TestConfig) {
   ConsistentHashingConfig factory;
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  auto matcher = factory.createInputMatcherFactoryCb(*message, context);
+  auto matcher =
+      factory.createInputMatcherFactoryCb(*message, ProtobufMessage::getStrictValidationVisitor());
   ASSERT_NE(nullptr, matcher);
   matcher();
 }
 
 TEST(ConfigTest, InvalidConfig) {
-  NiceMock<Server::Configuration::MockFactoryContext> context;
-
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -49,8 +46,9 @@ TEST(ConfigTest, InvalidConfig) {
   ConsistentHashingConfig factory;
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  EXPECT_THROW_WITH_MESSAGE(factory.createInputMatcherFactoryCb(*message, context), EnvoyException,
-                            "threshold cannot be greater than modulo: 200 > 100");
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createInputMatcherFactoryCb(*message, ProtobufMessage::getStrictValidationVisitor()),
+      EnvoyException, "threshold cannot be greater than modulo: 200 > 100");
 }
 } // namespace ConsistentHashing
 } // namespace InputMatchers

--- a/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
+++ b/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
@@ -26,8 +26,7 @@ TEST(ConfigTest, TestConfig) {
   ConsistentHashingConfig factory;
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  auto matcher =
-      factory.createInputMatcherFactoryCb(*message, factory_context);
+  auto matcher = factory.createInputMatcherFactoryCb(*message, factory_context);
   ASSERT_NE(nullptr, matcher);
   matcher();
 }
@@ -49,9 +48,8 @@ TEST(ConfigTest, InvalidConfig) {
   ConsistentHashingConfig factory;
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createInputMatcherFactoryCb(*message, factory_context),
-      EnvoyException, "threshold cannot be greater than modulo: 200 > 100");
+  EXPECT_THROW_WITH_MESSAGE(factory.createInputMatcherFactoryCb(*message, factory_context),
+                            EnvoyException, "threshold cannot be greater than modulo: 200 > 100");
 }
 } // namespace ConsistentHashing
 } // namespace InputMatchers

--- a/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
+++ b/test/extensions/matching/input_matchers/consistent_hashing/config_test.cc
@@ -11,6 +11,7 @@ namespace InputMatchers {
 namespace ConsistentHashing {
 
 TEST(ConfigTest, TestConfig) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -26,12 +27,14 @@ TEST(ConfigTest, TestConfig) {
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
   auto matcher =
-      factory.createInputMatcherFactoryCb(*message, ProtobufMessage::getStrictValidationVisitor());
+      factory.createInputMatcherFactoryCb(*message, factory_context);
   ASSERT_NE(nullptr, matcher);
   matcher();
 }
 
 TEST(ConfigTest, InvalidConfig) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+
   const std::string yaml_string = R"EOF(
     name: hashing
     typed_config:
@@ -47,7 +50,7 @@ TEST(ConfigTest, InvalidConfig) {
   auto message = Config::Utility::translateAnyToFactoryConfig(
       config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), factory);
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createInputMatcherFactoryCb(*message, ProtobufMessage::getStrictValidationVisitor()),
+      factory.createInputMatcherFactoryCb(*message, factory_context),
       EnvoyException, "threshold cannot be greater than modulo: 200 > 100");
 }
 } // namespace ConsistentHashing

--- a/test/extensions/matching/input_matchers/ip/config_test.cc
+++ b/test/extensions/matching/input_matchers/ip/config_test.cc
@@ -11,7 +11,7 @@ namespace InputMatchers {
 namespace IP {
 
 TEST(ConfigTest, TestConfig) {
-  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   const std::string yaml_string = R"EOF(
     name: ip
@@ -34,7 +34,7 @@ TEST(ConfigTest, TestConfig) {
 }
 
 TEST(ConfigTest, InvalidConfigIP) {
-  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   const std::string yaml_string = R"EOF(
     name: ip
@@ -57,7 +57,7 @@ TEST(ConfigTest, InvalidConfigIP) {
 }
 
 TEST(ConfigTest, InvalidConfigStats) {
-  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   const std::string yaml_string = R"EOF(
     name: ip


### PR DESCRIPTION
…t (#17025)" (#17191)"

This reverts commit 27b4f08738951e203bfabecb18cd0264d413d505.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: n/a
Additional Description: n/a
Risk Level: Low
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
