### PR TITLE
bazel: remove old luajit workaround

### DIFF
--- a/bazel/envoy_binary.bzl
+++ b/bazel/envoy_binary.bzl
@@ -54,12 +54,7 @@ def _envoy_select_exported_symbols(xs):
 # Compute the final linkopts based on various options.
 def _envoy_linkopts():
     return select({
-        # The macOS system library transitively links common libraries (e.g., pthread).
-        "@envoy//bazel:apple": [
-            # See note here: https://luajit.org/install.html
-            "-pagezero_size 10000",
-            "-image_base 100000000",
-        ],
+        "@envoy//bazel:apple": [],
         "@envoy//bazel:windows_opt_build": [
             "-DEFAULTLIB:ws2_32.lib",
             "-DEFAULTLIB:iphlpapi.lib",

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -60,11 +60,7 @@ def _envoy_cc_test_infrastructure_library(
 # Compute the test linkopts based on various options.
 def _envoy_test_linkopts():
     return select({
-        "@envoy//bazel:apple": [
-            # See note here: https://luajit.org/install.html
-            "-pagezero_size 10000",
-            "-image_base 100000000",
-        ],
+        "@envoy//bazel:apple": [],
         "@envoy//bazel:windows_x86_64": [
             "-DEFAULTLIB:ws2_32.lib",
             "-DEFAULTLIB:iphlpapi.lib",


### PR DESCRIPTION
According to https://luajit.org/install.html

> Important: this relates to LuaJIT 2.0 only — use LuaJIT 2.1 to avoid these complications.

Since we have updated past 2.1 we shouldn't need these anymore which is
great since it breaks on Apple Silicon

https://github.com/envoyproxy/envoy/issues/16482#issuecomment-846439439

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>