### PR TITLE
tools: exempting dependabot from unassigned warnings

### DIFF
--- a/.github/actions/pr_notifier/pr_notifier.py
+++ b/.github/actions/pr_notifier/pr_notifier.py
@@ -128,7 +128,11 @@ def track_prs():
         # If the PR is waiting, continue.
         if is_waiting(labels):
             continue
+        # Drafts are not covered by our SLO (repokitteh warns of this)
         if pr_info.draft:
+            continue
+        # Don't warn for dependabot.
+        if pr_info.user.login == 'dependabot[bot]':
             continue
 
         # Update the time based on the time zone delta from github's
@@ -153,7 +157,7 @@ def track_prs():
             pr_info.assignees, maintainers_and_prs, message, MAINTAINERS)
 
         # If there was no maintainer, track it as unassigned.
-        if not has_maintainer_assignee and pr_info.user.login != 'dependabot[bot]':
+        if not has_maintainer_assignee:
             maintainers_and_prs['unassigned'] = maintainers_and_prs['unassigned'] + message
 
     # Return the dict of {maintainers : PR notifications},
@@ -198,8 +202,6 @@ def post_to_oncall(client, unassigned_prs, out_slo_prs):
 
 if __name__ == '__main__':
     maintainers_and_messages, shephards_and_messages, stalled_prs = track_prs()
-
-    print(maintainers_and_messages['unassigned'])
 
     SLACK_BOT_TOKEN = os.getenv('SLACK_BOT_TOKEN')
     if not SLACK_BOT_TOKEN:

--- a/.github/actions/pr_notifier/pr_notifier.py
+++ b/.github/actions/pr_notifier/pr_notifier.py
@@ -153,7 +153,7 @@ def track_prs():
             pr_info.assignees, maintainers_and_prs, message, MAINTAINERS)
 
         # If there was no maintainer, track it as unassigned.
-        if not has_maintainer_assignee:
+        if not has_maintainer_assignee and pr_info.user.login != 'dependabot[bot]':
             maintainers_and_prs['unassigned'] = maintainers_and_prs['unassigned'] + message
 
     # Return the dict of {maintainers : PR notifications},
@@ -198,6 +198,8 @@ def post_to_oncall(client, unassigned_prs, out_slo_prs):
 
 if __name__ == '__main__':
     maintainers_and_messages, shephards_and_messages, stalled_prs = track_prs()
+
+    print(maintainers_and_messages['unassigned'])
 
     SLACK_BOT_TOKEN = os.getenv('SLACK_BOT_TOKEN')
     if not SLACK_BOT_TOKEN:


### PR DESCRIPTION
I don't think we need 24h turnaround for bots.