### PR TITLE
access log: fix %UPSTREAM_CLUSTER% in upstream http access logs

### DIFF
--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -32,6 +32,7 @@ Bug Fixes
 ---------
 *Changes expected to improve the state of the world and are unlikely to have negative effects*
 
+* access log: fix `%UPSTREAM_CLUSTER%` when used in http upstream access logs. Previously, it was always logging as an unset value.
 * xray: fix the AWS X-Ray tracer bug where span's error, fault and throttle information was not reported properly as per the `AWS X-Ray documentation <https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html>`_. Before this fix, server error was reported under 'annotations' section of the segment data.
 
 Removed Config or Runtime

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -62,6 +62,11 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
   }
 
   stream_info_.healthCheck(parent_.callbacks()->streamInfo().healthCheck());
+  absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info =
+      parent_.callbacks()->streamInfo().upstreamClusterInfo();
+  if (cluster_info.has_value()) {
+    stream_info_.setUpstreamClusterInfo(*cluster_info);
+  }
 }
 
 UpstreamRequest::~UpstreamRequest() {

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -165,6 +165,7 @@ public:
 
     EXPECT_CALL(context_.cluster_manager_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
                 putHttpResponseCode(response_code));
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     response_decoder->decodeHeaders(std::move(response_headers), false);
 
     Http::ResponseTrailerMapPtr response_trailers(

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -83,10 +83,11 @@ class RouterUpstreamLogTest : public testing::Test {
 public:
   void init(absl::optional<envoy::config::accesslog::v3::AccessLog> upstream_log) {
     envoy::extensions::filters::http::router::v3::Router router_proto;
+    static const std::string cluster_name = "cluster_0";
 
     cluster_info_ = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
-    ON_CALL(*cluster_info_, name()).WillByDefault(ReturnRef("cluster_0"));
-    ON_CALL(*cluster_info_, observabilityName()).WillByDefault(ReturnRef("cluster_0"));
+    ON_CALL(*cluster_info_, name()).WillByDefault(ReturnRef(cluster_name));
+    ON_CALL(*cluster_info_, observabilityName()).WillByDefault(ReturnRef(cluster_name));
     ON_CALL(callbacks_.stream_info_, upstreamClusterInfo()).WillByDefault(Return(cluster_info_));
 
     if (upstream_log) {


### PR DESCRIPTION


Signed-off-by: Greg Greenway <ggreenway@apple.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description: This has been broken for several versions, possibly by
commit 980c84dca7305e1dd29afe2ba9ce0d2d4a36bc9f.
Risk Level: Low
Testing: Added new test
Docs Changes: none
Release Notes: added
Platform Specific Features: none
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
