### PR TITLE
wasm: allow partial buffer replacement/drains.

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -122,16 +122,11 @@ WasmResult Buffer::copyTo(WasmBase* wasm, size_t start, size_t length, uint64_t 
 WasmResult Buffer::copyFrom(size_t start, size_t length, std::string_view data) {
   if (buffer_instance_) {
     if (start == 0) {
-      if (length == 0) {
-        buffer_instance_->prepend(toAbslStringView(data));
-        return WasmResult::Ok;
-      } else if (length >= buffer_instance_->length()) {
-        buffer_instance_->drain(buffer_instance_->length());
-        buffer_instance_->add(toAbslStringView(data));
-        return WasmResult::Ok;
-      } else {
-        return WasmResult::BadArgument;
+      if (length != 0) {
+        buffer_instance_->drain(length);
       }
+      buffer_instance_->prepend(toAbslStringView(data));
+      return WasmResult::Ok;
     } else if (start >= buffer_instance_->length()) {
       buffer_instance_->add(toAbslStringView(data));
       return WasmResult::Ok;

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -477,7 +477,6 @@ TEST_P(WasmCommonTest, Utilities) {
               buffer.copyTo(wasm.get(), 0, 1, 1 << 30 /* bad pointer location */, 0));
     EXPECT_EQ(WasmResult::InvalidMemoryAccess,
               buffer.copyTo(wasm.get(), 0, 1, 0, 1 << 30 /* bad size location */));
-    EXPECT_EQ(WasmResult::BadArgument, buffer.copyFrom(0, 1, data));
     EXPECT_EQ(WasmResult::BadArgument, buffer.copyFrom(1, 1, data));
     EXPECT_EQ(WasmResult::BadArgument, const_buffer.copyFrom(1, 1, data));
     EXPECT_EQ(WasmResult::BadArgument, string_buffer.copyFrom(1, 1, data));

--- a/test/extensions/filters/http/wasm/test_data/body_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/body_rust.rs
@@ -18,6 +18,15 @@ struct TestStream {
     body_chunks: usize,
 }
 
+impl TestStream {
+    fn log_body(&mut self, body: Option<Bytes>) {
+        error!(
+            "onBody {}",
+            body.map_or(String::from(""), |b| String::from_utf8(b).unwrap())
+        );
+    }
+}
+
 impl HttpContext for TestStream {
     fn on_http_request_headers(&mut self, _: usize) -> Action {
         self.test = self.get_http_request_header("x-test-operation");
@@ -28,35 +37,37 @@ impl HttpContext for TestStream {
     fn on_http_request_body(&mut self, body_size: usize, end_of_stream: bool) -> Action {
         match self.test.as_deref() {
             Some("ReadBody") => {
-                let body = self.get_http_request_body(0, body_size).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("PrependAndAppendToBody") => {
                 self.set_http_request_body(0, 0, b"prepend.");
                 self.set_http_request_body(0xffffffff, 0, b".append");
-                let body = self.get_http_request_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("ReplaceBody") => {
                 self.set_http_request_body(0, 0xffffffff, b"replace");
-                let body = self.get_http_request_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
+                Action::Continue
+            }
+            Some("PartialReplaceBody") => {
+                self.set_http_request_body(0, 1, b"partial.replace.");
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("RemoveBody") => {
                 self.set_http_request_body(0, 0xffffffff, b"");
-                if let Some(body) = self.get_http_request_body(0, 0xffffffff) {
-                    error!("onBody {}", String::from_utf8(body).unwrap());
-                } else {
-                    error!("onBody ");
-                }
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
+                Action::Continue
+            }
+            Some("PartialRemoveBody") => {
+                self.set_http_request_body(0, 1, b"");
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("BufferBody") => {
-                let body = self.get_http_request_body(0, body_size).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -66,8 +77,7 @@ impl HttpContext for TestStream {
             Some("PrependAndAppendToBufferedBody") => {
                 self.set_http_request_body(0, 0, b"prepend.");
                 self.set_http_request_body(0xffffffff, 0, b".append");
-                let body = self.get_http_request_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -76,8 +86,16 @@ impl HttpContext for TestStream {
             }
             Some("ReplaceBufferedBody") => {
                 self.set_http_request_body(0, 0xffffffff, b"replace");
-                let body = self.get_http_request_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
+                if end_of_stream {
+                    Action::Continue
+                } else {
+                    Action::Pause
+                }
+            }
+            Some("PartialReplaceBufferedBody") => {
+                self.set_http_request_body(0, 1, b"partial.replace.");
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -86,11 +104,16 @@ impl HttpContext for TestStream {
             }
             Some("RemoveBufferedBody") => {
                 self.set_http_request_body(0, 0xffffffff, b"");
-                if let Some(body) = self.get_http_request_body(0, 0xffffffff) {
-                    error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
+                if end_of_stream {
+                    Action::Continue
                 } else {
-                    error!("onBody ");
+                    Action::Pause
                 }
+            }
+            Some("PartialRemoveBufferedBody") => {
+                self.set_http_request_body(0, 1, b"");
+                self.log_body(self.get_http_request_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -120,35 +143,37 @@ impl HttpContext for TestStream {
     fn on_http_response_body(&mut self, body_size: usize, end_of_stream: bool) -> Action {
         match self.test.as_deref() {
             Some("ReadBody") => {
-                let body = self.get_http_response_body(0, body_size).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("PrependAndAppendToBody") => {
                 self.set_http_response_body(0, 0, b"prepend.");
                 self.set_http_response_body(0xffffffff, 0, b".append");
-                let body = self.get_http_response_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("ReplaceBody") => {
                 self.set_http_response_body(0, 0xffffffff, b"replace");
-                let body = self.get_http_response_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
+                Action::Continue
+            }
+            Some("PartialReplaceBody") => {
+                self.set_http_response_body(0, 1, b"partial.replace.");
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("RemoveBody") => {
                 self.set_http_response_body(0, 0xffffffff, b"");
-                if let Some(body) = self.get_http_response_body(0, 0xffffffff) {
-                    error!("onBody {}", String::from_utf8(body).unwrap());
-                } else {
-                    error!("onBody ");
-                }
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
+                Action::Continue
+            }
+            Some("PartialRemoveBody") => {
+                self.set_http_response_body(0, 1, b"");
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 Action::Continue
             }
             Some("BufferBody") => {
-                let body = self.get_http_response_body(0, body_size).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -158,8 +183,7 @@ impl HttpContext for TestStream {
             Some("PrependAndAppendToBufferedBody") => {
                 self.set_http_response_body(0, 0, b"prepend.");
                 self.set_http_response_body(0xffffffff, 0, b".append");
-                let body = self.get_http_response_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -168,8 +192,16 @@ impl HttpContext for TestStream {
             }
             Some("ReplaceBufferedBody") => {
                 self.set_http_response_body(0, 0xffffffff, b"replace");
-                let body = self.get_http_response_body(0, 0xffffffff).unwrap();
-                error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
+                if end_of_stream {
+                    Action::Continue
+                } else {
+                    Action::Pause
+                }
+            }
+            Some("PartialReplaceBufferedBody") => {
+                self.set_http_response_body(0, 1, b"partial.replace.");
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {
@@ -178,11 +210,16 @@ impl HttpContext for TestStream {
             }
             Some("RemoveBufferedBody") => {
                 self.set_http_response_body(0, 0xffffffff, b"");
-                if let Some(body) = self.get_http_response_body(0, 0xffffffff) {
-                    error!("onBody {}", String::from_utf8(body).unwrap());
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
+                if end_of_stream {
+                    Action::Continue
                 } else {
-                    error!("onBody ");
+                    Action::Pause
                 }
+            }
+            Some("PartialRemoveBufferedBody") => {
+                self.set_http_response_body(0, 1, b"");
+                self.log_body(self.get_http_response_body(0, 0xffffffff));
                 if end_of_stream {
                     Action::Continue
                 } else {

--- a/test/extensions/filters/http/wasm/test_data/test_body_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_body_cpp.cc
@@ -49,51 +49,64 @@ FilterDataStatus BodyContext::onBody(WasmBufferType type, size_t buffer_length,
   size_t size;
   uint32_t flags;
   if (body_op_ == "ReadBody") {
-    auto body = getBufferBytes(type, 0, buffer_length);
-    logError("onBody " + std::string(body->view()));
+    logBody(type);
+    return FilterDataStatus::Continue;
 
   } else if (body_op_ == "PrependAndAppendToBody") {
-    setBuffer(WasmBufferType::HttpRequestBody, 0, 0, "prepend.");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    setBuffer(WasmBufferType::HttpRequestBody, size, 0, ".append");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    auto updated = getBufferBytes(WasmBufferType::HttpRequestBody, 0, size);
-    logError("onBody " + std::string(updated->view()));
-    return FilterDataStatus::StopIterationNoBuffer;
+    setBuffer(type, 0, 0, "prepend.");
+    getBufferStatus(type, &size, &flags);
+    setBuffer(type, size, 0, ".append");
+    logBody(type);
+    return FilterDataStatus::Continue;
+
   } else if (body_op_ == "ReplaceBody") {
-    setBuffer(WasmBufferType::HttpRequestBody, 0, buffer_length, "replace");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    auto replaced = getBufferBytes(WasmBufferType::HttpRequestBody, 0, size);
-    logError("onBody " + std::string(replaced->view()));
-    return FilterDataStatus::StopIterationAndWatermark;
+    setBuffer(type, 0, buffer_length, "replace");
+    logBody(type);
+    return FilterDataStatus::Continue;
+
+  } else if (body_op_ == "PartialReplaceBody") {
+    setBuffer(type, 0, 1, "partial.replace.");
+    logBody(type);
+    return FilterDataStatus::Continue;
+
   } else if (body_op_ == "RemoveBody") {
-    setBuffer(WasmBufferType::HttpRequestBody, 0, buffer_length, "");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    auto erased = getBufferBytes(WasmBufferType::HttpRequestBody, 0, size);
-    logError("onBody " + std::string(erased->view()));
+    setBuffer(type, 0, buffer_length, "");
+    logBody(type);
+    return FilterDataStatus::Continue;
+
+  } else if (body_op_ == "PartialRemoveBody") {
+    setBuffer(type, 0, 1, "");
+    logBody(type);
+    return FilterDataStatus::Continue;
 
   } else if (body_op_ == "BufferBody") {
     logBody(type);
     return end_of_stream ? FilterDataStatus::Continue : FilterDataStatus::StopIterationAndBuffer;
 
   } else if (body_op_ == "PrependAndAppendToBufferedBody") {
-    setBuffer(WasmBufferType::HttpRequestBody, 0, 0, "prepend.");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    setBuffer(WasmBufferType::HttpRequestBody, size, 0, ".append");
+    setBuffer(type, 0, 0, "prepend.");
+    getBufferStatus(type, &size, &flags);
+    setBuffer(type, size, 0, ".append");
     logBody(type);
     return end_of_stream ? FilterDataStatus::Continue : FilterDataStatus::StopIterationAndBuffer;
 
   } else if (body_op_ == "ReplaceBufferedBody") {
-    setBuffer(WasmBufferType::HttpRequestBody, 0, buffer_length, "replace");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    auto replaced = getBufferBytes(WasmBufferType::HttpRequestBody, 0, size);
+    setBuffer(type, 0, buffer_length, "replace");
+    logBody(type);
+    return end_of_stream ? FilterDataStatus::Continue : FilterDataStatus::StopIterationAndBuffer;
+
+  } else if (body_op_ == "PartialReplaceBufferedBody") {
+    setBuffer(type, 0, 1, "partial.replace.");
     logBody(type);
     return end_of_stream ? FilterDataStatus::Continue : FilterDataStatus::StopIterationAndBuffer;
 
   } else if (body_op_ == "RemoveBufferedBody") {
-    setBuffer(WasmBufferType::HttpRequestBody, 0, buffer_length, "");
-    getBufferStatus(WasmBufferType::HttpRequestBody, &size, &flags);
-    auto erased = getBufferBytes(WasmBufferType::HttpRequestBody, 0, size);
+    setBuffer(type, 0, buffer_length, "");
+    logBody(type);
+    return end_of_stream ? FilterDataStatus::Continue : FilterDataStatus::StopIterationAndBuffer;
+
+  } else if (body_op_ == "PartialRemoveBufferedBody") {
+    setBuffer(type, 0, 1, "");
     logBody(type);
     return end_of_stream ? FilterDataStatus::Continue : FilterDataStatus::StopIterationAndBuffer;
 

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -380,15 +380,8 @@ TEST_P(WasmHttpFilterTest, BodyRequestPrependAndAppendToBody) {
                                                  {"x-test-operation", "PrependAndAppendToBody"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  if (std::get<1>(GetParam()) == "rust") {
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
-  } else {
-    // This status is not available in the rust SDK.
-    // TODO: update all SDKs to the new revision of the spec and update the tests accordingly.
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter().decodeData(data, true));
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter().encodeData(data, true));
-  }
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
   filter().onDestroy();
 }
 
@@ -401,15 +394,25 @@ TEST_P(WasmHttpFilterTest, BodyRequestReplaceBody) {
                                                  {"x-test-operation", "ReplaceBody"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  if (std::get<1>(GetParam()) == "rust") {
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
-    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
-  } else {
-    // This status is not available in the rust SDK.
-    // TODO: update all SDKs to the new revision of the spec and update the tests accordingly.
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter().decodeData(data, true));
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter().encodeData(data, true));
-  }
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
+  filter().onDestroy();
+}
+
+// Script that replaces the first character in the body.
+TEST_P(WasmHttpFilterTest, BodyRequestPartialReplaceBody) {
+  setupTest("body");
+  setupFilter();
+  EXPECT_CALL(filter(),
+              log_(spdlog::level::err, Eq(absl::string_view("onBody partial.replace.ello"))));
+  EXPECT_CALL(filter(), log_(spdlog::level::err,
+                             Eq(absl::string_view("onBody partial.replace.artial.replace.ello"))));
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
+                                                 {"x-test-operation", "PartialReplaceBody"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
   filter().onDestroy();
 }
 
@@ -420,6 +423,19 @@ TEST_P(WasmHttpFilterTest, BodyRequestRemoveBody) {
   EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody "))));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
                                                  {"x-test-operation", "RemoveBody"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+  filter().onDestroy();
+}
+
+// Script that removes the first character from the body.
+TEST_P(WasmHttpFilterTest, BodyRequestPartialRemoveBody) {
+  setupTest("body");
+  setupFilter();
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody ello"))));
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
+                                                 {"x-test-operation", "PartialRemoveBody"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
@@ -495,6 +511,20 @@ TEST_P(WasmHttpFilterTest, BodyRequestReplaceBufferedBody) {
   filter().onDestroy();
 }
 
+// Script that replaces the first character in the buffered body.
+TEST_P(WasmHttpFilterTest, BodyRequestPartialReplaceBufferedBody) {
+  setupTest("body");
+  setupFilter();
+  EXPECT_CALL(filter(),
+              log_(spdlog::level::err, Eq(absl::string_view("onBody partial.replace.ello"))));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":path", "/"}, {"x-test-operation", "PartialReplaceBufferedBody"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+  filter().onDestroy();
+}
+
 // Script that removes the buffered body.
 TEST_P(WasmHttpFilterTest, BodyRequestRemoveBufferedBody) {
   setupTest("body");
@@ -502,6 +532,19 @@ TEST_P(WasmHttpFilterTest, BodyRequestRemoveBufferedBody) {
   EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody "))));
   Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
                                                  {"x-test-operation", "RemoveBufferedBody"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+  filter().onDestroy();
+}
+
+// Script that removes the first character from the buffered body.
+TEST_P(WasmHttpFilterTest, BodyRequestPartialRemoveBufferedBody) {
+  setupTest("body");
+  setupFilter();
+  EXPECT_CALL(filter(), log_(spdlog::level::err, Eq(absl::string_view("onBody ello"))));
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"},
+                                                 {"x-test-operation", "PartialRemoveBufferedBody"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));


### PR DESCRIPTION
While there, fix Wasm C++ plugin and refactor Wasm Rust plugin.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>