### PR TITLE
tls: move ssl connection info into SocketAddressProvider

### DIFF
--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -117,6 +117,7 @@ envoy_cc_library(
         ":address_interface",
         ":io_handle_interface",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "//envoy/ssl:connection_interface",
     ],
 )
 

--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -116,8 +116,8 @@ envoy_cc_library(
     deps = [
         ":address_interface",
         ":io_handle_interface",
-        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "//envoy/ssl:connection_interface",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -195,7 +195,7 @@ public:
    * @return the address provider backing this connection.
    */
   virtual const SocketAddressProvider& addressProvider() const PURE;
-  virtual SocketAddressProviderSharedPtr addressProviderSharedPtr() const PURE;
+  virtual SocketAddressSetterSharedPtr addressProviderSharedPtr() const PURE;
 
   /**
    * Credentials of the peer of a socket as decided by SO_PEERCRED.

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -9,6 +9,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/io_handle.h"
+#include "envoy/ssl/connection.h"
 
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -92,6 +93,18 @@ public:
    * @param indent_level the level of indentation.
    */
   virtual void dumpState(std::ostream& os, int indent_level) const PURE;
+
+  /**
+   * @return the upstream SSL connection. This will be nullptr if the upstream
+   * connection does not use SSL.
+   */
+  virtual Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const PURE;
+
+  /**
+   * @return the downstream SSL connection. This will be nullptr if the downstream
+   * connection does not use SSL.
+   */
+  virtual Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const PURE;
 };
 
 class SocketAddressSetter : public SocketAddressProvider {
@@ -131,6 +144,18 @@ public:
    * @param id Connection ID of the downstream connection.
    **/
   virtual void setConnectionID(uint64_t id) PURE;
+
+  /**
+   * @param connection_info sets the downstream ssl connection.
+   */
+  virtual void
+  setDownstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
+
+  /**
+   * @param connection_info sets the upstream ssl connection.
+   */
+  virtual void
+  setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
 };
 
 using SocketAddressSetterSharedPtr = std::shared_ptr<SocketAddressSetter>;

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -178,7 +178,7 @@ public:
    */
   virtual SocketAddressSetter& addressProvider() PURE;
   virtual const SocketAddressProvider& addressProvider() const PURE;
-  virtual SocketAddressProviderSharedPtr addressProviderSharedPtr() const PURE;
+  virtual SocketAddressSetterSharedPtr addressProviderSharedPtr() const PURE;
 
   /**
    * @return IoHandle for the underlying connection

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -474,12 +474,6 @@ public:
   setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
 
   /**
-   * @return the upstream SSL connection. This will be nullptr if the upstream
-   * connection does not use SSL.
-   */
-  virtual Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const PURE;
-
-  /**
    * @return const Router::RouteEntry* Get the route entry selected for this request. Note: this
    * will be nullptr if no route was selected.
    */

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -468,18 +468,6 @@ public:
   virtual const Network::SocketAddressProvider& downstreamAddressProvider() const PURE;
 
   /**
-   * @param connection_info sets the downstream ssl connection.
-   */
-  virtual void
-  setDownstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) PURE;
-
-  /**
-   * @return the downstream SSL connection. This will be nullptr if the downstream
-   * connection does not use SSL.
-   */
-  virtual Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const PURE;
-
-  /**
    * @param connection_info sets the upstream ssl connection.
    */
   virtual void

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -659,7 +659,8 @@ public:
       return absl::nullopt;
     }
 
-    const auto value = field_extractor_(*stream_info.downstreamAddressProvider().downstreamSslConnection());
+    const auto value =
+        field_extractor_(*stream_info.downstreamAddressProvider().downstreamSslConnection());
     if (value && value->empty()) {
       return absl::nullopt;
     }
@@ -672,7 +673,8 @@ public:
       return unspecifiedValue();
     }
 
-    const auto value = field_extractor_(*stream_info.downstreamAddressProvider().downstreamSslConnection());
+    const auto value =
+        field_extractor_(*stream_info.downstreamAddressProvider().downstreamSslConnection());
     if (value && value->empty()) {
       return unspecifiedValue();
     }
@@ -1335,7 +1337,8 @@ DownstreamPeerCertVStartFormatter::DownstreamPeerCertVStartFormatter(const std::
           parseFormat(token, sizeof("DOWNSTREAM_PEER_CERT_V_START(") - 1),
           std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
               [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
-                const auto connection_info = stream_info.downstreamAddressProvider().downstreamSslConnection();
+                const auto connection_info =
+                    stream_info.downstreamAddressProvider().downstreamSslConnection();
                 return connection_info != nullptr ? connection_info->validFromPeerCertificate()
                                                   : absl::optional<SystemTime>();
               })) {}
@@ -1347,7 +1350,8 @@ DownstreamPeerCertVEndFormatter::DownstreamPeerCertVEndFormatter(const std::stri
           parseFormat(token, sizeof("DOWNSTREAM_PEER_CERT_V_END(") - 1),
           std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
               [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
-                const auto connection_info = stream_info.downstreamAddressProvider().downstreamSslConnection();
+                const auto connection_info =
+                    stream_info.downstreamAddressProvider().downstreamSslConnection();
                 return connection_info != nullptr ? connection_info->expirationPeerCertificate()
                                                   : absl::optional<SystemTime>();
               })) {}

--- a/source/common/formatter/substitution_formatter.cc
+++ b/source/common/formatter/substitution_formatter.cc
@@ -655,11 +655,11 @@ public:
   StreamInfoSslConnectionInfoFieldExtractor(FieldExtractor f) : field_extractor_(f) {}
 
   absl::optional<std::string> extract(const StreamInfo::StreamInfo& stream_info) const override {
-    if (stream_info.downstreamSslConnection() == nullptr) {
+    if (stream_info.downstreamAddressProvider().downstreamSslConnection() == nullptr) {
       return absl::nullopt;
     }
 
-    const auto value = field_extractor_(*stream_info.downstreamSslConnection());
+    const auto value = field_extractor_(*stream_info.downstreamAddressProvider().downstreamSslConnection());
     if (value && value->empty()) {
       return absl::nullopt;
     }
@@ -668,11 +668,11 @@ public:
   }
 
   ProtobufWkt::Value extractValue(const StreamInfo::StreamInfo& stream_info) const override {
-    if (stream_info.downstreamSslConnection() == nullptr) {
+    if (stream_info.downstreamAddressProvider().downstreamSslConnection() == nullptr) {
       return unspecifiedValue();
     }
 
-    const auto value = field_extractor_(*stream_info.downstreamSslConnection());
+    const auto value = field_extractor_(*stream_info.downstreamAddressProvider().downstreamSslConnection());
     if (value && value->empty()) {
       return unspecifiedValue();
     }
@@ -1335,7 +1335,7 @@ DownstreamPeerCertVStartFormatter::DownstreamPeerCertVStartFormatter(const std::
           parseFormat(token, sizeof("DOWNSTREAM_PEER_CERT_V_START(") - 1),
           std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
               [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
-                const auto connection_info = stream_info.downstreamSslConnection();
+                const auto connection_info = stream_info.downstreamAddressProvider().downstreamSslConnection();
                 return connection_info != nullptr ? connection_info->validFromPeerCertificate()
                                                   : absl::optional<SystemTime>();
               })) {}
@@ -1347,7 +1347,7 @@ DownstreamPeerCertVEndFormatter::DownstreamPeerCertVEndFormatter(const std::stri
           parseFormat(token, sizeof("DOWNSTREAM_PEER_CERT_V_END(") - 1),
           std::make_unique<SystemTimeFormatter::TimeFieldExtractor>(
               [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<SystemTime> {
-                const auto connection_info = stream_info.downstreamSslConnection();
+                const auto connection_info = stream_info.downstreamAddressProvider().downstreamSslConnection();
                 return connection_info != nullptr ? connection_info->expirationPeerCertificate()
                                                   : absl::optional<SystemTime>();
               })) {}

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -86,7 +86,6 @@ RequestEncoder& CodecClient::newStream(ResponseDecoder& response_decoder) {
 void CodecClient::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::Connected) {
     ENVOY_CONN_LOG(debug, "connected", *connection_);
-    connection_->streamInfo().setDownstreamSslConnection(connection_->ssl());
     connected_ = true;
   }
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -648,9 +648,6 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
     connection_manager_.stats_.named_.downstream_rq_http1_total_.inc();
   }
 
-  filter_manager_.streamInfo().setDownstreamSslConnection(
-      connection_manager_.read_callbacks_->connection().ssl());
-
   if (connection_manager_.config_.streamIdleTimeout().count()) {
     idle_timeout_ms_ = connection_manager_.config_.streamIdleTimeout();
     stream_idle_timer_ =

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -630,7 +630,7 @@ public:
     return StreamInfoImpl::downstreamAddressProvider().downstreamSslConnection();
   }
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
-    return StreamInfoImpl::upstreamSslConnection();
+    return StreamInfoImpl::downstreamAddressProvider().upstreamSslConnection();
   }
   void dumpState(std::ostream& os, int indent_level) const override {
     StreamInfoImpl::dumpState(os, indent_level);

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -627,7 +627,7 @@ public:
     return StreamInfoImpl::downstreamAddressProvider().connectionID();
   }
   Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const override {
-    return StreamInfoImpl::downstreamSslConnection();;
+    return StreamInfoImpl::downstreamAddressProvider().downstreamSslConnection();
   }
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
     return StreamInfoImpl::upstreamSslConnection();

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -626,6 +626,12 @@ public:
   absl::optional<uint64_t> connectionID() const override {
     return StreamInfoImpl::downstreamAddressProvider().connectionID();
   }
+  Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const override {
+    return StreamInfoImpl::downstreamSslConnection();;
+  }
+  Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
+    return StreamInfoImpl::upstreamSslConnection();
+  }
   void dumpState(std::ostream& os, int indent_level) const override {
     StreamInfoImpl::dumpState(os, indent_level);
 

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -99,6 +99,7 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
   // TODO(soulxu): generate the connection id inside the addressProvider directly,
   // then we don't need a setter or any of the optional stuff.
   socket_->addressProvider().setConnectionID(id());
+  socket_->addressProvider().setDownstreamSslConnection(transport_socket_->ssl());
 }
 
 ConnectionImpl::~ConnectionImpl() {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -73,7 +73,7 @@ public:
   const SocketAddressProvider& addressProvider() const override {
     return socket_->addressProvider();
   }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return socket_->addressProviderSharedPtr();
   }
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -85,7 +85,7 @@ public:
   // Network::Socket
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
   const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   SocketPtr duplicate() override {

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -51,6 +51,20 @@ public:
   }
   absl::optional<uint64_t> connectionID() const override { return connection_id_; }
   void setConnectionID(uint64_t id) override { connection_id_ = id; }
+  Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const override {
+    return downstream_ssl_info_;
+  }
+  void
+  setDownstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) override {
+    downstream_ssl_info_ = ssl_connection_info;
+  }
+  Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
+    return upstream_ssl_info_;
+  }
+  void
+  setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) override {
+    upstream_ssl_info_ = ssl_connection_info;
+  }
 
 private:
   Address::InstanceConstSharedPtr local_address_;
@@ -59,6 +73,8 @@ private:
   Address::InstanceConstSharedPtr direct_remote_address_;
   std::string server_name_;
   absl::optional<uint64_t> connection_id_;
+  Ssl::ConnectionInfoConstSharedPtr downstream_ssl_info_;
+  Ssl::ConnectionInfoConstSharedPtr upstream_ssl_info_;
 };
 
 class SocketImpl : public virtual Socket {

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -54,8 +54,8 @@ public:
   Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const override {
     return downstream_ssl_info_;
   }
-  void
-  setDownstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) override {
+  void setDownstreamSslConnection(
+      const Ssl::ConnectionInfoConstSharedPtr& ssl_connection_info) override {
     downstream_ssl_info_ = ssl_connection_info;
   }
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {

--- a/source/common/quic/quic_filter_manager_connection_impl.h
+++ b/source/common/quic/quic_filter_manager_connection_impl.h
@@ -73,7 +73,7 @@ public:
   const Network::SocketAddressSetter& addressProvider() const override {
     return network_connection_->connectionSocket()->addressProvider();
   }
-  Network::SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  Network::SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return network_connection_->connectionSocket()->addressProviderSharedPtr();
   }
   absl::optional<Network::Connection::UnixDomainSocketPeerCredentials>

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -503,13 +503,17 @@ bool RouteEntryImplBase::evaluateTlsContextMatch(const StreamInfo::StreamInfo& s
 
   if (criteria.presented().has_value()) {
     const bool peer_presented = stream_info.downstreamAddressProvider().downstreamSslConnection() &&
-                                stream_info.downstreamAddressProvider().downstreamSslConnection()->peerCertificatePresented();
+                                stream_info.downstreamAddressProvider()
+                                    .downstreamSslConnection()
+                                    ->peerCertificatePresented();
     matches &= criteria.presented().value() == peer_presented;
   }
 
   if (criteria.validated().has_value()) {
     const bool peer_validated = stream_info.downstreamAddressProvider().downstreamSslConnection() &&
-                                stream_info.downstreamAddressProvider().downstreamSslConnection()->peerCertificateValidated();
+                                stream_info.downstreamAddressProvider()
+                                    .downstreamSslConnection()
+                                    ->peerCertificateValidated();
     matches &= criteria.validated().value() == peer_validated;
   }
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -502,14 +502,14 @@ bool RouteEntryImplBase::evaluateTlsContextMatch(const StreamInfo::StreamInfo& s
   const TlsContextMatchCriteria& criteria = *tlsContextMatchCriteria();
 
   if (criteria.presented().has_value()) {
-    const bool peer_presented = stream_info.downstreamSslConnection() &&
-                                stream_info.downstreamSslConnection()->peerCertificatePresented();
+    const bool peer_presented = stream_info.downstreamAddressProvider().downstreamSslConnection() &&
+                                stream_info.downstreamAddressProvider().downstreamSslConnection()->peerCertificatePresented();
     matches &= criteria.presented().value() == peer_presented;
   }
 
   if (criteria.validated().has_value()) {
-    const bool peer_validated = stream_info.downstreamSslConnection() &&
-                                stream_info.downstreamSslConnection()->peerCertificateValidated();
+    const bool peer_validated = stream_info.downstreamAddressProvider().downstreamSslConnection() &&
+                                stream_info.downstreamAddressProvider().downstreamSslConnection()->peerCertificateValidated();
     matches &= criteria.validated().value() == peer_validated;
   }
 

--- a/source/common/router/header_formatter.cc
+++ b/source/common/router/header_formatter.cc
@@ -224,11 +224,11 @@ parseRequestHeader(absl::string_view param) {
 StreamInfoHeaderFormatter::FieldExtractor sslConnectionInfoStringHeaderExtractor(
     std::function<std::string(const Ssl::ConnectionInfo& connection_info)> string_extractor) {
   return [string_extractor](const StreamInfo::StreamInfo& stream_info) {
-    if (stream_info.downstreamSslConnection() == nullptr) {
+    if (stream_info.downstreamAddressProvider().downstreamSslConnection() == nullptr) {
       return std::string();
     }
 
-    return string_extractor(*stream_info.downstreamSslConnection());
+    return string_extractor(*stream_info.downstreamAddressProvider().downstreamSslConnection());
   };
 }
 

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -605,7 +605,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
                                        !config_.suppress_envoy_headers_);
   FilterUtility::setUpstreamScheme(headers,
-                                   callbacks_->streamInfo().downstreamSslConnection() != nullptr,
+                                   callbacks_->streamInfo().downstreamAddressProvider().downstreamSslConnection() != nullptr,
                                    host->transportSocketFactory().implementsSecureTransport());
 
   // Ensure an http transport scheme is selected before continuing with decoding.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -604,9 +604,10 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
   route_entry_->finalizeRequestHeaders(headers, callbacks_->streamInfo(),
                                        !config_.suppress_envoy_headers_);
-  FilterUtility::setUpstreamScheme(headers,
-                                   callbacks_->streamInfo().downstreamAddressProvider().downstreamSslConnection() != nullptr,
-                                   host->transportSocketFactory().implementsSecureTransport());
+  FilterUtility::setUpstreamScheme(
+      headers,
+      callbacks_->streamInfo().downstreamAddressProvider().downstreamSslConnection() != nullptr,
+      host->transportSocketFactory().implementsSecureTransport());
 
   // Ensure an http transport scheme is selected before continuing with decoding.
   ASSERT(headers.Scheme());

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -412,8 +412,8 @@ void UpstreamRequest::onPoolReady(
   stream_info_.setUpstreamLocalAddress(upstream_local_address);
   parent_.callbacks()->streamInfo().setUpstreamLocalAddress(upstream_local_address);
 
-  stream_info_.setUpstreamSslConnection(info.downstreamSslConnection());
-  parent_.callbacks()->streamInfo().setUpstreamSslConnection(info.downstreamSslConnection());
+  stream_info_.setUpstreamSslConnection(info.downstreamAddressProvider().downstreamSslConnection());
+  parent_.callbacks()->streamInfo().setUpstreamSslConnection(info.downstreamAddressProvider().downstreamSslConnection());
 
   if (parent_.downstreamEndStream()) {
     setupPerTryTimeout();

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -413,7 +413,8 @@ void UpstreamRequest::onPoolReady(
   parent_.callbacks()->streamInfo().setUpstreamLocalAddress(upstream_local_address);
 
   stream_info_.setUpstreamSslConnection(info.downstreamAddressProvider().downstreamSslConnection());
-  parent_.callbacks()->streamInfo().setUpstreamSslConnection(info.downstreamAddressProvider().downstreamSslConnection());
+  parent_.callbacks()->streamInfo().setUpstreamSslConnection(
+      info.downstreamAddressProvider().downstreamSslConnection());
 
   if (parent_.downstreamEndStream()) {
     setupPerTryTimeout();

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -197,15 +197,6 @@ struct StreamInfoImpl : public StreamInfo {
     return *downstream_address_provider_;
   }
 
-  void
-  setDownstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    downstream_ssl_info_ = connection_info;
-  }
-
-  Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const override {
-    return downstream_ssl_info_;
-  }
-
   void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
     upstream_ssl_info_ = connection_info;
   }
@@ -324,7 +315,6 @@ private:
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   const Network::SocketAddressProviderSharedPtr downstream_address_provider_;
-  Ssl::ConnectionInfoConstSharedPtr downstream_ssl_info_;
   Ssl::ConnectionInfoConstSharedPtr upstream_ssl_info_;
   std::string requested_server_name_;
   const Http::RequestHeaderMap* request_headers_{};

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -198,11 +198,7 @@ struct StreamInfoImpl : public StreamInfo {
   }
 
   void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    downstream_address_provider_->setDownstreamSslConnection(connection_info);
-  }
-
-  Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
-    return upstream_ssl_info_;
+    downstream_address_provider_->setUpstreamSslConnection(connection_info);
   }
 
   const Router::RouteEntry* routeEntry() const override { return route_entry_; }

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -36,18 +36,18 @@ const ReplacementMap& emptySpaceReplacement() {
 
 struct StreamInfoImpl : public StreamInfo {
   StreamInfoImpl(TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider,
+                 const Network::SocketAddressSetterSharedPtr& downstream_address_provider,
                  FilterState::LifeSpan life_span = FilterState::LifeSpan::FilterChain)
       : StreamInfoImpl(absl::nullopt, time_source, downstream_address_provider,
                        std::make_shared<FilterStateImpl>(life_span)) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider)
+                 const Network::SocketAddressSetterSharedPtr& downstream_address_provider)
       : StreamInfoImpl(protocol, time_source, downstream_address_provider,
                        std::make_shared<FilterStateImpl>(FilterState::LifeSpan::FilterChain)) {}
 
   StreamInfoImpl(Http::Protocol protocol, TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider,
+                 const Network::SocketAddressSetterSharedPtr& downstream_address_provider,
                  FilterStateSharedPtr parent_filter_state, FilterState::LifeSpan life_span)
       : StreamInfoImpl(
             protocol, time_source, downstream_address_provider,
@@ -198,7 +198,7 @@ struct StreamInfoImpl : public StreamInfo {
   }
 
   void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    upstream_ssl_info_ = connection_info;
+    downstream_address_provider_->setDownstreamSslConnection(connection_info);
   }
 
   Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
@@ -294,14 +294,14 @@ struct StreamInfoImpl : public StreamInfo {
   std::string route_name_;
 
 private:
-  static Network::SocketAddressProviderSharedPtr emptyDownstreamAddressProvider() {
+  static Network::SocketAddressSetterSharedPtr emptyDownstreamAddressProvider() {
     MUTABLE_CONSTRUCT_ON_FIRST_USE(
-        Network::SocketAddressProviderSharedPtr,
+        Network::SocketAddressSetterSharedPtr,
         std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr));
   }
 
   StreamInfoImpl(absl::optional<Http::Protocol> protocol, TimeSource& time_source,
-                 const Network::SocketAddressProviderSharedPtr& downstream_address_provider,
+                 const Network::SocketAddressSetterSharedPtr& downstream_address_provider,
                  FilterStateSharedPtr filter_state)
       : time_source_(time_source), start_time_(time_source.systemTime()),
         start_time_monotonic_(time_source.monotonicTime()), protocol_(protocol),
@@ -314,7 +314,7 @@ private:
   uint64_t bytes_received_{};
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
-  const Network::SocketAddressProviderSharedPtr downstream_address_provider_;
+  const Network::SocketAddressSetterSharedPtr downstream_address_provider_;
   Ssl::ConnectionInfoConstSharedPtr upstream_ssl_info_;
   std::string requested_server_name_;
   const Http::RequestHeaderMap* request_headers_{};

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -64,7 +64,6 @@ void ActiveTcpClient::onEvent(Network::ConnectionEvent event) {
   // This is also necessary for prefetch to be used with such protocols.
   if (event == Network::ConnectionEvent::Connected) {
     connection_->readDisable(true);
-    connection_->streamInfo().setDownstreamSslConnection(connection_->ssl());
   }
   Envoy::ConnectionPool::ActiveClient::onEvent(event);
   if (callbacks_) {

--- a/source/common/tcp/original_conn_pool.cc
+++ b/source/common/tcp/original_conn_pool.cc
@@ -225,7 +225,6 @@ void OriginalConnPoolImpl::onConnectionEvent(ActiveConn& conn, Network::Connecti
   // whether the connection is in the ready list (connected) or the pending list (failed to
   // connect).
   if (event == Network::ConnectionEvent::Connected) {
-    conn.conn_->streamInfo().setDownstreamSslConnection(conn.conn_->ssl());
     conn_connect_ms_->complete();
     processIdleConnection(conn, true, false);
   }

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -187,7 +187,10 @@ void TcpConnPool::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data
   auto upstream = std::make_unique<TcpUpstream>(std::move(conn_data), upstream_callbacks_);
   callbacks_->onGenericPoolReady(&connection.streamInfo(), std::move(upstream), host,
                                  latched_data->connection().addressProvider().localAddress(),
-                                 latched_data->connection().streamInfo().downstreamAddressProvider().downstreamSslConnection());
+                                 latched_data->connection()
+                                     .streamInfo()
+                                     .downstreamAddressProvider()
+                                     .downstreamSslConnection());
 }
 
 HttpConnPool::HttpConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
@@ -237,8 +240,8 @@ void HttpConnPool::onPoolReady(Http::RequestEncoder& request_encoder,
 
   if (Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.http_upstream_wait_connect_response")) {
-    upstream_->setConnPoolCallbacks(
-        std::make_unique<HttpConnPool::Callbacks>(*this, host, info.downstreamAddressProvider().downstreamSslConnection()));
+    upstream_->setConnPoolCallbacks(std::make_unique<HttpConnPool::Callbacks>(
+        *this, host, info.downstreamAddressProvider().downstreamSslConnection()));
   } else {
     callbacks_->onGenericPoolReady(nullptr, std::move(upstream_), host,
                                    latched_encoder->getStream().connectionLocalAddress(),

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -187,7 +187,7 @@ void TcpConnPool::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data
   auto upstream = std::make_unique<TcpUpstream>(std::move(conn_data), upstream_callbacks_);
   callbacks_->onGenericPoolReady(&connection.streamInfo(), std::move(upstream), host,
                                  latched_data->connection().addressProvider().localAddress(),
-                                 latched_data->connection().streamInfo().downstreamSslConnection());
+                                 latched_data->connection().streamInfo().downstreamAddressProvider().downstreamSslConnection());
 }
 
 HttpConnPool::HttpConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
@@ -238,11 +238,11 @@ void HttpConnPool::onPoolReady(Http::RequestEncoder& request_encoder,
   if (Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.http_upstream_wait_connect_response")) {
     upstream_->setConnPoolCallbacks(
-        std::make_unique<HttpConnPool::Callbacks>(*this, host, info.downstreamSslConnection()));
+        std::make_unique<HttpConnPool::Callbacks>(*this, host, info.downstreamAddressProvider().downstreamSslConnection()));
   } else {
     callbacks_->onGenericPoolReady(nullptr, std::move(upstream_), host,
                                    latched_encoder->getStream().connectionLocalAddress(),
-                                   info.downstreamSslConnection());
+                                   info.downstreamAddressProvider().downstreamSslConnection());
   }
 }
 

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -141,7 +141,7 @@ private:
     Http::ResponseHeaderMapPtr response_headers_;
     const std::string& hostname_;
     const Http::Protocol protocol_;
-    Network::SocketAddressProviderSharedPtr local_address_provider_;
+    Network::SocketAddressSetterSharedPtr local_address_provider_;
     bool expect_reset_{};
     bool reuse_connection_ = false;
     bool request_in_flight_ = false;

--- a/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_utils.cc
@@ -166,10 +166,10 @@ void Utility::extractCommonAccessLogProperties(
         *stream_info.downstreamAddressProvider().localAddress(),
         *common_access_log.mutable_downstream_local_address());
   }
-  if (stream_info.downstreamSslConnection() != nullptr) {
+  if (stream_info.downstreamAddressProvider().downstreamSslConnection() != nullptr) {
     auto* tls_properties = common_access_log.mutable_tls_properties();
     const Ssl::ConnectionInfoConstSharedPtr downstream_ssl_connection =
-        stream_info.downstreamSslConnection();
+        stream_info.downstreamAddressProvider().downstreamSslConnection();
 
     tls_properties->set_tls_sni_hostname(
         std::string(stream_info.downstreamAddressProvider().requestedServerName()));

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -181,8 +181,8 @@ absl::optional<CelValue> ConnectionWrapper::operator[](CelValue key) const {
   }
   auto value = key.StringOrDie().value();
   if (value == MTLS) {
-    return CelValue::CreateBool(info_.downstreamSslConnection() != nullptr &&
-                                info_.downstreamSslConnection()->peerCertificatePresented());
+    return CelValue::CreateBool(info_.downstreamAddressProvider().downstreamSslConnection() != nullptr &&
+                                info_.downstreamAddressProvider().downstreamSslConnection()->peerCertificatePresented());
   } else if (value == RequestedServerName) {
     return CelValue::CreateStringView(info_.downstreamAddressProvider().requestedServerName());
   } else if (value == ID) {
@@ -198,7 +198,7 @@ absl::optional<CelValue> ConnectionWrapper::operator[](CelValue key) const {
     return {};
   }
 
-  auto ssl_info = info_.downstreamSslConnection();
+  auto ssl_info = info_.downstreamAddressProvider().downstreamSslConnection();
   if (ssl_info != nullptr) {
     return extractSslInfo(*ssl_info, value);
   }

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -181,8 +181,9 @@ absl::optional<CelValue> ConnectionWrapper::operator[](CelValue key) const {
   }
   auto value = key.StringOrDie().value();
   if (value == MTLS) {
-    return CelValue::CreateBool(info_.downstreamAddressProvider().downstreamSslConnection() != nullptr &&
-                                info_.downstreamAddressProvider().downstreamSslConnection()->peerCertificatePresented());
+    return CelValue::CreateBool(
+        info_.downstreamAddressProvider().downstreamSslConnection() != nullptr &&
+        info_.downstreamAddressProvider().downstreamSslConnection()->peerCertificatePresented());
   } else if (value == RequestedServerName) {
     return CelValue::CreateStringView(info_.downstreamAddressProvider().requestedServerName());
   } else if (value == ID) {

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -231,7 +231,7 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
     return CelValue::CreateStringView(info_.upstreamTransportFailureReason());
   }
 
-  auto ssl_info = info_.upstreamSslConnection();
+  auto ssl_info = info_.downstreamAddressProvider().upstreamSslConnection();
   if (ssl_info != nullptr) {
     return extractSslInfo(*ssl_info, value);
   }

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -114,7 +114,7 @@ int StreamInfoWrapper::luaDynamicMetadata(lua_State* state) {
 }
 
 int StreamInfoWrapper::luaDownstreamSslConnection(lua_State* state) {
-  const auto& ssl = stream_info_.downstreamSslConnection();
+  const auto& ssl = stream_info_.downstreamAddressProvider().downstreamSslConnection();
   if (ssl != nullptr) {
     if (downstream_ssl_connection_.get() != nullptr) {
       downstream_ssl_connection_.pushStack();

--- a/source/server/active_tcp_listener.cc
+++ b/source/server/active_tcp_listener.cc
@@ -302,7 +302,6 @@ void ActiveTcpListener::newConnection(Network::ConnectionSocketPtr&& socket,
 
   stream_info->setFilterChainName(filter_chain->name());
   auto transport_socket = filter_chain->transportSocketFactory().createTransportSocket(nullptr);
-  stream_info->setDownstreamSslConnection(transport_socket->ssl());
   auto& active_connections = getOrCreateActiveConnections(*filter_chain);
   auto server_conn_ptr = parent_.dispatcher().createServerConnection(
       std::move(socket), std::move(transport_socket), *stream_info);

--- a/source/server/api_listener_impl.h
+++ b/source/server/api_listener_impl.h
@@ -123,7 +123,7 @@ protected:
       const Network::SocketAddressSetter& addressProvider() const override {
         return *address_provider_;
       }
-      Network::SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+      Network::SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
         return address_provider_;
       }
       absl::optional<Network::Connection::UnixDomainSocketPeerCredentials>

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -698,7 +698,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     const std::vector<std::string> sans{"san"};
     EXPECT_CALL(*connection_info, uriSanPeerCertificate()).WillRepeatedly(Return(sans));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("san", upstream_format.format(request_headers, response_headers, response_trailers,
                                             stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -711,7 +711,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     const std::vector<std::string> sans{"san1", "san2"};
     EXPECT_CALL(*connection_info, uriSanPeerCertificate()).WillRepeatedly(Return(sans));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("san1,san2", upstream_format.format(request_headers, response_headers,
                                                   response_trailers, stream_info, body));
   }
@@ -720,7 +720,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, uriSanPeerCertificate())
         .WillRepeatedly(Return(std::vector<std::string>()));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -728,7 +728,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_URI_SAN");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -741,7 +741,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     const std::vector<std::string> sans{"san"};
     EXPECT_CALL(*connection_info, uriSanLocalCertificate()).WillRepeatedly(Return(sans));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("san", upstream_format.format(request_headers, response_headers, response_trailers,
                                             stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -753,7 +753,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     const std::vector<std::string> sans{"san1", "san2"};
     EXPECT_CALL(*connection_info, uriSanLocalCertificate()).WillRepeatedly(Return(sans));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("san1,san2", upstream_format.format(request_headers, response_headers,
                                                   response_trailers, stream_info, body));
   }
@@ -762,7 +762,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, uriSanLocalCertificate())
         .WillRepeatedly(Return(std::vector<std::string>()));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -770,7 +770,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_LOCAL_URI_SAN");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -784,7 +784,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     const std::string subject_local = "subject";
     EXPECT_CALL(*connection_info, subjectLocalCertificate())
         .WillRepeatedly(ReturnRef(subject_local));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("subject", upstream_format.format(request_headers, response_headers,
                                                 response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -796,7 +796,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, subjectLocalCertificate())
         .WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -804,7 +804,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_LOCAL_SUBJECT");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -817,7 +817,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     const std::string subject_peer = "subject";
     EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject_peer));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("subject", upstream_format.format(request_headers, response_headers,
                                                 response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -828,7 +828,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_SUBJECT");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -836,7 +836,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_SUBJECT");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -849,7 +849,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     const std::string session_id = "deadbeef";
     EXPECT_CALL(*connection_info, sessionId()).WillRepeatedly(ReturnRef(session_id));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("deadbeef", upstream_format.format(request_headers, response_headers,
                                                  response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -860,7 +860,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("DOWNSTREAM_TLS_SESSION_ID");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, sessionId()).WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -868,7 +868,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_TLS_SESSION_ID");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -881,7 +881,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, ciphersuiteString())
         .WillRepeatedly(Return("TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
               upstream_format.format(request_headers, response_headers, response_trailers,
                                      stream_info, body));
@@ -890,7 +890,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("DOWNSTREAM_TLS_CIPHER");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, ciphersuiteString()).WillRepeatedly(Return(""));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -898,7 +898,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_TLS_CIPHER");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -911,7 +911,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     std::string tlsVersion = "TLSv1.2";
     EXPECT_CALL(*connection_info, tlsVersion()).WillRepeatedly(ReturnRef(tlsVersion));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("TLSv1.2", upstream_format.format(request_headers, response_headers,
                                                 response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -922,7 +922,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("DOWNSTREAM_TLS_VERSION");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, tlsVersion()).WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -930,7 +930,8 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_TLS_VERSION");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -944,7 +945,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string expected_sha = "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f";
     EXPECT_CALL(*connection_info, sha256PeerCertificateDigest())
         .WillRepeatedly(ReturnRef(expected_sha));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(expected_sha, upstream_format.format(request_headers, response_headers,
                                                    response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -957,7 +958,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string expected_sha;
     EXPECT_CALL(*connection_info, sha256PeerCertificateDigest())
         .WillRepeatedly(ReturnRef(expected_sha));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -965,7 +966,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_FINGERPRINT_256");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -979,7 +980,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string expected_sha = "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f";
     EXPECT_CALL(*connection_info, sha1PeerCertificateDigest())
         .WillRepeatedly(ReturnRef(expected_sha));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(expected_sha, upstream_format.format(request_headers, response_headers,
                                                    response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -992,7 +993,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string expected_sha;
     EXPECT_CALL(*connection_info, sha1PeerCertificateDigest())
         .WillRepeatedly(ReturnRef(expected_sha));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1000,7 +1001,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_FINGERPRINT_1");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -1014,7 +1015,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     const std::string serial_number = "b8b5ecc898f2124a";
     EXPECT_CALL(*connection_info, serialNumberPeerCertificate())
         .WillRepeatedly(ReturnRef(serial_number));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("b8b5ecc898f2124a", upstream_format.format(request_headers, response_headers,
                                                          response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1026,7 +1027,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, serialNumberPeerCertificate())
         .WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1034,7 +1035,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_SERIAL");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -1048,7 +1049,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     const std::string issuer_peer =
         "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
     EXPECT_CALL(*connection_info, issuerPeerCertificate()).WillRepeatedly(ReturnRef(issuer_peer));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
               upstream_format.format(request_headers, response_headers, response_trailers,
                                      stream_info, body));
@@ -1057,7 +1058,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_ISSUER");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, issuerPeerCertificate()).WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1065,7 +1066,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_ISSUER");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -1079,7 +1080,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     const std::string subject_peer =
         "CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
     EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject_peer));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("CN=Test Server,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US",
               upstream_format.format(request_headers, response_headers, response_trailers,
                                      stream_info, body));
@@ -1088,7 +1089,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_SUBJECT");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, subjectPeerCertificate()).WillRepeatedly(ReturnRef(EMPTY_STRING));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1096,7 +1097,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_SUBJECT");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -1110,7 +1111,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string expected_cert = "<some cert>";
     EXPECT_CALL(*connection_info, urlEncodedPemEncodedPeerCertificate())
         .WillRepeatedly(ReturnRef(expected_cert));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(expected_cert, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1123,7 +1124,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     std::string expected_cert = "";
     EXPECT_CALL(*connection_info, urlEncodedPemEncodedPeerCertificate())
         .WillRepeatedly(ReturnRef(expected_cert));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(upstream_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1131,7 +1132,7 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
                 ProtoEq(ValueUtil::nullValue()));
   }
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     StreamInfoFormatter upstream_format("DOWNSTREAM_PEER_CERT");
     EXPECT_EQ(absl::nullopt, upstream_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -1616,7 +1617,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
 
   // No downstreamSslConnection
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     DownstreamPeerCertVStartFormatter cert_start_formart("DOWNSTREAM_PEER_CERT_V_START(%Y/%m/%d)");
     EXPECT_EQ(absl::nullopt, cert_start_formart.format(request_headers, response_headers,
                                                        response_trailers, stream_info, body));
@@ -1629,7 +1630,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     DownstreamPeerCertVStartFormatter cert_start_formart("DOWNSTREAM_PEER_CERT_V_START(%Y/%m/%d)");
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(absl::nullopt));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, cert_start_formart.format(request_headers, response_headers,
                                                        response_trailers, stream_info, body));
     EXPECT_THAT(cert_start_formart.formatValue(request_headers, response_headers, response_trailers,
@@ -1643,7 +1644,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     time_t test_epoch = 1522280158;
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
               cert_start_format.format(request_headers, response_headers, response_trailers,
                                        stream_info, body));
@@ -1656,7 +1657,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     time_t test_epoch = 1522280158;
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("Mar 28 23:35:58 2018 UTC",
               cert_start_format.format(request_headers, response_headers, response_trailers,
                                        stream_info, body));
@@ -1672,7 +1673,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
 
   // No downstreamSslConnection
   {
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
     DownstreamPeerCertVEndFormatter cert_end_format("DOWNSTREAM_PEER_CERT_V_END(%Y/%m/%d)");
     EXPECT_EQ(absl::nullopt, cert_end_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
@@ -1686,7 +1687,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, expirationPeerCertificate())
         .WillRepeatedly(Return(absl::nullopt));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(absl::nullopt, cert_end_format.format(request_headers, response_headers,
                                                     response_trailers, stream_info, body));
     EXPECT_THAT(cert_end_format.formatValue(request_headers, response_headers, response_trailers,
@@ -1700,7 +1701,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
     time_t test_epoch = 1522280158;
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
               cert_end_format.format(request_headers, response_headers, response_trailers,
                                      stream_info, body));
@@ -1713,7 +1714,7 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
     time_t test_epoch = 1522280158;
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     EXPECT_EQ("Mar 28 23:35:58 2018 UTC",
               cert_end_format.format(request_headers, response_headers, response_trailers,
                                      stream_info, body));
@@ -2610,7 +2611,7 @@ TEST(SubstitutionFormatterTest, JsonFormatterTest) {
 }
 
 TEST(SubstitutionFormatterTest, CompositeFormatterSuccess) {
-  StreamInfo::MockStreamInfo stream_info;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
   Http::TestRequestHeaderMapImpl request_header{{"first", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_header{{"second", "PUT"}, {"test", "test"}};
   Http::TestResponseTrailerMapImpl response_trailer{{"third", "POST"}, {"test-2", "test-2"}};
@@ -2708,7 +2709,7 @@ TEST(SubstitutionFormatterTest, CompositeFormatterSuccess) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     SystemTime time = std::chrono::system_clock::from_time_t(expected_time_in_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     FormatterImpl formatter(format, false);
 
     EXPECT_EQ(
@@ -2728,7 +2729,7 @@ TEST(SubstitutionFormatterTest, CompositeFormatterSuccess) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     SystemTime time = std::chrono::system_clock::from_time_t(expected_time_in_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     FormatterImpl formatter(format, false);
 
     EXPECT_EQ(

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -280,17 +280,6 @@ TEST_F(CodecClientTest, WatermarkPassthrough) {
   connection_cb_->onBelowWriteBufferLowWatermark();
 }
 
-TEST_F(CodecClientTest, SSLConnectionInfo) {
-  initialize();
-  std::string session_id = "D62A523A65695219D46FE1FFE285A4C371425ACE421B110B5B8D11D3EB4D5F0B";
-  auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
-  ON_CALL(*connection_info, sessionId()).WillByDefault(ReturnRef(session_id));
-  EXPECT_CALL(*connection_, ssl()).WillRepeatedly(Return(connection_info));
-  connection_cb_->onEvent(Network::ConnectionEvent::Connected);
-  EXPECT_NE(nullptr, stream_info_.downstreamSslConnection());
-  EXPECT_EQ(session_id, stream_info_.downstreamSslConnection()->sessionId());
-}
-
 // Test the codec getting input from a real TCP connection.
 class CodecNetworkTest : public Event::TestUsingSimulatedTime,
                          public testing::TestWithParam<Network::Address::IpVersion> {

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -301,7 +301,7 @@ TEST_F(HttpConnectionManagerImplTest, PopulateStreamInfo) {
   decoder_ = &conn_manager_->newStream(response_encoder_);
 
   EXPECT_EQ(requestIDExtension().get(), decoder_->streamInfo().getRequestIDProvider());
-  EXPECT_EQ(ssl_connection_, decoder_->streamInfo().downstreamSslConnection());
+  EXPECT_EQ(ssl_connection_, decoder_->streamInfo().downstreamAddressProvider().downstreamSslConnection());
   EXPECT_EQ(filter_callbacks_.connection_.id_,
             decoder_->streamInfo().downstreamAddressProvider().connectionID());
   EXPECT_EQ(server_name_, decoder_->streamInfo().downstreamAddressProvider().requestedServerName());
@@ -2251,7 +2251,7 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogSsl) {
         EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().localAddress());
         EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().remoteAddress());
         EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().directRemoteAddress());
-        EXPECT_NE(nullptr, stream_info.downstreamSslConnection());
+        EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().downstreamSslConnection());
         EXPECT_NE(nullptr, stream_info.routeEntry());
       }));
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -301,7 +301,8 @@ TEST_F(HttpConnectionManagerImplTest, PopulateStreamInfo) {
   decoder_ = &conn_manager_->newStream(response_encoder_);
 
   EXPECT_EQ(requestIDExtension().get(), decoder_->streamInfo().getRequestIDProvider());
-  EXPECT_EQ(ssl_connection_, decoder_->streamInfo().downstreamAddressProvider().downstreamSslConnection());
+  EXPECT_EQ(ssl_connection_,
+            decoder_->streamInfo().downstreamAddressProvider().downstreamSslConnection());
   EXPECT_EQ(filter_callbacks_.connection_.id_,
             decoder_->streamInfo().downstreamAddressProvider().connectionID());
   EXPECT_EQ(server_name_, decoder_->streamInfo().downstreamAddressProvider().requestedServerName());

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -72,6 +72,8 @@ void HttpConnectionManagerImplTest::setup(bool ssl, const std::string& server_na
       ->setDirectRemoteAddressForTest(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0"));
   filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setRequestedServerName(
       server_name_);
+  filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setDownstreamSslConnection(
+      ssl_connection_);
   conn_manager_ = std::make_unique<ConnectionManagerImpl>(
       *this, drain_close_, random_, http_context_, runtime_, local_info_, cluster_manager_,
       overload_manager_, test_time_.timeSystem());

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -72,8 +72,8 @@ void HttpConnectionManagerImplTest::setup(bool ssl, const std::string& server_na
       ->setDirectRemoteAddressForTest(std::make_shared<Network::Address::Ipv4Instance>("0.0.0.0"));
   filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setRequestedServerName(
       server_name_);
-  filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setDownstreamSslConnection(
-      ssl_connection_);
+  filter_callbacks_.connection_.stream_info_.downstream_address_provider_
+      ->setDownstreamSslConnection(ssl_connection_);
   conn_manager_ = std::make_unique<ConnectionManagerImpl>(
       *this, drain_close_, random_, http_context_, runtime_, local_info_, cluster_manager_,
       overload_manager_, test_time_.timeSystem());

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6920,7 +6920,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(true));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(true));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/peer-cert-test", "GET");
     EXPECT_EQ("server_peer-cert-presented",
@@ -6932,7 +6932,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(false));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(true));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/peer-cert-test", "GET");
     EXPECT_EQ("server_peer-cert-not-presented",
@@ -6944,7 +6944,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(false));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(true));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-cert-no-tls-context-match", "GET");
@@ -6957,7 +6957,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(true));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(true));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-cert-no-tls-context-match", "GET");
@@ -6970,7 +6970,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(true));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(true));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-validated-cert-test", "GET");
@@ -6983,7 +6983,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(true));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(false));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-validated-cert-test", "GET");
@@ -6996,7 +6996,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(true));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(false));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-cert-no-tls-context-match", "GET");
@@ -7009,7 +7009,7 @@ virtual_hosts:
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, peerCertificatePresented()).WillRepeatedly(Return(true));
     EXPECT_CALL(*connection_info, peerCertificateValidated()).WillRepeatedly(Return(true));
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-cert-no-tls-context-match", "GET");
@@ -7020,7 +7020,7 @@ virtual_hosts:
   {
     NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
     std::shared_ptr<Ssl::MockConnectionInfo> connection_info;
-    EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
     Http::TestRequestHeaderMapImpl headers =
         genHeaders("www.lyft.com", "/peer-cert-no-tls-context-match", "GET");

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -147,7 +147,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerUriSanVariable
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::vector<std::string> sans{"san"};
   ON_CALL(*connection_info, uriSanPeerCertificate()).WillByDefault(Return(sans));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_URI_SAN", "san");
 }
 
@@ -156,7 +156,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerUriSanVariable
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::vector<std::string> sans{"san1", "san2"};
   ON_CALL(*connection_info, uriSanPeerCertificate()).WillByDefault(Return(sans));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_URI_SAN", "san1,san2");
 }
 
@@ -165,13 +165,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerUriSanEmpty) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, uriSanPeerCertificate())
       .WillByDefault(Return(std::vector<std::string>()));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_URI_SAN", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_URI_SAN", EMPTY_STRING);
 }
 
@@ -180,7 +180,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalUriSanVariabl
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::vector<std::string> sans{"san"};
   ON_CALL(*connection_info, uriSanLocalCertificate()).WillByDefault(Return(sans));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_URI_SAN", "san");
 }
 
@@ -189,7 +189,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalUriSanVariabl
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::vector<std::string> sans{"san1", "san2"};
   ON_CALL(*connection_info, uriSanLocalCertificate()).WillByDefault(Return(sans));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_URI_SAN", "san1,san2");
 }
 
@@ -198,13 +198,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalUriSanVariabl
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, uriSanLocalCertificate())
       .WillByDefault(Return(std::vector<std::string>()));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_URI_SAN", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalUriSanNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_URI_SAN", EMPTY_STRING);
 }
 
@@ -213,7 +213,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalSubject) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string subject = "subject";
   ON_CALL(*connection_info, subjectLocalCertificate()).WillByDefault(ReturnRef(subject));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_SUBJECT", "subject");
 }
 
@@ -222,13 +222,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalSubjectEmpty)
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string subject;
   ON_CALL(*connection_info, subjectLocalCertificate()).WillByDefault(ReturnRef(subject));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_SUBJECT", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamLocalSubjectNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_LOCAL_SUBJECT", EMPTY_STRING);
 }
 
@@ -237,7 +237,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsSessionId) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string session_id = "deadbeef";
   ON_CALL(*connection_info, sessionId()).WillByDefault(ReturnRef(session_id));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_TLS_SESSION_ID", "deadbeef");
 }
 
@@ -246,13 +246,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsSessionIdEmpty)
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string session_id;
   ON_CALL(*connection_info, sessionId()).WillByDefault(ReturnRef(session_id));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_TLS_SESSION_ID", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsSessionIdNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_TLS_SESSION_ID", EMPTY_STRING);
 }
 
@@ -261,7 +261,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsCipher) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, ciphersuiteString())
       .WillByDefault(Return("TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_TLS_CIPHER", "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384");
 }
 
@@ -269,13 +269,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsCipherEmpty) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, ciphersuiteString()).WillByDefault(Return(""));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_TLS_CIPHER", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsCipherNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_TLS_CIPHER", EMPTY_STRING);
 }
 
@@ -284,7 +284,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsVersion) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string tls_version = "TLSv1.2";
   ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(tls_version));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_TLS_VERSION", "TLSv1.2");
 }
 
@@ -292,13 +292,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsVersionEmpty) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(EMPTY_STRING));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_TLS_VERSION", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamTlsVersionNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_TLS_VERSION", EMPTY_STRING);
 }
 
@@ -307,7 +307,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha256Fingerpr
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string expected_sha = "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f";
   ON_CALL(*connection_info, sha256PeerCertificateDigest()).WillByDefault(ReturnRef(expected_sha));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_FINGERPRINT_256",
                  "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f");
 }
@@ -317,13 +317,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha256Fingerpr
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string expected_sha;
   ON_CALL(*connection_info, sha256PeerCertificateDigest()).WillByDefault(ReturnRef(expected_sha));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_FINGERPRINT_256", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha256FingerprintNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_FINGERPRINT_256", EMPTY_STRING);
 }
 
@@ -332,7 +332,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha1Fingerprin
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string expected_sha = "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f";
   ON_CALL(*connection_info, sha1PeerCertificateDigest()).WillByDefault(ReturnRef(expected_sha));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_FINGERPRINT_1",
                  "685a2db593d5f86d346cb1a297009c3b467ad77f1944aa799039a2fb3d531f3f");
 }
@@ -342,13 +342,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha1Fingerprin
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   std::string expected_sha;
   ON_CALL(*connection_info, sha1PeerCertificateDigest()).WillByDefault(ReturnRef(expected_sha));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_FINGERPRINT_1", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSha1FingerprintNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_FINGERPRINT_1", EMPTY_STRING);
 }
 
@@ -357,7 +357,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSerial) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::string serial_number = "b8b5ecc898f2124a";
   ON_CALL(*connection_info, serialNumberPeerCertificate()).WillByDefault(ReturnRef(serial_number));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_SERIAL", "b8b5ecc898f2124a");
 }
 
@@ -366,13 +366,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSerialEmpty) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::string serial_number;
   ON_CALL(*connection_info, serialNumberPeerCertificate()).WillByDefault(ReturnRef(serial_number));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_SERIAL", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSerialNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_SERIAL", EMPTY_STRING);
 }
 
@@ -382,7 +382,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerIssuer) {
   const std::string issuer_peer =
       "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
   ON_CALL(*connection_info, issuerPeerCertificate()).WillByDefault(ReturnRef(issuer_peer));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_ISSUER",
                  "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US");
 }
@@ -392,13 +392,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerIssuerEmpty) {
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::string issuer_peer;
   ON_CALL(*connection_info, issuerPeerCertificate()).WillByDefault(ReturnRef(issuer_peer));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_ISSUER", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerIssuerNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_ISSUER", EMPTY_STRING);
 }
 
@@ -408,7 +408,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSubject) {
   const std::string subject_peer =
       "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US";
   ON_CALL(*connection_info, subjectPeerCertificate()).WillByDefault(ReturnRef(subject_peer));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_SUBJECT",
                  "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US");
 }
@@ -418,13 +418,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSubjectEmpty) 
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   const std::string subject_peer;
   ON_CALL(*connection_info, subjectPeerCertificate()).WillByDefault(ReturnRef(subject_peer));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_SUBJECT", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerSubjectNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_SUBJECT", EMPTY_STRING);
 }
 
@@ -434,7 +434,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCert) {
   std::string expected_cert = "<some cert>";
   ON_CALL(*connection_info, urlEncodedPemEncodedPeerCertificate())
       .WillByDefault(ReturnRef(expected_cert));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT", expected_cert);
 }
 
@@ -444,13 +444,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertEmpty) {
   std::string expected_cert;
   ON_CALL(*connection_info, urlEncodedPemEncodedPeerCertificate())
       .WillByDefault(ReturnRef(expected_cert));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT", EMPTY_STRING);
 }
 
@@ -461,7 +461,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVStart) {
       TestUtility::parseTime("Dec 18 01:50:34 2018 GMT", "%b %e %H:%M:%S %Y GMT");
   SystemTime startTime = absl::ToChronoTime(abslStartTime);
   ON_CALL(*connection_info, validFromPeerCertificate()).WillByDefault(Return(startTime));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_START", "2018-12-18T01:50:34.000Z");
 }
 
@@ -472,7 +472,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVStartCust
       TestUtility::parseTime("Dec 18 01:50:34 2018 GMT", "%b %e %H:%M:%S %Y GMT");
   SystemTime startTime = absl::ToChronoTime(abslStartTime);
   ON_CALL(*connection_info, validFromPeerCertificate()).WillByDefault(Return(startTime));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_START(%b %e %H:%M:%S %Y %Z)",
                  "Dec 18 01:50:34 2018 UTC");
 }
@@ -481,13 +481,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVStartEmpt
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, validFromPeerCertificate()).WillByDefault(Return(absl::nullopt));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_START", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVStartNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_START", EMPTY_STRING);
 }
 
@@ -498,7 +498,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVEnd) {
       TestUtility::parseTime("Dec 17 01:50:34 2020 GMT", "%b %e %H:%M:%S %Y GMT");
   SystemTime startTime = absl::ToChronoTime(abslStartTime);
   ON_CALL(*connection_info, expirationPeerCertificate()).WillByDefault(Return(startTime));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_END", "2020-12-17T01:50:34.000Z");
 }
 
@@ -509,7 +509,7 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVEndCustom
       TestUtility::parseTime("Dec 17 01:50:34 2020 GMT", "%b %e %H:%M:%S %Y GMT");
   SystemTime startTime = absl::ToChronoTime(abslStartTime);
   ON_CALL(*connection_info, expirationPeerCertificate()).WillByDefault(Return(startTime));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_END(%b %e %H:%M:%S %Y %Z)",
                  "Dec 17 01:50:34 2020 UTC");
 }
@@ -518,13 +518,13 @@ TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVEndEmpty)
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, expirationPeerCertificate()).WillByDefault(Return(absl::nullopt));
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_END", EMPTY_STRING);
 }
 
 TEST_F(StreamInfoHeaderFormatterTest, TestFormatWithDownstreamPeerCertVEndNoTls) {
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
-  EXPECT_CALL(stream_info, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(nullptr);
   testFormatting(stream_info, "DOWNSTREAM_PEER_CERT_V_END", EMPTY_STRING);
 }
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4843,7 +4843,7 @@ TEST_F(RouterTest, UpstreamSSLConnection) {
   std::string session_id = "D62A523A65695219D46FE1FFE285A4C371425ACE421B110B5B8D11D3EB4D5F0B";
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, sessionId()).WillByDefault(ReturnRef(session_id));
-  upstream_stream_info_.setDownstreamSslConnection(connection_info);
+  upstream_stream_info_.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
   expectResponseTimerCreate();
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _))

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4868,7 +4868,9 @@ TEST_F(RouterTest, UpstreamSSLConnection) {
   EXPECT_TRUE(verifyHostUpstreamStats(1, 0));
 
   ASSERT_NE(nullptr, callbacks_.streamInfo().downstreamAddressProvider().upstreamSslConnection());
-  EXPECT_EQ(session_id, callbacks_.streamInfo().downstreamAddressProvider().upstreamSslConnection()->sessionId());
+  EXPECT_EQ(
+      session_id,
+      callbacks_.streamInfo().downstreamAddressProvider().upstreamSslConnection()->sessionId());
 }
 
 // Verify that upstream timing information is set into the StreamInfo after the upstream

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -4867,8 +4867,8 @@ TEST_F(RouterTest, UpstreamSSLConnection) {
   response_decoder->decodeHeaders(std::move(response_headers), true);
   EXPECT_TRUE(verifyHostUpstreamStats(1, 0));
 
-  ASSERT_NE(nullptr, callbacks_.streamInfo().upstreamSslConnection());
-  EXPECT_EQ(session_id, callbacks_.streamInfo().upstreamSslConnection()->sessionId());
+  ASSERT_NE(nullptr, callbacks_.streamInfo().downstreamAddressProvider().upstreamSslConnection());
+  EXPECT_EQ(session_id, callbacks_.streamInfo().downstreamAddressProvider().upstreamSslConnection()->sessionId());
 }
 
 // Verify that upstream timing information is set into the StreamInfo after the upstream

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -135,7 +135,9 @@ TEST_F(StreamInfoImplTest, ResponseFlagTest) {
 
 TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
   {
-    StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr));
+    StreamInfoImpl stream_info(
+        Http::Protocol::Http2, test_time_.timeSystem(),
+        std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr));
 
     EXPECT_EQ(Http::Protocol::Http2, stream_info.protocol().value());
 
@@ -191,7 +193,8 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*ssl_info, sessionId()).WillRepeatedly(testing::ReturnRef(session_id));
     stream_info.setUpstreamSslConnection(ssl_info);
-    EXPECT_EQ(session_id, stream_info.downstreamAddressProvider().upstreamSslConnection()->sessionId());
+    EXPECT_EQ(session_id,
+              stream_info.downstreamAddressProvider().upstreamSslConnection()->sessionId());
   }
 }
 

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -135,7 +135,7 @@ TEST_F(StreamInfoImplTest, ResponseFlagTest) {
 
 TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
   {
-    StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), nullptr);
+    StreamInfoImpl stream_info(Http::Protocol::Http2, test_time_.timeSystem(), std::make_shared<Network::SocketAddressSetterImpl>(nullptr, nullptr));
 
     EXPECT_EQ(Http::Protocol::Http2, stream_info.protocol().value());
 
@@ -191,7 +191,7 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*ssl_info, sessionId()).WillRepeatedly(testing::ReturnRef(session_id));
     stream_info.setUpstreamSslConnection(ssl_info);
-    EXPECT_EQ(session_id, stream_info.upstreamSslConnection()->sessionId());
+    EXPECT_EQ(session_id, stream_info.downstreamAddressProvider().upstreamSslConnection()->sessionId());
   }
 }
 

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -78,14 +78,6 @@ public:
   const Network::SocketAddressSetter& downstreamAddressProvider() const override {
     return *downstream_address_provider_;
   }
-  void
-  setDownstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    downstream_connection_info_ = connection_info;
-  }
-
-  Ssl::ConnectionInfoConstSharedPtr downstreamSslConnection() const override {
-    return downstream_connection_info_;
-  }
 
   void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
     upstream_connection_info_ = connection_info;

--- a/test/common/stream_info/test_util.h
+++ b/test/common/stream_info/test_util.h
@@ -80,12 +80,9 @@ public:
   }
 
   void setUpstreamSslConnection(const Ssl::ConnectionInfoConstSharedPtr& connection_info) override {
-    upstream_connection_info_ = connection_info;
+    downstream_address_provider_->setUpstreamSslConnection(connection_info);
   }
 
-  Ssl::ConnectionInfoConstSharedPtr upstreamSslConnection() const override {
-    return upstream_connection_info_;
-  }
   void setRouteName(absl::string_view route_name) override {
     route_name_ = std::string(route_name);
   }

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -57,7 +57,8 @@ struct ConnPoolCallbacks : public Tcp::ConnectionPool::Callbacks {
     conn_data_ = std::move(conn);
     conn_data_->addUpstreamCallbacks(callbacks_);
     host_ = host;
-    ssl_ = conn_data_->connection().streamInfo().downstreamAddressProvider().downstreamSslConnection();
+    ssl_ =
+        conn_data_->connection().streamInfo().downstreamAddressProvider().downstreamSslConnection();
     pool_ready_.ready();
   }
 

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -57,7 +57,7 @@ struct ConnPoolCallbacks : public Tcp::ConnectionPool::Callbacks {
     conn_data_ = std::move(conn);
     conn_data_->addUpstreamCallbacks(callbacks_);
     host_ = host;
-    ssl_ = conn_data_->connection().streamInfo().downstreamSslConnection();
+    ssl_ = conn_data_->connection().streamInfo().downstreamAddressProvider().downstreamSslConnection();
     pool_ready_.ready();
   }
 
@@ -327,7 +327,7 @@ public:
     EXPECT_CALL(*connection_, connect());
     EXPECT_CALL(*connection_, setConnectionStats(_));
     EXPECT_CALL(*connection_, noDelay(true));
-    EXPECT_CALL(*connection_, streamInfo()).Times(3);
+    EXPECT_CALL(*connection_, streamInfo());
     EXPECT_CALL(*connection_, id()).Times(AnyNumber());
     EXPECT_CALL(*connection_, readDisable(_)).Times(AnyNumber());
 
@@ -341,10 +341,8 @@ public:
 
     EXPECT_CALL(*connect_timer_, disableTimer());
     EXPECT_CALL(callbacks_->pool_ready_, ready());
-    EXPECT_CALL(*connection_, ssl()).WillOnce(Return(ssl_));
     connection_->raiseEvent(Network::ConnectionEvent::Connected);
-    EXPECT_EQ(connection_->streamInfo().downstreamSslConnection(), ssl_);
-    EXPECT_EQ(callbacks_->ssl_, ssl_);
+    connection_->stream_info_.downstream_address_provider_->setDownstreamSslConnection(ssl_);
   }
 
   bool test_new_connection_pool_;

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -122,7 +122,7 @@ public:
       EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
       EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
       filter_->initializeReadFilterCallbacks(filter_callbacks_);
-      filter_callbacks_.connection_.streamInfo().setDownstreamSslConnection(
+      filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setDownstreamSslConnection(
           filter_callbacks_.connection_.ssl());
     }
 
@@ -225,7 +225,7 @@ TEST_F(TcpProxyTest, BadFactory) {
   EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
   EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
-  filter_callbacks_.connection_.streamInfo().setDownstreamSslConnection(
+  filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setDownstreamSslConnection(
       filter_callbacks_.connection_.ssl());
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 }
@@ -936,7 +936,7 @@ TEST_F(TcpProxyTest, AccessLogUpstreamSSLConnection) {
   const std::string session_id = "D62A523A65695219D46FE1FFE285A4C371425ACE421B110B5B8D11D3EB4D5F0B";
   auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
   EXPECT_CALL(*ssl_info, sessionId()).WillRepeatedly(ReturnRef(session_id));
-  stream_info.setDownstreamSslConnection(ssl_info);
+  stream_info.downstream_address_provider_->setDownstreamSslConnection(ssl_info);
   EXPECT_CALL(*upstream_connections_.at(0), streamInfo()).WillRepeatedly(ReturnRef(stream_info));
 
   raiseEventUpstreamConnected(0);
@@ -1096,12 +1096,12 @@ TEST_F(TcpProxyTest, AccessDownstreamAndUpstreamProperties) {
   setup(1);
 
   raiseEventUpstreamConnected(0);
-  EXPECT_EQ(filter_callbacks_.connection().streamInfo().downstreamSslConnection(),
+  EXPECT_EQ(filter_callbacks_.connection().streamInfo().downstreamAddressProvider().downstreamSslConnection(),
             filter_callbacks_.connection().ssl());
   EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamLocalAddress(),
             upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().localAddress());
   EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamSslConnection(),
-            upstream_connections_.at(0)->streamInfo().downstreamSslConnection());
+            upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().downstreamSslConnection());
 }
 } // namespace
 } // namespace TcpProxy

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -122,8 +122,8 @@ public:
       EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
       EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
       filter_->initializeReadFilterCallbacks(filter_callbacks_);
-      filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setDownstreamSslConnection(
-          filter_callbacks_.connection_.ssl());
+      filter_callbacks_.connection_.stream_info_.downstream_address_provider_
+          ->setDownstreamSslConnection(filter_callbacks_.connection_.ssl());
     }
 
     if (connections > 0) {
@@ -225,8 +225,8 @@ TEST_F(TcpProxyTest, BadFactory) {
   EXPECT_CALL(filter_callbacks_.connection_, enableHalfClose(true));
   EXPECT_CALL(filter_callbacks_.connection_, readDisable(true));
   filter_->initializeReadFilterCallbacks(filter_callbacks_);
-  filter_callbacks_.connection_.stream_info_.downstream_address_provider_->setDownstreamSslConnection(
-      filter_callbacks_.connection_.ssl());
+  filter_callbacks_.connection_.stream_info_.downstream_address_provider_
+      ->setDownstreamSslConnection(filter_callbacks_.connection_.ssl());
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
 }
 
@@ -941,7 +941,9 @@ TEST_F(TcpProxyTest, AccessLogUpstreamSSLConnection) {
 
   raiseEventUpstreamConnected(0);
   ASSERT_NE(nullptr, filter_->getStreamInfo().downstreamAddressProvider().upstreamSslConnection());
-  EXPECT_EQ(session_id, filter_->getStreamInfo().downstreamAddressProvider().upstreamSslConnection()->sessionId());
+  EXPECT_EQ(
+      session_id,
+      filter_->getStreamInfo().downstreamAddressProvider().upstreamSslConnection()->sessionId());
 }
 
 // Tests that upstream flush works properly with no idle timeout configured.
@@ -1096,12 +1098,21 @@ TEST_F(TcpProxyTest, AccessDownstreamAndUpstreamProperties) {
   setup(1);
 
   raiseEventUpstreamConnected(0);
-  EXPECT_EQ(filter_callbacks_.connection().streamInfo().downstreamAddressProvider().downstreamSslConnection(),
+  EXPECT_EQ(filter_callbacks_.connection()
+                .streamInfo()
+                .downstreamAddressProvider()
+                .downstreamSslConnection(),
             filter_callbacks_.connection().ssl());
   EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamLocalAddress(),
             upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().localAddress());
-  EXPECT_EQ(filter_callbacks_.connection().streamInfo().downstreamAddressProvider().upstreamSslConnection(),
-            upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().downstreamSslConnection());
+  EXPECT_EQ(filter_callbacks_.connection()
+                .streamInfo()
+                .downstreamAddressProvider()
+                .upstreamSslConnection(),
+            upstream_connections_.at(0)
+                ->streamInfo()
+                .downstreamAddressProvider()
+                .downstreamSslConnection());
 }
 } // namespace
 } // namespace TcpProxy

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -940,8 +940,8 @@ TEST_F(TcpProxyTest, AccessLogUpstreamSSLConnection) {
   EXPECT_CALL(*upstream_connections_.at(0), streamInfo()).WillRepeatedly(ReturnRef(stream_info));
 
   raiseEventUpstreamConnected(0);
-  ASSERT_NE(nullptr, filter_->getStreamInfo().upstreamSslConnection());
-  EXPECT_EQ(session_id, filter_->getStreamInfo().upstreamSslConnection()->sessionId());
+  ASSERT_NE(nullptr, filter_->getStreamInfo().downstreamAddressProvider().upstreamSslConnection());
+  EXPECT_EQ(session_id, filter_->getStreamInfo().downstreamAddressProvider().upstreamSslConnection()->sessionId());
 }
 
 // Tests that upstream flush works properly with no idle timeout configured.
@@ -1100,7 +1100,7 @@ TEST_F(TcpProxyTest, AccessDownstreamAndUpstreamProperties) {
             filter_callbacks_.connection().ssl());
   EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamLocalAddress(),
             upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().localAddress());
-  EXPECT_EQ(filter_callbacks_.connection().streamInfo().upstreamSslConnection(),
+  EXPECT_EQ(filter_callbacks_.connection().streamInfo().downstreamAddressProvider().upstreamSslConnection(),
             upstream_connections_.at(0)->streamInfo().downstreamAddressProvider().downstreamSslConnection());
 }
 } // namespace

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -388,7 +388,7 @@ response: {}
     const std::string tlsVersion = "TLSv1.3";
     ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(tlsVersion));
     ON_CALL(*connection_info, ciphersuiteId()).WillByDefault(Return(0x2CC0));
-    stream_info.setDownstreamSslConnection(connection_info);
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     stream_info.downstream_address_provider_->setRequestedServerName("sni");
 
     Http::TestRequestHeaderMapImpl request_headers{
@@ -448,7 +448,7 @@ response: {}
     const std::string tlsVersion = "TLSv1.2";
     ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(tlsVersion));
     ON_CALL(*connection_info, ciphersuiteId()).WillByDefault(Return(0x2F));
-    stream_info.setDownstreamSslConnection(connection_info);
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     stream_info.downstream_address_provider_->setRequestedServerName("sni");
 
     Http::TestRequestHeaderMapImpl request_headers{
@@ -498,7 +498,7 @@ response: {}
     const std::string tlsVersion = "TLSv1.1";
     ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(tlsVersion));
     ON_CALL(*connection_info, ciphersuiteId()).WillByDefault(Return(0x2F));
-    stream_info.setDownstreamSslConnection(connection_info);
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     stream_info.downstream_address_provider_->setRequestedServerName("sni");
 
     Http::TestRequestHeaderMapImpl request_headers{
@@ -548,7 +548,7 @@ response: {}
     const std::string tlsVersion = "TLSv1";
     ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(tlsVersion));
     ON_CALL(*connection_info, ciphersuiteId()).WillByDefault(Return(0x2F));
-    stream_info.setDownstreamSslConnection(connection_info);
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     stream_info.downstream_address_provider_->setRequestedServerName("sni");
 
     Http::TestRequestHeaderMapImpl request_headers{
@@ -598,7 +598,7 @@ response: {}
     const std::string tlsVersion = "TLSv1.4";
     ON_CALL(*connection_info, tlsVersion()).WillByDefault(ReturnRef(tlsVersion));
     ON_CALL(*connection_info, ciphersuiteId()).WillByDefault(Return(0x2F));
-    stream_info.setDownstreamSslConnection(connection_info);
+    stream_info.downstream_address_provider_->setDownstreamSslConnection(connection_info);
     stream_info.downstream_address_provider_->setRequestedServerName("sni");
 
     Http::TestRequestHeaderMapImpl request_headers{

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -441,7 +441,7 @@ TEST(Context, ConnectionAttributes) {
   info.downstream_address_provider_->setLocalAddress(local);
   info.downstream_address_provider_->setRemoteAddress(remote);
   info.downstream_address_provider_->setRequestedServerName(sni_name);
-  EXPECT_CALL(info, downstreamSslConnection()).WillRepeatedly(Return(downstream_ssl_info));
+  info.downstream_address_provider_->setDownstreamSslConnection(downstream_ssl_info);
   EXPECT_CALL(info, upstreamSslConnection()).WillRepeatedly(Return(upstream_ssl_info));
   EXPECT_CALL(info, upstreamHost()).WillRepeatedly(Return(upstream_host));
   EXPECT_CALL(info, upstreamLocalAddress()).WillRepeatedly(ReturnRef(upstream_local_address));

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -442,7 +442,7 @@ TEST(Context, ConnectionAttributes) {
   info.downstream_address_provider_->setRemoteAddress(remote);
   info.downstream_address_provider_->setRequestedServerName(sni_name);
   info.downstream_address_provider_->setDownstreamSslConnection(downstream_ssl_info);
-  EXPECT_CALL(info, upstreamSslConnection()).WillRepeatedly(Return(upstream_ssl_info));
+  info.downstream_address_provider_->setUpstreamSslConnection(upstream_ssl_info);
   EXPECT_CALL(info, upstreamHost()).WillRepeatedly(Return(upstream_host));
   EXPECT_CALL(info, upstreamLocalAddress()).WillRepeatedly(ReturnRef(upstream_local_address));
   const std::string upstream_transport_failure_reason = "ConnectionTermination";

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1913,7 +1913,7 @@ TEST_F(LuaHttpFilterTest, InspectStreamInfoDowstreamSslConnection) {
 
   const auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
-  EXPECT_CALL(stream_info_, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info_.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
   EXPECT_CALL(*connection_info, peerCertificatePresented()).WillOnce(Return(true));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("peerCertificatePresented")));
@@ -2011,7 +2011,7 @@ TEST_F(LuaHttpFilterTest, InspectStreamInfoDowstreamSslConnectionOnPlainConnecti
   setup(SCRIPT);
 
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
-  EXPECT_CALL(stream_info_, downstreamSslConnection()).WillRepeatedly(Return(nullptr));
+  stream_info_.downstream_address_provider_->setDownstreamSslConnection(nullptr);
 
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("downstreamSslConnection is nil")));
 
@@ -2034,7 +2034,7 @@ TEST_F(LuaHttpFilterTest, SurviveMultipleDownstreamSslConnectionCalls) {
 
   const auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
-  EXPECT_CALL(stream_info_, downstreamSslConnection()).WillRepeatedly(Return(connection_info));
+  stream_info_.downstream_address_provider_->setDownstreamSslConnection(connection_info);
 
   for (uint64_t i = 0; i < 200; i++) {
     EXPECT_CALL(*filter_,

--- a/test/fuzz/utility.h
+++ b/test/fuzz/utility.h
@@ -172,7 +172,7 @@ inline std::unique_ptr<TestStreamInfo> fromStreamInfo(const test::fuzz::StreamIn
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
   ON_CALL(*connection_info, subjectPeerCertificate())
       .WillByDefault(testing::ReturnRef(TestSubjectPeer));
-  test_stream_info->setDownstreamSslConnection(connection_info);
+  test_stream_info->downstream_address_provider_->setDownstreamSslConnection(connection_info);
   return test_stream_info;
 }
 

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -66,7 +66,7 @@ public:
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
   MOCK_METHOD(const SocketAddressProvider&, addressProvider, (), (const));                         \
-  MOCK_METHOD(SocketAddressProviderSharedPtr, addressProviderSharedPtr, (), (const));              \
+  MOCK_METHOD(SocketAddressSetterSharedPtr, addressProviderSharedPtr, (), (const));              \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -66,7 +66,7 @@ public:
   MOCK_METHOD(void, detectEarlyCloseWhenReadDisabled, (bool));                                     \
   MOCK_METHOD(bool, readEnabled, (), (const));                                                     \
   MOCK_METHOD(const SocketAddressProvider&, addressProvider, (), (const));                         \
-  MOCK_METHOD(SocketAddressSetterSharedPtr, addressProviderSharedPtr, (), (const));              \
+  MOCK_METHOD(SocketAddressSetterSharedPtr, addressProviderSharedPtr, (), (const));                \
   MOCK_METHOD(absl::optional<Connection::UnixDomainSocketPeerCredentials>,                         \
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -235,7 +235,7 @@ public:
 
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
   const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   MOCK_METHOD(IoHandle&, ioHandle, ());
@@ -289,7 +289,7 @@ public:
 
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
   const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   MOCK_METHOD(void, setDetectedTransportProtocol, (absl::string_view));

--- a/test/mocks/network/socket.h
+++ b/test/mocks/network/socket.h
@@ -16,7 +16,7 @@ public:
 
   SocketAddressSetter& addressProvider() override { return *address_provider_; }
   const SocketAddressProvider& addressProvider() const override { return *address_provider_; }
-  SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
   IoHandle& ioHandle() override;

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -64,15 +64,9 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, upstreamLocalAddress()).WillByDefault(ReturnRef(upstream_local_address_));
   ON_CALL(*this, downstreamAddressProvider())
       .WillByDefault(ReturnPointee(downstream_address_provider_));
-  ON_CALL(*this, setDownstreamSslConnection(_))
-      .WillByDefault(Invoke(
-          [this](const auto& connection_info) { downstream_connection_info_ = connection_info; }));
   ON_CALL(*this, setUpstreamSslConnection(_))
       .WillByDefault(Invoke(
           [this](const auto& connection_info) { upstream_connection_info_ = connection_info; }));
-  ON_CALL(*this, downstreamSslConnection()).WillByDefault(Invoke([this]() {
-    return downstream_connection_info_;
-  }));
   ON_CALL(*this, upstreamSslConnection()).WillByDefault(Invoke([this]() {
     return upstream_connection_info_;
   }));

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -66,10 +66,7 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(ReturnPointee(downstream_address_provider_));
   ON_CALL(*this, setUpstreamSslConnection(_))
       .WillByDefault(Invoke(
-          [this](const auto& connection_info) { upstream_connection_info_ = connection_info; }));
-  ON_CALL(*this, upstreamSslConnection()).WillByDefault(Invoke([this]() {
-    return upstream_connection_info_;
-  }));
+          [this](const auto& connection_info) { downstream_address_provider_->setUpstreamSslConnection(connection_info); }));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));
   ON_CALL(*this, responseCode()).WillByDefault(ReturnPointee(&response_code_));
   ON_CALL(*this, responseCodeDetails()).WillByDefault(ReturnPointee(&response_code_details_));

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -65,8 +65,9 @@ MockStreamInfo::MockStreamInfo()
   ON_CALL(*this, downstreamAddressProvider())
       .WillByDefault(ReturnPointee(downstream_address_provider_));
   ON_CALL(*this, setUpstreamSslConnection(_))
-      .WillByDefault(Invoke(
-          [this](const auto& connection_info) { downstream_address_provider_->setUpstreamSslConnection(connection_info); }));
+      .WillByDefault(Invoke([this](const auto& connection_info) {
+        downstream_address_provider_->setUpstreamSslConnection(connection_info);
+      }));
   ON_CALL(*this, protocol()).WillByDefault(ReturnPointee(&protocol_));
   ON_CALL(*this, responseCode()).WillByDefault(ReturnPointee(&response_code_));
   ON_CALL(*this, responseCodeDetails()).WillByDefault(ReturnPointee(&response_code_details_));

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -121,8 +121,6 @@ public:
   uint64_t bytes_sent_{};
   Network::Address::InstanceConstSharedPtr upstream_local_address_;
   std::shared_ptr<Network::SocketAddressSetterImpl> downstream_address_provider_;
-  Ssl::ConnectionInfoConstSharedPtr downstream_connection_info_;
-  Ssl::ConnectionInfoConstSharedPtr upstream_connection_info_;
   std::string route_name_;
   std::string upstream_transport_failure_reason_;
   std::string filter_chain_name_;

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -66,8 +66,6 @@ public:
   MOCK_METHOD(bool, healthCheck, (), (const));
   MOCK_METHOD(void, healthCheck, (bool is_health_check));
   MOCK_METHOD(const Network::SocketAddressProvider&, downstreamAddressProvider, (), (const));
-  MOCK_METHOD(void, setDownstreamSslConnection, (const Ssl::ConnectionInfoConstSharedPtr&));
-  MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, downstreamSslConnection, (), (const));
   MOCK_METHOD(void, setUpstreamSslConnection, (const Ssl::ConnectionInfoConstSharedPtr&));
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, upstreamSslConnection, (), (const));
   MOCK_METHOD(const Router::RouteEntry*, routeEntry, (), (const));

--- a/test/server/filter_chain_benchmark_test.cc
+++ b/test/server/filter_chain_benchmark_test.cc
@@ -79,7 +79,7 @@ public:
   const Network::SocketAddressSetter& addressProvider() const override {
     return *address_provider_;
   }
-  Network::SocketAddressProviderSharedPtr addressProviderSharedPtr() const override {
+  Network::SocketAddressSetterSharedPtr addressProviderSharedPtr() const override {
     return address_provider_;
   }
 


### PR DESCRIPTION
Commit Message: tls: move ssl connection info into SocketAddressProvider
Additional Description:
Moving the StreamInfo's SSL connection info into the SocketAddressProvider.
Risk Level: low
Testing: unittest
Docs Changes: n/a
Release Notes: n/a
Part of #17168

Signed-off-by: He Jie Xu <hejie.xu@intel.com>
