### PR TITLE
wasm: remove unused no_mangle from extern "c"

### DIFF
--- a/test/extensions/bootstrap/wasm/test_data/logging_rust.rs
+++ b/test/extensions/bootstrap/wasm/test_data/logging_rust.rs
@@ -2,7 +2,6 @@ use log::{debug, error, info, trace, warn};
 use proxy_wasm::traits::{Context, RootContext};
 use proxy_wasm::types::LogLevel;
 
-#[no_mangle]
 extern "C" {
     fn __wasilibc_initialize_environ();
 }

--- a/test/extensions/filters/http/wasm/test_data/headers_rust.rs
+++ b/test/extensions/filters/http/wasm/test_data/headers_rust.rs
@@ -2,7 +2,6 @@ use log::{debug, error, info, trace, warn};
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::*;
 
-#[no_mangle]
 extern "C" {
     fn __wasilibc_initialize_environ();
 }


### PR DESCRIPTION
This PR suppresses the warning by rustc which will result in compiler error in the future.

```
warning: attribute should be applied to a function or static
   = note: `#[warn(unused_attributes)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
```

Reference: https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/180

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
