### PR TITLE
Increase buffer size of `Win32RedirectRecords`

### DIFF
--- a/envoy/network/io_handle.h
+++ b/envoy/network/io_handle.h
@@ -29,7 +29,7 @@ namespace Network {
 struct Win32RedirectRecords {
   // The size of the buffer is selected based on:
   // https://docs.microsoft.com/en-us/windows-hardware/drivers/network/sio-query-wfp-connection-redirect-records
-  uint8_t buf_[1024];
+  uint8_t buf_[2048];
   unsigned long buf_size_;
 };
 


### PR DESCRIPTION
Commit Message:

While testing the feature I noticed that we can not retrieve the
redirect records for the following curl request:

`curl.exe -s -o NUL -D - -I -w StatusCode:%{http_code} -L http://edition.cnn.com`

Increase the buffer size to 2kb to resolve the issue.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

Additional Description:
Risk Level: Low
Testing: Manually tested with the repro
Docs Changes: N/A
Release Notes: This feature is still in alpha so I do not think we need it
Platform Specific Features: Windows only
