### PR TITLE
http: fixing upstream stream limit bug (backport #14820)

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -237,6 +237,10 @@ message Http2ProtocolOptions {
   // For upstream connections, this also limits how many streams Envoy will initiate concurrently
   // on a single connection. If the limit is reached, Envoy may queue requests or establish
   // additional connections (as allowed per circuit breaker limits).
+  //
+  // This acts as an upper bound: Envoy will lower the max concurrent streams allowed on a given
+  // connection based on upstream settings. Config dumps will reflect the configured upper bound,
+  // not the per-connection negotiated limits.
   google.protobuf.UInt32Value max_concurrent_streams = 2
       [(validate.rules).uint32 = {lte: 2147483647 gte: 1}];
 

--- a/api/envoy/config/core/v4alpha/protocol.proto
+++ b/api/envoy/config/core/v4alpha/protocol.proto
@@ -244,6 +244,10 @@ message Http2ProtocolOptions {
   // For upstream connections, this also limits how many streams Envoy will initiate concurrently
   // on a single connection. If the limit is reached, Envoy may queue requests or establish
   // additional connections (as allowed per circuit breaker limits).
+  //
+  // This acts as an upper bound: Envoy will lower the max concurrent streams allowed on a given
+  // connection based on upstream settings. Config dumps will reflect the configured upper bound,
+  // not the per-connection negotiated limits.
   google.protobuf.UInt32Value max_concurrent_streams = 2
       [(validate.rules).uint32 = {lte: 2147483647 gte: 1}];
 

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,6 +13,12 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* http: fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
+* http: fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
+* http: fixed an issue where Enovy did not handle peer stream limits correctly, and queued streams in nghttp2 rather than establish new connections. This behavior can be temporarily reverted by setting `envoy.reloadable_features.improved_stream_limit_handling` to false.
+* http: reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure` to false.
+* tls: fix a crash when peer sends a TLS Alert with an unknown code.
+
 Removed Config or Runtime
 -------------------------
 *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -13,11 +13,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
-* http: fixed a crash upon receiving empty HTTP/2 metadata frames. Received empty metadata frames are now counted in the HTTP/2 codec stat :ref:`metadata_empty_frames <config_http_conn_man_stats_per_codec>`.
-* http: fixed a remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
 * http: fixed an issue where Enovy did not handle peer stream limits correctly, and queued streams in nghttp2 rather than establish new connections. This behavior can be temporarily reverted by setting `envoy.reloadable_features.improved_stream_limit_handling` to false.
-* http: reverting a behavioral change where upstream connect timeouts were temporarily treated differently from other connection failures. The change back to the original behavior can be temporarily reverted by setting `envoy.reloadable_features.treat_upstream_connect_timeout_as_connect_failure` to false.
-* tls: fix a crash when peer sends a TLS Alert with an unknown code.
 
 Removed Config or Runtime
 -------------------------

--- a/generated_api_shadow/envoy/config/core/v3/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v3/protocol.proto
@@ -237,6 +237,10 @@ message Http2ProtocolOptions {
   // For upstream connections, this also limits how many streams Envoy will initiate concurrently
   // on a single connection. If the limit is reached, Envoy may queue requests or establish
   // additional connections (as allowed per circuit breaker limits).
+  //
+  // This acts as an upper bound: Envoy will lower the max concurrent streams allowed on a given
+  // connection based on upstream settings. Config dumps will reflect the configured upper bound,
+  // not the per-connection negotiated limits.
   google.protobuf.UInt32Value max_concurrent_streams = 2
       [(validate.rules).uint32 = {lte: 2147483647 gte: 1}];
 

--- a/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
@@ -240,6 +240,10 @@ message Http2ProtocolOptions {
   // For upstream connections, this also limits how many streams Envoy will initiate concurrently
   // on a single connection. If the limit is reached, Envoy may queue requests or establish
   // additional connections (as allowed per circuit breaker limits).
+  //
+  // This acts as an upper bound: Envoy will lower the max concurrent streams allowed on a given
+  // connection based on upstream settings. Config dumps will reflect the configured upper bound,
+  // not the per-connection negotiated limits.
   google.protobuf.UInt32Value max_concurrent_streams = 2
       [(validate.rules).uint32 = {lte: 2147483647 gte: 1}];
 

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -355,6 +355,19 @@ public:
 };
 
 /**
+ * A class for sharing what HTTP/2 SETTINGS were received from the peer.
+ */
+class ReceivedSettings {
+public:
+  virtual ~ReceivedSettings() = default;
+
+  /**
+   * @return value of SETTINGS_MAX_CONCURRENT_STREAMS, or absl::nullopt if it was not present.
+   */
+  virtual const absl::optional<uint32_t>& maxConcurrentStreams() const PURE;
+};
+
+/**
  * Connection level callbacks.
  */
 class ConnectionCallbacks {
@@ -365,6 +378,13 @@ public:
    * Fires when the remote indicates "go away." No new streams should be created.
    */
   virtual void onGoAway(GoAwayErrorCode error_code) PURE;
+
+  /**
+   * Fires when the peer settings frame is received from the peer.
+   * This may occur multiple times across the lifetime of the connection.
+   * @param ReceivedSettings the settings received from the peer.
+   */
+  virtual void onSettings(ReceivedSettings& settings) { UNREFERENCED_PARAMETER(settings); }
 };
 
 /**

--- a/include/envoy/upstream/cluster_manager.h
+++ b/include/envoy/upstream/cluster_manager.h
@@ -82,25 +82,25 @@ struct ClusterConnectivityState {
   }
 
   template <class T> void checkAndDecrement(T& value, uint32_t delta) {
-    ASSERT(delta <= value);
+    ASSERT(std::numeric_limits<T>::min() + delta <= value);
     value -= delta;
   }
 
   template <class T> void checkAndIncrement(T& value, uint32_t delta) {
-    ASSERT(std::numeric_limits<T>::max() - value > delta);
+    ASSERT(std::numeric_limits<T>::max() - delta >= value);
     value += delta;
   }
 
-  void incrPendingStreams(uint32_t delta) { checkAndIncrement<uint32_t>(pending_streams_, delta); }
-  void decrPendingStreams(uint32_t delta) { checkAndDecrement<uint32_t>(pending_streams_, delta); }
+  void incrPendingStreams(uint32_t delta) { checkAndIncrement(pending_streams_, delta); }
+  void decrPendingStreams(uint32_t delta) { checkAndDecrement(pending_streams_, delta); }
   void incrConnectingStreamCapacity(uint32_t delta) {
-    checkAndIncrement<uint64_t>(connecting_stream_capacity_, delta);
+    checkAndIncrement(connecting_stream_capacity_, delta);
   }
   void decrConnectingStreamCapacity(uint32_t delta) {
-    checkAndDecrement<uint64_t>(connecting_stream_capacity_, delta);
+    checkAndDecrement(connecting_stream_capacity_, delta);
   }
-  void incrActiveStreams(uint32_t delta) { checkAndIncrement<uint32_t>(active_streams_, delta); }
-  void decrActiveStreams(uint32_t delta) { checkAndDecrement<uint32_t>(active_streams_, delta); }
+  void incrActiveStreams(uint32_t delta) { checkAndIncrement(active_streams_, delta); }
+  void decrActiveStreams(uint32_t delta) { checkAndDecrement(active_streams_, delta); }
 
   // Tracks the number of pending streams for this ClusterManager.
   uint32_t pending_streams_{};
@@ -111,7 +111,11 @@ struct ClusterConnectivityState {
   // For example, if an H2 connection is started with concurrent stream limit of 100, this
   // goes up by 100. If the connection is established and 2 streams are in use, it
   // would be reduced to 98 (as 2 of the 100 are not available).
-  uint64_t connecting_stream_capacity_{};
+  //
+  // Note that if more HTTP/2 streams have been established than are allowed by
+  // a late-received SETTINGS frame, this MAY BE NEGATIVE.
+  // Note this tracks the sum of multiple 32 bit stream capacities so must remain 64 bit.
+  int64_t connecting_stream_capacity_{};
 };
 
 /**

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -146,6 +146,11 @@ protected:
       codec_callbacks_->onGoAway(error_code);
     }
   }
+  void onSettings(ReceivedSettings& settings) override {
+    if (codec_callbacks_) {
+      codec_callbacks_->onSettings(settings);
+    }
+  }
 
   void onIdleTimeout() {
     host_->cluster().stats().upstream_cx_idle_timeout_.inc();

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -77,6 +77,15 @@ int reasonToReset(StreamResetReason reason) {
 
 using Http2ResponseCodeDetails = ConstSingleton<Http2ResponseCodeDetailValues>;
 
+ReceivedSettingsImpl::ReceivedSettingsImpl(const nghttp2_settings& settings) {
+  for (uint32_t i = 0; i < settings.niv; ++i) {
+    if (settings.iv[i].settings_id == NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS) {
+      concurrent_stream_limit_ = settings.iv[i].value;
+      break;
+    }
+  }
+}
+
 bool Utility::reconstituteCrumbledCookies(const HeaderString& key, const HeaderString& value,
                                           HeaderString& cookies) {
   if (key != Headers::get().Cookie.get().c_str()) {
@@ -783,7 +792,7 @@ Status ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
   }
 
   if (frame->hd.type == NGHTTP2_SETTINGS && frame->hd.flags == NGHTTP2_FLAG_NONE) {
-    onSettingsForTest(frame->settings);
+    onSettings(frame->settings);
   }
 
   StreamImpl* stream = getStream(frame->hd.stream_id);

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -39,6 +39,19 @@ namespace Http2 {
 // differentiate between HTTP/1 and HTTP/2.
 const std::string CLIENT_MAGIC_PREFIX = "PRI * HTTP/2";
 
+class ReceivedSettingsImpl : public ReceivedSettings {
+public:
+  explicit ReceivedSettingsImpl(const nghttp2_settings& settings);
+
+  // ReceivedSettings
+  const absl::optional<uint32_t>& maxConcurrentStreams() const override {
+    return concurrent_stream_limit_;
+  }
+
+private:
+  absl::optional<uint32_t> concurrent_stream_limit_{};
+};
+
 class Utility {
 public:
   /**
@@ -439,8 +452,10 @@ protected:
   void sendSettings(const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
                     bool disable_push);
   // Callback triggered when the peer's SETTINGS frame is received.
-  // NOTE: This is only used for tests.
-  virtual void onSettingsForTest(const nghttp2_settings&) {}
+  virtual void onSettings(const nghttp2_settings& settings) {
+    ReceivedSettingsImpl received_settings(settings);
+    callbacks().onSettings(received_settings);
+  }
 
   /**
    * Check if header name contains underscore character.

--- a/source/common/http/http2/conn_pool.cc
+++ b/source/common/http/http2/conn_pool.cc
@@ -28,6 +28,35 @@ void ActiveClient::onGoAway(Http::GoAwayErrorCode) {
   }
 }
 
+// Adjust the concurrent stream limit if the negotiated concurrent stream limit
+// is lower than the local max configured streams.
+//
+// Note: if multiple streams are assigned to a connection before the settings
+// are received, they may still be reset by the peer. This could be avoided by
+// not considering http/2 connections connected until the SETTINGS frame is
+// received, but that would result in a latency penalty instead.
+void ActiveClient::onSettings(ReceivedSettings& settings) {
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.improved_stream_limit_handling") &&
+      settings.maxConcurrentStreams().has_value() &&
+      settings.maxConcurrentStreams().value() < concurrent_stream_limit_) {
+    int64_t old_unused_capacity = currentUnusedCapacity();
+    // Given config limits old_unused_capacity should never exceed int32_t.
+    // TODO(alyssawilk) move remaining_streams_, concurrent_stream_limit_ and
+    // currentUnusedCapacity() to be explicit int32_t
+    ASSERT(std::numeric_limits<int32_t>::max() >= old_unused_capacity);
+    concurrent_stream_limit_ = settings.maxConcurrentStreams().value();
+    int64_t delta = old_unused_capacity - currentUnusedCapacity();
+    parent_.decrClusterStreamCapacity(delta);
+    ENVOY_CONN_LOG(trace, "Decreasing stream capacity by {}", *codec_client_, delta);
+    negative_capacity_ += delta;
+  }
+  // As we don't increase stream limits when maxConcurrentStreams goes up, treat
+  // a stream limit of 0 as a GOAWAY.
+  if (concurrent_stream_limit_ == 0) {
+    parent_.transitionActiveClientState(*this, ActiveClient::State::DRAINING);
+  }
+}
+
 void ActiveClient::onStreamDestroy() {
   parent().onStreamClosed(*this, false);
 

--- a/source/common/http/http2/conn_pool.h
+++ b/source/common/http/http2/conn_pool.h
@@ -33,6 +33,20 @@ public:
 
   // Http::ConnectionCallbacks
   void onGoAway(Http::GoAwayErrorCode error_code) override;
+  void onSettings(ReceivedSettings& settings) override;
+
+  // As this is called once when the stream is closed, it's a good place to
+  // update the counter as one stream has been "returned" and the negative
+  // capacity should be reduced.
+  bool hadNegativeDeltaOnStreamClosed() override {
+    int ret = negative_capacity_ != 0;
+    if (negative_capacity_ > 0) {
+      negative_capacity_--;
+    }
+    return ret;
+  }
+
+  uint64_t negative_capacity_{};
 
   bool closed_with_active_rq_{};
 };

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -77,6 +77,7 @@ constexpr const char* runtime_features[] = {
     "envoy.reloadable_features.http_transport_failure_reason_in_body",
     "envoy.reloadable_features.http_upstream_wait_connect_response",
     "envoy.reloadable_features.http2_skip_encoding_empty_trailers",
+    "envoy.reloadable_features.improved_stream_limit_handling",
     "envoy.reloadable_features.listener_in_place_filterchain_update",
     "envoy.reloadable_features.overload_manager_disable_keepalive_drain_http2",
     "envoy.reloadable_features.prefer_quic_kernel_bpf_packet_routing",

--- a/test/common/http/common.h
+++ b/test/common/http/common.h
@@ -30,6 +30,7 @@ public:
   }
   void raiseGoAway(Http::GoAwayErrorCode error_code) { onGoAway(error_code); }
   Event::Timer* idleTimer() { return idle_timer_.get(); }
+  using Http::CodecClient::onSettings;
 
   DestroyCb destroy_cb_;
 };

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -79,8 +79,10 @@ public:
   using ServerConnectionImpl::getStream;
 
 protected:
-  // Overrides ServerConnectionImpl::onSettingsForTest().
-  void onSettingsForTest(const nghttp2_settings& settings) override { onSettingsFrame(settings); }
+  // Overrides ServerConnectionImpl::onSettings().
+  void onSettings(const nghttp2_settings& settings) override { onSettingsFrame(settings); }
+
+  testing::NiceMock<Random::MockRandomGenerator> random_;
 };
 
 class TestClientConnectionImpl : public TestCodecStatsProvider,
@@ -111,8 +113,8 @@ public:
   using ConnectionImpl::sendPendingFrames;
 
 protected:
-  // Overrides ClientConnectionImpl::onSettingsForTest().
-  void onSettingsForTest(const nghttp2_settings& settings) override { onSettingsFrame(settings); }
+  // Overrides ClientConnectionImpl::onSettings().
+  void onSettings(const nghttp2_settings& settings) override { onSettingsFrame(settings); }
 };
 
 } // namespace Http2

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -1440,10 +1440,102 @@ TEST_F(Http2ConnPoolImplTest, PreconnectOff) {
   // disable.
   expectClientsCreate(1);
   ActiveTestRequest r1(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 1 /*pending*/, 1 /*capacity*/);
 
   // Clean up.
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
   pool_->drainConnections();
+  closeAllClients();
+}
+
+TEST_F(Http2ConnPoolImplTest, PreconnectOffWithSettings) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.allow_preconnect", "false"}});
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.improved_stream_limit_handling", "true"}});
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(2);
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1));
+
+  // One stream results in one connection. Two streams result in two connections.
+  expectClientsCreate(1);
+  ActiveTestRequest r1(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 1 /*pending*/, 2 /*capacity*/);
+  ActiveTestRequest r2(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 2 /*pending*/, 2 /*capacity*/);
+
+  // When the connection connects, there is zero spare capacity in this pool.
+  EXPECT_CALL(*test_clients_[0].codec_, newStream(_))
+      .WillOnce(DoAll(SaveArgAddress(&r1.inner_decoder_), ReturnRef(r1.inner_encoder_)))
+      .WillOnce(DoAll(SaveArgAddress(&r2.inner_decoder_), ReturnRef(r2.inner_encoder_)));
+  EXPECT_CALL(r1.callbacks_.pool_ready_, ready());
+  EXPECT_CALL(r2.callbacks_.pool_ready_, ready());
+  expectClientConnect(0);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+
+  // Settings frame without max_concurrent_streams_ is a no-op.
+  NiceMock<MockReceivedSettings> settings;
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+
+  // Settings frame reducing capacity to one stream per connection results in -1 capacity.
+  settings.max_concurrent_streams_ = 1;
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, -1 /*capacity*/);
+
+  // Getting the same settings again should not affect capacity.
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, -1 /*capacity*/);
+
+  // As the first request completes, capacity returns to 0.
+  completeRequest(r1);
+  CHECK_STATE(1 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+  // As the second request completes, capacity returns to 1.
+  completeRequest(r2);
+  CHECK_STATE(0 /*active*/, 0 /*pending*/, 1 /*capacity*/);
+
+  // Increased limits are (currently) ignored: capacity will remain 1.
+  settings.max_concurrent_streams_ = 3;
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(0 /*active*/, 0 /*pending*/, 1 /*capacity*/);
+
+  // Now set the limit to 0. This could result in the connection being drained.
+  settings.max_concurrent_streams_ = 0;
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+
+  closeAllClients();
+}
+
+TEST_F(Http2ConnPoolImplTest, DisconnectWithNegativeCapacity) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.allow_preconnect", "false"}});
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(2);
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1));
+
+  // One stream results in one connection. Two streams result in two connections.
+  expectClientsCreate(1);
+  ActiveTestRequest r1(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 1 /*pending*/, 2 /*capacity*/);
+  ActiveTestRequest r2(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 2 /*pending*/, 2 /*capacity*/);
+
+  // When the connection connects, there is zero spare capacity in this pool.
+  EXPECT_CALL(*test_clients_[0].codec_, newStream(_))
+      .WillOnce(DoAll(SaveArgAddress(&r1.inner_decoder_), ReturnRef(r1.inner_encoder_)))
+      .WillOnce(DoAll(SaveArgAddress(&r2.inner_decoder_), ReturnRef(r2.inner_encoder_)));
+  EXPECT_CALL(r1.callbacks_.pool_ready_, ready());
+  EXPECT_CALL(r2.callbacks_.pool_ready_, ready());
+  expectClientConnect(0);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+
+  // Settings frame reducing capacity to one stream per connection results in -1 capacity.
+  NiceMock<MockReceivedSettings> settings;
+  settings.max_concurrent_streams_ = 1;
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, -1 /*capacity*/);
+
   closeAllClients();
 }
 
@@ -1462,6 +1554,41 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithMultiplexing) {
   expectClientsCreate(1);
   ActiveTestRequest r2(*this, 0, false);
   CHECK_STATE(0 /*active*/, 2 /*pending*/, 4 /*capacity*/);
+
+  // Clean up.
+  r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  r2.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
+  pool_->drainConnections();
+  closeAllClients();
+}
+
+TEST_F(Http2ConnPoolImplTest, PreconnectWithSettings) {
+  TestScopedRuntime scoped_runtime;
+  Runtime::LoaderSingleton::getExisting()->mergeValues(
+      {{"envoy.reloadable_features.improved_stream_limit_handling", "true"}});
+
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(2);
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
+
+  // With two requests per connection, and preconnect 1.5, the first request will
+  // only kick off 1 connection.
+  expectClientsCreate(1);
+  ActiveTestRequest r1(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 1 /*pending*/, 2 /*capacity*/);
+
+  // With another incoming request, we'll have capacity(2) in flight and want 1.5*2 so
+  // create an additional connection.
+  expectClientsCreate(1);
+  ActiveTestRequest r2(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 2 /*pending*/, 4 /*capacity*/);
+
+  // Now have the codecs receive SETTINGS frames limiting the streams per connection to one.
+  // onSettings
+  NiceMock<MockReceivedSettings> settings;
+  settings.max_concurrent_streams_ = 1;
+  test_clients_[0].codec_client_->onSettings(settings);
+  test_clients_[1].codec_client_->onSettings(settings);
+  CHECK_STATE(0 /*active*/, 2 /*pending*/, 2 /*capacity*/);
 
   // Clean up.
   r1.handle_->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -377,6 +377,10 @@ protected:
     proxy_buffer_factory_ = proxy_buffer_factory;
   }
 
+  void mergeOptions(envoy::config::core::v3::Http2ProtocolOptions& options) {
+    upstream_config_.http2_options_.MergeFrom(options);
+  }
+
   std::unique_ptr<Stats::Scope> upstream_stats_store_;
 
   // Make sure the test server will be torn down after any fake client.

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -326,11 +326,7 @@ FakeHttpConnection::FakeHttpConnection(
         shared_connection_.connection(), stats, *this, http1_settings, max_request_headers_kb,
         max_request_headers_count, headers_with_underscores_action);
   } else {
-    envoy::config::core::v3::Http2ProtocolOptions http2_options =
-        ::Envoy::Http2::Utility::initializeAndValidateOptions(
-            envoy::config::core::v3::Http2ProtocolOptions());
-    http2_options.set_allow_connect(true);
-    http2_options.set_allow_metadata(true);
+    envoy::config::core::v3::Http2ProtocolOptions http2_options = fake_upstream.http2Options();
     Http::Http2::CodecStats& stats = fake_upstream.http2CodecStats();
     codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(
         shared_connection_.connection(), *this, stats, random_, http2_options,
@@ -486,7 +482,7 @@ FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket
 
 FakeUpstream::FakeUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
                            Network::SocketPtr&& listen_socket, const FakeUpstreamConfig& config)
-    : http_type_(config.upstream_protocol_),
+    : http_type_(config.upstream_protocol_), http2_options_(config.http2_options_),
       socket_(Network::SocketSharedPtr(listen_socket.release())),
       socket_factory_(std::make_shared<FakeListenSocketFactory>(socket_)),
       api_(Api::createApiForTest(stats_store_)), time_system_(config.time_system_),

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -528,12 +528,18 @@ private:
 using FakeRawConnectionPtr = std::unique_ptr<FakeRawConnection>;
 
 struct FakeUpstreamConfig {
-  FakeUpstreamConfig(Event::TestTimeSystem& time_system) : time_system_(time_system) {}
+  FakeUpstreamConfig(Event::TestTimeSystem& time_system) : time_system_(time_system) {
+    http2_options_ = ::Envoy::Http2::Utility::initializeAndValidateOptions(http2_options_);
+    // Legacy options which are always set.
+    http2_options_.set_allow_connect(true);
+    http2_options_.set_allow_metadata(true);
+  }
 
   Event::TestTimeSystem& time_system_;
   FakeHttpConnection::Type upstream_protocol_{FakeHttpConnection::Type::HTTP1};
   bool enable_half_close_{};
   bool udp_fake_upstream_{};
+  envoy::config::core::v3::Http2ProtocolOptions http2_options_;
 };
 
 /**
@@ -634,6 +640,8 @@ public:
   testing::AssertionResult
   rawWriteConnection(uint32_t index, const std::string& data, bool end_stream = false,
                      std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
+  const envoy::config::core::v3::Http2ProtocolOptions& http2Options() { return http2_options_; }
 
 protected:
   Stats::IsolatedStoreImpl stats_store_;
@@ -737,6 +745,7 @@ private:
   SharedConnectionWrapper& consumeConnection() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   void onRecvDatagram(Network::UdpRecvData& data);
 
+  const envoy::config::core::v3::Http2ProtocolOptions http2_options_;
   Network::SocketSharedPtr socket_;
   Network::ListenSocketFactorySharedPtr socket_factory_;
   ConditionalInitializer server_initialized_;

--- a/test/mocks/http/mocks.cc
+++ b/test/mocks/http/mocks.cc
@@ -174,5 +174,9 @@ IsSupersetOfHeadersMatcher IsSupersetOfHeaders(const HeaderMap& expected_headers
   return IsSupersetOfHeadersMatcher(expected_headers);
 }
 
+MockReceivedSettings::MockReceivedSettings() {
+  ON_CALL(*this, maxConcurrentStreams()).WillByDefault(ReturnRef(max_concurrent_streams_));
+}
+
 } // namespace Http
 } // namespace Envoy

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -50,6 +50,7 @@ public:
 
   // Http::ConnectionCallbacks
   MOCK_METHOD(void, onGoAway, (GoAwayErrorCode error_code));
+  MOCK_METHOD(void, onSettings, (ReceivedSettings & settings));
 };
 
 class MockFilterManagerCallbacks : public FilterManagerCallbacks {
@@ -570,6 +571,16 @@ public:
 
   std::unique_ptr<Http::InternalAddressConfig> internal_address_config_ =
       std::make_unique<DefaultInternalAddressConfig>();
+};
+
+class MockReceivedSettings : public ReceivedSettings {
+public:
+  MockReceivedSettings();
+  ~MockReceivedSettings() override = default;
+
+  MOCK_METHOD(const absl::optional<uint32_t>&, maxConcurrentStreams, (), (const));
+
+  absl::optional<uint32_t> max_concurrent_streams_{};
 };
 
 } // namespace Http


### PR DESCRIPTION
Fixing a bug where the Envoy upstream logic didn't respect stream limits capped by upstream.
Backport of 06d0780 into v1.17

Signed-off-by: Yan Avlasov <yavlasov@google.com>
