### PR TITLE
updates links to jaegertracing-plugin.tar.gz

### DIFF
--- a/examples/front-proxy/Dockerfile-jaeger-service
+++ b/examples/front-proxy/Dockerfile-jaeger-service
@@ -11,7 +11,7 @@ RUN chmod u+x /usr/local/bin/start_service.sh
 #  https://github.com/envoyproxy/envoy/issues/11382#issuecomment-638012072
 #
 RUN echo "4a7d17d4724ee890490bcd6cfdedb12a02316a3d33214348d30979abd201f1ca  /usr/local/lib/libjaegertracing_plugin.so" > /tmp/checksum \
-         && curl -Ls https://github.com/tetratelabs/getenvoy-package/files/3518103/getenvoy-centos-jaegertracing-plugin.tar.gz \
+         && curl -Ls https://github.com/envoyproxy/misc/releases/download/jaegertracing-plugin/jaegertracing-plugin-centos.tar.gz \
               | tar zxf - -C /usr/local/lib \
          && mv /usr/local/lib/libjaegertracing.so.0.4.2 /usr/local/lib/libjaegertracing_plugin.so \
          && sha256sum -c /tmp/checksum \

--- a/examples/jaeger-native-tracing/Dockerfile-frontenvoy
+++ b/examples/jaeger-native-tracing/Dockerfile-frontenvoy
@@ -12,7 +12,7 @@ COPY ./front-envoy-jaeger.yaml /etc/front-envoy.yaml
 #  https://github.com/envoyproxy/envoy/issues/11382#issuecomment-638012072
 #
 RUN echo "4a7d17d4724ee890490bcd6cfdedb12a02316a3d33214348d30979abd201f1ca /usr/local/lib/libjaegertracing_plugin.so" > /tmp/checksum \
-         && curl -Ls https://github.com/tetratelabs/getenvoy-package/files/3518103/getenvoy-centos-jaegertracing-plugin.tar.gz \
+         && curl -Ls https://github.com/envoyproxy/misc/releases/download/jaegertracing-plugin/jaegertracing-plugin-centos.tar.gz \
               | tar zxf - -C /usr/local/lib \
          && mv /usr/local/lib/libjaegertracing.so.0.4.2 /usr/local/lib/libjaegertracing_plugin.so \
          && sha256sum -c /tmp/checksum \


### PR DESCRIPTION
This moves links used by example Docker configuration to a 1st party
repository: [misc](https://github.com/envoyproxy/misc)

Fixes #16866

Signed-off-by: Adrian Cole <adrian@tetrate.io>