### PR TITLE
tracing: pack trace context into stream metadata for access logging

### DIFF
--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -160,6 +160,13 @@ public:
    * @return trace ID as a hex string
    */
   virtual std::string getTraceIdAsHex() const PURE;
+
+  /**
+   * Serialize span information (e.g. trace id) and pack into stream_info to metadata.
+   * The properties of this metadata differs from tracing provider.
+   * @param stream info.
+   */
+  virtual void packSpanContextToMetadata(StreamInfo::StreamInfo& info) const PURE;
 };
 
 /**

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -280,6 +280,7 @@ void AsyncRequestImpl::onComplete() {
   Tracing::HttpTracerUtility::finalizeUpstreamSpan(*child_span_, &response_->headers(),
                                                    response_->trailers(), streamInfo(),
                                                    Tracing::EgressConfig::get());
+  child_span_->packSpanContextToMetadata(streamInfo());
 
   callbacks_.onSuccess(*this, std::move(response_));
 }
@@ -313,6 +314,7 @@ void AsyncRequestImpl::onReset() {
   Tracing::HttpTracerUtility::finalizeUpstreamSpan(
       *child_span_, remoteClosed() ? &response_->headers() : nullptr,
       remoteClosed() ? response_->trailers() : nullptr, streamInfo(), Tracing::EgressConfig::get());
+  child_span_->packSpanContextToMetadata(streamInfo());
 
   if (!cancelled_) {
     // In this case we don't have a valid response so we do need to raise a failure.

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -708,6 +708,7 @@ void ConnectionManagerImpl::ActiveStream::completeRequest() {
     Tracing::HttpTracerUtility::finalizeDownstreamSpan(
         *active_span_, request_headers_.get(), response_headers_.get(), response_trailers_.get(),
         filter_manager_.streamInfo(), *this);
+    active_span_->packSpanContextToMetadata(filter_manager_.streamInfo());
   }
   if (state_.successful_upgrade_) {
     connection_manager_.stats_.named_.downstream_cx_upgrades_active_.dec();

--- a/source/common/tracing/null_span_impl.h
+++ b/source/common/tracing/null_span_impl.h
@@ -30,6 +30,7 @@ public:
     return SpanPtr{new NullSpan()};
   }
   void setSampled(bool) override {}
+  void packSpanContextToMetadata(StreamInfo::StreamInfo&) const override {}
 };
 
 } // namespace Tracing

--- a/source/extensions/tracers/common/ot/opentracing_driver_impl.h
+++ b/source/extensions/tracers/common/ot/opentracing_driver_impl.h
@@ -46,6 +46,7 @@ public:
 
   // TODO: This method is unimplemented for OpenTracing.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
+  void packSpanContextToMetadata(StreamInfo::StreamInfo&) const override {}
 
 private:
   OpenTracingDriver& driver_;

--- a/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
+++ b/source/extensions/tracers/opencensus/opencensus_tracer_impl.cc
@@ -79,6 +79,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; };
 
   std::string getTraceIdAsHex() const override;
+  void packSpanContextToMetadata(StreamInfo::StreamInfo&) const override {}
 
 private:
   ::opencensus::trace::Span span_;

--- a/source/extensions/tracers/skywalking/tracer.cc
+++ b/source/extensions/tracers/skywalking/tracer.cc
@@ -64,6 +64,17 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& nam
   return std::make_unique<Span>(child_span, tracing_context_, parent_tracer_);
 }
 
+void Span::packSpanContextToMetadata(StreamInfo::StreamInfo& info) const {
+  ProtobufWkt::Struct output;
+  auto* fields = output.mutable_fields();
+  (*fields)["sw_service"] = ValueUtil::stringValue(tracing_context_->service());
+  (*fields)["sw_service_instance"] = ValueUtil::stringValue(tracing_context_->serviceInstance());
+  (*fields)["sw_trace_id"] = ValueUtil::stringValue(tracing_context_->traceId());
+  (*fields)["sw_segment_id"] = ValueUtil::stringValue(tracing_context_->traceSegmentId());
+  (*fields)["sw_span_id"] = ValueUtil::numberValue(span_entity_->spanId());
+  info.setDynamicMetadata("envoy.tracers.skywalking", output);
+}
+
 Tracer::Tracer(TraceSegmentReporterPtr reporter) : reporter_(std::move(reporter)) {}
 
 void Tracer::sendSegment(TracingContextPtr segment_context) {

--- a/source/extensions/tracers/skywalking/tracer.h
+++ b/source/extensions/tracers/skywalking/tracer.h
@@ -73,6 +73,7 @@ public:
   std::string getBaggage(absl::string_view) override { return EMPTY_STRING; }
   void setBaggage(absl::string_view, absl::string_view) override {}
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; }
+  void packSpanContextToMetadata(StreamInfo::StreamInfo& info) const override;
 
   const TracingContextPtr tracingContext() { return tracing_context_; }
   const TracingSpanPtr spanEntity() { return span_entity_; }

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -159,6 +159,8 @@ public:
   // TODO: This method is unimplemented for X-Ray.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
+  void packSpanContextToMetadata(StreamInfo::StreamInfo&) const override {}
+
   /**
    * Creates a child span.
    * In X-Ray terms this creates a sub-segment and sets its parent ID to the current span's ID.

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.h
@@ -85,6 +85,8 @@ public:
   // TODO: This method is unimplemented for Zipkin.
   std::string getTraceIdAsHex() const override { return EMPTY_STRING; };
 
+  void packSpanContextToMetadata(StreamInfo::StreamInfo&) const override {}
+
   /**
    * @return a reference to the Zipkin::Span object.
    */

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -241,6 +241,7 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(*child_span, finishSpan());
+  EXPECT_CALL(*child_span, packSpanContextToMetadata(_));
 
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
@@ -293,6 +294,7 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(*child_span, finishSpan());
+  EXPECT_CALL(*child_span, packSpanContextToMetadata(_));
 
   ResponseHeaderMapPtr response_headers(new TestResponseHeaderMapImpl{{":status", "200"}});
   response_decoder_->decodeHeaders(std::move(response_headers), false);
@@ -1121,6 +1123,7 @@ TEST_F(AsyncClientImplTracingTest, CancelRequest) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Canceled), Eq(Tracing::Tags::get().True)));
   EXPECT_CALL(*child_span, finishSpan());
+  EXPECT_CALL(*child_span, packSpanContextToMetadata(_));
 
   request->cancel();
 }
@@ -1208,6 +1211,7 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
       .Times(AnyNumber());
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().ErrorReason), Eq("Reset")));
   EXPECT_CALL(*child_span, finishSpan());
+  EXPECT_CALL(*child_span, packSpanContextToMetadata(_));
 }
 
 TEST_F(AsyncClientImplTest, PoolFailure) {
@@ -1394,6 +1398,7 @@ TEST_F(AsyncClientImplTracingTest, RequestTimeout) {
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)))
       .Times(AnyNumber());
   EXPECT_CALL(*child_span, finishSpan());
+  EXPECT_CALL(*child_span, packSpanContextToMetadata(_));
   timer_->invokeCallback();
 }
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -1462,6 +1462,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
+  EXPECT_CALL(*span, packSpanContextToMetadata(_));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
@@ -1529,6 +1530,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
+  EXPECT_CALL(*span, packSpanContextToMetadata(_));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
@@ -1594,6 +1596,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowIngressDecorat
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(Eq("testOp")));
+  EXPECT_CALL(*span, packSpanContextToMetadata(_));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
@@ -1676,6 +1679,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
+  EXPECT_CALL(*span, packSpanContextToMetadata(_));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
@@ -1759,6 +1763,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
       featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .WillOnce(Return(true));
   EXPECT_CALL(*span, setOperation(_)).Times(0);
+  EXPECT_CALL(*span, packSpanContextToMetadata(_));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 
@@ -1842,6 +1847,7 @@ TEST_F(HttpConnectionManagerImplTest, StartAndFinishSpanNormalFlowEgressDecorato
       .WillOnce(Return(true));
   // Verify that span operation overridden by value supplied in response header.
   EXPECT_CALL(*span, setOperation(Eq("testOp")));
+  EXPECT_CALL(*span, packSpanContextToMetadata(_));
 
   std::shared_ptr<MockStreamDecoderFilter> filter(new NiceMock<MockStreamDecoderFilter>());
 

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -41,6 +41,7 @@ public:
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));
   MOCK_METHOD(std::string, getBaggage, (absl::string_view key));
   MOCK_METHOD(std::string, getTraceIdAsHex, (), (const));
+  MOCK_METHOD(void, packSpanContextToMetadata, (StreamInfo::StreamInfo&), (const));
 
   SpanPtr spawnChild(const Config& config, const std::string& name,
                      SystemTime start_time) override {


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Close #16962. In this PR, we will add the ability to pour the information that makes up Span into the Metadata of StreamInfo. This feature will make it possible to read the Span metadata from access logging. Since this feature is required by Apache SkyWalking, it can only be actually poured into Metadata if you are using the SkyWalking Provider. This PR does not add this feature to other tracing providers, but it can be supported if needed. See below for more details.
https://github.com/SkyAPM/cpp2sky/issues/75
Additional Description:
Risk Level: Low
Testing: Unit
Docs Changes: Required
Release Notes: Required
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
