### PR TITLE
quic: add QUIC upstream stream reset error stats

### DIFF
--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -114,7 +114,8 @@ HTTP/3 protocol stats are global with the following statistics:
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  <tx/rx>.quic_connection_close_error_code_<error_code>, Counter, A collection of counters that are lazily initialized to record each QUIC connection close's error code.
+  upstream.<tx/rx>.quic_connection_close_error_code_<error_code>, Counter, A collection of counters that are lazily initialized to record each QUIC connection close's error code.
+  upstream.<tx/rx>.quic_reset_stream_error_code_<error_code>, Counter, A collection of counters that are lazily initialized to record each QUIC stream reset error code.
 
 
 Health check statistics

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -71,6 +71,9 @@ public:
       quic::QuicStreamId id, spdy::SpdyHeaderBlock headers, bool fin,
       const spdy::SpdyStreamPrecedence& precedence,
       quic::QuicReferenceCountedPointer<quic::QuicAckListenerInterface> ack_listener) override;
+  void MaybeSendRstStreamFrame(quic::QuicStreamId id, quic::QuicRstStreamErrorCode error,
+                               quic::QuicStreamOffset bytes_written) override;
+  void OnRstStream(const quic::QuicRstStreamFrame& frame) override;
   // quic::QuicSpdyClientSessionBase
   void SetDefaultEncryptionLevel(quic::EncryptionLevel level) override;
 


### PR DESCRIPTION
Commit Message: add QUIC upstream stream reset error stats.
Risk Level: Low
Testing: Unit tests
Docs Changes:
Release Notes: n/a.
