### PR TITLE
Add local_end_stream_ to crash dump for H1

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -899,16 +899,8 @@ void ConnectionImpl::dumpState(std::ostream& os, int indent_level) const {
 
 void ServerConnectionImpl::dumpAdditionalState(std::ostream& os, int indent_level) const {
   const char* spaces = spacesForLevel(indent_level);
-  os << DUMP_MEMBER_AS(active_request_.request_url_,
-                       active_request_.has_value() &&
-                               !active_request_.value().request_url_.getStringView().empty()
-                           ? active_request_.value().request_url_.getStringView()
-                           : "null");
-  os << DUMP_MEMBER_AS(
-      active_request_.response_encoder_.local_end_stream_,
-      active_request_.has_value()
-          ? absl::StrCat(active_request_.value().response_encoder_.local_end_stream_)
-          : "null");
+
+  DUMP_DETAILS(active_request_);
   os << '\n';
 
   // Dump header map, it may be null if it was moved to the request, and
@@ -1231,6 +1223,13 @@ Status ServerConnectionImpl::checkHeaderNameForUnderscores() {
     }
   }
   return okStatus();
+}
+
+void ServerConnectionImpl::ActiveRequest::dumpState(std::ostream& os, int indent_level) const {
+  (void)indent_level;
+  os << DUMP_MEMBER_AS(
+      request_url_, !request_url_.getStringView().empty() ? request_url_.getStringView() : "null");
+  os << DUMP_MEMBER(response_encoder_.local_end_stream_);
 }
 
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection, CodecStats& stats,

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -904,6 +904,11 @@ void ServerConnectionImpl::dumpAdditionalState(std::ostream& os, int indent_leve
                                !active_request_.value().request_url_.getStringView().empty()
                            ? active_request_.value().request_url_.getStringView()
                            : "null");
+  os << DUMP_MEMBER_AS(
+      active_request_.response_encoder_.local_end_stream_,
+      active_request_.has_value()
+          ? absl::StrCat(active_request_.value().response_encoder_.local_end_stream_)
+          : "null");
   os << '\n';
 
   // Dump header map, it may be null if it was moved to the request, and

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -440,6 +440,7 @@ protected:
         : response_encoder_(connection,
                             connection.codec_settings_.stream_error_on_invalid_http_message_) {}
 
+    void dumpState(std::ostream& os, int indent_level) const;
     HeaderString request_url_;
     RequestDecoder* request_decoder_{};
     ResponseEncoderImpl response_encoder_;

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -2157,11 +2157,10 @@ TEST_F(Http1ServerConnectionImplTest, ShouldDumpDispatchBufferWithoutAllocatingM
   EXPECT_TRUE(status.ok());
 
   // Check dump contents
-  EXPECT_THAT(ostream.contents(),
-              HasSubstr("buffered_body_.length(): 5, header_parsing_state_: "
-                        "Done, current_header_field_: , current_header_value_: "
-                        "\n, active_request_.request_url_: null"
-                        ", active_request_.response_encoder_.local_end_stream_: 0"));
+  EXPECT_THAT(ostream.contents(), HasSubstr("buffered_body_.length(): 5, header_parsing_state_: "
+                                            "Done, current_header_field_: , current_header_value_: "
+                                            "\nactive_request_: \n, request_url_: null"
+                                            ", response_encoder_.local_end_stream_: 0"));
   EXPECT_THAT(ostream.contents(),
               HasSubstr("current_dispatching_buffer_ front_slice length: 43 contents: \"POST / "
                         "HTTP/1.1\\r\\nContent-Length: 5\\r\\n\\r\\nHello\"\n"));

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -2157,9 +2157,11 @@ TEST_F(Http1ServerConnectionImplTest, ShouldDumpDispatchBufferWithoutAllocatingM
   EXPECT_TRUE(status.ok());
 
   // Check dump contents
-  EXPECT_THAT(ostream.contents(), HasSubstr("buffered_body_.length(): 5, header_parsing_state_: "
-                                            "Done, current_header_field_: , current_header_value_: "
-                                            "\n, active_request_.request_url_: null"));
+  EXPECT_THAT(ostream.contents(),
+              HasSubstr("buffered_body_.length(): 5, header_parsing_state_: "
+                        "Done, current_header_field_: , current_header_value_: "
+                        "\n, active_request_.request_url_: null"
+                        ", active_request_.response_encoder_.local_end_stream_: 0"));
   EXPECT_THAT(ostream.contents(),
               HasSubstr("current_dispatching_buffer_ front_slice length: 43 contents: \"POST / "
                         "HTTP/1.1\\r\\nContent-Length: 5\\r\\n\\r\\nHello\"\n"));


### PR DESCRIPTION
Signed-off-by: Pradeep Rao <pcrao@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
