### PR TITLE
hds: reset specifier_hash on remoteClose

### DIFF
--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -330,6 +330,7 @@ void HdsDelegate::onRemoteClose(Grpc::Status::GrpcStatus status, const std::stri
   hds_stream_response_timer_->disableTimer();
   stream_ = nullptr;
   server_response_ms_ = 0;
+  specifier_hash_ = 0;
   handleFailure();
 }
 

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -1320,7 +1320,8 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthyHttpHdsReconnect) {
             envoy::service::health::v3::Capability::HTTP);
 
   // Server asks for health checking
-  server_health_check_specifier_ = makeHttpHealthCheckSpecifier(envoy::type::v3::CodecClientType::HTTP1, false);
+  server_health_check_specifier_ =
+      makeHttpHealthCheckSpecifier(envoy::type::v3::CodecClientType::HTTP1, false);
   hds_stream_->startGrpcStream();
   hds_stream_->sendGrpcMessage(server_health_check_specifier_);
   test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -1279,5 +1279,55 @@ TEST_P(HdsIntegrationTest, SingleEndpointUnhealthyHttpCustomPort) {
   cleanupHdsConnection();
 }
 
+// Tests Envoy keeps sending EndpointHealthResponses after the HDS server reconnection
+TEST_P(HdsIntegrationTest, SingleEndpointHealthyHttpHdsReconnect) {
+  XDS_DEPRECATED_FEATURE_TEST_SKIP;
+  initialize();
+
+  // Server <--> Envoy
+  waitForHdsStream();
+  ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
+  EXPECT_EQ(envoy_msg_.health_check_request().capability().health_check_protocols(0),
+            envoy::service::health::v3::Capability::HTTP);
+
+  // Server asks for health checking
+  server_health_check_specifier_ =
+      makeHttpHealthCheckSpecifier(envoy::type::v3::CodecClientType::HTTP1, false);
+  hds_stream_->startGrpcStream();
+  hds_stream_->sendGrpcMessage(server_health_check_specifier_);
+  test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
+
+  // Envoy sends a health check message to an endpoint
+  healthcheckEndpoints();
+
+  // Endpoint responds to the health check
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  host_stream_->encodeData(1024, true);
+
+  // Receive updates until the one we expect arrives
+  waitForEndpointHealthResponse(envoy::config::core::v3::HEALTHY);
+
+  checkCounters(1, 2, 1, 0);
+
+  // Simulate disconnection of HDS server
+  hds_fake_connection_->encodeProtocolError();
+  ASSERT_TRUE(hds_fake_connection_->waitForDisconnect());
+
+  // Server <--> Envoy, connect once again
+  waitForHdsStream();
+  ASSERT_TRUE(hds_stream_->waitForGrpcMessage(*dispatcher_, envoy_msg_));
+  EXPECT_EQ(envoy_msg_.health_check_request().capability().health_check_protocols(0),
+            envoy::service::health::v3::Capability::HTTP);
+
+  // Server asks for health checking
+  server_health_check_specifier_ = makeHttpHealthCheckSpecifier(envoy::type::v3::CodecClientType::HTTP1, false);
+  hds_stream_->startGrpcStream();
+  hds_stream_->sendGrpcMessage(server_health_check_specifier_);
+  test_server_->waitForCounterGe("hds_delegate.requests", ++hds_requests_);
+
+  // Receive updates until the one we expect arrives
+  waitForEndpointHealthResponse(envoy::config::core::v3::HEALTHY);
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -1310,7 +1310,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthyHttpHdsReconnect) {
   checkCounters(1, 2, 1, 0);
 
   // Simulate disconnection of HDS server
-  hds_fake_connection_->encodeProtocolError();
+  ASSERT_TRUE(hds_fake_connection_->close());
   ASSERT_TRUE(hds_fake_connection_->waitForDisconnect());
 
   // Server <--> Envoy, connect once again
@@ -1327,6 +1327,10 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthyHttpHdsReconnect) {
 
   // Receive updates until the one we expect arrives
   waitForEndpointHealthResponse(envoy::config::core::v3::HEALTHY);
+
+  // Clean up connections
+  cleanupHostConnections();
+  cleanupHdsConnection();
 }
 
 } // namespace


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: when Envoy is reconnected to the management server it may receive the same `HealthCheckSpecifier`. Since `specifier_hash_` is equal to the new `hash` Envoy won't call `enableTimer` and thus `EndpointHealthResponse` won't be sent after reconnect at all. That's why in the `onRemoteClose` this `specifier_hash_` has to be reset.
Additional Description: N/A
Risk Level: low
Testing: manual
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
