### PR TITLE
docs: Fix the confusing word in http3 upsteam documents

### DIFF
--- a/source/docs/http3_upstream.md
+++ b/source/docs/http3_upstream.md
@@ -26,7 +26,7 @@ HTTP/3 is marked as broken it will be for the initial 5 minutes.
 
 #### Alternate Protocols Cache
 The `AlternateProtocolsCache` is responsible for tracking servers which advertise HTTP/3.
-These advertisements may arrive via HTTP Altnernate Service (alt-svc) or soon via the HTTPS
+These advertisements may arrive via HTTP Alternate Service (alt-svc) or soon via the HTTPS
 DNS RR. Currently only advertisements which specify the same hostname and port are stored.
 
 #### Connectivity Grid

--- a/source/docs/http3_upstream.md
+++ b/source/docs/http3_upstream.md
@@ -26,7 +26,7 @@ HTTP/3 is marked as broken it will be for the initial 5 minutes.
 
 #### Alternate Protocols Cache
 The `AlternateProtocolsCache` is responsible for tracking servers which advertise HTTP/3.
-These advertisements may arrive via HTTP Alternate Service (alt-svc) or soon via the HTTPS
+These advertisements may arrive via HTTP Alternative Service (alt-svc) or soon via the HTTPS
 DNS RR. Currently only advertisements which specify the same hostname and port are stored.
 
 #### Connectivity Grid


### PR DESCRIPTION
Signed-off-by: Le Yao <le.yao@intel.com>

Commit Message: Fix the confusing word in http3 upsteam section
Additional Description: The `Altnernate` confused the readers, I think it may be `Alternate`.
Risk Level: Low
Testing: N/A
Docs Changes: Yes
Release Notes: N/A
Platform Specific Features: N/A