### PR TITLE
upstream: support multiple HTTP conn pool on single cluster

### DIFF
--- a/envoy/upstream/thread_local_cluster.h
+++ b/envoy/upstream/thread_local_cluster.h
@@ -44,6 +44,8 @@ private:
   Http::ConnectionPool::Instance* pool_;
 };
 
+using HttpPoolDataVector = std::vector<HttpPoolData>;
+
 // Tcp pool returns information about a given pool, as well as a function to
 // create connections on that pool.
 class TcpPoolData {
@@ -105,9 +107,10 @@ public:
    *        valid until newConnection is called on the pool (if it is to be called).
    * @return the connection pool data or nullopt if there is no host available in the cluster.
    */
-  virtual absl::optional<HttpPoolData>
-  httpConnPool(ResourcePriority priority, absl::optional<Http::Protocol> downstream_protocol,
-               LoadBalancerContext* context) PURE;
+  virtual HttpPoolDataVector httpConnPool(ResourcePriority priority,
+                                          absl::optional<Http::Protocol> downstream_protocol,
+                                          LoadBalancerContext* context,
+                                          bool fetch_pool_all_hosts) PURE;
 
   /**
    * Allocate a load balanced TCP connection pool for a cluster. This is *per-thread* so that

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -402,10 +402,11 @@ private:
                    const LoadBalancerFactorySharedPtr& lb_factory);
       ~ClusterEntry() override;
 
-      Http::ConnectionPool::Instance* connPool(ResourcePriority priority,
+      std::vector<HostConstSharedPtr> selectHosts(LoadBalancerContext* context, bool peek,
+                                                  bool fetch_all_hosts);
+      Http::ConnectionPool::Instance* connPool(HostConstSharedPtr host, ResourcePriority priority,
                                                absl::optional<Http::Protocol> downstream_protocol,
-                                               LoadBalancerContext* context, bool peek);
-
+                                               LoadBalancerContext* context);
       Tcp::ConnectionPool::Instance* tcpConnPool(ResourcePriority priority,
                                                  LoadBalancerContext* context, bool peek);
 
@@ -413,9 +414,10 @@ private:
       const PrioritySet& prioritySet() override { return priority_set_; }
       ClusterInfoConstSharedPtr info() override { return cluster_info_; }
       LoadBalancer& loadBalancer() override { return *lb_; }
-      absl::optional<HttpPoolData> httpConnPool(ResourcePriority priority,
-                                                absl::optional<Http::Protocol> downstream_protocol,
-                                                LoadBalancerContext* context) override;
+      HttpPoolDataVector httpConnPool(ResourcePriority priority,
+                                      absl::optional<Http::Protocol> downstream_protocol,
+                                      LoadBalancerContext* context,
+                                      bool fetch_pool_all_hosts) override;
       absl::optional<TcpPoolData> tcpConnPool(ResourcePriority priority,
                                               LoadBalancerContext* context) override;
       Host::CreateConnectionData tcpConn(LoadBalancerContext* context) override;

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -50,7 +50,7 @@ public:
 
 protected:
   // Points to the actual connection pool to create streams from.
-  absl::optional<Envoy::Upstream::HttpPoolData> pool_data_{};
+  Envoy::Upstream::HttpPoolDataVector pool_data_set_;
   Envoy::Http::ConnectionPool::Cancellable* conn_pool_stream_handle_{};
   Router::GenericConnectionPoolCallbacks* callbacks_{};
 };

--- a/test/mocks/upstream/thread_local_cluster.cc
+++ b/test/mocks/upstream/thread_local_cluster.cc
@@ -13,8 +13,8 @@ MockThreadLocalCluster::MockThreadLocalCluster() {
   ON_CALL(*this, prioritySet()).WillByDefault(ReturnRef(cluster_.priority_set_));
   ON_CALL(*this, info()).WillByDefault(Return(cluster_.info_));
   ON_CALL(*this, loadBalancer()).WillByDefault(ReturnRef(lb_));
-  ON_CALL(*this, httpConnPool(_, _, _))
-      .WillByDefault(Return(Upstream::HttpPoolData([]() {}, &conn_pool_)));
+  ON_CALL(*this, httpConnPool(_, _, _, _))
+      .WillByDefault(Return(HttpPoolDataVector{Upstream::HttpPoolData([]() {}, &conn_pool_)}));
   ON_CALL(*this, tcpConnPool(_, _))
       .WillByDefault(Return(Upstream::TcpPoolData([]() {}, &tcp_conn_pool_)));
   ON_CALL(*this, httpAsyncClient()).WillByDefault(ReturnRef(async_client_));

--- a/test/mocks/upstream/thread_local_cluster.h
+++ b/test/mocks/upstream/thread_local_cluster.h
@@ -30,9 +30,9 @@ public:
   MOCK_METHOD(const PrioritySet&, prioritySet, ());
   MOCK_METHOD(ClusterInfoConstSharedPtr, info, ());
   MOCK_METHOD(LoadBalancer&, loadBalancer, ());
-  MOCK_METHOD(absl::optional<HttpPoolData>, httpConnPool,
+  MOCK_METHOD(HttpPoolDataVector, httpConnPool,
               (ResourcePriority priority, absl::optional<Http::Protocol> downstream_protocol,
-               LoadBalancerContext* context));
+               LoadBalancerContext* context, bool fetch_pool_all_hosts));
   MOCK_METHOD(absl::optional<TcpPoolData>, tcpConnPool,
               (ResourcePriority priority, LoadBalancerContext* context));
   MOCK_METHOD(MockHost::MockCreateConnectionData, tcpConn_, (LoadBalancerContext * context));


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message: Part of #17331. To achieve #17331, we need to get connection pools for all hosts belonging to one Cluster. In this PR, this functionality is achieved with a small refactor.
Additional Description:
Risk Level: Mid (because of core connection management)
Testing: Unit
Docs Changes: N/A
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
