### PR TITLE
Proposal: Add CachePolicy interface to allow for custom cache behavior

### DIFF
--- a/source/extensions/filters/http/cache/BUILD
+++ b/source/extensions/filters/http/cache/BUILD
@@ -44,6 +44,16 @@ envoy_cc_library(
     ],
 )
 
+envoy_cc_library(
+    name = "cache_policy_lib",
+    hdrs = ["cache_policy.h"],
+    deps = [
+        ":cache_headers_utils_lib",
+        ":http_cache_lib",
+        "//source/common/http:header_map_lib",
+    ],
+)
+
 envoy_proto_library(
     name = "key",
     srcs = ["key.proto"],

--- a/source/extensions/filters/http/cache/BUILD
+++ b/source/extensions/filters/http/cache/BUILD
@@ -50,9 +50,8 @@ envoy_cc_library(
     deps = [
         ":cache_headers_utils_lib",
         ":http_cache_lib",
-        "//envoy/http:header_map",
-        "//envoy/stream_info:filter_state",
         "//source/common/http:header_map_lib",
+        "//source/common/stream_info:filter_state_lib",
     ],
 )
 

--- a/source/extensions/filters/http/cache/BUILD
+++ b/source/extensions/filters/http/cache/BUILD
@@ -50,6 +50,8 @@ envoy_cc_library(
     deps = [
         ":cache_headers_utils_lib",
         ":http_cache_lib",
+        "//envoy/http:header_map",
+        "//envoy/stream_info:filter_state",
         "//source/common/http:header_map_lib",
     ],
 )

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -13,14 +13,14 @@ namespace Cache {
 
 struct CacheEntryUsability {
   CacheEntryStatus status = CacheEntryStatus::Unusable;
-  Envoy::Seconds age = Envoy::Seconds::max();
+  Seconds age = Seconds::max();
 };
 
 class CachePolicyCallbacks {
 public:
   virtual ~CachePolicyCallbacks() = default;
 
-  virtual const Envoy::StreamInfo::FilterStateSharedPtr& filterState() PURE;
+  virtual const StreamInfo::FilterStateSharedPtr& filterState() PURE;
 };
 
 // CachePolicy is an extension point for deployment specific caching behavior.
@@ -29,19 +29,19 @@ public:
   virtual ~CachePolicy() = default;
 
   // createCacheKey calculates the lookup key for storing the entry in the cache.
-  virtual Key createCacheKey(const Envoy::Http::RequestHeaderMap& request_headers) PURE;
+  virtual Key createCacheKey(const Http::RequestHeaderMap& request_headers) PURE;
 
   // requestCacheable modifies the cacheability of the response during
   // decoding. request_cache_control is the result of parsing the request's
   // Cache-Control header, parsed by the caller.
-  virtual bool requestCacheable(const Envoy::Http::RequestHeaderMap& request_headers,
+  virtual bool requestCacheable(const Http::RequestHeaderMap& request_headers,
                                 const RequestCacheControl& request_cache_control) PURE;
 
   // responseCacheable modifies the cacheability of the response during
   // encoding. response_cache_control is the result of parsing the response's
   // Cache-Control header, parsed by the caller.
-  virtual bool responseCacheable(const Envoy::Http::RequestHeaderMap& request_headers,
-                                 const Envoy::Http::ResponseHeaderMap& response_headers,
+  virtual bool responseCacheable(const Http::RequestHeaderMap& request_headers,
+                                 const Http::ResponseHeaderMap& response_headers,
                                  const ResponseCacheControl& response_cache_control,
                                  const VaryHeader& vary_allow_list) PURE;
 
@@ -50,12 +50,12 @@ public:
   // response_cache_control are the result of parsing the request's and
   // response's Cache-Control header, respectively, parsed by the caller.
   virtual CacheEntryUsability
-  computeCacheEntryUsability(const Envoy::Http::RequestHeaderMap& request_headers,
-                             const Envoy::Http::ResponseHeaderMap& cached_response_headers,
+  computeCacheEntryUsability(const Http::RequestHeaderMap& request_headers,
+                             const Http::ResponseHeaderMap& cached_response_headers,
                              const RequestCacheControl& request_cache_control,
                              const ResponseCacheControl& cached_response_cache_control,
                              const uint64_t content_length, const ResponseMetadata& cached_metadata,
-                             Envoy::SystemTime now) PURE;
+                             SystemTime now) PURE;
 
   // setCallbacks allows additional callbacks to be set when the CacheFilter
   // sets decoder filter callbacks.

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -17,7 +17,7 @@ struct CacheEntryUsability {
 };
 
 class CachePolicyCallbacks {
- public:
+public:
   virtual ~CachePolicyCallbacks() = default;
 
   virtual const Envoy::StreamInfo::FilterStateSharedPtr& filterState() PURE;

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "envoy/http/header_map.h"
+
+#include "source/extensions/filters/http/cache/cache_headers_utils.h"
+#include "source/extensions/filters/http/cache/http_cache.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Cache {
+
+struct CacheEntryUsability {
+  CacheEntryStatus status = CacheEntryStatus::Unusable;
+  Envoy::Seconds age = Envoy::Seconds::max();
+};
+
+// CachePolicy is an extension point for deployment specific caching behavior.
+class CachePolicy {
+public:
+  virtual ~CachePolicy() = default;
+
+  // createCacheKey calculates the lookup key for storing the entry in the cache.
+  virtual Key createCacheKey(const Envoy::Http::RequestHeaderMap& request_headers) PURE;
+
+  // requestCacheable modifies the cacheability of the response during
+  // decoding. request_cache_control is the result of parsing the request's
+  // Cache-Control header, parsed by the caller.
+  virtual bool requestCacheable(const Envoy::Http::RequestHeaderMap& request_headers,
+                                const RequestCacheControl& request_cache_control) PURE;
+
+  // responseCacheable modifies the cacheability of the response during
+  // encoding. response_cache_control is the result of parsing the response's
+  // Cache-Control header, parsed by the caller.
+  virtual bool responseCacheable(const Envoy::Http::RequestHeaderMap& request_headers,
+                                 const Envoy::Http::ResponseHeaderMap& response_headers,
+                                 const ResponseCacheControl& response_cache_control,
+                                 const VaryHeader& vary_allow_list) PURE;
+
+  // computeCacheEntryUsability calculates whether the cached entry may be used
+  // directly or must be validated with upstream. request_cache_control and
+  // response_cache_control are the result of parsing the request's and
+  // response's Cache-Control header, respectively, parsed by the caller.
+  virtual CacheEntryUsability
+  computeCacheEntryUsability(const Envoy::Http::RequestHeaderMap& request_headers,
+                             const Envoy::Http::ResponseHeaderMap& cached_response_headers,
+                             const RequestCacheControl& request_cache_control,
+                             const ResponseCacheControl& cached_response_cache_control,
+                             const uint64_t content_length, const ResponseMetadata& cached_metadata,
+                             Envoy::SystemTime now) PURE;
+
+  // setCallbacks allows additional callbacks to be set when the CacheFilter
+  // sets decoder filter callbacks.
+  virtual void setCallbacks(CachePolicyCallbacks& callbacks) PURE;
+};
+
+} // namespace Cache
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -2,6 +2,7 @@
 
 #include "envoy/http/header_map.h"
 #include "envoy/stream_info/filter_state.h"
+
 #include "source/extensions/filters/http/cache/cache_headers_utils.h"
 #include "source/extensions/filters/http/cache/http_cache.h"
 

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -2,7 +2,6 @@
 
 #include "envoy/http/header_map.h"
 #include "envoy/stream_info/filter_state.h"
-
 #include "source/extensions/filters/http/cache/cache_headers_utils.h"
 #include "source/extensions/filters/http/cache/http_cache.h"
 
@@ -74,7 +73,7 @@ public:
   /**
    * Determines whether the cached entry may be used directly or must be validated with upstream.
    * @param request_headers - request headers associated with the response_headers.
-   * @param response_headers - headers from the cached response.
+   * @param cached_response_headers - headers from the cached response.
    * @param request_cache_control - the parsed result of the request's Cache-Control header, parsed
    * by the caller.
    * @param cached_response_cache_control - the parsed result of the response's Cache-Control

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -11,8 +11,17 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
+/**
+ * Contains information about whether the cache entry is usable.
+ */
 struct CacheEntryUsability {
+  /**
+   * Whether the cache entry is usable, additional checks are required to be usable, or unusable.
+   */
   CacheEntryStatus status = CacheEntryStatus::Unusable;
+  /**
+   * Value to be put in the Age header for cache responses.
+   */
   Seconds age = Seconds::max();
 };
 
@@ -37,7 +46,7 @@ public:
   virtual Key createCacheKey(const Http::RequestHeaderMap& request_headers) PURE;
 
   /**
-   * Modifies the cacheability of the response during decoding.
+   * Determines the cacheability of the response during decoding.
    * @param request_headers - headers from the request the CacheFilter is currently processing.
    * @param request_cache_control - the result of parsing the request's Cache-Control header, parsed
    * by the caller.
@@ -47,7 +56,7 @@ public:
                                 const RequestCacheControl& request_cache_control) PURE;
 
   /**
-   * Modifies the cacheability of the response during encoding.
+   * Determines the cacheability of the response during encoding.
    * @param request_headers - headers from the request the CacheFilter is currently processing.
    * @param response_headers - headers from the upstream response the CacheFilter is currently
    * processing.
@@ -63,9 +72,9 @@ public:
                                  const VaryHeader& vary_allow_list) PURE;
 
   /**
-   * Calculates whether the cached entry may be used directly or must be validated with upstream.
-   * @param request_headers - headers from the request the CacheFilter is currently processing.
-   * @param response_headers - headers from the cached response the CacheFilter has retrieved.
+   * Determines whether the cached entry may be used directly or must be validated with upstream.
+   * @param request_headers - request headers associated with the response_headers.
+   * @param response_headers - headers from the cached response.
    * @param request_cache_control - the parsed result of the request's Cache-Control header, parsed
    * by the caller.
    * @param cached_response_cache_control - the parsed result of the response's Cache-Control
@@ -84,7 +93,7 @@ public:
                              SystemTime now) PURE;
 
   /**
-   * Perform actions when StreamInfo and FilterState become available, for
+   * Performs actions when StreamInfo and FilterState become available, for
    * example for logging and observability, or to adapt CacheFilter behavior based on
    * route-specific CacheFilter config.
    * @param callbacks - Gives access to StreamInfo and FilterState

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/http/header_map.h"
+#include "envoy/stream_info/filter_state.h"
 
 #include "source/extensions/filters/http/cache/cache_headers_utils.h"
 #include "source/extensions/filters/http/cache/http_cache.h"
@@ -13,6 +14,13 @@ namespace Cache {
 struct CacheEntryUsability {
   CacheEntryStatus status = CacheEntryStatus::Unusable;
   Envoy::Seconds age = Envoy::Seconds::max();
+};
+
+class CachePolicyCallbacks {
+ public:
+  virtual ~CachePolicyCallbacks() = default;
+
+  virtual const Envoy::StreamInfo::FilterStateSharedPtr& filterState() PURE;
 };
 
 // CachePolicy is an extension point for deployment specific caching behavior.

--- a/source/extensions/filters/http/cache/cache_policy.h
+++ b/source/extensions/filters/http/cache/cache_policy.h
@@ -23,32 +23,58 @@ public:
   virtual const StreamInfo::FilterStateSharedPtr& filterState() PURE;
 };
 
-// CachePolicy is an extension point for deployment specific caching behavior.
+/**
+ * An extension point for deployment specific caching behavior.
+ */
 class CachePolicy {
 public:
   virtual ~CachePolicy() = default;
 
-  // createCacheKey calculates the lookup key for storing the entry in the cache.
+  /**
+   * Calculates the lookup key for storing the entry in the cache.
+   * @param request_headers - headers from the request the CacheFilter is currently processing.
+   */
   virtual Key createCacheKey(const Http::RequestHeaderMap& request_headers) PURE;
 
-  // requestCacheable modifies the cacheability of the response during
-  // decoding. request_cache_control is the result of parsing the request's
-  // Cache-Control header, parsed by the caller.
+  /**
+   * Modifies the cacheability of the response during decoding.
+   * @param request_headers - headers from the request the CacheFilter is currently processing.
+   * @param request_cache_control - the result of parsing the request's Cache-Control header, parsed
+   * by the caller.
+   * @return true if the response may be cached, based on the contents of the request.
+   */
   virtual bool requestCacheable(const Http::RequestHeaderMap& request_headers,
                                 const RequestCacheControl& request_cache_control) PURE;
 
-  // responseCacheable modifies the cacheability of the response during
-  // encoding. response_cache_control is the result of parsing the response's
-  // Cache-Control header, parsed by the caller.
+  /**
+   * Modifies the cacheability of the response during encoding.
+   * @param request_headers - headers from the request the CacheFilter is currently processing.
+   * @param response_headers - headers from the upstream response the CacheFilter is currently
+   * processing.
+   * @param response_cache_control - the result of parsing the response's Cache-Control header,
+   * parsed by the caller.
+   * @param vary_allow_list - list of headers that the cache will respect when creating the Key for
+   * Vary-differentiated responses.
+   * @return true if the response may be cached.
+   */
   virtual bool responseCacheable(const Http::RequestHeaderMap& request_headers,
                                  const Http::ResponseHeaderMap& response_headers,
                                  const ResponseCacheControl& response_cache_control,
                                  const VaryHeader& vary_allow_list) PURE;
 
-  // computeCacheEntryUsability calculates whether the cached entry may be used
-  // directly or must be validated with upstream. request_cache_control and
-  // response_cache_control are the result of parsing the request's and
-  // response's Cache-Control header, respectively, parsed by the caller.
+  /**
+   * Calculates whether the cached entry may be used directly or must be validated with upstream.
+   * @param request_headers - headers from the request the CacheFilter is currently processing.
+   * @param response_headers - headers from the cached response the CacheFilter has retrieved.
+   * @param request_cache_control - the parsed result of the request's Cache-Control header, parsed
+   * by the caller.
+   * @param cached_response_cache_control - the parsed result of the response's Cache-Control
+   * header, parsed by the caller.
+   * @param content_length - the byte length of the cached content.
+   * @param cached_metadata - the metadata that has been stored along side the cached entry.
+   * @param now - the timestamp for this request.
+   * @return details about whether or not the cached entry can be used.
+   */
   virtual CacheEntryUsability
   computeCacheEntryUsability(const Http::RequestHeaderMap& request_headers,
                              const Http::ResponseHeaderMap& cached_response_headers,
@@ -57,8 +83,12 @@ public:
                              const uint64_t content_length, const ResponseMetadata& cached_metadata,
                              SystemTime now) PURE;
 
-  // setCallbacks allows additional callbacks to be set when the CacheFilter
-  // sets decoder filter callbacks.
+  /**
+   * Perform actions when StreamInfo and FilterState become available, for
+   * example for logging and observability, or to adapt CacheFilter behavior based on
+   * route-specific CacheFilter config.
+   * @param callbacks - Gives access to StreamInfo and FilterState
+   */
   virtual void setCallbacks(CachePolicyCallbacks& callbacks) PURE;
 };
 


### PR DESCRIPTION
Commit Message:
Add CachePolicy interface

Additional Description:
In order to support custom cache behavior, we need to provide an extension point that allows the results of basic cache semantics to be modified prior to acting on the calculated results.

A CachePolicy implementation contains logic that modifies how the CacheFilter interacts with an implementation of HttpCache. This includes key generation, cacheability and cache entry usability concerns.

A CachePolicy implementation does not contain:
- Logic that handles encoding or decoding a request or response. That belongs in CacheFilter.
- Logic specific to a cache. That belongs in HttpCache and related utils.

After we agree on the interface, I'll follow this PR with CachePolicyImpl and full integration in the CacheFilter.

Risk Level: None. Code is not in use.