### PR TITLE
wasm: increase coverage on encode/decodeData.

### DIFF
--- a/test/extensions/filters/http/wasm/test_data/test_body_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/test_body_cpp.cc
@@ -57,12 +57,12 @@ FilterDataStatus BodyContext::onBody(WasmBufferType type, size_t buffer_length,
     getBufferStatus(type, &size, &flags);
     setBuffer(type, size, 0, ".append");
     logBody(type);
-    return FilterDataStatus::Continue;
+    return FilterDataStatus::StopIterationNoBuffer;
 
   } else if (body_op_ == "ReplaceBody") {
     setBuffer(type, 0, buffer_length, "replace");
     logBody(type);
-    return FilterDataStatus::Continue;
+    return FilterDataStatus::StopIterationAndWatermark;
 
   } else if (body_op_ == "PartialReplaceBody") {
     setBuffer(type, 0, 1, "partial.replace.");

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -380,8 +380,15 @@ TEST_P(WasmHttpFilterTest, BodyRequestPrependAndAppendToBody) {
                                                  {"x-test-operation", "PrependAndAppendToBody"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
+  if (std::get<1>(GetParam()) == "rust") {
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
+  } else {
+    // This status is not available in the rust SDK.
+    // TODO: update all SDKs to the new revision of the spec and update the tests accordingly.
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter().decodeData(data, true));
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter().encodeData(data, true));
+  }
   filter().onDestroy();
 }
 
@@ -394,8 +401,15 @@ TEST_P(WasmHttpFilterTest, BodyRequestReplaceBody) {
                                                  {"x-test-operation", "ReplaceBody"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter().decodeHeaders(request_headers, false));
   Buffer::OwnedImpl data("hello");
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
-  EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
+  if (std::get<1>(GetParam()) == "rust") {
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().decodeData(data, true));
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter().encodeData(data, true));
+  } else {
+    // This status is not available in the rust SDK.
+    // TODO: update all SDKs to the new revision of the spec and update the tests accordingly.
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter().decodeData(data, true));
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter().encodeData(data, true));
+  }
   filter().onDestroy();
 }
 


### PR DESCRIPTION
Some of the test code paths in encode/decodeData and convertFilterDataStatus had lost in  https://github.com/envoyproxy/envoy/pull/17280. So this PR backfills them and increase the test coverage. 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
