### PR TITLE
bazel: disable -Wrange-loop-analysis on macOS

### DIFF
--- a/bazel/envoy_internal.bzl
+++ b/bazel/envoy_internal.bzl
@@ -77,6 +77,10 @@ def envoy_copts(repository, test = False):
                repository + "//bazel:clang_cl_build": ["-Wno-unused-result"] if test else [],
                "//conditions:default": [],
            }) + select({
+               # TODO: Remove once https://reviews.llvm.org/D73007 is in the lowest supported Xcode version
+               repository + "//bazel:apple": ["-Wno-range-loop-analysis"],
+               "//conditions:default": [],
+           }) + select({
                repository + "//bazel:no_debug_info": ["-g0"],
                "//conditions:default": [],
            }) + select({


### PR DESCRIPTION
The version of clang that ships with Xcode 12 has false positives with
this warning that might be fixed by https://reviews.llvm.org/D73007

In the meantime we can disable it entirely as discussed on
https://github.com/envoyproxy/envoy/pull/17393

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>