### PR TITLE
Remove unused powershell call from Windows docker file

### DIFF
--- a/ci/Dockerfile-envoy-windows
+++ b/ci/Dockerfile-envoy-windows
@@ -13,8 +13,6 @@ ADD ["windows/amd64/envoy.exe", "C:/Program Files/envoy/"]
 
 RUN mkdir "C:\\ProgramData\\envoy"
 ADD ["configs/envoyproxy_io_proxy.yaml", "C:/ProgramData/envoy/envoy.yaml"]
-# Replace temp path with Windows temp path
-RUN powershell -Command "(cat C:\ProgramData\envoy\envoy.yaml -raw) -replace '/tmp/','C:\Windows\Temp\' | Set-Content -Encoding Ascii C:\ProgramData\envoy\envoy.yaml"
 
 EXPOSE 10000
 


### PR DESCRIPTION
Ever since https://github.com/envoyproxy/envoy/pull/15461 we no longer have a reference to `/tmp/` in `envoyproxy_io_proxy.yaml` so we do not need this powershell call.

Removing this call is important because it allows to build the Envoy Windows Container on `Nanoserver` which is required for #16759

Risk Level: Low
Testing: Manually build the container
Docs Changes: N/A
Release Notes: N/A (Null-Op)
Platform Specific Features: Windows only 

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>