### PR TITLE
Change envoy_package to envoy_extension_package for ext_proc tests

### DIFF
--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_package",
+    "envoy_extension_package",
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
@@ -10,7 +10,7 @@ load(
 
 licenses(["notice"])  # Apache 2
 
-envoy_package()
+envoy_extension_package()
 
 envoy_extension_cc_test(
     name = "config_test",


### PR DESCRIPTION
Risk Level: Low
Testing: ext_proc tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Signed-off-by: Yan Avlasov <yavlasov@google.com>
