### PR TITLE
tooling: Fix runner log

### DIFF
--- a/tools/base/checker.py
+++ b/tools/base/checker.py
@@ -114,6 +114,7 @@ class Checker(runner.Runner):
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         """Add arguments to the arg parser"""
+        super().add_arguments(parser)
         parser.add_argument(
             "--fix", action="store_true", default=False, help="Attempt to fix in place")
         parser.add_argument(
@@ -155,12 +156,6 @@ class Checker(runner.Runner):
             help=
             "Path to the test root (usually Envoy source dir). If not specified the first path of paths is used"
         )
-        parser.add_argument(
-            "--log-level",
-            "-l",
-            choices=["info", "warn", "debug", "error"],
-            default="info",
-            help="Log level to display")
         parser.add_argument(
             "paths",
             nargs="*",

--- a/tools/base/runner.py
+++ b/tools/base/runner.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from functools import cached_property
 
-LOG_LEVELS = (("info", logging.INFO), ("debug", logging.DEBUG), ("warn", logging.WARN),
+LOG_LEVELS = (("debug", logging.DEBUG), ("info", logging.INFO), ("warn", logging.WARN),
               ("error", logging.ERROR))
 
 
@@ -75,7 +75,12 @@ class Runner(object):
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         """Override this method to add custom arguments to the arg parser"""
-        pass
+        parser.add_argument(
+            "--log-level",
+            "-l",
+            choices=[level[0] for level in LOG_LEVELS],
+            default="info",
+            help="Log level to display")
 
 
 class ForkingAdapter(object):

--- a/tools/base/tests/test_checker.py
+++ b/tools/base/tests/test_checker.py
@@ -268,10 +268,20 @@ def test_checker_warning_count():
     assert "warning_count" not in checker.__dict__
 
 
-def test_checker_add_arguments():
+def test_checker_add_arguments(patches):
     checker = DummyCheckerWithChecks("path1", "path2", "path3")
     parser = MagicMock()
-    checker.add_arguments(parser)
+    patched = patches(
+        "runner.Runner.add_arguments",
+        prefix="tools.base.checker")
+
+    with patched as (m_super, ):
+        assert checker.add_arguments(parser) is None
+
+    assert (
+        list(m_super.call_args)
+        == [(parser,), {}])
+
     assert (
         list(list(c) for c in parser.add_argument.call_args_list)
         == [[('--fix',),
@@ -311,9 +321,6 @@ def test_checker_add_arguments():
             [('--path', '-p'),
              {'default': None,
               'help': 'Path to the test root (usually Envoy source dir). If not specified the first path of paths is used'}],
-            [('--log-level', '-l'),
-             {'choices': ['info', 'warn', 'debug', 'error'],
-              'default': 'info', 'help': 'Log level to display'}],
             [('paths',),
              {'nargs': '*',
               'help': 'Paths to check. At least one path must be specified, or the `path` argument should be provided'}]])

--- a/tools/base/tests/test_runner.py
+++ b/tools/base/tests/test_runner.py
@@ -156,9 +156,18 @@ def test_checker_path():
         == [(), {}])
 
 
-def test_runner_add_arguments(patches):
+def test_runner_add_arguments():
     run = runner.Runner("path1", "path2", "path3")
-    assert run.add_arguments("PARSER") is None
+    parser = MagicMock()
+
+    assert run.add_arguments(parser) is None
+
+    assert (
+        list(list(c) for c in parser.add_argument.call_args_list)
+        == [[('--log-level', '-l'),
+             {'choices': ['debug', 'info', 'warn', 'error'],
+              'default': 'info', 'help': 'Log level to display'}],
+            ])
 
 
 # LogFilter tests


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: tooling: Fix runner log
Additional Description:

currently the log is half implemented in runner and half in checker, making it unusable for runner implementations

this fixes that

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
