### PR TITLE
bazel: set PATH automatically on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -79,6 +79,8 @@ build:clang-asan --linkopt -fuse-ld=lld
 
 # macOS ASAN/UBSAN
 build:macos --cxxopt=-std=c++17
+build:macos --action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
+build:macos --host_action_env=PATH=/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin:/opt/local/bin
 
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -113,17 +113,6 @@ for how to update or override dependencies.
     Envoy compiles and passes tests with the version of clang installed by Xcode 11.1:
     Apple clang version 11.0.0 (clang-1100.0.33.8).
 
-    In order for bazel to be aware of the tools installed by brew, the PATH
-    variable must be set for bazel builds. This can be accomplished by setting
-    this in your `user.bazelrc` file:
-
-    ```
-    build --action_env=PATH="/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
-    ```
-
-    Alternatively, you can pass `--action_env` on the command line when running
-    `bazel build`/`bazel test`.
-
     Having the binutils keg installed in Brew is known to cause issues due to putting an incompatible
     version of `ar` on the PATH, so if you run into issues building third party code like luajit
     consider uninstalling binutils.

--- a/ci/mac_ci_steps.sh
+++ b/ci/mac_ci_steps.sh
@@ -25,7 +25,6 @@ BAZEL_BUILD_OPTIONS=(
     "--curses=no"
     --show_task_finish
     --verbose_failures
-    "--action_env=PATH=/usr/local/bin:/opt/local/bin:/usr/bin:/bin"
     "--test_output=all"
     "--flaky_test_attempts=integration@2"
     "--override_repository=envoy_build_config=${BUILD_CONFIG}"


### PR DESCRIPTION
Previously there was a docs recommendation to set the path manually when
building on macOS. Since we can use the `build:macos` config we can do
this automatically. This also allows us to transparently solve PATH
differences with Apple Silicon homebrew and intel homebrew, for the host
configuration as well.

This fixes this issue
https://github.com/bazelbuild/rules_foreign_cc/issues/672 that intel
homebrew didn't have because `--incompatible_strict_action_env` contains
`/usr/local/bin` but not `/opt/homebrew/bin`

This also reorders these so that we prefer pre-installed tools for
stability.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>