### PR TITLE
connection_impl: Use early returns to reduce nested code in connection_impl.cc

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -148,59 +148,59 @@ void ConnectionImpl::close(ConnectionCloseType type) {
       closeConnectionImmediately();
       return;
     }
-      // The socket is being closed and either there is no more data to write or the data can not be
-      // flushed (!transport_socket_->canFlushClose()). Since a delayed close has been requested,
-      // start the delayed close timer if it hasn't been done already by a previous close().
-      // NOTE: Even though the delayed_close_state_ is being set to CloseAfterFlushAndWait, since
-      // a write event is not being registered for the socket, this logic is simply setting the
-      // timer and waiting for it to trigger to close the socket.
-      if (!inDelayedClose()) {
-        initializeDelayedCloseTimer();
-        delayed_close_state_ = DelayedCloseState::CloseAfterFlushAndWait;
-        // Monitor for the peer closing the connection.
-        ioHandle().enableFileEvents(enable_half_close_ ? 0 : Event::FileReadyType::Closed);
-      }
+    // The socket is being closed and either there is no more data to write or the data can not be
+    // flushed (!transport_socket_->canFlushClose()). Since a delayed close has been requested,
+    // start the delayed close timer if it hasn't been done already by a previous close().
+    // NOTE: Even though the delayed_close_state_ is being set to CloseAfterFlushAndWait, since
+    // a write event is not being registered for the socket, this logic is simply setting the
+    // timer and waiting for it to trigger to close the socket.
+    if (!inDelayedClose()) {
+      initializeDelayedCloseTimer();
+      delayed_close_state_ = DelayedCloseState::CloseAfterFlushAndWait;
+      // Monitor for the peer closing the connection.
+      ioHandle().enableFileEvents(enable_half_close_ ? 0 : Event::FileReadyType::Closed);
+    }
     return;
   }
 
-    ASSERT(type == ConnectionCloseType::FlushWrite ||
-           type == ConnectionCloseType::FlushWriteAndDelay);
+  ASSERT(type == ConnectionCloseType::FlushWrite ||
+         type == ConnectionCloseType::FlushWriteAndDelay);
 
-    // If there is a pending delayed close, simply update the delayed close state.
-    //
-    // An example of this condition manifests when a downstream connection is closed early by Envoy,
-    // such as when a route can't be matched:
-    //   In ConnectionManagerImpl::onData()
-    //     1) Via codec_->dispatch(), a local reply with a 404 is sent to the client
-    //       a) ConnectionManagerImpl::doEndStream() issues the first connection close() via
-    //          ConnectionManagerImpl::checkForDeferredClose()
-    //     2) A second close is issued by a subsequent call to
-    //        ConnectionManagerImpl::checkForDeferredClose() prior to returning from onData()
-    if (inDelayedClose()) {
-      // Validate that a delayed close timer is already enabled unless it was disabled via
-      // configuration.
-      ASSERT(!delayed_close_timeout_set || delayed_close_timer_ != nullptr);
-      if (type == ConnectionCloseType::FlushWrite || !delayed_close_timeout_set) {
-        delayed_close_state_ = DelayedCloseState::CloseAfterFlush;
-      } else {
-        delayed_close_state_ = DelayedCloseState::CloseAfterFlushAndWait;
-      }
-      return;
-    }
-
-    // NOTE: At this point, it's already been validated that the connection is not already in
-    // delayed close processing and therefore the timer has not yet been created.
-    if (delayed_close_timeout_set) {
-      initializeDelayedCloseTimer();
-      delayed_close_state_ = (type == ConnectionCloseType::FlushWrite)
-                                 ? DelayedCloseState::CloseAfterFlush
-                                 : DelayedCloseState::CloseAfterFlushAndWait;
-    } else {
+  // If there is a pending delayed close, simply update the delayed close state.
+  //
+  // An example of this condition manifests when a downstream connection is closed early by Envoy,
+  // such as when a route can't be matched:
+  //   In ConnectionManagerImpl::onData()
+  //     1) Via codec_->dispatch(), a local reply with a 404 is sent to the client
+  //       a) ConnectionManagerImpl::doEndStream() issues the first connection close() via
+  //          ConnectionManagerImpl::checkForDeferredClose()
+  //     2) A second close is issued by a subsequent call to
+  //        ConnectionManagerImpl::checkForDeferredClose() prior to returning from onData()
+  if (inDelayedClose()) {
+    // Validate that a delayed close timer is already enabled unless it was disabled via
+    // configuration.
+    ASSERT(!delayed_close_timeout_set || delayed_close_timer_ != nullptr);
+    if (type == ConnectionCloseType::FlushWrite || !delayed_close_timeout_set) {
       delayed_close_state_ = DelayedCloseState::CloseAfterFlush;
+    } else {
+      delayed_close_state_ = DelayedCloseState::CloseAfterFlushAndWait;
     }
+    return;
+  }
 
-    ioHandle().enableFileEvents(Event::FileReadyType::Write |
-                                (enable_half_close_ ? 0 : Event::FileReadyType::Closed));
+  // NOTE: At this point, it's already been validated that the connection is not already in
+  // delayed close processing and therefore the timer has not yet been created.
+  if (delayed_close_timeout_set) {
+    initializeDelayedCloseTimer();
+    delayed_close_state_ = (type == ConnectionCloseType::FlushWrite)
+                               ? DelayedCloseState::CloseAfterFlush
+                               : DelayedCloseState::CloseAfterFlushAndWait;
+  } else {
+    delayed_close_state_ = DelayedCloseState::CloseAfterFlush;
+  }
+
+  ioHandle().enableFileEvents(Event::FileReadyType::Write |
+                              (enable_half_close_ ? 0 : Event::FileReadyType::Closed));
 }
 
 Connection::State ConnectionImpl::state() const {
@@ -828,37 +828,37 @@ ClientConnectionImpl::ClientConnectionImpl(
   if (remote_address->ip() != nullptr) {
     return;
   }
-    if (!Network::Socket::applyOptions(options, *socket_,
-                                       envoy::config::core::v3::SocketOption::STATE_PREBIND)) {
+  if (!Network::Socket::applyOptions(options, *socket_,
+                                     envoy::config::core::v3::SocketOption::STATE_PREBIND)) {
+    // Set a special error state to ensure asynchronous close to give the owner of the
+    // ConnectionImpl a chance to add callbacks and detect the "disconnect".
+    immediate_error_event_ = ConnectionEvent::LocalClose;
+    // Trigger a write event to close this connection out-of-band.
+    ioHandle().activateFileEvents(Event::FileReadyType::Write);
+    return;
+  }
+
+  const Network::Address::InstanceConstSharedPtr* source = &source_address;
+
+  if (socket_->addressProvider().localAddress()) {
+    source = &socket_->addressProvider().localAddress();
+  }
+
+  if (*source != nullptr) {
+    Api::SysCallIntResult result = socket_->bind(*source);
+    if (result.rc_ < 0) {
+      // TODO(lizan): consider add this error into transportFailureReason.
+      ENVOY_LOG_MISC(debug, "Bind failure. Failed to bind to {}: {}", source->get()->asString(),
+                     errorDetails(result.errno_));
+      bind_error_ = true;
       // Set a special error state to ensure asynchronous close to give the owner of the
       // ConnectionImpl a chance to add callbacks and detect the "disconnect".
       immediate_error_event_ = ConnectionEvent::LocalClose;
+
       // Trigger a write event to close this connection out-of-band.
       ioHandle().activateFileEvents(Event::FileReadyType::Write);
-      return;
     }
-
-    const Network::Address::InstanceConstSharedPtr* source = &source_address;
-
-    if (socket_->addressProvider().localAddress()) {
-      source = &socket_->addressProvider().localAddress();
-    }
-
-    if (*source != nullptr) {
-      Api::SysCallIntResult result = socket_->bind(*source);
-      if (result.rc_ < 0) {
-        // TODO(lizan): consider add this error into transportFailureReason.
-        ENVOY_LOG_MISC(debug, "Bind failure. Failed to bind to {}: {}", source->get()->asString(),
-                       errorDetails(result.errno_));
-        bind_error_ = true;
-        // Set a special error state to ensure asynchronous close to give the owner of the
-        // ConnectionImpl a chance to add callbacks and detect the "disconnect".
-        immediate_error_event_ = ConnectionEvent::LocalClose;
-
-        // Trigger a write event to close this connection out-of-band.
-        ioHandle().activateFileEvents(Event::FileReadyType::Write);
-      }
-    }
+  }
 }
 
 void ClientConnectionImpl::connect() {
@@ -889,7 +889,7 @@ void ClientConnectionImpl::connect() {
 
     // Trigger a write event. This is needed on macOS and seems harmless on Linux.
     ioHandle().activateFileEvents(Event::FileReadyType::Write);
-   }
+  }
 }
 
 } // namespace Network

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -144,7 +144,7 @@ void ConnectionImpl::close(ConnectionCloseType type) {
       transport_socket_->doWrite(*write_buffer_, true);
     }
 
-    if (type != ConnectionCloseType::FlushWriteAndDelay && !delayed_close_timeout_set) {
+    if (type != ConnectionCloseType::FlushWriteAndDelay || !delayed_close_timeout_set) {
       closeConnectionImmediately();
       return;
     }
@@ -825,7 +825,7 @@ ClientConnectionImpl::ClientConnectionImpl(
       stream_info_(dispatcher.timeSource(), socket_->addressProviderSharedPtr()) {
   // There are no meaningful socket options or source address semantics for
   // non-IP sockets, so skip.
-  if (remote_address->ip() != nullptr) {
+  if (remote_address->ip() == nullptr) {
     return;
   }
   if (!Network::Socket::applyOptions(options, *socket_,


### PR DESCRIPTION
connection_impl: Use early returns to reduce nested code in connection_impl.cc

No code change, just refactoring.

Risk Level: Low
Testing: N/A - no code change
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A