### PR TITLE
jwt_authn: fix a flaky integration test

### DIFF
--- a/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
+++ b/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc
@@ -68,10 +68,9 @@ void JwksAsyncFetcher::handleFetchDone() {
 }
 
 void JwksAsyncFetcher::onJwksSuccess(google::jwt_verify::JwksPtr&& jwks) {
-  stats_.jwks_fetch_success_.inc();
-
   done_fn_(std::move(jwks));
   handleFetchDone();
+  stats_.jwks_fetch_success_.inc();
 
   // Note: not to free fetcher_ within onJwksSuccess or onJwksError function.
   // They are passed to fetcher_->fetch() and are called by fetcher_ after fetch is done.
@@ -84,10 +83,9 @@ void JwksAsyncFetcher::onJwksSuccess(google::jwt_verify::JwksPtr&& jwks) {
 }
 
 void JwksAsyncFetcher::onJwksError(Failure) {
-  stats_.jwks_fetch_failed_.inc();
-
   ENVOY_LOG(warn, "{}: failed", debug_name_);
   handleFetchDone();
+  stats_.jwks_fetch_failed_.inc();
 
   // Note: not to free fetcher_ in this function. Please see comment at onJwksSuccess.
 }

--- a/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_integration_test.cc
@@ -523,12 +523,13 @@ TEST_P(RemoteJwksIntegrationTest, WithGoodTokenAsyncFetchFast) {
   on_server_init_function_ = [this]() { waitForJwksResponse("200", PublicKey); };
   initializeAsyncFetchFilter(true);
 
-  // There is a race condition in this test:
-  // In fast_fatch mode, the listener is activated without waiting for jwks fetch to be
-  // done. When the first request comes, if jwks is not fetched, it will fetch again.
-  // The second fetch will fail in this test since its fake_upstream is not waiting.
-  // To avoid such race condition, before sending out the first request,
-  // wait for the first fetch stats to be updated.
+  // This test is only expecting one jwks fetch, but there is a race condition in the test:
+  // In fast fetch mode, the listener is activated without waiting for jwks fetch to be
+  // completed. When the first request comes at the worker thread, jwks fetch could be at
+  // any state at the main thread. If its result is not saved into jwks thread local slot,
+  // the first request will trigger a second jwks fetch, this is not expected, test will fail.
+  // To avoid such race condition, before making the first request, wait for the first
+  // fetch stats to be updated.
   test_server_->waitForCounterGe("http.config_test.jwt_authn.jwks_fetch_success", 1);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Integration test: RemoteJwksIntegrationTest.WithGoodTokenAsyncFetchFast in test/extensions/filters/http/jwt_authn/filter_integration_test.cc   is flaky.

This is an integration test to test async_fetch with fast_fetch mode.  In this mode,  the listener is activated without waiting for async_fetch to be completed.  This causes a race condition in this test.  When the first request comes, if jwks is not fetched, it will fetch again.  But the second fetch will fail in this test since its fake_upstream is not waiting.
* To avoid such race condition, before sending out the first request, wait for the first fetch stats to be updated.

Risk Level: None, just fixing test code
Testing: fixed test code
Docs Changes: None
Release Notes: None
Platform Specific Features: None
