### PR TITLE
quic: remove the extra space in the quic_logging_impl.h

### DIFF
--- a/source/common/quic/platform/quic_logging_impl.h
+++ b/source/common/quic/platform/quic_logging_impl.h
@@ -147,7 +147,7 @@ enum {
 // DFATAL is FATAL in debug mode, ERROR in release mode.
 #ifdef NDEBUG
   LogLevelDFATAL = LogLevelERROR,
-#else  // NDEBUG
+#else // NDEBUG
   LogLevelDFATAL = LogLevelFATAL,
 #endif // NDEBUG
 };


### PR DESCRIPTION



Commit Message: quic: remove the extra space in the quic_logging_impl.h
Additional Description:
This keep annoying me when I execute the format check script.

Risk Level: low
Testing:
Docs Changes:
Release Notes:


Signed-off-by: He Jie Xu <hejie.xu@intel.com>