### PR TITLE
build: fix mac build on xcode 12

### DIFF
--- a/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
@@ -496,7 +496,7 @@ void DecoderImpl::onStartup() {
   // It is skipped. After that message contains attributes.
   std::vector<absl::string_view> splitter =
       absl::StrSplit(absl::string_view(message_).substr(4), absl::ByChar('\0'), absl::SkipEmpty());
-  // With Xcode12, StrSplit with map return type fails range-loop-analysis as absl does not use
+  // With "Xcode12", StrSplit with map return type fails range-loop-analysis as absl does not use
   // reference type in range loop while constructing map.
   // This is a workaround to use reference type to avoid that compilation error.
   bool insert = true;

--- a/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
@@ -492,21 +492,23 @@ void DecoderImpl::onQuery() { callbacks_->processQuery(message_); }
 // The message format is continuous string of the following format:
 // user<username>database<database-name>application_name<application>encoding<encoding-type>
 void DecoderImpl::onStartup() {
-// First 4 bytes of startup message contains version code.
+  // First 4 bytes of startup message contains version code.
   // It is skipped. After that message contains attributes.
-  std::vector<absl::string_view> splitter = absl::StrSplit(absl::string_view(message_).substr(4), absl::ByChar('\0'), absl::SkipEmpty());
-  // With Xcode12, StrSplit with map return type fails range-loop-analysis as absl does not use reference type in range loop while copying.
+  std::vector<absl::string_view> splitter =
+      absl::StrSplit(absl::string_view(message_).substr(4), absl::ByChar('\0'), absl::SkipEmpty());
+  // With Xcode12, StrSplit with map return type fails range-loop-analysis as absl does not use
+  // reference type in range loop while constructing map.
   // This is a workaround to use reference type to avoid that compilation error.
   bool insert = true;
   std::string key;
   for (const auto& sp : splitter) {
-        if (insert) {
-          key = std::string(sp);
-        } else {
-          attributes_[key] = std::string(sp);
-        }
-        insert = !insert;
-      }
+    if (insert) {
+      key = std::string(sp);
+    } else {
+      attributes_[key] = std::string(sp);
+    }
+    insert = !insert;
+  }
 
   // If "database" attribute is not found, default it to "user" attribute.
   if ((attributes_.find("database") == attributes_.end()) &&

--- a/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
+++ b/source/extensions/filters/network/postgres_proxy/postgres_decoder.cc
@@ -492,9 +492,21 @@ void DecoderImpl::onQuery() { callbacks_->processQuery(message_); }
 // The message format is continuous string of the following format:
 // user<username>database<database-name>application_name<application>encoding<encoding-type>
 void DecoderImpl::onStartup() {
-  // First 4 bytes of startup message contains version code.
+// First 4 bytes of startup message contains version code.
   // It is skipped. After that message contains attributes.
-  attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'), absl::SkipEmpty());
+  std::vector<absl::string_view> splitter = absl::StrSplit(absl::string_view(message_).substr(4), absl::ByChar('\0'), absl::SkipEmpty());
+  // With Xcode12, StrSplit with map return type fails range-loop-analysis as absl does not use reference type in range loop while copying.
+  // This is a workaround to use reference type to avoid that compilation error.
+  bool insert = true;
+  std::string key;
+  for (const auto& sp : splitter) {
+        if (insert) {
+          key = std::string(sp);
+        } else {
+          attributes_[key] = std::string(sp);
+        }
+        insert = !insert;
+      }
 
   // If "database" attribute is not found, default it to "user" attribute.
   if ((attributes_.find("database") == attributes_.end()) &&


### PR DESCRIPTION
Commit Message: fix mac build on xcode 12
Additional Description:
Build with Xcode 12 on Mac fails with the following error as abseil while constructing map uses non reference range loop.
```

source/extensions/filters/network/postgres_proxy/postgres_decoder.cc:502:19: error: loop variable 'sp' of type 'const absl::string_view' creates a copy from type 'const absl::string_view' [-Werror,-Wrange-loop-analysis]
  for (const auto sp : splitter) {
                  ^
source/extensions/filters/network/postgres_proxy/postgres_decoder.cc:502:8: note: use reference type 'const absl::string_view &' to prevent copying
  for (const auto sp : splitter) {
       ^~~~~~~~~~~~~~~
```
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
