### PR TITLE
bazel: add darwin_arm64 to apple config group

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -550,6 +550,7 @@ selects.config_setting_group(
     name = "apple",
     match_any = [
         ":darwin",
+        ":darwin_arm64",
         ":darwin_x86_64",
         ":ios_arm64",
         ":ios_arm64e",


### PR DESCRIPTION
This is the CPU you target when building on an Apple Silicon mac. All
the apple settings should apply.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>