### PR TITLE
[DRAFT] rbac: [matcher] support matching on upstream IP

### DIFF
--- a/api/envoy/config/rbac/v3/rbac.proto
+++ b/api/envoy/config/rbac/v3/rbac.proto
@@ -141,7 +141,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.Permission";
 
@@ -177,6 +177,9 @@ message Permission {
 
     // A CIDR block that describes the destination IP.
     core.v3.CidrRange destination_ip = 5;
+
+    // A CIDR block that describes the upstream IP, where applicable to the cluster.
+    core.v3.CidrRange upstream_ip = 11;
 
     // A port number that describes the destination port connecting to.
     uint32 destination_port = 6 [(validate.rules).uint32 = {lte: 65535}];

--- a/api/envoy/config/rbac/v4alpha/rbac.proto
+++ b/api/envoy/config/rbac/v4alpha/rbac.proto
@@ -139,7 +139,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v3.Permission";
 
@@ -175,6 +175,9 @@ message Permission {
 
     // A CIDR block that describes the destination IP.
     core.v4alpha.CidrRange destination_ip = 5;
+
+    // A CIDR block that describes the upstream IP, where applicable to the cluster.
+    core.v4alpha.CidrRange upstream_ip = 11;
 
     // A port number that describes the destination port connecting to.
     uint32 destination_port = 6 [(validate.rules).uint32 = {lte: 65535}];

--- a/generated_api_shadow/envoy/config/rbac/v3/rbac.proto
+++ b/generated_api_shadow/envoy/config/rbac/v3/rbac.proto
@@ -141,7 +141,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v2.Permission";
 
@@ -177,6 +177,9 @@ message Permission {
 
     // A CIDR block that describes the destination IP.
     core.v3.CidrRange destination_ip = 5;
+
+    // A CIDR block that describes the upstream IP, where applicable to the cluster.
+    core.v3.CidrRange upstream_ip = 11;
 
     // A port number that describes the destination port connecting to.
     uint32 destination_port = 6 [(validate.rules).uint32 = {lte: 65535}];

--- a/generated_api_shadow/envoy/config/rbac/v4alpha/rbac.proto
+++ b/generated_api_shadow/envoy/config/rbac/v4alpha/rbac.proto
@@ -140,7 +140,7 @@ message Policy {
 }
 
 // Permission defines an action (or actions) that a principal can take.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message Permission {
   option (udpa.annotations.versioning).previous_message_type = "envoy.config.rbac.v3.Permission";
 
@@ -176,6 +176,9 @@ message Permission {
 
     // A CIDR block that describes the destination IP.
     core.v4alpha.CidrRange destination_ip = 5;
+
+    // A CIDR block that describes the upstream IP, where applicable to the cluster.
+    core.v4alpha.CidrRange upstream_ip = 11;
 
     // A port number that describes the destination port connecting to.
     uint32 destination_port = 6 [(validate.rules).uint32 = {lte: 65535}];

--- a/source/extensions/filters/common/rbac/matchers.cc
+++ b/source/extensions/filters/common/rbac/matchers.cc
@@ -21,6 +21,9 @@ MatcherConstSharedPtr Matcher::create(const envoy::config::rbac::v3::Permission&
   case envoy::config::rbac::v3::Permission::RuleCase::kDestinationIp:
     return std::make_shared<const IPMatcher>(permission.destination_ip(),
                                              IPMatcher::Type::DownstreamLocal);
+  case envoy::config::rbac::v3::Permission::RuleCase::kUpstreamIp:
+    return std::make_shared<const IPMatcher>(permission.upstream_ip(),
+                                             IPMatcher::Type::UpstreamRemote);
   case envoy::config::rbac::v3::Permission::RuleCase::kDestinationPort:
     return std::make_shared<const PortMatcher>(permission.destination_port());
   case envoy::config::rbac::v3::Permission::RuleCase::kAny:
@@ -145,6 +148,12 @@ bool IPMatcher::matches(const Network::Connection& connection, const Envoy::Http
     break;
   case DownstreamRemote:
     ip = info.downstreamAddressProvider().remoteAddress();
+    break;
+  case UpstreamRemote:
+    if (!info.upstreamHost()) {
+      return false;
+    }
+    ip = info.upstreamHost()->address();
     break;
   default:
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/common/rbac/matchers.h
+++ b/source/extensions/filters/common/rbac/matchers.h
@@ -136,7 +136,13 @@ private:
  */
 class IPMatcher : public Matcher {
 public:
-  enum Type { ConnectionRemote = 0, DownstreamLocal, DownstreamDirectRemote, DownstreamRemote };
+  enum Type {
+    ConnectionRemote = 0,
+    DownstreamLocal,
+    DownstreamDirectRemote,
+    DownstreamRemote,
+    UpstreamRemote
+  };
 
   IPMatcher(const envoy::config::core::v3::CidrRange& range, Type type)
       : range_(Network::Address::CidrRange::create(range)), type_(type) {}

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -180,6 +180,7 @@ TEST(IPMatcher, IPMatcher) {
   info.downstream_address_provider_->setLocalAddress(direct_local);
   info.downstream_address_provider_->setDirectRemoteAddressForTest(direct_remote);
   info.downstream_address_provider_->setRemoteAddress(downstream_remote);
+  // note: upstream address defaults to 10.0.0.1 via MockHostDescription constructor
 
   envoy::config::core::v3::CidrRange connection_remote_cidr;
   connection_remote_cidr.set_address_prefix("12.13.14.15");
@@ -197,6 +198,10 @@ TEST(IPMatcher, IPMatcher) {
   downstream_remote_cidr.set_address_prefix("8.9.10.11");
   downstream_remote_cidr.mutable_prefix_len()->set_value(32);
 
+  envoy::config::core::v3::CidrRange upstream_cidr;
+  upstream_cidr.set_address_prefix("10.0.0.1");
+  upstream_cidr.mutable_prefix_len()->set_value(32);
+
   checkMatcher(IPMatcher(connection_remote_cidr, IPMatcher::Type::ConnectionRemote), true, conn,
                headers, info);
   checkMatcher(IPMatcher(downstream_local_cidr, IPMatcher::Type::DownstreamLocal), true, conn,
@@ -205,11 +210,14 @@ TEST(IPMatcher, IPMatcher) {
                true, conn, headers, info);
   checkMatcher(IPMatcher(downstream_remote_cidr, IPMatcher::Type::DownstreamRemote), true, conn,
                headers, info);
+  checkMatcher(IPMatcher(upstream_cidr, IPMatcher::Type::UpstreamRemote), true, conn, headers,
+               info);
 
   connection_remote_cidr.set_address_prefix("4.5.6.7");
   downstream_local_cidr.set_address_prefix("1.2.4.8");
   downstream_direct_remote_cidr.set_address_prefix("4.5.6.0");
   downstream_remote_cidr.set_address_prefix("4.5.6.7");
+  upstream_cidr.set_address_prefix("10.2.2.2");
 
   checkMatcher(IPMatcher(connection_remote_cidr, IPMatcher::Type::ConnectionRemote), false, conn,
                headers, info);
@@ -219,6 +227,8 @@ TEST(IPMatcher, IPMatcher) {
                false, conn, headers, info);
   checkMatcher(IPMatcher(downstream_remote_cidr, IPMatcher::Type::DownstreamRemote), false, conn,
                headers, info);
+  checkMatcher(IPMatcher(upstream_cidr, IPMatcher::Type::UpstreamRemote), false, conn, headers,
+               info);
 }
 
 TEST(PortMatcher, PortMatcher) {


### PR DESCRIPTION
**Commit Message:**

> rbac: [matcher] support matching on upstream IP
>
> The addition of dynamic_forward_proxy presents the security challenge of
> access control based not on attributes of the local proxy, but on those
> of the upstream cluster. Notably, IP-based access control is crucial for
> enterprise forward proxy deployments of envoy that wish to guard against
> SSRF and pivoting to protected IPs via a deny-list of CIDR ranges.
> 
> This patch adds support for matching the upstream IP to a CidrRange in
> the RBAC filter.
> 
> Signed-off-by: Dan Fuhry \<dan@fuhry.com\>

**Additional Description:**

The `dynamic_forward_proxy` extension presents the security challenge of access control based not on attributes of the local request or host, but on those of the upstream cluster/IP. Notably, IP-based access control is considered integral to
enterprise forward proxy deployments that wish to guard against SSRF and pivoting to protected IPs via a deny-list of CIDR ranges.

This patch is intended to add support for matching the upstream IP to a CidrRange in the RBAC filter.

RFC: Currently, this does not work because upstreamHost is never set at the time of request parsing, and indeed may not be until the router runs (final step in the http filter chain). I'm requesting guidance on where to move the upstream IP check. It appears to need to run after [`onLoadDnsCacheComplete` in the dynamic_forward_proxy extension](https://github.com/envoyproxy/envoy/blob/main/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc#L141). Ideally only RBAC rules that actually need late evaluation would be processed here, and all rules that can be evaluated early will continue to be processed at request parsing time.

**Risk Level:** Medium - may require some refactoring to accomplish this

**Testing:** Unit tests included. Integration test TODO.

**Docs Changes:**

* Generated protobuf docs should include the new `upstream_ip` field

**Release Notes:**

> * Added the `upstream_ip` field in `envoy.config.rbac.v3.Policy`, allowing RBAC policies based on the IP of the upstream. This enables destination-based policies which are particularly useful in deployments using `dynamic_forward_proxy`, but may slow performance as these rules cannot be evaluated until after the upstream IP is resolved.

**Platform Specific Features:**

None