### PR TITLE
Fix bazel.msan bazel-build-options argument

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -285,7 +285,7 @@ elif [[ "$CI_TARGET" == "bazel.msan" ]]; then
   ENVOY_STDLIB=libc++
   setup_clang_toolchain
   # rbe-toolchain-msan must comes as first to win library link order.
-  BAZEL_BUILD_OPTIONS=("--config=rbe-toolchain-msan" "${BAZEL_BUILD_OPTIONS[@]}" "-c dbg" "--build_tests_only")
+  BAZEL_BUILD_OPTIONS=("--config=rbe-toolchain-msan" "${BAZEL_BUILD_OPTIONS[@]}" "-c" "dbg" "--build_tests_only")
   echo "bazel MSAN debug build with tests"
   echo "Building and testing envoy tests ${TEST_TARGETS[*]}"
   bazel_with_collection test "${BAZEL_BUILD_OPTIONS[@]}" "${TEST_TARGETS[@]}"


### PR DESCRIPTION
Commit Message:
Update usage of `"-c dbg"` in array to be `"-c" "dbg"` to prevent it from being
interpreted as a single argument with a space. This makes the usage consistent
with other usages in this file.

The existing format has been observed to cause issues:
```
ERROR: -c dbg :: Invalid options syntax: -c dbg
```

Additional Description:
Risk Level: low
Testing: Covered by successful CI run
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
