### PR TITLE
[WIP] tooling: Ensure Checker always runs `on_checks_complete`

### DIFF
--- a/tools/base/checker.py
+++ b/tools/base/checker.py
@@ -194,12 +194,14 @@ class Checker(runner.Runner):
     def run(self) -> int:
         """Run all configured checks and return the sum of their error counts"""
         checks = self.get_checks()
-        self.on_checks_begin()
-        for check in checks:
-            self.log.info(f"[CHECKS:{self.name}] {check}")
-            getattr(self, f"check_{check}")()
-            self.on_check_run(check)
-        return self.on_checks_complete()
+        try:
+            self.on_checks_begin()
+            for check in checks:
+                self.log.info(f"[CHECKS:{self.name}] {check}")
+                getattr(self, f"check_{check}")()
+                self.on_check_run(check)
+        finally:
+            return self.on_checks_complete()
 
     def succeed(self, name: str, success: list, log: bool = True) -> None:
         """Record (and log) success for a check type"""
@@ -279,11 +281,13 @@ class AsyncChecker(Checker):
     async def _run(self) -> int:
         checks = self.get_checks()
         await self.on_checks_begin()
-        for check in checks:
-            self.log.info(f"[CHECKS:{self.name}] {check}")
-            await getattr(self, f"check_{check}")()
-            await self.on_check_run(check)
-        return await self.on_checks_complete()
+        try:
+            for check in checks:
+                self.log.info(f"[CHECKS:{self.name}] {check}")
+                await getattr(self, f"check_{check}")()
+                await self.on_check_run(check)
+        finally:
+            return await self.on_checks_complete()
 
     def run(self) -> int:
         return asyncio.get_event_loop().run_until_complete(self._run())


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Commit Message: tooling: Ensure Checker always runs `on_checks_complete`
Additional Description:

this can be used for closing connections etc, so it should run even when the checker has failed

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
